### PR TITLE
feat: route client requests through JinnRouter

### DIFF
--- a/client/scripts/e2e-validate.ts
+++ b/client/scripts/e2e-validate.ts
@@ -15,10 +15,12 @@
  */
 
 import { spawn, type ChildProcess } from 'node:child_process';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   createPublicClient,
+  createWalletClient,
   decodeEventLog,
   http,
   type Address,
@@ -30,6 +32,7 @@ import {
   decodeMarketplaceRequestLogs,
 } from '../src/adapters/mech/contracts.js';
 import {
+  MECH_ABI,
   MECH_MARKETPLACE_ABI,
   JINN_ROUTER_ABI,
 } from '../src/adapters/mech/types.js';
@@ -507,6 +510,205 @@ async function main(): Promise<void> {
           await daemon.stop();
           console.log('    Daemon stopped');
         }
+      }),
+    );
+
+    // ── Phase 9: Priority window ────────────────────────────────────────────
+
+    results.push(
+      await runPhase('Phase 9: Priority window — non-priority mech delivers after timeout', async () => {
+        // Create a fresh adapter for this test
+        const windowAdapter = new MechAdapter({
+          rpcUrl: ANVIL_RPC,
+          mechMarketplaceAddress: MARKETPLACE_ADDRESS,
+          routerAddress: ROUTER_ADDRESS,
+          mechContractAddress: MECH_ADDRESS,  // Priority mech = 0xD03d
+          safeAddress: OPERATOR_SAFE_ADDRESS,
+          agentEoaPrivateKey: OPERATOR_EOA_KEY as Hex,
+          ipfsRegistryUrl: 'https://registry.autonolas.tech',
+          ipfsGatewayUrl: 'https://gateway.autonolas.tech',
+          pollIntervalMs: 500,
+          chainId: 8453,
+        });
+        await windowAdapter.initialize();
+
+        // Post a request with priorityMech = 0xD03d
+        const requestId = await windowAdapter.postDesiredState({
+          id: 'priority-window-test',
+          description: 'Priority window test',
+          type: 'restoration',
+          attemptId: 'priority-window-test/1',
+          attemptNumber: 1,
+        });
+        console.log(`    Posted request: ${requestId.slice(0, 14)}...`);
+        await jsonRpc(ANVIL_RPC, 'evm_mine', []);
+
+        // Read the response timeout from mapRequestIdInfos
+        const info = await publicClient.readContract({
+          address: MARKETPLACE_ADDRESS,
+          abi: MECH_MARKETPLACE_ABI,
+          functionName: 'mapRequestIdInfos',
+          args: [requestId as Hex],
+        });
+        const responseTimeout = (info as unknown as any[])[3] as bigint;
+        const currentBlock = await publicClient.getBlock();
+        const timeToWait = Number(responseTimeout) - Number(currentBlock.timestamp) + 1;
+        console.log(`    Response timeout: ${responseTimeout}, need to advance ${timeToWait}s`);
+
+        // Advance time past the timeout
+        await jsonRpc(ANVIL_RPC, 'evm_increaseTime', [timeToWait > 0 ? timeToWait : 301]);
+        await jsonRpc(ANVIL_RPC, 'evm_mine', []);
+
+        // Now impersonate the SECOND mech's operator (0x8c083's operator)
+        const SECOND_MECH: Address = '0x8c083Dfe9bee719a05Ba3c75A9B16BE4ba52c299';
+        const secondOperator = await publicClient.readContract({
+          address: SECOND_MECH,
+          abi: MECH_ABI,
+          functionName: 'getOperator',
+        }) as Address;
+        console.log(`    Second mech operator: ${secondOperator}`);
+
+        await jsonRpc(ANVIL_RPC, 'anvil_setBalance', [secondOperator, '0x56BC75E2D63100000']);
+        await jsonRpc(ANVIL_RPC, 'anvil_impersonateAccount', [secondOperator]);
+
+        const secondOpWallet = createWalletClient({
+          chain: base,
+          transport: http(ANVIL_RPC),
+          account: secondOperator,
+        });
+
+        // Deliver from the SECOND mech (not the priority mech)
+        const deliveryData = ('0x' + 'ff'.repeat(32)) as Hex;
+        const deliverHash = await secondOpWallet.writeContract({
+          address: SECOND_MECH,
+          abi: MECH_ABI,
+          functionName: 'deliverToMarketplace',
+          args: [[requestId as Hex], [deliveryData]],
+        });
+        await jsonRpc(ANVIL_RPC, 'anvil_stopImpersonatingAccount', [secondOperator]);
+
+        const receipt = await publicClient.waitForTransactionReceipt({ hash: deliverHash });
+        if (receipt.status !== 'success') throw new Error('Delivery from non-priority mech failed');
+
+        // Verify: deliveryMech should be the SECOND mech, not the priority mech
+        const postInfo = await publicClient.readContract({
+          address: MARKETPLACE_ADDRESS,
+          abi: MECH_MARKETPLACE_ABI,
+          functionName: 'mapRequestIdInfos',
+          args: [requestId as Hex],
+        });
+        const deliveryMech = (postInfo as unknown as any[])[1] as string;
+        if (deliveryMech.toLowerCase() === MECH_ADDRESS.toLowerCase()) {
+          throw new Error('deliveryMech is the priority mech — expected the second mech');
+        }
+        if (deliveryMech.toLowerCase() !== SECOND_MECH.toLowerCase()) {
+          throw new Error(`Unexpected deliveryMech: ${deliveryMech}`);
+        }
+        console.log(`    Non-priority mech delivered after timeout: ${deliveryMech}`);
+
+        await windowAdapter.stop();
+      }),
+    );
+
+    // ── Phase 10: Crash recovery ──────────────────────────────────────────────
+
+    results.push(
+      await runPhase('Phase 10: Crash recovery — adapter recovers pending state', async () => {
+        // Use a temp file for the store (not :memory:) so it persists across adapter instances
+        const tmpDbPath = join(tmpdir(), `jinn-e2e-${Date.now()}.db`);
+        const { Store } = await import('../src/store/store.js');
+
+        // Step 1: Create adapter with persistent store, post a request
+        const store1 = new Store(tmpDbPath);
+        const adapter1 = new MechAdapter({
+          rpcUrl: ANVIL_RPC,
+          mechMarketplaceAddress: MARKETPLACE_ADDRESS,
+          routerAddress: ROUTER_ADDRESS,
+          mechContractAddress: MECH_ADDRESS,
+          safeAddress: OPERATOR_SAFE_ADDRESS,
+          agentEoaPrivateKey: OPERATOR_EOA_KEY as Hex,
+          ipfsRegistryUrl: 'https://registry.autonolas.tech',
+          ipfsGatewayUrl: 'https://gateway.autonolas.tech',
+          pollIntervalMs: 500,
+          chainId: 8453,
+        }, store1);
+        await adapter1.initialize();
+
+        const requestId = await adapter1.postDesiredState({
+          id: 'crash-recovery-test',
+          description: 'Crash recovery test',
+          type: 'restoration',
+          attemptId: 'crash-recovery-test/1',
+          attemptNumber: 1,
+        });
+        console.log(`    Posted request: ${requestId.slice(0, 14)}...`);
+
+        // Save the block cursor
+        store1.setLastProcessedBlock(await publicClient.getBlockNumber());
+
+        // Step 2: Stop adapter (simulating crash)
+        await adapter1.stop();
+        store1.close();
+        console.log('    Adapter stopped (simulating crash)');
+
+        // Step 3: Deliver while adapter is down (impersonate operator)
+        await jsonRpc(ANVIL_RPC, 'evm_mine', []);
+        const operator = await publicClient.readContract({
+          address: MECH_ADDRESS,
+          abi: MECH_ABI,
+          functionName: 'getOperator',
+        }) as Address;
+        await jsonRpc(ANVIL_RPC, 'anvil_setBalance', [operator, '0x56BC75E2D63100000']);
+        await jsonRpc(ANVIL_RPC, 'anvil_impersonateAccount', [operator]);
+        const opWallet = createWalletClient({
+          chain: base,
+          transport: http(ANVIL_RPC),
+          account: operator,
+        });
+        const deliveryData = ('0x' + 'ee'.repeat(32)) as Hex;
+        await opWallet.writeContract({
+          address: MECH_ADDRESS,
+          abi: MECH_ABI,
+          functionName: 'deliverToMarketplace',
+          args: [[requestId as Hex], [deliveryData]],
+        });
+        await jsonRpc(ANVIL_RPC, 'anvil_stopImpersonatingAccount', [operator]);
+        await jsonRpc(ANVIL_RPC, 'evm_mine', []);
+        console.log('    Delivery happened while adapter was down');
+
+        // Step 4: Create NEW adapter with same store — should recover
+        const store2 = new Store(tmpDbPath);
+        const adapter2 = new MechAdapter({
+          rpcUrl: ANVIL_RPC,
+          mechMarketplaceAddress: MARKETPLACE_ADDRESS,
+          routerAddress: ROUTER_ADDRESS,
+          mechContractAddress: MECH_ADDRESS,
+          safeAddress: OPERATOR_SAFE_ADDRESS,
+          agentEoaPrivateKey: OPERATOR_EOA_KEY as Hex,
+          ipfsRegistryUrl: 'https://registry.autonolas.tech',
+          ipfsGatewayUrl: 'https://gateway.autonolas.tech',
+          pollIntervalMs: 500,
+          chainId: 8453,
+        }, store2);
+        await adapter2.initialize();
+
+        // Verify recovery — check adapter internal state
+        // Access via type assertion since these are private
+        const adapterAny = adapter2 as any;
+        const recoveredPending = adapterAny.pendingEvaluations?.size ?? 0;
+        const recoveredClaimed = adapterAny.claimedButNotEvaluated?.size ?? 0;
+        console.log(`    Recovered: ${recoveredPending} pending, ${recoveredClaimed} claimed-not-evaluated`);
+
+        if (recoveredPending === 0 && recoveredClaimed === 0) {
+          throw new Error('Recovery did not rebuild pending state');
+        }
+        console.log('    Crash recovery verified — pending state rebuilt from on-chain events');
+
+        await adapter2.stop();
+        store2.close();
+
+        // Clean up temp DB
+        try { (await import('node:fs')).unlinkSync(tmpDbPath); } catch {}
       }),
     );
 

--- a/client/scripts/e2e-validate.ts
+++ b/client/scripts/e2e-validate.ts
@@ -47,7 +47,7 @@ const __dirname = join(fileURLToPath(import.meta.url), '..');
 // ── Constants ────────────────────────────────────────────────────────────────
 
 const BASE_RPC_URL = process.env['BASE_RPC_URL'] ?? 'https://mainnet.base.org';
-const ANVIL_PATH = process.env['ANVIL_PATH'] ?? '/Users/adrianobradley/.foundry/bin/anvil';
+const ANVIL_PATH = process.env['ANVIL_PATH'] ?? '/Users/gcd/.foundry/bin/anvil';
 const ANVIL_PORT = 8546;
 const ANVIL_RPC = `http://127.0.0.1:${ANVIL_PORT}`;
 
@@ -451,10 +451,11 @@ async function main(): Promise<void> {
           args: [submittedRequestId],
         });
         const [priorityMech, , requester] = info as [Address, Address, Address, bigint, bigint, Hex];
-        if (requester.toLowerCase() !== safeAddress.toLowerCase()) {
-          throw new Error(`Expected requester=${safeAddress}, got ${requester}`);
+        // With the JinnRouter, the marketplace sees the router as the requester (not the Safe)
+        if (requester.toLowerCase() !== ROUTER_ADDRESS.toLowerCase()) {
+          throw new Error(`Expected requester=${ROUTER_ADDRESS} (router), got ${requester}`);
         }
-        console.log(`    Requester (Safe): ${requester}`);
+        console.log(`    Requester (router): ${requester}`);
         console.log(`    Priority mech: ${priorityMech}`);
       }),
     );
@@ -531,20 +532,10 @@ async function main(): Promise<void> {
         }) as Address;
         console.log(`    Mech operator: ${operator}`);
 
-        // Create adapter for delivery watching
-        const deliveryAdapter = new MechAdapter({
-          rpcUrl: ANVIL_RPC,
-          mechMarketplaceAddress: MARKETPLACE_ADDRESS,
-          routerAddress: ROUTER_ADDRESS,
-          mechContractAddress: MECH_ADDRESS,
-          safeAddress,
-          agentEoaPrivateKey: ANVIL_ACCOUNT_KEY,
-          ipfsRegistryUrl: mockIpfsUrl,
-          ipfsGatewayUrl: mockIpfsUrl,
-          pollIntervalMs: 500,
-          chainId: base.id,
-        });
-        await deliveryAdapter.initialize();
+        // Reuse the adapter from Phase 5c — it holds pendingEvaluations for the submitted request.
+        // The isOurs guard in watchForDeliveries skips deliveries not tracked by this adapter.
+        if (!adapter) throw new Error('No adapter from Phase 5c');
+        const deliveryAdapter = adapter;
 
         // Fund and impersonate the operator, then deliver
         await jsonRpc(ANVIL_RPC, 'anvil_setBalance', [operator, '0x56BC75E2D63100000']);

--- a/client/scripts/e2e-validate.ts
+++ b/client/scripts/e2e-validate.ts
@@ -15,9 +15,10 @@
  */
 
 import { spawn, type ChildProcess } from 'node:child_process';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   createPublicClient,
-  createWalletClient,
   decodeEventLog,
   http,
   type Address,
@@ -30,15 +31,11 @@ import {
 } from '../src/adapters/mech/contracts.js';
 import {
   MECH_MARKETPLACE_ABI,
-  MECH_ABI,
   JINN_ROUTER_ABI,
 } from '../src/adapters/mech/types.js';
 import { MechAdapter } from '../src/adapters/mech/adapter.js';
-import {
-  uploadToIpfs,
-  cidToDigestHex,
-  buildResultPayload,
-} from '../src/adapters/mech/ipfs.js';
+
+const __dirname = join(fileURLToPath(import.meta.url), '..');
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -235,98 +232,61 @@ async function main(): Promise<void> {
       }),
     );
 
-    // ── Phase 3: Restorer picks up request and delivers ──────────────────────
+    // ── Phase 3: Restorer picks up and delivers via RestorerLoop + ClaudeRunner ──
 
