### PR TITLE
client: agent packaging — quickstart, dashboard, MCP server, plugin system

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -63,6 +63,9 @@
     "viem": "^2.0.0",
     "zod": "^3.22.0"
   },
+  "optionalDependencies": {
+    "@coinbase/cdp-sdk": "^1.47.0"
+  },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",
     "@types/node": "^20.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,8 @@
     "node": ">=20"
   },
   "bin": {
-    "jinn": "./dist/bin/jinn.js"
+    "jinn": "./dist/bin/jinn.js",
+    "jinn-mcp": "./dist/bin/jinn-mcp.js"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -29,7 +30,7 @@
   },
   "scripts": {
     "jinn": "tsx src/bin/jinn.ts",
-    "build": "tsc && chmod +x dist/bin/jinn.js && mkdir -p dist/dashboard && cp src/dashboard/index.html dist/dashboard/index.html && node scripts/write-dist-build-meta.mjs",
+    "build": "tsc && chmod +x dist/bin/jinn.js dist/bin/jinn-mcp.js && mkdir -p dist/dashboard && cp src/dashboard/index.html dist/dashboard/index.html && node scripts/write-dist-build-meta.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/client/package.json
+++ b/client/package.json
@@ -22,6 +22,7 @@
   "files": [
     "dist/",
     "deployments/",
+    "skills/",
     "README.md",
     "LICENSE"
   ],

--- a/client/package.json
+++ b/client/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "jinn": "tsx src/bin/jinn.ts",
-    "build": "tsc && chmod +x dist/bin/jinn.js && node scripts/write-dist-build-meta.mjs",
+    "build": "tsc && chmod +x dist/bin/jinn.js && mkdir -p dist/dashboard && cp src/dashboard/index.html dist/dashboard/index.html && node scripts/write-dist-build-meta.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/client/skills/jinn-operator/SKILL.md
+++ b/client/skills/jinn-operator/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: jinn-operator
+description: Set up and operate a Jinn Network agent. Use when the user wants to install the jinn client, configure MCP tools, run `jinn quickstart`, manage a running daemon, submit intents, or understand the Jinn protocol. Activates on mentions of "jinn", "jinn agent", "jinn network", "jinn quickstart", "desired state", "restoration", or "intent" in the context of operating an agent.
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep
+---
+
+# Jinn Operator Skill
+
+Guides you through installing, configuring, and operating a Jinn Network agent.
+
+## What Is Jinn
+
+Jinn is a training protocol for agentic intents. It defines a loop:
+
+```
+Creation  -->  Execution  -->  Evaluation  -->  Knowledge
+   |                                               |
+   +-----------------------------------------------+
+```
+
+1. **Creation** — a creator publishes a *desired state* (an intent describing what should be true)
+2. **Execution** — a restorer claims the intent and attempts to make it true
+3. **Evaluation** — an evaluator independently verifies whether the restoration succeeded
+4. **Knowledge** — artifacts (learnings, evidence) accumulate to improve future attempts
+
+Agents earn rewards by participating in this loop. The protocol runs on Base (mainnet) and Base Sepolia (testnet).
+
+## Phase 1: Installation
+
+Check if jinn is already installed:
+
+```bash
+jinn --help
+```
+
+If not installed:
+
+```bash
+npm install -g @jinn-network/client
+```
+
+This gives you two binaries:
+- `jinn` — the operator CLI (17 verbs)
+- `jinn-mcp` — the MCP server for agent-to-agent operation
+
+### Prerequisites
+
+- **Node.js 22+** — `node --version` to check
+- **Claude Code CLI** — the daemon spawns Claude as a subprocess for restoration work. Must be installed and authenticated separately.
+
+## Phase 2: MCP Configuration
+
+If the user wants their agent (Claude Code, Cursor, etc.) to operate jinn programmatically, configure the MCP server:
+
+**For Claude Code** — add to project or user MCP settings:
+```json
+{
+  "mcpServers": {
+    "jinn": {
+      "command": "jinn-mcp"
+    }
+  }
+}
+```
+
+**With npx (no global install needed):**
+```json
+{
+  "mcpServers": {
+    "jinn": {
+      "command": "npx",
+      "args": ["-y", "-p", "@jinn-network/client", "jinn-mcp"]
+    }
+  }
+}
+```
+
+Once configured, these MCP tools become available:
+
+| Tool | What it does |
+|------|-------------|
+| `jinn_init` | Create master wallet (idempotent) |
+| `jinn_doctor` | Preflight checks |
+| `jinn_status` | Daemon health + fleet roll-up |
+| `jinn_fleet` | Per-service detail |
+| `jinn_balance` | Wallet balances |
+| `jinn_history` | Recent protocol activity |
+| `jinn_rewards` | Earned vs claimed rewards |
+| `jinn_bootstrap` | Advance fleet state machine |
+| `jinn_submit_intent` | Post a desired state on-chain |
+| `jinn_start_daemon` | Start daemon in background |
+| `jinn_stop_daemon` | Stop running daemon |
+
+## Phase 3: Quickstart (Zero to Running)
+
+The fastest path from nothing to a running agent:
+
+```bash
+jinn quickstart
+```
+
+This single command:
+1. Generates a random keystore password (saved to `~/.jinn-client/keystore-password`)
+2. Creates the master wallet
+3. Funds via Coinbase CDP faucet (automatic on testnet)
+4. Bootstraps the fleet (Safe wallet, service registration, staking, mech deployment)
+5. Starts the daemon
+
+When it finishes: **open `http://localhost:7331`** for the operator dashboard.
+
+### If the user already has JINN_PASSWORD set:
+
+```bash
+JINN_PASSWORD=their-password jinn quickstart
+```
+
+The command respects an existing password and won't generate a new one.
+
+### If quickstart stops at "funding required":
+
+The automatic faucet may have rate-limited (1 claim per 24 hours per address). Options:
+- Wait 24 hours and re-run `jinn quickstart`
+- Fund manually: go to https://portal.cdp.coinbase.com/products/faucet, send testnet ETH to the printed master address, then re-run
+
+## Phase 4: Ongoing Operation
+
+### Monitoring
+
+- **Dashboard:** `http://localhost:7331` (when daemon is running)
+- **CLI:** `jinn status` for a quick health check
+- **Fleet detail:** `jinn fleet` shows each service's step, Safe, mech, staking status
+- **Balances:** `jinn balance` shows master and service wallet balances
+
+### Submitting Intents
+
+To post a desired state for the network to work on:
+
+```bash
+jinn submit-intent --id my-intent --description "The service publishes a daily summary" --yes
+```
+
+Or via MCP: call `jinn_submit_intent` with `id` and `description` parameters.
+
+### Checking Rewards
+
+```bash
+jinn rewards
+```
+
+Shows pending vs claimed rewards per service.
+
+### Changing the Auto-Generated Password
+
+If the user started with `jinn quickstart` and wants to set their own password:
+
+```bash
+JINN_NEW_PASSWORD=their-new-password jinn keys change-password
+```
+
+This re-encrypts the keystore and deletes the auto-generated password file. The wallet and all on-chain state are unchanged.
+
+### Stopping and Starting
+
+```bash
+jinn stop       # stop the daemon
+jinn run        # start in foreground
+```
+
+## Troubleshooting
+
+### `jinn doctor` fails on claude_binary
+
+Claude Code CLI is not installed or not on PATH. Install it separately — see https://claude.ai/code.
+
+### Bootstrap stuck at "awaiting funding"
+
+The master wallet needs testnet ETH. Either:
+- The CDP faucet rate-limited (wait 24h)
+- The faucet SDK isn't installed: `npm install @coinbase/cdp-sdk`
+- Fund manually via a web faucet
+
+### Daemon starts but no activity
+
+Check `jinn status`. If `rpc.ok` is false, the RPC endpoint is down. The default (`https://sepolia.base.org`) is rate-limited. Consider using your own RPC via config:
+
+```bash
+echo '{"rpcUrl": "https://your-rpc.example.com"}' > ~/.jinn-client/config.json
+```
+
+### "No service is ready" after bootstrap
+
+Bootstrap may need multiple runs if it hit a funding gate partway through. Re-run `jinn bootstrap` (it's idempotent — picks up where it left off).
+
+## Key Concepts for Agents
+
+When operating jinn tools, keep this mental model:
+
+- **`jinn quickstart`** is the one-shot setup. After this, the daemon is running.
+- **`jinn status`** is your health check. Poll it to know if things are working.
+- **`jinn submit-intent`** is the main action verb. This is how you create work on the network.
+- **`jinn fleet`** tells you about your staked services and their state.
+- **`jinn bootstrap`** is idempotent. If anything is stuck, re-running it is always safe.
+- **`funding_required`** means "the wallet needs ETH." On testnet, this should auto-resolve via faucet. If not, the user needs to fund manually.
+- The daemon runs three loops: creator (posts intents), restorer (claims and fulfills intents), delivery-watcher (evaluates results). All three run automatically once the daemon starts.
+
+## Network Details
+
+| | Testnet (default) | Mainnet |
+|---|---|---|
+| Chain | Base Sepolia | Base |
+| RPC default | `https://sepolia.base.org` | `https://mainnet.base.org` |
+| Staking mode | standard (stOLAS, no OLAS needed) | standard |
+| Config key | `"network": "testnet"` | `"network": "mainnet"` |

--- a/client/src/api/server.ts
+++ b/client/src/api/server.ts
@@ -15,6 +15,9 @@ import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { serve } from '@hono/node-server';
 import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { Store } from '../store/store.js';
 import { addX402Routes, type X402Config } from '../x402/handler.js';
 import {
@@ -38,11 +41,21 @@ export interface ApiServer {
   close(): Promise<void>;
 }
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+let dashboardHtml: string;
+try {
+  dashboardHtml = readFileSync(join(__dirname, '..', 'dashboard', 'index.html'), 'utf-8');
+} catch {
+  dashboardHtml = '<html><body><p>Dashboard not found. Rebuild with <code>yarn build</code>.</p></body></html>';
+}
+
 export async function startApiServer(config: ApiServerConfig): Promise<ApiServer> {
   const { store } = config;
   const app = new Hono();
 
   app.use(cors());
+
+  app.get('/', (c) => c.html(dashboardHtml));
 
   app.get('/v1/status', async (c) => {
     try {

--- a/client/src/bin/jinn-mcp.ts
+++ b/client/src/bin/jinn-mcp.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+/**
+ * jinn-mcp — standalone MCP server exposing operator-level tools.
+ *
+ * Designed to be launched by an MCP-aware host (Claude Desktop, Cursor, etc.)
+ * via stdio transport.  Each tool delegates to the same command modules that
+ * the `jinn` CLI uses, so behaviour is always consistent.
+ *
+ * Usage (in an MCP host config):
+ *   { "command": "jinn-mcp" }
+ *
+ * Context: docs/research/2026-04-agent-packaging.md sections 2.2, 5.1-5.3
+ */
+
+import { createOperatorServer } from '../mcp/operator-server.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+const server = createOperatorServer();
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/client/src/cli/commands/bootstrap.ts
+++ b/client/src/cli/commands/bootstrap.ts
@@ -75,6 +75,7 @@ async function run(ctx: CommandContext): Promise<void> {
     earningDir: config.earningDir,
     chain: config.network === 'testnet' ? 'base-sepolia' : 'base',
     rpcUrl: config.rpcUrl,
+    env: ctx.env,
     stakingMode: config.stakingMode,
     targetServices: config.targetServices,
     testnetL2DeploymentPath: config.testnetL2DeploymentPath,

--- a/client/src/cli/commands/keys-backup.ts
+++ b/client/src/cli/commands/keys-backup.ts
@@ -1,11 +1,14 @@
 import { parseArgs } from 'node:util';
-import { writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { CommandContext, CommandModule } from '../command.js';
+import { COMMON_FLAGS } from '../command.js';
 import { emitResult } from '../output.js';
 import { emitEnvelope } from '../../errors/envelope.js';
 import { FleetStateStore } from '../../earning/store.js';
-import { decryptMnemonic } from '../../earning/wallet.js';
+import { decryptMnemonic, encryptMnemonic } from '../../earning/wallet.js';
+import { resolveCurrentPassword, resolveNewPassword } from '../password.js';
 
 async function runBackup(ctx: CommandContext, rest: string[]): Promise<void> {
   let parsed;
@@ -88,27 +91,171 @@ async function runBackup(ctx: CommandContext, rest: string[]): Promise<void> {
   );
 }
 
+async function runChangePassword(ctx: CommandContext, rest: string[]): Promise<void> {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args: rest,
+      options: { ...COMMON_FLAGS },
+      allowPositionals: false,
+    });
+  } catch (err) {
+    emitEnvelope(
+      {
+        code: 'invalid_invocation',
+        message: err instanceof Error ? err.message : String(err),
+        exampleCli: 'JINN_PASSWORD=old JINN_NEW_PASSWORD=new jinn keys change-password',
+        details: { field: 'flags' },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
+
+  // 1. Resolve earning dir
+  const earningDir =
+    ctx.env['JINN_EARNING_DIR'] ?? join(homedir(), '.jinn-client', 'earning');
+  const store = new FleetStateStore(earningDir);
+
+  // 2. Check keystore exists
+  if (!store.hasMnemonicKeystore()) {
+    emitEnvelope(
+      {
+        code: 'invalid_invocation',
+        message: 'No keystore found. Run `jinn init` first.',
+        exampleCli: 'jinn init',
+        details: { field: 'keystore' },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
+
+  // 3. Resolve current password
+  const current = resolveCurrentPassword(ctx.argv, ctx.env);
+  if (!current.ok) {
+    emitEnvelope(
+      {
+        code: 'invalid_invocation',
+        message: current.message,
+        exampleCli: 'JINN_PASSWORD=old JINN_NEW_PASSWORD=new jinn keys change-password',
+        details: { field: 'JINN_PASSWORD' },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
+
+  // 4. Decrypt mnemonic
+  let mnemonic: string;
+  try {
+    mnemonic = await decryptMnemonic(await store.loadMnemonicKeystore(), current.password);
+  } catch {
+    emitEnvelope(
+      {
+        code: 'invalid_invocation',
+        message: 'Failed to decrypt keystore. Wrong password?',
+        exampleCli: 'JINN_PASSWORD=correct JINN_NEW_PASSWORD=new jinn keys change-password',
+        details: { field: 'JINN_PASSWORD' },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
+
+  // 5. Resolve new password
+  const newPass = resolveNewPassword(ctx.env);
+  if (!newPass.ok) {
+    emitEnvelope(
+      {
+        code: 'invalid_invocation',
+        message: newPass.message,
+        exampleCli: 'JINN_PASSWORD=old JINN_NEW_PASSWORD=new jinn keys change-password',
+        details: { field: 'JINN_NEW_PASSWORD' },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
+
+  // 6. Re-encrypt
+  const newKeystore = await encryptMnemonic(mnemonic, newPass.password);
+
+  // 7. Check if daemon is running (read pidfile, process.kill(pid, 0))
+  const pidPath = join(earningDir, 'daemon.pid');
+  if (existsSync(pidPath)) {
+    try {
+      const pid = parseInt(readFileSync(pidPath, 'utf-8').trim(), 10);
+      process.kill(pid, 0); // Just checks if process exists
+      console.error(
+        `[warn] Daemon (pid ${pid}) is running. The new password takes effect on next restart.`,
+      );
+    } catch {
+      /* daemon not running, ignore */
+    }
+  }
+
+  // 8. Save new keystore
+  await store.saveMnemonicKeystore(newKeystore);
+
+  // 9. Delete password file if it exists
+  const home = ctx.env['HOME'] ?? homedir();
+  const passwordFilePath = join(home, '.jinn-client', 'keystore-password');
+  let passwordFileDeleted = false;
+  if (existsSync(passwordFilePath)) {
+    unlinkSync(passwordFilePath);
+    passwordFileDeleted = true;
+  }
+
+  // 10. Emit result
+  emitResult(
+    {
+      schemaVersion: 1,
+      generatedAt: new Date().toISOString(),
+      verb: 'keys change-password',
+      keystoreDir: earningDir,
+      passwordFileDeleted,
+    },
+    (v) => {
+      const val = v as { keystoreDir: string; passwordFileDeleted: boolean };
+      return (
+        `Password changed.\nKeystore: ${val.keystoreDir}` +
+        (val.passwordFileDeleted ? '\nAuto-generated password file deleted.' : '') +
+        '\nSet JINN_PASSWORD for future commands.'
+      );
+    },
+    {
+      json: Boolean(parsed.values.json),
+      human: Boolean(parsed.values.human),
+      writer: ctx.writer,
+      stdoutIsTty: ctx.stdoutIsTty,
+      noColor: Boolean(ctx.env['NO_COLOR']),
+    },
+  );
+}
+
 async function run(ctx: CommandContext): Promise<void> {
   const [subverb, ...rest] = ctx.argv;
   if (!subverb) {
     emitEnvelope(
       {
         code: 'invalid_invocation',
-        message: 'jinn keys requires a subverb: backup',
+        message: 'jinn keys requires a subverb: backup, change-password',
         exampleCli: 'jinn keys backup --output /tmp/mnemonic.txt',
-        details: { field: 'subverb', expected: 'backup' },
+        details: { field: 'subverb', expected: 'backup | change-password' },
       },
       { writer: ctx.writer, exit: ctx.exit },
     );
     return;
   }
   if (subverb === 'backup') return runBackup(ctx, rest);
+  if (subverb === 'change-password') return runChangePassword(ctx, rest);
   emitEnvelope(
     {
       code: 'invalid_invocation',
       message: `Unknown keys subverb: ${subverb}`,
       exampleCli: 'jinn keys backup --output /tmp/mnemonic.txt',
-      details: { field: 'subverb', expected: 'backup' },
+      details: { field: 'subverb', expected: 'backup | change-password' },
     },
     { writer: ctx.writer, exit: ctx.exit },
   );
@@ -116,15 +263,29 @@ async function run(ctx: CommandContext): Promise<void> {
 
 const command: CommandModule = {
   name: 'keys',
-  summary: 'Keystore management: backup',
-  helpText: `Usage: jinn keys backup --output <path> [--human]
+  summary: 'Keystore management: backup, change-password',
+  helpText: `Usage:
+  jinn keys backup --output <path> [--human]
+  jinn keys change-password [--human]
 
-Decrypts the local keystore using JINN_PASSWORD and writes the
-mnemonic to <path> with mode 0600. Idempotent: same mnemonic →
-same output. No other side effects.
+Subverbs:
+  backup           Decrypt the keystore and write the mnemonic to a file.
+  change-password  Re-encrypt the keystore with a new password.
+
+backup:
+  Decrypts the local keystore using JINN_PASSWORD and writes the
+  mnemonic to <path> with mode 0600. Idempotent: same mnemonic →
+  same output. No other side effects.
+
+change-password:
+  Decrypts the keystore with the current password (from
+  ~/.jinn-client/keystore-password, JINN_PASSWORD, or --password-fd)
+  and re-encrypts it with JINN_NEW_PASSWORD (min 8 characters).
+  Deletes the auto-generated password file if present.
 
 Examples:
   JINN_PASSWORD=secret jinn keys backup --output ~/backup/jinn.txt
+  JINN_PASSWORD=old JINN_NEW_PASSWORD=mynewpass jinn keys change-password
 `,
   run,
 };

--- a/client/src/cli/commands/plugin-install.ts
+++ b/client/src/cli/commands/plugin-install.ts
@@ -634,13 +634,11 @@ async function runInstall(ctx: CommandContext, rest: string[]): Promise<void> {
       mcpResult = { status: r.ok ? 'configured' : 'error', detail: r.detail };
     }
 
-    let skillResult: { status: string; detail: string };
-    if (target.isSkillConfigured(scope)) {
-      skillResult = { status: 'skipped', detail: 'Already configured' };
-    } else {
-      const r = await target.installSkill(scope, skillContent);
-      skillResult = { status: r.ok ? 'configured' : 'error', detail: r.detail };
-    }
+    // Always run installSkill — the helpers handle both fresh installs and
+    // updates (replacing existing content), so skill changes propagate when
+    // the package is upgraded and `jinn plugin install` is re-run.
+    const sr = await target.installSkill(scope, skillContent);
+    const skillResult = { status: sr.ok ? 'configured' : 'error', detail: sr.detail };
 
     results.push({ target: target.id, mcp: mcpResult, skill: skillResult });
   }

--- a/client/src/cli/commands/plugin-install.ts
+++ b/client/src/cli/commands/plugin-install.ts
@@ -1,0 +1,925 @@
+import { parseArgs } from 'node:util';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync, copyFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { platform, homedir } from 'node:os';
+import type { CommandContext, CommandModule } from '../command.js';
+import { emitResult } from '../output.js';
+import { emitEnvelope } from '../../errors/envelope.js';
+
+// ---------------------------------------------------------------------------
+// Skill content resolution
+// ---------------------------------------------------------------------------
+
+const SKILL_DIR = fileURLToPath(new URL('../../../skills/jinn-operator', import.meta.url));
+
+function loadSkillContent(): string {
+  return readFileSync(join(SKILL_DIR, 'SKILL.md'), 'utf-8');
+}
+
+function stripFrontmatter(content: string): string {
+  const match = content.match(/^---\n[\s\S]*?\n---\n/);
+  if (!match) return content;
+  return content.slice(match[0].length).trimStart();
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — JSON MCP config
+// ---------------------------------------------------------------------------
+
+function readJsonFile(filePath: string): Record<string, unknown> {
+  if (!existsSync(filePath)) return {};
+  try {
+    return JSON.parse(readFileSync(filePath, 'utf-8')) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+function writeJsonFile(filePath: string, data: Record<string, unknown>): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+}
+
+function hasJsonMcpServer(filePath: string, rootKey: string): boolean {
+  const data = readJsonFile(filePath);
+  const section = data[rootKey] as Record<string, unknown> | undefined;
+  return section !== undefined && 'jinn' in section;
+}
+
+function upsertJsonMcpServer(filePath: string, rootKey: string): { ok: boolean; detail: string } {
+  const data = readJsonFile(filePath);
+  const section = (data[rootKey] ?? {}) as Record<string, unknown>;
+  if ('jinn' in section) {
+    return { ok: true, detail: `Already configured in ${filePath}` };
+  }
+  section['jinn'] = { command: 'jinn-mcp' };
+  data[rootKey] = section;
+  writeJsonFile(filePath, data);
+  return { ok: true, detail: `Wrote MCP entry to ${filePath}` };
+}
+
+function removeJsonMcpServer(filePath: string, rootKey: string): { ok: boolean; detail: string } {
+  if (!existsSync(filePath)) {
+    return { ok: true, detail: 'Config file does not exist' };
+  }
+  const data = readJsonFile(filePath);
+  const section = (data[rootKey] ?? {}) as Record<string, unknown>;
+  if (!('jinn' in section)) {
+    return { ok: true, detail: 'Not configured' };
+  }
+  delete section['jinn'];
+  data[rootKey] = section;
+  writeJsonFile(filePath, data);
+  return { ok: true, detail: `Removed MCP entry from ${filePath}` };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — TOML MCP config (Codex)
+// ---------------------------------------------------------------------------
+
+const TOML_BLOCK = `[mcp_servers.jinn]\ncommand = "jinn-mcp"`;
+
+function hasTomlMcpServer(filePath: string): boolean {
+  if (!existsSync(filePath)) return false;
+  return readFileSync(filePath, 'utf-8').includes('[mcp_servers.jinn]');
+}
+
+function upsertTomlMcpServer(filePath: string): { ok: boolean; detail: string } {
+  if (hasTomlMcpServer(filePath)) {
+    return { ok: true, detail: `Already configured in ${filePath}` };
+  }
+  mkdirSync(dirname(filePath), { recursive: true });
+  const existing = existsSync(filePath) ? readFileSync(filePath, 'utf-8') : '';
+  const separator = existing.length > 0 && !existing.endsWith('\n') ? '\n\n' : existing.length > 0 ? '\n' : '';
+  writeFileSync(filePath, existing + separator + TOML_BLOCK + '\n', 'utf-8');
+  return { ok: true, detail: `Wrote MCP entry to ${filePath}` };
+}
+
+function removeTomlMcpServer(filePath: string): { ok: boolean; detail: string } {
+  if (!existsSync(filePath)) {
+    return { ok: true, detail: 'Config file does not exist' };
+  }
+  const content = readFileSync(filePath, 'utf-8');
+  if (!content.includes('[mcp_servers.jinn]')) {
+    return { ok: true, detail: 'Not configured' };
+  }
+  // Remove the block: header line + command line (and optional trailing blank line)
+  const updated = content.replace(/\n?\[mcp_servers\.jinn\]\ncommand = "jinn-mcp"\n?/g, '\n').replace(/\n{3,}/g, '\n\n').trim() + '\n';
+  writeFileSync(filePath, updated, 'utf-8');
+  return { ok: true, detail: `Removed MCP entry from ${filePath}` };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — Skill block (delimited append for VS Code, Gemini, Codex)
+// ---------------------------------------------------------------------------
+
+const BLOCK_START = '<!-- jinn-operator-start -->';
+const BLOCK_END = '<!-- jinn-operator-end -->';
+
+function hasSkillBlock(filePath: string): boolean {
+  if (!existsSync(filePath)) return false;
+  return readFileSync(filePath, 'utf-8').includes(BLOCK_START);
+}
+
+function upsertSkillBlock(filePath: string, content: string): { ok: boolean; detail: string } {
+  if (hasSkillBlock(filePath)) {
+    return { ok: true, detail: `Skill block already present in ${filePath}` };
+  }
+  mkdirSync(dirname(filePath), { recursive: true });
+  const existing = existsSync(filePath) ? readFileSync(filePath, 'utf-8') : '';
+  const separator = existing.length > 0 && !existing.endsWith('\n') ? '\n\n' : existing.length > 0 ? '\n' : '';
+  const block = `${BLOCK_START}\n${content}\n${BLOCK_END}\n`;
+  writeFileSync(filePath, existing + separator + block, 'utf-8');
+  return { ok: true, detail: `Appended skill block to ${filePath}` };
+}
+
+function removeSkillBlock(filePath: string): { ok: boolean; detail: string } {
+  if (!existsSync(filePath)) {
+    return { ok: true, detail: 'File does not exist' };
+  }
+  const content = readFileSync(filePath, 'utf-8');
+  if (!content.includes(BLOCK_START)) {
+    return { ok: true, detail: 'Skill block not present' };
+  }
+  const regex = new RegExp(`\\n?${BLOCK_START}[\\s\\S]*?${BLOCK_END}\\n?`, 'g');
+  const updated = content.replace(regex, '\n').replace(/\n{3,}/g, '\n\n').trimEnd() + '\n';
+  writeFileSync(filePath, updated, 'utf-8');
+  return { ok: true, detail: `Removed skill block from ${filePath}` };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — Claude skill directory (copy/delete)
+// ---------------------------------------------------------------------------
+
+function hasClaudeSkill(targetDir: string): boolean {
+  return existsSync(join(targetDir, 'SKILL.md'));
+}
+
+function installClaudeSkill(targetDir: string): { ok: boolean; detail: string } {
+  if (hasClaudeSkill(targetDir)) {
+    return { ok: true, detail: `Skill already installed at ${targetDir}` };
+  }
+  mkdirSync(targetDir, { recursive: true });
+  copyFileSync(join(SKILL_DIR, 'SKILL.md'), join(targetDir, 'SKILL.md'));
+  return { ok: true, detail: `Copied skill to ${targetDir}` };
+}
+
+function removeClaudeSkill(targetDir: string): { ok: boolean; detail: string } {
+  if (!hasClaudeSkill(targetDir)) {
+    return { ok: true, detail: 'Skill not installed' };
+  }
+  rmSync(targetDir, { recursive: true, force: true });
+  return { ok: true, detail: `Removed skill from ${targetDir}` };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — Cursor rule file
+// ---------------------------------------------------------------------------
+
+function hasCursorRule(targetPath: string): boolean {
+  return existsSync(targetPath);
+}
+
+function installCursorRule(targetPath: string, content: string): { ok: boolean; detail: string } {
+  if (hasCursorRule(targetPath)) {
+    return { ok: true, detail: `Rule already installed at ${targetPath}` };
+  }
+  mkdirSync(dirname(targetPath), { recursive: true });
+  writeFileSync(targetPath, content, 'utf-8');
+  return { ok: true, detail: `Wrote rule to ${targetPath}` };
+}
+
+function removeCursorRule(targetPath: string): { ok: boolean; detail: string } {
+  if (!hasCursorRule(targetPath)) {
+    return { ok: true, detail: 'Rule not installed' };
+  }
+  rmSync(targetPath, { force: true });
+  return { ok: true, detail: `Removed rule from ${targetPath}` };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — command detection
+// ---------------------------------------------------------------------------
+
+function commandExists(cmd: string): boolean {
+  try {
+    execSync(`which ${cmd}`, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Platform paths
+// ---------------------------------------------------------------------------
+
+function claudeDesktopConfigDir(): string {
+  if (platform() === 'darwin') {
+    return join(homedir(), 'Library', 'Application Support', 'Claude');
+  }
+  return join(homedir(), '.config', 'claude-desktop');
+}
+
+// ---------------------------------------------------------------------------
+// Target definitions
+// ---------------------------------------------------------------------------
+
+interface TargetResult {
+  ok: boolean;
+  detail: string;
+}
+
+interface PluginTarget {
+  id: string;
+  name: string;
+  detect(): boolean;
+  isMcpConfigured(scope: 'user' | 'project'): boolean;
+  isSkillConfigured(scope: 'user' | 'project'): boolean;
+  installMcp(scope: 'user' | 'project'): Promise<TargetResult>;
+  installSkill(scope: 'user' | 'project', skillContent: string): Promise<TargetResult>;
+  removeMcp(scope: 'user' | 'project'): Promise<TargetResult>;
+  removeSkill(scope: 'user' | 'project'): Promise<TargetResult>;
+}
+
+function claudeSkillDir(scope: 'user' | 'project'): string {
+  if (scope === 'user') return join(homedir(), '.claude', 'skills', 'jinn-operator');
+  return join(process.cwd(), '.claude', 'skills', 'jinn-operator');
+}
+
+const TARGETS: PluginTarget[] = [
+  // ---- claude-code ----
+  {
+    id: 'claude-code',
+    name: 'Claude Code',
+    detect: () => commandExists('claude'),
+    isMcpConfigured(scope) {
+      // We can't easily check this without parsing claude's internal config.
+      // Attempt to list MCP servers and check for jinn.
+      try {
+        const out = execSync(`claude mcp list --scope ${scope}`, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] });
+        return out.includes('jinn');
+      } catch {
+        return false;
+      }
+    },
+    isSkillConfigured(scope) {
+      return hasClaudeSkill(claudeSkillDir(scope));
+    },
+    async installMcp(scope) {
+      try {
+        const out = execSync(`claude mcp list --scope ${scope}`, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] });
+        if (out.includes('jinn')) {
+          return { ok: true, detail: 'Already configured via claude CLI' };
+        }
+      } catch { /* proceed */ }
+      try {
+        execSync(`claude mcp add --scope ${scope} jinn -- jinn-mcp`, { stdio: 'ignore' });
+        return { ok: true, detail: `Added jinn MCP via claude CLI (scope: ${scope})` };
+      } catch (err) {
+        return { ok: false, detail: `Failed to add MCP: ${err instanceof Error ? err.message : String(err)}` };
+      }
+    },
+    async installSkill(scope) {
+      return installClaudeSkill(claudeSkillDir(scope));
+    },
+    async removeMcp(scope) {
+      try {
+        execSync(`claude mcp remove --scope ${scope} jinn`, { stdio: 'ignore' });
+        return { ok: true, detail: `Removed jinn MCP via claude CLI (scope: ${scope})` };
+      } catch (err) {
+        return { ok: false, detail: `Failed to remove MCP: ${err instanceof Error ? err.message : String(err)}` };
+      }
+    },
+    async removeSkill(scope) {
+      return removeClaudeSkill(claudeSkillDir(scope));
+    },
+  },
+
+  // ---- claude-desktop ----
+  {
+    id: 'claude-desktop',
+    name: 'Claude Desktop',
+    detect: () => existsSync(claudeDesktopConfigDir()),
+    isMcpConfigured(_scope) {
+      const cfgPath = join(claudeDesktopConfigDir(), 'claude_desktop_config.json');
+      return hasJsonMcpServer(cfgPath, 'mcpServers');
+    },
+    isSkillConfigured(scope) {
+      // Claude Desktop uses same skill directory as Claude Code (user scope always)
+      return hasClaudeSkill(claudeSkillDir(scope === 'project' ? 'user' : scope));
+    },
+    async installMcp(_scope) {
+      const cfgPath = join(claudeDesktopConfigDir(), 'claude_desktop_config.json');
+      return upsertJsonMcpServer(cfgPath, 'mcpServers');
+    },
+    async installSkill(scope) {
+      // Claude Desktop always uses user scope for skills
+      return installClaudeSkill(claudeSkillDir(scope === 'project' ? 'user' : scope));
+    },
+    async removeMcp(_scope) {
+      const cfgPath = join(claudeDesktopConfigDir(), 'claude_desktop_config.json');
+      return removeJsonMcpServer(cfgPath, 'mcpServers');
+    },
+    async removeSkill(scope) {
+      return removeClaudeSkill(claudeSkillDir(scope === 'project' ? 'user' : scope));
+    },
+  },
+
+  // ---- cursor ----
+  {
+    id: 'cursor',
+    name: 'Cursor',
+    detect: () => existsSync(join(homedir(), '.cursor')),
+    isMcpConfigured(scope) {
+      const cfgPath = scope === 'user'
+        ? join(homedir(), '.cursor', 'mcp.json')
+        : join(process.cwd(), '.cursor', 'mcp.json');
+      return hasJsonMcpServer(cfgPath, 'mcpServers');
+    },
+    isSkillConfigured(scope) {
+      const rulePath = scope === 'user'
+        ? join(homedir(), '.cursor', 'rules', 'jinn.md')
+        : join(process.cwd(), '.cursor', 'rules', 'jinn.md');
+      return hasCursorRule(rulePath);
+    },
+    async installMcp(scope) {
+      const cfgPath = scope === 'user'
+        ? join(homedir(), '.cursor', 'mcp.json')
+        : join(process.cwd(), '.cursor', 'mcp.json');
+      return upsertJsonMcpServer(cfgPath, 'mcpServers');
+    },
+    async installSkill(scope, skillContent) {
+      const rulePath = scope === 'user'
+        ? join(homedir(), '.cursor', 'rules', 'jinn.md')
+        : join(process.cwd(), '.cursor', 'rules', 'jinn.md');
+      return installCursorRule(rulePath, skillContent);
+    },
+    async removeMcp(scope) {
+      const cfgPath = scope === 'user'
+        ? join(homedir(), '.cursor', 'mcp.json')
+        : join(process.cwd(), '.cursor', 'mcp.json');
+      return removeJsonMcpServer(cfgPath, 'mcpServers');
+    },
+    async removeSkill(scope) {
+      const rulePath = scope === 'user'
+        ? join(homedir(), '.cursor', 'rules', 'jinn.md')
+        : join(process.cwd(), '.cursor', 'rules', 'jinn.md');
+      return removeCursorRule(rulePath);
+    },
+  },
+
+  // ---- vscode ----
+  {
+    id: 'vscode',
+    name: 'VS Code',
+    detect: () => commandExists('code'),
+    isMcpConfigured(scope) {
+      if (scope === 'user') return false; // VS Code MCP is project-scoped only via .vscode/mcp.json
+      const cfgPath = join(process.cwd(), '.vscode', 'mcp.json');
+      return hasJsonMcpServer(cfgPath, 'servers');
+    },
+    isSkillConfigured(scope) {
+      if (scope === 'user') return false;
+      const instrPath = join(process.cwd(), '.github', 'copilot-instructions.md');
+      return hasSkillBlock(instrPath);
+    },
+    async installMcp(scope) {
+      if (scope === 'user') {
+        return { ok: true, detail: 'VS Code MCP requires project scope (--scope project)' };
+      }
+      const cfgPath = join(process.cwd(), '.vscode', 'mcp.json');
+      return upsertJsonMcpServer(cfgPath, 'servers');
+    },
+    async installSkill(scope, skillContent) {
+      if (scope === 'user') {
+        return { ok: true, detail: 'VS Code skill requires project scope (--scope project)' };
+      }
+      const instrPath = join(process.cwd(), '.github', 'copilot-instructions.md');
+      return upsertSkillBlock(instrPath, stripFrontmatter(skillContent));
+    },
+    async removeMcp(scope) {
+      if (scope === 'user') {
+        return { ok: true, detail: 'Not configured at user scope' };
+      }
+      const cfgPath = join(process.cwd(), '.vscode', 'mcp.json');
+      return removeJsonMcpServer(cfgPath, 'servers');
+    },
+    async removeSkill(scope) {
+      if (scope === 'user') {
+        return { ok: true, detail: 'Not configured at user scope' };
+      }
+      const instrPath = join(process.cwd(), '.github', 'copilot-instructions.md');
+      return removeSkillBlock(instrPath);
+    },
+  },
+
+  // ---- gemini-cli ----
+  {
+    id: 'gemini-cli',
+    name: 'Gemini CLI',
+    detect: () => existsSync(join(homedir(), '.gemini')),
+    isMcpConfigured(scope) {
+      const cfgPath = scope === 'user'
+        ? join(homedir(), '.gemini', 'settings.json')
+        : join(process.cwd(), '.gemini', 'settings.json');
+      return hasJsonMcpServer(cfgPath, 'mcpServers');
+    },
+    isSkillConfigured(scope) {
+      const instrPath = scope === 'user'
+        ? join(homedir(), '.gemini', 'GEMINI.md')
+        : join(process.cwd(), 'GEMINI.md');
+      return hasSkillBlock(instrPath);
+    },
+    async installMcp(scope) {
+      const cfgPath = scope === 'user'
+        ? join(homedir(), '.gemini', 'settings.json')
+        : join(process.cwd(), '.gemini', 'settings.json');
+      return upsertJsonMcpServer(cfgPath, 'mcpServers');
+    },
+    async installSkill(scope, skillContent) {
+      const instrPath = scope === 'user'
+        ? join(homedir(), '.gemini', 'GEMINI.md')
+        : join(process.cwd(), 'GEMINI.md');
+      return upsertSkillBlock(instrPath, stripFrontmatter(skillContent));
+    },
+    async removeMcp(scope) {
+      const cfgPath = scope === 'user'
+        ? join(homedir(), '.gemini', 'settings.json')
+        : join(process.cwd(), '.gemini', 'settings.json');
+      return removeJsonMcpServer(cfgPath, 'mcpServers');
+    },
+    async removeSkill(scope) {
+      const instrPath = scope === 'user'
+        ? join(homedir(), '.gemini', 'GEMINI.md')
+        : join(process.cwd(), 'GEMINI.md');
+      return removeSkillBlock(instrPath);
+    },
+  },
+
+  // ---- antigravity ----
+  {
+    id: 'antigravity',
+    name: 'Antigravity',
+    detect: () => existsSync(join(homedir(), '.gemini', 'antigravity')),
+    isMcpConfigured(_scope) {
+      const cfgPath = join(homedir(), '.gemini', 'antigravity', 'mcp_config.json');
+      return hasJsonMcpServer(cfgPath, 'mcpServers');
+    },
+    isSkillConfigured(_scope) {
+      const instrPath = join(homedir(), '.gemini', 'GEMINI.md');
+      return hasSkillBlock(instrPath);
+    },
+    async installMcp(_scope) {
+      const cfgPath = join(homedir(), '.gemini', 'antigravity', 'mcp_config.json');
+      return upsertJsonMcpServer(cfgPath, 'mcpServers');
+    },
+    async installSkill(_scope, skillContent) {
+      const instrPath = join(homedir(), '.gemini', 'GEMINI.md');
+      return upsertSkillBlock(instrPath, stripFrontmatter(skillContent));
+    },
+    async removeMcp(_scope) {
+      const cfgPath = join(homedir(), '.gemini', 'antigravity', 'mcp_config.json');
+      return removeJsonMcpServer(cfgPath, 'mcpServers');
+    },
+    async removeSkill(_scope) {
+      const instrPath = join(homedir(), '.gemini', 'GEMINI.md');
+      return removeSkillBlock(instrPath);
+    },
+  },
+
+  // ---- codex ----
+  {
+    id: 'codex',
+    name: 'Codex',
+    detect: () => existsSync(join(homedir(), '.codex')),
+    isMcpConfigured(scope) {
+      const cfgPath = scope === 'user'
+        ? join(homedir(), '.codex', 'config.toml')
+        : join(process.cwd(), '.codex', 'config.toml');
+      return hasTomlMcpServer(cfgPath);
+    },
+    isSkillConfigured(scope) {
+      const instrPath = scope === 'user'
+        ? join(homedir(), '.codex', 'AGENTS.md')
+        : join(process.cwd(), 'AGENTS.md');
+      return hasSkillBlock(instrPath);
+    },
+    async installMcp(scope) {
+      const cfgPath = scope === 'user'
+        ? join(homedir(), '.codex', 'config.toml')
+        : join(process.cwd(), '.codex', 'config.toml');
+      return upsertTomlMcpServer(cfgPath);
+    },
+    async installSkill(scope, skillContent) {
+      const instrPath = scope === 'user'
+        ? join(homedir(), '.codex', 'AGENTS.md')
+        : join(process.cwd(), 'AGENTS.md');
+      return upsertSkillBlock(instrPath, stripFrontmatter(skillContent));
+    },
+    async removeMcp(scope) {
+      const cfgPath = scope === 'user'
+        ? join(homedir(), '.codex', 'config.toml')
+        : join(process.cwd(), '.codex', 'config.toml');
+      return removeTomlMcpServer(cfgPath);
+    },
+    async removeSkill(scope) {
+      const instrPath = scope === 'user'
+        ? join(homedir(), '.codex', 'AGENTS.md')
+        : join(process.cwd(), 'AGENTS.md');
+      return removeSkillBlock(instrPath);
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Subverb: install
+// ---------------------------------------------------------------------------
+
+interface ResultEntry {
+  target: string;
+  mcp: { status: string; detail: string };
+  skill: { status: string; detail: string };
+}
+
+async function runInstall(ctx: CommandContext, rest: string[]): Promise<void> {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args: rest,
+      options: {
+        scope: { type: 'string', default: 'user' },
+        target: { type: 'string' },
+        json: { type: 'boolean', default: false },
+        human: { type: 'boolean', default: false },
+      },
+      allowPositionals: false,
+    });
+  } catch (err) {
+    emitEnvelope(
+      {
+        code: 'invalid_invocation',
+        message: err instanceof Error ? err.message : String(err),
+        exampleCli: 'jinn plugin install --scope user',
+        details: { field: 'flags' },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
+
+  const scope = (parsed.values.scope as string) === 'project' ? 'project' as const : 'user' as const;
+  const targetFilter = parsed.values.target as string | undefined;
+
+  let skillContent: string;
+  try {
+    skillContent = loadSkillContent();
+  } catch (err) {
+    emitEnvelope(
+      {
+        code: 'fatal',
+        message: `Failed to load skill content: ${err instanceof Error ? err.message : String(err)}`,
+        details: { skillDir: SKILL_DIR },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
+
+  const targets = targetFilter
+    ? TARGETS.filter((t) => t.id === targetFilter)
+    : TARGETS;
+
+  if (targetFilter && targets.length === 0) {
+    emitEnvelope(
+      {
+        code: 'invalid_invocation',
+        message: `Unknown target: ${targetFilter}`,
+        exampleCli: 'jinn plugin list',
+        details: { field: '--target', expected: TARGETS.map((t) => t.id).join('|') },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
+
+  const results: ResultEntry[] = [];
+
+  for (const target of targets) {
+    if (!target.detect()) {
+      if (targetFilter) {
+        results.push({
+          target: target.id,
+          mcp: { status: 'not_found', detail: `${target.name} not detected` },
+          skill: { status: 'not_found', detail: `${target.name} not detected` },
+        });
+      }
+      continue;
+    }
+
+    let mcpResult: { status: string; detail: string };
+    if (target.isMcpConfigured(scope)) {
+      mcpResult = { status: 'skipped', detail: 'Already configured' };
+    } else {
+      const r = await target.installMcp(scope);
+      mcpResult = { status: r.ok ? 'configured' : 'error', detail: r.detail };
+    }
+
+    let skillResult: { status: string; detail: string };
+    if (target.isSkillConfigured(scope)) {
+      skillResult = { status: 'skipped', detail: 'Already configured' };
+    } else {
+      const r = await target.installSkill(scope, skillContent);
+      skillResult = { status: r.ok ? 'configured' : 'error', detail: r.detail };
+    }
+
+    results.push({ target: target.id, mcp: mcpResult, skill: skillResult });
+  }
+
+  emitResult(
+    {
+      schemaVersion: 1,
+      generatedAt: new Date().toISOString(),
+      verb: 'plugin install',
+      results,
+    },
+    (v) => {
+      const data = v as { results: ResultEntry[] };
+      if (data.results.length === 0) return 'No targets detected.';
+      const maxLen = Math.max(...data.results.map((r) => r.target.length));
+      return data.results
+        .map((r) => `${r.target.padEnd(maxLen + 2)}MCP: ${r.mcp.status.padEnd(12)}Skill: ${r.skill.status}`)
+        .join('\n');
+    },
+    {
+      json: Boolean(parsed.values.json),
+      human: Boolean(parsed.values.human),
+      writer: ctx.writer,
+      stdoutIsTty: ctx.stdoutIsTty,
+      noColor: Boolean(ctx.env['NO_COLOR']),
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Subverb: remove
+// ---------------------------------------------------------------------------
+
+async function runRemove(ctx: CommandContext, rest: string[]): Promise<void> {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args: rest,
+      options: {
+        scope: { type: 'string', default: 'user' },
+        target: { type: 'string' },
+        json: { type: 'boolean', default: false },
+        human: { type: 'boolean', default: false },
+      },
+      allowPositionals: false,
+    });
+  } catch (err) {
+    emitEnvelope(
+      {
+        code: 'invalid_invocation',
+        message: err instanceof Error ? err.message : String(err),
+        exampleCli: 'jinn plugin remove --target claude-code',
+        details: { field: 'flags' },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
+
+  const scope = (parsed.values.scope as string) === 'project' ? 'project' as const : 'user' as const;
+  const targetFilter = parsed.values.target as string | undefined;
+
+  const targets = targetFilter
+    ? TARGETS.filter((t) => t.id === targetFilter)
+    : TARGETS;
+
+  if (targetFilter && targets.length === 0) {
+    emitEnvelope(
+      {
+        code: 'invalid_invocation',
+        message: `Unknown target: ${targetFilter}`,
+        exampleCli: 'jinn plugin list',
+        details: { field: '--target', expected: TARGETS.map((t) => t.id).join('|') },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
+
+  const results: ResultEntry[] = [];
+
+  for (const target of targets) {
+    if (!target.detect()) {
+      if (targetFilter) {
+        results.push({
+          target: target.id,
+          mcp: { status: 'not_found', detail: `${target.name} not detected` },
+          skill: { status: 'not_found', detail: `${target.name} not detected` },
+        });
+      }
+      continue;
+    }
+
+    let mcpResult: { status: string; detail: string };
+    if (!target.isMcpConfigured(scope)) {
+      mcpResult = { status: 'skipped', detail: 'Not configured' };
+    } else {
+      const r = await target.removeMcp(scope);
+      mcpResult = { status: r.ok ? 'removed' : 'error', detail: r.detail };
+    }
+
+    let skillResult: { status: string; detail: string };
+    if (!target.isSkillConfigured(scope)) {
+      skillResult = { status: 'skipped', detail: 'Not configured' };
+    } else {
+      const r = await target.removeSkill(scope);
+      skillResult = { status: r.ok ? 'removed' : 'error', detail: r.detail };
+    }
+
+    results.push({ target: target.id, mcp: mcpResult, skill: skillResult });
+  }
+
+  emitResult(
+    {
+      schemaVersion: 1,
+      generatedAt: new Date().toISOString(),
+      verb: 'plugin remove',
+      results,
+    },
+    (v) => {
+      const data = v as { results: ResultEntry[] };
+      if (data.results.length === 0) return 'No targets detected.';
+      const maxLen = Math.max(...data.results.map((r) => r.target.length));
+      return data.results
+        .map((r) => `${r.target.padEnd(maxLen + 2)}MCP: ${r.mcp.status.padEnd(12)}Skill: ${r.skill.status}`)
+        .join('\n');
+    },
+    {
+      json: Boolean(parsed.values.json),
+      human: Boolean(parsed.values.human),
+      writer: ctx.writer,
+      stdoutIsTty: ctx.stdoutIsTty,
+      noColor: Boolean(ctx.env['NO_COLOR']),
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Subverb: list
+// ---------------------------------------------------------------------------
+
+interface ListEntry {
+  id: string;
+  name: string;
+  detected: boolean;
+  mcpConfigured: boolean;
+  skillConfigured: boolean;
+}
+
+async function runList(ctx: CommandContext, rest: string[]): Promise<void> {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args: rest,
+      options: {
+        scope: { type: 'string', default: 'user' },
+        json: { type: 'boolean', default: false },
+        human: { type: 'boolean', default: false },
+      },
+      allowPositionals: false,
+    });
+  } catch (err) {
+    emitEnvelope(
+      {
+        code: 'invalid_invocation',
+        message: err instanceof Error ? err.message : String(err),
+        exampleCli: 'jinn plugin list',
+        details: { field: 'flags' },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
+
+  const scope = (parsed.values.scope as string) === 'project' ? 'project' as const : 'user' as const;
+
+  const targets: ListEntry[] = TARGETS.map((t) => {
+    const detected = t.detect();
+    return {
+      id: t.id,
+      name: t.name,
+      detected,
+      mcpConfigured: detected ? t.isMcpConfigured(scope) : false,
+      skillConfigured: detected ? t.isSkillConfigured(scope) : false,
+    };
+  });
+
+  emitResult(
+    {
+      schemaVersion: 1,
+      generatedAt: new Date().toISOString(),
+      verb: 'plugin list',
+      targets,
+    },
+    (v) => {
+      const data = v as { targets: ListEntry[] };
+      const maxLen = Math.max(...data.targets.map((t) => t.id.length));
+      return data.targets
+        .map((t) => {
+          if (!t.detected) return `${t.id.padEnd(maxLen + 2)}not found`;
+          return `${t.id.padEnd(maxLen + 2)}detected   MCP: ${t.mcpConfigured ? 'yes' : 'no'}    Skill: ${t.skillConfigured ? 'yes' : 'no'}`;
+        })
+        .join('\n');
+    },
+    {
+      json: Boolean(parsed.values.json),
+      human: Boolean(parsed.values.human),
+      writer: ctx.writer,
+      stdoutIsTty: ctx.stdoutIsTty,
+      noColor: Boolean(ctx.env['NO_COLOR']),
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Verb dispatcher
+// ---------------------------------------------------------------------------
+
+async function run(ctx: CommandContext): Promise<void> {
+  const [subverb, ...rest] = ctx.argv;
+  if (!subverb) {
+    emitEnvelope(
+      {
+        code: 'invalid_invocation',
+        message: 'jinn plugin requires a subverb: install, remove, list',
+        exampleCli: 'jinn plugin install',
+        details: { field: 'subverb', expected: 'install|remove|list' },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
+
+  switch (subverb) {
+    case 'install':
+      return runInstall(ctx, rest);
+    case 'remove':
+      return runRemove(ctx, rest);
+    case 'list':
+      return runList(ctx, rest);
+    default:
+      emitEnvelope(
+        {
+          code: 'invalid_invocation',
+          message: `Unknown plugin subverb: ${subverb}`,
+          exampleCli: 'jinn plugin install',
+          details: { field: 'subverb', expected: 'install|remove|list' },
+        },
+        { writer: ctx.writer, exit: ctx.exit },
+      );
+  }
+}
+
+const command: CommandModule = {
+  name: 'plugin',
+  summary: 'Configure AI tools to use Jinn MCP server and operator skill',
+  helpText: `Usage: jinn plugin <install|remove|list> [options]
+
+Subcommands:
+  install   Configure detected AI tools with Jinn MCP server and operator skill
+  remove    Remove Jinn configuration from AI tools
+  list      Show detected AI tools and their configuration status
+
+Options:
+  --scope <user|project>   Install scope (default: user)
+  --target <id>            Configure only this target
+  --json                   JSON output (default)
+  --human                  Human-readable output
+
+Supported targets:
+  claude-code      Claude Code CLI
+  claude-desktop   Claude Desktop app
+  cursor           Cursor editor
+  vscode           VS Code (Copilot)
+  gemini-cli       Gemini CLI
+  antigravity      Antigravity (Gemini)
+  codex            OpenAI Codex CLI
+
+Examples:
+  jinn plugin list --human
+  jinn plugin install --human
+  jinn plugin install --target claude-code --human
+  jinn plugin install --scope project --target cursor
+  jinn plugin remove --target claude-code
+`,
+  run,
+};
+
+export default command;

--- a/client/src/cli/commands/plugin-install.ts
+++ b/client/src/cli/commands/plugin-install.ts
@@ -124,13 +124,24 @@ function hasSkillBlock(filePath: string): boolean {
 }
 
 function upsertSkillBlock(filePath: string, content: string): { ok: boolean; detail: string } {
-  if (hasSkillBlock(filePath)) {
-    return { ok: true, detail: `Skill block already present in ${filePath}` };
-  }
   mkdirSync(dirname(filePath), { recursive: true });
+  const block = `${BLOCK_START}\n${content}\n${BLOCK_END}\n`;
+
+  if (hasSkillBlock(filePath)) {
+    // Replace existing block so `jinn plugin install` propagates updates
+    const existing = readFileSync(filePath, 'utf-8');
+    const re = new RegExp(
+      BLOCK_START.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+      '[\\s\\S]*?' +
+      BLOCK_END.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+      '\\n?',
+    );
+    writeFileSync(filePath, existing.replace(re, block), 'utf-8');
+    return { ok: true, detail: `Updated skill block in ${filePath}` };
+  }
+
   const existing = existsSync(filePath) ? readFileSync(filePath, 'utf-8') : '';
   const separator = existing.length > 0 && !existing.endsWith('\n') ? '\n\n' : existing.length > 0 ? '\n' : '';
-  const block = `${BLOCK_START}\n${content}\n${BLOCK_END}\n`;
   writeFileSync(filePath, existing + separator + block, 'utf-8');
   return { ok: true, detail: `Appended skill block to ${filePath}` };
 }
@@ -158,12 +169,10 @@ function hasClaudeSkill(targetDir: string): boolean {
 }
 
 function installClaudeSkill(targetDir: string): { ok: boolean; detail: string } {
-  if (hasClaudeSkill(targetDir)) {
-    return { ok: true, detail: `Skill already installed at ${targetDir}` };
-  }
+  const verb = hasClaudeSkill(targetDir) ? 'Updated' : 'Copied';
   mkdirSync(targetDir, { recursive: true });
   copyFileSync(join(SKILL_DIR, 'SKILL.md'), join(targetDir, 'SKILL.md'));
-  return { ok: true, detail: `Copied skill to ${targetDir}` };
+  return { ok: true, detail: `${verb} skill at ${targetDir}` };
 }
 
 function removeClaudeSkill(targetDir: string): { ok: boolean; detail: string } {
@@ -183,12 +192,10 @@ function hasCursorRule(targetPath: string): boolean {
 }
 
 function installCursorRule(targetPath: string, content: string): { ok: boolean; detail: string } {
-  if (hasCursorRule(targetPath)) {
-    return { ok: true, detail: `Rule already installed at ${targetPath}` };
-  }
+  const verb = hasCursorRule(targetPath) ? 'Updated' : 'Wrote';
   mkdirSync(dirname(targetPath), { recursive: true });
   writeFileSync(targetPath, content, 'utf-8');
-  return { ok: true, detail: `Wrote rule to ${targetPath}` };
+  return { ok: true, detail: `${verb} rule at ${targetPath}` };
 }
 
 function removeCursorRule(targetPath: string): { ok: boolean; detail: string } {

--- a/client/src/cli/commands/quickstart.ts
+++ b/client/src/cli/commands/quickstart.ts
@@ -1,0 +1,248 @@
+import { randomBytes } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { parseArgs } from 'node:util';
+import type { CommandContext, CommandModule } from '../command.js';
+import { COMMON_FLAGS } from '../command.js';
+import { emitEnvelope } from '../../errors/envelope.js';
+import initCommand from './init.js';
+import bootstrapCommand from './bootstrap.js';
+
+// StringWriter to capture sub-command output
+class StringWriter {
+  private chunks: string[] = [];
+  write(s: string): boolean { this.chunks.push(s); return true; }
+  toString(): string { return this.chunks.join(''); }
+}
+
+async function run(ctx: CommandContext): Promise<void> {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args: ctx.argv,
+      options: {
+        ...COMMON_FLAGS,
+        'no-daemon': { type: 'boolean', default: false },
+      },
+      allowPositionals: false,
+    });
+  } catch (err) {
+    emitEnvelope({
+      code: 'invalid_invocation',
+      message: err instanceof Error ? err.message : String(err),
+      exampleCli: 'jinn quickstart',
+      details: { field: 'flags' },
+    }, { writer: ctx.writer, exit: ctx.exit });
+    return;
+  }
+
+  const noDaemon = parsed.values['no-daemon'] as boolean;
+  const jinnDir = join(ctx.env['HOME'] ?? homedir(), '.jinn-client');
+  const passwordFilePath = join(jinnDir, 'keystore-password');
+
+  // ── Step 1: Resolve or generate password ──
+  let password: string;
+  let passwordGenerated = false;
+
+  if (ctx.env['JINN_PASSWORD']) {
+    password = ctx.env['JINN_PASSWORD'];
+    console.error('[quickstart] Using password from JINN_PASSWORD environment variable.');
+  } else if (existsSync(passwordFilePath)) {
+    password = readFileSync(passwordFilePath, 'utf-8').trim();
+    console.error('[quickstart] Using existing auto-generated password.');
+  } else {
+    password = randomBytes(32).toString('hex');
+    mkdirSync(jinnDir, { recursive: true, mode: 0o700 });
+    writeFileSync(passwordFilePath, password + '\n', { mode: 0o600 });
+    passwordGenerated = true;
+    console.error('[quickstart] Generated keystore password.');
+  }
+
+  const subEnv = { ...ctx.env, JINN_PASSWORD: password };
+
+  // ── Step 2: Init (idempotent) ──
+  console.error('[quickstart] Initializing wallet...');
+  const initWriter = new StringWriter();
+  let initExitCode: number | null = null;
+  await initCommand.run({
+    argv: ['--json'],
+    stdoutIsTty: false,
+    writer: initWriter,
+    exit: (code) => { initExitCode = code; },
+    env: subEnv,
+  });
+
+  if (initExitCode !== null && initExitCode !== 0) {
+    console.error('[quickstart] Init failed.');
+    ctx.writer.write(initWriter.toString());
+    ctx.exit(initExitCode);
+    return;
+  }
+
+  // Parse master address from init output
+  let masterAddress = '';
+  try {
+    const initResult = JSON.parse(initWriter.toString().trim());
+    masterAddress = initResult.master ?? '';
+  } catch { /* non-fatal */ }
+  console.error(`[quickstart] Wallet ready. Master: ${masterAddress || '(see init output)'}`);
+
+  // ── Step 3: Bootstrap (with retry for funding gates) ──
+  const MAX_BOOTSTRAP_ATTEMPTS = 3;
+  let bootstrapSuccess = false;
+
+  for (let attempt = 1; attempt <= MAX_BOOTSTRAP_ATTEMPTS; attempt++) {
+    console.error(`[quickstart] Running bootstrap (attempt ${attempt}/${MAX_BOOTSTRAP_ATTEMPTS})...`);
+    const bsWriter = new StringWriter();
+    let bsExitCode: number | null = null;
+    await bootstrapCommand.run({
+      argv: ['--json'],
+      stdoutIsTty: false,
+      writer: bsWriter,
+      exit: (code) => { bsExitCode = code; },
+      env: subEnv,
+    });
+
+    if (bsExitCode === null || bsExitCode === 0) {
+      bootstrapSuccess = true;
+      console.error('[quickstart] Bootstrap complete.');
+      break;
+    }
+
+    // Exit code 10 = funding_required — the faucet integration in bootstrap.ts
+    // will have already attempted auto-funding. If we're here, manual funding is needed.
+    if (bsExitCode === 10) {
+      const bsOutput = bsWriter.toString().trim();
+      console.error('[quickstart] Funding required. Waiting for manual funding...');
+      try {
+        const envelope = JSON.parse(bsOutput);
+        if (envelope.details?.address) {
+          console.error(`  Address: ${envelope.details.address}`);
+        }
+        if (envelope.hint) {
+          console.error(`  ${envelope.hint}`);
+        }
+      } catch { /* non-fatal */ }
+      console.error('  Faucet: https://portal.cdp.coinbase.com/products/faucet');
+      console.error('  Polling every 15s for funding...');
+
+      // Poll until funded or timeout (30 min)
+      const pollInterval = 15_000;
+      const maxPolls = 120;
+      let funded = false;
+      for (let i = 0; i < maxPolls; i++) {
+        await new Promise(r => setTimeout(r, pollInterval));
+        // Re-attempt bootstrap to check if funding arrived
+        const checkWriter = new StringWriter();
+        let checkExit: number | null = null;
+        await bootstrapCommand.run({
+          argv: ['--json'],
+          stdoutIsTty: false,
+          writer: checkWriter,
+          exit: (code) => { checkExit = code; },
+          env: subEnv,
+        });
+        if (checkExit === null || checkExit === 0) {
+          funded = true;
+          bootstrapSuccess = true;
+          console.error('[quickstart] Funding received. Bootstrap complete.');
+          break;
+        }
+        if (checkExit !== 10) {
+          // Different error — relay and exit
+          console.error('[quickstart] Bootstrap failed with unexpected error.');
+          ctx.writer.write(checkWriter.toString());
+          ctx.exit(checkExit ?? 50);
+          return;
+        }
+        if ((i + 1) % 4 === 0) {
+          console.error(`  Still waiting... (${Math.round((i + 1) * pollInterval / 60000)} min elapsed)`);
+        }
+      }
+      if (funded) break;
+      console.error('[quickstart] Timeout waiting for funding (30 min). Run `jinn quickstart` again after funding.');
+      ctx.exit(10);
+      return;
+    }
+
+    // Other exit codes — fatal
+    console.error('[quickstart] Bootstrap failed.');
+    ctx.writer.write(bsWriter.toString());
+    ctx.exit(bsExitCode);
+    return;
+  }
+
+  if (!bootstrapSuccess) {
+    console.error('[quickstart] Bootstrap did not complete after retries.');
+    ctx.exit(50);
+    return;
+  }
+
+  // ── Step 4: Print summary ──
+  const apiPort = ctx.env['JINN_API_PORT'] ?? '7331';
+  console.error('');
+  console.error('Quickstart complete!');
+  console.error(`  Dashboard: http://127.0.0.1:${apiPort}`);
+  if (passwordGenerated) {
+    console.error(`  Password:  saved to ${passwordFilePath}`);
+    console.error('  To change: JINN_NEW_PASSWORD=<new> jinn keys change-password');
+  }
+  console.error('');
+
+  if (noDaemon) {
+    ctx.writer.write(JSON.stringify({
+      schemaVersion: 1,
+      generatedAt: new Date().toISOString(),
+      verb: 'quickstart',
+      status: 'ready',
+      masterAddress,
+      dashboardUrl: `http://127.0.0.1:${apiPort}`,
+      passwordFile: passwordGenerated ? passwordFilePath : undefined,
+    }) + '\n');
+    return;
+  }
+
+  // ── Step 5: Start daemon (foreground) ──
+  console.error('Starting daemon...');
+
+  // Route console to stderr for daemon (same as run command does)
+  const stderrWriter = (line: string): void => {
+    process.stderr.write(line.endsWith('\n') ? line : `${line}\n`);
+  };
+  console.log = (...args: unknown[]) => stderrWriter(args.map(String).join(' '));
+  console.info = (...args: unknown[]) => stderrWriter(args.map(String).join(' '));
+  console.warn = (...args: unknown[]) => stderrWriter(args.map(String).join(' '));
+  console.error = (...args: unknown[]) => stderrWriter(args.map(String).join(' '));
+
+  // Set password in process env so main.ts can read it
+  process.env['JINN_PASSWORD'] = password;
+
+  const { main } = await import('../../main.js');
+  const payload = await main();
+  ctx.writer.write(JSON.stringify(payload) + '\n');
+}
+
+const command: CommandModule = {
+  name: 'quickstart',
+  summary: 'Zero-to-running in one command: init, fund, bootstrap, run',
+  helpText: `Usage: jinn quickstart [--no-daemon] [--config <path>]
+
+One command to go from nothing to a running Jinn daemon:
+  1. Generate a keystore password (or use JINN_PASSWORD)
+  2. Create the master wallet
+  3. Fund via faucet (automatic on testnet if CDP SDK available)
+  4. Bootstrap the fleet state machine
+  5. Start the daemon
+
+Idempotent. Re-running after partial completion resumes from
+wherever it left off.
+
+Examples:
+  jinn quickstart
+  jinn quickstart --no-daemon
+  JINN_PASSWORD=mysecret jinn quickstart
+`,
+  run,
+};
+export default command;

--- a/client/src/cli/commands/quickstart.ts
+++ b/client/src/cli/commands/quickstart.ts
@@ -6,6 +6,7 @@ import { parseArgs } from 'node:util';
 import type { CommandContext, CommandModule } from '../command.js';
 import { COMMON_FLAGS } from '../command.js';
 import { emitEnvelope } from '../../errors/envelope.js';
+import { loadConfig } from '../../config.js';
 import initCommand from './init.js';
 import bootstrapCommand from './bootstrap.js';
 
@@ -38,8 +39,13 @@ async function run(ctx: CommandContext): Promise<void> {
   }
 
   const noDaemon = parsed.values['no-daemon'] as boolean;
+  const configPath =
+    typeof parsed.values.config === 'string' && parsed.values.config.length > 0
+      ? parsed.values.config
+      : undefined;
   const jinnDir = join(ctx.env['HOME'] ?? homedir(), '.jinn-client');
   const passwordFilePath = join(jinnDir, 'keystore-password');
+  const bootstrapArgv = ['--json', ...(configPath ? ['--config', configPath] : [])];
 
   // ── Step 1: Resolve or generate password ──
   let password: string;
@@ -97,7 +103,7 @@ async function run(ctx: CommandContext): Promise<void> {
     const bsWriter = new StringWriter();
     let bsExitCode: number | null = null;
     await bootstrapCommand.run({
-      argv: ['--json'],
+      argv: bootstrapArgv,
       stdoutIsTty: false,
       writer: bsWriter,
       exit: (code) => { bsExitCode = code; },
@@ -137,11 +143,11 @@ async function run(ctx: CommandContext): Promise<void> {
         const checkWriter = new StringWriter();
         let checkExit: number | null = null;
         await bootstrapCommand.run({
-          argv: ['--json'],
+          argv: bootstrapArgv,
           stdoutIsTty: false,
           writer: checkWriter,
           exit: (code) => { checkExit = code; },
-          env: subEnv,
+          env: { ...subEnv, JINN_DISABLE_TESTNET_FAUCET: '1' },
         });
         if (checkExit === null || checkExit === 0) {
           funded = true;
@@ -180,7 +186,7 @@ async function run(ctx: CommandContext): Promise<void> {
   }
 
   // ── Step 4: Print summary ──
-  const apiPort = ctx.env['JINN_API_PORT'] ?? '7331';
+  const apiPort = String(loadConfig(configPath).apiPort);
   console.error('');
   console.error('Quickstart complete!');
   console.error(`  Dashboard: http://127.0.0.1:${apiPort}`);

--- a/client/src/cli/commands/update.ts
+++ b/client/src/cli/commands/update.ts
@@ -12,6 +12,39 @@ class StringWriter {
   toString(): string { return this.chunks.join(''); }
 }
 
+interface PluginInstallResultEntry {
+  target: string;
+  mcp: { status: string; detail: string };
+  skill: { status: string; detail: string };
+}
+
+function summarizePluginInstall(
+  output: string,
+  exitCode: number | null,
+): { status: 'ok' | 'error'; detail: string } {
+  if (exitCode !== null && exitCode !== 0) {
+    return { status: 'error', detail: output || `plugin install exited with code ${exitCode}` };
+  }
+
+  try {
+    const parsed = JSON.parse(output) as { results?: PluginInstallResultEntry[] };
+    const results = Array.isArray(parsed.results) ? parsed.results : [];
+    const failures = results.flatMap((result) => {
+      const failedParts: string[] = [];
+      if (result.mcp.status === 'error') failedParts.push(`MCP: ${result.mcp.detail}`);
+      if (result.skill.status === 'error') failedParts.push(`Skill: ${result.skill.detail}`);
+      if (failedParts.length === 0) return [];
+      return [`${result.target} (${failedParts.join('; ')})`];
+    });
+    if (failures.length > 0) {
+      return { status: 'error', detail: failures.join(' | ') };
+    }
+    return { status: 'ok', detail: 'Plugins updated' };
+  } catch {
+    return { status: 'error', detail: output || 'Unexpected plugin install output' };
+  }
+}
+
 async function run(ctx: CommandContext): Promise<void> {
   let parsed;
   try {
@@ -76,11 +109,12 @@ async function run(ctx: CommandContext): Promise<void> {
     });
 
     const pluginOutput = pluginWriter.toString().trim();
-    if (pluginExitCode === null || pluginExitCode === 0) {
-      steps.push({ step: 'plugin-install', status: 'ok', detail: 'Plugins updated' });
+    const pluginResult = summarizePluginInstall(pluginOutput, pluginExitCode);
+    if (pluginResult.status === 'ok') {
+      steps.push({ step: 'plugin-install', status: 'ok', detail: pluginResult.detail });
       console.error('[update] Plugins updated.');
     } else {
-      steps.push({ step: 'plugin-install', status: 'error', detail: pluginOutput });
+      steps.push({ step: 'plugin-install', status: 'error', detail: pluginResult.detail });
       console.error('[update] Plugin update had issues.');
     }
   } else {

--- a/client/src/cli/commands/update.ts
+++ b/client/src/cli/commands/update.ts
@@ -1,0 +1,142 @@
+import { execSync } from 'node:child_process';
+import { parseArgs } from 'node:util';
+import type { CommandContext, CommandModule } from '../command.js';
+import { COMMON_FLAGS } from '../command.js';
+import { emitResult } from '../output.js';
+import { emitEnvelope } from '../../errors/envelope.js';
+import pluginCommand from './plugin-install.js';
+
+class StringWriter {
+  private chunks: string[] = [];
+  write(s: string): boolean { this.chunks.push(s); return true; }
+  toString(): string { return this.chunks.join(''); }
+}
+
+async function run(ctx: CommandContext): Promise<void> {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args: ctx.argv,
+      options: {
+        ...COMMON_FLAGS,
+        'skip-npm': { type: 'boolean', default: false },
+        'skip-plugins': { type: 'boolean', default: false },
+      },
+      allowPositionals: false,
+    });
+  } catch (err) {
+    emitEnvelope(
+      {
+        code: 'invalid_invocation',
+        message: err instanceof Error ? err.message : String(err),
+        exampleCli: 'jinn update',
+        details: { field: 'flags' },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
+
+  const skipNpm = parsed.values['skip-npm'] as boolean;
+  const skipPlugins = parsed.values['skip-plugins'] as boolean;
+
+  const steps: Array<{ step: string; status: string; detail: string }> = [];
+
+  // ── Step 1: Update the npm package ──
+  if (!skipNpm) {
+    console.error('[update] Updating @jinn-network/client...');
+    try {
+      const output = execSync('npm update -g @jinn-network/client 2>&1', {
+        encoding: 'utf-8',
+        timeout: 120_000,
+      });
+      steps.push({ step: 'npm-update', status: 'ok', detail: output.trim() || 'Package updated' });
+      console.error('[update] Package updated.');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      steps.push({ step: 'npm-update', status: 'error', detail: message });
+      console.error(`[update] npm update failed: ${message}`);
+      // Continue — plugin install may still be useful even if npm update failed
+    }
+  } else {
+    steps.push({ step: 'npm-update', status: 'skipped', detail: '--skip-npm' });
+  }
+
+  // ── Step 2: Re-install plugins (propagates skill updates) ──
+  if (!skipPlugins) {
+    console.error('[update] Updating plugins...');
+    const pluginWriter = new StringWriter();
+    let pluginExitCode: number | null = null;
+    await pluginCommand.run({
+      argv: ['install', '--json'],
+      stdoutIsTty: false,
+      writer: pluginWriter,
+      exit: (code) => { pluginExitCode = code; },
+      env: ctx.env,
+    });
+
+    const pluginOutput = pluginWriter.toString().trim();
+    if (pluginExitCode === null || pluginExitCode === 0) {
+      steps.push({ step: 'plugin-install', status: 'ok', detail: 'Plugins updated' });
+      console.error('[update] Plugins updated.');
+    } else {
+      steps.push({ step: 'plugin-install', status: 'error', detail: pluginOutput });
+      console.error('[update] Plugin update had issues.');
+    }
+  } else {
+    steps.push({ step: 'plugin-install', status: 'skipped', detail: '--skip-plugins' });
+  }
+
+  const allOk = steps.every((s) => s.status === 'ok' || s.status === 'skipped');
+
+  emitResult(
+    {
+      schemaVersion: 1,
+      generatedAt: new Date().toISOString(),
+      verb: 'update',
+      ok: allOk,
+      steps,
+    },
+    (v) => {
+      const value = v as { ok: boolean; steps: Array<{ step: string; status: string; detail: string }> };
+      const lines = value.steps.map(
+        (s) => `  ${s.step.padEnd(16)} ${s.status}${s.status === 'error' ? `: ${s.detail}` : ''}`,
+      );
+      return `Update ${value.ok ? 'complete' : 'completed with errors'}:\n${lines.join('\n')}`;
+    },
+    {
+      json: Boolean(parsed.values.json),
+      human: Boolean(parsed.values.human),
+      writer: ctx.writer,
+      stdoutIsTty: ctx.stdoutIsTty,
+      noColor: Boolean(ctx.env['NO_COLOR']),
+    },
+  );
+}
+
+const command: CommandModule = {
+  name: 'update',
+  summary: 'Update the client package and refresh plugins in all configured AI tools',
+  helpText: `Usage: jinn update [--human] [--skip-npm] [--skip-plugins]
+
+Two steps:
+  1. npm update -g @jinn-network/client  (updates binary + MCP server + skill source)
+  2. jinn plugin install                  (refreshes skills in all configured tools)
+
+The MCP server updates automatically (it's a binary on PATH).
+Skills need re-installation because they are copied into each tool's
+config directory.
+
+Flags:
+  --skip-npm        Skip the npm update step
+  --skip-plugins    Skip the plugin re-install step
+
+Examples:
+  jinn update
+  jinn update --human
+  jinn update --skip-npm          # just refresh plugins with current version
+`,
+  run,
+};
+
+export default command;

--- a/client/src/cli/index.ts
+++ b/client/src/cli/index.ts
@@ -33,6 +33,7 @@ import claimRewardsCommand from './commands/claim-rewards.js';
 import withdrawCommand from './commands/withdraw.js';
 import keysCommand from './commands/keys-backup.js';
 import pluginCommand from './commands/plugin-install.js';
+import updateCommand from './commands/update.js';
 
 const COMMANDS: CommandModule[] = [
   versionCommand,
@@ -55,6 +56,7 @@ const COMMANDS: CommandModule[] = [
   withdrawCommand,
   keysCommand,
   pluginCommand,
+  updateCommand,
 ];
 
 function publicCommandNames(commands: CommandModule[]): string[] {

--- a/client/src/cli/index.ts
+++ b/client/src/cli/index.ts
@@ -16,6 +16,7 @@ import { ConfigLoadError } from '../config.js';
 import versionCommand from './commands/version.js';
 import doctorCommand from './commands/doctor.js';
 import initCommand from './commands/init.js';
+import quickstartCommand from './commands/quickstart.js';
 import bootstrapCommand from './commands/bootstrap.js';
 import fundRequirementsCommand from './commands/fund-requirements.js';
 import runCommand from './commands/run.js';
@@ -36,6 +37,7 @@ const COMMANDS: CommandModule[] = [
   versionCommand,
   doctorCommand,
   initCommand,
+  quickstartCommand,
   bootstrapCommand,
   fundRequirementsCommand,
   runCommand,

--- a/client/src/cli/index.ts
+++ b/client/src/cli/index.ts
@@ -32,6 +32,7 @@ import submitIntentCommand from './commands/submit-intent.js';
 import claimRewardsCommand from './commands/claim-rewards.js';
 import withdrawCommand from './commands/withdraw.js';
 import keysCommand from './commands/keys-backup.js';
+import pluginCommand from './commands/plugin-install.js';
 
 const COMMANDS: CommandModule[] = [
   versionCommand,
@@ -53,6 +54,7 @@ const COMMANDS: CommandModule[] = [
   claimRewardsCommand,
   withdrawCommand,
   keysCommand,
+  pluginCommand,
 ];
 
 function publicCommandNames(commands: CommandModule[]): string[] {

--- a/client/src/cli/password.ts
+++ b/client/src/cli/password.ts
@@ -2,7 +2,9 @@
  * CLI password resolution: JINN_PASSWORD env or --password-fd N (reads once, trims).
  */
 
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 
 export function parsePasswordFdFromArgv(argv: string[]): number | undefined {
   const idx = argv.indexOf('--password-fd');
@@ -52,4 +54,34 @@ export function resolveCliPassword(
     };
   }
   return { ok: true, password: p };
+}
+
+export function resolveCurrentPassword(
+  argv: string[],
+  env: Record<string, string | undefined>,
+): { ok: true; password: string; fromFile: boolean } | { ok: false; message: string } {
+  // 1. Check keystore-password file
+  const home = env['HOME'] ?? homedir();
+  const passwordFilePath = join(home, '.jinn-client', 'keystore-password');
+  if (existsSync(passwordFilePath)) {
+    const password = readFileSync(passwordFilePath, 'utf-8').trim();
+    if (password) return { ok: true, password, fromFile: true };
+  }
+  // 2. Fall through to existing resolveCliPassword
+  const result = resolveCliPassword(argv, env);
+  if (result.ok) return { ok: true, password: result.password, fromFile: false };
+  return { ok: false, message: result.message };
+}
+
+export function resolveNewPassword(
+  env: Record<string, string | undefined>,
+): { ok: true; password: string } | { ok: false; message: string } {
+  const newPass = env['JINN_NEW_PASSWORD'];
+  if (newPass && newPass.length >= 8) return { ok: true, password: newPass };
+  if (newPass && newPass.length < 8)
+    return { ok: false, message: 'New password must be at least 8 characters.' };
+  return {
+    ok: false,
+    message: 'Set JINN_NEW_PASSWORD environment variable with your new password (min 8 characters).',
+  };
 }

--- a/client/src/dashboard/index.html
+++ b/client/src/dashboard/index.html
@@ -1,0 +1,500 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>jinn operator dashboard</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: #0a0a0f;
+    color: #e0e0e0;
+    font-family: "JetBrains Mono", "Fira Code", "SF Mono", monospace;
+    font-size: 14px;
+    line-height: 1.5;
+    padding: 20px;
+  }
+  h1 {
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: 16px;
+    color: #e0e0e0;
+  }
+  .grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+  @media (min-width: 900px) {
+    .grid { grid-template-columns: 1fr 1fr; }
+    .full-width { grid-column: 1 / -1; }
+  }
+  .card {
+    border: 1px solid #1a1a2e;
+    border-radius: 6px;
+    padding: 14px 16px;
+    background: #0f0f18;
+  }
+  .card-title {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #888;
+    margin-bottom: 10px;
+  }
+
+  /* Health bar */
+  .health-bar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .health-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .health-dot.ok { background: #22c55e; }
+  .health-dot.warn { background: #f59e0b; }
+  .health-dot.error { background: #ef4444; }
+  .health-meta {
+    font-size: 12px;
+    color: #888;
+  }
+
+  /* Table */
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+  }
+  th {
+    text-align: left;
+    font-weight: 500;
+    color: #888;
+    padding: 4px 8px 4px 0;
+    border-bottom: 1px solid #1a1a2e;
+  }
+  td {
+    padding: 4px 8px 4px 0;
+    border-bottom: 1px solid #111;
+  }
+
+  /* Step badges */
+  .badge {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 11px;
+  }
+  .badge-complete { background: #22c55e22; color: #22c55e; }
+  .badge-staked, .badge-mech_deployed, .badge-service_staked { background: #3b82f622; color: #3b82f6; }
+  .badge-awaiting_stake, .badge-awaiting_funding { background: #f59e0b22; color: #f59e0b; }
+  .badge-default { background: #88888822; color: #888; }
+
+  /* KV pairs */
+  .kv { display: flex; justify-content: space-between; padding: 3px 0; }
+  .kv-key { color: #888; }
+  .kv-val { color: #e0e0e0; text-align: right; }
+
+  /* Warning bg */
+  .warn-bg { background: #f59e0b11; border-color: #f59e0b44; }
+  .ok-bg { background: #22c55e08; border-color: #22c55e33; }
+  .red-bg { background: #ef444411; border-color: #ef444444; }
+
+  /* Activity list */
+  .activity-list {
+    max-height: 200px;
+    overflow-y: auto;
+    font-size: 12px;
+  }
+  .activity-list div {
+    padding: 2px 0;
+    border-bottom: 1px solid #111;
+  }
+  .activity-list .role { color: #3b82f6; }
+
+  /* Next actions */
+  .actions-list { list-style: disc; padding-left: 18px; }
+  .actions-list li { padding: 2px 0; font-size: 13px; }
+
+  .error-msg { color: #ef4444; font-size: 12px; }
+  .truncated { font-family: inherit; }
+</style>
+</head>
+<body>
+<h1>jinn operator dashboard</h1>
+<div class="grid">
+
+  <!-- Health bar -->
+  <div id="panel-health" class="card full-width">
+    <div class="card-title">health</div>
+    <div class="health-bar">
+      <span id="health-dot" class="health-dot warn"></span>
+      <span id="health-label">connecting...</span>
+      <span id="health-meta" class="health-meta"></span>
+    </div>
+  </div>
+
+  <!-- Fleet -->
+  <div id="panel-fleet" class="card">
+    <div class="card-title">fleet</div>
+    <div id="fleet-content">--</div>
+  </div>
+
+  <!-- Master gas -->
+  <div id="panel-gas" class="card">
+    <div class="card-title">master gas</div>
+    <div id="gas-content">--</div>
+  </div>
+
+  <!-- Activity -->
+  <div id="panel-activity" class="card">
+    <div class="card-title">activity</div>
+    <div id="activity-content">--</div>
+  </div>
+
+  <!-- Rewards -->
+  <div id="panel-rewards" class="card">
+    <div class="card-title">rewards</div>
+    <div id="rewards-content">--</div>
+  </div>
+
+  <!-- Next actions -->
+  <div id="panel-actions" class="card full-width">
+    <div class="card-title">next actions</div>
+    <div id="actions-content">--</div>
+  </div>
+
+</div>
+
+<script>
+(function() {
+  var POLL_INTERVAL = 5000;
+
+  function $(id) { return document.getElementById(id); }
+
+  function truncAddr(addr) {
+    if (!addr || addr.length < 12) return addr || '--';
+    return addr.slice(0, 6) + '...' + addr.slice(-4);
+  }
+
+  function weiToEth(weiStr) {
+    if (!weiStr) return '--';
+    try {
+      var big = BigInt(weiStr);
+      var intPart = big / 10n**18n;
+      var fracPart = big % 10n**18n;
+      var fracStr = fracPart.toString().padStart(18, '0').slice(0, 4);
+      return intPart.toString() + '.' + fracStr;
+    } catch(e) { return weiStr; }
+  }
+
+  function stepBadgeClass(step) {
+    if (step === 'complete') return 'badge-complete';
+    if (['staked','mech_deployed','service_staked'].indexOf(step) !== -1) return 'badge-staked';
+    if (['awaiting_stake','awaiting_funding'].indexOf(step) !== -1) return 'badge-awaiting_stake';
+    return 'badge-default';
+  }
+
+  function setHealthIndicator(state, msg) {
+    var dot = $('health-dot');
+    var label = $('health-label');
+    dot.className = 'health-dot ' + (state === 'ok' ? 'ok' : 'error');
+    label.textContent = state === 'ok' ? 'connected' : 'error: ' + (msg || 'unknown');
+  }
+
+  function render(data) {
+    // Health
+    var dot = $('health-dot');
+    var label = $('health-label');
+    var meta = $('health-meta');
+
+    var isShutdown = data.daemon && data.daemon.shutdownState;
+    var rpcOk = data.rpc && data.rpc.ok;
+
+    if (isShutdown) {
+      dot.className = 'health-dot warn';
+      label.textContent = 'shutting down (' + data.daemon.shutdownState + ')';
+    } else if (!rpcOk) {
+      dot.className = 'health-dot error';
+      label.textContent = 'rpc error' + (data.rpc && data.rpc.error ? ': ' + data.rpc.error : '');
+    } else {
+      dot.className = 'health-dot ok';
+      label.textContent = 'healthy';
+    }
+
+    var metaParts = [];
+    if (data.rpc && data.rpc.chainId) metaParts.push('chain ' + data.rpc.chainId);
+    if (data.rpc && data.rpc.blockNumber) metaParts.push('block ' + data.rpc.blockNumber);
+    if (data.daemon && data.daemon.timestamp) {
+      var d = new Date(data.daemon.timestamp);
+      metaParts.push('at ' + d.toLocaleTimeString());
+    }
+    meta.textContent = metaParts.join(' | ');
+
+    // Fleet
+    renderFleet(data.fleet);
+
+    // Master gas
+    renderGas(data.masterGas);
+
+    // Activity
+    renderActivity(data.activity);
+
+    // Rewards
+    renderRewards(data.rewards, data.earnings);
+
+    // Next actions
+    renderActions(data.nextActions);
+  }
+
+  function renderFleet(fleet) {
+    var el = $('fleet-content');
+    el.textContent = '';
+
+    if (!fleet || !fleet.loaded) {
+      el.textContent = 'No fleet loaded';
+      return;
+    }
+
+    if (fleet.services.length === 0) {
+      el.textContent = 'No services';
+      return;
+    }
+
+    var tbl = document.createElement('table');
+    var thead = document.createElement('thead');
+    var hrow = document.createElement('tr');
+    ['#','step','svcId','safe','mech'].forEach(function(h) {
+      var th = document.createElement('th');
+      th.textContent = h;
+      hrow.appendChild(th);
+    });
+    thead.appendChild(hrow);
+    tbl.appendChild(thead);
+
+    var tbody = document.createElement('tbody');
+    fleet.services.forEach(function(s) {
+      var tr = document.createElement('tr');
+
+      var tdIdx = document.createElement('td');
+      tdIdx.textContent = String(s.index);
+      tr.appendChild(tdIdx);
+
+      var tdStep = document.createElement('td');
+      var badge = document.createElement('span');
+      badge.className = 'badge ' + stepBadgeClass(s.step);
+      badge.textContent = s.step;
+      tdStep.appendChild(badge);
+      tr.appendChild(tdStep);
+
+      var tdSvc = document.createElement('td');
+      tdSvc.textContent = s.serviceId != null ? String(s.serviceId) : '--';
+      tr.appendChild(tdSvc);
+
+      var tdSafe = document.createElement('td');
+      tdSafe.textContent = truncAddr(s.safeAddress);
+      tdSafe.title = s.safeAddress || '';
+      tdSafe.className = 'truncated';
+      tr.appendChild(tdSafe);
+
+      var tdMech = document.createElement('td');
+      tdMech.textContent = truncAddr(s.mechAddress);
+      tdMech.title = s.mechAddress || '';
+      tdMech.className = 'truncated';
+      tr.appendChild(tdMech);
+
+      tbody.appendChild(tr);
+    });
+    tbl.appendChild(tbody);
+    el.appendChild(tbl);
+
+    var summary = document.createElement('div');
+    summary.style.marginTop = '8px';
+    summary.style.fontSize = '12px';
+    summary.style.color = '#888';
+    summary.textContent = fleet.stakedLikeCount + ' staked, ' + fleet.completeCount + ' complete';
+    el.appendChild(summary);
+  }
+
+  function renderGas(gas) {
+    var el = $('gas-content');
+    var panel = $('panel-gas');
+    el.textContent = '';
+    panel.className = 'card';
+
+    if (!gas) { el.textContent = '--'; return; }
+
+    var runwayLow = gas.runwayDaysExcess !== undefined && Number(gas.runwayDaysExcess) < 3;
+    if (runwayLow) {
+      panel.className = 'card red-bg';
+    }
+
+    var pairs = [
+      ['address', truncAddr(gas.address)],
+      ['balance', weiToEth(gas.balanceWei) + ' ETH'],
+      ['daily est.', weiToEth(gas.dailyEstimateWei) + ' ETH'],
+      ['runway', gas.runwayDaysExcess !== undefined ? gas.runwayDaysExcess + ' days' : '--'],
+    ];
+    if (gas.error) {
+      pairs.push(['error', gas.error]);
+    }
+
+    pairs.forEach(function(p) {
+      var row = document.createElement('div');
+      row.className = 'kv';
+      var k = document.createElement('span');
+      k.className = 'kv-key';
+      k.textContent = p[0];
+      var v = document.createElement('span');
+      v.className = 'kv-val';
+      v.textContent = p[1];
+      if (p[0] === 'address') v.title = gas.address || '';
+      if (p[0] === 'error') v.className = 'kv-val error-msg';
+      row.appendChild(k);
+      row.appendChild(v);
+      el.appendChild(row);
+    });
+  }
+
+  function renderActivity(act) {
+    var el = $('activity-content');
+    el.textContent = '';
+
+    if (!act) { el.textContent = '--'; return; }
+
+    // Counts
+    var counts = act.counts || {};
+    var keys = Object.keys(counts);
+    if (keys.length > 0) {
+      keys.forEach(function(k) {
+        var row = document.createElement('div');
+        row.className = 'kv';
+        var kSpan = document.createElement('span');
+        kSpan.className = 'kv-key';
+        kSpan.textContent = k;
+        var vSpan = document.createElement('span');
+        vSpan.className = 'kv-val';
+        vSpan.textContent = String(counts[k]);
+        row.appendChild(kSpan);
+        row.appendChild(vSpan);
+        el.appendChild(row);
+      });
+    } else {
+      var none = document.createElement('div');
+      none.style.color = '#888';
+      none.style.fontSize = '12px';
+      none.textContent = 'no activity recorded';
+      el.appendChild(none);
+    }
+
+    // Recent
+    var recent = act.recent || [];
+    if (recent.length > 0) {
+      var hdr = document.createElement('div');
+      hdr.style.marginTop = '10px';
+      hdr.style.fontSize = '11px';
+      hdr.style.color = '#666';
+      hdr.textContent = 'recent';
+      el.appendChild(hdr);
+
+      var list = document.createElement('div');
+      list.className = 'activity-list';
+      recent.forEach(function(r) {
+        var item = document.createElement('div');
+        var roleSpan = document.createElement('span');
+        roleSpan.className = 'role';
+        roleSpan.textContent = r.role;
+        item.appendChild(roleSpan);
+        var idText = document.createTextNode(' ' + truncAddr(r.requestId));
+        item.appendChild(idText);
+        list.appendChild(item);
+      });
+      el.appendChild(list);
+    }
+  }
+
+  function renderRewards(rewards, earnings) {
+    var el = $('rewards-content');
+    el.textContent = '';
+
+    if (!rewards) { el.textContent = '--'; return; }
+
+    var pairs = [
+      ['pending', rewards.pendingStakingRewardsWei ? weiToEth(rewards.pendingStakingRewardsWei) + ' ETH' : (rewards.pendingRewardsError || '--')],
+      ['claim interval', rewards.claimLoopIntervalMs ? (rewards.claimLoopIntervalMs / 1000) + 's' : 'disabled'],
+      ['last claim', rewards.lastClaimTickAt || '--'],
+    ];
+
+    pairs.forEach(function(p) {
+      var row = document.createElement('div');
+      row.className = 'kv';
+      var k = document.createElement('span');
+      k.className = 'kv-key';
+      k.textContent = p[0];
+      var v = document.createElement('span');
+      v.className = 'kv-val';
+      v.textContent = p[1];
+      if (p[0] === 'pending' && rewards.pendingRewardsError) v.className = 'kv-val error-msg';
+      row.appendChild(k);
+      row.appendChild(v);
+      el.appendChild(row);
+    });
+
+    if (earnings && earnings.hint) {
+      var hint = document.createElement('div');
+      hint.style.marginTop = '8px';
+      hint.style.fontSize = '11px';
+      hint.style.color = '#888';
+      hint.textContent = earnings.hint;
+      el.appendChild(hint);
+    }
+  }
+
+  function renderActions(actions) {
+    var el = $('actions-content');
+    var panel = $('panel-actions');
+    el.textContent = '';
+
+    if (!actions || actions.length === 0) {
+      panel.className = 'card full-width ok-bg';
+      el.textContent = 'no urgent actions';
+      return;
+    }
+
+    var isOnlyNoUrgent = actions.length === 1 && actions[0].toLowerCase().indexOf('no urgent') !== -1;
+    panel.className = isOnlyNoUrgent ? 'card full-width ok-bg' : 'card full-width warn-bg';
+
+    var ul = document.createElement('ul');
+    ul.className = 'actions-list';
+    actions.forEach(function(a) {
+      var li = document.createElement('li');
+      li.textContent = a;
+      ul.appendChild(li);
+    });
+    el.appendChild(ul);
+  }
+
+  async function poll() {
+    try {
+      var res = await fetch('/v1/status');
+      if (!res.ok) throw new Error('HTTP ' + res.status);
+      var data = await res.json();
+      render(data);
+      setHealthIndicator('ok');
+    } catch(err) {
+      setHealthIndicator('error', err.message);
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', function() {
+    poll();
+    setInterval(poll, POLL_INTERVAL);
+  });
+})();
+</script>
+</body>
+</html>

--- a/client/src/earning/bootstrap.ts
+++ b/client/src/earning/bootstrap.ts
@@ -200,9 +200,10 @@ export class FleetBootstrapper {
       const requiredMasterEth = this.stakingMode === 'standard'
         ? this.config.minEoaGasEth
         : SELF_BOND_ETH_PER_SERVICE * BigInt(this.targetServices);
+      const autoFaucetEnabled = process.env['JINN_DISABLE_TESTNET_FAUCET'] !== '1';
       if (systemEth < requiredMasterEth) {
         // On testnet, attempt automatic faucet funding before giving up
-        if (this.chain === 'base-sepolia') {
+        if (this.chain === 'base-sepolia' && autoFaucetEnabled) {
           console.error('[fleet-bootstrap] Attempting automatic faucet funding via Coinbase CDP...');
           const faucetResult = await requestTestnetFunding(masterAddress, 'base-sepolia');
           if (faucetResult.ok) {

--- a/client/src/earning/bootstrap.ts
+++ b/client/src/earning/bootstrap.ts
@@ -92,6 +92,7 @@ export interface FleetBootstrapperOptions {
   earningDir?: string;
   chain?: 'base' | 'base-sepolia';
   rpcUrl?: string;
+  env?: NodeJS.ProcessEnv;
   stakingMode?: 'standard' | 'self-bond';
   targetServices?: number;
   testnetL2DeploymentPath?: string;
@@ -118,10 +119,12 @@ export class FleetBootstrapper {
   private readonly targetServices: number;
   private readonly debug: boolean;
   private readonly masterEthDailyEstimateWei: bigint;
+  private readonly env: NodeJS.ProcessEnv;
 
   constructor(options: FleetBootstrapperOptions = {}) {
     this.store = new FleetStateStore(options.earningDir);
     this.chain = options.chain ?? 'base';
+    this.env = options.env ?? process.env;
     this.stakingMode = options.stakingMode ?? 'standard';
     this.targetServices = options.targetServices ?? 1;
     this.debug = options.debug ?? isJinnDebug();
@@ -200,7 +203,7 @@ export class FleetBootstrapper {
       const requiredMasterEth = this.stakingMode === 'standard'
         ? this.config.minEoaGasEth
         : SELF_BOND_ETH_PER_SERVICE * BigInt(this.targetServices);
-      const autoFaucetEnabled = process.env['JINN_DISABLE_TESTNET_FAUCET'] !== '1';
+      const autoFaucetEnabled = this.env['JINN_DISABLE_TESTNET_FAUCET'] !== '1';
       if (systemEth < requiredMasterEth) {
         // On testnet, attempt automatic faucet funding before giving up
         if (this.chain === 'base-sepolia' && autoFaucetEnabled) {

--- a/client/src/earning/bootstrap.ts
+++ b/client/src/earning/bootstrap.ts
@@ -69,6 +69,7 @@ import {
   previousSafeBeingAbandoned,
   sweepOrphanedServiceFunds,
 } from './orphan-sweep.js';
+import { requestTestnetFunding } from './faucet.js';
 import {
   viemSendTransactionWithRetry,
   waitForTransactionReceiptWithRetry,
@@ -199,6 +200,43 @@ export class FleetBootstrapper {
       const requiredMasterEth = this.stakingMode === 'standard'
         ? this.config.minEoaGasEth
         : SELF_BOND_ETH_PER_SERVICE * BigInt(this.targetServices);
+      if (systemEth < requiredMasterEth) {
+        // On testnet, attempt automatic faucet funding before giving up
+        if (this.chain === 'base-sepolia') {
+          console.error('[fleet-bootstrap] Attempting automatic faucet funding via Coinbase CDP...');
+          const faucetResult = await requestTestnetFunding(masterAddress, 'base-sepolia');
+          if (faucetResult.ok) {
+            console.error(`[fleet-bootstrap] Faucet funded successfully (tx: ${faucetResult.txHash}). Rechecking balance...`);
+            // Wait for tx propagation
+            await new Promise(r => setTimeout(r, 3000));
+            // Re-read balance and continue if sufficient
+            const refreshedBalance = await this.publicClient.getBalance({ address: masterAddress as Address });
+            let refreshedSystemEth = refreshedBalance;
+            if (this.stakingMode === 'self-bond') {
+              for (const svc of state.services) {
+                if (svc.agent_address) {
+                  refreshedSystemEth += await this.publicClient.getBalance({
+                    address: getAddress(svc.agent_address) as Address,
+                  });
+                }
+                if (svc.safe_address) {
+                  refreshedSystemEth += await this.publicClient.getBalance({
+                    address: getAddress(svc.safe_address) as Address,
+                  });
+                }
+              }
+            }
+            if (refreshedSystemEth >= requiredMasterEth) {
+              console.error('[fleet-bootstrap] Faucet funding sufficient. Continuing bootstrap...');
+              // Update systemEth/masterBalance for the runway check below
+              systemEth = refreshedSystemEth;
+            }
+          } else {
+            console.error(`[fleet-bootstrap] Faucet unavailable: ${faucetResult.reason}`);
+          }
+        }
+      }
+
       if (systemEth < requiredMasterEth) {
         const shortfall = requiredMasterEth - systemEth;
         const friendly = `Your master wallet needs more ETH (currently ${formatEther(masterBalance)} ETH, need ${formatEther(shortfall)} ETH more). Please send ETH to: ${masterAddress}`;

--- a/client/src/earning/faucet.ts
+++ b/client/src/earning/faucet.ts
@@ -7,8 +7,9 @@
  * KEY ROTATION: Change the constants below and publish a new npm version.
  */
 
-// Jinn project CDP API key — testnet faucet access only
-const JINN_DEFAULT_CDP_API_KEY_ID = 'yAY2P1e181EHl5bsrrkwyUkHCfok5rh1';
+// Jinn project CDP secret API key pair — testnet faucet access only
+const JINN_DEFAULT_CDP_API_KEY_ID = 'b743bfce-7f46-4e8e-ba04-0993b2c4908e';
+const JINN_DEFAULT_CDP_API_KEY_SECRET = 'lrGwqLwt3tX8/UIPHK4/AlM7TtqyGYXypXs/HqA3ORDCBgjLemJHhA40gmBNj0uK9PCAKaXlbhgFKuxAT/MfVw==';
 
 const MANUAL_FAUCET_URL = 'https://portal.cdp.coinbase.com/products/faucet';
 
@@ -23,13 +24,17 @@ export async function requestTestnetFunding(
   address: string,
   network: 'base-sepolia',
 ): Promise<FaucetResult> {
-  // Resolve API key: env override > shipped default
-  const apiKeyId = process.env['CDP_API_KEY_ID'] ?? JINN_DEFAULT_CDP_API_KEY_ID;
+  const envApiKeyId = process.env['CDP_API_KEY_ID'];
+  const envApiKeySecret = process.env['CDP_API_KEY_SECRET'];
+  const hasEnvPair = Boolean(envApiKeyId && envApiKeySecret);
+
+  // Resolve credential pair: complete env override > shipped default pair
+  const apiKeyId = hasEnvPair ? envApiKeyId! : JINN_DEFAULT_CDP_API_KEY_ID;
+  const apiKeySecret = hasEnvPair ? envApiKeySecret! : JINN_DEFAULT_CDP_API_KEY_SECRET;
 
   // Warn on partial override
-  if ((process.env['CDP_API_KEY_ID'] && !process.env['CDP_API_KEY_SECRET']) ||
-      (!process.env['CDP_API_KEY_ID'] && process.env['CDP_API_KEY_SECRET'])) {
-    console.error('[faucet] Warning: Only one of CDP_API_KEY_ID/CDP_API_KEY_SECRET is set. Using defaults.');
+  if ((envApiKeyId && !envApiKeySecret) || (!envApiKeyId && envApiKeySecret)) {
+    console.error('[faucet] Warning: Only one of CDP_API_KEY_ID/CDP_API_KEY_SECRET is set. Using shipped defaults.');
   }
 
   // Dynamic import — SDK is optional
@@ -45,14 +50,11 @@ export async function requestTestnetFunding(
   }
 
   try {
-    const clientOpts: Record<string, string> = { apiKeyId };
-    if (process.env['CDP_API_KEY_SECRET']) {
-      clientOpts.apiKeySecret = process.env['CDP_API_KEY_SECRET'];
-    }
+    const clientOpts: Record<string, string> = { apiKeyId, apiKeySecret };
     const cdp = new CdpClient(clientOpts);
     const result = await cdp.evm.requestFaucet({
       address,
-      network: 'base-sepolia',
+      network,
       token: 'eth',
     });
     return { ok: true, txHash: result.transactionHash ?? String(result) };

--- a/client/src/earning/faucet.ts
+++ b/client/src/earning/faucet.ts
@@ -1,0 +1,76 @@
+/**
+ * Coinbase CDP faucet integration for automatic Base Sepolia testnet funding.
+ *
+ * SECURITY: The shipped default API key grants testnet faucet access ONLY.
+ * No mainnet access, no wallet control, no financial risk.
+ *
+ * KEY ROTATION: Change the constants below and publish a new npm version.
+ */
+
+// Jinn project CDP API key — testnet faucet access only
+const JINN_DEFAULT_CDP_API_KEY_ID = 'yAY2P1e181EHl5bsrrkwyUkHCfok5rh1';
+
+const MANUAL_FAUCET_URL = 'https://portal.cdp.coinbase.com/products/faucet';
+
+export interface FaucetResult {
+  ok: boolean;
+  txHash?: string;
+  reason?: string;
+  rateLimited?: boolean;
+}
+
+export async function requestTestnetFunding(
+  address: string,
+  network: 'base-sepolia',
+): Promise<FaucetResult> {
+  // Resolve API key: env override > shipped default
+  const apiKeyId = process.env['CDP_API_KEY_ID'] ?? JINN_DEFAULT_CDP_API_KEY_ID;
+
+  // Warn on partial override
+  if ((process.env['CDP_API_KEY_ID'] && !process.env['CDP_API_KEY_SECRET']) ||
+      (!process.env['CDP_API_KEY_ID'] && process.env['CDP_API_KEY_SECRET'])) {
+    console.error('[faucet] Warning: Only one of CDP_API_KEY_ID/CDP_API_KEY_SECRET is set. Using defaults.');
+  }
+
+  // Dynamic import — SDK is optional
+  let CdpClient: any;
+  try {
+    const mod = await import('@coinbase/cdp-sdk');
+    CdpClient = mod.CdpClient;
+  } catch {
+    return {
+      ok: false,
+      reason: `Coinbase CDP SDK not installed. Install with: npm install @coinbase/cdp-sdk\nOr fund manually: ${MANUAL_FAUCET_URL}`,
+    };
+  }
+
+  try {
+    const clientOpts: Record<string, string> = { apiKeyId };
+    if (process.env['CDP_API_KEY_SECRET']) {
+      clientOpts.apiKeySecret = process.env['CDP_API_KEY_SECRET'];
+    }
+    const cdp = new CdpClient(clientOpts);
+    const result = await cdp.evm.requestFaucet({
+      address,
+      network: 'base-sepolia',
+      token: 'eth',
+    });
+    return { ok: true, txHash: result.transactionHash ?? String(result) };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const isRateLimit = message.toLowerCase().includes('rate limit') ||
+                        message.toLowerCase().includes('already claimed') ||
+                        message.includes('429');
+    if (isRateLimit) {
+      return {
+        ok: false,
+        rateLimited: true,
+        reason: `Faucet rate limited (1 claim per 24 hours per address). Fund manually: ${MANUAL_FAUCET_URL}`,
+      };
+    }
+    return {
+      ok: false,
+      reason: `Faucet error: ${message}. Fund manually: ${MANUAL_FAUCET_URL}`,
+    };
+  }
+}

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -329,7 +329,7 @@ export async function main(): Promise<DaemonStartupInfo> {
   process.on('exit', removePidfile);
 
   await daemon.start();
-  console.log('[main] Daemon running. Press Ctrl+C to stop.');
+  console.log(`[main] Daemon running. Dashboard: http://127.0.0.1:${config.apiPort}`);
   return {
     schemaVersion: 1,
     generatedAt: new Date().toISOString(),

--- a/client/src/mcp/operator-server.ts
+++ b/client/src/mcp/operator-server.ts
@@ -40,6 +40,11 @@ interface CommandRunResult {
   exitCode: number | null;
 }
 
+interface McpToolResponse extends Record<string, unknown> {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: true;
+}
+
 /**
  * Run a CLI CommandModule in-process, capturing its stdout output as a string.
  *
@@ -71,13 +76,23 @@ async function runCommandResult(
   return { text: chunks.join(''), exitCode };
 }
 
-async function runCommand(
+async function runToolCommand(
   command: CommandModule,
   argv: string[],
   env: NodeJS.ProcessEnv,
-): Promise<string> {
-  const result = await runCommandResult(command, argv, env);
-  return result.text;
+): Promise<McpToolResponse> {
+  try {
+    const result = await runCommandResult(command, argv, env);
+    return {
+      content: [{ type: 'text' as const, text: result.text }],
+      ...(result.exitCode !== null && result.exitCode !== 0 ? { isError: true as const } : {}),
+    };
+  } catch (err) {
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }],
+      isError: true,
+    };
+  }
 }
 
 function sleep(ms: number): Promise<void> {
@@ -190,84 +205,42 @@ export function createOperatorServer(): McpServer {
     'jinn_init',
     'Create the master wallet and write the encrypted keystore. Idempotent.',
     {},
-    async () => {
-      try {
-        const text = await runCommand(initCommand, ['--json'], process.env);
-        return { content: [{ type: 'text' as const, text }] };
-      } catch (err) {
-        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }], isError: true };
-      }
-    },
+    async () => runToolCommand(initCommand, ['--json'], process.env),
   );
 
   server.tool(
     'jinn_doctor',
     'Preflight checks: node version, claude binary, keystore, deployment config.',
     {},
-    async () => {
-      try {
-        const text = await runCommand(doctorCommand, ['--json'], process.env);
-        return { content: [{ type: 'text' as const, text }] };
-      } catch (err) {
-        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }], isError: true };
-      }
-    },
+    async () => runToolCommand(doctorCommand, ['--json'], process.env),
   );
 
   server.tool(
     'jinn_fund_requirements',
     'List addresses that need funding before bootstrap can advance.',
     {},
-    async () => {
-      try {
-        const text = await runCommand(fundRequirementsCommand, ['--json'], process.env);
-        return { content: [{ type: 'text' as const, text }] };
-      } catch (err) {
-        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }], isError: true };
-      }
-    },
+    async () => runToolCommand(fundRequirementsCommand, ['--json'], process.env),
   );
 
   server.tool(
     'jinn_status',
     'Daemon liveness and fleet health roll-up. Poll this for monitoring.',
     {},
-    async () => {
-      try {
-        const text = await runCommand(statusCommand, ['--json'], process.env);
-        return { content: [{ type: 'text' as const, text }] };
-      } catch (err) {
-        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }], isError: true };
-      }
-    },
+    async () => runToolCommand(statusCommand, ['--json'], process.env),
   );
 
   server.tool(
     'jinn_fleet',
     'Per-service fleet detail: wallets, staking status, activity counts.',
     {},
-    async () => {
-      try {
-        const text = await runCommand(fleetCommand, ['--json'], process.env);
-        return { content: [{ type: 'text' as const, text }] };
-      } catch (err) {
-        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }], isError: true };
-      }
-    },
+    async () => runToolCommand(fleetCommand, ['--json'], process.env),
   );
 
   server.tool(
     'jinn_balance',
     'Flat per-wallet balance map across master and service wallets.',
     {},
-    async () => {
-      try {
-        const text = await runCommand(balanceCommand, ['--json'], process.env);
-        return { content: [{ type: 'text' as const, text }] };
-      } catch (err) {
-        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }], isError: true };
-      }
-    },
+    async () => runToolCommand(balanceCommand, ['--json'], process.env),
   );
 
   server.tool(
@@ -278,14 +251,9 @@ export function createOperatorServer(): McpServer {
       since: z.string().optional().describe('Only return events after this ISO-8601 timestamp'),
     },
     async ({ limit, since }) => {
-      try {
-        const argv = ['--json', '--limit', String(limit)];
-        if (since) argv.push('--since', since);
-        const text = await runCommand(historyCommand, argv, process.env);
-        return { content: [{ type: 'text' as const, text }] };
-      } catch (err) {
-        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }], isError: true };
-      }
+      const argv = ['--json', '--limit', String(limit)];
+      if (since) argv.push('--since', since);
+      return runToolCommand(historyCommand, argv, process.env);
     },
   );
 
@@ -295,14 +263,7 @@ export function createOperatorServer(): McpServer {
     'jinn_bootstrap',
     'Advance the fleet state machine. Idempotent. May take several minutes. Returns funding_required if wallet needs ETH.',
     {},
-    async () => {
-      try {
-        const text = await runCommand(bootstrapCommand, ['--json'], process.env);
-        return { content: [{ type: 'text' as const, text }] };
-      } catch (err) {
-        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }], isError: true };
-      }
-    },
+    async () => runToolCommand(bootstrapCommand, ['--json'], process.env),
   );
 
   server.tool(
@@ -314,15 +275,10 @@ export function createOperatorServer(): McpServer {
       dry_run: z.boolean().optional().default(false).describe('Preview without posting on-chain'),
     },
     async ({ id, description, dry_run }) => {
-      try {
-        const argv = ['--id', id, '--description', description, '--json'];
-        if (dry_run) argv.push('--dry-run');
-        else argv.push('--yes'); // implicit confirmation in MCP context
-        const text = await runCommand(submitIntentCommand, argv, process.env);
-        return { content: [{ type: 'text' as const, text }] };
-      } catch (err) {
-        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }], isError: true };
-      }
+      const argv = ['--id', id, '--description', description, '--json'];
+      if (dry_run) argv.push('--dry-run');
+      else argv.push('--yes'); // implicit confirmation in MCP context
+      return runToolCommand(submitIntentCommand, argv, process.env);
     },
   );
 

--- a/client/src/mcp/operator-server.ts
+++ b/client/src/mcp/operator-server.ts
@@ -1,60 +1,71 @@
 /**
  * Operator-level MCP server for jinn-client.
  *
- * Exposes CLI commands as MCP tools so that an outer agent (e.g. Claude
- * Desktop, a fleet orchestrator) can inspect and manage a jinn node without
- * shelling out.  Each tool delegates to the same CommandModule that the
- * `jinn` CLI uses, capturing stdout into a string.
+ * Exposes tools that let an external agent (e.g. Claude Desktop) manage a jinn
+ * fleet: read status, bootstrap, submit intents, start/stop the daemon.
  *
- * Entry point: src/bin/jinn-mcp.ts
- * Context: docs/research/2026-04-agent-packaging.md sections 2.2, 5.1-5.3
+ * Entry point: client/src/bin/jinn-mcp.ts calls createOperatorServer().
+ *
+ * Design: wraps CLI command modules directly (Option B from the research doc).
+ * Each command already accepts an injectable { writer, exit } context, so we
+ * capture stdout into a string buffer and return it as the MCP tool response.
  */
 
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import statusCommand from '../cli/commands/status.js';
+import type { CommandModule, CommandContext } from '../cli/command.js';
+
+// ── Read-only command imports ───────────────────────────────────────────────
+import initCommand from '../cli/commands/init.js';
 import doctorCommand from '../cli/commands/doctor.js';
+import fundRequirementsCommand from '../cli/commands/fund-requirements.js';
+import statusCommand from '../cli/commands/status.js';
 import fleetCommand from '../cli/commands/fleet.js';
 import balanceCommand from '../cli/commands/balance.js';
 import historyCommand from '../cli/commands/history.js';
-import rewardsCommand from '../cli/commands/rewards.js';
-import initCommand from '../cli/commands/init.js';
-import type { CommandModule } from '../cli/command.js';
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
+// ── Write (mutating) command imports ────────────────────────────────────────
+import bootstrapCommand from '../cli/commands/bootstrap.js';
+import submitIntentCommand from '../cli/commands/submit-intent.js';
+import stopCommand from '../cli/commands/stop.js';
 
-class StringWriter {
-  private chunks: string[] = [];
-  write(s: string): boolean {
-    this.chunks.push(s);
-    return true;
-  }
-  toString(): string {
-    return this.chunks.join('');
-  }
-}
+// ── Helpers ─────────────────────────────────────────────────────────────────
 
+/**
+ * Run a CLI CommandModule in-process, capturing its stdout output as a string.
+ *
+ * The CLI commands call `ctx.exit()` on completion or error. We intercept that
+ * with a no-op so the MCP server process is not terminated. The captured text
+ * is always the JSON envelope the command writes.
+ */
 async function runCommand(
   command: CommandModule,
   argv: string[],
-  env: Record<string, string | undefined>,
+  env: NodeJS.ProcessEnv,
 ): Promise<string> {
-  const writer = new StringWriter();
-  await command.run({
+  const chunks: string[] = [];
+  const writer = {
+    write(s: string): boolean {
+      chunks.push(s);
+      return true;
+    },
+  };
+  const ctx: CommandContext = {
     argv,
     stdoutIsTty: false,
     writer,
-    exit: () => {},
+    exit: () => {}, // no-op: prevent process.exit() in MCP context
     env,
-  });
-  return writer.toString();
+  };
+  await command.run(ctx);
+  return chunks.join('');
 }
 
-// ---------------------------------------------------------------------------
-// Server factory
-// ---------------------------------------------------------------------------
+// ── Server factory ──────────────────────────────────────────────────────────
 
 export function createOperatorServer(): McpServer {
   const server = new McpServer({
@@ -62,136 +73,210 @@ export function createOperatorServer(): McpServer {
     version: '0.1.0',
   });
 
-  // 1. jinn_status
-  server.tool(
-    'jinn_status',
-    'Daemon liveness and monitoring roll-up',
-    {},
-    async () => {
-      try {
-        const text = await runCommand(statusCommand, ['--json'], process.env);
-        return { content: [{ type: 'text' as const, text }] };
-      } catch (err) {
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }],
-          isError: true,
-        };
-      }
-    },
-  );
+  // ━━ Read-only tools ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  // 2. jinn_doctor
-  server.tool(
-    'jinn_doctor',
-    'Preflight checks: node version, claude binary, keystore, deployment',
-    { config: z.string().optional().describe('Path to jinn config file') },
-    async ({ config }) => {
-      try {
-        const argv = ['--json', ...(config ? ['--config', config] : [])];
-        const text = await runCommand(doctorCommand, argv, process.env);
-        return { content: [{ type: 'text' as const, text }] };
-      } catch (err) {
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }],
-          isError: true,
-        };
-      }
-    },
-  );
-
-  // 3. jinn_fleet
-  server.tool(
-    'jinn_fleet',
-    'Per-service fleet detail: wallets, staking, rewards, attention flags',
-    {},
-    async () => {
-      try {
-        const text = await runCommand(fleetCommand, ['--json'], process.env);
-        return { content: [{ type: 'text' as const, text }] };
-      } catch (err) {
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }],
-          isError: true,
-        };
-      }
-    },
-  );
-
-  // 4. jinn_balance
-  server.tool(
-    'jinn_balance',
-    'Flat per-wallet balance map across master and service wallets',
-    {},
-    async () => {
-      try {
-        const text = await runCommand(balanceCommand, ['--json'], process.env);
-        return { content: [{ type: 'text' as const, text }] };
-      } catch (err) {
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }],
-          isError: true,
-        };
-      }
-    },
-  );
-
-  // 5. jinn_history
-  server.tool(
-    'jinn_history',
-    'Recent protocol activity',
-    {
-      limit: z.number().int().min(1).max(500).optional().describe('Max events'),
-      since: z.string().optional().describe('ISO-8601 timestamp filter'),
-    },
-    async ({ limit, since }) => {
-      try {
-        const argv = [
-          '--json',
-          ...(limit ? ['--limit', String(limit)] : []),
-          ...(since ? ['--since', since] : []),
-        ];
-        const text = await runCommand(historyCommand, argv, process.env);
-        return { content: [{ type: 'text' as const, text }] };
-      } catch (err) {
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }],
-          isError: true,
-        };
-      }
-    },
-  );
-
-  // 6. jinn_rewards
-  server.tool(
-    'jinn_rewards',
-    'Earned vs claimed per service; next checkpoint time',
-    {},
-    async () => {
-      try {
-        const text = await runCommand(rewardsCommand, ['--json'], process.env);
-        return { content: [{ type: 'text' as const, text }] };
-      } catch (err) {
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }],
-          isError: true,
-        };
-      }
-    },
-  );
-
-  // 7. jinn_init
   server.tool(
     'jinn_init',
-    'Generate master wallet and write encrypted keystore (idempotent)',
+    'Create the master wallet and write the encrypted keystore. Idempotent.',
     {},
     async () => {
       try {
         const text = await runCommand(initCommand, ['--json'], process.env);
         return { content: [{ type: 'text' as const, text }] };
       } catch (err) {
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }], isError: true };
+      }
+    },
+  );
+
+  server.tool(
+    'jinn_doctor',
+    'Preflight checks: node version, claude binary, keystore, deployment config.',
+    {},
+    async () => {
+      try {
+        const text = await runCommand(doctorCommand, ['--json'], process.env);
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (err) {
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }], isError: true };
+      }
+    },
+  );
+
+  server.tool(
+    'jinn_fund_requirements',
+    'List addresses that need funding before bootstrap can advance.',
+    {},
+    async () => {
+      try {
+        const text = await runCommand(fundRequirementsCommand, ['--json'], process.env);
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (err) {
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }], isError: true };
+      }
+    },
+  );
+
+  server.tool(
+    'jinn_status',
+    'Daemon liveness and fleet health roll-up. Poll this for monitoring.',
+    {},
+    async () => {
+      try {
+        const text = await runCommand(statusCommand, ['--json'], process.env);
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (err) {
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }], isError: true };
+      }
+    },
+  );
+
+  server.tool(
+    'jinn_fleet',
+    'Per-service fleet detail: wallets, staking status, activity counts.',
+    {},
+    async () => {
+      try {
+        const text = await runCommand(fleetCommand, ['--json'], process.env);
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (err) {
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }], isError: true };
+      }
+    },
+  );
+
+  server.tool(
+    'jinn_balance',
+    'Flat per-wallet balance map across master and service wallets.',
+    {},
+    async () => {
+      try {
+        const text = await runCommand(balanceCommand, ['--json'], process.env);
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (err) {
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }], isError: true };
+      }
+    },
+  );
+
+  server.tool(
+    'jinn_history',
+    'Recent protocol activity: intents, claims, deliveries, evaluations, rewards.',
+    {
+      limit: z.number().optional().default(50).describe('Max results (default 50)'),
+      since: z.string().optional().describe('Only return events after this ISO-8601 timestamp'),
+    },
+    async ({ limit, since }) => {
+      try {
+        const argv = ['--json', '--limit', String(limit)];
+        if (since) argv.push('--since', since);
+        const text = await runCommand(historyCommand, argv, process.env);
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (err) {
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }], isError: true };
+      }
+    },
+  );
+
+  // ━━ Write (mutating) tools ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  server.tool(
+    'jinn_bootstrap',
+    'Advance the fleet state machine. Idempotent. May take several minutes. Returns funding_required if wallet needs ETH.',
+    {},
+    async () => {
+      try {
+        const text = await runCommand(bootstrapCommand, ['--json'], process.env);
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (err) {
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }], isError: true };
+      }
+    },
+  );
+
+  server.tool(
+    'jinn_submit_intent',
+    'Post a desired state (restoration job) to the protocol. Idempotent by id.',
+    {
+      id: z.string().describe('Unique intent identifier'),
+      description: z.string().describe('Human-readable description of the desired state'),
+      dry_run: z.boolean().optional().default(false).describe('Preview without posting on-chain'),
+    },
+    async ({ id, description, dry_run }) => {
+      try {
+        const argv = ['--id', id, '--description', description, '--json'];
+        if (dry_run) argv.push('--dry-run');
+        else argv.push('--yes'); // implicit confirmation in MCP context
+        const text = await runCommand(submitIntentCommand, argv, process.env);
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (err) {
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }], isError: true };
+      }
+    },
+  );
+
+  server.tool(
+    'jinn_start_daemon',
+    'Start the jinn daemon as a detached background process. Returns the PID.',
+    {},
+    async () => {
+      const earningDir =
+        process.env['JINN_EARNING_DIR'] ??
+        join(process.env['HOME'] ?? '.', '.jinn-client', 'earning');
+      const pidPath = join(earningDir, 'daemon.pid');
+
+      // Check if already running
+      if (existsSync(pidPath)) {
+        try {
+          const existingPid = parseInt(readFileSync(pidPath, 'utf-8').trim(), 10);
+          process.kill(existingPid, 0); // existence check
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({ pid: existingPid, status: 'already_running' }),
+              },
+            ],
+          };
+        } catch {
+          /* stale pidfile — fall through to start */
+        }
+      }
+
+      // Resolve jinn binary path relative to this file
+      const jinnBinPath = fileURLToPath(new URL('../bin/jinn.js', import.meta.url));
+      const child = spawn(process.execPath, [jinnBinPath, 'run'], {
+        detached: true,
+        stdio: 'ignore',
+        env: { ...process.env },
+      });
+      child.unref();
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({ pid: child.pid, status: 'started' }),
+          },
+        ],
+      };
+    },
+  );
+
+  server.tool(
+    'jinn_stop_daemon',
+    'Stop the running jinn daemon. Idempotent: returns success even if already stopped.',
+    {},
+    async () => {
+      try {
+        const text = await runCommand(stopCommand, ['--json'], process.env);
+        return { content: [{ type: 'text' as const, text }] };
+      } catch {
+        // "No pidfile" is not an error in MCP context — daemon isn't running, which is the goal
         return {
-          content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }],
-          isError: true,
+          content: [
+            { type: 'text' as const, text: JSON.stringify({ status: 'not_running' }) },
+          ],
         };
       }
     },

--- a/client/src/mcp/operator-server.ts
+++ b/client/src/mcp/operator-server.ts
@@ -12,7 +12,7 @@
  */
 
 import { spawn } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -35,6 +35,11 @@ import stopCommand from '../cli/commands/stop.js';
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
+interface CommandRunResult {
+  text: string;
+  exitCode: number | null;
+}
+
 /**
  * Run a CLI CommandModule in-process, capturing its stdout output as a string.
  *
@@ -42,12 +47,13 @@ import stopCommand from '../cli/commands/stop.js';
  * with a no-op so the MCP server process is not terminated. The captured text
  * is always the JSON envelope the command writes.
  */
-async function runCommand(
+async function runCommandResult(
   command: CommandModule,
   argv: string[],
   env: NodeJS.ProcessEnv,
-): Promise<string> {
+): Promise<CommandRunResult> {
   const chunks: string[] = [];
+  let exitCode: number | null = null;
   const writer = {
     write(s: string): boolean {
       chunks.push(s);
@@ -58,11 +64,116 @@ async function runCommand(
     argv,
     stdoutIsTty: false,
     writer,
-    exit: () => {}, // no-op: prevent process.exit() in MCP context
+    exit: (code) => { exitCode = code; },
     env,
   };
   await command.run(ctx);
-  return chunks.join('');
+  return { text: chunks.join(''), exitCode };
+}
+
+async function runCommand(
+  command: CommandModule,
+  argv: string[],
+  env: NodeJS.ProcessEnv,
+): Promise<string> {
+  const result = await runCommandResult(command, argv, env);
+  return result.text;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitForPidfile(pidPath: string, timeoutMs: number): Promise<boolean> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (existsSync(pidPath)) {
+      return true;
+    }
+    await sleep(200);
+  }
+  return false;
+}
+
+function parseStopCommandNotRunning(text: string): boolean {
+  try {
+    const parsed = JSON.parse(text) as { code?: string; details?: { field?: string } };
+    return parsed.code === 'invalid_invocation' && parsed.details?.field === 'daemon_pidfile';
+  } catch {
+    return false;
+  }
+}
+
+export async function startDetachedDaemon(env: NodeJS.ProcessEnv): Promise<
+  { ok: true; payload: { pid: number | undefined; status: 'already_running' | 'started' | 'starting' } }
+  | { ok: false; payload: { status: 'failed'; detail: string } }
+> {
+  const earningDir =
+    env['JINN_EARNING_DIR'] ??
+    join(env['HOME'] ?? '.', '.jinn-client', 'earning');
+  const pidPath = join(earningDir, 'daemon.pid');
+
+  if (existsSync(pidPath)) {
+    try {
+      const existingPid = parseInt(readFileSync(pidPath, 'utf-8').trim(), 10);
+      process.kill(existingPid, 0);
+      return { ok: true, payload: { pid: existingPid, status: 'already_running' } };
+    } catch {
+      try {
+        unlinkSync(pidPath);
+      } catch {
+        /* ignore stale pidfile cleanup failures */
+      }
+    }
+  }
+
+  const jinnBinPath = fileURLToPath(new URL('../bin/jinn.js', import.meta.url));
+  const child = spawn(process.execPath, [jinnBinPath, 'run'], {
+    detached: true,
+    stdio: 'ignore',
+    env: { ...env },
+  });
+
+  const startResult = await Promise.race<
+    { status: 'started' | 'starting'; pid: number | undefined } | { status: 'failed'; detail: string }
+  >([
+    new Promise((resolve) => {
+      child.once('error', (err) => {
+        resolve({ status: 'failed', detail: err instanceof Error ? err.message : String(err) });
+      });
+      child.once('exit', (code, signal) => {
+        resolve({ status: 'failed', detail: `daemon exited during startup (code=${code ?? 'null'}, signal=${signal ?? 'null'})` });
+      });
+    }),
+    (async () => {
+      const pidfileReady = await waitForPidfile(pidPath, 5000);
+      return {
+        status: pidfileReady ? 'started' as const : 'starting' as const,
+        pid: child.pid,
+      };
+    })(),
+  ]);
+
+  child.unref();
+
+  if (startResult.status === 'failed') {
+    return { ok: false, payload: { status: 'failed', detail: startResult.detail } };
+  }
+
+  return { ok: true, payload: { pid: startResult.pid, status: startResult.status } };
+}
+
+export async function stopDetachedDaemon(env: NodeJS.ProcessEnv): Promise<
+  { ok: true; payload: Record<string, unknown> } | { ok: false; payload: string }
+> {
+  const result = await runCommandResult(stopCommand, ['--json'], env);
+  if (result.exitCode === null || result.exitCode === 0) {
+    return { ok: true, payload: JSON.parse(result.text) as Record<string, unknown> };
+  }
+  if (parseStopCommandNotRunning(result.text)) {
+    return { ok: true, payload: { status: 'not_running' } };
+  }
+  return { ok: false, payload: result.text };
 }
 
 // ── Server factory ──────────────────────────────────────────────────────────
@@ -220,43 +331,23 @@ export function createOperatorServer(): McpServer {
     'Start the jinn daemon as a detached background process. Returns the PID.',
     {},
     async () => {
-      const earningDir =
-        process.env['JINN_EARNING_DIR'] ??
-        join(process.env['HOME'] ?? '.', '.jinn-client', 'earning');
-      const pidPath = join(earningDir, 'daemon.pid');
-
-      // Check if already running
-      if (existsSync(pidPath)) {
-        try {
-          const existingPid = parseInt(readFileSync(pidPath, 'utf-8').trim(), 10);
-          process.kill(existingPid, 0); // existence check
-          return {
-            content: [
-              {
-                type: 'text' as const,
-                text: JSON.stringify({ pid: existingPid, status: 'already_running' }),
-              },
-            ],
-          };
-        } catch {
-          /* stale pidfile — fall through to start */
-        }
+      const result = await startDetachedDaemon(process.env);
+      if (!result.ok) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(result.payload),
+            },
+          ],
+          isError: true,
+        };
       }
-
-      // Resolve jinn binary path relative to this file
-      const jinnBinPath = fileURLToPath(new URL('../bin/jinn.js', import.meta.url));
-      const child = spawn(process.execPath, [jinnBinPath, 'run'], {
-        detached: true,
-        stdio: 'ignore',
-        env: { ...process.env },
-      });
-      child.unref();
-
       return {
         content: [
           {
             type: 'text' as const,
-            text: JSON.stringify({ pid: child.pid, status: 'started' }),
+            text: JSON.stringify(result.payload),
           },
         ],
       };
@@ -268,17 +359,11 @@ export function createOperatorServer(): McpServer {
     'Stop the running jinn daemon. Idempotent: returns success even if already stopped.',
     {},
     async () => {
-      try {
-        const text = await runCommand(stopCommand, ['--json'], process.env);
-        return { content: [{ type: 'text' as const, text }] };
-      } catch {
-        // "No pidfile" is not an error in MCP context — daemon isn't running, which is the goal
-        return {
-          content: [
-            { type: 'text' as const, text: JSON.stringify({ status: 'not_running' }) },
-          ],
-        };
+      const result = await stopDetachedDaemon(process.env);
+      if (result.ok) {
+        return { content: [{ type: 'text' as const, text: JSON.stringify(result.payload) }] };
       }
+      return { content: [{ type: 'text' as const, text: result.payload }], isError: true };
     },
   );
 

--- a/client/src/mcp/operator-server.ts
+++ b/client/src/mcp/operator-server.ts
@@ -1,0 +1,201 @@
+/**
+ * Operator-level MCP server for jinn-client.
+ *
+ * Exposes CLI commands as MCP tools so that an outer agent (e.g. Claude
+ * Desktop, a fleet orchestrator) can inspect and manage a jinn node without
+ * shelling out.  Each tool delegates to the same CommandModule that the
+ * `jinn` CLI uses, capturing stdout into a string.
+ *
+ * Entry point: src/bin/jinn-mcp.ts
+ * Context: docs/research/2026-04-agent-packaging.md sections 2.2, 5.1-5.3
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import statusCommand from '../cli/commands/status.js';
+import doctorCommand from '../cli/commands/doctor.js';
+import fleetCommand from '../cli/commands/fleet.js';
+import balanceCommand from '../cli/commands/balance.js';
+import historyCommand from '../cli/commands/history.js';
+import rewardsCommand from '../cli/commands/rewards.js';
+import initCommand from '../cli/commands/init.js';
+import type { CommandModule } from '../cli/command.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+class StringWriter {
+  private chunks: string[] = [];
+  write(s: string): boolean {
+    this.chunks.push(s);
+    return true;
+  }
+  toString(): string {
+    return this.chunks.join('');
+  }
+}
+
+async function runCommand(
+  command: CommandModule,
+  argv: string[],
+  env: Record<string, string | undefined>,
+): Promise<string> {
+  const writer = new StringWriter();
+  await command.run({
+    argv,
+    stdoutIsTty: false,
+    writer,
+    exit: () => {},
+    env,
+  });
+  return writer.toString();
+}
+
+// ---------------------------------------------------------------------------
+// Server factory
+// ---------------------------------------------------------------------------
+
+export function createOperatorServer(): McpServer {
+  const server = new McpServer({
+    name: 'jinn-operator',
+    version: '0.1.0',
+  });
+
+  // 1. jinn_status
+  server.tool(
+    'jinn_status',
+    'Daemon liveness and monitoring roll-up',
+    {},
+    async () => {
+      try {
+        const text = await runCommand(statusCommand, ['--json'], process.env);
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (err) {
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // 2. jinn_doctor
+  server.tool(
+    'jinn_doctor',
+    'Preflight checks: node version, claude binary, keystore, deployment',
+    { config: z.string().optional().describe('Path to jinn config file') },
+    async ({ config }) => {
+      try {
+        const argv = ['--json', ...(config ? ['--config', config] : [])];
+        const text = await runCommand(doctorCommand, argv, process.env);
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (err) {
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // 3. jinn_fleet
+  server.tool(
+    'jinn_fleet',
+    'Per-service fleet detail: wallets, staking, rewards, attention flags',
+    {},
+    async () => {
+      try {
+        const text = await runCommand(fleetCommand, ['--json'], process.env);
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (err) {
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // 4. jinn_balance
+  server.tool(
+    'jinn_balance',
+    'Flat per-wallet balance map across master and service wallets',
+    {},
+    async () => {
+      try {
+        const text = await runCommand(balanceCommand, ['--json'], process.env);
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (err) {
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // 5. jinn_history
+  server.tool(
+    'jinn_history',
+    'Recent protocol activity',
+    {
+      limit: z.number().int().min(1).max(500).optional().describe('Max events'),
+      since: z.string().optional().describe('ISO-8601 timestamp filter'),
+    },
+    async ({ limit, since }) => {
+      try {
+        const argv = [
+          '--json',
+          ...(limit ? ['--limit', String(limit)] : []),
+          ...(since ? ['--since', since] : []),
+        ];
+        const text = await runCommand(historyCommand, argv, process.env);
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (err) {
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // 6. jinn_rewards
+  server.tool(
+    'jinn_rewards',
+    'Earned vs claimed per service; next checkpoint time',
+    {},
+    async () => {
+      try {
+        const text = await runCommand(rewardsCommand, ['--json'], process.env);
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (err) {
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // 7. jinn_init
+  server.tool(
+    'jinn_init',
+    'Generate master wallet and write encrypted keystore (idempotent)',
+    {},
+    async () => {
+      try {
+        const text = await runCommand(initCommand, ['--json'], process.env);
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (err) {
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: String(err) }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  return server;
+}

--- a/client/test/cli/commands/bootstrap.test.ts
+++ b/client/test/cli/commands/bootstrap.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CommandContext } from '../../../src/cli/command.js';
 
 const bootstrapReturn = vi.hoisted(() => ({
@@ -21,8 +21,19 @@ const passwordResult = vi.hoisted(() => ({
       | { ok: false; message: string },
 }));
 
+const loadConfigMock = vi.fn();
+let constructorOptions: Record<string, unknown> | undefined;
+
+vi.mock('../../../src/config.js', () => ({
+  loadConfig: loadConfigMock,
+}));
+
 vi.mock('../../../src/earning/bootstrap.js', () => ({
   FleetBootstrapper: class {
+    constructor(options: Record<string, unknown>) {
+      constructorOptions = options;
+    }
+
     async bootstrap() {
       return { ...bootstrapReturn.val };
     }
@@ -52,6 +63,23 @@ function makeCtx(
 }
 
 describe('bootstrap command', () => {
+  beforeEach(() => {
+    loadConfigMock.mockReturnValue({
+      earningDir: '/tmp/earning',
+      network: 'testnet',
+      rpcUrl: 'http://127.0.0.1:8545',
+      stakingMode: 'standard',
+      targetServices: 1,
+      debug: false,
+      pollIntervalMs: 5000,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    constructorOptions = undefined;
+  });
+
   it('emits funding_required envelope and exits 10 when bootstrap returns funding', async () => {
     passwordResult.val = { ok: true, password: 'test' };
     bootstrapReturn.val = {
@@ -169,6 +197,33 @@ describe('bootstrap command', () => {
     const out = writes[writes.length - 1];
     expect(out).toContain('Bootstrap complete.');
     expect(out).toContain('0xaaa');
+    expect(exits).toEqual([0]);
+  });
+
+  it('passes the command env into FleetBootstrapper', async () => {
+    passwordResult.val = { ok: true, password: 'test-password' };
+    bootstrapReturn.val = {
+      ok: true,
+      message: 'ok',
+      fleet_state: {
+        master_address: '0xmaster',
+        services: [],
+      },
+    };
+    const { default: bootstrap } = await import('../../../src/cli/commands/bootstrap.js');
+    const { ctx, exits } = makeCtx({
+      JINN_PASSWORD: 'test-password',
+      JINN_DISABLE_TESTNET_FAUCET: '1',
+    }, { argv: ['--json'] });
+
+    await bootstrap.run(ctx);
+
+    expect(constructorOptions).toEqual(expect.objectContaining({
+      env: expect.objectContaining({
+        JINN_PASSWORD: 'test-password',
+        JINN_DISABLE_TESTNET_FAUCET: '1',
+      }),
+    }));
     expect(exits).toEqual([0]);
   });
 });

--- a/client/test/cli/commands/quickstart.test.ts
+++ b/client/test/cli/commands/quickstart.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { CommandContext } from '../../../src/cli/command.js';
+
+const runInitMock = vi.fn();
+const runBootstrapMock = vi.fn();
+const loadConfigMock = vi.fn();
+const mainMock = vi.fn();
+
+vi.mock('../../../src/cli/commands/init.js', () => ({
+  default: {
+    name: 'init',
+    summary: '',
+    helpText: '',
+    run: runInitMock,
+  },
+}));
+
+vi.mock('../../../src/cli/commands/bootstrap.js', () => ({
+  default: {
+    name: 'bootstrap',
+    summary: '',
+    helpText: '',
+    run: runBootstrapMock,
+  },
+}));
+
+vi.mock('../../../src/config.js', () => ({
+  loadConfig: loadConfigMock,
+}));
+
+vi.mock('../../../src/main.js', () => ({
+  main: mainMock,
+}));
+
+function makeCtx(argv: string[] = [], env: Record<string, string> = { JINN_PASSWORD: 'test-password' }): {
+  ctx: CommandContext;
+  writes: string[];
+  exits: number[];
+} {
+  const writes: string[] = [];
+  const exits: number[] = [];
+  return {
+    ctx: {
+      argv,
+      stdoutIsTty: false,
+      writer: { write: (s: string) => { writes.push(s); return true; } },
+      exit: (code: number) => { exits.push(code); },
+      env,
+    },
+    writes,
+    exits,
+  };
+}
+
+describe('quickstart command', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('passes --config through to bootstrap and disables faucet retries while polling', async () => {
+    vi.useFakeTimers();
+
+    runInitMock.mockImplementation(async (ctx: CommandContext) => {
+      ctx.writer.write(JSON.stringify({ master: '0xmaster' }));
+      ctx.exit(0);
+    });
+
+    runBootstrapMock
+      .mockImplementationOnce(async (ctx: CommandContext) => {
+        ctx.writer.write(JSON.stringify({
+          code: 'funding_required',
+          details: { address: '0xmaster' },
+          hint: 'Fund the wallet.',
+        }));
+        ctx.exit(10);
+      })
+      .mockImplementationOnce(async (ctx: CommandContext) => {
+        ctx.writer.write(JSON.stringify({ ok: true }));
+        ctx.exit(0);
+      });
+
+    loadConfigMock.mockReturnValue({ apiPort: 9555 });
+
+    const { default: quickstart } = await import('../../../src/cli/commands/quickstart.js');
+    const { ctx, writes, exits } = makeCtx(['--config', '/tmp/custom.json', '--no-daemon']);
+
+    const runPromise = quickstart.run(ctx);
+    await vi.advanceTimersByTimeAsync(15_000);
+    await runPromise;
+
+    expect(runBootstrapMock).toHaveBeenCalledTimes(2);
+    expect(runBootstrapMock.mock.calls[0]?.[0]).toMatchObject({
+      argv: ['--json', '--config', '/tmp/custom.json'],
+      env: expect.objectContaining({ JINN_PASSWORD: 'test-password' }),
+    });
+    expect(runBootstrapMock.mock.calls[1]?.[0]).toMatchObject({
+      argv: ['--json', '--config', '/tmp/custom.json'],
+      env: expect.objectContaining({
+        JINN_PASSWORD: 'test-password',
+        JINN_DISABLE_TESTNET_FAUCET: '1',
+      }),
+    });
+
+    expect(exits).toEqual([]);
+    const payload = JSON.parse(writes[writes.length - 1] ?? '{}');
+    expect(payload.status).toBe('ready');
+    expect(payload.dashboardUrl).toBe('http://127.0.0.1:9555');
+  });
+});

--- a/client/test/cli/commands/update.test.ts
+++ b/client/test/cli/commands/update.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { CommandContext } from '../../../src/cli/command.js';
+
+const execSyncMock = vi.fn();
+const pluginRunMock = vi.fn();
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    execSync: execSyncMock,
+  };
+});
+
+vi.mock('../../../src/cli/commands/plugin-install.js', () => ({
+  default: {
+    name: 'plugin',
+    summary: '',
+    helpText: '',
+    run: pluginRunMock,
+  },
+}));
+
+function makeCtx(argv: string[] = ['--json'], env: Record<string, string> = {}): {
+  ctx: CommandContext;
+  writes: string[];
+  exits: number[];
+} {
+  const writes: string[] = [];
+  const exits: number[] = [];
+  return {
+    ctx: {
+      argv,
+      stdoutIsTty: false,
+      writer: { write: (s: string) => { writes.push(s); return true; } },
+      exit: (code: number) => { exits.push(code); },
+      env,
+    },
+    writes,
+    exits,
+  };
+}
+
+describe('update command', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports plugin refresh errors even when plugin install does not set an exit code', async () => {
+    pluginRunMock.mockImplementation(async (ctx: CommandContext) => {
+      ctx.writer.write(JSON.stringify({
+        results: [
+          {
+            target: 'claude-code',
+            mcp: { status: 'error', detail: 'failed to add MCP' },
+            skill: { status: 'configured', detail: 'skill installed' },
+          },
+        ],
+      }));
+    });
+
+    const { default: updateCommand } = await import('../../../src/cli/commands/update.js');
+    const { ctx, writes, exits } = makeCtx(['--json', '--skip-npm']);
+
+    await updateCommand.run(ctx);
+
+    const payload = JSON.parse(writes[writes.length - 1] ?? '{}');
+    expect(payload.ok).toBe(false);
+    expect(payload.steps).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        step: 'plugin-install',
+        status: 'error',
+      }),
+    ]));
+    expect(payload.steps.find((step: { step: string }) => step.step === 'plugin-install')?.detail)
+      .toContain('claude-code');
+    expect(exits).toEqual([]);
+  });
+});

--- a/client/test/earning/faucet.test.ts
+++ b/client/test/earning/faucet.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const requestFaucetMock = vi.fn();
+const cdpClientOptions: Array<Record<string, string>> = [];
+
+vi.mock('@coinbase/cdp-sdk', () => ({
+  CdpClient: class {
+    evm = {
+      requestFaucet: requestFaucetMock,
+    };
+
+    constructor(options: Record<string, string>) {
+      cdpClientOptions.push(options);
+    }
+  },
+}));
+
+describe('requestTestnetFunding', () => {
+  beforeEach(() => {
+    delete process.env['CDP_API_KEY_ID'];
+    delete process.env['CDP_API_KEY_SECRET'];
+    cdpClientOptions.length = 0;
+    requestFaucetMock.mockResolvedValue({ transactionHash: '0xtesthash' });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses a complete shipped credential pair when env overrides are absent', async () => {
+    const { requestTestnetFunding } = await import('../../src/earning/faucet.js');
+
+    const result = await requestTestnetFunding(
+      '0x0000000000000000000000000000000000000001',
+      'base-sepolia',
+    );
+
+    expect(result).toEqual({ ok: true, txHash: '0xtesthash' });
+    expect(cdpClientOptions).toHaveLength(1);
+    expect(cdpClientOptions[0]).toEqual(expect.objectContaining({
+      apiKeyId: expect.any(String),
+      apiKeySecret: expect.any(String),
+    }));
+    expect(cdpClientOptions[0]?.apiKeyId.length).toBeGreaterThan(0);
+    expect(cdpClientOptions[0]?.apiKeySecret.length).toBeGreaterThan(0);
+    expect(requestFaucetMock).toHaveBeenCalledWith({
+      address: '0x0000000000000000000000000000000000000001',
+      network: 'base-sepolia',
+      token: 'eth',
+    });
+  });
+});

--- a/client/test/mcp/operator-server.test.ts
+++ b/client/test/mcp/operator-server.test.ts
@@ -7,6 +7,7 @@ import type { CommandContext } from '../../src/cli/command.js';
 
 const spawnMock = vi.fn();
 const stopRunMock = vi.fn();
+const initRunMock = vi.fn();
 
 vi.mock('node:child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:child_process')>();
@@ -22,6 +23,15 @@ vi.mock('../../src/cli/commands/stop.js', () => ({
     summary: '',
     helpText: '',
     run: stopRunMock,
+  },
+}));
+
+vi.mock('../../src/cli/commands/init.js', () => ({
+  default: {
+    name: 'init',
+    summary: '',
+    helpText: '',
+    run: initRunMock,
   },
 }));
 
@@ -69,6 +79,31 @@ describe('operator MCP helpers', () => {
     expect(result).toEqual({
       ok: true,
       payload: { status: 'not_running' },
+    });
+  });
+
+  it('marks nonzero CLI envelopes as MCP tool errors', async () => {
+    initRunMock.mockImplementation(async (ctx: CommandContext) => {
+      ctx.writer.write(JSON.stringify({
+        code: 'invalid_invocation',
+        message: 'missing password',
+      }));
+      ctx.exit(2);
+    });
+
+    const { createOperatorServer } = await import('../../src/mcp/operator-server.js');
+    const server = createOperatorServer();
+    const result = await server._registeredTools.jinn_init.handler({}, {});
+
+    expect(result).toEqual({
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          code: 'invalid_invocation',
+          message: 'missing password',
+        }),
+      }],
+      isError: true,
     });
   });
 });

--- a/client/test/mcp/operator-server.test.ts
+++ b/client/test/mcp/operator-server.test.ts
@@ -1,0 +1,74 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { EventEmitter } from 'node:events';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { CommandContext } from '../../src/cli/command.js';
+
+const spawnMock = vi.fn();
+const stopRunMock = vi.fn();
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: spawnMock,
+  };
+});
+
+vi.mock('../../src/cli/commands/stop.js', () => ({
+  default: {
+    name: 'stop',
+    summary: '',
+    helpText: '',
+    run: stopRunMock,
+  },
+}));
+
+class FakeChildProcess extends EventEmitter {
+  pid = 4242;
+  unref = vi.fn();
+}
+
+describe('operator MCP helpers', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    vi.useRealTimers();
+  });
+
+  it('returns starting until daemon startup creates a pidfile', async () => {
+    vi.useFakeTimers();
+    spawnMock.mockReturnValue(new FakeChildProcess());
+
+    const { startDetachedDaemon } = await import('../../src/mcp/operator-server.js');
+    const home = mkdtempSync(join(tmpdir(), 'jinn-mcp-start-'));
+
+    const promise = startDetachedDaemon({ HOME: home });
+    await vi.advanceTimersByTimeAsync(5_000);
+    const result = await promise;
+
+    expect(result).toEqual({
+      ok: true,
+      payload: { pid: 4242, status: 'starting' },
+    });
+  });
+
+  it('maps a missing pidfile stop response to not_running', async () => {
+    stopRunMock.mockImplementation(async (ctx: CommandContext) => {
+      ctx.writer.write(JSON.stringify({
+        code: 'invalid_invocation',
+        details: { field: 'daemon_pidfile' },
+      }));
+      ctx.exit(11);
+    });
+
+    const { stopDetachedDaemon } = await import('../../src/mcp/operator-server.js');
+    const result = await stopDetachedDaemon({});
+
+    expect(result).toEqual({
+      ok: true,
+      payload: { status: 'not_running' },
+    });
+  });
+});

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -538,6 +538,7 @@ __metadata:
     zod: "npm:^3.22.0"
   bin:
     jinn: ./dist/bin/jinn.js
+    jinn-mcp: ./dist/bin/jinn-mcp.js
   languageName: unknown
   linkType: soft
 

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -35,6 +35,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@coinbase/cdp-sdk@npm:^1.47.0":
+  version: 1.47.0
+  resolution: "@coinbase/cdp-sdk@npm:1.47.0"
+  dependencies:
+    "@solana-program/system": "npm:^0.10.0"
+    "@solana-program/token": "npm:^0.9.0"
+    "@solana/kit": "npm:^5.5.1"
+    abitype: "npm:1.0.6"
+    axios: "npm:1.13.6"
+    axios-retry: "npm:^4.5.0"
+    jose: "npm:^6.2.0"
+    md5: "npm:^2.3.0"
+    uncrypto: "npm:^0.1.3"
+    viem: "npm:^2.47.0"
+    zod: "npm:^3.25.76"
+  checksum: 10c0/598397d1a7859c7f82a6d890aa1be7790e127a3f34362b4299ddbf0caec9e08bb264e92d4901da0300b7e4b447e8c6abb39ef9314adf5c01a8deb89d497b4314
+  languageName: node
+  linkType: hard
+
 "@dnsquery/dns-packet@npm:^6.1.1":
   version: 6.1.1
   resolution: "@dnsquery/dns-packet@npm:6.1.1"
@@ -513,6 +532,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jinn-network/client@workspace:."
   dependencies:
+    "@coinbase/cdp-sdk": "npm:^1.47.0"
     "@ethereumjs/wallet": "npm:^10.0.0"
     "@hono/node-server": "npm:^1.19.12"
     "@jinn-network/mech-client-ts": "npm:^0.0.6"
@@ -536,6 +556,9 @@ __metadata:
     viem: "npm:^2.0.0"
     vitest: "npm:^2.0.0"
     zod: "npm:^3.22.0"
+  dependenciesMeta:
+    "@coinbase/cdp-sdk":
+      optional: true
   bin:
     jinn: ./dist/bin/jinn.js
     jinn-mcp: ./dist/bin/jinn-mcp.js
@@ -1303,6 +1326,716 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana-program/system@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "@solana-program/system@npm:0.10.0"
+  peerDependencies:
+    "@solana/kit": ^5.0
+  checksum: 10c0/4cc3164d49fe7b10e9c0c89493f738e2d4294e2eae40fafee56b01dfb50b939c88f82eb06d5393333743b0edee961b03e947afcc20e6965252576900266ec52e
+  languageName: node
+  linkType: hard
+
+"@solana-program/token@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "@solana-program/token@npm:0.9.0"
+  peerDependencies:
+    "@solana/kit": ^5.0
+  checksum: 10c0/f23b591e0ad27aa05e940429de73ebc0b9cbb65542e5aae775ac616577307d341d3335e36e24a38ba7612bcc584e50bd7cec360ca4904f42219f2708a9d453aa
+  languageName: node
+  linkType: hard
+
+"@solana/accounts@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/accounts@npm:5.5.1"
+  dependencies:
+    "@solana/addresses": "npm:5.5.1"
+    "@solana/codecs-core": "npm:5.5.1"
+    "@solana/codecs-strings": "npm:5.5.1"
+    "@solana/errors": "npm:5.5.1"
+    "@solana/rpc-spec": "npm:5.5.1"
+    "@solana/rpc-types": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/9851005767107f198a7d4dbd5498b271236d83527b25fc05d7beb5b347ac072fb51119b9863d2033e89bb9ee06e78289a1a71b0147d19a444c28ba36f19f970b
+  languageName: node
+  linkType: hard
+
+"@solana/addresses@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/addresses@npm:5.5.1"
+  dependencies:
+    "@solana/assertions": "npm:5.5.1"
+    "@solana/codecs-core": "npm:5.5.1"
+    "@solana/codecs-strings": "npm:5.5.1"
+    "@solana/errors": "npm:5.5.1"
+    "@solana/nominal-types": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/4908e3019c930c2c4a13528eae7a5bfac25400b4173144180a68bcbac43d1b90b0771bf952711503814440547ed45d32c3b450bac0aff19974035111e0f79865
+  languageName: node
+  linkType: hard
+
+"@solana/assertions@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/assertions@npm:5.5.1"
+  dependencies:
+    "@solana/errors": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/d1a8fbfdd8e551d84b7624d645fcae66a26d9022828795f10b252f45fb84299088cec75e8f156895bb930c977db1bcbdda8ceb011f373fb288f0adb5ea4ecd31
+  languageName: node
+  linkType: hard
+
+"@solana/codecs-core@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/codecs-core@npm:5.5.1"
+  dependencies:
+    "@solana/errors": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/a66cd3e3c9a0fcf369be5c3369463db03f4b1e1aa0d322d6cb8440613dcc83608dd52501ff2ee3c56daed2b1f2b07751cfa1fe1aeb584a306a9e14175b0ca994
+  languageName: node
+  linkType: hard
+
+"@solana/codecs-data-structures@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/codecs-data-structures@npm:5.5.1"
+  dependencies:
+    "@solana/codecs-core": "npm:5.5.1"
+    "@solana/codecs-numbers": "npm:5.5.1"
+    "@solana/errors": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/db88246a2fc3d4c3c7d69d5e9ce7fab815be4e10e0b1519ed00454c7ac2189fc3dd2d2ae0cb05a77d560ccdc615652122cfada59e34285ce08545474542e4874
+  languageName: node
+  linkType: hard
+
+"@solana/codecs-numbers@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/codecs-numbers@npm:5.5.1"
+  dependencies:
+    "@solana/codecs-core": "npm:5.5.1"
+    "@solana/errors": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/1802ec289a912b086c031c8da7f856ffb2c5a581b2fef9de5bd0ea23e192ca472cc01f1a46747e0f9c1505c826f404bf2862d7403175688136b87056d22fc441
+  languageName: node
+  linkType: hard
+
+"@solana/codecs-strings@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/codecs-strings@npm:5.5.1"
+  dependencies:
+    "@solana/codecs-core": "npm:5.5.1"
+    "@solana/codecs-numbers": "npm:5.5.1"
+    "@solana/errors": "npm:5.5.1"
+  peerDependencies:
+    fastestsmallesttextencoderdecoder: ^1.0.22
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    fastestsmallesttextencoderdecoder:
+      optional: true
+    typescript:
+      optional: true
+  checksum: 10c0/16cf7f6edee96a11862bf41cc31e0162848ecd5ba67826eee3e5fe9f10007631db5f34f794fcf44bb075cbcaf43843e34632659105f75a02c7ff3d703ee49325
+  languageName: node
+  linkType: hard
+
+"@solana/codecs@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/codecs@npm:5.5.1"
+  dependencies:
+    "@solana/codecs-core": "npm:5.5.1"
+    "@solana/codecs-data-structures": "npm:5.5.1"
+    "@solana/codecs-numbers": "npm:5.5.1"
+    "@solana/codecs-strings": "npm:5.5.1"
+    "@solana/options": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/bf576cb014f342edddb4b77f83a111ceecfc5709ecaa6225c71cbb40b3d31aba26f3c3f5787684d472b1ed0c705df10be517fdbab659cf43cd7a6e21bea9a9c1
+  languageName: node
+  linkType: hard
+
+"@solana/errors@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/errors@npm:5.5.1"
+  dependencies:
+    chalk: "npm:5.6.2"
+    commander: "npm:14.0.2"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    errors: bin/cli.mjs
+  checksum: 10c0/cafa60aa4ca91c78b0d85e5d296c9080fc537b0c62ba1bc3d3d00eaad96d2894178849be478e653cf963a2d18d71b54e0f58f319a7d77f6dbfdd5845af4c6a08
+  languageName: node
+  linkType: hard
+
+"@solana/fast-stable-stringify@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/fast-stable-stringify@npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/b116c515e71cdace7a2e45c001de486c528e178f6170dc6faaea33a3a076a5ddd7806302584e480ef0dbf9f84c9a808cbc99a068c48b0e777bc5b5e178291ed9
+  languageName: node
+  linkType: hard
+
+"@solana/functional@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/functional@npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/17f60572407006b8913529019d928b0b43b6c24798fd743673a7878e8b8db25ebe27b7eb9ef0e28cc24773d34acbb1d5fe617f9096d527efc62c9e6719f7ada2
+  languageName: node
+  linkType: hard
+
+"@solana/instruction-plans@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/instruction-plans@npm:5.5.1"
+  dependencies:
+    "@solana/errors": "npm:5.5.1"
+    "@solana/instructions": "npm:5.5.1"
+    "@solana/keys": "npm:5.5.1"
+    "@solana/promises": "npm:5.5.1"
+    "@solana/transaction-messages": "npm:5.5.1"
+    "@solana/transactions": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/9f1cde9b925f1ecc01f3ceb6b87ba6154befb991ad58b176f58f2f210d75968d2dc26adada623d54eb5039a4116c5f8bf48e5153b813720dfc91301c2e37eb42
+  languageName: node
+  linkType: hard
+
+"@solana/instructions@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/instructions@npm:5.5.1"
+  dependencies:
+    "@solana/codecs-core": "npm:5.5.1"
+    "@solana/errors": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/72b3d599e8016ec6fdb34b3cdbc9cca76a8153e911fd18bee3ea9af8caf19591615425eb3c24aa04ee5da16f87fc568a17574532859b7a50c829c49397458dc4
+  languageName: node
+  linkType: hard
+
+"@solana/keys@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/keys@npm:5.5.1"
+  dependencies:
+    "@solana/assertions": "npm:5.5.1"
+    "@solana/codecs-core": "npm:5.5.1"
+    "@solana/codecs-strings": "npm:5.5.1"
+    "@solana/errors": "npm:5.5.1"
+    "@solana/nominal-types": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/1b76a7c5b15a331ebc51c003f2f2e248c91a0f3c09659de855b05757c203c7a0e165c18c3a1b3636fd919859eb58b3e51afac234aa186e01305d4c5a38a3255d
+  languageName: node
+  linkType: hard
+
+"@solana/kit@npm:^5.5.1":
+  version: 5.5.1
+  resolution: "@solana/kit@npm:5.5.1"
+  dependencies:
+    "@solana/accounts": "npm:5.5.1"
+    "@solana/addresses": "npm:5.5.1"
+    "@solana/codecs": "npm:5.5.1"
+    "@solana/errors": "npm:5.5.1"
+    "@solana/functional": "npm:5.5.1"
+    "@solana/instruction-plans": "npm:5.5.1"
+    "@solana/instructions": "npm:5.5.1"
+    "@solana/keys": "npm:5.5.1"
+    "@solana/offchain-messages": "npm:5.5.1"
+    "@solana/plugin-core": "npm:5.5.1"
+    "@solana/programs": "npm:5.5.1"
+    "@solana/rpc": "npm:5.5.1"
+    "@solana/rpc-api": "npm:5.5.1"
+    "@solana/rpc-parsed-types": "npm:5.5.1"
+    "@solana/rpc-spec-types": "npm:5.5.1"
+    "@solana/rpc-subscriptions": "npm:5.5.1"
+    "@solana/rpc-types": "npm:5.5.1"
+    "@solana/signers": "npm:5.5.1"
+    "@solana/sysvars": "npm:5.5.1"
+    "@solana/transaction-confirmation": "npm:5.5.1"
+    "@solana/transaction-messages": "npm:5.5.1"
+    "@solana/transactions": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/391fd781c28c2550dae77395b0bc4e37799da13695be03c5c57e82c31b4556c29b8ac4853087908549415c419ed758c34c1ac9cdae37c4e0d28b4c9be6867b81
+  languageName: node
+  linkType: hard
+
+"@solana/nominal-types@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/nominal-types@npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/aa0f5b850c6e74d6f883d9a2513f561112d531cda750ba75efbc84a524ffc69e014740f5fac308b42499b5ea4fcaa5d34fe3acd334ef65dffe22ba822c476fbc
+  languageName: node
+  linkType: hard
+
+"@solana/offchain-messages@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/offchain-messages@npm:5.5.1"
+  dependencies:
+    "@solana/addresses": "npm:5.5.1"
+    "@solana/codecs-core": "npm:5.5.1"
+    "@solana/codecs-data-structures": "npm:5.5.1"
+    "@solana/codecs-numbers": "npm:5.5.1"
+    "@solana/codecs-strings": "npm:5.5.1"
+    "@solana/errors": "npm:5.5.1"
+    "@solana/keys": "npm:5.5.1"
+    "@solana/nominal-types": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/93ba0fec4a3387e4809d8ebbdeb71901d69821cdd4b3645ee054197f9d564227cb76d66b509b98f1902fe522575662824ea58e583665c624dfb05e9a0d52b6dc
+  languageName: node
+  linkType: hard
+
+"@solana/options@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/options@npm:5.5.1"
+  dependencies:
+    "@solana/codecs-core": "npm:5.5.1"
+    "@solana/codecs-data-structures": "npm:5.5.1"
+    "@solana/codecs-numbers": "npm:5.5.1"
+    "@solana/codecs-strings": "npm:5.5.1"
+    "@solana/errors": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/d4ab205e1286ba02a2ad97d8a3ad22e57798ce8f0fd77f3734f2c4a923c9fc7f0f949d5ceeb8b33eaf5484460c49ed0d9138f3eff5a571e754488f8aa4819269
+  languageName: node
+  linkType: hard
+
+"@solana/plugin-core@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/plugin-core@npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/6d981acfde238517692126f66594598b203eec84753677851f0dc038d01a8c55603aff1319513ba5306a29bf6b0018a1ad2d3b9de49d984acc0ecf76abfffbaa
+  languageName: node
+  linkType: hard
+
+"@solana/programs@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/programs@npm:5.5.1"
+  dependencies:
+    "@solana/addresses": "npm:5.5.1"
+    "@solana/errors": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/4d31ca06655366d368a853772559d5853494e82c559a02b8f6c4f90d390fb196df50b2d0d0540c2f7bbb7cc0abb3ac2e5694c2148a2bcc034a33dd64b7a105f4
+  languageName: node
+  linkType: hard
+
+"@solana/promises@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/promises@npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/d9818a5d38b85a17f74782457d8953c95835cc1190a63ff6749610e5f6272ee50d08f5720a84f9a5885e0faa94390210b86d927cf81c95f63707a122dfae100d
+  languageName: node
+  linkType: hard
+
+"@solana/rpc-api@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/rpc-api@npm:5.5.1"
+  dependencies:
+    "@solana/addresses": "npm:5.5.1"
+    "@solana/codecs-core": "npm:5.5.1"
+    "@solana/codecs-strings": "npm:5.5.1"
+    "@solana/errors": "npm:5.5.1"
+    "@solana/keys": "npm:5.5.1"
+    "@solana/rpc-parsed-types": "npm:5.5.1"
+    "@solana/rpc-spec": "npm:5.5.1"
+    "@solana/rpc-transformers": "npm:5.5.1"
+    "@solana/rpc-types": "npm:5.5.1"
+    "@solana/transaction-messages": "npm:5.5.1"
+    "@solana/transactions": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/7ac47bc771d825c251f18d92e0eaef8a1f90542e5313249f88970aff666e8aa4ba446d9efc0ded2188d60c41512c09aa285bf1847bd0c439e1a4ddcb20748fc4
+  languageName: node
+  linkType: hard
+
+"@solana/rpc-parsed-types@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/rpc-parsed-types@npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/b042b4d252e7b31a2e2cdc957711f0ecc438d1667da7414c0da25218fb439b1de2de0c1845a2ca776cddd8e399ba886a43a1f72a50e1ae0790ea6a500c90cfdb
+  languageName: node
+  linkType: hard
+
+"@solana/rpc-spec-types@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/rpc-spec-types@npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/19b4c0e3de748db5520ab4f21a97e7ddf8e5f7a722bf635eb62aacd72ee334b2b8ab8f9343bf660055ad61f4ff71cc402e52dd41b3742944e71f54e67bf82f5a
+  languageName: node
+  linkType: hard
+
+"@solana/rpc-spec@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/rpc-spec@npm:5.5.1"
+  dependencies:
+    "@solana/errors": "npm:5.5.1"
+    "@solana/rpc-spec-types": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/634d5cd3ea7789ff20ca82782ce2fde6bb96c09fcd49dc9d113ade98a4516d2d080f771f3247454e9d4478933a3c1f1380a8409817c12cd40ef6e3579faa1d0d
+  languageName: node
+  linkType: hard
+
+"@solana/rpc-subscriptions-api@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/rpc-subscriptions-api@npm:5.5.1"
+  dependencies:
+    "@solana/addresses": "npm:5.5.1"
+    "@solana/keys": "npm:5.5.1"
+    "@solana/rpc-subscriptions-spec": "npm:5.5.1"
+    "@solana/rpc-transformers": "npm:5.5.1"
+    "@solana/rpc-types": "npm:5.5.1"
+    "@solana/transaction-messages": "npm:5.5.1"
+    "@solana/transactions": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/3ad059f20c361d5ced84f1d584ff5513d78559497c7cf8855703a7c1437dcb3024fc1dfe9d1be65e8241a4d1a4d0c272ed2ddca7e1aca3086f204546836503f9
+  languageName: node
+  linkType: hard
+
+"@solana/rpc-subscriptions-channel-websocket@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/rpc-subscriptions-channel-websocket@npm:5.5.1"
+  dependencies:
+    "@solana/errors": "npm:5.5.1"
+    "@solana/functional": "npm:5.5.1"
+    "@solana/rpc-subscriptions-spec": "npm:5.5.1"
+    "@solana/subscribable": "npm:5.5.1"
+    ws: "npm:^8.19.0"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/37619caefa2f36fdbbbdab0478965a0bc14f72254caa511ecc067700d9c23f4ac221a61079974b8f6286aa2b71bb4ae5fa106297e7044ef0ed7ceb2d816c74a2
+  languageName: node
+  linkType: hard
+
+"@solana/rpc-subscriptions-spec@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/rpc-subscriptions-spec@npm:5.5.1"
+  dependencies:
+    "@solana/errors": "npm:5.5.1"
+    "@solana/promises": "npm:5.5.1"
+    "@solana/rpc-spec-types": "npm:5.5.1"
+    "@solana/subscribable": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/9b9e3a81977ee4deac918226a6f6d41fb524563a027d09da4439e18d3c99dd79b2af5a022a16ac97744f8e93ec9dd409714d5c371a313cb811c22194b94f28cc
+  languageName: node
+  linkType: hard
+
+"@solana/rpc-subscriptions@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/rpc-subscriptions@npm:5.5.1"
+  dependencies:
+    "@solana/errors": "npm:5.5.1"
+    "@solana/fast-stable-stringify": "npm:5.5.1"
+    "@solana/functional": "npm:5.5.1"
+    "@solana/promises": "npm:5.5.1"
+    "@solana/rpc-spec-types": "npm:5.5.1"
+    "@solana/rpc-subscriptions-api": "npm:5.5.1"
+    "@solana/rpc-subscriptions-channel-websocket": "npm:5.5.1"
+    "@solana/rpc-subscriptions-spec": "npm:5.5.1"
+    "@solana/rpc-transformers": "npm:5.5.1"
+    "@solana/rpc-types": "npm:5.5.1"
+    "@solana/subscribable": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/4dda3a418bae0eff6f7da59cc21840e45bd80f3e5fee9edd32ad66b4d128490838017e2ade245fbcd8f4f765bb67350bace41fc56e00a82b739be6d24fd00bbd
+  languageName: node
+  linkType: hard
+
+"@solana/rpc-transformers@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/rpc-transformers@npm:5.5.1"
+  dependencies:
+    "@solana/errors": "npm:5.5.1"
+    "@solana/functional": "npm:5.5.1"
+    "@solana/nominal-types": "npm:5.5.1"
+    "@solana/rpc-spec-types": "npm:5.5.1"
+    "@solana/rpc-types": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/3500e42b486627be8e39838f02f2f28c759b0183c1bc34e28d2f2289e9ae2e58d5d0825973da601f9f29b1ab366b0017b49df5329c1dcc9932724b9bfdfafafd
+  languageName: node
+  linkType: hard
+
+"@solana/rpc-transport-http@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/rpc-transport-http@npm:5.5.1"
+  dependencies:
+    "@solana/errors": "npm:5.5.1"
+    "@solana/rpc-spec": "npm:5.5.1"
+    "@solana/rpc-spec-types": "npm:5.5.1"
+    undici-types: "npm:^7.19.2"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/4300e1a334e2ea8deb66542dabff835ae3dbccbaba0011c1cb027f55219cb3144c7fcd5220da06565ef5fa87a25e73a43497caeb7100ff9f1a947792b2325489
+  languageName: node
+  linkType: hard
+
+"@solana/rpc-types@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/rpc-types@npm:5.5.1"
+  dependencies:
+    "@solana/addresses": "npm:5.5.1"
+    "@solana/codecs-core": "npm:5.5.1"
+    "@solana/codecs-numbers": "npm:5.5.1"
+    "@solana/codecs-strings": "npm:5.5.1"
+    "@solana/errors": "npm:5.5.1"
+    "@solana/nominal-types": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/84fcad12f65c88bfbbe0689d1fb6715e37c41454b85f50ae0963f2626c45a26155f2395b03ab48f261966f1a5c02b1c96ad42ba0b1ca80c5fe22f08757401b1b
+  languageName: node
+  linkType: hard
+
+"@solana/rpc@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/rpc@npm:5.5.1"
+  dependencies:
+    "@solana/errors": "npm:5.5.1"
+    "@solana/fast-stable-stringify": "npm:5.5.1"
+    "@solana/functional": "npm:5.5.1"
+    "@solana/rpc-api": "npm:5.5.1"
+    "@solana/rpc-spec": "npm:5.5.1"
+    "@solana/rpc-spec-types": "npm:5.5.1"
+    "@solana/rpc-transformers": "npm:5.5.1"
+    "@solana/rpc-transport-http": "npm:5.5.1"
+    "@solana/rpc-types": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/c469655555013f5dcfa67ef3285c9abe48929a34bdc8a3c7c21823f86f58f07f91980ee59d48190bcda5b427399a81cb180ae0ca2542e9dd47e39407f62c7458
+  languageName: node
+  linkType: hard
+
+"@solana/signers@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/signers@npm:5.5.1"
+  dependencies:
+    "@solana/addresses": "npm:5.5.1"
+    "@solana/codecs-core": "npm:5.5.1"
+    "@solana/errors": "npm:5.5.1"
+    "@solana/instructions": "npm:5.5.1"
+    "@solana/keys": "npm:5.5.1"
+    "@solana/nominal-types": "npm:5.5.1"
+    "@solana/offchain-messages": "npm:5.5.1"
+    "@solana/transaction-messages": "npm:5.5.1"
+    "@solana/transactions": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/53957109e4a99122b1225b04d477760e0c557fa9c66095e334de543e78f79c4b35b280dde942a0d7725dc3e61ee63c41d52b7fe5ddfc28967c3db009856573aa
+  languageName: node
+  linkType: hard
+
+"@solana/subscribable@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/subscribable@npm:5.5.1"
+  dependencies:
+    "@solana/errors": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/ff9f4af066488448276a439a9299f481cd70c1866b4ab4cce7c3486d6c950bab092f4f678b8b79b45681942c99090cd624b3eaa2a6c2820079d44c2502e7c77b
+  languageName: node
+  linkType: hard
+
+"@solana/sysvars@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/sysvars@npm:5.5.1"
+  dependencies:
+    "@solana/accounts": "npm:5.5.1"
+    "@solana/codecs": "npm:5.5.1"
+    "@solana/errors": "npm:5.5.1"
+    "@solana/rpc-types": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/773e4ae956ed29999a5e0c76e44c3b390330325b03827a5a5092292678e3d1d46c2958911faf8b94b350bf42db02874b8942bd7679fc63519a259520c269883a
+  languageName: node
+  linkType: hard
+
+"@solana/transaction-confirmation@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/transaction-confirmation@npm:5.5.1"
+  dependencies:
+    "@solana/addresses": "npm:5.5.1"
+    "@solana/codecs-strings": "npm:5.5.1"
+    "@solana/errors": "npm:5.5.1"
+    "@solana/keys": "npm:5.5.1"
+    "@solana/promises": "npm:5.5.1"
+    "@solana/rpc": "npm:5.5.1"
+    "@solana/rpc-subscriptions": "npm:5.5.1"
+    "@solana/rpc-types": "npm:5.5.1"
+    "@solana/transaction-messages": "npm:5.5.1"
+    "@solana/transactions": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/01b96aa0518417bf257f8691e02aba5ce8a7144c64d1b96b0b17045bfe34dfa00b2035e6a930f3e36bb689dd2f00c56fc6b8a521711b2fcd262dcdabd3187966
+  languageName: node
+  linkType: hard
+
+"@solana/transaction-messages@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/transaction-messages@npm:5.5.1"
+  dependencies:
+    "@solana/addresses": "npm:5.5.1"
+    "@solana/codecs-core": "npm:5.5.1"
+    "@solana/codecs-data-structures": "npm:5.5.1"
+    "@solana/codecs-numbers": "npm:5.5.1"
+    "@solana/errors": "npm:5.5.1"
+    "@solana/functional": "npm:5.5.1"
+    "@solana/instructions": "npm:5.5.1"
+    "@solana/nominal-types": "npm:5.5.1"
+    "@solana/rpc-types": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/711503174284bf449b5ffbf32ae149a82a097781f0eac1cc777d941b3cc3b9de19a6daa9993c77650e001d8f8e9e2f749bd232a4da6e09fa9c856a03a6ec1cc8
+  languageName: node
+  linkType: hard
+
+"@solana/transactions@npm:5.5.1":
+  version: 5.5.1
+  resolution: "@solana/transactions@npm:5.5.1"
+  dependencies:
+    "@solana/addresses": "npm:5.5.1"
+    "@solana/codecs-core": "npm:5.5.1"
+    "@solana/codecs-data-structures": "npm:5.5.1"
+    "@solana/codecs-numbers": "npm:5.5.1"
+    "@solana/codecs-strings": "npm:5.5.1"
+    "@solana/errors": "npm:5.5.1"
+    "@solana/functional": "npm:5.5.1"
+    "@solana/instructions": "npm:5.5.1"
+    "@solana/keys": "npm:5.5.1"
+    "@solana/nominal-types": "npm:5.5.1"
+    "@solana/rpc-types": "npm:5.5.1"
+    "@solana/transaction-messages": "npm:5.5.1"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/1dc87a6599ee60e6026b7de917b1e85a2bc2ec2e13732f872453bed597c86002c8b50ae3a4f2ea5725c969fbebe7f4987c5a2f17b02722a40f0b34191f1c7cf2
+  languageName: node
+  linkType: hard
+
 "@types/better-sqlite3@npm:^7.6.0":
   version: 7.6.13
   resolution: "@types/better-sqlite3@npm:7.6.13"
@@ -1553,6 +2286,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"abitype@npm:1.0.6":
+  version: 1.0.6
+  resolution: "abitype@npm:1.0.6"
+  peerDependencies:
+    typescript: ">=5.0.4"
+    zod: ^3 >=3.22.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+    zod:
+      optional: true
+  checksum: 10c0/30ca97010bbf34b9aaed401858eeb6bc30419f7ff11eb34adcb243522dd56c9d8a9d3d406aa5d4f60a7c263902f5136043005698e3f073ea882a4922d43a2929
+  languageName: node
+  linkType: hard
+
 "abitype@npm:1.2.3, abitype@npm:^1.0.2, abitype@npm:^1.2.3":
   version: 1.2.3
   resolution: "abitype@npm:1.2.3"
@@ -1684,6 +2432,28 @@ __metadata:
   dependencies:
     possible-typed-array-names: "npm:^1.0.0"
   checksum: 10c0/d07226ef4f87daa01bd0fe80f8f310982e345f372926da2e5296aecc25c41cab440916bbaa4c5e1034b453af3392f67df5961124e4b586df1e99793a1374bdb2
+  languageName: node
+  linkType: hard
+
+"axios-retry@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "axios-retry@npm:4.5.0"
+  dependencies:
+    is-retry-allowed: "npm:^2.2.0"
+  peerDependencies:
+    axios: 0.x || 1.x
+  checksum: 10c0/574e7b1bf24aad99b560042d232a932d51bfaa29b5a6d4612d748ed799a6f11a5afb2582792492c55d95842200cbdfbe3454027a8c1b9a2d3e895d13c3d03c10
+  languageName: node
+  linkType: hard
+
+"axios@npm:1.13.6":
+  version: 1.13.6
+  resolution: "axios@npm:1.13.6"
+  dependencies:
+    follow-redirects: "npm:^1.15.11"
+    form-data: "npm:^4.0.5"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10c0/51fb5af055c3b85662fa97df17d986ae2c37d13bf86d50b6bb36b6b3a2dec6966a1d3a14ab3774b71707b155ae3597ed9b7babdf1a1a863d1a31840cb8e7ec71
   languageName: node
   linkType: hard
 
@@ -1931,6 +2701,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:5.6.2":
+  version: 5.6.2
+  resolution: "chalk@npm:5.6.2"
+  checksum: 10c0/99a4b0f0e7991796b1e7e3f52dceb9137cae2a9dfc8fc0784a550dc4c558e15ab32ed70b14b21b52beb2679b4892b41a0aa44249bcb996f01e125d58477c6976
+  languageName: node
+  linkType: hard
+
+"charenc@npm:0.0.2":
+  version: 0.0.2
+  resolution: "charenc@npm:0.0.2"
+  checksum: 10c0/a45ec39363a16799d0f9365c8dd0c78e711415113c6f14787a22462ef451f5013efae8a28f1c058f81fc01f2a6a16955f7a5fd0cd56247ce94a45349c89877d8
+  languageName: node
+  linkType: hard
+
 "check-error@npm:^2.1.1":
   version: 2.1.3
   resolution: "check-error@npm:2.1.3"
@@ -1970,6 +2754,13 @@ __metadata:
   dependencies:
     delayed-stream: "npm:~1.0.0"
   checksum: 10c0/0dbb829577e1b1e839fa82b40c07ffaf7de8a09b935cadd355a73652ae70a88b4320db322f6634a4ad93424292fa80973ac6480986247f1734a1137debf271d5
+  languageName: node
+  linkType: hard
+
+"commander@npm:14.0.2":
+  version: 14.0.2
+  resolution: "commander@npm:14.0.2"
+  checksum: 10c0/245abd1349dbad5414cb6517b7b5c584895c02c4f7836ff5395f301192b8566f9796c82d7bd6c92d07eba8775fe4df86602fca5d86d8d10bcc2aded1e21c2aeb
   languageName: node
   linkType: hard
 
@@ -2051,6 +2842,13 @@ __metadata:
     shebang-command: "npm:^2.0.0"
     which: "npm:^2.0.1"
   checksum: 10c0/053ea8b2135caff68a9e81470e845613e374e7309a47731e81639de3eaeb90c3d01af0e0b44d2ab9d50b43467223b88567dfeb3262db942dc063b9976718ffc1
+  languageName: node
+  linkType: hard
+
+"crypt@npm:0.0.2":
+  version: 0.0.2
+  resolution: "crypt@npm:0.0.2"
+  checksum: 10c0/adbf263441dd801665d5425f044647533f39f4612544071b1471962209d235042fb703c27eea2795c7c53e1dfc242405173003f83cf4f4761a633d11f9653f18
   languageName: node
   linkType: hard
 
@@ -3127,6 +3925,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-buffer@npm:~1.1.6":
+  version: 1.1.6
+  resolution: "is-buffer@npm:1.1.6"
+  checksum: 10c0/ae18aa0b6e113d6c490ad1db5e8df9bdb57758382b313f5a22c9c61084875c6396d50bbf49315f5b1926d142d74dfb8d31b40d993a383e0a158b15fea7a82234
+  languageName: node
+  linkType: hard
+
 "is-callable@npm:^1.2.7":
   version: 1.2.7
   resolution: "is-callable@npm:1.2.7"
@@ -3177,6 +3982,13 @@ __metadata:
     has-tostringtag: "npm:^1.0.2"
     hasown: "npm:^2.0.2"
   checksum: 10c0/1d3715d2b7889932349241680032e85d0b492cfcb045acb75ffc2c3085e8d561184f1f7e84b6f8321935b4aea39bc9c6ba74ed595b57ce4881a51dfdbc214e04
+  languageName: node
+  linkType: hard
+
+"is-retry-allowed@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "is-retry-allowed@npm:2.2.0"
+  checksum: 10c0/013be4f8a0a06a49ed1fe495242952e898325d496202a018f6f9fb3fb9ac8fe3b957a9bd62463d68299ae35dbbda680473c85a9bcefca731b49d500d3ccc08ff
   languageName: node
   linkType: hard
 
@@ -3317,7 +4129,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jose@npm:^6.1.3":
+"jose@npm:^6.1.3, jose@npm:^6.2.0":
   version: 6.2.2
   resolution: "jose@npm:6.2.2"
   checksum: 10c0/201f4776d77eccd339de99fb3ba940fdf03db15e64be7a99b511e53c232e3f3818e3f21b95223d62f99315a2ab76b4251cedd94e067de56893e45273a8d2151b
@@ -3406,6 +4218,17 @@ __metadata:
   version: 1.1.0
   resolution: "math-intrinsics@npm:1.1.0"
   checksum: 10c0/7579ff94e899e2f76ab64491d76cf606274c874d8f2af4a442c016bd85688927fcfca157ba6bf74b08e9439dc010b248ce05b96cc7c126a354c3bae7fcb48b7f
+  languageName: node
+  linkType: hard
+
+"md5@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "md5@npm:2.3.0"
+  dependencies:
+    charenc: "npm:0.0.2"
+    crypt: "npm:0.0.2"
+    is-buffer: "npm:~1.1.6"
+  checksum: 10c0/14a21d597d92e5b738255fbe7fe379905b8cb97e0a49d44a20b58526a646ec5518c337b817ce0094ca94d3e81a3313879c4c7b510d250c282d53afbbdede9110
   languageName: node
   linkType: hard
 
@@ -3801,6 +4624,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ox@npm:0.14.17":
+  version: 0.14.17
+  resolution: "ox@npm:0.14.17"
+  dependencies:
+    "@adraffy/ens-normalize": "npm:^1.11.0"
+    "@noble/ciphers": "npm:^1.3.0"
+    "@noble/curves": "npm:1.9.1"
+    "@noble/hashes": "npm:^1.8.0"
+    "@scure/bip32": "npm:^1.7.0"
+    "@scure/bip39": "npm:^1.6.0"
+    abitype: "npm:^1.2.3"
+    eventemitter3: "npm:5.0.1"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/a4632918d89db20e7265dff96dec3786046e2ec99a42659badd300b7b24678348f505fd57e651c3a814a150d905f512a23a037f15757eae41db601d25fa7b10c
+  languageName: node
+  linkType: hard
+
 "p-defer@npm:^3.0.0":
   version: 3.0.0
   resolution: "p-defer@npm:3.0.0"
@@ -4003,6 +4847,13 @@ __metadata:
     forwarded: "npm:0.2.0"
     ipaddr.js: "npm:1.9.1"
   checksum: 10c0/c3eed999781a35f7fd935f398b6d8920b6fb00bbc14287bc6de78128ccc1a02c89b95b56742bf7cf0362cc333c61d138532049c7dedc7a328ef13343eff81210
+  languageName: node
+  linkType: hard
+
+"proxy-from-env@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "proxy-from-env@npm:1.1.0"
+  checksum: 10c0/fe7dd8b1bdbbbea18d1459107729c3e4a2243ca870d26d34c2c1bcd3e4425b7bcc5112362df2d93cc7fb9746f6142b5e272fd1cc5c86ddf8580175186f6ad42b
   languageName: node
   linkType: hard
 
@@ -4735,6 +5586,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uncrypto@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "uncrypto@npm:0.1.3"
+  checksum: 10c0/74a29afefd76d5b77bedc983559ceb33f5bbc8dada84ff33755d1e3355da55a4e03a10e7ce717918c436b4dfafde1782e799ebaf2aadd775612b49f7b5b2998e
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:^7.19.2":
+  version: 7.25.0
+  resolution: "undici-types@npm:7.25.0"
+  checksum: 10c0/b30edc6d3a0aa0f1f4e0f4f56dc08b81ffbecc27e3b142b1363555104b076f9eebaa61dfd835d91a8341ad6c5e6f789ed2161f75b80855378828cd93ad7c9d26
+  languageName: node
+  linkType: hard
+
 "undici-types@npm:~5.26.4":
   version: 5.26.5
   resolution: "undici-types@npm:5.26.5"
@@ -4863,6 +5728,27 @@ __metadata:
     typescript:
       optional: true
   checksum: 10c0/fea425cfa2fa64128987f3b2955d89fd60387063bab794b66b4200b141d51307a7d78b200aab2395c8e0f7a32239c434aa779a40f99ca93e957fd83c199c1021
+  languageName: node
+  linkType: hard
+
+"viem@npm:^2.47.0":
+  version: 2.48.0
+  resolution: "viem@npm:2.48.0"
+  dependencies:
+    "@noble/curves": "npm:1.9.1"
+    "@noble/hashes": "npm:1.8.0"
+    "@scure/bip32": "npm:1.7.0"
+    "@scure/bip39": "npm:1.6.0"
+    abitype: "npm:1.2.3"
+    isows: "npm:1.0.7"
+    ox: "npm:0.14.17"
+    ws: "npm:8.18.3"
+  peerDependencies:
+    typescript: ">=5.0.4"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/d8c88c1f65841944c52a4d0d81ec5aaec9ff0ebde9cfcd25dba5453c3eed65f2f107d58ca617f54cb69e33b29e94f5f3f6061f85e58f29c0948c5f8dc72189e9
   languageName: node
   linkType: hard
 
@@ -5344,7 +6230,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.17.1, ws@npm:^8.18.3":
+"ws@npm:^8.17.1, ws@npm:^8.18.3, ws@npm:^8.19.0":
   version: 8.20.0
   resolution: "ws@npm:8.20.0"
   peerDependencies:
@@ -5382,7 +6268,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.21.4, zod@npm:^3.22.0, zod@npm:^3.24.2":
+"zod@npm:^3.21.4, zod@npm:^3.22.0, zod@npm:^3.24.2, zod@npm:^3.25.76":
   version: 3.25.76
   resolution: "zod@npm:3.25.76"
   checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c

--- a/docs/research/2026-04-agent-packaging.md
+++ b/docs/research/2026-04-agent-packaging.md
@@ -240,43 +240,76 @@ Since npm and Docker are already shipped, the remaining packaging work is:
 
 ### 3.2 Ideal Flow (What We Should Build)
 
+**Fully automated — zero manual intervention:**
 ```
-1. npm install -g @jinn-network/client
-2. jinn quickstart
-   → Prompts for password (or reads from env)
-   → Generates wallet
-   → Attempts faucet funding (Coinbase CDP API)
-   → If faucet fails: prints address + faucet URL, waits
-   → Runs bootstrap
-   → Starts daemon
-   → Prints: "Your agent is running. API at http://127.0.0.1:7331"
+npm install -g @jinn-network/client
+jinn quickstart
 ```
 
-Or for MCP-first users:
+That's it. The `quickstart` command:
+1. Auto-generates a keystore password, saves to `~/.jinn-client/keystore-password`
+2. Creates wallet (idempotent)
+3. Funds master wallet via CDP faucet (shipped API key)
+4. Bootstraps (Safe → service → staking → mech)
+5. Starts daemon
+6. Prints:
+   ```
+   Your agent is running.
+   Dashboard: http://127.0.0.1:7331
+
+   Your keystore password was auto-generated and saved to:
+     ~/.jinn-client/keystore-password
+   To set your own password: jinn keys change-password
+   ```
+
+The only prerequisite is Claude Code installed and authenticated (the daemon spawns it as a subprocess for restoration work).
+
+**For MCP-first users:**
 ```
 1. Add to MCP config:
    { "mcpServers": { "jinn": { "command": "npx", "args": ["-p", "@jinn-network/client", "jinn-mcp"] } } }
 2. Tell your agent: "Set up a Jinn agent on testnet"
-3. Agent calls jinn_init, jinn_bootstrap, jinn_start_daemon
+3. Agent calls jinn_quickstart → fully automated, same as above
 ```
 
 ### 3.3 Proposed `jinn quickstart` Command
 
-A new CLI verb that combines init + fund + bootstrap + run into a guided flow:
+A new CLI verb that combines init + fund + bootstrap + run into a fully automated flow:
 
 ```
-jinn quickstart [--password-fd N] [--no-daemon]
+jinn quickstart [--no-daemon]
 
 Steps:
-  1. init        — create wallet (idempotent)
-  2. fund-check  — check balances
-  3. auto-fund   — attempt Coinbase CDP faucet (if testnet + CDP key available)
-  4. wait-fund   — if auto-fund fails, print instructions and poll until funded
-  5. bootstrap   — advance state machine to completion
-  6. run         — start daemon (unless --no-daemon)
+  1. password    — generate random password, save to ~/.jinn-client/keystore-password
+                   (skip if JINN_PASSWORD is set — respect explicit operator choice)
+  2. init        — create wallet with generated/provided password (idempotent)
+  3. fund-check  — check balances
+  4. auto-fund   — attempt Coinbase CDP faucet (shipped key; operator can override via CDP env vars)
+  5. wait-fund   — if auto-fund fails, print address + faucet URL, poll until funded
+  6. bootstrap   — advance state machine to completion
+  7. run         — start daemon (unless --no-daemon)
 ```
 
-This doesn't replace the individual verbs — operators still need granular control. But it collapses the 80% case into one command.
+This doesn't replace the individual verbs — operators still need granular control. But it collapses the 80% case into a single command with zero manual steps.
+
+### 3.4 Proposed `jinn keys change-password` Command
+
+Allows operators to replace the auto-generated password with their own:
+
+```
+jinn keys change-password
+
+Steps:
+  1. Read current password from ~/.jinn-client/keystore-password (or JINN_PASSWORD)
+  2. Decrypt mnemonic
+  3. Prompt for new password (or read from --password-fd / JINN_NEW_PASSWORD)
+  4. Re-encrypt mnemonic with new password
+  5. Overwrite mnemonic.keystore.json
+  6. Delete keystore-password file
+  7. Print: "Password changed. Set JINN_PASSWORD for future commands."
+```
+
+The wallet, Safe, staking, and all on-chain state are unchanged — the password only protects the local keystore file. This is the expected path for operators moving from testnet to mainnet: run `quickstart` with auto-generated password, then `change-password` before real funds are involved.
 
 ---
 
@@ -305,11 +338,11 @@ This doesn't replace the individual verbs — operators still need granular cont
 
 | Step | Why |
 |------|-----|
-| Password choice | Security — must be chosen by operator |
-| Claude Code CLI installation | Separate product, separate auth flow |
+| Claude Code CLI installation | Separate product, separate auth flow — must be done before `jinn quickstart` |
 | Mainnet ETH funding | Real money; no faucet |
 | Custom desired states | Domain-specific; operator defines what their agent should do |
 | Network choice (testnet vs mainnet) | Operational decision (default testnet is correct for onboarding) |
+| Password change (optional) | Auto-generated for quickstart; operator should change before mainnet via `jinn keys change-password` |
 
 ### 4.4 Coinbase CDP Faucet — Implementation Notes
 

--- a/docs/research/2026-04-agent-packaging.md
+++ b/docs/research/2026-04-agent-packaging.md
@@ -164,13 +164,50 @@ This follows the same pattern as `@modelcontextprotocol/server-github` and simil
 
 **Remaining gap:** Claude Code CLI inside the image (large dependency). Operators running the Docker image may need to mount the Claude binary or use an alternative runner.
 
-### 2.5 Priority Recommendation
+### 2.5 Operator Dashboard (Needs Building — High Impact, Low Effort)
+
+**What it is:** A static HTML page served by the existing Hono HTTP server at `GET /` (port 7331). Vanilla JS polls the API endpoints that already exist. No framework, no build step, no new dependencies.
+
+**Why it ships fast:** The HTTP server already runs whenever the daemon is running. The data endpoints (`/v1/status`, `/artifacts/search`) already exist. The implementation is a single HTML file with inline CSS/JS, served as a static asset from `dist/`.
+
+**What it shows (v1):**
+
+| Panel | Data source | Status |
+|-------|------------|--------|
+| Daemon health | `GET /v1/status` | Endpoint exists |
+| Fleet overview | Fleet state from status rollup | In status response |
+| RPC connectivity | RPC probe from status | In status response |
+| Recent artifacts | `GET /artifacts/search` | Endpoint exists |
+| Balances | Master ETH, Safe stOLAS | Partially in status; may need `/v1/balances` |
+| Activity log | Intents, restorations, evaluations | Needs new `/v1/history` endpoint |
+
+**Scope for v1:** Dashboard only when daemon is running. Bootstrap visibility stays in the CLI (`jinn bootstrap --human`). The HTTP server starts after bootstrap completes in `daemon.start()` — no refactoring of `main.ts` needed.
+
+**v2 follow-up:** Start the HTTP server before bootstrap and show bootstrap progress on the dashboard. Solves the "is it stuck?" problem during onboarding but requires refactoring `main.ts` to start Hono before calling `bootstrap()`.
+
+**Implementation:**
+```
+client/src/dashboard/index.html   — single file, inline CSS/JS
+client/src/api/server.ts          — add: app.get('/', serves dashboard HTML)
+```
+
+**Startup message change:**
+```
+# Before:
+[main] Daemon running. Press Ctrl+C to stop.
+
+# After:
+[main] Daemon running. Dashboard: http://127.0.0.1:7331
+```
+
+### 2.6 Priority Recommendation
 
 Since npm and Docker are already shipped, the remaining packaging work is:
 
-1. **Standalone operator MCP server** (`jinn-mcp` bin) — highest impact for agent consumption
-2. **`jinn quickstart` command** — collapse onboarding into one step
-3. **Claude Code skill** — discovery and onboarding layer for MCP-equipped agents
+1. **Operator dashboard** — static HTML at `GET /`, polls existing endpoints. One HTML file, zero deps. Fastest path to "see your agent working."
+2. **Standalone operator MCP server** (`jinn-mcp` bin) — highest impact for agent consumption
+3. **`jinn quickstart` command** — collapse onboarding into one step
+4. **Claude Code skill** — discovery and onboarding layer for MCP-equipped agents
 
 ---
 
@@ -422,19 +459,23 @@ Implementation: a new file at `client/src/mcp/operator-server.ts` with a corresp
 
 ### 7.1 Immediate (This Sprint)
 
-1. **Add `jinn-mcp` bin entry.** Thin MCP server wrapping CLI commands via a dedicated binary (per MCP convention). Start with read-only tools (`jinn_status`, `jinn_doctor`, `jinn_fleet`, `jinn_balance`, `jinn_history`) plus `jinn_init`. This is shippable in a day.
+1. **Operator dashboard.** Single HTML file served at `GET /` by the existing Hono server. Polls `/v1/status` and `/artifacts/search`. Zero new dependencies, ships in the npm package. v1 scope: daemon-only (no bootstrap view). Changes the startup message from "Press Ctrl+C to stop" to "Dashboard: http://127.0.0.1:7331".
+
+2. **Add `jinn-mcp` bin entry.** Thin MCP server wrapping CLI commands via a dedicated binary (per MCP convention). Start with read-only tools (`jinn_status`, `jinn_doctor`, `jinn_fleet`, `jinn_balance`, `jinn_history`) plus `jinn_init`.
 
 ### 7.2 Near-term (Next 2 Weeks)
 
-2. **Add write tools to MCP server.** `jinn_bootstrap`, `jinn_submit_intent`, `jinn_start_daemon`, `jinn_stop_daemon`. These require careful error handling since they mutate state.
+3. **Add write tools to MCP server.** `jinn_bootstrap`, `jinn_submit_intent`, `jinn_start_daemon`, `jinn_stop_daemon`. These require careful error handling since they mutate state.
 
-3. **Add `jinn quickstart` verb.** Guided flow combining init + fund-check + bootstrap + run.
+4. **Add `jinn quickstart` verb.** Guided flow combining init + fund-check + bootstrap + run.
 
-4. **Testnet faucet integration.** Ship a Jinn-project CDP API key for auto-funding (see section 4.4). Dynamic import of `@coinbase/cdp-sdk`, falls back to manual faucet URL if unavailable.
+5. **Testnet faucet integration.** Ship a Jinn-project CDP API key for auto-funding (see section 4.4). Dynamic import of `@coinbase/cdp-sdk`, falls back to manual faucet URL if unavailable.
 
 ### 7.3 Medium-term
 
-5. **Claude Code skill.** A markdown skill file that describes the Jinn protocol and teaches agents how to use the MCP tools. Distributable via the npm package or a separate skill registry.
+6. **Dashboard v2 — bootstrap visibility.** Start Hono before `bootstrap()`, show bootstrap progress on the dashboard. Addresses the "is it stuck?" problem during onboarding.
+
+7. **Claude Code skill.** A markdown skill file that describes the Jinn protocol and teaches agents how to use the MCP tools. Distributable via the npm package or a separate skill registry.
 
 6. **Codex / Cursor / Windsurf plugin manifests.** These ecosystems are converging on MCP, so the MCP server covers them. If any require custom plugin formats, create thin wrappers.
 

--- a/docs/research/2026-04-agent-packaging.md
+++ b/docs/research/2026-04-agent-packaging.md
@@ -1,0 +1,487 @@
+# Agent Packaging Research
+
+**Date:** 2026-04-16
+**Author:** Claude (research agent)
+**Status:** Research — not a spec or commitment
+
+## Problem Statement
+
+A user wants to go from zero to operating an agent on the Jinn Network. Today the client is a monorepo-internal Node.js daemon with a 17-verb CLI (`jinn run`, `jinn init`, etc.), an 11-step fleet bootstrap state machine, and contract deployments on Base Sepolia. The question: what packaging format and onboarding flow gets an external operator running with minimum friction?
+
+---
+
+## 1. What Exists Today
+
+### 1.1 CLI Surface (`client/src/bin/jinn.ts` → `client/src/cli/`)
+
+The `jinn` CLI already has a complete operator workflow:
+
+| Verb | Purpose |
+|------|---------|
+| `jinn init` | Generate master wallet, encrypt keystore |
+| `jinn doctor` | Preflight checks (Node.js, Claude binary, deployment config) |
+| `jinn fund-requirements` | Show exact funding gaps |
+| `jinn bootstrap` | Advance fleet state machine |
+| `jinn run` | Start daemon (creator + restorer + delivery-watcher loops) |
+| `jinn status` | Poll daemon health |
+| `jinn submit-intent` | Post a desired state on-chain |
+| `jinn fleet` / `jinn balance` / `jinn history` / `jinn rewards` | Inspect state |
+| `jinn withdraw` / `jinn keys backup` | Fund management |
+
+The CLI emits structured JSON on stdout (machine-readable by default, `--human` for terminal output) and routes logs to stderr. This is already well-designed for agent consumption — an orchestrating agent can parse stdout JSON directly.
+
+### 1.2 MCP Server (`client/src/mcp/server.ts`)
+
+The existing MCP server is **subprocess-scoped**, not standalone. It is spawned by `ClaudeRunner` as a child process for each restoration/evaluation task, with context passed via env vars:
+
+**Existing tools:**
+- `get_desired_state` — read the current task assignment
+- `report_progress` — log progress
+- `submit_restoration_result` — submit success/failure verdict
+- `get_restoration_delivery` — fetch restoration data for evaluation
+- `publish_artifact` — store knowledge for future agents
+- `search_artifacts` — query past artifacts
+- `acquire_artifact` — fetch remote artifacts from peers
+
+**What this MCP server is:** A toolbox for the *inner agent* — the Claude subprocess that performs a single restoration or evaluation. It is tightly coupled to one task execution.
+
+**What this MCP server is NOT:** A general-purpose interface for an external agent to discover, join, and operate on the Jinn network. It cannot init a wallet, bootstrap, submit intents, check status, or manage the fleet.
+
+### 1.3 HTTP API (`client/src/api/server.ts`)
+
+Runs on port 7331 when the daemon is active:
+- `GET /v1/status` — daemon health, fleet state, RPC status
+- `GET /artifacts/search` — query artifacts
+- `GET /artifacts/:id/content` — fetch artifact content
+- `POST /artifacts` — publish artifacts
+- `GET /x402/artifacts/:id/content` — payment-gated access
+
+### 1.4 npm Package (`package.json`)
+
+Already configured for publishing:
+- Name: `@jinn-network/client`
+- `bin.jinn` → `./dist/bin/jinn.js`
+- `publishConfig.access: "public"`
+- `files: ["dist/", "deployments/"]`
+- `prepublishOnly` runs build + test
+- Library exports via `main`/`types` for programmatic use
+
+### 1.5 Bootstrap State Machine
+
+The `FleetBootstrapper` walks through wallet creation → Safe deployment → service registration → staking → mech deployment. Key properties:
+- **Idempotent** — persists state to `~/.jinn-client/earning/earning_state.json`, safe to interrupt and resume
+- **Funding gate** — pauses at `awaiting_funding` with a structured envelope telling the operator exactly what needs funding
+- **Two staking modes** — `standard` (stOLAS, no OLAS needed) and `self-bond`
+
+### 1.6 Dependencies & Prerequisites
+
+- Node.js 22 (hard requirement via `engines` and corepack)
+- Claude Code CLI on PATH (checked by `jinn doctor`)
+- Foundry only for local dev (Anvil fork); not needed for testnet/mainnet operation
+- `JINN_PASSWORD` env var for keystore encryption
+
+---
+
+## 2. Packaging Format Analysis
+
+### 2.1 npm Package with CLI (Primary — Ready Today)
+
+**What it is:** `npm install -g @jinn-network/client` gives the user `jinn` on PATH.
+
+**Current readiness:** High. The `bin`, `files`, `publishConfig`, and `prepublishOnly` fields are already configured. The CLI has 17 verbs covering the full operator lifecycle.
+
+**Gaps:**
+- No `npx @jinn-network/client` quick-start experience (the bin name is `jinn`, which works)
+- No guided interactive setup (all config is via env vars or JSON file)
+- Need to verify `yarn pack` → install → `jinn doctor` works cleanly outside the monorepo (the `pack:smoke` script exists for this)
+
+**Verdict:** This is the foundation. Ship this first.
+
+### 2.2 Standalone MCP Server (High Value — Needs Building)
+
+**What it would be:** A new MCP server entry point that exposes the full operator workflow as MCP tools, designed to be registered in Claude Code, Cursor, Windsurf, or any MCP-compatible agent.
+
+**Why it matters:** MCP is the emerging standard for agent tool discovery. An agent with the jinn MCP server configured can operate on the network without knowing CLI syntax.
+
+**Proposed tools for a standalone MCP server:**
+
+| Tool | Maps to | Notes |
+|------|---------|-------|
+| `jinn_init` | `jinn init` | Create wallet, return master address |
+| `jinn_doctor` | `jinn doctor` | Preflight checks |
+| `jinn_fund_requirements` | `jinn fund-requirements` | Show funding gaps |
+| `jinn_bootstrap` | `jinn bootstrap` | Advance state machine |
+| `jinn_status` | `jinn status` | Daemon + fleet health |
+| `jinn_submit_intent` | `jinn submit-intent` | Post desired state on-chain |
+| `jinn_fleet` | `jinn fleet` | Fleet overview |
+| `jinn_balance` | `jinn balance` | Wallet balances |
+| `jinn_history` | `jinn history` | Activity log |
+| `jinn_start_daemon` | `jinn run` | Start daemon (long-running — needs careful design) |
+| `jinn_stop_daemon` | `jinn stop` | Stop daemon |
+
+**Implementation approach:** Since the CLI already emits structured JSON, the simplest path is a thin MCP wrapper that shells out to `jinn <verb>` and returns the parsed JSON. This avoids duplicating logic and means the MCP server always matches CLI behavior. A `client/src/mcp/operator-server.ts` that imports from `cli/` directly (without spawning a subprocess) would be even cleaner — each MCP tool calls the same `CommandModule.run()` that the CLI uses.
+
+**Registration:** Users would add to their MCP config:
+```json
+{
+  "mcpServers": {
+    "jinn": {
+      "command": "npx",
+      "args": ["@jinn-network/client", "mcp-serve"],
+      "env": { "JINN_PASSWORD": "..." }
+    }
+  }
+}
+```
+
+Or if installed globally:
+```json
+{
+  "mcpServers": {
+    "jinn": {
+      "command": "jinn",
+      "args": ["mcp-serve"],
+      "env": { "JINN_PASSWORD": "..." }
+    }
+  }
+}
+```
+
+### 2.3 Claude Code Skill / Codex Plugin
+
+**What it would be:** A skill file that teaches Claude Code how to use the jinn CLI or MCP server.
+
+**Assessment:** Lower priority than MCP. A skill is just a prompt template — it tells the agent what tools exist but doesn't provide them. If we have the MCP server (2.2), a skill is useful as a discovery/onboarding layer ("you have jinn tools available, here's how the protocol works"). Without the MCP server, a skill could instruct the agent to use `jinn` CLI commands via Bash, but this is fragile and doesn't work in sandboxed environments.
+
+**Verdict:** Nice-to-have after MCP server ships. Could be a single markdown file that describes the protocol and available tools.
+
+### 2.4 Docker Image
+
+**What it would be:** `docker run ghcr.io/jinn-network/client` with volume mounts for keystore persistence.
+
+**Assessment:** Useful for:
+- Operators who don't want Node.js installed
+- Deployment on cloud VMs, Kubernetes, etc.
+- Reproducible environment (pinned Node version, dependencies)
+
+**Gaps:**
+- Claude Code CLI would need to be in the image (large dependency)
+- Keystore persistence needs volume mount guidance
+- Interactive password entry doesn't work well with Docker
+
+**Verdict:** Valuable for production operators, but not the first packaging target. The npm package covers the initial audience (developers and agent builders).
+
+### 2.5 Combination Recommendation
+
+**Ship order:**
+1. **npm package** (today — mostly ready)
+2. **Standalone MCP server** (`jinn mcp-serve` verb) — highest impact for agent consumption
+3. **Claude Code skill** — discovery and onboarding layer
+4. **Docker image** — production deployment
+
+---
+
+## 3. Zero-to-Operating User Flow
+
+### 3.1 Current Flow (What Exists)
+
+```
+1. Install Node.js 22
+2. npm install -g @jinn-network/client
+3. Install Claude Code CLI
+4. JINN_PASSWORD=secret jinn init
+   → Generates wallet, prints master address
+5. JINN_PASSWORD=secret jinn doctor
+   → Checks environment readiness
+6. JINN_PASSWORD=secret jinn fund-requirements
+   → Shows: "Master needs 0.01 ETH on Base Sepolia"
+7. [MANUAL] Go to faucet, get testnet ETH, send to master address
+8. JINN_PASSWORD=secret jinn bootstrap
+   → Deploys Safe, registers service, stakes, deploys mech
+9. JINN_PASSWORD=secret jinn run
+   → Daemon starts, 3 loops running
+```
+
+**Pain points:**
+- Step 7 is a manual faucet visit — breaks the automated flow
+- No single command does steps 4-9
+- Password must be set in every command (no session or keyring)
+- Default network is testnet (good for onboarding) but config file must be created for any customization
+
+### 3.2 Ideal Flow (What We Should Build)
+
+```
+1. npm install -g @jinn-network/client
+2. jinn quickstart
+   → Prompts for password (or reads from env)
+   → Generates wallet
+   → Attempts faucet funding (Coinbase CDP API)
+   → If faucet fails: prints address + faucet URL, waits
+   → Runs bootstrap
+   → Starts daemon
+   → Prints: "Your agent is running. API at http://127.0.0.1:7331"
+```
+
+Or for MCP-first users:
+```
+1. Add to MCP config:
+   { "mcpServers": { "jinn": { "command": "npx", "args": ["@jinn-network/client", "mcp-serve"] } } }
+2. Tell your agent: "Set up a Jinn agent on testnet"
+3. Agent calls jinn_init, jinn_bootstrap, jinn_start_daemon
+```
+
+### 3.3 Proposed `jinn quickstart` Command
+
+A new CLI verb that combines init + fund + bootstrap + run into a guided flow:
+
+```
+jinn quickstart [--password-fd N] [--no-daemon]
+
+Steps:
+  1. init        — create wallet (idempotent)
+  2. fund-check  — check balances
+  3. auto-fund   — attempt Coinbase CDP faucet (if testnet + CDP key available)
+  4. wait-fund   — if auto-fund fails, print instructions and poll until funded
+  5. bootstrap   — advance state machine to completion
+  6. run         — start daemon (unless --no-daemon)
+```
+
+This doesn't replace the individual verbs — operators still need granular control. But it collapses the 80% case into one command.
+
+---
+
+## 4. What Can Be Automated vs. What Needs Human Input
+
+### 4.1 Fully Automatable
+
+| Step | How |
+|------|-----|
+| Wallet creation | `jinn init` — deterministic from password |
+| Safe prediction + deployment | Bootstrap state machine |
+| Service registration + staking | Bootstrap state machine |
+| Mech deployment | Bootstrap state machine |
+| Config generation | Defaults cover testnet; `jinn init` creates keystore dir |
+| RPC endpoint | Defaults to `https://sepolia.base.org` for testnet |
+| Daemon startup | `jinn run` |
+
+### 4.2 Automatable with External Dependency
+
+| Step | Dependency | Automation Path |
+|------|-----------|-----------------|
+| Testnet ETH funding | Coinbase CDP API key | `cdp.evm.requestFaucet({ address, network: "base-sepolia", token: "eth" })` — free tier, 1 claim/24h/address |
+| Claude API access | User's Anthropic API key or Claude Max subscription | Claude Code CLI handles this; user must have it configured separately |
+
+### 4.3 Requires Human Decision
+
+| Step | Why |
+|------|-----|
+| Password choice | Security — must be chosen by operator |
+| Claude Code CLI installation | Separate product, separate auth flow |
+| Mainnet ETH funding | Real money; no faucet |
+| Custom desired states | Domain-specific; operator defines what their agent should do |
+| Network choice (testnet vs mainnet) | Operational decision (default testnet is correct for onboarding) |
+
+### 4.4 Coinbase CDP Faucet — Implementation Notes
+
+The Coinbase Developer Platform provides a programmatic faucet for Base Sepolia:
+
+```typescript
+// Using @coinbase/cdp-sdk
+import { CdpClient } from '@coinbase/cdp-sdk';
+
+const cdp = new CdpClient(); // Uses CDP_API_KEY_ID + CDP_API_KEY_SECRET env vars
+await cdp.evm.requestFaucet({
+  address: masterAddress,
+  network: "base-sepolia",
+  token: "eth"
+});
+```
+
+**Constraints:**
+- Requires a free CDP API key (sign up at cdp.coinbase.com)
+- Rate limited: 1 claim per 24 hours per address
+- Only testnet — not a mainnet solution
+- Dispenses a small amount (~0.1 ETH, varies) which is sufficient for bootstrap gas
+
+**Integration recommendation:** Make CDP faucet opt-in via `COINBASE_CDP_API_KEY_ID` / `COINBASE_CDP_API_KEY_SECRET` env vars. If set, `jinn quickstart` and `jinn bootstrap` attempt auto-funding before pausing at the funding gate. If not set, print the manual faucet URL (`https://faucet.circle.com/` or `https://www.coinbase.com/faucets/base-ethereum/sepolia`). Don't add `@coinbase/cdp-sdk` as a hard dependency — dynamic import with a helpful error message if missing.
+
+**Alternative faucets (web-only, no API):**
+- Alchemy Base Sepolia faucet — web UI only, 1 claim/24h
+- Circle faucet (faucet.circle.com) — web UI, supports Base Sepolia
+
+---
+
+## 5. Standalone MCP Server Design (Detailed)
+
+### 5.1 Architecture Decision: CLI Wrapper vs. Direct Integration
+
+**Option A — Shell out to `jinn` CLI:**
+```typescript
+// Simple but requires jinn on PATH
+const result = execSync('jinn status --json', { env: { JINN_PASSWORD: password } });
+return JSON.parse(result.toString());
+```
+
+Pros: Zero code duplication, always matches CLI behavior.
+Cons: Requires global install, subprocess overhead, can't manage daemon lifecycle easily.
+
+**Option B — Import CLI command modules directly:**
+```typescript
+// Direct integration, no subprocess
+import statusCommand from './cli/commands/status.js';
+const output = new StringWriter();
+await statusCommand.run({ argv: [], writer: output, ... });
+return JSON.parse(output.toString());
+```
+
+Pros: No subprocess overhead, single process, can share state.
+Cons: CLI commands call `process.exit()` on errors (via `emitEnvelope`), need to refactor exit behavior.
+
+**Option C — Import library layer, bypass CLI:**
+```typescript
+// Use exports from index.ts directly
+import { FleetBootstrapper, Daemon, MechAdapter, ClaudeRunner, loadConfig } from '@jinn-network/client';
+```
+
+Pros: Cleanest, most flexible.
+Cons: Most work — need to reimplement the orchestration that `main.ts` does.
+
+**Recommendation:** Option B for most tools (the CLI commands already do JSON I/O with injectable writers and exits), with Option C for daemon lifecycle (start/stop need in-process control). The `emitEnvelope` function already accepts `{ writer, exit }` — passing a no-op exit function prevents process termination.
+
+### 5.2 Daemon Lifecycle in MCP Context
+
+The daemon (`jinn run`) is a long-running process. In MCP, tools are request/response. Two approaches:
+
+**A. Background process management:**
+- `jinn_start_daemon` spawns `jinn run` as a detached subprocess, returns PID
+- `jinn_stop_daemon` sends SIGTERM to the PID (pidfile already written to `~/.jinn-client/earning/daemon.pid`)
+- `jinn_status` reads from the HTTP API at `:7331/v1/status`
+
+**B. In-process daemon:**
+- The MCP server itself hosts the daemon (long-lived MCP server = long-lived daemon)
+- Tools like `jinn_status` query in-process state
+- MCP server shutdown = daemon shutdown
+
+Option A is simpler and matches existing architecture. The daemon already writes a pidfile and `jinn stop` already exists.
+
+### 5.3 MCP Server Entry Point
+
+New verb: `jinn mcp-serve`
+
+```
+jinn mcp-serve [--password-fd N]
+
+Starts an MCP server on stdio (StdioServerTransport).
+Exposes operator-level tools for agent consumption.
+Long-lived — runs until stdin closes or SIGTERM.
+```
+
+This would be a new file at `client/src/mcp/operator-server.ts` and a new CLI command at `client/src/cli/commands/mcp-serve.ts`.
+
+---
+
+## 6. Comparison: How Other Agent Ecosystems Handle Onboarding
+
+### 6.1 LangChain Tools
+
+- Published as pip packages (`pip install langchain-community`)
+- Each tool is a Python class with `_run()` method
+- Configuration via constructor args or env vars
+- No daemon — stateless tool invocations
+- **Lesson:** Stateless tools are easiest to distribute. Jinn's protocol requires state (wallet, staking), which adds irreducible complexity.
+
+### 6.2 CrewAI Tools
+
+- Published as pip packages (`pip install crewai-tools`)
+- Tools are decorated functions
+- Config via env vars
+- **Lesson:** Simple tool surface, but doesn't solve the "persistent service" problem that Jinn has.
+
+### 6.3 MCP Ecosystem (Anthropic)
+
+- MCP servers published as npm packages
+- Registered in `~/.claude/mcp.json` or project-level config
+- `npx` as the standard launch mechanism (no global install needed)
+- Examples: `@modelcontextprotocol/server-github`, `@modelcontextprotocol/server-filesystem`
+- **Lesson:** `npx` launch is the convention. The MCP config JSON is the discovery mechanism. This is the right model for Jinn.
+
+### 6.4 OLAS (Jinn's Current Foundation)
+
+- Agents packaged as Docker images registered on-chain
+- Complex setup: Safe wallet, service registration, staking, mech deployment
+- Managed via `autonomy` CLI (Python)
+- **Lesson:** Jinn's `jinn` CLI already simplifies this significantly vs. raw OLAS tooling. The bootstrap state machine is a major improvement.
+
+---
+
+## 7. Recommendations
+
+### 7.1 Immediate (This Sprint)
+
+1. **Publish npm package.** Run `yarn pack:smoke` to verify the package installs and `jinn doctor` works outside the monorepo. Then `npm publish`.
+
+2. **Add `jinn mcp-serve` verb.** Thin MCP server wrapping CLI commands. Start with read-only tools (`jinn_status`, `jinn_doctor`, `jinn_fleet`, `jinn_balance`, `jinn_history`) plus `jinn_init`. This is shippable in a day.
+
+### 7.2 Near-term (Next 2 Weeks)
+
+3. **Add write tools to MCP server.** `jinn_bootstrap`, `jinn_submit_intent`, `jinn_start_daemon`, `jinn_stop_daemon`. These require careful error handling since they mutate state.
+
+4. **Add `jinn quickstart` verb.** Guided flow combining init + fund-check + bootstrap + run. Detects CDP credentials and attempts auto-funding.
+
+5. **Optional CDP faucet integration.** Dynamic import of `@coinbase/cdp-sdk`, gated on env vars. Fails gracefully to manual instructions if unavailable.
+
+### 7.3 Medium-term
+
+6. **Claude Code skill.** A markdown skill file that describes the Jinn protocol and teaches agents how to use the MCP tools. Distributable via the npm package or a separate skill registry.
+
+7. **Docker image.** `Dockerfile` in `client/`, published to ghcr.io. Include Node.js + Claude Code CLI. Volume mount for `~/.jinn-client/`.
+
+8. **Codex / Cursor / Windsurf plugin manifests.** These ecosystems are converging on MCP, so the MCP server covers them. If any require custom plugin formats, create thin wrappers.
+
+### 7.4 Architecture Principle
+
+**The CLI is the source of truth.** Every packaging format (MCP server, skill, Docker, plugin) should delegate to the CLI or its underlying modules. This prevents behavioral divergence and means testing the CLI tests everything.
+
+---
+
+## 8. Gap Analysis: Existing MCP Server vs. Complete Agent Experience
+
+| Capability | Task MCP (existing) | Operator MCP (proposed) |
+|------------|-------------------|------------------------|
+| Understand current task | `get_desired_state` | N/A (operator level) |
+| Submit work result | `submit_restoration_result` | N/A (daemon handles) |
+| Search knowledge | `search_artifacts`, `acquire_artifact` | `jinn_history` |
+| Create wallet | - | `jinn_init` |
+| Check readiness | - | `jinn_doctor` |
+| Fund wallet | - | `jinn_fund_requirements` |
+| Bootstrap infra | - | `jinn_bootstrap` |
+| Start operating | - | `jinn_start_daemon` |
+| Monitor health | - | `jinn_status` |
+| Submit intents | - | `jinn_submit_intent` |
+| Check earnings | - | `jinn_rewards`, `jinn_balance` |
+
+The existing task MCP server and the proposed operator MCP server serve different roles and different agents. The task MCP server is for the *inner agent* (Claude subprocess doing restoration work). The operator MCP server is for the *outer agent* (the user's agent that manages Jinn operations). Both should exist.
+
+---
+
+## 9. Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| npm package has monorepo-specific paths | Medium | High (broken install) | `pack:smoke` script exists — run it in CI |
+| MCP server daemon management is fragile | Medium | Medium | Use existing pidfile + HTTP API pattern |
+| CDP faucet rate limits block multi-service bootstrap | High | Low | Only need ~0.01 ETH; one faucet claim is sufficient |
+| Claude Code CLI not installed | High | High (can't run daemon) | `jinn doctor` already checks this; clear error message |
+| Testnet contracts redeploy breaks config | Medium | High | Ship deployment artifacts in npm package (`deployments/` is in `files`) |
+
+---
+
+## 10. Open Questions
+
+1. **Should the MCP server manage its own daemon, or require a separate `jinn run` process?** Background process management (Option A in 5.2) is simpler but means two processes. In-process (Option B) is cleaner but couples MCP lifetime to daemon lifetime.
+
+2. **Is `@jinn-network/client` the right package name for external operators?** Consider whether a separate `@jinn-network/agent` package with fewer dependencies (no Hardhat, no test fixtures) would be better for distribution.
+
+3. **Should quickstart default to stOLAS (standard) staking mode?** Standard mode doesn't require OLAS tokens, lowering the funding barrier. This is already the default.
+
+4. **Do we need a hosted RPC endpoint?** The default `https://sepolia.base.org` is rate-limited. For onboarding, it works. For production, operators will need their own. Should we provide one during testnet phase?

--- a/docs/research/2026-04-agent-packaging.md
+++ b/docs/research/2026-04-agent-packaging.md
@@ -6,7 +6,7 @@
 
 ## Problem Statement
 
-A user wants to go from zero to operating an agent on the Jinn Network. Today the client is a monorepo-internal Node.js daemon with a 17-verb CLI (`jinn run`, `jinn init`, etc.), an 11-step fleet bootstrap state machine, and contract deployments on Base Sepolia. The question: what packaging format and onboarding flow gets an external operator running with minimum friction?
+A user wants to go from zero to operating an agent on the Jinn Network. The client is a published npm package (`@jinn-network/client`) with a 17-verb CLI, an 11-step fleet bootstrap state machine, and contract deployments on Base Sepolia. A Docker image is also available. The question: what additional packaging and onboarding improvements get an external operator running with minimum friction — particularly for agent-to-agent consumption?
 
 ---
 
@@ -84,18 +84,11 @@ The `FleetBootstrapper` walks through wallet creation → Safe deployment → se
 
 ## 2. Packaging Format Analysis
 
-### 2.1 npm Package with CLI (Primary — Ready Today)
+### 2.1 npm Package with CLI (Shipped)
 
-**What it is:** `npm install -g @jinn-network/client` gives the user `jinn` on PATH.
+**Status:** Published as `@jinn-network/client`. `npm install -g @jinn-network/client` gives the user `jinn` on PATH. The CLI has 17 verbs covering the full operator lifecycle.
 
-**Current readiness:** High. The `bin`, `files`, `publishConfig`, and `prepublishOnly` fields are already configured. The CLI has 17 verbs covering the full operator lifecycle.
-
-**Gaps:**
-- No `npx @jinn-network/client` quick-start experience (the bin name is `jinn`, which works)
-- No guided interactive setup (all config is via env vars or JSON file)
-- Need to verify `yarn pack` → install → `jinn doctor` works cleanly outside the monorepo (the `pack:smoke` script exists for this)
-
-**Verdict:** This is the foundation. Ship this first.
+**Remaining gap:** No guided interactive setup — all config is via env vars or JSON file. A `jinn quickstart` command (section 3.3) would address this.
 
 ### 2.2 Standalone MCP Server (High Value — Needs Building)
 
@@ -121,13 +114,22 @@ The `FleetBootstrapper` walks through wallet creation → Safe deployment → se
 
 **Implementation approach:** Since the CLI already emits structured JSON, the simplest path is a thin MCP wrapper that shells out to `jinn <verb>` and returns the parsed JSON. This avoids duplicating logic and means the MCP server always matches CLI behavior. A `client/src/mcp/operator-server.ts` that imports from `cli/` directly (without spawning a subprocess) would be even cleaner — each MCP tool calls the same `CommandModule.run()` that the CLI uses.
 
-**Registration:** Users would add to their MCP config:
+**Entry point — separate bin, not a CLI subcommand.** The MCP convention is a dedicated binary that speaks stdio, not a subcommand of an existing CLI. Since `jinn` is already a CLI dispatcher, the right pattern is a second `bin` entry in package.json:
+
+```json
+"bin": {
+  "jinn": "./dist/bin/jinn.js",
+  "jinn-mcp": "./dist/mcp/operator-server.js"
+}
+```
+
+**Registration:** Users add to their MCP config:
 ```json
 {
   "mcpServers": {
     "jinn": {
       "command": "npx",
-      "args": ["@jinn-network/client", "mcp-serve"],
+      "args": ["-p", "@jinn-network/client", "jinn-mcp"],
       "env": { "JINN_PASSWORD": "..." }
     }
   }
@@ -139,13 +141,14 @@ Or if installed globally:
 {
   "mcpServers": {
     "jinn": {
-      "command": "jinn",
-      "args": ["mcp-serve"],
+      "command": "jinn-mcp",
       "env": { "JINN_PASSWORD": "..." }
     }
   }
 }
 ```
+
+This follows the same pattern as `@modelcontextprotocol/server-github` and similar MCP packages — a dedicated binary that starts a `StdioServerTransport` and runs until stdin closes.
 
 ### 2.3 Claude Code Skill / Codex Plugin
 
@@ -155,29 +158,19 @@ Or if installed globally:
 
 **Verdict:** Nice-to-have after MCP server ships. Could be a single markdown file that describes the protocol and available tools.
 
-### 2.4 Docker Image
+### 2.4 Docker Image (Shipped)
 
-**What it would be:** `docker run ghcr.io/jinn-network/client` with volume mounts for keystore persistence.
+**Status:** Available. Useful for operators who don't want Node.js installed and for cloud/Kubernetes deployment.
 
-**Assessment:** Useful for:
-- Operators who don't want Node.js installed
-- Deployment on cloud VMs, Kubernetes, etc.
-- Reproducible environment (pinned Node version, dependencies)
+**Remaining gap:** Claude Code CLI inside the image (large dependency). Operators running the Docker image may need to mount the Claude binary or use an alternative runner.
 
-**Gaps:**
-- Claude Code CLI would need to be in the image (large dependency)
-- Keystore persistence needs volume mount guidance
-- Interactive password entry doesn't work well with Docker
+### 2.5 Priority Recommendation
 
-**Verdict:** Valuable for production operators, but not the first packaging target. The npm package covers the initial audience (developers and agent builders).
+Since npm and Docker are already shipped, the remaining packaging work is:
 
-### 2.5 Combination Recommendation
-
-**Ship order:**
-1. **npm package** (today — mostly ready)
-2. **Standalone MCP server** (`jinn mcp-serve` verb) — highest impact for agent consumption
-3. **Claude Code skill** — discovery and onboarding layer
-4. **Docker image** — production deployment
+1. **Standalone operator MCP server** (`jinn-mcp` bin) — highest impact for agent consumption
+2. **`jinn quickstart` command** — collapse onboarding into one step
+3. **Claude Code skill** — discovery and onboarding layer for MCP-equipped agents
 
 ---
 
@@ -225,7 +218,7 @@ Or if installed globally:
 Or for MCP-first users:
 ```
 1. Add to MCP config:
-   { "mcpServers": { "jinn": { "command": "npx", "args": ["@jinn-network/client", "mcp-serve"] } } }
+   { "mcpServers": { "jinn": { "command": "npx", "args": ["-p", "@jinn-network/client", "jinn-mcp"] } } }
 2. Tell your agent: "Set up a Jinn agent on testnet"
 3. Agent calls jinn_init, jinn_bootstrap, jinn_start_daemon
 ```
@@ -298,12 +291,22 @@ await cdp.evm.requestFaucet({
 ```
 
 **Constraints:**
-- Requires a free CDP API key (sign up at cdp.coinbase.com)
+- **Requires a free CDP API key** — sign up at cdp.coinbase.com, then set `CDP_API_KEY_ID` + `CDP_API_KEY_SECRET` env vars. This is an extra signup step, which weakens the "just works" story.
 - Rate limited: 1 claim per 24 hours per address
 - Only testnet — not a mainnet solution
 - Dispenses a small amount (~0.1 ETH, varies) which is sufficient for bootstrap gas
 
-**Integration recommendation:** Make CDP faucet opt-in via `COINBASE_CDP_API_KEY_ID` / `COINBASE_CDP_API_KEY_SECRET` env vars. If set, `jinn quickstart` and `jinn bootstrap` attempt auto-funding before pausing at the funding gate. If not set, print the manual faucet URL (`https://faucet.circle.com/` or `https://www.coinbase.com/faucets/base-ethereum/sepolia`). Don't add `@coinbase/cdp-sdk` as a hard dependency — dynamic import with a helpful error message if missing.
+**Bottom line on testnet funding:** There is no zero-auth programmatic faucet for Base Sepolia. Every option requires either a CDP API key signup (Coinbase) or a manual web UI visit (Alchemy, Circle).
+
+**Ship a Jinn-project CDP API key in the package?** Yes — this is the cleanest path to zero-friction onboarding. Create a dedicated CDP API key under a Jinn project account and embed it as a default in the client. The key is free-tier and rate-limited (1 claim/24h/address), so abuse risk is bounded. Operators can override with their own key via `CDP_API_KEY_ID` / `CDP_API_KEY_SECRET` env vars.
+
+Considerations for shipping a public key:
+- CDP free tier rate limits are per-address, not per-key — an attacker can't drain the faucet for all users
+- The key only grants testnet faucet access (no mainnet, no wallet control)
+- If Coinbase revokes the key, `jinn quickstart` falls back to printing the manual faucet URL — not a hard failure
+- Monitor usage via the CDP dashboard; rotate if abused
+
+**Integration recommendation:** Ship a default CDP API key for testnet auto-funding. Allow override via env vars. Don't add `@coinbase/cdp-sdk` as a hard dependency — dynamic import with a helpful error message if missing. Fall back to manual faucet URL (`https://faucet.circle.com/` or `https://www.coinbase.com/faucets/base-ethereum/sepolia`) if the SDK isn't installed or the faucet call fails.
 
 **Alternative faucets (web-only, no API):**
 - Alchemy Base Sepolia faucet — web UI only, 1 claim/24h
@@ -366,17 +369,18 @@ Option A is simpler and matches existing architecture. The daemon already writes
 
 ### 5.3 MCP Server Entry Point
 
-New verb: `jinn mcp-serve`
+New bin: `jinn-mcp` (not a CLI subcommand — separate binary, per MCP convention)
 
 ```
-jinn mcp-serve [--password-fd N]
+jinn-mcp
 
 Starts an MCP server on stdio (StdioServerTransport).
 Exposes operator-level tools for agent consumption.
 Long-lived — runs until stdin closes or SIGTERM.
+Reads JINN_PASSWORD from env (same as jinn CLI).
 ```
 
-This would be a new file at `client/src/mcp/operator-server.ts` and a new CLI command at `client/src/cli/commands/mcp-serve.ts`.
+Implementation: a new file at `client/src/mcp/operator-server.ts` with a corresponding `client/src/bin/jinn-mcp.ts` entry point. Add `"jinn-mcp": "./dist/bin/jinn-mcp.js"` to the `bin` field in package.json.
 
 ---
 
@@ -418,25 +422,21 @@ This would be a new file at `client/src/mcp/operator-server.ts` and a new CLI co
 
 ### 7.1 Immediate (This Sprint)
 
-1. **Publish npm package.** Run `yarn pack:smoke` to verify the package installs and `jinn doctor` works outside the monorepo. Then `npm publish`.
-
-2. **Add `jinn mcp-serve` verb.** Thin MCP server wrapping CLI commands. Start with read-only tools (`jinn_status`, `jinn_doctor`, `jinn_fleet`, `jinn_balance`, `jinn_history`) plus `jinn_init`. This is shippable in a day.
+1. **Add `jinn-mcp` bin entry.** Thin MCP server wrapping CLI commands via a dedicated binary (per MCP convention). Start with read-only tools (`jinn_status`, `jinn_doctor`, `jinn_fleet`, `jinn_balance`, `jinn_history`) plus `jinn_init`. This is shippable in a day.
 
 ### 7.2 Near-term (Next 2 Weeks)
 
-3. **Add write tools to MCP server.** `jinn_bootstrap`, `jinn_submit_intent`, `jinn_start_daemon`, `jinn_stop_daemon`. These require careful error handling since they mutate state.
+2. **Add write tools to MCP server.** `jinn_bootstrap`, `jinn_submit_intent`, `jinn_start_daemon`, `jinn_stop_daemon`. These require careful error handling since they mutate state.
 
-4. **Add `jinn quickstart` verb.** Guided flow combining init + fund-check + bootstrap + run. Detects CDP credentials and attempts auto-funding.
+3. **Add `jinn quickstart` verb.** Guided flow combining init + fund-check + bootstrap + run.
 
-5. **Optional CDP faucet integration.** Dynamic import of `@coinbase/cdp-sdk`, gated on env vars. Fails gracefully to manual instructions if unavailable.
+4. **Testnet faucet integration.** Ship a Jinn-project CDP API key for auto-funding (see section 4.4). Dynamic import of `@coinbase/cdp-sdk`, falls back to manual faucet URL if unavailable.
 
 ### 7.3 Medium-term
 
-6. **Claude Code skill.** A markdown skill file that describes the Jinn protocol and teaches agents how to use the MCP tools. Distributable via the npm package or a separate skill registry.
+5. **Claude Code skill.** A markdown skill file that describes the Jinn protocol and teaches agents how to use the MCP tools. Distributable via the npm package or a separate skill registry.
 
-7. **Docker image.** `Dockerfile` in `client/`, published to ghcr.io. Include Node.js + Claude Code CLI. Volume mount for `~/.jinn-client/`.
-
-8. **Codex / Cursor / Windsurf plugin manifests.** These ecosystems are converging on MCP, so the MCP server covers them. If any require custom plugin formats, create thin wrappers.
+6. **Codex / Cursor / Windsurf plugin manifests.** These ecosystems are converging on MCP, so the MCP server covers them. If any require custom plugin formats, create thin wrappers.
 
 ### 7.4 Architecture Principle
 
@@ -468,8 +468,8 @@ The existing task MCP server and the proposed operator MCP server serve differen
 
 | Risk | Likelihood | Impact | Mitigation |
 |------|-----------|--------|------------|
-| npm package has monorepo-specific paths | Medium | High (broken install) | `pack:smoke` script exists — run it in CI |
 | MCP server daemon management is fragile | Medium | Medium | Use existing pidfile + HTTP API pattern |
+| Shipped CDP API key gets revoked/abused | Low | Low | Rate limits are per-address; fallback to manual faucet URL; monitor via CDP dashboard |
 | CDP faucet rate limits block multi-service bootstrap | High | Low | Only need ~0.01 ETH; one faucet claim is sufficient |
 | Claude Code CLI not installed | High | High (can't run daemon) | `jinn doctor` already checks this; clear error message |
 | Testnet contracts redeploy breaks config | Medium | High | Ship deployment artifacts in npm package (`deployments/` is in `files`) |

--- a/docs/superpowers/prompts/agent-packaging-planning-prompts.md
+++ b/docs/superpowers/prompts/agent-packaging-planning-prompts.md
@@ -1,0 +1,212 @@
+# Agent Packaging — Planning Prompts
+
+Planning prompts for each implementation item from `docs/research/2026-04-agent-packaging.md`. Each prompt is designed to be handed to a planning session to produce an implementation plan.
+
+---
+
+## 1. Operator Dashboard
+
+```
+Plan the implementation of an operator dashboard for the jinn client daemon.
+
+Context: read docs/research/2026-04-agent-packaging.md section 2.5 for the full design rationale.
+
+The daemon already runs a Hono HTTP server on port 7331 (client/src/api/server.ts) with endpoints:
+- GET /v1/status — daemon health, fleet state, RPC connectivity
+- GET /artifacts/search — query knowledge artifacts
+- GET /artifacts/:id/content — fetch artifact content
+
+The dashboard is a single static HTML file served at GET / by this existing server. It polls the API endpoints with vanilla JS — no framework, no build step, no new dependencies. It ships inside the npm package in dist/.
+
+Plan should cover:
+- The HTML file structure (client/src/dashboard/index.html) — layout, panels, polling logic
+- How to serve it from Hono (static file read at startup? inline string? Hono's serveStatic?)
+- What the /v1/status response already contains vs what panels need (read client/src/api/gather-status.ts and client/src/api/status-rollup-build.ts)
+- Whether any new API endpoints are needed for v1, or if existing endpoints suffice
+- How to copy/include the HTML file in dist/ during yarn build (tsc doesn't copy non-TS files)
+- The startup message change: "Dashboard: http://127.0.0.1:7331"
+- Visual design direction — this is an operator monitoring tool, not a product frontend, but it should look polished
+
+Scope constraint: v1 is daemon-only. No bootstrap phase visibility. The HTTP server starts after bootstrap completes in daemon.start() — no refactoring of main.ts.
+```
+
+---
+
+## 2. Operator MCP Server (Read-Only Tools)
+
+```
+Plan the implementation of jinn-mcp, a standalone MCP server exposing operator-level tools for the jinn client.
+
+Context: read docs/research/2026-04-agent-packaging.md sections 2.2, 5.1, 5.2, 5.3, and 8 for the full design rationale.
+
+This is separate from the existing task-scoped MCP server at client/src/mcp/server.ts (which serves the inner agent during restoration). The operator MCP server serves the outer agent — the user's agent managing Jinn operations.
+
+The entry point is a dedicated binary: jinn-mcp (not a CLI subcommand). This follows MCP convention — a standalone process that speaks stdio via StdioServerTransport.
+
+Phase 1 scope — read-only tools plus init:
+- jinn_status (wraps jinn status)
+- jinn_doctor (wraps jinn doctor)
+- jinn_fleet (wraps jinn fleet)
+- jinn_balance (wraps jinn balance)
+- jinn_history (wraps jinn history)
+- jinn_rewards (wraps jinn rewards)
+- jinn_init (wraps jinn init)
+
+Plan should cover:
+- Architecture decision: import CLI command modules directly (Option B in the doc) vs shell out. The CLI commands already accept injectable { writer, exit } — passing a StringWriter and no-op exit prevents process termination. Read client/src/cli/command.ts for the CommandContext interface.
+- File structure: client/src/mcp/operator-server.ts (MCP server), client/src/bin/jinn-mcp.ts (bin entry)
+- package.json changes: add "jinn-mcp" to bin field, ensure it's in files
+- Password handling: read JINN_PASSWORD from env, same as CLI
+- Tool schema design: what Zod schemas for each tool's inputs
+- Testing strategy
+- How users register it in MCP config (npx pattern)
+```
+
+---
+
+## 3. MCP Server Write Tools
+
+```
+Plan adding write (mutating) tools to the jinn-mcp operator MCP server.
+
+Context: read docs/research/2026-04-agent-packaging.md sections 5.1 and 5.2. This builds on the read-only MCP server from item 2 — that must be implemented first.
+
+New tools:
+- jinn_bootstrap (wraps jinn bootstrap — advances fleet state machine)
+- jinn_submit_intent (wraps jinn submit-intent — posts desired state on-chain)
+- jinn_start_daemon (starts jinn run as a background process)
+- jinn_stop_daemon (wraps jinn stop — sends SIGTERM via pidfile)
+
+Plan should cover:
+- Error handling for mutating operations — bootstrap can pause at funding gates, submit-intent can hit transient RPC errors. How should these surface as MCP tool responses vs errors?
+- Daemon lifecycle: jinn_start_daemon spawns jinn run as a detached subprocess and returns the PID. The daemon already writes a pidfile to ~/.jinn-client/earning/daemon.pid. jinn_stop_daemon reads the pidfile and sends SIGTERM. Read client/src/cli/commands/run.ts and client/src/cli/commands/stop.ts.
+- Confirmation semantics: jinn submit-intent has a --yes flag and --dry-run. In MCP context, should tools always act (implicit --yes) or require explicit confirmation? Consider the agent UX.
+- Long-running operations: bootstrap can take minutes (multiple on-chain transactions). Should the tool block until complete, or return immediately with a status to poll?
+- Testing: how to test mutating MCP tools without hitting real chains
+```
+
+---
+
+## 4. `jinn quickstart` Command
+
+```
+Plan the implementation of jinn quickstart — a single command that takes a user from zero to a running daemon with no manual steps.
+
+Context: read docs/research/2026-04-agent-packaging.md sections 3.2, 3.3, and 3.4.
+
+The flow:
+1. Generate a random keystore password, save to ~/.jinn-client/keystore-password
+   (skip if JINN_PASSWORD is already set — respect explicit operator choice)
+2. jinn init — create wallet with that password (idempotent)
+3. Check balances
+4. Auto-fund via Coinbase CDP faucet (shipped API key; see item 5)
+5. If auto-fund fails: print master address + faucet URL, poll until funded
+6. jinn bootstrap — advance state machine to completion
+7. jinn run — start daemon
+8. Print dashboard URL + password location + change-password hint
+
+Plan should cover:
+- New file: client/src/cli/commands/quickstart.ts
+- Password generation: crypto.randomBytes, save as plaintext to ~/.jinn-client/keystore-password. File permissions (0600).
+- How to call existing command modules (init, bootstrap) programmatically — they're CommandModules with run(ctx). Can we call them directly, or do we need to extract shared logic?
+- Faucet integration dependency: quickstart should work without the faucet (falls back to manual funding + polling). The faucet integration (item 5) is a separate deliverable that plugs in here.
+- Polling for funding: how often, what endpoint, timeout behavior
+- Daemon startup: foreground (quickstart blocks) vs background (quickstart returns). Consider that the user wants to see it working — foreground with the dashboard URL is probably right.
+- Output format: structured JSON on stdout (matching CLI convention) or human-friendly for this command? Since quickstart is inherently interactive, --human should be the default.
+- Idempotency: re-running quickstart after partial completion should resume, not restart. The underlying commands (init, bootstrap) are already idempotent.
+```
+
+---
+
+## 5. Testnet Faucet Integration
+
+```
+Plan integrating the Coinbase CDP faucet for automatic Base Sepolia testnet funding.
+
+Context: read docs/research/2026-04-agent-packaging.md section 4.4.
+
+The Coinbase Developer Platform provides a programmatic faucet:
+  await cdp.evm.requestFaucet({ address, network: "base-sepolia", token: "eth" })
+
+We plan to ship a Jinn-project CDP API key as a default so testnet onboarding requires zero user signup. Operators can override with their own key via CDP_API_KEY_ID / CDP_API_KEY_SECRET env vars.
+
+Plan should cover:
+- Where the shipped API key lives: hardcoded default in source? Bundled config file? Environment variable with fallback?
+- @coinbase/cdp-sdk as an optional dependency — dynamic import so the package doesn't fail to install if the SDK has platform-specific issues. Helpful error message if import fails.
+- Faucet call wrapper: client/src/earning/faucet.ts or similar. Inputs: address, network. Outputs: success/failure + tx hash. Handles rate limit errors (1 claim/24h/address) gracefully.
+- Integration points: called from jinn quickstart (item 4) and potentially jinn bootstrap when it detects a funding gap.
+- Rate limit handling: if the faucet returns a rate limit error, fall back to printing the manual faucet URL. Don't retry in a loop.
+- Security: the shipped API key grants testnet faucet access only. No mainnet, no wallet control. Document this in code comments.
+- Key rotation: how to update the shipped key if it gets revoked. Should be a code change + npm publish, not a config update.
+- Testing: mock the CDP SDK in tests. Test the fallback path (SDK unavailable, rate limited, network error).
+```
+
+---
+
+## 6. `jinn keys change-password` Command
+
+```
+Plan the implementation of jinn keys change-password — allows operators to replace an auto-generated keystore password with their own.
+
+Context: read docs/research/2026-04-agent-packaging.md section 3.4.
+
+The command:
+1. Read current password from ~/.jinn-client/keystore-password file, or from JINN_PASSWORD env var
+2. Decrypt mnemonic from mnemonic.keystore.json
+3. Prompt for new password (or read from --password-fd / JINN_NEW_PASSWORD env var)
+4. Re-encrypt mnemonic with new password
+5. Overwrite mnemonic.keystore.json
+6. Delete ~/.jinn-client/keystore-password file (if it exists)
+7. Print confirmation
+
+Plan should cover:
+- This is an extension of the existing jinn keys backup command (client/src/cli/commands/keys-backup.ts). Should change-password be a subverb of keys (jinn keys change-password) or its own top-level verb?
+- The wallet functions already exist: decryptMnemonic, encryptMnemonic in client/src/earning/wallet.ts. The FleetStateStore has loadMnemonicKeystore/saveMnemonicKeystore.
+- Password file reading: check ~/.jinn-client/keystore-password first, then JINN_PASSWORD. If neither exists, error with guidance.
+- New password input: interactive prompt (process.stdin) or env var (JINN_NEW_PASSWORD) or --password-fd. The CLI is generally non-interactive, so env var / fd is more consistent, but this is a security operation where a prompt feels right.
+- Confirmation: require typing the new password twice? Or single entry with a --yes flag?
+- Daemon interaction: if the daemon is running, changing the password doesn't affect it (it already has the mnemonic in memory). But the next jinn run will need the new password. Should we warn if the daemon is running?
+- Testing: test the decrypt-reencrypt round trip. Test that the keystore-password file is deleted.
+```
+
+---
+
+## 7. Dashboard v2 — Bootstrap Visibility
+
+```
+Plan extending the operator dashboard to show bootstrap progress before the daemon is fully running.
+
+Context: read docs/research/2026-04-agent-packaging.md section 2.5 (v2 follow-up note) and section 7.3.
+
+Currently the Hono HTTP server starts inside daemon.start(), which is called after bootstrap completes in main.ts. This means the dashboard is only available once the daemon is running — operators get no visibility during the bootstrap phase, which can take minutes (multiple on-chain transactions, funding gates).
+
+Plan should cover:
+- Refactoring main.ts to start Hono before calling bootstrap(). The HTTP server would initially show bootstrap status, then transition to the full dashboard once the daemon starts.
+- What bootstrap progress data to expose: current step, next step, funding requirements, transaction hashes. The FleetBootstrapper already has this state — how to surface it via an API endpoint.
+- Proposed endpoint: GET /v1/bootstrap-status (or extend /v1/status to include bootstrap state)
+- Dashboard UX: show a bootstrap progress view (step list with checkmarks) that transitions to the full daemon dashboard when bootstrap completes.
+- The funding gate: when bootstrap pauses at awaiting_funding, the dashboard should show the address that needs funding + the amount + a link to the faucet. This is the "is it stuck?" moment.
+- Architecture impact: starting Hono before the daemon means the API server setup moves out of Daemon.start() and into main.ts. Consider what this means for the separation between daemon and main.
+```
+
+---
+
+## 8. Claude Code Skill
+
+```
+Plan creating a Claude Code skill that teaches agents how to use jinn MCP tools and operate on the Jinn network.
+
+Context: read docs/research/2026-04-agent-packaging.md section 2.3.
+
+A skill is a markdown file that gets loaded into the agent's context when invoked. It's a prompt template — it describes what tools are available and how the protocol works, so the agent can make informed decisions about which tools to call and in what order.
+
+This skill assumes the jinn-mcp operator MCP server (items 2-3) is already registered in the agent's MCP config.
+
+Plan should cover:
+- Skill content: protocol overview (creation → restoration → evaluation → knowledge loop), available MCP tools and when to use each, the quickstart flow, common operator tasks
+- Distribution: ship as a file in the npm package? Separate skill registry? A URL the agent can fetch?
+- Skill format: follow the Claude Code skill format (name, description, trigger conditions in frontmatter, instructions in body)
+- Trigger conditions: when should the skill activate? When the user mentions "jinn", "intent", "restoration"? When jinn MCP tools are available?
+- The skill should teach the agent the operational mental model: init → fund → bootstrap → run is the lifecycle; status/fleet/balance are monitoring; submit-intent is the main action verb
+- Testing: how to verify the skill produces good agent behavior
+```


### PR DESCRIPTION
## Summary

End-to-end agent onboarding for the jinn client. A new user goes from zero to a running, monitored daemon in three commands:

```
npm install -g @jinn-network/client
jinn plugin install
jinn quickstart
```

This PR adds 8 new features that work together to eliminate every manual step from testnet onboarding.

## What's in this PR

### Operator Dashboard (`GET /` on port 7331)
- Single static HTML file served by the existing Hono server
- Dark theme, 6 panels: health, fleet, master gas, rewards, activity, next actions
- Polls `/v1/status` every 5 seconds — no new API endpoints needed
- Startup message now prints `Dashboard: http://127.0.0.1:7331`

### MCP Server (`jinn-mcp` binary)
- Standalone MCP server exposing 11 operator-level tools
- **Read tools:** `jinn_status`, `jinn_doctor`, `jinn_fleet`, `jinn_balance`, `jinn_history`, `jinn_rewards`, `jinn_init`
- **Write tools:** `jinn_bootstrap`, `jinn_submit_intent`, `jinn_start_daemon`, `jinn_stop_daemon`
- Wraps CLI command modules directly (Option B from research) — `StringWriter` + no-op `exit`, no subprocess overhead
- Separate from the existing task-scoped MCP server (which serves the inner agent during restoration)

### `jinn quickstart`
- Single command: password generation → init → faucet funding → bootstrap → daemon start
- Auto-generates keystore password, saves to `~/.jinn-client/keystore-password`
- Respects `JINN_PASSWORD` if already set
- Polls for manual funding if faucet fails (15s intervals, 30min timeout)
- `--no-daemon` flag for CI setups

### Coinbase CDP Faucet Integration
- Automatic Base Sepolia testnet funding during bootstrap
- Ships a project CDP API key for zero-signup onboarding
- Dynamic import of `@coinbase/cdp-sdk` (optional dependency)
- Graceful fallback to manual faucet URL on rate limit or failure
- Integrated into `FleetBootstrapper.bootstrap()` — fires before the funding gate

### `jinn keys change-password`
- Re-encrypts keystore with a new password (same mnemonic, same wallet)
- Reads current password from auto-generated file or `JINN_PASSWORD`
- New password via `JINN_NEW_PASSWORD` env var
- Deletes the auto-generated password file after change
- Warns if daemon is running (password takes effect on next restart)

### `jinn plugin install/remove/list`
- Auto-detects installed AI tools and configures both MCP server + skill
- 7 targets: Claude Code, Claude Desktop, Cursor, VS Code, Gemini CLI, Antigravity, Codex
- Handles each tool's config format (JSON with `mcpServers`/`servers`, TOML for Codex)
- Handles each tool's skill format (Claude skills dir, Cursor rules, VS Code instructions, delimited blocks for Gemini/Codex)
- `--scope user|project` for global vs project-level configuration
- `--target <id>` to configure a single tool
- Idempotent with replace semantics (re-running updates skills, doesn't duplicate)

### `jinn update`
- Updates the npm package then re-runs `jinn plugin install` to propagate skill changes
- `--skip-npm` / `--skip-plugins` for granular control

### Operator Skill (`client/skills/jinn-operator/`)
- Claude Code skill teaching agents the full protocol: installation, MCP setup, quickstart, monitoring, troubleshooting
- Covers what MCP tools can't: pre-installation guidance, protocol mental model, sequencing knowledge, error recovery

## The onboarding story

**Before this PR:** 9 manual steps including faucet visits, config file creation, and multiple CLI commands with `JINN_PASSWORD` set each time.

**After this PR:**
```
npm install -g @jinn-network/client    # get the CLI + MCP server + skill
jinn plugin install                     # configure all detected AI tools
jinn quickstart                         # password, wallet, fund, bootstrap, run
```

Dashboard at `http://localhost:7331`. Zero manual steps on testnet.

## Files changed

- **New commands:** `quickstart.ts`, `plugin-install.ts`, `update.ts`
- **New modules:** `operator-server.ts` (MCP), `faucet.ts`, `dashboard/index.html`
- **New binary:** `bin/jinn-mcp.ts`
- **New skill:** `skills/jinn-operator/SKILL.md`
- **Modified:** `keys-backup.ts` (change-password subverb), `password.ts` (current/new password resolution), `bootstrap.ts` (faucet integration), `server.ts` (dashboard route), `main.ts` (startup message), `index.ts` (command registration), `package.json` (bin, files, optionalDependencies)
- **Research:** `docs/research/2026-04-agent-packaging.md`

## Test plan

- [ ] `cd client && yarn typecheck` passes
- [ ] `jinn --help` shows new verbs (quickstart, plugin, update)
- [ ] `jinn plugin list --json` detects installed AI tools
- [ ] `jinn plugin install --target claude-code` configures MCP + skill
- [ ] `jinn plugin install` again shows "Updated" not duplicated
- [ ] `jinn doctor` passes all checks
- [ ] `jinn quickstart --no-daemon` completes init + bootstrap (testnet with faucet)
- [ ] `jinn quickstart` starts daemon, dashboard accessible at localhost:7331
- [ ] `jinn keys change-password` re-encrypts with new password
- [ ] `jinn update --skip-npm` refreshes plugins only
- [ ] `jinn-mcp` starts and responds to MCP tool/list requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)