-    // Create the generators once — they are infinite and carry state
-    const requestIter = adapter!.watchForRequests()[Symbol.asyncIterator]();
+    const { RestorerLoop } = await import('../src/daemon/restorer.js');
+    const { ClaudeRunner } = await import('../src/runner/claude.js');
+    const { Store } = await import('../src/store/store.js');
+
+    const store = new Store(':memory:');
+    const mockAgentPath = join(__dirname, 'mock-agent.sh');
+    const runner = new ClaudeRunner({ claudePath: mockAgentPath });
+    const restorer = new RestorerLoop(adapter!, runner, store);
+
+    // Create the delivery iterator once — it is infinite and carries state
     const deliveryIter = adapter!.watchForDeliveries()[Symbol.asyncIterator]();
 
     results.push(
-      await runPhase('Phase 3: Restorer picks up request and delivers', async () => {
+      await runPhase('Phase 3: Restorer picks up request and delivers via ClaudeRunner', async () => {
         if (!adapter || !restorationRequestId) throw new Error('Missing state from prior phases');
 
-        // Mine blocks to advance past the cursor
+        // Mine blocks so the restorer sees the request
         await jsonRpc(ANVIL_RPC, 'evm_mine', []);
 
-        // Start watching for requests with timeout
+        // Mine blocks continuously while processOne runs
         const miningInterval = setInterval(async () => {
           try { await jsonRpc(ANVIL_RPC, 'evm_mine', []); } catch { /* ignore */ }
         }, 1000);
 
-        let request: Awaited<ReturnType<typeof requestIter.next>>;
         try {
-          request = await Promise.race([
-            requestIter.next(),
-            sleep(20000).then(() => { throw new Error('watchForRequests timed out after 20s'); }),
+          // processOne: watchForRequests → ClaudeRunner → mock-agent.sh → submitResult
+          const processed = await Promise.race([
+            restorer.processOne(),
+            sleep(60000).then(() => { throw new Error('restorer.processOne timed out after 60s'); }),
           ]);
+          if (!processed) throw new Error('processOne returned false — no request found');
         } finally {
           clearInterval(miningInterval);
         }
 
-        if (request.done || !request.value) throw new Error('watchForRequests ended unexpectedly');
-        const req = request.value;
+        console.log('    RestorerLoop.processOne() completed');
 
-        if (!req.desiredState.description.includes('E2E router flow test')) {
-          throw new Error(`Expected description containing "E2E router flow test", got "${req.desiredState.description}"`);
-        }
-        console.log(`    watchForRequests yielded requestId: ${req.requestId}`);
-        console.log(`    description: "${req.desiredState.description}"`);
-
-        // Read mech operator
-        const mechOperator = await publicClient.readContract({
-          address: MECH_ADDRESS,
-          abi: MECH_ABI,
-          functionName: 'getOperator',
-        }) as Address;
-        console.log(`    Mech operator: ${mechOperator}`);
-
-        // Fund and impersonate operator
-        await jsonRpc(ANVIL_RPC, 'anvil_setBalance', [mechOperator, '0x56BC75E2D63100000']);
-        await jsonRpc(ANVIL_RPC, 'anvil_impersonateAccount', [mechOperator]);
-
-        const operatorWallet = createWalletClient({
-          chain: base,
-          transport: http(ANVIL_RPC),
-          account: mechOperator,
-        });
-
-        // Build mock delivery data — upload to real IPFS and get CID digest
-        const deliveryPayload = buildResultPayload(restorationRequestId, {
-          data: 'E2E mock restoration delivery',
-        });
-        const deliveryCid = await uploadToIpfs('https://registry.autonolas.tech', deliveryPayload);
-        const deliveryDigest = cidToDigestHex(deliveryCid);
-
-        // Call AgentMech.deliverToMarketplace as impersonated operator
-        const deliverHash = await operatorWallet.writeContract({
-          address: MECH_ADDRESS,
-          abi: MECH_ABI,
-          functionName: 'deliverToMarketplace',
-          args: [[restorationRequestId as Hex], [deliveryDigest]],
-        });
-
-        await jsonRpc(ANVIL_RPC, 'anvil_stopImpersonatingAccount', [mechOperator]);
-
-        const deliverReceipt = await publicClient.waitForTransactionReceipt({ hash: deliverHash });
-        if (deliverReceipt.status !== 'success') throw new Error('Deliver transaction reverted');
-
-        // Verify Deliver event in receipt
-        let hasDeliverEvent = false;
-        for (const log of deliverReceipt.logs) {
-          try {
-            const decoded = decodeEventLog({
-              abi: MECH_ABI,
-              data: log.data,
-              topics: log.topics,
-            });
-            if (decoded.eventName === 'Deliver') hasDeliverEvent = true;
-          } catch { /* not our event */ }
-        }
-        if (!hasDeliverEvent) throw new Error('No Deliver event in receipt');
-        console.log('    Deliver event confirmed in receipt');
-
-        // Mine a block
+        // Mine a block to confirm the delivery transaction
         await jsonRpc(ANVIL_RPC, 'evm_mine', []);
+
+        // Verify on-chain: mapRequestIdInfos should show a non-zero deliveryMech
+        const info = await publicClient.readContract({
+          address: MARKETPLACE_ADDRESS,
+          abi: MECH_MARKETPLACE_ABI,
+          functionName: 'mapRequestIdInfos',
+          args: [restorationRequestId as Hex],
+        }) as [string, string, string, bigint, bigint, string];
+
+        const deliveryMech = info[1];
+        if (deliveryMech === '0x0000000000000000000000000000000000000000') {
+          throw new Error('deliveryMech is zero — delivery did not happen');
+        }
+        console.log(`    Delivery confirmed on-chain, deliveryMech: ${deliveryMech}`);
       }),
     );
 
@@ -402,72 +362,31 @@ async function main(): Promise<void> {
     // ── Phase 5: Restorer picks up evaluation and delivers ───────────────────
 
     results.push(
-      await runPhase('Phase 5: Restorer picks up evaluation and delivers', async () => {
+      await runPhase('Phase 5: Restorer picks up evaluation and delivers via ClaudeRunner', async () => {
         if (!adapter) throw new Error('Missing adapter');
 
-        // Mine blocks to advance
+        // Mine blocks so the restorer sees the evaluation request
+        await jsonRpc(ANVIL_RPC, 'evm_mine', []);
+
+        // Mine blocks continuously while processOne runs
         const miningInterval = setInterval(async () => {
           try { await jsonRpc(ANVIL_RPC, 'evm_mine', []); } catch { /* ignore */ }
         }, 1000);
 
-        let request: Awaited<ReturnType<typeof requestIter.next>>;
         try {
-          request = await Promise.race([
-            requestIter.next(),
-            sleep(20000).then(() => { throw new Error('watchForRequests timed out after 20s'); }),
+          // processOne: watchForRequests yields evaluation → ClaudeRunner → mock-agent.sh → submitResult
+          const processed = await Promise.race([
+            restorer.processOne(),
+            sleep(60000).then(() => { throw new Error('restorer.processOne timed out after 60s'); }),
           ]);
+          if (!processed) throw new Error('processOne returned false — no evaluation request found');
         } finally {
           clearInterval(miningInterval);
         }
 
-        if (request.done || !request.value) throw new Error('watchForRequests ended unexpectedly');
-        const req = request.value;
+        console.log('    RestorerLoop.processOne() completed for evaluation');
 
-        console.log(`    watchForRequests yielded evaluation request: ${req.requestId}`);
-        console.log(`    type: ${req.desiredState.type}`);
-
-        if (req.desiredState.type !== 'evaluation') {
-          throw new Error(`Expected type 'evaluation', got '${req.desiredState.type}'`);
-        }
-
-        // Read mech operator
-        const mechOperator = await publicClient.readContract({
-          address: MECH_ADDRESS,
-          abi: MECH_ABI,
-          functionName: 'getOperator',
-        }) as Address;
-
-        // Impersonate mech operator and deliver evaluation
-        await jsonRpc(ANVIL_RPC, 'anvil_setBalance', [mechOperator, '0x56BC75E2D63100000']);
-        await jsonRpc(ANVIL_RPC, 'anvil_impersonateAccount', [mechOperator]);
-
-        const operatorWallet = createWalletClient({
-          chain: base,
-          transport: http(ANVIL_RPC),
-          account: mechOperator,
-        });
-
-        // Build evaluation delivery data — upload to real IPFS
-        const evalPayload = buildResultPayload(req.requestId, {
-          data: JSON.stringify({ verdict: 'pass', score: 0.95 }),
-        });
-        const evalCid = await uploadToIpfs('https://registry.autonolas.tech', evalPayload);
-        const evalDigest = cidToDigestHex(evalCid);
-
-        const deliverHash = await operatorWallet.writeContract({
-          address: MECH_ADDRESS,
-          abi: MECH_ABI,
-          functionName: 'deliverToMarketplace',
-          args: [[req.requestId as Hex], [evalDigest]],
-        });
-
-        await jsonRpc(ANVIL_RPC, 'anvil_stopImpersonatingAccount', [mechOperator]);
-
-        const deliverReceipt = await publicClient.waitForTransactionReceipt({ hash: deliverHash });
-        if (deliverReceipt.status !== 'success') throw new Error('Evaluation deliver tx reverted');
-        console.log('    Evaluation delivery submitted');
-
-        // Mine a block
+        // Mine a block to confirm
         await jsonRpc(ANVIL_RPC, 'evm_mine', []);
       }),
     );
@@ -514,10 +433,82 @@ async function main(): Promise<void> {
       }),
     );
 
-    // ── Phase 7: Full daemon loop (skipped) ──────────────────────────────────
-    // The step-by-step phases 2-6 already validate the complete flow.
-    // A full daemon test with impersonation + real signing is complex and
-    // deferred as a follow-up.
+    // ── Phase 7: Full daemon loop ──────────────────────────────────────────────
+
+    results.push(
+      await runPhase('Phase 7: Full daemon loop — all three concurrent loops', async () => {
+        const { Daemon } = await import('../src/daemon/daemon.js');
+
+        // Fresh adapter for daemon — independent state from phases 2-6
+        const daemonAdapter = new MechAdapter({
+          rpcUrl: ANVIL_RPC,
+          mechMarketplaceAddress: MARKETPLACE_ADDRESS,
+          routerAddress: ROUTER_ADDRESS,
+          mechContractAddress: MECH_ADDRESS,
+          safeAddress: OPERATOR_SAFE_ADDRESS,
+          agentEoaPrivateKey: OPERATOR_EOA_KEY as Hex,
+          ipfsRegistryUrl: 'https://registry.autonolas.tech',
+          ipfsGatewayUrl: 'https://gateway.autonolas.tech',
+          pollIntervalMs: 500,
+          chainId: base.id,
+        });
+        await daemonAdapter.initialize();
+
+        const daemon = new Daemon({
+          adapter: daemonAdapter,
+          runner: new ClaudeRunner({ claudePath: mockAgentPath }),
+          desiredStates: [{ id: 'daemon-e2e', description: 'Daemon full loop test' }],
+          dbPath: ':memory:',
+          shutdownTimeoutMs: 10000,
+        });
+
+        await daemon.start();
+        console.log('    Daemon started with all three loops');
+
+        // Mine blocks continuously so on-chain state advances
+        const mineInterval = setInterval(async () => {
+          try { await jsonRpc(ANVIL_RPC, 'evm_mine', []); } catch { /* ignore */ }
+        }, 1000);
+
+        try {
+          // Record block before daemon activity for event scanning
+          const startBlock = await publicClient.getBlockNumber();
+
+          // Wait for the full cycle: restoration + evaluation both claimed
+          await waitFor('Daemon completes full cycle', async () => {
+            const currentBlock = await publicClient.getBlockNumber();
+            if (currentBlock <= startBlock) return false;
+
+            const logs = await publicClient.getLogs({
+              address: ROUTER_ADDRESS,
+              fromBlock: startBlock,
+              toBlock: currentBlock,
+            });
+
+            let claimCount = 0;
+            for (const log of logs) {
+              try {
+                const decoded = decodeEventLog({
+                  abi: JINN_ROUTER_ABI,
+                  data: log.data,
+                  topics: log.topics,
+                });
+                if (decoded.eventName === 'DeliveryClaimed') claimCount++;
+              } catch { /* not our event */ }
+            }
+
+            console.log(`    DeliveryClaimed events so far: ${claimCount}`);
+            return claimCount >= 2;
+          }, 120000, 3000);
+
+          console.log('    Daemon completed full restoration + evaluation cycle');
+        } finally {
+          clearInterval(mineInterval);
+          await daemon.stop();
+          console.log('    Daemon stopped');
+        }
+      }),
+    );
 
   } finally {
     // ── Phase 8: Cleanup ─────────────────────────────────────────────────────

--- a/client/scripts/e2e-validate.ts
+++ b/client/scripts/e2e-validate.ts
@@ -1,66 +1,57 @@
 /**
- * End-to-end validation script for MechAdapter against real Mech marketplace
- * contracts on a Base mainnet fork (via Anvil).
+ * End-to-end validation script for the JinnRouter production flow on a Base
+ * mainnet fork (via Anvil).
+ *
+ * Validates the complete lifecycle:
+ *   Creator posts -> router.createRestorationJob -> marketplace
+ *   Restorer picks up -> delivers
+ *   Creator claims -> router.claimDelivery -> creates evaluation
+ *   Restorer picks up evaluation -> delivers
+ *   Creator claims evaluation -> done
+ *
+ * Uses real IPFS, real JinnRouter, real operator credentials.
  *
  * Usage: npx tsx scripts/e2e-validate.ts
  */
 
 import { spawn, type ChildProcess } from 'node:child_process';
-import { createServer, type Server } from 'node:http';
 import {
   createPublicClient,
   createWalletClient,
+  decodeEventLog,
   http,
   type Address,
   type Hex,
   type PublicClient,
-  type WalletClient,
 } from 'viem';
-import { privateKeyToAccount } from 'viem/accounts';
 import { base } from 'viem/chains';
 import {
-  getMechDeliveryRate,
-  getTimeoutBounds,
   decodeMarketplaceRequestLogs,
-  decodeDeliverLogs,
 } from '../src/adapters/mech/contracts.js';
-import { digestHexToGatewayUrl } from '../src/adapters/mech/ipfs.js';
 import {
   MECH_MARKETPLACE_ABI,
   MECH_ABI,
-  NATIVE_PAYMENT_TYPE,
-  SAFE_SETUP_ABI,
-  SAFE_PROXY_FACTORY_ABI,
-  SAFE_ABI,
-  SAFE_SINGLETON_ADDRESS,
-  SAFE_PROXY_FACTORY_ADDRESS,
+  JINN_ROUTER_ABI,
 } from '../src/adapters/mech/types.js';
-import { executeSafeTransaction } from '../src/adapters/mech/safe.js';
 import { MechAdapter } from '../src/adapters/mech/adapter.js';
-import { Daemon, type DaemonConfig } from '../src/daemon/daemon.js';
-import { ClaudeRunner } from '../src/runner/claude.js';
-import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = join(fileURLToPath(import.meta.url), '..');
+import {
+  uploadToIpfs,
+  cidToDigestHex,
+  buildResultPayload,
+} from '../src/adapters/mech/ipfs.js';
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
 const BASE_RPC_URL = process.env['BASE_RPC_URL'] ?? 'https://mainnet.base.org';
-const ANVIL_PATH = process.env['ANVIL_PATH'] ?? '/Users/gcd/.foundry/bin/anvil';
 const ANVIL_PORT = 8546;
 const ANVIL_RPC = `http://127.0.0.1:${ANVIL_PORT}`;
 
 const MARKETPLACE_ADDRESS: Address = '0xf24eE42edA0fc9b33B7D41B06Ee8ccD2Ef7C5020';
 const ROUTER_ADDRESS: Address = '0xfFa7118A3D820cd4E820010837D65FAfF463181B';
-const MECH_ADDRESS: Address = '0x8c083Dfe9bee719a05Ba3c75A9B16BE4ba52c299';
-
-const ANVIL_ACCOUNT_KEY: Hex = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
-
-// Real operator credentials — loaded from environment
-const OPERATOR_MECH_ADDRESS: Address = '0xD03d75D3B59Ac252F2e8C7Bf4617cf91a102E613';
+const MECH_ADDRESS: Address = '0xD03d75D3B59Ac252F2e8C7Bf4617cf91a102E613';
 const OPERATOR_SAFE_ADDRESS: Address = '0x608d976Da1Dd9BC53aeA87Abe74e1306Ab96280c';
-const OPERATOR_EOA_KEY: Hex = (process.env['OPERATOR_EOA_KEY'] ?? '') as Hex;
+
+const OPERATOR_EOA_KEY: Hex | '' = (process.env['OPERATOR_EOA_KEY'] ?? '') as Hex | '';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -93,36 +84,6 @@ async function jsonRpc(url: string, method: string, params: unknown[] = []): Pro
   return body.result;
 }
 
-// ── Mock IPFS server ────────────────────────────────────────────────────────
-
-function startMockIpfs(): Promise<{ url: string; server: Server }> {
-  return new Promise((resolve) => {
-    let lastBody = '{}';
-    const server = createServer((req, res) => {
-      if (req.method === 'POST' && req.url === '/api/v0/add') {
-        const chunks: Buffer[] = [];
-        req.on('data', (c: Buffer) => chunks.push(c));
-        req.on('end', () => {
-          lastBody = Buffer.concat(chunks).toString();
-          res.writeHead(200, { 'Content-Type': 'application/json' });
-          // Return a well-known CIDv0 (empty unixfs directory)
-          res.end(JSON.stringify({ Hash: 'QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn' }));
-        });
-      } else if (req.method === 'GET' && req.url?.startsWith('/ipfs/')) {
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(lastBody);
-      } else {
-        res.writeHead(404);
-        res.end();
-      }
-    });
-    server.listen(0, () => {
-      const addr = server.address() as { port: number };
-      resolve({ url: `http://127.0.0.1:${addr.port}`, server });
-    });
-  });
-}
-
 // ── Phase runner ─────────────────────────────────────────────────────────────
 
 interface PhaseResult {
@@ -150,28 +111,29 @@ async function runPhase(name: string, fn: () => Promise<void>): Promise<PhaseRes
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
-  console.log('\n=== Jinn-Client E2E Validation (Anvil Base Fork) ===\n');
+  console.log('\n=== Jinn-Client E2E Validation (JinnRouter Production Flow) ===\n');
+
+  // Check for operator credentials early
+  if (!OPERATOR_EOA_KEY) {
+    console.log('Set OPERATOR_EOA_KEY to run e2e');
+    process.exit(0);
+  }
 
   let anvil: ChildProcess | null = null;
   const results: PhaseResult[] = [];
 
   // Shared state populated across phases
-  const account = privateKeyToAccount(ANVIL_ACCOUNT_KEY);
   let publicClient: PublicClient;
-  let walletClient: WalletClient;
-  let historicalRequestDataHex: string | undefined;
-  let safeAddress: Address | undefined;
-  let submittedRequestId: Hex | undefined;
-  let mockIpfsServer: Server | undefined;
-  let mockIpfsUrl: string | undefined;
   let adapter: MechAdapter | undefined;
+  let restorationRequestId: string | undefined;
 
   try {
-    // ── Phase 1: Infrastructure ────────────────────────────────────────────
+    // ── Phase 1: Infrastructure ──────────────────────────────────────────────
 
     results.push(
-      await runPhase('Phase 1: Infrastructure — spawn Anvil fork', async () => {
-        anvil = spawn(ANVIL_PATH, [
+      await runPhase('Phase 1: Infrastructure — spawn Anvil fork, fund accounts', async () => {
+        const anvilPath = process.env['ANVIL_PATH'] ?? 'anvil';
+        anvil = spawn(anvilPath, [
           '--fork-url', BASE_RPC_URL,
           '--port', String(ANVIL_PORT),
           '--silent',
@@ -194,581 +156,377 @@ async function main(): Promise<void> {
           }
         });
 
-        // Create viem clients (cast to plain types expected by contract helpers)
         publicClient = createPublicClient({
           chain: base,
           transport: http(ANVIL_RPC),
         }) as unknown as PublicClient;
 
-        walletClient = createWalletClient({
-          chain: base,
-          transport: http(ANVIL_RPC),
-          account,
-        }) as unknown as WalletClient;
-
         const blockNumber = await publicClient.getBlockNumber();
         console.log(`    Anvil forked at block ${blockNumber}`);
-      }),
-    );
 
-    // ── Phase 2: Contract Reads ────────────────────────────────────────────
+        // Fund operator EOA and Safe
+        const { privateKeyToAccount } = await import('viem/accounts');
+        const operatorAccount = privateKeyToAccount(OPERATOR_EOA_KEY as Hex);
+        await jsonRpc(ANVIL_RPC, 'anvil_setBalance', [operatorAccount.address, '0x56BC75E2D63100000']); // 100 ETH
+        await jsonRpc(ANVIL_RPC, 'anvil_setBalance', [OPERATOR_SAFE_ADDRESS, '0x56BC75E2D63100000']); // 100 ETH
+        console.log(`    Funded operator EOA (${operatorAccount.address}) and Safe (${OPERATOR_SAFE_ADDRESS})`);
 
-    results.push(
-      await runPhase('Phase 2: Contract reads', async () => {
-        const deliveryRate = await getMechDeliveryRate(publicClient, MECH_ADDRESS);
-        if (typeof deliveryRate !== 'bigint' || deliveryRate === 0n) {
-          throw new Error(`Expected non-zero bigint delivery rate, got ${deliveryRate}`);
-        }
-        console.log(`    deliveryRate = ${deliveryRate}`);
-
-        const { min, max } = await getTimeoutBounds(publicClient, MARKETPLACE_ADDRESS);
-        if (min >= max) throw new Error(`Expected min < max, got min=${min} max=${max}`);
-        if (min <= 0n || max <= 0n) throw new Error(`Expected both > 0, got min=${min} max=${max}`);
-        console.log(`    timeoutBounds = { min: ${min}, max: ${max} }`);
-
-        const adapter = new MechAdapter({
-          rpcUrl: ANVIL_RPC,
-          mechMarketplaceAddress: MARKETPLACE_ADDRESS,
-          routerAddress: ROUTER_ADDRESS,
-          mechContractAddress: MECH_ADDRESS,
-          safeAddress: account.address, // dummy for initialization
-          agentEoaPrivateKey: ANVIL_ACCOUNT_KEY,
-          ipfsRegistryUrl: 'https://registry.autonolas.tech',
-          ipfsGatewayUrl: 'https://gateway.autonolas.tech',
-          pollIntervalMs: 5000,
-          chainId: base.id,
-        });
-        await adapter.initialize();
-        await adapter.stop();
-        console.log('    MechAdapter.initialize() succeeded');
-      }),
-    );
-
-    // ── Phase 3: Historical Event Decoding ─────────────────────────────────
-
-    results.push(
-      await runPhase('Phase 3: Historical event decoding', async () => {
-        const currentBlock = await publicClient.getBlockNumber();
-        const totalRange = 5000n; // Small range to avoid RPC timeouts on public endpoints
-        const chunkSize = 2499n;
-        const fromBlock = currentBlock - totalRange;
-
-        // Query MarketplaceRequest events in chunks
-        const allMarketplaceLogs: Awaited<ReturnType<typeof publicClient.getLogs>> = [];
-        for (let start = fromBlock; start <= currentBlock; start += chunkSize + 1n) {
-          const end = start + chunkSize > currentBlock ? currentBlock : start + chunkSize;
-          const logs = await publicClient.getLogs({
-            address: MARKETPLACE_ADDRESS,
-            fromBlock: start,
-            toBlock: end,
-          });
-          allMarketplaceLogs.push(...logs);
-          if (allMarketplaceLogs.length > 0) break; // Found some — no need to scan all chunks
-        }
-        const decodedRequests = decodeMarketplaceRequestLogs(allMarketplaceLogs);
-        if (decodedRequests.length === 0) {
-          throw new Error('Expected at least 1 MarketplaceRequest event in last 50k blocks');
-        }
-        console.log(`    Decoded ${decodedRequests.length} MarketplaceRequest event(s)`);
-        console.log(`    First requestId: ${decodedRequests[0].requestId}`);
-
-        // Save for Phase 4
-        historicalRequestDataHex = decodedRequests[0].requestDataHex;
-
-        // Query Deliver events from Mech contract in chunks
-        const allMechLogs: Awaited<ReturnType<typeof publicClient.getLogs>> = [];
-        for (let start = fromBlock; start <= currentBlock; start += chunkSize + 1n) {
-          const end = start + chunkSize > currentBlock ? currentBlock : start + chunkSize;
-          const logs = await publicClient.getLogs({
-            address: MECH_ADDRESS,
-            fromBlock: start,
-            toBlock: end,
-          });
-          allMechLogs.push(...logs);
-          if (allMechLogs.length > 0) break;
-        }
-        const decodedDeliveries = decodeDeliverLogs(allMechLogs);
-        if (decodedDeliveries.length === 0) {
-          console.log('    No Deliver events found for this mech in range (mech may be inactive — OK)');
-        } else {
-          console.log(`    Decoded ${decodedDeliveries.length} Deliver event(s)`);
-          console.log(`    First delivery mechAddress: ${decodedDeliveries[0].mechAddress}`);
-        }
-      }),
-    );
-
-    // ── Phase 4: IPFS Roundtrip ────────────────────────────────────────────
-
-    results.push(
-      await runPhase('Phase 4: IPFS roundtrip', async () => {
-        if (!historicalRequestDataHex) {
-          throw new Error('No requestDataHex available from Phase 3');
-        }
-
-        // Extract the 32-byte digest from the request data
-        // It may be raw 32 bytes (0x + 64 hex chars = 66 chars) or ABI-encoded bytes
-        let digestHex: string;
-        const raw = historicalRequestDataHex.startsWith('0x')
-          ? historicalRequestDataHex.slice(2)
-          : historicalRequestDataHex;
-
-        if (raw.length === 64) {
-          // Raw 32-byte digest
-          digestHex = raw;
-        } else {
-          // ABI-encoded bytes — take the last 64 hex chars as the digest
-          digestHex = raw.slice(-64);
-        }
-
-        const url = digestHexToGatewayUrl(digestHex);
-        console.log(`    Gateway URL: ${url}`);
-
-        const response = await fetch(url);
-        if (!response.ok) {
-          // Content may have been garbage collected — that's OK, we validated the URL format
-          console.log(`    Gateway returned ${response.status} — content may be GC'd, URL format validated`);
-          return;
-        }
-
-        const text = await response.text();
-        try {
-          const content = JSON.parse(text);
-          if (typeof content !== 'object' || content === null) {
-            throw new Error(`Expected JSON object, got ${typeof content}`);
-          }
-          console.log(`    Fetched valid JSON with keys: ${Object.keys(content as Record<string, unknown>).join(', ')}`);
-        } catch {
-          // Non-JSON response (HTML error page etc) — URL format is still validated
-          console.log(`    Gateway returned non-JSON content (${text.length} bytes) — URL format validated`);
-        }
-      }),
-    );
-
-    // ── Phase 5a: Deploy Safe ──────────────────────────────────────────────
-
-    results.push(
-      await runPhase('Phase 5a: Deploy 1-of-1 Safe', async () => {
-        const { encodeFunctionData } = await import('viem');
-
-        // Encode Safe.setup() initializer
-        const initializer = encodeFunctionData({
-          abi: SAFE_SETUP_ABI,
-          functionName: 'setup',
-          args: [
-            [account.address],    // owners
-            1n,                   // threshold
-            '0x0000000000000000000000000000000000000000' as Address, // to
-            '0x' as Hex,          // data
-            '0x0000000000000000000000000000000000000000' as Address, // fallbackHandler
-            '0x0000000000000000000000000000000000000000' as Address, // paymentToken
-            0n,                   // payment
-            '0x0000000000000000000000000000000000000000' as Address, // paymentReceiver
-          ],
-        });
-
-        // Deploy via ProxyFactory.createProxyWithNonce()
-        const hash = await walletClient.writeContract({
-          address: SAFE_PROXY_FACTORY_ADDRESS,
-          abi: SAFE_PROXY_FACTORY_ABI,
-          functionName: 'createProxyWithNonce',
-          args: [SAFE_SINGLETON_ADDRESS, initializer, 0n],
-          account,
-          chain: base,
-        });
-
-        const receipt = await publicClient.waitForTransactionReceipt({ hash });
-        if (receipt.status !== 'success') throw new Error('Safe deployment reverted');
-
-        // Extract Safe address from ProxyCreation event
-        // ProxyCreation(address proxy, address singleton) — neither param is indexed in Safe v1.3.0
-        // proxy address is in the first 32 bytes of log data (ABI-encoded address)
-        const proxyLog = receipt.logs.find(l => l.address.toLowerCase() === SAFE_PROXY_FACTORY_ADDRESS.toLowerCase());
-        if (!proxyLog) throw new Error('No ProxyCreation event found');
-        // ABI-encoded address: 32 bytes, right-padded — take bytes 12-32 (last 20 bytes)
-        safeAddress = ('0x' + proxyLog.data.slice(26, 66)) as Address;
-
-        // Fund the Safe with ETH
-        await jsonRpc(ANVIL_RPC, 'anvil_setBalance', [safeAddress, '0x56BC75E2D63100000']); // 100 ETH
-
-        // Verify Safe is operational
-        const nonce = await publicClient.readContract({
-          address: safeAddress,
-          abi: SAFE_ABI,
-          functionName: 'nonce',
-        });
-        if (nonce !== 0n) throw new Error(`Expected nonce 0, got ${nonce}`);
-
-        console.log(`    Safe deployed at: ${safeAddress}`);
-        console.log(`    Safe nonce: ${nonce}`);
-      }),
-    );
-
-    // ── Phase 5b: Start mock IPFS server ─────────────────────────────────────
-
-    results.push(
-      await runPhase('Phase 5b: Start mock IPFS server', async () => {
-        const mock = await startMockIpfs();
-        mockIpfsServer = mock.server;
-        mockIpfsUrl = mock.url;
-        console.log(`    Mock IPFS running at: ${mockIpfsUrl}`);
-      }),
-    );
-
-    // ── Phase 5c: postDesiredState through adapter ──────────────────────────
-
-    results.push(
-      await runPhase('Phase 5c: postDesiredState through adapter', async () => {
-        if (!safeAddress) throw new Error('No Safe address from Phase 5a');
-        if (!mockIpfsUrl) throw new Error('No mock IPFS URL from Phase 5b');
-
+        // Create adapter
         adapter = new MechAdapter({
           rpcUrl: ANVIL_RPC,
           mechMarketplaceAddress: MARKETPLACE_ADDRESS,
           routerAddress: ROUTER_ADDRESS,
           mechContractAddress: MECH_ADDRESS,
-          safeAddress,
-          agentEoaPrivateKey: ANVIL_ACCOUNT_KEY,
-          ipfsRegistryUrl: mockIpfsUrl,
-          ipfsGatewayUrl: mockIpfsUrl,
-          pollIntervalMs: 1000,
-          chainId: base.id,
-        });
-        await adapter.initialize();
-
-        // Call the actual adapter method — tests IPFS upload + cidToDigestHex + Safe tx
-        submittedRequestId = await adapter.postDesiredState({
-          id: 'e2e-test-1',
-          description: 'E2E test desired state',
-        }) as Hex;
-
-        console.log(`    postDesiredState returned requestId: ${submittedRequestId}`);
-
-        // Verify on-chain
-        const info = await publicClient.readContract({
-          address: MARKETPLACE_ADDRESS,
-          abi: MECH_MARKETPLACE_ABI,
-          functionName: 'mapRequestIdInfos',
-          args: [submittedRequestId],
-        });
-        const [priorityMech, , requester] = info as [Address, Address, Address, bigint, bigint, Hex];
-        // With the JinnRouter, the marketplace sees the router as the requester (not the Safe)
-        if (requester.toLowerCase() !== ROUTER_ADDRESS.toLowerCase()) {
-          throw new Error(`Expected requester=${ROUTER_ADDRESS} (router), got ${requester}`);
-        }
-        console.log(`    Requester (router): ${requester}`);
-        console.log(`    Priority mech: ${priorityMech}`);
-      }),
-    );
-
-    // ── Phase 5d: watchForRequests picks up request ──────────────────────────
-
-    results.push(
-      await runPhase('Phase 5d: watchForRequests picks up request (real IPFS)', async () => {
-        if (!safeAddress) throw new Error('No Safe address');
-
-        // Create a fresh adapter with REAL IPFS so content is verifiable
-        const pollAdapter = new MechAdapter({
-          rpcUrl: ANVIL_RPC,
-          mechMarketplaceAddress: MARKETPLACE_ADDRESS,
-          routerAddress: ROUTER_ADDRESS,
-          mechContractAddress: MECH_ADDRESS,
-          safeAddress,
-          agentEoaPrivateKey: ANVIL_ACCOUNT_KEY,
+          safeAddress: OPERATOR_SAFE_ADDRESS,
+          agentEoaPrivateKey: OPERATOR_EOA_KEY as Hex,
           ipfsRegistryUrl: 'https://registry.autonolas.tech',
           ipfsGatewayUrl: 'https://gateway.autonolas.tech',
           pollIntervalMs: 500,
           chainId: base.id,
         });
-        await pollAdapter.initialize();
-
-        // Submit a new request AFTER initialization (so event is after cursor)
-        const newRequestId = await pollAdapter.postDesiredState({
-          id: 'e2e-test-watch',
-          description: 'watchForRequests content verification test',
-        });
-        console.log(`    Posted new request: ${newRequestId}`);
-
-        // Mine a block to advance
-        await jsonRpc(ANVIL_RPC, 'evm_mine', []);
-
-        // Start watching and wait for it to yield
-        const request = await Promise.race([
-          (async () => {
-            for await (const req of pollAdapter.watchForRequests()) {
-              return req;
-            }
-            return null;
-          })(),
-          sleep(15000).then(() => { throw new Error('watchForRequests timed out after 15s'); }),
-        ]);
-
-        await pollAdapter.stop();
-
-        if (!request) throw new Error('watchForRequests yielded null');
-        console.log(`    watchForRequests yielded requestId: ${request.requestId}`);
-        console.log(`    Desired state description: "${request.desiredState.description}"`);
-
-        // Verify content matches what was uploaded
-        if (!request.desiredState.description.includes('watchForRequests content verification')) {
-          throw new Error(`Content mismatch: expected uploaded description, got "${request.desiredState.description}"`);
-        }
-        console.log('    IPFS content verified: description matches uploaded data');
+        await adapter.initialize();
+        console.log('    MechAdapter initialized');
       }),
     );
 
-    // ── Phase 5e: Deliver through AgentMech + watchForDeliveries ────────────
+    // ── Phase 2: Creator posts desired state ─────────────────────────────────
 
     results.push(
-      await runPhase('Phase 5e: Deliver through AgentMech + watchForDeliveries', async () => {
-        if (!submittedRequestId) throw new Error('No requestId from Phase 5c');
-        if (!mockIpfsUrl) throw new Error('No mock IPFS URL');
-        if (!safeAddress) throw new Error('No Safe address');
+      await runPhase('Phase 2: Creator posts desired state', async () => {
+        if (!adapter) throw new Error('No adapter from Phase 1');
 
-        // Read the mech's authorized operator
-        const operator = await publicClient.readContract({
+        restorationRequestId = await adapter.postDesiredState({
+          id: 'e2e-test',
+          description: 'E2E router flow test',
+          type: 'restoration',
+          attemptId: 'e2e-test/1',
+          attemptNumber: 1,
+        });
+
+        // Mine a block to make events visible
+        await jsonRpc(ANVIL_RPC, 'evm_mine', []);
+
+        console.log(`    requestId: ${restorationRequestId}`);
+
+        // Verify MarketplaceRequest event on marketplace
+        const currentBlock = await publicClient.getBlockNumber();
+        const logs = await publicClient.getLogs({
+          address: MARKETPLACE_ADDRESS,
+          fromBlock: currentBlock - 5n,
+          toBlock: currentBlock,
+        });
+        const decoded = decodeMarketplaceRequestLogs(logs);
+        if (decoded.length === 0) {
+          throw new Error('No MarketplaceRequest event found');
+        }
+
+        const found = decoded.find(d => d.requestId === restorationRequestId);
+        if (!found) {
+          throw new Error(`MarketplaceRequest event not found for requestId ${restorationRequestId}`);
+        }
+        console.log('    MarketplaceRequest event verified on-chain');
+
+        // Verify adapter's pendingEvaluations has the requestId
+        const adapterAny = adapter as unknown as { pendingEvaluations: Map<string, unknown> };
+        if (!adapterAny.pendingEvaluations.has(restorationRequestId)) {
+          throw new Error('pendingEvaluations does not contain the requestId');
+        }
+        console.log('    pendingEvaluations tracking confirmed');
+      }),
+    );
+
+    // ── Phase 3: Restorer picks up request and delivers ──────────────────────
+
+    // Create the generators once — they are infinite and carry state
+    const requestIter = adapter!.watchForRequests()[Symbol.asyncIterator]();
+    const deliveryIter = adapter!.watchForDeliveries()[Symbol.asyncIterator]();
+
+    results.push(
+      await runPhase('Phase 3: Restorer picks up request and delivers', async () => {
+        if (!adapter || !restorationRequestId) throw new Error('Missing state from prior phases');
+
+        // Mine blocks to advance past the cursor
+        await jsonRpc(ANVIL_RPC, 'evm_mine', []);
+
+        // Start watching for requests with timeout
+        const miningInterval = setInterval(async () => {
+          try { await jsonRpc(ANVIL_RPC, 'evm_mine', []); } catch { /* ignore */ }
+        }, 1000);
+
+        let request: Awaited<ReturnType<typeof requestIter.next>>;
+        try {
+          request = await Promise.race([
+            requestIter.next(),
+            sleep(20000).then(() => { throw new Error('watchForRequests timed out after 20s'); }),
+          ]);
+        } finally {
+          clearInterval(miningInterval);
+        }
+
+        if (request.done || !request.value) throw new Error('watchForRequests ended unexpectedly');
+        const req = request.value;
+
+        if (!req.desiredState.description.includes('E2E router flow test')) {
+          throw new Error(`Expected description containing "E2E router flow test", got "${req.desiredState.description}"`);
+        }
+        console.log(`    watchForRequests yielded requestId: ${req.requestId}`);
+        console.log(`    description: "${req.desiredState.description}"`);
+
+        // Read mech operator
+        const mechOperator = await publicClient.readContract({
           address: MECH_ADDRESS,
           abi: MECH_ABI,
           functionName: 'getOperator',
         }) as Address;
-        console.log(`    Mech operator: ${operator}`);
+        console.log(`    Mech operator: ${mechOperator}`);
 
-        // Reuse the adapter from Phase 5c — it holds pendingEvaluations for the submitted request.
-        // The isOurs guard in watchForDeliveries skips deliveries not tracked by this adapter.
-        if (!adapter) throw new Error('No adapter from Phase 5c');
-        const deliveryAdapter = adapter;
-
-        // Fund and impersonate the operator, then deliver
-        await jsonRpc(ANVIL_RPC, 'anvil_setBalance', [operator, '0x56BC75E2D63100000']);
-        await jsonRpc(ANVIL_RPC, 'anvil_impersonateAccount', [operator]);
+        // Fund and impersonate operator
+        await jsonRpc(ANVIL_RPC, 'anvil_setBalance', [mechOperator, '0x56BC75E2D63100000']);
+        await jsonRpc(ANVIL_RPC, 'anvil_impersonateAccount', [mechOperator]);
 
         const operatorWallet = createWalletClient({
           chain: base,
           transport: http(ANVIL_RPC),
-          account: operator,
+          account: mechOperator,
         });
 
-        const deliveryData: Hex = ('0x' + 'cd'.repeat(32)) as Hex;
+        // Build mock delivery data — upload to real IPFS and get CID digest
+        const deliveryPayload = buildResultPayload(restorationRequestId, {
+          data: 'E2E mock restoration delivery',
+        });
+        const deliveryCid = await uploadToIpfs('https://registry.autonolas.tech', deliveryPayload);
+        const deliveryDigest = cidToDigestHex(deliveryCid);
+
+        // Call AgentMech.deliverToMarketplace as impersonated operator
         const deliverHash = await operatorWallet.writeContract({
           address: MECH_ADDRESS,
           abi: MECH_ABI,
           functionName: 'deliverToMarketplace',
-          args: [[submittedRequestId as Hex], [deliveryData]],
+          args: [[restorationRequestId as Hex], [deliveryDigest]],
         });
 
-        await jsonRpc(ANVIL_RPC, 'anvil_stopImpersonatingAccount', [operator]);
+        await jsonRpc(ANVIL_RPC, 'anvil_stopImpersonatingAccount', [mechOperator]);
 
         const deliverReceipt = await publicClient.waitForTransactionReceipt({ hash: deliverHash });
-        console.log(`    Deliver tx: ${deliverHash} (status: ${deliverReceipt.status})`);
         if (deliverReceipt.status !== 'success') throw new Error('Deliver transaction reverted');
 
-        // Mine a block and watch for the delivery event via adapter
-        await jsonRpc(ANVIL_RPC, 'evm_mine', []);
-
-        const delivery = await Promise.race([
-          (async () => {
-            for await (const del of deliveryAdapter.watchForDeliveries()) {
-              return del;
-            }
-            return null;
-          })(),
-          sleep(15000).then(() => { throw new Error('watchForDeliveries timed out after 15s'); }),
-        ]);
-
-        await deliveryAdapter.stop();
-
-        if (!delivery) throw new Error('watchForDeliveries yielded null');
-        console.log(`    watchForDeliveries yielded requestId: ${delivery.requestId}`);
-        console.log(`    Delivery mech address: ${delivery.deliveryMechAddress}`);
-
-        // Verify on-chain state
-        const postInfo = await publicClient.readContract({
-          address: MARKETPLACE_ADDRESS,
-          abi: MECH_MARKETPLACE_ABI,
-          functionName: 'mapRequestIdInfos',
-          args: [submittedRequestId as Hex],
-        });
-        const [, deliveryMech] = postInfo as [Address, Address, Address, bigint, bigint, Hex];
-        if (deliveryMech === '0x0000000000000000000000000000000000000000') {
-          throw new Error('deliveryMech is still zero after delivery');
+        // Verify Deliver event in receipt
+        let hasDeliverEvent = false;
+        for (const log of deliverReceipt.logs) {
+          try {
+            const decoded = decodeEventLog({
+              abi: MECH_ABI,
+              data: log.data,
+              topics: log.topics,
+            });
+            if (decoded.eventName === 'Deliver') hasDeliverEvent = true;
+          } catch { /* not our event */ }
         }
-        console.log(`    On-chain deliveryMech: ${deliveryMech}`);
+        if (!hasDeliverEvent) throw new Error('No Deliver event in receipt');
+        console.log('    Deliver event confirmed in receipt');
+
+        // Mine a block
+        await jsonRpc(ANVIL_RPC, 'evm_mine', []);
       }),
     );
 
-    // ── Phase 5f: submitResult through adapter (real operator credentials) ──
+    // ── Phase 4: Creator claims delivery + creates evaluation ────────────────
 
     results.push(
-      await runPhase('Phase 5f: submitResult through adapter', async () => {
-        if (!OPERATOR_EOA_KEY) {
-          console.log('    Skipped — set OPERATOR_EOA_KEY env var to run');
-          return;
+      await runPhase('Phase 4: Creator claims delivery + creates evaluation', async () => {
+        if (!adapter || !restorationRequestId) throw new Error('Missing state from prior phases');
+
+        // Mine blocks periodically to advance chain state
+        const miningInterval = setInterval(async () => {
+          try { await jsonRpc(ANVIL_RPC, 'evm_mine', []); } catch { /* ignore */ }
+        }, 1000);
+
+        let delivery: Awaited<ReturnType<typeof deliveryIter.next>>;
+        try {
+          delivery = await Promise.race([
+            deliveryIter.next(),
+            sleep(20000).then(() => { throw new Error('watchForDeliveries timed out after 20s'); }),
+          ]);
+        } finally {
+          clearInterval(miningInterval);
         }
-        if (!mockIpfsUrl) throw new Error('No mock IPFS URL');
 
-        // First, submit a request that we can deliver against
-        // Use the real operator Safe as requester so it can also deliver
-        const operatorAccount = privateKeyToAccount(OPERATOR_EOA_KEY);
-        // Fund both the Safe (for tx value) and the EOA (for gas)
-        await jsonRpc(ANVIL_RPC, 'anvil_setBalance', [OPERATOR_SAFE_ADDRESS, '0x56BC75E2D63100000']); // 100 ETH
-        await jsonRpc(ANVIL_RPC, 'anvil_setBalance', [operatorAccount.address, '0x56BC75E2D63100000']); // 100 ETH
+        if (delivery.done || !delivery.value) throw new Error('watchForDeliveries ended unexpectedly');
+        const del = delivery.value;
 
-        const operatorWalletClient = createWalletClient({
-          chain: base,
-          transport: http(ANVIL_RPC),
-          account: operatorAccount,
-        }) as unknown as WalletClient;
-
-        // Create adapter configured as the real operator — with REAL IPFS
-        const operatorAdapter = new MechAdapter({
-          rpcUrl: ANVIL_RPC,
-          mechMarketplaceAddress: MARKETPLACE_ADDRESS,
-          routerAddress: ROUTER_ADDRESS,
-          mechContractAddress: OPERATOR_MECH_ADDRESS,
-          safeAddress: OPERATOR_SAFE_ADDRESS,
-          agentEoaPrivateKey: OPERATOR_EOA_KEY,
-          ipfsRegistryUrl: 'https://registry.autonolas.tech',
-          ipfsGatewayUrl: 'https://gateway.autonolas.tech',
-          pollIntervalMs: 500,
-          chainId: base.id,
-        });
-        await operatorAdapter.initialize();
-
-        // Post a request (from the operator's Safe, targeting the operator's mech)
-        const requestId = await operatorAdapter.postDesiredState({
-          id: 'e2e-submit-result',
-          description: 'Testing submitResult through adapter',
-        });
-        console.log(`    Posted request: ${requestId}`);
-
-        // Now deliver using adapter.submitResult() — the real production flow:
-        // agent EOA signs → operator Safe executes → AgentMech.deliverToMarketplace()
-        await operatorAdapter.submitResult(requestId, {
-          data: 'E2E test delivery result',
-        });
-        console.log('    submitResult() completed successfully');
-
-        // Verify on-chain
-        const info = await publicClient.readContract({
-          address: MARKETPLACE_ADDRESS,
-          abi: MECH_MARKETPLACE_ABI,
-          functionName: 'mapRequestIdInfos',
-          args: [requestId as Hex],
-        });
-        const [, deliveryMech] = info as [Address, Address, Address, bigint, bigint, Hex];
-        if (deliveryMech === '0x0000000000000000000000000000000000000000') {
-          throw new Error('deliveryMech is zero — submitResult did not deliver');
+        // Verify delivered result
+        if (del.requestId !== restorationRequestId) {
+          throw new Error(`Expected requestId ${restorationRequestId}, got ${del.requestId}`);
         }
-        console.log(`    On-chain deliveryMech: ${deliveryMech}`);
-
-        // Verify Deliver event was emitted
-        await jsonRpc(ANVIL_RPC, 'evm_mine', []);
-        const deliveryResult = await Promise.race([
-          (async () => {
-            for await (const del of operatorAdapter.watchForDeliveries()) {
-              return del;
-            }
-            return null;
-          })(),
-          sleep(15000).then(() => { throw new Error('watchForDeliveries timed out'); }),
-        ]);
-
-        await operatorAdapter.stop();
-
-        if (!deliveryResult) throw new Error('No delivery event after submitResult');
-        console.log(`    Deliver event confirmed: requestId=${deliveryResult.requestId}`);
-
-        // Verify the content fetched from IPFS matches what was uploaded
-        if (!deliveryResult.result.data.includes('E2E test delivery result')) {
-          throw new Error(`IPFS content mismatch: expected uploaded data, got "${deliveryResult.result.data.slice(0, 100)}"`);
+        if (del.desiredState.type !== 'restoration') {
+          throw new Error(`Expected type 'restoration', got '${del.desiredState.type}'`);
         }
-        console.log(`    IPFS content verified: "${deliveryResult.result.data.slice(0, 80)}..."`);
-      }),
-    );
-
-    // ── Phase 5g: Full daemon loop — create → restore → deliver ──────────────
-
-    results.push(
-      await runPhase('Phase 5g: Full loop — create → restore → evaluate (linked)', async () => {
-        if (!OPERATOR_EOA_KEY) {
-          console.log('    Skipped — set OPERATOR_EOA_KEY env var to run');
-          return;
+        if (!del.result.data) {
+          throw new Error('Expected result.data to be present');
         }
-        const operatorAccount = privateKeyToAccount(OPERATOR_EOA_KEY);
+        console.log(`    Delivery claimed for requestId: ${del.requestId}`);
+        console.log(`    desiredState.type: ${del.desiredState.type}`);
+        console.log(`    result.data: "${del.result.data.slice(0, 80)}"`);
 
-        // Fund operator EOA and Safe
-        await jsonRpc(ANVIL_RPC, 'anvil_setBalance', [operatorAccount.address, '0x56BC75E2D63100000']);
-        await jsonRpc(ANVIL_RPC, 'anvil_setBalance', [OPERATOR_SAFE_ADDRESS, '0x56BC75E2D63100000']);
-
-        const loopAdapter = new MechAdapter({
-          rpcUrl: ANVIL_RPC,
-          mechMarketplaceAddress: MARKETPLACE_ADDRESS,
-          routerAddress: ROUTER_ADDRESS,
-          mechContractAddress: OPERATOR_MECH_ADDRESS,
-          safeAddress: OPERATOR_SAFE_ADDRESS,
-          agentEoaPrivateKey: OPERATOR_EOA_KEY,
-          ipfsRegistryUrl: 'https://registry.autonolas.tech',
-          ipfsGatewayUrl: 'https://gateway.autonolas.tech',
-          pollIntervalMs: 500,
-          chainId: base.id,
-        });
-        await loopAdapter.initialize();
-
-        const loopStore = new (await import('../src/store/store.js')).Store(':memory:');
-        const mockAgentPath = join(__dirname, 'mock-agent.sh');
-        const mockRunner = new ClaudeRunner({ claudePath: mockAgentPath });
-
-        // Step 1: Creator posts desired state (creates restoration + evaluation requests)
-        const { CreatorLoop } = await import('../src/daemon/creator.js');
-        const creator = new CreatorLoop(loopAdapter, [
-          { id: 'daemon-e2e-linked', description: 'Linked requests E2E test' },
-        ], loopStore);
-        await creator.tick();
-        console.log('    Creator posted desired state (restoration + evaluation requests)');
+        // Mine to ensure evaluation creation tx is confirmed
         await jsonRpc(ANVIL_RPC, 'evm_mine', []);
 
-        // Step 2: Restorer picks up restoration request, runs mock agent, delivers
-        const { RestorerLoop } = await import('../src/daemon/restorer.js');
-        const restorer = new RestorerLoop(loopAdapter, mockRunner, loopStore);
-        await restorer.processOne();
-        console.log('    Restorer delivered restoration');
-        await jsonRpc(ANVIL_RPC, 'evm_mine', []);
-
-        // Step 3: Restorer picks up evaluation request (now ready), runs mock agent, delivers
-        await restorer.processOne();
-        console.log('    Restorer delivered evaluation');
-
-        // Verify both deliveries on-chain by scanning recent events
-        await jsonRpc(ANVIL_RPC, 'evm_mine', []);
+        // Verify EvaluationJobCreated event from the router
         const currentBlock = await publicClient.getBlockNumber();
-        const logs = await publicClient.getLogs({
-          address: OPERATOR_MECH_ADDRESS,
-          fromBlock: currentBlock - 50n,
+        const routerLogs = await publicClient.getLogs({
+          address: ROUTER_ADDRESS,
+          fromBlock: currentBlock - 10n,
           toBlock: currentBlock,
         });
-        const deliveries = decodeDeliverLogs(logs);
-        console.log(`    On-chain deliveries from this mech: ${deliveries.length}`);
-        if (deliveries.length < 2) {
-          throw new Error(`Expected at least 2 deliveries, got ${deliveries.length}`);
-        }
-        console.log('    Full cycle: create → restore → evaluate (linked requests)');
 
-        loopStore.close();
-        await loopAdapter.stop();
+        let foundEvalJob = false;
+        for (const log of routerLogs) {
+          try {
+            const decoded = decodeEventLog({
+              abi: JINN_ROUTER_ABI,
+              data: log.data,
+              topics: log.topics,
+            });
+            if (decoded.eventName === 'EvaluationJobCreated') {
+              foundEvalJob = true;
+              console.log('    EvaluationJobCreated event confirmed on-chain');
+            }
+          } catch { /* not our event */ }
+        }
+        if (!foundEvalJob) {
+          throw new Error('No EvaluationJobCreated event found on router');
+        }
       }),
     );
 
-  } finally {
-    // ── Phase 6: Cleanup ─────────────────────────────────────────────────────
+    // ── Phase 5: Restorer picks up evaluation and delivers ───────────────────
 
     results.push(
-      await runPhase('Phase 6: Cleanup', async () => {
+      await runPhase('Phase 5: Restorer picks up evaluation and delivers', async () => {
+        if (!adapter) throw new Error('Missing adapter');
+
+        // Mine blocks to advance
+        const miningInterval = setInterval(async () => {
+          try { await jsonRpc(ANVIL_RPC, 'evm_mine', []); } catch { /* ignore */ }
+        }, 1000);
+
+        let request: Awaited<ReturnType<typeof requestIter.next>>;
+        try {
+          request = await Promise.race([
+            requestIter.next(),
+            sleep(20000).then(() => { throw new Error('watchForRequests timed out after 20s'); }),
+          ]);
+        } finally {
+          clearInterval(miningInterval);
+        }
+
+        if (request.done || !request.value) throw new Error('watchForRequests ended unexpectedly');
+        const req = request.value;
+
+        console.log(`    watchForRequests yielded evaluation request: ${req.requestId}`);
+        console.log(`    type: ${req.desiredState.type}`);
+
+        if (req.desiredState.type !== 'evaluation') {
+          throw new Error(`Expected type 'evaluation', got '${req.desiredState.type}'`);
+        }
+
+        // Read mech operator
+        const mechOperator = await publicClient.readContract({
+          address: MECH_ADDRESS,
+          abi: MECH_ABI,
+          functionName: 'getOperator',
+        }) as Address;
+
+        // Impersonate mech operator and deliver evaluation
+        await jsonRpc(ANVIL_RPC, 'anvil_setBalance', [mechOperator, '0x56BC75E2D63100000']);
+        await jsonRpc(ANVIL_RPC, 'anvil_impersonateAccount', [mechOperator]);
+
+        const operatorWallet = createWalletClient({
+          chain: base,
+          transport: http(ANVIL_RPC),
+          account: mechOperator,
+        });
+
+        // Build evaluation delivery data — upload to real IPFS
+        const evalPayload = buildResultPayload(req.requestId, {
+          data: JSON.stringify({ verdict: 'pass', score: 0.95 }),
+        });
+        const evalCid = await uploadToIpfs('https://registry.autonolas.tech', evalPayload);
+        const evalDigest = cidToDigestHex(evalCid);
+
+        const deliverHash = await operatorWallet.writeContract({
+          address: MECH_ADDRESS,
+          abi: MECH_ABI,
+          functionName: 'deliverToMarketplace',
+          args: [[req.requestId as Hex], [evalDigest]],
+        });
+
+        await jsonRpc(ANVIL_RPC, 'anvil_stopImpersonatingAccount', [mechOperator]);
+
+        const deliverReceipt = await publicClient.waitForTransactionReceipt({ hash: deliverHash });
+        if (deliverReceipt.status !== 'success') throw new Error('Evaluation deliver tx reverted');
+        console.log('    Evaluation delivery submitted');
+
+        // Mine a block
+        await jsonRpc(ANVIL_RPC, 'evm_mine', []);
+      }),
+    );
+
+    // ── Phase 6: Creator claims evaluation delivery ──────────────────────────
+
+    results.push(
+      await runPhase('Phase 6: Creator claims evaluation delivery', async () => {
+        if (!adapter) throw new Error('Missing adapter');
+
+        // Mine blocks periodically
+        const miningInterval = setInterval(async () => {
+          try { await jsonRpc(ANVIL_RPC, 'evm_mine', []); } catch { /* ignore */ }
+        }, 1000);
+
+        let delivery: Awaited<ReturnType<typeof deliveryIter.next>>;
+        try {
+          delivery = await Promise.race([
+            deliveryIter.next(),
+            sleep(20000).then(() => { throw new Error('watchForDeliveries timed out after 20s'); }),
+          ]);
+        } finally {
+          clearInterval(miningInterval);
+        }
+
+        if (delivery.done || !delivery.value) throw new Error('watchForDeliveries ended unexpectedly');
+        const del = delivery.value;
+
+        if (del.desiredState.type !== 'evaluation') {
+          throw new Error(`Expected type 'evaluation', got '${del.desiredState.type}'`);
+        }
+        console.log(`    Evaluation delivery claimed for requestId: ${del.requestId}`);
+        console.log(`    desiredState.type: ${del.desiredState.type}`);
+
+        // Verify tracking is clean
+        const adapterAny = adapter as unknown as {
+          pendingEvaluations: Map<string, unknown>;
+          pendingEvaluationClaims: Set<string>;
+        };
+        if (adapterAny.pendingEvaluationClaims.size !== 0) {
+          throw new Error(`Expected pendingEvaluationClaims to be empty, got ${adapterAny.pendingEvaluationClaims.size}`);
+        }
+        console.log('    pendingEvaluationClaims is empty — lifecycle complete');
+      }),
+    );
+
+    // ── Phase 7: Full daemon loop (skipped) ──────────────────────────────────
+    // The step-by-step phases 2-6 already validate the complete flow.
+    // A full daemon test with impersonation + real signing is complex and
+    // deferred as a follow-up.
+
+  } finally {
+    // ── Phase 8: Cleanup ─────────────────────────────────────────────────────
+
+    results.push(
+      await runPhase('Phase 8: Cleanup', async () => {
         if (adapter) {
           await adapter.stop().catch(() => {});
           console.log('    Adapter stopped');
-        }
-        if (mockIpfsServer) {
-          mockIpfsServer.close();
-          console.log('    Mock IPFS server closed');
         }
         if (anvil) {
           anvil.kill('SIGTERM');

--- a/client/scripts/e2e-validate.ts
+++ b/client/scripts/e2e-validate.ts
@@ -52,6 +52,7 @@ const ANVIL_PORT = 8546;
 const ANVIL_RPC = `http://127.0.0.1:${ANVIL_PORT}`;
 
 const MARKETPLACE_ADDRESS: Address = '0xf24eE42edA0fc9b33B7D41B06Ee8ccD2Ef7C5020';
+const ROUTER_ADDRESS: Address = '0xfFa7118A3D820cd4E820010837D65FAfF463181B';
 const MECH_ADDRESS: Address = '0x8c083Dfe9bee719a05Ba3c75A9B16BE4ba52c299';
 
 const ANVIL_ACCOUNT_KEY: Hex = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
@@ -228,6 +229,7 @@ async function main(): Promise<void> {
         const adapter = new MechAdapter({
           rpcUrl: ANVIL_RPC,
           mechMarketplaceAddress: MARKETPLACE_ADDRESS,
+          routerAddress: ROUTER_ADDRESS,
           mechContractAddress: MECH_ADDRESS,
           safeAddress: account.address, // dummy for initialization
           agentEoaPrivateKey: ANVIL_ACCOUNT_KEY,
@@ -422,6 +424,7 @@ async function main(): Promise<void> {
         adapter = new MechAdapter({
           rpcUrl: ANVIL_RPC,
           mechMarketplaceAddress: MARKETPLACE_ADDRESS,
+          routerAddress: ROUTER_ADDRESS,
           mechContractAddress: MECH_ADDRESS,
           safeAddress,
           agentEoaPrivateKey: ANVIL_ACCOUNT_KEY,
@@ -466,6 +469,7 @@ async function main(): Promise<void> {
         const pollAdapter = new MechAdapter({
           rpcUrl: ANVIL_RPC,
           mechMarketplaceAddress: MARKETPLACE_ADDRESS,
+          routerAddress: ROUTER_ADDRESS,
           mechContractAddress: MECH_ADDRESS,
           safeAddress,
           agentEoaPrivateKey: ANVIL_ACCOUNT_KEY,
@@ -531,6 +535,7 @@ async function main(): Promise<void> {
         const deliveryAdapter = new MechAdapter({
           rpcUrl: ANVIL_RPC,
           mechMarketplaceAddress: MARKETPLACE_ADDRESS,
+          routerAddress: ROUTER_ADDRESS,
           mechContractAddress: MECH_ADDRESS,
           safeAddress,
           agentEoaPrivateKey: ANVIL_ACCOUNT_KEY,
@@ -626,6 +631,7 @@ async function main(): Promise<void> {
         const operatorAdapter = new MechAdapter({
           rpcUrl: ANVIL_RPC,
           mechMarketplaceAddress: MARKETPLACE_ADDRESS,
+          routerAddress: ROUTER_ADDRESS,
           mechContractAddress: OPERATOR_MECH_ADDRESS,
           safeAddress: OPERATOR_SAFE_ADDRESS,
           agentEoaPrivateKey: OPERATOR_EOA_KEY,
@@ -705,6 +711,7 @@ async function main(): Promise<void> {
         const loopAdapter = new MechAdapter({
           rpcUrl: ANVIL_RPC,
           mechMarketplaceAddress: MARKETPLACE_ADDRESS,
+          routerAddress: ROUTER_ADDRESS,
           mechContractAddress: OPERATOR_MECH_ADDRESS,
           safeAddress: OPERATOR_SAFE_ADDRESS,
           agentEoaPrivateKey: OPERATOR_EOA_KEY,

--- a/client/scripts/e2e-validate.ts
+++ b/client/scripts/e2e-validate.ts
@@ -362,6 +362,27 @@ async function main(): Promise<void> {
         if (!foundEvalJob) {
           throw new Error('No EvaluationJobCreated event found on router');
         }
+
+        // Verify DeliveryClaimed event (staking counter increment)
+        let foundClaim = false;
+        for (const log of routerLogs) {
+          try {
+            const decoded = decodeEventLog({
+              abi: JINN_ROUTER_ABI,
+              data: log.data,
+              topics: log.topics,
+            });
+            if (decoded.eventName === 'DeliveryClaimed') {
+              const claimArgs = decoded.args as unknown as { jobType: number };
+              console.log(`    DeliveryClaimed event: jobType=${claimArgs.jobType}`);
+              foundClaim = true;
+            }
+          } catch { /* not our event */ }
+        }
+        if (!foundClaim) {
+          throw new Error('No DeliveryClaimed event found — staking counter not incremented');
+        }
+        console.log('    Staking counter verified: delivery claimed on router');
       }),
     );
 
@@ -436,6 +457,34 @@ async function main(): Promise<void> {
           throw new Error(`Expected pendingEvaluationClaims to be empty, got ${adapterAny.pendingEvaluationClaims.size}`);
         }
         console.log('    pendingEvaluationClaims is empty — lifecycle complete');
+
+        // Verify DeliveryClaimed event for evaluation (staking counter)
+        await jsonRpc(ANVIL_RPC, 'evm_mine', []);
+        const evalBlock = await publicClient.getBlockNumber();
+        const evalRouterLogs = await publicClient.getLogs({
+          address: ROUTER_ADDRESS,
+          fromBlock: evalBlock - 10n,
+          toBlock: evalBlock,
+        });
+        let foundEvalClaim = false;
+        for (const log of evalRouterLogs) {
+          try {
+            const decoded = decodeEventLog({
+              abi: JINN_ROUTER_ABI,
+              data: log.data,
+              topics: log.topics,
+            });
+            if (decoded.eventName === 'DeliveryClaimed') {
+              const claimArgs = decoded.args as unknown as { jobType: number };
+              console.log(`    DeliveryClaimed event: jobType=${claimArgs.jobType}`);
+              foundEvalClaim = true;
+            }
+          } catch {}
+        }
+        if (!foundEvalClaim) {
+          throw new Error('No DeliveryClaimed event found for evaluation — staking counter not incremented');
+        }
+        console.log('    Staking counter verified: evaluation delivery claimed');
       }),
     );
 

--- a/client/scripts/e2e-validate.ts
+++ b/client/scripts/e2e-validate.ts
@@ -52,6 +52,9 @@ const MECH_ADDRESS: Address = '0xD03d75D3B59Ac252F2e8C7Bf4617cf91a102E613';
 const OPERATOR_SAFE_ADDRESS: Address = '0x608d976Da1Dd9BC53aeA87Abe74e1306Ab96280c';
 
 const OPERATOR_EOA_KEY: Hex | '' = (process.env['OPERATOR_EOA_KEY'] ?? '') as Hex | '';
+const OPERATOR_B_EOA_KEY: Hex = (process.env['OPERATOR_B_EOA_KEY'] ?? '') as Hex;
+const OPERATOR_B_SAFE: Address = '0xC440e601e22429C8f93a65548A746F015DDa26d2';
+const MECH_B: Address = '0xb55FaDf1f0Bb1DE99c13301397c7B67FdE44f6b1';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -709,6 +712,117 @@ async function main(): Promise<void> {
 
         // Clean up temp DB
         try { (await import('node:fs')).unlinkSync(tmpDbPath); } catch {}
+      }),
+    );
+
+    // ── Phase 11: Cross-operator flow ────────────────────────────────────────
+
+    results.push(
+      await runPhase('Phase 11: Cross-operator — A creates, B restores + evaluates', async () => {
+        if (!OPERATOR_EOA_KEY || !OPERATOR_B_EOA_KEY) {
+          console.log('    Skipped — set both OPERATOR_EOA_KEY and OPERATOR_B_EOA_KEY');
+          return;
+        }
+
+        const { privateKeyToAccount } = await import('viem/accounts');
+        const operatorA = privateKeyToAccount(OPERATOR_EOA_KEY);
+        const operatorB = privateKeyToAccount(OPERATOR_B_EOA_KEY);
+
+        // Fund both operators
+        await jsonRpc(ANVIL_RPC, 'anvil_setBalance', [operatorA.address, '0x56BC75E2D63100000']);
+        await jsonRpc(ANVIL_RPC, 'anvil_setBalance', [OPERATOR_SAFE_ADDRESS, '0x56BC75E2D63100000']);
+        await jsonRpc(ANVIL_RPC, 'anvil_setBalance', [operatorB.address, '0x56BC75E2D63100000']);
+        await jsonRpc(ANVIL_RPC, 'anvil_setBalance', [OPERATOR_B_SAFE, '0x56BC75E2D63100000']);
+
+        // Creator adapter (Operator A) — routes requests to Operator B's mech
+        const creatorAdapter = new MechAdapter({
+          rpcUrl: ANVIL_RPC,
+          mechMarketplaceAddress: MARKETPLACE_ADDRESS,
+          routerAddress: ROUTER_ADDRESS,
+          mechContractAddress: MECH_B,  // Route to B's mech
+          safeAddress: OPERATOR_SAFE_ADDRESS,
+          agentEoaPrivateKey: OPERATOR_EOA_KEY,
+          ipfsRegistryUrl: 'https://registry.autonolas.tech',
+          ipfsGatewayUrl: 'https://gateway.autonolas.tech',
+          pollIntervalMs: 500,
+          chainId: 8453,
+        });
+        await creatorAdapter.initialize();
+
+        // Restorer adapter (Operator B) — delivers through B's mech
+        const restorerAdapter = new MechAdapter({
+          rpcUrl: ANVIL_RPC,
+          mechMarketplaceAddress: MARKETPLACE_ADDRESS,
+          routerAddress: ROUTER_ADDRESS,
+          mechContractAddress: MECH_B,
+          safeAddress: OPERATOR_B_SAFE,
+          agentEoaPrivateKey: OPERATOR_B_EOA_KEY,
+          ipfsRegistryUrl: 'https://registry.autonolas.tech',
+          ipfsGatewayUrl: 'https://gateway.autonolas.tech',
+          pollIntervalMs: 500,
+          chainId: 8453,
+        });
+        await restorerAdapter.initialize();
+
+        // Step 1: Operator A posts desired state
+        const requestId = await creatorAdapter.postDesiredState({
+          id: 'cross-operator-test',
+          description: 'Cross-operator flow test',
+          type: 'restoration',
+          attemptId: 'cross-operator-test/1',
+          attemptNumber: 1,
+        });
+        console.log(`    Operator A posted: ${requestId.slice(0, 14)}...`);
+        await jsonRpc(ANVIL_RPC, 'evm_mine', []);
+
+        // Step 2: Operator B delivers restoration (via RestorerLoop + ClaudeRunner)
+        const { RestorerLoop: CrossRestorerLoop } = await import('../src/daemon/restorer.js');
+        const { ClaudeRunner: CrossClaudeRunner } = await import('../src/runner/claude.js');
+        const { Store: CrossStore } = await import('../src/store/store.js');
+
+        const crossStore = new CrossStore(':memory:');
+        const crossMockAgentPath = join(__dirname, 'mock-agent.sh');
+        const crossRunner = new CrossClaudeRunner({ claudePath: crossMockAgentPath });
+        const crossRestorer = new CrossRestorerLoop(restorerAdapter, crossRunner, crossStore);
+
+        await jsonRpc(ANVIL_RPC, 'evm_mine', []);
+        await crossRestorer.processOne();
+        console.log('    Operator B delivered restoration via ClaudeRunner');
+
+        // Step 3: Operator A claims delivery + creates evaluation
+        await jsonRpc(ANVIL_RPC, 'evm_mine', []);
+        const mineInterval = setInterval(() => jsonRpc(ANVIL_RPC, 'evm_mine', []).catch(() => {}), 1000);
+
+        const crossDeliveryIter = creatorAdapter.watchForDeliveries()[Symbol.asyncIterator]();
+        const restorationDelivery = await Promise.race([
+          crossDeliveryIter.next().then(r => r.value),
+          sleep(30000).then(() => { throw new Error('timeout waiting for restoration delivery'); }),
+        ]);
+        console.log(`    Operator A claimed restoration, type: ${restorationDelivery?.desiredState?.type}`);
+
+        // Step 4: Operator B delivers evaluation
+        await crossRestorer.processOne();
+        console.log('    Operator B delivered evaluation via ClaudeRunner');
+
+        // Step 5: Operator A claims evaluation
+        await jsonRpc(ANVIL_RPC, 'evm_mine', []);
+        const evalDelivery = await Promise.race([
+          crossDeliveryIter.next().then(r => r.value),
+          sleep(30000).then(() => { throw new Error('timeout waiting for evaluation delivery'); }),
+        ]);
+
+        clearInterval(mineInterval);
+        console.log(`    Operator A claimed evaluation, type: ${evalDelivery?.desiredState?.type}`);
+
+        // Verify: two different operators, zero impersonation
+        console.log('    Cross-operator flow complete:');
+        console.log(`      Creator Safe: ${OPERATOR_SAFE_ADDRESS}`);
+        console.log(`      Restorer Safe: ${OPERATOR_B_SAFE}`);
+        console.log(`      Mech used: ${MECH_B}`);
+
+        crossStore.close();
+        await creatorAdapter.stop();
+        await restorerAdapter.stop();
       }),
     );
 

--- a/client/scripts/mock-agent.ts
+++ b/client/scripts/mock-agent.ts
@@ -3,14 +3,12 @@
  *
  * Reads an MCP config file from --mcp-config, spawns the jinn-client MCP server
  * as a subprocess via StdioClientTransport, discovers tools, and executes
- * a deterministic restoration sequence.
+ * a deterministic sequence based on the request type.
  *
- * Matches the protocol repo's mock-agent.ts pattern — the agent is a separate
- * process that interacts with the system via MCP tools, not inline code.
+ * For restoration requests: produces a mock restoration result.
+ * For evaluation requests: fetches the restoration context, produces a verdict.
  *
  * Args: -p <prompt> --mcp-config <path> [--allowedTools <filter>] [--model <model>]
- *
- * Usage: npx tsx scripts/mock-agent.ts -p "prompt" --mcp-config /path/to/config.json
  */
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -36,8 +34,6 @@ if (!prompt) {
 }
 
 if (!mcpConfigPath) {
-  // No MCP config — fall back to simple prompt-in/result-out mode
-  // (backwards compatible with non-MCP usage)
   const descMatch = prompt.match(/Description:\s*(.+)/);
   const description = descMatch?.[1]?.trim() ?? 'unknown';
   process.stdout.write(JSON.stringify({
@@ -72,7 +68,7 @@ if (!serverName) {
 }
 
 const serverDef = config.mcpServers[serverName]!;
-process.stderr.write(`[mock-agent] Connecting to MCP server '${serverName}': ${serverDef.command} ${serverDef.args.join(' ')}\n`);
+process.stderr.write(`[mock-agent] Connecting to MCP server '${serverName}'\n`);
 
 // ── Spawn MCP server and connect ─────────────────────────────────────────────
 
@@ -88,65 +84,100 @@ const client = new Client({
 });
 
 await client.connect(transport);
-process.stderr.write('[mock-agent] Connected to MCP server\n');
-
-// ── Discover tools ───────────────────────────────────────────────────────────
 
 const { tools } = await client.listTools();
-process.stderr.write(`[mock-agent] Discovered ${tools.length} tools: ${tools.map(t => t.name).join(', ')}\n`);
+process.stderr.write(`[mock-agent] Discovered ${tools.length} tools\n`);
 
 // ── Helper ───────────────────────────────────────────────────────────────────
 
 async function callTool(name: string, toolArgs: Record<string, unknown>): Promise<string> {
-  process.stderr.write(`[mock-agent] Calling tool: ${name}(${JSON.stringify(toolArgs)})\n`);
+  process.stderr.write(`[mock-agent] Calling: ${name}\n`);
   const result = await client.callTool({ name, arguments: toolArgs });
   const content = result.content as Array<{ type: string; text?: string }>;
-  const text = content
+  return content
     .filter((c) => c.type === 'text' && c.text)
     .map(c => c.text!)
     .join('\n');
-  process.stderr.write(`[mock-agent] Result: ${text.slice(0, 200)}\n`);
-  return text;
 }
 
-// ── Execute deterministic restoration sequence ───────────────────────────────
+// ── Get desired state ────────────────────────────────────────────────────────
 
-// Step 1: Get desired state from MCP server
-process.stderr.write('[mock-agent] Step 1: Getting desired state...\n');
 const stateJson = await callTool('get_desired_state', {});
-const state = JSON.parse(stateJson) as { id: string; description: string; requestId: string };
+const state = JSON.parse(stateJson) as {
+  id: string;
+  description: string;
+  requestId: string;
+  type?: string;
+  restorationRequestId?: string;
+};
 
-// Step 2: Report progress
-process.stderr.write('[mock-agent] Step 2: Reporting progress...\n');
-await callTool('report_progress', { message: `Starting restoration for: ${state.description}` });
+const isEvaluation = state.type === 'evaluation';
+process.stderr.write(`[mock-agent] Request type: ${state.type || 'restoration'}\n`);
 
-// Step 3: Submit restoration result
-process.stderr.write('[mock-agent] Step 3: Submitting result...\n');
-await callTool('submit_restoration_result', {
-  success: true,
-  description: `Mock restoration completed for: ${state.description}`,
-  data: JSON.stringify({
+// ── Execute based on type ────────────────────────────────────────────────────
+
+if (isEvaluation) {
+  // ── Evaluation flow ──────────────────────────────────────────────────────
+  // A real agent would:
+  // 1. Fetch the restoration delivery from IPFS using restorationRequestId
+  // 2. Read the original desired state description
+  // 3. Compare: did the restoration achieve the desired state?
+  // 4. Return a verdict
+
+  await callTool('report_progress', {
+    message: `Evaluating restoration ${state.restorationRequestId?.slice(0, 14)}... for: ${state.description}`,
+  });
+
+  // Mock evaluation: always succeeds (deterministic)
+  // A real agent would do actual verification here
+  const verdict = {
+    protocol: 'jinn-client/v1',
+    type: 'evaluation-verdict',
+    desiredStateId: state.id,
+    restorationRequestId: state.restorationRequestId,
+    requestId: state.requestId,
+    success: true,
+    reason: `Mock evaluation: desired state "${state.description}" verified as restored`,
+    evaluatedAt: new Date().toISOString(),
+    agent: 'mock-agent',
+  };
+
+  await callTool('submit_restoration_result', {
+    success: true,
+    description: verdict.reason,
+    data: JSON.stringify(verdict),
+  });
+
+  process.stdout.write(JSON.stringify(verdict));
+  process.stderr.write('[mock-agent] Evaluation verdict delivered.\n');
+
+} else {
+  // ── Restoration flow ─────────────────────────────────────────────────────
+
+  await callTool('report_progress', {
+    message: `Restoring: ${state.description}`,
+  });
+
+  const result = {
     protocol: 'jinn-client/v1',
     type: 'restoration-result',
     desiredStateId: state.id,
     requestId: state.requestId,
+    description: state.description,
+    success: true,
     restoredAt: new Date().toISOString(),
     agent: 'mock-agent',
-  }),
-});
+  };
 
-// Step 4: Write final result to stdout (captured by ClaudeRunner)
-const finalResult = JSON.stringify({
-  protocol: 'jinn-client/v1',
-  type: 'restoration-result',
-  desiredStateId: state.id,
-  description: state.description,
-  success: true,
-  agent: 'mock-agent',
-});
-process.stdout.write(finalResult);
+  await callTool('submit_restoration_result', {
+    success: true,
+    description: `Mock restoration completed for: ${state.description}`,
+    data: JSON.stringify(result),
+  });
 
-process.stderr.write('[mock-agent] Restoration complete. Exiting.\n');
+  process.stdout.write(JSON.stringify(result));
+  process.stderr.write('[mock-agent] Restoration delivered.\n');
+}
 
 // ── Cleanup ──────────────────────────────────────────────────────────────────
 

--- a/client/src/adapters/mech/adapter.ts
+++ b/client/src/adapters/mech/adapter.ts
@@ -41,6 +41,9 @@ export class MechAdapter implements ExecutionAdapter {
   private deliveryBlockCursor = 0n;
   private pendingEvaluations = new Map<string, import('../../types/index.js').DesiredState>();
   private pendingEvaluationClaims = new Set<string>();
+  // Restoration requests where claimDelivery succeeded but evaluation creation failed.
+  // Swept on each poll cycle so they don't require a new Deliver event.
+  private claimedButNotEvaluated = new Set<string>();
 
   constructor(config: MechAdapterConfig) {
     this.config = config;
@@ -152,6 +155,11 @@ export class MechAdapter implements ExecutionAdapter {
   async *watchForDeliveries(): AsyncIterable<DeliveredResult> {
     while (!this.stopped) {
       try {
+        // Retry evaluation creation for claimed restorations that failed previously
+        for (const rid of [...this.claimedButNotEvaluated]) {
+          await this.tryCreateEvaluationJob(rid);
+        }
+
         const currentBlock = await this.publicClient.getBlockNumber();
         if (currentBlock > this.deliveryBlockCursor) {
           const logs = await this.publicClient.getLogs({
@@ -189,42 +197,7 @@ export class MechAdapter implements ExecutionAdapter {
 
             // If this was a restoration delivery, post the evaluation job
             if (this.pendingEvaluations.has(requestId)) {
-              const originalState = this.pendingEvaluations.get(requestId)!;
-              try {
-                const evaluationState: DesiredState = {
-                  ...originalState,
-                  type: 'evaluation',
-                  restorationRequestId: requestId,
-                };
-                const evaluationPayload = buildDesiredStatePayload(evaluationState);
-                const evaluationCid = await uploadToIpfs(this.config.ipfsRegistryUrl, evaluationPayload);
-                const evaluationDataHex = cidToDigestHex(evaluationCid);
-
-                const deliveryRate = await getMechDeliveryRate(this.publicClient, this.config.mechContractAddress);
-                const { max: maxTimeout } = await getTimeoutBounds(this.publicClient, this.config.mechMarketplaceAddress);
-
-                const evalRequestIds = await submitEvaluationJob(
-                  this.publicClient,
-                  this.walletClient,
-                  this.config.safeAddress,
-                  this.config.routerAddress,
-                  requestId as `0x${string}`,
-                  this.config.mechContractAddress,
-                  evaluationDataHex,
-                  deliveryRate,
-                  maxTimeout,
-                );
-
-                if (evalRequestIds.length > 0) {
-                  this.pendingEvaluationClaims.add(evalRequestIds[0]);
-                }
-
-                // Only remove after evaluation job succeeds
-                this.pendingEvaluations.delete(requestId);
-              } catch (err) {
-                console.error(`[mech] Failed to create evaluation job for ${requestId}:`, err);
-                // Don't remove from pendingEvaluations — will retry on next delivery detection
-              }
+              await this.tryCreateEvaluationJob(requestId);
             }
 
             // If this was an evaluation delivery, just clear the tracking
@@ -263,6 +236,48 @@ export class MechAdapter implements ExecutionAdapter {
       }
 
       await new Promise(r => setTimeout(r, this.config.pollIntervalMs));
+    }
+  }
+
+  private async tryCreateEvaluationJob(requestId: string): Promise<void> {
+    if (!this.pendingEvaluations.has(requestId)) return;
+    const originalState = this.pendingEvaluations.get(requestId)!;
+    try {
+      const evaluationState: DesiredState = {
+        ...originalState,
+        type: 'evaluation',
+        restorationRequestId: requestId,
+      };
+      const evaluationPayload = buildDesiredStatePayload(evaluationState);
+      const evaluationCid = await uploadToIpfs(this.config.ipfsRegistryUrl, evaluationPayload);
+      const evaluationDataHex = cidToDigestHex(evaluationCid);
+
+      const deliveryRate = await getMechDeliveryRate(this.publicClient, this.config.mechContractAddress);
+      const { max: maxTimeout } = await getTimeoutBounds(this.publicClient, this.config.mechMarketplaceAddress);
+
+      const evalRequestIds = await submitEvaluationJob(
+        this.publicClient,
+        this.walletClient,
+        this.config.safeAddress,
+        this.config.routerAddress,
+        requestId as `0x${string}`,
+        this.config.mechContractAddress,
+        evaluationDataHex,
+        deliveryRate,
+        maxTimeout,
+      );
+
+      if (evalRequestIds.length > 0) {
+        this.pendingEvaluationClaims.add(evalRequestIds[0]);
+      }
+
+      // Success — clean up both tracking sets
+      this.pendingEvaluations.delete(requestId);
+      this.claimedButNotEvaluated.delete(requestId);
+    } catch (err) {
+      console.error(`[mech] Failed to create evaluation job for ${requestId}:`, err);
+      // Track for retry on next poll cycle (doesn't require a new Deliver event)
+      this.claimedButNotEvaluated.add(requestId);
     }
   }
 

--- a/client/src/adapters/mech/adapter.ts
+++ b/client/src/adapters/mech/adapter.ts
@@ -27,8 +27,11 @@ import {
   decodeMarketplaceRequestLogs,
   decodeDeliverLogs,
   callDeliverToMarketplace,
+  scanRestorationJobs,
+  scanEvaluationJobs,
 } from './contracts.js';
 import { type MechAdapterConfig, MECH_MARKETPLACE_ABI } from './types.js';
+import type { Store } from '../../store/store.js';
 
 export class MechAdapter implements ExecutionAdapter {
   readonly name = 'mech';
@@ -44,9 +47,11 @@ export class MechAdapter implements ExecutionAdapter {
   // Restoration requests where claimDelivery succeeded but evaluation creation failed.
   // Swept on each poll cycle so they don't require a new Deliver event.
   private claimedButNotEvaluated = new Set<string>();
+  private store?: Store;
 
-  constructor(config: MechAdapterConfig) {
+  constructor(config: MechAdapterConfig, store?: Store) {
     this.config = config;
+    this.store = store;
   }
 
   async initialize(): Promise<void> {
@@ -60,6 +65,93 @@ export class MechAdapter implements ExecutionAdapter {
     const blockNumber = await this.publicClient.getBlockNumber();
     this.requestBlockCursor = blockNumber;
     this.deliveryBlockCursor = blockNumber;
+
+    // Recover pending state from on-chain events
+    if (this.store) {
+      await this.recoverPendingState(blockNumber);
+    }
+  }
+
+  private async recoverPendingState(currentBlock: bigint): Promise<void> {
+    const fromBlock = this.store?.getLastProcessedBlock() ?? currentBlock;
+    if (fromBlock >= currentBlock) return;
+
+    console.error(`[mech] Recovering pending state from block ${fromBlock} to ${currentBlock}`);
+
+    // Scan for restoration jobs this creator posted
+    const restorations = await scanRestorationJobs(
+      this.publicClient,
+      this.config.routerAddress,
+      this.config.safeAddress,
+      fromBlock,
+      currentBlock,
+    );
+
+    // Scan for evaluation jobs this creator posted
+    const evaluations = await scanEvaluationJobs(
+      this.publicClient,
+      this.config.routerAddress,
+      this.config.safeAddress,
+      fromBlock,
+      currentBlock,
+    );
+
+    // Build set of restoration IDs that already have evaluation jobs
+    const hasEvaluation = new Set(evaluations.map(e => e.restorationRequestId));
+
+    // Check each restoration's delivery status
+    for (const restoration of restorations) {
+      if (hasEvaluation.has(restoration.requestId)) {
+        // Evaluation already created — check if eval delivery needs claiming
+        const evalJob = evaluations.find(e => e.restorationRequestId === restoration.requestId);
+        if (evalJob) {
+          const evalInfo = await this.publicClient.readContract({
+            address: this.config.mechMarketplaceAddress,
+            abi: MECH_MARKETPLACE_ABI,
+            functionName: 'mapRequestIdInfos',
+            args: [evalJob.requestId as `0x${string}`],
+          }) as [string, string, string, bigint, bigint, string];
+          if (evalInfo[1] === '0x0000000000000000000000000000000000000000') {
+            // Evaluation not yet delivered — track it
+            this.pendingEvaluationClaims.add(evalJob.requestId);
+          }
+          // If delivered, fully complete — nothing to track
+        }
+        continue;
+      }
+
+      // No evaluation job yet — check delivery status
+      const info = await this.publicClient.readContract({
+        address: this.config.mechMarketplaceAddress,
+        abi: MECH_MARKETPLACE_ABI,
+        functionName: 'mapRequestIdInfos',
+        args: [restoration.requestId as `0x${string}`],
+      }) as [string, string, string, bigint, bigint, string];
+
+      const deliveryMech = info[1];
+      if (deliveryMech === '0x0000000000000000000000000000000000000000') {
+        // Not delivered yet — track for evaluation after delivery
+        this.pendingEvaluations.set(restoration.requestId, {
+          id: restoration.requestId,
+          description: '', // Original description not available from events, but not needed for evaluation creation
+        });
+      } else {
+        // Delivered but no evaluation — needs claim + evaluation creation
+        this.pendingEvaluations.set(restoration.requestId, {
+          id: restoration.requestId,
+          description: '',
+        });
+        this.claimedButNotEvaluated.add(restoration.requestId);
+      }
+    }
+
+    // Set delivery block cursor to scan from recovery point
+    this.deliveryBlockCursor = fromBlock;
+
+    const recovered = this.pendingEvaluations.size + this.pendingEvaluationClaims.size + this.claimedButNotEvaluated.size;
+    if (recovered > 0) {
+      console.error(`[mech] Recovered: ${this.pendingEvaluations.size} pending evaluations, ${this.pendingEvaluationClaims.size} pending eval claims, ${this.claimedButNotEvaluated.size} claimed but not evaluated`);
+    }
   }
 
   async postDesiredState(state: DesiredState): Promise<RequestId> {
@@ -233,6 +325,11 @@ export class MechAdapter implements ExecutionAdapter {
         }
       } catch (err) {
         console.error('[mech] Error polling for deliveries:', err);
+      }
+
+      // Persist block cursor for crash recovery
+      if (this.store && this.deliveryBlockCursor > 0n) {
+        this.store.setLastProcessedBlock(this.deliveryBlockCursor);
       }
 
       await new Promise(r => setTimeout(r, this.config.pollIntervalMs));

--- a/client/src/adapters/mech/adapter.ts
+++ b/client/src/adapters/mech/adapter.ts
@@ -19,7 +19,9 @@ import {
   parseDesiredStateFromPayload,
 } from './ipfs.js';
 import {
-  submitMarketplaceRequest,
+  submitRestorationJob,
+  submitEvaluationJob,
+  claimDelivery,
   getMechDeliveryRate,
   getTimeoutBounds,
   decodeMarketplaceRequestLogs,
@@ -37,7 +39,8 @@ export class MechAdapter implements ExecutionAdapter {
   private stopped = false;
   private requestBlockCursor = 0n;
   private deliveryBlockCursor = 0n;
-  private deferredEvaluations: Array<{ requestId: string; desiredState: import('../../types/index.js').DesiredState }> = [];
+  private pendingEvaluations = new Map<string, import('../../types/index.js').DesiredState>();
+  private pendingEvaluationClaims = new Set<string>();
 
   constructor(config: MechAdapterConfig) {
     this.config = config;
@@ -57,7 +60,6 @@ export class MechAdapter implements ExecutionAdapter {
   }
 
   async postDesiredState(state: DesiredState): Promise<RequestId> {
-    // Post restoration request
     const restorationState: DesiredState = {
       ...state,
       type: state.type ?? 'restoration',
@@ -71,11 +73,11 @@ export class MechAdapter implements ExecutionAdapter {
     const deliveryRate = await getMechDeliveryRate(this.publicClient, this.config.mechContractAddress);
     const { max: maxTimeout } = await getTimeoutBounds(this.publicClient, this.config.mechMarketplaceAddress);
 
-    const restorationRequestIds = await submitMarketplaceRequest(
+    const restorationRequestIds = await submitRestorationJob(
       this.publicClient,
       this.walletClient,
       this.config.safeAddress,
-      this.config.mechMarketplaceAddress,
+      this.config.routerAddress,
       this.config.mechContractAddress,
       restorationDataHex,
       deliveryRate,
@@ -83,33 +85,13 @@ export class MechAdapter implements ExecutionAdapter {
     );
 
     if (restorationRequestIds.length === 0) {
-      throw new PermanentError('No request IDs returned from marketplace');
+      throw new PermanentError('No request IDs returned from router');
     }
 
     const restorationRequestId = restorationRequestIds[0];
 
-    // Post linked evaluation request
-    const evaluationState: DesiredState = {
-      ...state,
-      type: 'evaluation',
-      attemptId: state.attemptId,
-      attemptNumber: state.attemptNumber,
-      restorationRequestId,
-    };
-    const evaluationPayload = buildDesiredStatePayload(evaluationState);
-    const evaluationCid = await uploadToIpfs(this.config.ipfsRegistryUrl, evaluationPayload);
-    const evaluationDataHex = cidToDigestHex(evaluationCid);
-
-    await submitMarketplaceRequest(
-      this.publicClient,
-      this.walletClient,
-      this.config.safeAddress,
-      this.config.mechMarketplaceAddress,
-      this.config.mechContractAddress,
-      evaluationDataHex,
-      deliveryRate,
-      maxTimeout,
-    );
+    // Store for evaluation creation after delivery is claimed
+    this.pendingEvaluations.set(restorationRequestId, state);
 
     return restorationRequestId;
   }
@@ -117,24 +99,6 @@ export class MechAdapter implements ExecutionAdapter {
   async *watchForRequests(): AsyncIterable<RestorationRequest> {
     while (!this.stopped) {
       try {
-        console.error(`[mech] watchForRequests poll — deferred: ${this.deferredEvaluations.length}, cursor: ${this.requestBlockCursor}`);
-        // Re-check deferred evaluation requests first
-        if (this.deferredEvaluations.length > 0) {
-          console.error(`[mech] Checking ${this.deferredEvaluations.length} deferred evaluation(s)`);
-        }
-        const stillDeferred: typeof this.deferredEvaluations = [];
-        for (const deferred of this.deferredEvaluations) {
-          const ready = await this.isEvaluationReady(deferred.desiredState);
-          if (ready) {
-            console.error(`[mech] Deferred evaluation ${deferred.requestId} is now ready`);
-            yield { requestId: deferred.requestId, desiredState: deferred.desiredState };
-          } else {
-            stillDeferred.push(deferred);
-          }
-        }
-        this.deferredEvaluations = stillDeferred;
-
-        // Poll for new events
         const currentBlock = await this.publicClient.getBlockNumber();
         if (currentBlock > this.requestBlockCursor) {
           const logs = await this.publicClient.getLogs({
@@ -151,17 +115,6 @@ export class MechAdapter implements ExecutionAdapter {
               const payload = await fetchFromIpfs(this.config.ipfsGatewayUrl, `f01551220${digest}`) as Record<string, unknown>;
               const desiredState = parseDesiredStateFromPayload(payload);
 
-              // Evaluation requests: only yield after restoration has been delivered
-              if (desiredState.type === 'evaluation' && desiredState.restorationRequestId) {
-                if (await this.isEvaluationReady(desiredState)) {
-                  yield { requestId, desiredState };
-                } else {
-                  // Defer — re-check on next poll
-                  this.deferredEvaluations.push({ requestId, desiredState });
-                }
-                continue;
-              }
-
               yield { requestId, desiredState };
             } catch (err) {
               console.error(`[mech] Failed to parse request ${requestId}:`, err);
@@ -173,24 +126,6 @@ export class MechAdapter implements ExecutionAdapter {
       }
 
       await new Promise(r => setTimeout(r, this.config.pollIntervalMs));
-    }
-  }
-
-  private async isEvaluationReady(desiredState: DesiredState): Promise<boolean> {
-    if (!desiredState.restorationRequestId) return false;
-    try {
-      const info = await this.publicClient.readContract({
-        address: this.config.mechMarketplaceAddress,
-        abi: MECH_MARKETPLACE_ABI,
-        functionName: 'mapRequestIdInfos',
-        args: [desiredState.restorationRequestId as `0x${string}`],
-      }) as [string, string, string, bigint, bigint, string];
-      const deliveryMech = info[1];
-      console.error(`[mech] isEvaluationReady: restorationRequestId=${desiredState.restorationRequestId.slice(0, 10)}... deliveryMech=${deliveryMech}`);
-      return deliveryMech !== '0x0000000000000000000000000000000000000000';
-    } catch (err) {
-      console.error(`[mech] isEvaluationReady error:`, err);
-      return false;
     }
   }
 
@@ -228,22 +163,85 @@ export class MechAdapter implements ExecutionAdapter {
 
           const decoded = decodeDeliverLogs(logs);
           for (const { requestId, deliveryDataHex, mechAddress } of decoded) {
+            // Only claim deliveries for requests this client created
+            const isOurs = this.pendingEvaluations.has(requestId) || this.pendingEvaluationClaims.has(requestId);
+            if (!isOurs) continue;
+
             try {
-              // deliveryDataHex is the SHA256 digest of the result on IPFS
+              // Claim the delivery on the router
+              await claimDelivery(
+                this.publicClient,
+                this.walletClient,
+                this.config.safeAddress,
+                this.config.routerAddress,
+                requestId as `0x${string}`,
+              );
+            } catch (err) {
+              const message = err instanceof Error ? err.message : String(err);
+              if (message.includes('RequestNotFound')) {
+                console.error(`[mech] claimDelivery skipped (not a router request): ${requestId}`);
+                continue;
+              }
+              console.error(`[mech] claimDelivery failed for ${requestId}:`, err);
+              // Don't remove from pending — will retry next poll
+              continue;
+            }
+
+            // If this was a restoration delivery, post the evaluation job
+            if (this.pendingEvaluations.has(requestId)) {
+              const originalState = this.pendingEvaluations.get(requestId)!;
+              try {
+                const evaluationState: DesiredState = {
+                  ...originalState,
+                  type: 'evaluation',
+                  restorationRequestId: requestId,
+                };
+                const evaluationPayload = buildDesiredStatePayload(evaluationState);
+                const evaluationCid = await uploadToIpfs(this.config.ipfsRegistryUrl, evaluationPayload);
+                const evaluationDataHex = cidToDigestHex(evaluationCid);
+
+                const deliveryRate = await getMechDeliveryRate(this.publicClient, this.config.mechContractAddress);
+                const { max: maxTimeout } = await getTimeoutBounds(this.publicClient, this.config.mechMarketplaceAddress);
+
+                const evalRequestIds = await submitEvaluationJob(
+                  this.publicClient,
+                  this.walletClient,
+                  this.config.safeAddress,
+                  this.config.routerAddress,
+                  requestId as `0x${string}`,
+                  this.config.mechContractAddress,
+                  evaluationDataHex,
+                  deliveryRate,
+                  maxTimeout,
+                );
+
+                if (evalRequestIds.length > 0) {
+                  this.pendingEvaluationClaims.add(evalRequestIds[0]);
+                }
+
+                // Only remove after evaluation job succeeds
+                this.pendingEvaluations.delete(requestId);
+              } catch (err) {
+                console.error(`[mech] Failed to create evaluation job for ${requestId}:`, err);
+                // Don't remove from pendingEvaluations — will retry on next delivery detection
+              }
+            }
+
+            // If this was an evaluation delivery, just clear the tracking
+            if (this.pendingEvaluationClaims.has(requestId)) {
+              this.pendingEvaluationClaims.delete(requestId);
+            }
+
+            // Parse and yield the delivery result
+            try {
               const deliveryDigest = deliveryDataHex.startsWith('0x') ? deliveryDataHex.slice(2) : deliveryDataHex;
               const resultPayload = await fetchFromIpfs(this.config.ipfsGatewayUrl, `f01551220${deliveryDigest}`) as Record<string, unknown>;
 
-              // We need the original desired state too — fetch from the request's data
-              // The Deliver event includes the requestId but not the original requestData.
-              // We look up the original request by scanning MarketplaceRequest events,
-              // or we accept that the result payload includes enough context.
               const restorationResult: RestorationResult = {
                 data: (resultPayload.data as string) ?? JSON.stringify(resultPayload),
                 artifacts: resultPayload.artifacts as string[] | undefined,
               };
 
-              // Construct a minimal desired state from the result payload
-              // The result payload includes requestId which we can use to look up the state
               const desiredState: DesiredState = {
                 id: (resultPayload.requestId as string) ?? requestId,
                 description: (resultPayload.description as string) ?? '',

--- a/client/src/adapters/mech/adapter.ts
+++ b/client/src/adapters/mech/adapter.ts
@@ -47,6 +47,9 @@ export class MechAdapter implements ExecutionAdapter {
   // Restoration requests where claimDelivery succeeded but evaluation creation failed.
   // Swept on each poll cycle so they don't require a new Deliver event.
   private claimedButNotEvaluated = new Set<string>();
+  // Original desired states keyed by request ID (restoration and evaluation)
+  // so we can yield accurate desiredState in DeliveredResult
+  private originalStates = new Map<string, DesiredState>();
   private store?: Store;
 
   constructor(config: MechAdapterConfig, store?: Store) {
@@ -187,6 +190,7 @@ export class MechAdapter implements ExecutionAdapter {
 
     // Store for evaluation creation after delivery is claimed
     this.pendingEvaluations.set(restorationRequestId, state);
+    this.originalStates.set(restorationRequestId, { ...state, type: 'restoration' });
 
     return restorationRequestId;
   }
@@ -307,9 +311,10 @@ export class MechAdapter implements ExecutionAdapter {
                 artifacts: resultPayload.artifacts as string[] | undefined,
               };
 
-              const desiredState: DesiredState = {
-                id: (resultPayload.requestId as string) ?? requestId,
-                description: (resultPayload.description as string) ?? '',
+              // Use the original desired state — not the result payload
+              const desiredState = this.originalStates.get(requestId) ?? {
+                id: requestId,
+                description: '',
               };
 
               yield {
@@ -318,6 +323,9 @@ export class MechAdapter implements ExecutionAdapter {
                 result: restorationResult,
                 deliveryMechAddress: mechAddress,
               };
+
+              // Clean up after yielding
+              this.originalStates.delete(requestId);
             } catch (err) {
               console.error(`[mech] Failed to parse delivery ${requestId}:`, err);
             }
@@ -366,6 +374,11 @@ export class MechAdapter implements ExecutionAdapter {
 
       if (evalRequestIds.length > 0) {
         this.pendingEvaluationClaims.add(evalRequestIds[0]);
+        // Copy original state to evaluation request ID so delivery can use it
+        const origState = this.originalStates.get(requestId);
+        if (origState) {
+          this.originalStates.set(evalRequestIds[0], { ...origState, type: 'evaluation' });
+        }
       }
 
       // Success — clean up both tracking sets

--- a/client/src/adapters/mech/contracts.ts
+++ b/client/src/adapters/mech/contracts.ts
@@ -196,6 +196,99 @@ export async function pollDeliverEvents(
   });
 }
 
+// ── Router event scanning (for crash recovery) ──────────────────────────────
+
+export interface RestorationJobRecord {
+  requestId: string;
+  creator: string;
+}
+
+export interface EvaluationJobRecord {
+  requestId: string;
+  restorationRequestId: string;
+  creator: string;
+}
+
+export async function scanRestorationJobs(
+  publicClient: PublicClient,
+  routerAddress: Address,
+  creator: Address,
+  fromBlock: bigint,
+  toBlock: bigint,
+): Promise<RestorationJobRecord[]> {
+  const results: RestorationJobRecord[] = [];
+  const chunkSize = 9999n;
+
+  for (let start = fromBlock; start <= toBlock; start += chunkSize + 1n) {
+    const end = start + chunkSize > toBlock ? toBlock : start + chunkSize;
+    const logs = await publicClient.getLogs({
+      address: routerAddress,
+      fromBlock: start,
+      toBlock: end,
+    });
+
+    for (const log of logs) {
+      try {
+        const decoded = decodeEventLog({
+          abi: JINN_ROUTER_ABI,
+          data: log.data,
+          topics: log.topics,
+        });
+        if (decoded.eventName === 'RestorationJobCreated') {
+          const args = decoded.args as { creator: Address; requestId: Hex };
+          if (args.creator.toLowerCase() === creator.toLowerCase()) {
+            results.push({ requestId: String(args.requestId), creator: String(args.creator) });
+          }
+        }
+      } catch {}
+    }
+  }
+
+  return results;
+}
+
+export async function scanEvaluationJobs(
+  publicClient: PublicClient,
+  routerAddress: Address,
+  creator: Address,
+  fromBlock: bigint,
+  toBlock: bigint,
+): Promise<EvaluationJobRecord[]> {
+  const results: EvaluationJobRecord[] = [];
+  const chunkSize = 9999n;
+
+  for (let start = fromBlock; start <= toBlock; start += chunkSize + 1n) {
+    const end = start + chunkSize > toBlock ? toBlock : start + chunkSize;
+    const logs = await publicClient.getLogs({
+      address: routerAddress,
+      fromBlock: start,
+      toBlock: end,
+    });
+
+    for (const log of logs) {
+      try {
+        const decoded = decodeEventLog({
+          abi: JINN_ROUTER_ABI,
+          data: log.data,
+          topics: log.topics,
+        });
+        if (decoded.eventName === 'EvaluationJobCreated') {
+          const args = decoded.args as { creator: Address; requestId: Hex; restorationRequestId: Hex };
+          if (args.creator.toLowerCase() === creator.toLowerCase()) {
+            results.push({
+              requestId: String(args.requestId),
+              restorationRequestId: String(args.restorationRequestId),
+              creator: String(args.creator),
+            });
+          }
+        }
+      } catch {}
+    }
+  }
+
+  return results;
+}
+
 // ── Event decoding helpers ───────────────────────────────────────────────────
 
 export interface DecodedMarketplaceRequest {

--- a/client/src/adapters/mech/contracts.ts
+++ b/client/src/adapters/mech/contracts.ts
@@ -7,28 +7,28 @@ import {
   type WalletClient,
   type Log,
 } from 'viem';
-import { MECH_MARKETPLACE_ABI, MECH_ABI, NATIVE_PAYMENT_TYPE } from './types.js';
+import { MECH_MARKETPLACE_ABI, MECH_ABI, JINN_ROUTER_ABI, NATIVE_PAYMENT_TYPE } from './types.js';
 import { executeSafeTransaction } from './safe.js';
 
-export async function submitMarketplaceRequest(
+export async function submitRestorationJob(
   publicClient: PublicClient,
   walletClient: WalletClient,
   safeAddress: Address,
-  marketplaceAddress: Address,
+  routerAddress: Address,
   mechAddress: Address,
   requestDataHex: Hex,
   priceWei: bigint,
   responseTimeout: bigint,
 ): Promise<string[]> {
   const calldata = encodeFunctionData({
-    abi: MECH_MARKETPLACE_ABI,
-    functionName: 'request',
-    args: [requestDataHex, priceWei, NATIVE_PAYMENT_TYPE, mechAddress, responseTimeout, '0x' as Hex],
+    abi: JINN_ROUTER_ABI,
+    functionName: 'createRestorationJob',
+    args: [requestDataHex, mechAddress, priceWei, responseTimeout, NATIVE_PAYMENT_TYPE, '0x' as Hex],
   });
 
   const txHash = await executeSafeTransaction(publicClient, walletClient, {
     safeAddress,
-    to: marketplaceAddress,
+    to: routerAddress,
     value: priceWei,
     data: calldata,
   });
@@ -39,13 +39,13 @@ export async function submitMarketplaceRequest(
   for (const log of receipt.logs) {
     try {
       const decoded = decodeEventLog({
-        abi: MECH_MARKETPLACE_ABI,
+        abi: JINN_ROUTER_ABI,
         data: log.data,
         topics: log.topics,
       });
-      if (decoded.eventName === 'MarketplaceRequest') {
-        const ids = (decoded.args as { requestIds: readonly Hex[] }).requestIds;
-        requestIds.push(...ids.map(String));
+      if (decoded.eventName === 'RestorationJobCreated') {
+        const args = decoded.args as { requestId: Hex };
+        requestIds.push(String(args.requestId));
       }
     } catch {
       // Not our event
@@ -53,6 +53,104 @@ export async function submitMarketplaceRequest(
   }
 
   return requestIds;
+}
+
+export async function submitEvaluationJob(
+  publicClient: PublicClient,
+  walletClient: WalletClient,
+  safeAddress: Address,
+  routerAddress: Address,
+  restorationRequestId: Hex,
+  mechAddress: Address,
+  requestDataHex: Hex,
+  priceWei: bigint,
+  responseTimeout: bigint,
+): Promise<string[]> {
+  const calldata = encodeFunctionData({
+    abi: JINN_ROUTER_ABI,
+    functionName: 'createEvaluationJob',
+    args: [restorationRequestId, requestDataHex, mechAddress, priceWei, responseTimeout, NATIVE_PAYMENT_TYPE, '0x' as Hex],
+  });
+
+  const txHash = await executeSafeTransaction(publicClient, walletClient, {
+    safeAddress,
+    to: routerAddress,
+    value: priceWei,
+    data: calldata,
+  });
+
+  const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+
+  const requestIds: string[] = [];
+  for (const log of receipt.logs) {
+    try {
+      const decoded = decodeEventLog({
+        abi: JINN_ROUTER_ABI,
+        data: log.data,
+        topics: log.topics,
+      });
+      if (decoded.eventName === 'EvaluationJobCreated') {
+        const args = decoded.args as { requestId: Hex };
+        requestIds.push(String(args.requestId));
+      }
+    } catch {
+      // Not our event
+    }
+  }
+
+  return requestIds;
+}
+
+const CLAIM_RETRY_ATTEMPTS = 3;
+const CLAIM_RETRY_DELAY_MS = 2000;
+
+export async function claimDelivery(
+  publicClient: PublicClient,
+  walletClient: WalletClient,
+  safeAddress: Address,
+  routerAddress: Address,
+  requestId: Hex,
+): Promise<Hex> {
+  const calldata = encodeFunctionData({
+    abi: JINN_ROUTER_ABI,
+    functionName: 'claimDelivery',
+    args: [requestId],
+  });
+
+  for (let attempt = 1; attempt <= CLAIM_RETRY_ATTEMPTS; attempt++) {
+    try {
+      return await executeSafeTransaction(publicClient, walletClient, {
+        safeAddress,
+        to: routerAddress,
+        value: 0n,
+        data: calldata,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+
+      // AlreadyClaimed — idempotent, treat as success
+      if (message.includes('AlreadyClaimed')) {
+        console.error(`[router] claimDelivery: already claimed ${requestId}`);
+        return '0x' as Hex;
+      }
+
+      // RequestNotFound — not a router request, skip entirely
+      if (message.includes('RequestNotFound')) {
+        throw err;
+      }
+
+      // NotDelivered — marketplace state may not have settled yet, retry
+      if (message.includes('NotDelivered') && attempt < CLAIM_RETRY_ATTEMPTS) {
+        console.error(`[router] claimDelivery: not yet delivered, retry ${attempt}/${CLAIM_RETRY_ATTEMPTS}`);
+        await new Promise(r => setTimeout(r, CLAIM_RETRY_DELAY_MS));
+        continue;
+      }
+
+      throw err;
+    }
+  }
+
+  throw new Error(`claimDelivery failed after ${CLAIM_RETRY_ATTEMPTS} attempts for ${requestId}`);
 }
 
 export async function getMechDeliveryRate(

--- a/client/src/adapters/mech/types.ts
+++ b/client/src/adapters/mech/types.ts
@@ -1,6 +1,7 @@
 export interface MechAdapterConfig {
   rpcUrl: string;
   mechMarketplaceAddress: `0x${string}`;
+  routerAddress: `0x${string}`;  // JinnRouter proxy on Base
   mechContractAddress: `0x${string}`;
   safeAddress: `0x${string}`;
   agentEoaPrivateKey: `0x${string}`;
@@ -128,6 +129,71 @@ export const MECH_MARKETPLACE_DELIVER_ABI = [
       { name: 'deliveryRates', type: 'uint256[]' },
     ],
     outputs: [{ name: 'deliveredRequests', type: 'bool[]' }],
+  },
+] as const;
+
+export const JINN_ROUTER_ABI = [
+  {
+    name: 'createRestorationJob',
+    type: 'function',
+    stateMutability: 'payable',
+    inputs: [
+      { name: 'requestData', type: 'bytes' },
+      { name: 'priorityMech', type: 'address' },
+      { name: 'maxDeliveryRate', type: 'uint256' },
+      { name: 'responseTimeout', type: 'uint256' },
+      { name: 'paymentType', type: 'bytes32' },
+      { name: 'paymentData', type: 'bytes' },
+    ],
+    outputs: [{ name: 'requestId', type: 'bytes32' }],
+  },
+  {
+    name: 'createEvaluationJob',
+    type: 'function',
+    stateMutability: 'payable',
+    inputs: [
+      { name: 'restorationRequestId', type: 'bytes32' },
+      { name: 'requestData', type: 'bytes' },
+      { name: 'evaluationMech', type: 'address' },
+      { name: 'maxDeliveryRate', type: 'uint256' },
+      { name: 'responseTimeout', type: 'uint256' },
+      { name: 'paymentType', type: 'bytes32' },
+      { name: 'paymentData', type: 'bytes' },
+    ],
+    outputs: [{ name: 'requestId', type: 'bytes32' }],
+  },
+  {
+    name: 'claimDelivery',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [{ name: 'requestId', type: 'bytes32' }],
+    outputs: [],
+  },
+  {
+    name: 'RestorationJobCreated',
+    type: 'event',
+    inputs: [
+      { name: 'creator', type: 'address', indexed: true },
+      { name: 'requestId', type: 'bytes32', indexed: true },
+    ],
+  },
+  {
+    name: 'EvaluationJobCreated',
+    type: 'event',
+    inputs: [
+      { name: 'creator', type: 'address', indexed: true },
+      { name: 'requestId', type: 'bytes32', indexed: true },
+      { name: 'restorationRequestId', type: 'bytes32', indexed: true },
+    ],
+  },
+  {
+    name: 'DeliveryClaimed',
+    type: 'event',
+    inputs: [
+      { name: 'claimer', type: 'address', indexed: true },
+      { name: 'requestId', type: 'bytes32', indexed: true },
+      { name: 'jobType', type: 'uint8', indexed: false },
+    ],
   },
 ] as const;
 

--- a/client/src/daemon/daemon.ts
+++ b/client/src/daemon/daemon.ts
@@ -4,6 +4,7 @@ import type { DesiredState } from '../types/index.js';
 import { Store } from '../store/store.js';
 import { CreatorLoop } from './creator.js';
 import { RestorerLoop } from './restorer.js';
+import { DeliveryWatcherLoop } from './delivery-watcher.js';
 
 export interface DaemonConfig {
   adapter: ExecutionAdapter;
@@ -17,6 +18,7 @@ export class Daemon {
   private store: Store;
   private creatorLoop: CreatorLoop;
   private restorerLoop: RestorerLoop;
+  private deliveryWatcherLoop: DeliveryWatcherLoop;
   private adapter: ExecutionAdapter;
   private loopPromises: Promise<void>[] = [];
   private cachedShutdownState: string | null = null;
@@ -26,6 +28,7 @@ export class Daemon {
     this.adapter = config.adapter;
     this.creatorLoop = new CreatorLoop(this.adapter, config.desiredStates, this.store);
     this.restorerLoop = new RestorerLoop(this.adapter, config.runner, this.store);
+    this.deliveryWatcherLoop = new DeliveryWatcherLoop(this.adapter);
   }
 
   async start(): Promise<void> {
@@ -36,12 +39,14 @@ export class Daemon {
     this.loopPromises = [
       this.creatorLoop.run().catch(err => console.error('[daemon] creator crashed:', err)),
       this.restorerLoop.run().catch(err => console.error('[daemon] restorer crashed:', err)),
+      this.deliveryWatcherLoop.run().catch(err => console.error('[daemon] delivery-watcher crashed:', err)),
     ];
   }
 
   async stop(): Promise<void> {
     this.creatorLoop.stop();
     this.restorerLoop.stop();
+    this.deliveryWatcherLoop.stop();
 
     // Stop the adapter to unblock any pending async iterators
     await this.adapter.stop();

--- a/client/src/daemon/delivery-watcher.ts
+++ b/client/src/daemon/delivery-watcher.ts
@@ -1,0 +1,35 @@
+import type { ExecutionAdapter } from '../adapters/adapter.js';
+
+export class DeliveryWatcherLoop {
+  private stopped = false;
+  private stopResolve: (() => void) | null = null;
+  private stopPromise: Promise<void>;
+
+  constructor(private readonly adapter: ExecutionAdapter) {
+    this.stopPromise = new Promise(resolve => {
+      this.stopResolve = resolve;
+    });
+  }
+
+  async run(): Promise<void> {
+    while (!this.stopped) {
+      try {
+        for await (const delivery of this.adapter.watchForDeliveries()) {
+          if (this.stopped) break;
+          // The adapter handles claim + evaluation creation internally.
+          // We just drive the iteration and log for observability.
+          const type = delivery.desiredState.type ?? 'unknown';
+          console.error(`[delivery-watcher] Processed ${type} delivery: ${delivery.requestId.slice(0, 10)}...`);
+        }
+      } catch (err) {
+        console.error('[delivery-watcher] Error:', err);
+        await Promise.race([new Promise(r => setTimeout(r, 5000)), this.stopPromise]);
+      }
+    }
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.stopResolve?.();
+  }
+}

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -14,6 +14,7 @@ export { ClaudeRunner } from './runner/claude.js';
 
 // Daemon
 export { Daemon, type DaemonConfig } from './daemon/daemon.js';
+export { DeliveryWatcherLoop } from './daemon/delivery-watcher.js';
 
 // Store
 export { Store } from './store/store.js';

--- a/client/src/mcp/server.ts
+++ b/client/src/mcp/server.ts
@@ -27,6 +27,8 @@ const desiredState = {
   context: process.env['DESIRED_STATE_CONTEXT']
     ? JSON.parse(process.env['DESIRED_STATE_CONTEXT']) as Record<string, unknown>
     : undefined,
+  type: process.env['DESIRED_STATE_TYPE'] ?? '',
+  restorationRequestId: process.env['RESTORATION_REQUEST_ID'] ?? '',
 };
 
 const requestId = process.env['REQUEST_ID'] ?? '';
@@ -44,6 +46,8 @@ server.tool(
         id: desiredState.id,
         description: desiredState.description,
         context: desiredState.context,
+        type: desiredState.type || undefined,
+        restorationRequestId: desiredState.restorationRequestId || undefined,
         requestId,
       }),
     }],

--- a/client/src/runner/claude.ts
+++ b/client/src/runner/claude.ts
@@ -41,6 +41,8 @@ export class ClaudeRunner implements Runner {
             DESIRED_STATE_ID: desiredState.id,
             DESIRED_STATE_DESCRIPTION: desiredState.description,
             DESIRED_STATE_CONTEXT: desiredState.context ? JSON.stringify(desiredState.context) : '',
+            DESIRED_STATE_TYPE: desiredState.type ?? '',
+            RESTORATION_REQUEST_ID: desiredState.restorationRequestId ?? '',
             REQUEST_ID: context.requestId,
           },
         },

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -41,6 +41,15 @@ export class Store {
     return row?.value ?? null;
   }
 
+  getLastProcessedBlock(): bigint | null {
+    const row = this.db.prepare('SELECT value FROM config WHERE key = ?').get('last_processed_block') as { value: string } | undefined;
+    return row?.value ? BigInt(row.value) : null;
+  }
+
+  setLastProcessedBlock(block: bigint): void {
+    this.db.prepare('INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)').run('last_processed_block', block.toString());
+  }
+
   close(): void {
     this.db.close();
   }

--- a/client/test/adapters/mech/adapter.test.ts
+++ b/client/test/adapters/mech/adapter.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { MechAdapterConfig } from '../../../src/adapters/mech/types.js';
+
+// Mock contract helpers
+vi.mock('../../../src/adapters/mech/contracts.js', () => ({
+  submitRestorationJob: vi.fn().mockResolvedValue(['0x' + 'aa'.repeat(32)]),
+  submitEvaluationJob: vi.fn().mockResolvedValue(['0x' + 'bb'.repeat(32)]),
+  claimDelivery: vi.fn().mockResolvedValue('0x1234'),
+  getMechDeliveryRate: vi.fn().mockResolvedValue(1000000n),
+  getTimeoutBounds: vi.fn().mockResolvedValue({ min: 60n, max: 300n }),
+  decodeMarketplaceRequestLogs: vi.fn().mockReturnValue([]),
+  decodeDeliverLogs: vi.fn().mockReturnValue([]),
+  callDeliverToMarketplace: vi.fn(),
+}));
+
+// Mock IPFS
+vi.mock('../../../src/adapters/mech/ipfs.js', () => ({
+  buildDesiredStatePayload: vi.fn().mockReturnValue({ desiredStateId: 'ds-1', description: 'test' }),
+  uploadToIpfs: vi.fn().mockResolvedValue('QmFakeCid'),
+  cidToDigestHex: vi.fn().mockReturnValue('0x' + 'cc'.repeat(32)),
+  fetchFromIpfs: vi.fn().mockResolvedValue({ data: 'result' }),
+  parseDesiredStateFromPayload: vi.fn().mockReturnValue({ id: 'ds-1', description: 'test' }),
+  digestHexToGatewayUrl: vi.fn(),
+}));
+
+// Mock Safe
+vi.mock('../../../src/adapters/mech/safe.js', () => ({
+  createClients: vi.fn().mockReturnValue({
+    publicClient: {
+      getBlockNumber: vi.fn().mockResolvedValue(100n),
+      getLogs: vi.fn().mockResolvedValue([]),
+      readContract: vi.fn(),
+      waitForTransactionReceipt: vi.fn().mockResolvedValue({ logs: [] }),
+    },
+    walletClient: {},
+    account: {},
+  }),
+}));
+
+const TEST_CONFIG: MechAdapterConfig = {
+  rpcUrl: 'http://localhost:8545',
+  mechMarketplaceAddress: ('0x' + '11'.repeat(20)) as `0x${string}`,
+  routerAddress: ('0x' + '22'.repeat(20)) as `0x${string}`,
+  mechContractAddress: ('0x' + '33'.repeat(20)) as `0x${string}`,
+  safeAddress: ('0x' + '44'.repeat(20)) as `0x${string}`,
+  agentEoaPrivateKey: ('0x' + '55'.repeat(32)) as `0x${string}`,
+  ipfsRegistryUrl: 'http://localhost:5001',
+  ipfsGatewayUrl: 'http://localhost:8080',
+  pollIntervalMs: 1000,
+  chainId: 8453,
+};
+
+describe('MechAdapter with JinnRouter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('postDesiredState calls submitRestorationJob with router address', async () => {
+    const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+    const { submitRestorationJob } = await import('../../../src/adapters/mech/contracts.js');
+
+    const adapter = new MechAdapter(TEST_CONFIG);
+    await adapter.initialize();
+
+    const requestId = await adapter.postDesiredState({ id: 'ds-1', description: 'test' });
+
+    expect(requestId).toBe('0x' + 'aa'.repeat(32));
+    expect(submitRestorationJob).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      TEST_CONFIG.safeAddress,
+      TEST_CONFIG.routerAddress,
+      TEST_CONFIG.mechContractAddress,
+      expect.any(String),
+      expect.any(BigInt),
+      expect.any(BigInt),
+    );
+
+    await adapter.stop();
+  });
+
+  it('postDesiredState does NOT call submitEvaluationJob upfront', async () => {
+    const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+    const { submitEvaluationJob } = await import('../../../src/adapters/mech/contracts.js');
+
+    const adapter = new MechAdapter(TEST_CONFIG);
+    await adapter.initialize();
+
+    await adapter.postDesiredState({ id: 'ds-1', description: 'test' });
+
+    expect(submitEvaluationJob).not.toHaveBeenCalled();
+
+    await adapter.stop();
+  });
+});

--- a/client/test/adapters/mech/contracts.test.ts
+++ b/client/test/adapters/mech/contracts.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { encodeFunctionData, decodeFunctionData } from 'viem';
+import { JINN_ROUTER_ABI, NATIVE_PAYMENT_TYPE } from '../../../src/adapters/mech/types.js';
+
+describe('JinnRouter contract encoding', () => {
+  it('encodes createRestorationJob calldata', () => {
+    const calldata = encodeFunctionData({
+      abi: JINN_ROUTER_ABI,
+      functionName: 'createRestorationJob',
+      args: [
+        '0xabcd' as `0x${string}`,
+        '0x1234567890123456789012345678901234567890' as `0x${string}`,
+        1000000n,
+        300n,
+        NATIVE_PAYMENT_TYPE,
+        '0x' as `0x${string}`,
+      ],
+    });
+    expect(calldata).toMatch(/^0x/);
+
+    const decoded = decodeFunctionData({
+      abi: JINN_ROUTER_ABI,
+      data: calldata,
+    });
+    expect(decoded.functionName).toBe('createRestorationJob');
+  });
+
+  it('encodes createEvaluationJob calldata with restorationRequestId', () => {
+    const restorationRequestId = ('0x' + 'aa'.repeat(32)) as `0x${string}`;
+    const calldata = encodeFunctionData({
+      abi: JINN_ROUTER_ABI,
+      functionName: 'createEvaluationJob',
+      args: [
+        restorationRequestId,
+        '0xabcd' as `0x${string}`,
+        '0x1234567890123456789012345678901234567890' as `0x${string}`,
+        1000000n,
+        300n,
+        NATIVE_PAYMENT_TYPE,
+        '0x' as `0x${string}`,
+      ],
+    });
+
+    const decoded = decodeFunctionData({
+      abi: JINN_ROUTER_ABI,
+      data: calldata,
+    });
+    expect(decoded.functionName).toBe('createEvaluationJob');
+    expect((decoded.args as unknown[])[0]).toBe(restorationRequestId);
+  });
+
+  it('encodes claimDelivery calldata', () => {
+    const requestId = ('0x' + 'bb'.repeat(32)) as `0x${string}`;
+    const calldata = encodeFunctionData({
+      abi: JINN_ROUTER_ABI,
+      functionName: 'claimDelivery',
+      args: [requestId],
+    });
+
+    const decoded = decodeFunctionData({
+      abi: JINN_ROUTER_ABI,
+      data: calldata,
+    });
+    expect(decoded.functionName).toBe('claimDelivery');
+    expect((decoded.args as unknown[])[0]).toBe(requestId);
+  });
+});

--- a/docs/superpowers/plans/2026-03-26-jinnrouter-client-integration.md
+++ b/docs/superpowers/plans/2026-03-26-jinnrouter-client-integration.md
@@ -1,0 +1,923 @@
+# JinnRouter Client Integration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Modify MechAdapter to route all marketplace requests through the deployed JinnRouter contract, add delivery claiming, and defer evaluation creation until after restoration delivery is claimed.
+
+**Architecture:** In-place modification of MechAdapter. Requests go through the JinnRouter (`createRestorationJob`/`createEvaluationJob`) instead of `marketplace.request()` directly. A new `claimDelivery` step after mech delivery increments activity counters. Two in-memory tracking structures (`pendingEvaluations`, `pendingEvaluationClaims`) manage the deferred evaluation lifecycle.
+
+**Tech Stack:** TypeScript, viem, vitest, Safe multisig transactions
+
+**Spec:** `docs/superpowers/specs/2026-03-26-jinnrouter-client-integration-design.md`
+
+**JinnRouter Solidity source:** `/Users/gcd/Repositories/main/jinn-cli-agents/contracts/staking/JinnRouter.sol`
+
+**JinnRouter address (Base):** `0xfFa7118A3D820cd4E820010837D65FAfF463181B`
+
+---
+
+## File Map
+
+| File | Role | Change |
+|------|------|--------|
+| `client/src/adapters/mech/types.ts` | ABIs, config types, constants | Add `JINN_ROUTER_ABI`, add `routerAddress` to `MechAdapterConfig` |
+| `client/src/adapters/mech/contracts.ts` | Contract call helpers | Replace `submitMarketplaceRequest` with `submitRestorationJob`, `submitEvaluationJob`, `claimDelivery` |
+| `client/src/adapters/mech/adapter.ts` | MechAdapter class | Rewrite `postDesiredState`, `watchForDeliveries`; remove `deferredEvaluations`/`isEvaluationReady` |
+| `client/test/adapters/mech/contracts.test.ts` | Unit tests for contract helpers | **New file** — tests for encoding/decoding of router calls |
+| `client/test/adapters/mech/adapter.test.ts` | Unit tests for adapter flow | **New file** — tests for pending evaluation lifecycle |
+| `client/scripts/e2e-validate.ts` | E2E against Anvil fork | Add router constant, add `routerAddress` to all MechAdapter configs. Full e2e rewrite deferred. |
+
+---
+
+### Task 1: Add JinnRouter ABI and config field to types.ts
+
+**Files:**
+- Modify: `client/src/adapters/mech/types.ts:1-11`
+
+- [ ] **Step 1: Add `routerAddress` to `MechAdapterConfig`**
+
+In `client/src/adapters/mech/types.ts`, add `routerAddress` after `mechMarketplaceAddress`:
+
+```ts
+export interface MechAdapterConfig {
+  rpcUrl: string;
+  mechMarketplaceAddress: `0x${string}`;
+  routerAddress: `0x${string}`;         // JinnRouter proxy on Base
+  mechContractAddress: `0x${string}`;
+  safeAddress: `0x${string}`;
+  agentEoaPrivateKey: `0x${string}`;
+  ipfsRegistryUrl: string;
+  ipfsGatewayUrl: string;
+  pollIntervalMs: number;
+  chainId: number;
+}
+```
+
+- [ ] **Step 2: Add `JINN_ROUTER_ABI` constant**
+
+Append after the existing `MECH_MARKETPLACE_DELIVER_ABI` in the same file:
+
+```ts
+export const JINN_ROUTER_ABI = [
+  {
+    name: 'createRestorationJob',
+    type: 'function',
+    stateMutability: 'payable',
+    inputs: [
+      { name: 'requestData', type: 'bytes' },
+      { name: 'priorityMech', type: 'address' },
+      { name: 'maxDeliveryRate', type: 'uint256' },
+      { name: 'responseTimeout', type: 'uint256' },
+      { name: 'paymentType', type: 'bytes32' },
+      { name: 'paymentData', type: 'bytes' },
+    ],
+    outputs: [{ name: 'requestId', type: 'bytes32' }],
+  },
+  {
+    name: 'createEvaluationJob',
+    type: 'function',
+    stateMutability: 'payable',
+    inputs: [
+      { name: 'restorationRequestId', type: 'bytes32' },
+      { name: 'requestData', type: 'bytes' },
+      { name: 'evaluationMech', type: 'address' },
+      { name: 'maxDeliveryRate', type: 'uint256' },
+      { name: 'responseTimeout', type: 'uint256' },
+      { name: 'paymentType', type: 'bytes32' },
+      { name: 'paymentData', type: 'bytes' },
+    ],
+    outputs: [{ name: 'requestId', type: 'bytes32' }],
+  },
+  {
+    name: 'claimDelivery',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [{ name: 'requestId', type: 'bytes32' }],
+    outputs: [],
+  },
+  {
+    name: 'RestorationJobCreated',
+    type: 'event',
+    inputs: [
+      { name: 'creator', type: 'address', indexed: true },
+      { name: 'requestId', type: 'bytes32', indexed: true },
+    ],
+  },
+  {
+    name: 'EvaluationJobCreated',
+    type: 'event',
+    inputs: [
+      { name: 'creator', type: 'address', indexed: true },
+      { name: 'requestId', type: 'bytes32', indexed: true },
+      { name: 'restorationRequestId', type: 'bytes32', indexed: true },
+    ],
+  },
+  {
+    name: 'DeliveryClaimed',
+    type: 'event',
+    inputs: [
+      { name: 'claimer', type: 'address', indexed: true },
+      { name: 'requestId', type: 'bytes32', indexed: true },
+      { name: 'jobType', type: 'uint8', indexed: false },
+    ],
+  },
+] as const;
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+Run: `cd client && npx tsc --noEmit`
+Expected: No new errors (existing code will have errors from missing `routerAddress` in config objects — that's expected and fixed in later tasks).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/adapters/mech/types.ts
+git commit -m "feat(client): add JinnRouter ABI and routerAddress config field"
+```
+
+---
+
+### Task 2: Replace contract call helpers in contracts.ts
+
+**Files:**
+- Modify: `client/src/adapters/mech/contracts.ts`
+- Create: `client/test/adapters/mech/contracts.test.ts`
+
+- [ ] **Step 1: Write tests for new contract helpers**
+
+Create `client/test/adapters/mech/contracts.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { encodeFunctionData, decodeFunctionData } from 'viem';
+import { JINN_ROUTER_ABI, NATIVE_PAYMENT_TYPE } from '../../../src/adapters/mech/types.js';
+
+describe('JinnRouter contract encoding', () => {
+  it('encodes createRestorationJob calldata', () => {
+    const calldata = encodeFunctionData({
+      abi: JINN_ROUTER_ABI,
+      functionName: 'createRestorationJob',
+      args: [
+        '0xabcd' as `0x${string}`,
+        '0x1234567890123456789012345678901234567890' as `0x${string}`,
+        1000000n,
+        300n,
+        NATIVE_PAYMENT_TYPE,
+        '0x' as `0x${string}`,
+      ],
+    });
+    expect(calldata).toMatch(/^0x/);
+
+    const decoded = decodeFunctionData({
+      abi: JINN_ROUTER_ABI,
+      data: calldata,
+    });
+    expect(decoded.functionName).toBe('createRestorationJob');
+  });
+
+  it('encodes createEvaluationJob calldata with restorationRequestId', () => {
+    const restorationRequestId = ('0x' + 'aa'.repeat(32)) as `0x${string}`;
+    const calldata = encodeFunctionData({
+      abi: JINN_ROUTER_ABI,
+      functionName: 'createEvaluationJob',
+      args: [
+        restorationRequestId,
+        '0xabcd' as `0x${string}`,
+        '0x1234567890123456789012345678901234567890' as `0x${string}`,
+        1000000n,
+        300n,
+        NATIVE_PAYMENT_TYPE,
+        '0x' as `0x${string}`,
+      ],
+    });
+
+    const decoded = decodeFunctionData({
+      abi: JINN_ROUTER_ABI,
+      data: calldata,
+    });
+    expect(decoded.functionName).toBe('createEvaluationJob');
+    expect((decoded.args as unknown[])[0]).toBe(restorationRequestId);
+  });
+
+  it('encodes claimDelivery calldata', () => {
+    const requestId = ('0x' + 'bb'.repeat(32)) as `0x${string}`;
+    const calldata = encodeFunctionData({
+      abi: JINN_ROUTER_ABI,
+      functionName: 'claimDelivery',
+      args: [requestId],
+    });
+
+    const decoded = decodeFunctionData({
+      abi: JINN_ROUTER_ABI,
+      data: calldata,
+    });
+    expect(decoded.functionName).toBe('claimDelivery');
+    expect((decoded.args as unknown[])[0]).toBe(requestId);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd client && npx vitest run test/adapters/mech/contracts.test.ts`
+Expected: PASS — these tests only verify ABI encoding which already works with the types from Task 1. (These are baseline tests ensuring the ABI is correct before we change the contract helpers.)
+
+- [ ] **Step 3: Replace `submitMarketplaceRequest` with `submitRestorationJob`**
+
+In `client/src/adapters/mech/contracts.ts`, replace the `submitMarketplaceRequest` function:
+
+```ts
+import {
+  encodeFunctionData,
+  decodeEventLog,
+  type Address,
+  type Hex,
+  type PublicClient,
+  type WalletClient,
+  type Log,
+} from 'viem';
+import { MECH_MARKETPLACE_ABI, MECH_ABI, JINN_ROUTER_ABI, NATIVE_PAYMENT_TYPE } from './types.js';
+import { executeSafeTransaction } from './safe.js';
+
+export async function submitRestorationJob(
+  publicClient: PublicClient,
+  walletClient: WalletClient,
+  safeAddress: Address,
+  routerAddress: Address,
+  mechAddress: Address,
+  requestDataHex: Hex,
+  priceWei: bigint,
+  responseTimeout: bigint,
+): Promise<string[]> {
+  const calldata = encodeFunctionData({
+    abi: JINN_ROUTER_ABI,
+    functionName: 'createRestorationJob',
+    args: [requestDataHex, mechAddress, priceWei, responseTimeout, NATIVE_PAYMENT_TYPE, '0x' as Hex],
+  });
+
+  const txHash = await executeSafeTransaction(publicClient, walletClient, {
+    safeAddress,
+    to: routerAddress,
+    value: priceWei,
+    data: calldata,
+  });
+
+  const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+
+  const requestIds: string[] = [];
+  for (const log of receipt.logs) {
+    try {
+      const decoded = decodeEventLog({
+        abi: JINN_ROUTER_ABI,
+        data: log.data,
+        topics: log.topics,
+      });
+      if (decoded.eventName === 'RestorationJobCreated') {
+        const args = decoded.args as { requestId: Hex };
+        requestIds.push(String(args.requestId));
+      }
+    } catch {
+      // Not our event
+    }
+  }
+
+  return requestIds;
+}
+```
+
+- [ ] **Step 4: Add `submitEvaluationJob`**
+
+Add below `submitRestorationJob` in the same file:
+
+```ts
+export async function submitEvaluationJob(
+  publicClient: PublicClient,
+  walletClient: WalletClient,
+  safeAddress: Address,
+  routerAddress: Address,
+  restorationRequestId: Hex,
+  mechAddress: Address,
+  requestDataHex: Hex,
+  priceWei: bigint,
+  responseTimeout: bigint,
+): Promise<string[]> {
+  const calldata = encodeFunctionData({
+    abi: JINN_ROUTER_ABI,
+    functionName: 'createEvaluationJob',
+    args: [restorationRequestId, requestDataHex, mechAddress, priceWei, responseTimeout, NATIVE_PAYMENT_TYPE, '0x' as Hex],
+  });
+
+  const txHash = await executeSafeTransaction(publicClient, walletClient, {
+    safeAddress,
+    to: routerAddress,
+    value: priceWei,
+    data: calldata,
+  });
+
+  const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+
+  const requestIds: string[] = [];
+  for (const log of receipt.logs) {
+    try {
+      const decoded = decodeEventLog({
+        abi: JINN_ROUTER_ABI,
+        data: log.data,
+        topics: log.topics,
+      });
+      if (decoded.eventName === 'EvaluationJobCreated') {
+        const args = decoded.args as { requestId: Hex };
+        requestIds.push(String(args.requestId));
+      }
+    } catch {
+      // Not our event
+    }
+  }
+
+  return requestIds;
+}
+```
+
+- [ ] **Step 5: Add `claimDelivery`**
+
+Add below `submitEvaluationJob`:
+
+```ts
+const CLAIM_RETRY_ATTEMPTS = 3;
+const CLAIM_RETRY_DELAY_MS = 2000;
+
+export async function claimDelivery(
+  publicClient: PublicClient,
+  walletClient: WalletClient,
+  safeAddress: Address,
+  routerAddress: Address,
+  requestId: Hex,
+): Promise<Hex> {
+  const calldata = encodeFunctionData({
+    abi: JINN_ROUTER_ABI,
+    functionName: 'claimDelivery',
+    args: [requestId],
+  });
+
+  for (let attempt = 1; attempt <= CLAIM_RETRY_ATTEMPTS; attempt++) {
+    try {
+      return await executeSafeTransaction(publicClient, walletClient, {
+        safeAddress,
+        to: routerAddress,
+        value: 0n,
+        data: calldata,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+
+      // AlreadyClaimed — idempotent, treat as success
+      if (message.includes('AlreadyClaimed')) {
+        console.error(`[router] claimDelivery: already claimed ${requestId}`);
+        return '0x' as Hex;
+      }
+
+      // RequestNotFound — not a router request, skip entirely
+      if (message.includes('RequestNotFound')) {
+        throw err;
+      }
+
+      // NotDelivered — marketplace state may not have settled yet, retry
+      if (message.includes('NotDelivered') && attempt < CLAIM_RETRY_ATTEMPTS) {
+        console.error(`[router] claimDelivery: not yet delivered, retry ${attempt}/${CLAIM_RETRY_ATTEMPTS}`);
+        await new Promise(r => setTimeout(r, CLAIM_RETRY_DELAY_MS));
+        continue;
+      }
+
+      throw err;
+    }
+  }
+
+  throw new Error(`claimDelivery failed after ${CLAIM_RETRY_ATTEMPTS} attempts for ${requestId}`);
+}
+```
+
+- [ ] **Step 6: Remove the old `submitMarketplaceRequest` function**
+
+Delete the `submitMarketplaceRequest` function from `contracts.ts`. Keep all other functions unchanged: `getMechDeliveryRate`, `getTimeoutBounds`, `pollDeliverEvents`, `decodeMarketplaceRequestLogs`, `decodeDeliverLogs`, `callDeliverToMarketplace`.
+
+- [ ] **Step 7: Run tests**
+
+Run: `cd client && npx vitest run test/adapters/mech/contracts.test.ts`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add client/src/adapters/mech/contracts.ts client/test/adapters/mech/contracts.test.ts
+git commit -m "feat(client): replace marketplace.request with JinnRouter contract helpers"
+```
+
+---
+
+### Task 3: Rewrite MechAdapter.postDesiredState (restoration only)
+
+**Files:**
+- Modify: `client/src/adapters/mech/adapter.ts`
+
+- [ ] **Step 1: Update imports in adapter.ts**
+
+Replace the `submitMarketplaceRequest` import with the new functions:
+
+```ts
+import {
+  submitRestorationJob,
+  submitEvaluationJob,
+  claimDelivery,
+  getMechDeliveryRate,
+  getTimeoutBounds,
+  decodeMarketplaceRequestLogs,
+  decodeDeliverLogs,
+  callDeliverToMarketplace,
+} from './contracts.js';
+```
+
+- [ ] **Step 2: Add tracking fields to MechAdapter class**
+
+Add after the existing `private deferredEvaluations` field (which we'll remove shortly):
+
+```ts
+private pendingEvaluations = new Map<string, DesiredState>();
+private pendingEvaluationClaims = new Set<string>();
+```
+
+- [ ] **Step 3: Rewrite `postDesiredState`**
+
+Replace the entire `postDesiredState` method. The new version posts only the restoration request and stores the desired state for later evaluation:
+
+```ts
+async postDesiredState(state: DesiredState): Promise<RequestId> {
+  const restorationState: DesiredState = {
+    ...state,
+    type: state.type ?? 'restoration',
+    attemptId: state.attemptId,
+    attemptNumber: state.attemptNumber,
+  };
+  const restorationPayload = buildDesiredStatePayload(restorationState);
+  const restorationCid = await uploadToIpfs(this.config.ipfsRegistryUrl, restorationPayload);
+  const restorationDataHex = cidToDigestHex(restorationCid);
+
+  const deliveryRate = await getMechDeliveryRate(this.publicClient, this.config.mechContractAddress);
+  const { max: maxTimeout } = await getTimeoutBounds(this.publicClient, this.config.mechMarketplaceAddress);
+
+  const restorationRequestIds = await submitRestorationJob(
+    this.publicClient,
+    this.walletClient,
+    this.config.safeAddress,
+    this.config.routerAddress,
+    this.config.mechContractAddress,
+    restorationDataHex,
+    deliveryRate,
+    maxTimeout,
+  );
+
+  if (restorationRequestIds.length === 0) {
+    throw new PermanentError('No request IDs returned from router');
+  }
+
+  const restorationRequestId = restorationRequestIds[0];
+
+  // Store for evaluation creation after delivery is claimed
+  this.pendingEvaluations.set(restorationRequestId, state);
+
+  return restorationRequestId;
+}
+```
+
+- [ ] **Step 4: Remove `deferredEvaluations` field and `isEvaluationReady` method**
+
+Delete:
+- The `private deferredEvaluations` field (line 40)
+- The entire `isEvaluationReady` method (lines 179-195)
+
+- [ ] **Step 5: Verify TypeScript compiles (adapter will have errors in watchForRequests/watchForDeliveries — that's expected)**
+
+Run: `cd client && npx tsc --noEmit 2>&1 | head -20`
+Expected: Errors only in `watchForRequests` (references to deleted `deferredEvaluations`/`isEvaluationReady`) and `watchForDeliveries`. These are fixed in Tasks 4 and 5.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/adapters/mech/adapter.ts
+git commit -m "feat(client): rewrite postDesiredState to use JinnRouter restoration job"
+```
+
+---
+
+### Task 4: Rewrite MechAdapter.watchForDeliveries (claim + evaluation)
+
+**Files:**
+- Modify: `client/src/adapters/mech/adapter.ts`
+
+- [ ] **Step 1: Rewrite `watchForDeliveries`**
+
+Replace the entire `watchForDeliveries` method:
+
+```ts
+async *watchForDeliveries(): AsyncIterable<DeliveredResult> {
+  while (!this.stopped) {
+    try {
+      const currentBlock = await this.publicClient.getBlockNumber();
+      if (currentBlock > this.deliveryBlockCursor) {
+        const logs = await this.publicClient.getLogs({
+          address: this.config.mechContractAddress,
+          fromBlock: this.deliveryBlockCursor + 1n,
+          toBlock: currentBlock,
+        });
+        this.deliveryBlockCursor = currentBlock;
+
+        const decoded = decodeDeliverLogs(logs);
+        for (const { requestId, deliveryDataHex, mechAddress } of decoded) {
+          // Only claim deliveries for requests this client created
+          const isOurs = this.pendingEvaluations.has(requestId) || this.pendingEvaluationClaims.has(requestId);
+          if (!isOurs) continue;
+
+          try {
+            // Claim the delivery on the router
+            await claimDelivery(
+              this.publicClient,
+              this.walletClient,
+              this.config.safeAddress,
+              this.config.routerAddress,
+              requestId as `0x${string}`,
+            );
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            if (message.includes('RequestNotFound')) {
+              console.error(`[mech] claimDelivery skipped (not a router request): ${requestId}`);
+              continue;
+            }
+            console.error(`[mech] claimDelivery failed for ${requestId}:`, err);
+            // Don't remove from pending — will retry next poll
+            continue;
+          }
+
+          // If this was a restoration delivery, post the evaluation job
+          if (this.pendingEvaluations.has(requestId)) {
+            const originalState = this.pendingEvaluations.get(requestId)!;
+            try {
+              const evaluationState: DesiredState = {
+                ...originalState,
+                type: 'evaluation',
+                restorationRequestId: requestId,
+              };
+              const evaluationPayload = buildDesiredStatePayload(evaluationState);
+              const evaluationCid = await uploadToIpfs(this.config.ipfsRegistryUrl, evaluationPayload);
+              const evaluationDataHex = cidToDigestHex(evaluationCid);
+
+              const deliveryRate = await getMechDeliveryRate(this.publicClient, this.config.mechContractAddress);
+              const { max: maxTimeout } = await getTimeoutBounds(this.publicClient, this.config.mechMarketplaceAddress);
+
+              const evalRequestIds = await submitEvaluationJob(
+                this.publicClient,
+                this.walletClient,
+                this.config.safeAddress,
+                this.config.routerAddress,
+                requestId as `0x${string}`,
+                this.config.mechContractAddress,
+                evaluationDataHex,
+                deliveryRate,
+                maxTimeout,
+              );
+
+              if (evalRequestIds.length > 0) {
+                this.pendingEvaluationClaims.add(evalRequestIds[0]);
+              }
+
+              // Only remove after evaluation job succeeds
+              this.pendingEvaluations.delete(requestId);
+            } catch (err) {
+              console.error(`[mech] Failed to create evaluation job for ${requestId}:`, err);
+              // Don't remove from pendingEvaluations — will retry on next delivery detection
+            }
+          }
+
+          // If this was an evaluation delivery, just clear the tracking
+          if (this.pendingEvaluationClaims.has(requestId)) {
+            this.pendingEvaluationClaims.delete(requestId);
+          }
+
+          // Parse and yield the delivery result
+          try {
+            const deliveryDigest = deliveryDataHex.startsWith('0x') ? deliveryDataHex.slice(2) : deliveryDataHex;
+            const resultPayload = await fetchFromIpfs(this.config.ipfsGatewayUrl, `f01551220${deliveryDigest}`) as Record<string, unknown>;
+
+            const restorationResult: RestorationResult = {
+              data: (resultPayload.data as string) ?? JSON.stringify(resultPayload),
+              artifacts: resultPayload.artifacts as string[] | undefined,
+            };
+
+            const desiredState: DesiredState = {
+              id: (resultPayload.requestId as string) ?? requestId,
+              description: (resultPayload.description as string) ?? '',
+            };
+
+            yield {
+              requestId,
+              desiredState,
+              result: restorationResult,
+              deliveryMechAddress: mechAddress,
+            };
+          } catch (err) {
+            console.error(`[mech] Failed to parse delivery ${requestId}:`, err);
+          }
+        }
+      }
+    } catch (err) {
+      console.error('[mech] Error polling for deliveries:', err);
+    }
+
+    await new Promise(r => setTimeout(r, this.config.pollIntervalMs));
+  }
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd client && npx tsc --noEmit 2>&1 | head -20`
+Expected: Errors only in `watchForRequests` (still references deleted `deferredEvaluations`). Fixed in Task 5.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/adapters/mech/adapter.ts
+git commit -m "feat(client): rewrite watchForDeliveries with claimDelivery and evaluation creation"
+```
+
+---
+
+### Task 5: Simplify MechAdapter.watchForRequests (remove deferred logic)
+
+**Files:**
+- Modify: `client/src/adapters/mech/adapter.ts`
+
+- [ ] **Step 1: Rewrite `watchForRequests`**
+
+Replace the entire `watchForRequests` method. Remove all deferred evaluation logic — the router enforces ordering on-chain:
+
+```ts
+async *watchForRequests(): AsyncIterable<RestorationRequest> {
+  while (!this.stopped) {
+    try {
+      const currentBlock = await this.publicClient.getBlockNumber();
+      if (currentBlock > this.requestBlockCursor) {
+        const logs = await this.publicClient.getLogs({
+          address: this.config.mechMarketplaceAddress,
+          fromBlock: this.requestBlockCursor + 1n,
+          toBlock: currentBlock,
+        });
+        this.requestBlockCursor = currentBlock;
+
+        const decoded = decodeMarketplaceRequestLogs(logs);
+        for (const { requestId, requestDataHex } of decoded) {
+          try {
+            const digest = requestDataHex.startsWith('0x') ? requestDataHex.slice(2) : requestDataHex;
+            const payload = await fetchFromIpfs(this.config.ipfsGatewayUrl, `f01551220${digest}`) as Record<string, unknown>;
+            const desiredState = parseDesiredStateFromPayload(payload);
+
+            yield { requestId, desiredState };
+          } catch (err) {
+            console.error(`[mech] Failed to parse request ${requestId}:`, err);
+          }
+        }
+      }
+    } catch (err) {
+      console.error('[mech] Error polling for requests:', err);
+    }
+
+    await new Promise(r => setTimeout(r, this.config.pollIntervalMs));
+  }
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles cleanly**
+
+Run: `cd client && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 3: Run all existing tests**
+
+Run: `cd client && npx vitest run`
+Expected: All tests pass. (The daemon tests use `LocalAdapter`, not `MechAdapter`, so they are unaffected.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/adapters/mech/adapter.ts
+git commit -m "feat(client): simplify watchForRequests — router enforces ordering on-chain"
+```
+
+---
+
+### Task 6: Write adapter unit tests for pending evaluation lifecycle
+
+**Files:**
+- Create: `client/test/adapters/mech/adapter.test.ts`
+
+- [ ] **Step 1: Write tests for MechAdapter pending evaluation tracking**
+
+These tests verify the in-memory lifecycle without hitting the chain. They mock the contract helpers and IPFS to test the adapter's orchestration logic.
+
+Create `client/test/adapters/mech/adapter.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { MechAdapterConfig } from '../../../src/adapters/mech/types.js';
+
+// Mock contract helpers
+vi.mock('../../../src/adapters/mech/contracts.js', () => ({
+  submitRestorationJob: vi.fn().mockResolvedValue(['0x' + 'aa'.repeat(32)]),
+  submitEvaluationJob: vi.fn().mockResolvedValue(['0x' + 'bb'.repeat(32)]),
+  claimDelivery: vi.fn().mockResolvedValue('0x1234'),
+  getMechDeliveryRate: vi.fn().mockResolvedValue(1000000n),
+  getTimeoutBounds: vi.fn().mockResolvedValue({ min: 60n, max: 300n }),
+  decodeMarketplaceRequestLogs: vi.fn().mockReturnValue([]),
+  decodeDeliverLogs: vi.fn().mockReturnValue([]),
+  callDeliverToMarketplace: vi.fn(),
+}));
+
+// Mock IPFS
+vi.mock('../../../src/adapters/mech/ipfs.js', () => ({
+  buildDesiredStatePayload: vi.fn().mockReturnValue({ desiredStateId: 'ds-1', description: 'test' }),
+  uploadToIpfs: vi.fn().mockResolvedValue('QmFakeCid'),
+  cidToDigestHex: vi.fn().mockReturnValue('0x' + 'cc'.repeat(32)),
+  fetchFromIpfs: vi.fn().mockResolvedValue({ data: 'result' }),
+  parseDesiredStateFromPayload: vi.fn().mockReturnValue({ id: 'ds-1', description: 'test' }),
+  digestHexToGatewayUrl: vi.fn(),
+}));
+
+// Mock Safe
+vi.mock('../../../src/adapters/mech/safe.js', () => ({
+  createClients: vi.fn().mockReturnValue({
+    publicClient: {
+      getBlockNumber: vi.fn().mockResolvedValue(100n),
+      getLogs: vi.fn().mockResolvedValue([]),
+      readContract: vi.fn(),
+    },
+    walletClient: {},
+    account: {},
+  }),
+}));
+
+const TEST_CONFIG: MechAdapterConfig = {
+  rpcUrl: 'http://localhost:8545',
+  mechMarketplaceAddress: '0x' + '11'.repeat(20) as `0x${string}`,
+  routerAddress: '0x' + '22'.repeat(20) as `0x${string}`,
+  mechContractAddress: '0x' + '33'.repeat(20) as `0x${string}`,
+  safeAddress: '0x' + '44'.repeat(20) as `0x${string}`,
+  agentEoaPrivateKey: '0x' + '55'.repeat(32) as `0x${string}`,
+  ipfsRegistryUrl: 'http://localhost:5001',
+  ipfsGatewayUrl: 'http://localhost:8080',
+  pollIntervalMs: 1000,
+  chainId: 8453,
+};
+
+describe('MechAdapter with JinnRouter', () => {
+  it('postDesiredState calls submitRestorationJob with router address', async () => {
+    const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+    const { submitRestorationJob } = await import('../../../src/adapters/mech/contracts.js');
+
+    const adapter = new MechAdapter(TEST_CONFIG);
+    await adapter.initialize();
+
+    const requestId = await adapter.postDesiredState({ id: 'ds-1', description: 'test' });
+
+    expect(requestId).toBe('0x' + 'aa'.repeat(32));
+    expect(submitRestorationJob).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      TEST_CONFIG.safeAddress,
+      TEST_CONFIG.routerAddress,
+      TEST_CONFIG.mechContractAddress,
+      expect.any(String),
+      expect.any(BigInt),
+      expect.any(BigInt),
+    );
+
+    await adapter.stop();
+  });
+
+  it('postDesiredState does NOT call submitEvaluationJob upfront', async () => {
+    const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+    const { submitEvaluationJob } = await import('../../../src/adapters/mech/contracts.js');
+
+    const adapter = new MechAdapter(TEST_CONFIG);
+    await adapter.initialize();
+
+    await adapter.postDesiredState({ id: 'ds-1', description: 'test' });
+
+    expect(submitEvaluationJob).not.toHaveBeenCalled();
+
+    await adapter.stop();
+  });
+});
+
+describe('claimDelivery error handling', () => {
+  it('treats AlreadyClaimed as success', async () => {
+    const contracts = await import('../../../src/adapters/mech/contracts.js');
+    const mockClaim = vi.mocked(contracts.claimDelivery);
+    mockClaim.mockRejectedValueOnce(new Error('AlreadyClaimed'));
+
+    // AlreadyClaimed is handled inside claimDelivery itself (returns '0x'),
+    // so this test verifies the function signature works with the mock.
+    // The actual retry/idempotency logic lives in contracts.ts.
+    expect(mockClaim).toBeDefined();
+  });
+
+  it('retries on NotDelivered up to 3 times', async () => {
+    const contracts = await import('../../../src/adapters/mech/contracts.js');
+    const mockClaim = vi.mocked(contracts.claimDelivery);
+    mockClaim
+      .mockRejectedValueOnce(new Error('NotDelivered'))
+      .mockRejectedValueOnce(new Error('NotDelivered'))
+      .mockResolvedValueOnce('0x1234' as `0x${string}`);
+
+    // The retry logic lives in claimDelivery in contracts.ts.
+    // This verifies the mock can simulate the retry sequence.
+    expect(mockClaim).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cd client && npx vitest run test/adapters/mech/adapter.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/test/adapters/mech/adapter.test.ts
+git commit -m "test(client): add MechAdapter unit tests for JinnRouter integration"
+```
+
+---
+
+### Task 7: Update e2e-validate.ts for router
+
+**Files:**
+- Modify: `client/scripts/e2e-validate.ts`
+
+Note: `client/fixtures/local-config.json` is for the `LocalAdapter` and has no mech-related fields. Do not modify it.
+
+- [ ] **Step 1: Add ROUTER_ADDRESS constant**
+
+In `client/scripts/e2e-validate.ts`, add after the `MARKETPLACE_ADDRESS` constant:
+
+```ts
+const ROUTER_ADDRESS: Address = '0xfFa7118A3D820cd4E820010837D65FAfF463181B';
+```
+
+- [ ] **Step 2: Add `routerAddress` to all MechAdapter config objects in the script**
+
+Search for all `MechAdapter` constructor calls and `MechAdapterConfig` objects in `e2e-validate.ts`. Add `routerAddress: ROUTER_ADDRESS` to each config object. This is required because `MechAdapterConfig` now requires `routerAddress` (from Task 1).
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+Run: `cd client && npx tsc --noEmit`
+Expected: No errors related to `e2e-validate.ts`.
+
+Note: Full e2e script rewrite (updating `postDesiredState` assertions, adding claim + evaluation test phases) is deferred. The Anvil fork already includes the JinnRouter since it forks Base mainnet where the router is deployed and initialized. The existing requester assertions in Phase 5c will need updating (requester is now the router address, not the Safe) but that is a follow-up task.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/scripts/e2e-validate.ts
+git commit -m "chore(client): add JinnRouter address to e2e script configs"
+```
+
+---
+
+### Task 8: Final verification and cleanup
+
+**Files:**
+- All modified files from Tasks 1-7
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cd client && npx vitest run`
+Expected: All tests pass.
+
+- [ ] **Step 2: Verify TypeScript compiles cleanly**
+
+Run: `cd client && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 3: Verify no leftover references to `submitMarketplaceRequest`**
+
+Run: `grep -r "submitMarketplaceRequest" client/src/`
+Expected: No matches.
+
+- [ ] **Step 4: Verify no leftover references to `deferredEvaluations` or `isEvaluationReady`**
+
+Run: `grep -r "deferredEvaluations\|isEvaluationReady" client/src/`
+Expected: No matches.
+
+- [ ] **Step 5: Review diff for accidental changes**
+
+Run: `git diff HEAD~8 --stat` (or however many commits since Task 1)
+Expected: Only the files listed in the File Map are changed.

--- a/docs/superpowers/specs/2026-03-26-jinnrouter-client-integration-design.md
+++ b/docs/superpowers/specs/2026-03-26-jinnrouter-client-integration-design.md
@@ -1,0 +1,157 @@
+# JinnRouter Client Integration Design
+
+> Version: 0.1.0
+> Date: 2026-03-26
+> Author: Oak
+
+## Summary
+
+Modify the `MechAdapter` in `client/` to route all marketplace requests through the deployed JinnRouter contract instead of calling `marketplace.request()` directly. Add `claimDelivery()` after mech delivery and defer evaluation job creation until after restoration delivery is claimed, matching the on-chain loop enforcement.
+
+## Context
+
+The JinnRouter is deployed on Base at `0xfFa7118A3D820cd4E820010837D65FAfF463181B` behind the activity checker proxy at `0x477C41Cccc8bd08027e40CEF80c25918C595a24d`. It serves as both the request router for the Jinn training loop and the OLAS-compatible activity checker for staking rewards.
+
+The client at `client/` (commit `05b414c`) currently calls `marketplace.request()` directly and fires both restoration and evaluation requests upfront in `postDesiredState()`. The JinnRouter requires requests to go through `createRestorationJob()` / `createEvaluationJob()`, and enforces loop ordering on-chain: `createEvaluationJob` reverts unless `claimDelivery` has been called for the referenced restoration request.
+
+## Approach
+
+Modify `MechAdapter` in-place (Approach A). The router is the only path for all Jinn participants — there is no reason to keep raw marketplace access.
+
+## 1. Config and ABI
+
+`MechAdapterConfig` gains one field:
+
+```ts
+routerAddress: `0x${string}`;  // JinnRouter proxy on Base
+```
+
+`mechMarketplaceAddress` is retained for `getTimeoutBounds`, `mapRequestIdInfos` (delivery status checks), and `MarketplaceRequest` event decoding.
+
+New `JINN_ROUTER_ABI` in `types.ts`:
+
+| Function | Signature |
+|----------|-----------|
+| `createRestorationJob` | `(bytes requestData, address priorityMech, uint256 maxDeliveryRate, uint256 responseTimeout, bytes32 paymentType, bytes paymentData) payable returns (bytes32 requestId)` |
+| `createEvaluationJob` | `(bytes32 restorationRequestId, bytes requestData, address evaluationMech, uint256 maxDeliveryRate, uint256 responseTimeout, bytes32 paymentType, bytes paymentData) payable returns (bytes32 requestId)` |
+| `claimDelivery` | `(bytes32 requestId)` |
+
+Events: `RestorationJobCreated(address indexed creator, bytes32 indexed requestId)`, `EvaluationJobCreated(address indexed creator, bytes32 indexed requestId, bytes32 indexed restorationRequestId)`, `DeliveryClaimed(address indexed claimer, bytes32 indexed requestId, uint8 jobType)`.
+
+## 2. Contract call changes (`contracts.ts`)
+
+### Replace `submitMarketplaceRequest` with two functions
+
+**`submitRestorationJob()`** — encodes `router.createRestorationJob()`, sends Safe tx to `routerAddress` (not `marketplaceAddress`), parses `RestorationJobCreated` event for the request ID.
+
+**`submitEvaluationJob()`** — encodes `router.createEvaluationJob(restorationRequestId, ...)`, sends Safe tx to `routerAddress`, parses `EvaluationJobCreated` event for the request ID.
+
+### New `claimDelivery()`
+
+Encodes `router.claimDelivery(requestId)`, sends Safe tx to `routerAddress`. The Solidity function has no return value; the client returns the Safe-level tx hash. Success is confirmed by the `DeliveryClaimed` event.
+
+### Unchanged
+
+`getMechDeliveryRate`, `getTimeoutBounds`, `decodeDeliverLogs`, `callDeliverToMarketplace` — these interact with the mech and marketplace, which are unchanged.
+
+## 3. Adapter flow changes (`adapter.ts`)
+
+### `postDesiredState()`
+
+Current: posts restoration request + evaluation request upfront.
+New: posts restoration request only. Stores the desired state in `pendingEvaluations: Map<requestId, DesiredState>` for later evaluation creation.
+
+```
+postDesiredState(state)
+  1. Build payload, upload to IPFS, get digest
+  2. submitRestorationJob(routerAddress, ...) → restorationRequestId
+  3. pendingEvaluations.set(restorationRequestId, state)
+  4. return restorationRequestId
+```
+
+### `watchForDeliveries()`
+
+Current: polls `Deliver` events, yields `DeliveredResult`.
+New: after detecting a delivery, calls `claimDelivery(requestId)` via Safe tx. Handles both restoration deliveries (which trigger evaluation creation) and evaluation deliveries (which just need claiming).
+
+The adapter tracks two sets:
+- `pendingEvaluations: Map<requestId, DesiredState>` — restoration requests awaiting delivery before evaluation can be posted. Populated by `postDesiredState`, consumed after restoration delivery claim succeeds.
+- `pendingEvaluationClaims: Set<requestId>` — evaluation request IDs awaiting delivery. Populated when `submitEvaluationJob` returns, consumed after evaluation delivery claim succeeds.
+
+```
+watchForDeliveries()
+  for each Deliver event:
+    1. Parse delivery data from IPFS
+    2. Skip if requestId is not in pendingEvaluations or pendingEvaluationClaims
+       (avoids wasting gas on claimDelivery for requests this client didn't create)
+    3. claimDelivery(requestId) via Safe tx
+    4. if pendingEvaluations.has(requestId):
+       // Restoration delivery — post the evaluation job
+       a. Build evaluation payload, upload to IPFS
+       b. evalRequestId = submitEvaluationJob(routerAddress, requestId, ...)
+       c. pendingEvaluationClaims.add(evalRequestId)
+       d. pendingEvaluations.delete(requestId)  // only after eval job succeeds
+    5. if pendingEvaluationClaims.has(requestId):
+       // Evaluation delivery — claim already happened in step 3
+       a. pendingEvaluationClaims.delete(requestId)
+    6. yield DeliveredResult
+```
+
+**Evaluation mech address:** Phase 0 uses the same mech for both restoration and evaluation (`config.mechContractAddress`). If separate evaluation mechs are needed later, add an optional `evaluationMechAddress` to `MechAdapterConfig`.
+
+**Persistence:** `pendingEvaluations` and `pendingEvaluationClaims` are in-memory. If the client crashes between posting a restoration job and the delivery arriving, the pending evaluation is lost. This is a known Phase 0 limitation — recovery can be added later by scanning recent `RestorationJobCreated` events on startup and rebuilding the pending set for any unclaimed requests.
+
+### `watchForRequests()`
+
+Mostly unchanged. Still polls `MarketplaceRequest` events on the marketplace (the router calls `marketplace.request()` internally, so the same events fire). The `requester` indexed field is now the router address, not the Safe — but we already filter by mech, not requester.
+
+**Remove `isEvaluationReady` and `deferredEvaluations`.** The router enforces ordering on-chain. The client no longer needs to check marketplace delivery status before yielding evaluation requests — if the evaluation request exists on-chain, the router already verified the restoration was claimed.
+
+## 4. Safe nonce budget
+
+Nonces consumed per full loop:
+
+| Step | Safe tx | Router counter |
+|------|---------|----------------|
+| `createRestorationJob()` | +1 | creationCount +1 |
+| `mech.deliverToMarketplace()` | +1 | (none) |
+| `claimDelivery(restoration)` | +1 | restorationDeliveryCount +1 |
+| `createEvaluationJob()` | +1 | evaluationCreationCount +1 |
+| Evaluation mech delivers | +1 | (none) |
+| `claimDelivery(evaluation)` | +1 | evaluationDeliveryCount +1 |
+
+6 nonces, 4 activity counters. `4 <= 6` passes the `total <= nonceDelta` bound in `isRatioPass()`.
+
+No heartbeat logic is needed. The old jinn-node heartbeat compensated for V2's single-dimension checker. The JinnRouter counts real loop activity across four dimensions.
+
+## 5. Error handling
+
+### `claimDelivery` failures
+
+| Error | Handling |
+|-------|----------|
+| `AlreadyClaimed` | Idempotent. Catch, log, continue. |
+| `NotDelivered` | Race condition — delivery event seen but marketplace state not settled. Retry 3 times with 2s backoff. If all retries fail, skip — the entry remains in `pendingEvaluations`/`pendingEvaluationClaims` and will be retried on the next delivery poll cycle. |
+| `RequestNotFound` | Request wasn't created through router. Log warning, skip. |
+
+### `createEvaluationJob` failures
+
+| Error | Handling |
+|-------|----------|
+| `RestorationNotClaimed` | Re-attempt `claimDelivery` first, then retry evaluation creation. |
+
+### Delivery attribution
+
+The deployed JinnRouter does not verify the claimer is the actual deliverer (Phase 0 simplification per spec section 6.2). Any Safe can claim any router-created request. However, `claimDelivery` credits `msg.sender` — the counter increments for the *claiming* Safe. The client must always claim deliveries from the same Safe that created the job to ensure activity counters align with the correct service multisig.
+
+## 6. File-level changes
+
+| File | Change |
+|------|--------|
+| `src/adapters/mech/types.ts` | Add `JINN_ROUTER_ABI`. Add `routerAddress` to `MechAdapterConfig`. |
+| `src/adapters/mech/contracts.ts` | Replace `submitMarketplaceRequest()` with `submitRestorationJob()` and `submitEvaluationJob()`. Add `claimDelivery()`. Keep `getMechDeliveryRate`, `getTimeoutBounds`, `decodeDeliverLogs`, `callDeliverToMarketplace` unchanged. |
+| `src/adapters/mech/adapter.ts` | Rewrite `postDesiredState()` (restoration only + pending map). Update `watchForDeliveries()` (add claim + evaluation). Remove `isEvaluationReady` and `deferredEvaluations`. |
+| `scripts/e2e-validate.ts` | Update to use router address. Add claim + evaluation steps. |
+| `test/adapters/mech/*.test.ts` | Update for new function signatures. Add tests for claim retry and evaluation-after-claim. |
+
+No new files. No changes to the adapter interface, daemon, runners, store, IPFS, or Safe transaction handling.


### PR DESCRIPTION
## Summary

Route all marketplace requests through the deployed JinnRouter contract, add delivery claiming for OLAS staking counters, defer evaluation creation until after restoration delivery, and add crash recovery.

## Changes

### JinnRouter integration (original)
- Route requests through `router.createRestorationJob`/`createEvaluationJob` instead of `marketplace.request()` directly
- `claimDelivery()` after mech delivery increments staking activity counters
- Evaluation job creation deferred until restoration delivery is claimed (on-chain enforcement)
- Retry sweep for failed evaluation creation (`claimedButNotEvaluated`)

### Crash recovery
- `recoverPendingState()` in `initialize()` scans `RestorationJobCreated`/`EvaluationJobCreated` events to rebuild in-memory state after restart
- Persists last processed block in SQLite store for efficient recovery scans

### Delivery watcher
- New `DeliveryWatcherLoop` drives `watchForDeliveries()` — the claim→evaluate chain now runs in the daemon
- Daemon runs three concurrent loops: CreatorLoop + RestorerLoop + DeliveryWatcherLoop

### Smarter mock agent
- Mock agent reads `type` from MCP server and branches: restoration produces `restoration-result`, evaluation produces `evaluation-verdict` with `restorationRequestId` and `success` flag
- ClaudeRunner + MCP server pass `DESIRED_STATE_TYPE` and `RESTORATION_REQUEST_ID` env vars

### Fixed delivery yields
- `watchForDeliveries` now uses stored original `desiredState` (via `originalStates` map) instead of reconstructing from result payload
- Yielded `DeliveredResult` has correct `type` field for consumer disambiguation

## Files changed

| File | What |
|------|------|
| `types.ts` | `JINN_ROUTER_ABI`, `routerAddress` config field |
| `contracts.ts` | `submitRestorationJob`, `submitEvaluationJob`, `claimDelivery`, `scanRestorationJobs`, `scanEvaluationJobs` |
| `adapter.ts` | JinnRouter flow, crash recovery, `originalStates` tracking, deferred evaluation |
| `daemon.ts` | Added `DeliveryWatcherLoop` |
| `delivery-watcher.ts` | NEW — drives `watchForDeliveries()` |
| `store.ts` | `getLastProcessedBlock` / `setLastProcessedBlock` |
| `claude.ts` | Pass `DESIRED_STATE_TYPE` + `RESTORATION_REQUEST_ID` to MCP server |
| `server.ts` | Expose `type` + `restorationRequestId` in `get_desired_state` |
| `mock-agent.ts` | Differentiate restoration vs evaluation, structured outputs |
| `e2e-validate.ts` | Full rewrite — 11 phases |
| `adapter.test.ts` | NEW — mocked adapter tests for router flow |
| `contracts.test.ts` | NEW — ABI encoding roundtrip tests |

## E2E test phases (11 phases, all passing)

| Phase | What it validates |
|-------|------------------|
| 1 | Anvil fork, fund real operator |
| 2 | `postDesiredState` → real IPFS → real JinnRouter → marketplace |
| 3 | RestorerLoop → ClaudeRunner → mock agent via MCP → `submitResult` → Safe → AgentMech |
| 4 | `watchForDeliveries` → `claimDelivery` (DeliveryClaimed verified) → `createEvaluationJob` |
| 5 | RestorerLoop delivers evaluation via ClaudeRunner |
| 6 | `claimDelivery` for evaluation (DeliveryClaimed verified) → lifecycle complete |
| 7 | Full Daemon — three concurrent loops with Safe nonce mutex |
| 9 | Priority window — non-priority mech delivers after timeout |
| 10 | Crash recovery — stop adapter, deliver while down, restart, verify recovery |
| 11 | Cross-operator — Operator A creates, Operator B (different Safe + mech) restores + evaluates |

Real IPFS, real JinnRouter, real Safe signing, real agent subprocess, zero impersonation (except Phase 9 for marketplace timeout testing and Phase 10 for simulating delivery while down).

## Test plan

- [x] Unit tests pass (28/28)
- [x] TypeScript compiles clean
- [x] E2E validates full JinnRouter flow (11 phases)
- [x] Cross-operator flow with two real operator credentials
- [x] Staking counter verification (DeliveryClaimed events)
- [x] Crash recovery tested
- [x] Priority window tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)