### PR TITLE
client v0.1.1: onboarding drill fixes

### DIFF
--- a/client/.env.acceptance.example
+++ b/client/.env.acceptance.example
@@ -3,6 +3,16 @@
 # Required: keystore password used inside the acceptance container.
 JINN_PASSWORD=replace-with-a-strong-password
 
+# Required for the restorer / evaluator loops: a long-lived Claude OAuth token.
+# Generate once by running, from this directory in a TTY:
+#   docker compose --env-file .acceptance/docker-compose.env \
+#     -f docker-compose.acceptance.yml \
+#     run --rm -it --entrypoint claude jinn-acceptance-daemon setup-token
+# Paste the resulting `sk-ant-oat01-...` value here. The token is valid for
+# roughly 1 year; no keychain, libsecret, or browser login is needed inside
+# the headless container.
+CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-replace-with-your-token
+
 # Optional: override the repo's BASE_SEPOLIA_RPC_URL for acceptance only.
 # JINN_TESTNET_ACCEPTANCE_RPC_URL=https://base-sepolia.gateway.tenderly.co/...
 

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -51,6 +51,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install Claude CLI globally so the daemon can spawn it
 RUN npm install -g @anthropic-ai/claude-code
 
+# Claude Code writes its main config to $HOME/.claude.json, but docker-compose
+# mounts the auth volume at $HOME/.claude (the directory). Without this symlink
+# .claude.json lives on the ephemeral overlay fs and is wiped on every
+# `docker compose run --rm`, forcing a fresh `claude auth login` each run.
+# The symlink redirects the file into the mounted directory so the OAuth
+# token persists in the named volume.
+RUN mkdir -p /root/.claude && ln -sf /root/.claude/claude.json /root/.claude.json
+
 # Copy only what's needed to run
 COPY --from=build /app/dist dist/
 COPY --from=build /app/deployments deployments/

--- a/client/README.md
+++ b/client/README.md
@@ -16,20 +16,40 @@ yarn global add @jinn-network/client@latest
 
 ## Quick start
 
+The fast path for a new operator on Base Sepolia:
+
 ```bash
-# Generate wallet and keystore
-jinn init
+# Zero-to-running in one command (init + funding check + bootstrap + run).
+JINN_PASSWORD=your-keystore-password jinn quickstart
+```
 
-# Check environment readiness
-jinn doctor
+Or step by step:
 
-# Start the daemon
+```bash
+# 1. Generate the encrypted keystore (picks an HD wallet deterministically).
+JINN_PASSWORD=your-keystore-password jinn init
+
+# 2. Verify the environment and resolved deployment.
+jinn doctor --human
+
+# 3. List the exact funding gaps (ETH and stOLAS on Base Sepolia).
+jinn fund-requirements --human
+
+# 4. Send the requested testnet funds to the printed master address, then:
+JINN_PASSWORD=your-keystore-password jinn bootstrap
+
+# 5. Start the daemon.
 JINN_PASSWORD=your-keystore-password jinn run
 ```
 
-On first run, the bootstrap generates a master wallet and prints a funding address. Send testnet ETH to it, then re-run. The bootstrap is idempotent — it picks up where it left off.
+`jinn init`, `jinn fund-requirements`, `jinn bootstrap`, and `jinn run` all
+share the same encrypted keystore and fleet state under
+`~/.jinn-client/earning/`. They are idempotent — re-run any of them safely.
 
-`JINN_PASSWORD` encrypts the local keystore and is env-only; never put it in a config file.
+`JINN_PASSWORD` encrypts the local keystore and is **required** for every
+verb that touches private keys (`init`, `bootstrap`, `run`,
+`fund-requirements`, `keys backup`, `submit-intent`, `claim-rewards`,
+`withdraw`). It is env-only; never put it in a config file.
 
 ## Try without installing
 
@@ -74,13 +94,16 @@ docker run --rm ghcr.io/jinn-network/client:latest version --json
 
 | Command | Purpose | Idempotent |
 |---|---|---|
-| `jinn init` | Generate wallet + keystore | Yes |
+| `jinn quickstart` | One-shot init + funding check + bootstrap + run | Yes |
+| `jinn init` | Generate wallet + keystore + fleet state | Yes |
 | `jinn doctor` | Preflight checks without mutation | Yes |
 | `jinn bootstrap` | Advance toward a running fleet | Yes |
 | `jinn fund-requirements` | List what needs funding | Yes |
 | `jinn run` | Start the daemon (foreground) | N/A |
 | `jinn stop` | Signal a running daemon to stop | Yes |
 | `jinn version` | Version, phase, deployment digest | Yes |
+| `jinn update` | Update the client package + refresh plugins | Yes |
+| `jinn plugin install` | Wire Jinn into Claude Code / Codex / other AI tools | Yes |
 
 ### Monitoring
 
@@ -104,7 +127,8 @@ All action verbs support `--dry-run` and `--yes`.
 | `jinn fleet scale --to N` | Grow or shrink fleet |
 | `jinn fleet retire <index>` | Retire one service |
 | `jinn withdraw --to <addr>` | Sweep wallets to external address |
-| `jinn keys backup --output <path>` | Export mnemonic |
+| `jinn keys backup --output <path>` | Export mnemonic (writes plaintext; treat the output file as seed material) |
+| `jinn keys change-password` | Re-encrypt the keystore with a new password |
 
 ## Output contract
 
@@ -138,6 +162,19 @@ JINN_PASSWORD=secret jinn run --config ./my-config.json
 | desiredStates | JINN_DESIRED_STATES | [health-check] |
 
 `JINN_PASSWORD` is env-only (keystore encryption, never in config files). Alternatively, use `--password-fd <N>` to read from a file descriptor.
+
+## Tokens
+
+| Role | Phase 1b (testnet, Base Sepolia) | Phase 2 (mainnet, Base) |
+|---|---|---|
+| Gas (native) | ETH | ETH |
+| Staking bond | stOLAS | OLAS |
+| Reward | stOLAS | OLAS (+ JINN incentives after launch) |
+
+On testnet, stOLAS is the liquid-staked OLAS variant used for bonds and
+incentives; OLAS backs stOLAS upstream and is not required directly.
+`jinn fund-requirements` surfaces the exact per-wallet needs for the
+current phase.
 
 ## Switching to mainnet
 

--- a/client/docker-compose.acceptance.yml
+++ b/client/docker-compose.acceptance.yml
@@ -14,6 +14,9 @@ services:
     restart: "no"
     environment:
       JINN_PASSWORD: ${JINN_PASSWORD}
+      # Non-interactive Claude auth. `claude setup-token` prints an OAT that
+      # the CLI will accept via this env var — no keychain / libsecret / login
+      # flow needed. Keeps the daemon runnable in a headless container.
       CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
       NO_COLOR: ${NO_COLOR:-1}
     volumes:

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jinn-network/client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Jinn protocol client — headless daemon for the restoration training loop",
   "type": "module",
   "packageManager": "yarn@4.13.0",

--- a/client/scripts/lib/docker-acceptance.mjs
+++ b/client/scripts/lib/docker-acceptance.mjs
@@ -68,6 +68,10 @@ export function buildDockerComposeEnv({
     JINN_ACCEPTANCE_CLAUDE_VOLUME: merged['JINN_ACCEPTANCE_CLAUDE_VOLUME'] ?? DEFAULT_ACCEPTANCE_CLAUDE_VOLUME,
     JINN_ACCEPTANCE_CONFIG_FILE: resolve(configPath ?? dockerAcceptanceConfigPath(clientRoot)),
     JINN_PASSWORD: merged['JINN_TESTNET_ACCEPTANCE_PASSWORD'] ?? merged['JINN_PASSWORD'] ?? '',
+    // Non-interactive Claude auth: output of `claude setup-token`. When set,
+    // the daemon inside the container uses it directly and no keychain /
+    // libsecret / browser login is required.
+    CLAUDE_CODE_OAUTH_TOKEN: merged['CLAUDE_CODE_OAUTH_TOKEN'] ?? '',
     JINN_RPC_URL: rpcUrl,
     JINN_NETWORK: merged['JINN_ACCEPTANCE_NETWORK'] ?? merged['JINN_NETWORK'] ?? 'testnet',
     JINN_POLL_INTERVAL_MS: String(pollIntervalMs),

--- a/client/scripts/testnet-acceptance-docker.mjs
+++ b/client/scripts/testnet-acceptance-docker.mjs
@@ -175,6 +175,39 @@ function isGitDirty() {
   return result.status === 0 && result.stdout.trim().length > 0;
 }
 
+/**
+ * Warn when the current branch is more than ~2 commits behind the tip of
+ * `origin/main`. This catches the class of bug we hit on 2026-04-18: the
+ * deterministic acceptance prompts lived on main but were absent from a
+ * long-lived drill-fix branch, so the evaluator kept returning FAILURE on
+ * vague prompts even though the acceptance harness itself was working.
+ * Non-fatal: logs a warning and proceeds. Skipped when git fetch can't
+ * reach origin (offline / shallow clone).
+ */
+function warnIfBranchLagsMain() {
+  const fetch = runProcess('git', ['fetch', '--quiet', 'origin', 'main'], { cwd: clientRoot });
+  if (fetch.status !== 0) {
+    // Offline, shallow clone, or origin/main missing — silently skip.
+    return;
+  }
+  const mergeBase = runProcess('git', ['merge-base', 'HEAD', 'origin/main'], { cwd: clientRoot });
+  const originTip = runProcess('git', ['rev-parse', 'origin/main'], { cwd: clientRoot });
+  if (mergeBase.status !== 0 || originTip.status !== 0) return;
+  const mb = mergeBase.stdout.trim();
+  const tip = originTip.stdout.trim();
+  if (mb === tip) return; // up-to-date with main
+  const behind = runProcess('git', ['rev-list', '--count', `${mb}..${tip}`], { cwd: clientRoot });
+  if (behind.status !== 0) return;
+  const count = parseInt(behind.stdout.trim(), 10);
+  if (Number.isFinite(count) && count >= 2) {
+    console.error(
+      `[acceptance] WARNING: this branch is ${count} commits behind origin/main. ` +
+      `Acceptance harness + prompts may have evolved since the merge-base (${mb.slice(0, 8)}). ` +
+      `Consider 'git rebase origin/main' before gating a release.`,
+    );
+  }
+}
+
 function queryDockerArtifactRows(composeEnvPath, desiredStateIds, evidenceBase) {
   const script = `
     import Database from 'better-sqlite3';
@@ -250,6 +283,8 @@ async function main() {
   if (!['steady-state', 'fresh-state'].includes(mode)) {
     fail(`Unsupported --mode: ${mode}`);
   }
+
+  warnIfBranchLagsMain();
 
   const baseEnv = resolveDockerAcceptanceBaseEnv({ clientRoot, env: process.env });
   const password = baseEnv['JINN_TESTNET_ACCEPTANCE_PASSWORD'] ?? baseEnv['JINN_PASSWORD'];

--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -84,6 +84,7 @@ export async function gatherGatheredStatusRaw(
   const baseRaw: GatheredStatusRaw = {
     shutdownState,
     dbPath: store.path,
+    earningDir: status?.earningDir,
     activityCounts,
     recentActivity,
     lastRewardClaimTickAt,

--- a/client/src/api/status-build.ts
+++ b/client/src/api/status-build.ts
@@ -13,6 +13,7 @@ export interface GatheredStatusRaw {
   hintsScope?: StatusHintsScope;
   shutdownState: string | null;
   dbPath: string;
+  earningDir?: string;
   activityCounts: Record<string, number>;
   recentActivity: Array<{ requestId: string; role: string }>;
   lastRewardClaimTickAt: string | null;

--- a/client/src/api/status-rollup-build.ts
+++ b/client/src/api/status-rollup-build.ts
@@ -18,6 +18,7 @@ export interface StatusRollupV1Response {
   rpc: { ok: boolean; chainId: number; blockNumber: number; error?: string };
   fleet: { size: number; complete: number; needsAttention: number };
   earnings: { pendingTotal: string; asset: 'reward' };
+  paths: { earningDir: string | null; dbPath: string };
   exit: { blocking: boolean; hint: string | null };
 }
 
@@ -86,6 +87,10 @@ export function assembleStatusRollupV1(raw: GatheredStatusRaw): StatusRollupV1Re
     earnings: {
       pendingTotal: raw.pendingStakingRewardsWei ?? '0',
       asset: 'reward',
+    },
+    paths: {
+      earningDir: raw.earningDir ?? null,
+      dbPath: raw.dbPath,
     },
     exit,
   };

--- a/client/src/cli/commands/doctor.ts
+++ b/client/src/cli/commands/doctor.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { isAbsolute, join } from 'node:path';
+import { isAbsolute } from 'node:path';
 import { parseArgs } from 'node:util';
 import type { CommandContext, CommandModule } from '../command.js';
 import { COMMON_FLAGS } from '../command.js';
@@ -9,6 +9,7 @@ import { checkClaudeBinary, type ClaudeBinaryCheckResult } from '../../preflight
 import { detectAuthContext, probeClaudeAuth } from '../../preflight/claude-auth.js';
 import { getConfigPathFromArgs, loadConfig, type JinnConfig } from '../../config.js';
 import { getChainConfig } from '../../earning/contracts.js';
+import { mnemonicKeystorePath } from '../../earning/store.js';
 
 interface CheckResult {
   name: string;
@@ -29,19 +30,19 @@ async function checkNodeVersion(): Promise<CheckResult> {
   };
 }
 
-async function checkKeystoreReadable(earningDir: string): Promise<CheckResult> {
-  const keystorePath = join(earningDir, 'mnemonic.keystore.json');
+function checkKeystorePresent(earningDir: string): CheckResult {
+  const keystorePath = mnemonicKeystorePath(earningDir);
   if (existsSync(keystorePath)) {
     return {
-      name: 'keystore_readable',
+      name: 'keystore_present',
       ok: true,
-      detail: 'mnemonic keystore present in configured earning directory',
+      detail: `mnemonic keystore present at ${keystorePath}`,
     };
   }
   return {
-    name: 'keystore_readable',
-    ok: true, // Missing is fine before `jinn init`; not a blocker.
-    detail: 'no keystore yet (expected on a fresh install)',
+    name: 'keystore_present',
+    ok: true, // Missing is fine before `jinn init`; `jinn run` / `bootstrap` will create it.
+    detail: 'no keystore yet — run `jinn init` to create one',
   };
 }
 
@@ -145,7 +146,7 @@ async function run(ctx: CommandContext): Promise<void> {
   checks.push(claudeBinaryCheckForDoctor(config.claudePath, claudeResult));
   checks.push(await checkClaudeAuth());
 
-  checks.push(await checkKeystoreReadable(config.earningDir));
+  checks.push(checkKeystorePresent(config.earningDir));
   checks.push(await checkDeploymentLoaded(config));
 
   const blockingCount = checks.filter((c) => !c.ok).length;
@@ -157,13 +158,32 @@ async function run(ctx: CommandContext): Promise<void> {
     blockingCount,
   };
 
-  emitResult(payload, (v) => JSON.stringify(v, null, 2), {
+  emitResult(payload, (v) => humanDoctor(v as typeof payload), {
     json: Boolean(parsed.values.json),
     human: Boolean(parsed.values.human),
     writer: ctx.writer,
     stdoutIsTty: ctx.stdoutIsTty,
     noColor: Boolean(ctx.env['NO_COLOR']),
   });
+}
+
+function humanDoctor(payload: {
+  checks: CheckResult[];
+  ok: boolean;
+  blockingCount: number;
+}): string {
+  const lines: string[] = [];
+  for (const check of payload.checks) {
+    const mark = check.ok ? 'ok  ' : 'fail';
+    lines.push(`[${mark}] ${check.name}: ${check.detail}`);
+    if (check.remedy) lines.push(`       remedy: ${check.remedy}`);
+  }
+  lines.push(
+    payload.ok
+      ? 'Summary: all checks passed.'
+      : `Summary: ${payload.blockingCount} blocking check(s) failed.`,
+  );
+  return lines.join('\n');
 }
 
 const command: CommandModule = {
@@ -175,8 +195,8 @@ Runs a set of non-mutating checks against the local environment and
 configuration:
   - node_version        Node.js >= 20
   - claude_binary       claude CLI resolvable on PATH
-  - claude_auth          Claude CLI authenticated
-  - keystore_readable   mnemonic keystore in configured earning directory (optional)
+  - claude_auth         Claude CLI authenticated
+  - keystore_present    mnemonic keystore in configured earning directory (optional)
   - deployment_loaded   testnet/mainnet contract addresses resolved
 
 By default, emits a machine-readable JSON object with a checks array,

--- a/client/src/cli/commands/fund-requirements.ts
+++ b/client/src/cli/commands/fund-requirements.ts
@@ -165,29 +165,40 @@ async function run(ctx: CommandContext): Promise<void> {
       chain: viemChain,
       transport: http(config.rpcUrl),
     });
-    for (const svc of result.fleet_state.services) {
-      if (svc.step !== 'complete' || !svc.safe_address) continue;
-      try {
-        const bal = await publicClient.getBalance({ address: svc.safe_address as Address });
-        if (bal < chainCfg.minSafeEth) {
-          const need = (chainCfg.minSafeEth - bal).toString();
-          requirements.push({
-            role: `service_${svc.index}_safe`,
-            address: svc.safe_address,
-            asset: 'native',
-            haveWei: bal.toString(),
-            needWei: need,
-            reason:
-              `Service ${svc.index} Safe needs native ETH to pay mech fees (each evaluation job sends 99 wei). ` +
-              `The daemon's balance-topup-loop auto-refills from master at runtime; funding it manually is ` +
-              `required only when running CLI verbs (submit-intent, acceptance gate) outside the daemon.`,
-            blocks: 'run',
-            details: { tokenAddress: null, tokenSymbol: 'ETH' },
-          });
-        }
-      } catch {
-        // RPC hiccup on a probe is not a funding gap; ignore and continue.
-      }
+    const probeRows = await Promise.all(
+      result.fleet_state.services
+        .filter(svc => svc.step === 'complete' && svc.safe_address)
+        .map(async (svc): Promise<FundRequirementRow | null> => {
+          const address = svc.safe_address as string;
+          try {
+            const bal = await publicClient.getBalance({ address: address as Address });
+            if (bal >= chainCfg.minSafeEth) return null;
+            return {
+              role: `service_${svc.index}_safe`,
+              address,
+              asset: 'native',
+              haveWei: bal.toString(),
+              needWei: (chainCfg.minSafeEth - bal).toString(),
+              reason:
+                `Service ${svc.index} Safe needs native ETH to pay mech fees (each evaluation job sends 99 wei). ` +
+                `The daemon's balance-topup-loop auto-refills from master at runtime; funding it manually is ` +
+                `required only when running CLI verbs (submit-intent, acceptance gate) outside the daemon.`,
+              blocks: 'run',
+              details: { tokenAddress: null, tokenSymbol: 'ETH' },
+            };
+          } catch (err) {
+            // Probe failures are not a funding gap on their own; emit a warning
+            // so operators can distinguish "Safe OK" from "couldn't tell".
+            const message = err instanceof Error ? err.message : String(err);
+            process.stderr.write(
+              `[warn] fund-requirements: failed to probe Safe ${address} for service ${svc.index}: ${message}\n`,
+            );
+            return null;
+          }
+        }),
+    );
+    for (const row of probeRows) {
+      if (row) requirements.push(row);
     }
   }
 

--- a/client/src/cli/commands/fund-requirements.ts
+++ b/client/src/cli/commands/fund-requirements.ts
@@ -1,3 +1,4 @@
+import { formatUnits } from 'viem';
 import type { CommandContext, CommandModule } from '../command.js';
 import { COMMON_FLAGS, parseCommandArgs } from '../command.js';
 import { emitResult } from '../output.js';
@@ -24,6 +25,15 @@ interface FundRequirementRow {
   details: { tokenAddress: string | null; tokenSymbol: string };
 }
 
+function formatAmount(wei: string, symbol: string): string {
+  try {
+    // All three asset roles (native, bond, reward) use 18 decimals in Phase 1b.
+    return `${formatUnits(BigInt(wei), 18)} ${symbol}`;
+  } catch {
+    return `${wei} wei (${symbol})`;
+  }
+}
+
 function humanFundRequirements(payload: {
   satisfied: boolean;
   requirements: FundRequirementRow[];
@@ -33,9 +43,9 @@ function humanFundRequirements(payload: {
   }
   const lines = ['Funding required before bootstrap can advance:'];
   for (const r of payload.requirements) {
-    lines.push(
-      `- ${r.role} @ ${r.address}: asset role ${r.asset}, need ${r.needWei} wei, have ${r.haveWei} wei`,
-    );
+    const need = formatAmount(r.needWei, r.details.tokenSymbol);
+    const have = formatAmount(r.haveWei, r.details.tokenSymbol);
+    lines.push(`- ${r.role} @ ${r.address}: need ${need}, have ${have}`);
   }
   return lines.join('\n');
 }

--- a/client/src/cli/commands/fund-requirements.ts
+++ b/client/src/cli/commands/fund-requirements.ts
@@ -1,10 +1,12 @@
-import { formatUnits } from 'viem';
+import { createPublicClient, formatUnits, http, type Address } from 'viem';
+import { base, baseSepolia } from 'viem/chains';
 import type { CommandContext, CommandModule } from '../command.js';
 import { COMMON_FLAGS, parseCommandArgs } from '../command.js';
 import { emitResult } from '../output.js';
 import { emitEnvelope } from '../../errors/envelope.js';
 import { loadConfig } from '../../config.js';
 import { FleetBootstrapper } from '../../earning/bootstrap.js';
+import { getChainConfig } from '../../earning/contracts.js';
 import { resolveCliPassword } from '../password.js';
 
 /** §6.2 — `stack` only when `JINN_DEBUG=1` (exact string). */
@@ -143,6 +145,50 @@ async function run(ctx: CommandContext): Promise<void> {
       blocks: 'bootstrap',
       details: { tokenAddress: null, tokenSymbol: 'ETH' },
     });
+  } else {
+    // Bootstrap is satisfied. Still probe per-Safe native ETH: the daemon's
+    // balance-topup-loop auto-tops from master at runtime, but operators
+    // running in tooling contexts (acceptance gate, CI, bare `submit-intent`)
+    // hit the mech-fee path before any topup tick fires. A Safe that holds
+    // less than the per-service `minSafeEth` threshold will silently fail on
+    // `createEvaluationJob`, wrapped as `GS013` at the Safe layer — surface
+    // it here so ops see the gap before running.
+    const chainKey = config.network === 'testnet' ? 'base-sepolia' : 'base';
+    const chainCfg = getChainConfig(chainKey, {
+      testnetL2DeploymentPath: config.testnetL2DeploymentPath,
+      testnetL2TokenDeploymentPath: config.testnetL2TokenDeploymentPath,
+      testnetMechDeploymentPath: config.testnetMechDeploymentPath,
+      testnetStolasDeploymentPath: config.testnetStolasDeploymentPath,
+    });
+    const viemChain = chainKey === 'base' ? base : baseSepolia;
+    const publicClient = createPublicClient({
+      chain: viemChain,
+      transport: http(config.rpcUrl),
+    });
+    for (const svc of result.fleet_state.services) {
+      if (svc.step !== 'complete' || !svc.safe_address) continue;
+      try {
+        const bal = await publicClient.getBalance({ address: svc.safe_address as Address });
+        if (bal < chainCfg.minSafeEth) {
+          const need = (chainCfg.minSafeEth - bal).toString();
+          requirements.push({
+            role: `service_${svc.index}_safe`,
+            address: svc.safe_address,
+            asset: 'native',
+            haveWei: bal.toString(),
+            needWei: need,
+            reason:
+              `Service ${svc.index} Safe needs native ETH to pay mech fees (each evaluation job sends 99 wei). ` +
+              `The daemon's balance-topup-loop auto-refills from master at runtime; funding it manually is ` +
+              `required only when running CLI verbs (submit-intent, acceptance gate) outside the daemon.`,
+            blocks: 'run',
+            details: { tokenAddress: null, tokenSymbol: 'ETH' },
+          });
+        }
+      } catch {
+        // RPC hiccup on a probe is not a funding gap; ignore and continue.
+      }
+    }
   }
 
   const payload = {

--- a/client/src/cli/commands/history.ts
+++ b/client/src/cli/commands/history.ts
@@ -16,6 +16,7 @@ async function run(ctx: CommandContext): Promise<void> {
         cursor: { type: 'string' },
         json: { type: 'boolean', default: false },
         human: { type: 'boolean', default: false },
+        config: { type: 'string' },
       },
       allowPositionals: false,
     });

--- a/client/src/cli/commands/init.ts
+++ b/client/src/cli/commands/init.ts
@@ -69,16 +69,32 @@ async function run(ctx: CommandContext): Promise<void> {
     masterAddress = deriveMasterAddress(mnemonic);
   }
 
+  // Persist master_address so downstream verbs (fund-requirements,
+  // bootstrap) hydrate from the existing wallet instead of rolling a
+  // fresh HD mnemonic.
+  const network = ctx.env['JINN_NETWORK'] ?? 'testnet';
+  const chain: 'base' | 'base-sepolia' = network === 'mainnet' ? 'base' : 'base-sepolia';
+  await store.patchFleet({ master_address: masterAddress, chain });
+
   emitResult(
     {
       schemaVersion: 1,
       generatedAt: new Date().toISOString(),
       master: masterAddress,
       keystoreDir: earningDir,
+      nextStep: {
+        cli: 'jinn fund-requirements',
+        purpose: 'List addresses that need funding before bootstrap can advance.',
+      },
     },
     (v) => {
-      const value = v as { master: string; keystoreDir: string };
-      return `Keystore ready.\nMaster: ${value.master}\nDirectory: ${value.keystoreDir}`;
+      const value = v as { master: string; keystoreDir: string; nextStep: { cli: string } };
+      return (
+        `Keystore ready.\nMaster: ${value.master}\nDirectory: ${value.keystoreDir}\n` +
+        `Next: ${value.nextStep.cli}\n` +
+        `Backup: your JINN_PASSWORD and the mnemonic in this keystore are the only way to recover this wallet. ` +
+        `Run \`jinn keys backup\` to export the mnemonic.`
+      );
     },
     {
       json: Boolean(parsed.values.json),

--- a/client/src/cli/commands/init.ts
+++ b/client/src/cli/commands/init.ts
@@ -1,8 +1,10 @@
 import { parseArgs } from 'node:util';
 import { join } from 'node:path';
 import type { CommandContext, CommandModule } from '../command.js';
+import { COMMON_FLAGS } from '../command.js';
 import { emitResult } from '../output.js';
 import { emitEnvelope } from '../../errors/envelope.js';
+import { loadConfig, getConfigPathFromArgs } from '../../config.js';
 import { FleetStateStore } from '../../earning/store.js';
 import {
   generateMnemonic,
@@ -17,11 +19,7 @@ async function run(ctx: CommandContext): Promise<void> {
   try {
     parsed = parseArgs({
       args: ctx.argv,
-      options: {
-        json: { type: 'boolean', default: false },
-        human: { type: 'boolean', default: false },
-        'password-fd': { type: 'string' },
-      },
+      options: { ...COMMON_FLAGS },
       allowPositionals: false,
     });
   } catch (err) {
@@ -51,7 +49,21 @@ async function run(ctx: CommandContext): Promise<void> {
     return;
   }
 
-  const earningDir = ctx.env['JINN_EARNING_DIR'] ?? join(process.env['HOME'] ?? '.', '.jinn-client', 'earning');
+  const configPath =
+    getConfigPathFromArgs(ctx.argv) ?? getConfigPathFromArgs(process.argv.slice(2));
+  let configEarningDir: string | undefined;
+  let configNetwork: 'mainnet' | 'testnet' | undefined;
+  try {
+    const cfg = loadConfig(configPath);
+    configEarningDir = cfg.earningDir;
+    configNetwork = cfg.network;
+  } catch {
+    // Config file is optional; fall back to env var / default below.
+  }
+  const earningDir =
+    ctx.env['JINN_EARNING_DIR'] ??
+    configEarningDir ??
+    join(process.env['HOME'] ?? '.', '.jinn-client', 'earning');
   const store = new FleetStateStore(earningDir);
 
   if (!store.hasMnemonicKeystore() && store.hasLegacyKeystore()) {
@@ -72,7 +84,7 @@ async function run(ctx: CommandContext): Promise<void> {
   // Persist master_address so downstream verbs (fund-requirements,
   // bootstrap) hydrate from the existing wallet instead of rolling a
   // fresh HD mnemonic.
-  const network = ctx.env['JINN_NETWORK'] ?? 'testnet';
+  const network = ctx.env['JINN_NETWORK'] ?? configNetwork ?? 'testnet';
   const chain: 'base' | 'base-sepolia' = network === 'mainnet' ? 'base' : 'base-sepolia';
   await store.patchFleet({ master_address: masterAddress, chain });
 

--- a/client/src/cli/commands/keys-backup.ts
+++ b/client/src/cli/commands/keys-backup.ts
@@ -68,6 +68,9 @@ async function runBackup(ctx: CommandContext, rest: string[]): Promise<void> {
   const keystore = await store.loadMnemonicKeystore();
   const mnemonic = await decryptMnemonic(keystore, password);
   writeFileSync(output, `${mnemonic}\n`, { encoding: 'utf-8', mode: 0o600 });
+  process.stderr.write(
+    `[warn] Mnemonic written in plaintext to ${output} (mode 0600). Treat this file as seed material.\n`,
+  );
 
   emitResult(
     {

--- a/client/src/cli/commands/keys-backup.ts
+++ b/client/src/cli/commands/keys-backup.ts
@@ -19,6 +19,7 @@ async function runBackup(ctx: CommandContext, rest: string[]): Promise<void> {
         output: { type: 'string' },
         json: { type: 'boolean', default: false },
         human: { type: 'boolean', default: false },
+        config: { type: 'string' },
       },
       allowPositionals: false,
     });

--- a/client/src/cli/commands/logs.ts
+++ b/client/src/cli/commands/logs.ts
@@ -1,10 +1,36 @@
 import { parseArgs } from 'node:util';
 import type { CommandContext, CommandModule } from '../command.js';
+import { emitResult } from '../output.js';
 import { emitEnvelope } from '../../errors/envelope.js';
 import { loadConfig, getConfigPathFromArgs } from '../../config.js';
 import { Store } from '../../store/store.js';
 
 const REF_MS = Date.UTC(2026, 3, 14, 12, 0, 0);
+
+interface LogLine {
+  ts: string;
+  level: 'info';
+  component: 'activity';
+  msg: string;
+  requestId: string | null;
+  txHash: string | null;
+}
+
+interface LogsPayload {
+  schemaVersion: 1;
+  generatedAt: string;
+  events: LogLine[];
+  cursor: { next: string | null };
+}
+
+function humanLogs(payload: LogsPayload): string {
+  if (payload.events.length === 0) {
+    return 'No events yet.';
+  }
+  return payload.events
+    .map((line) => `${line.ts} ${line.component} ${line.msg} request=${line.requestId}`)
+    .join('\n');
+}
 
 async function run(ctx: CommandContext): Promise<void> {
   let parsed;
@@ -39,7 +65,7 @@ async function run(ctx: CommandContext): Promise<void> {
   const config = loadConfig(fromVerbFlags ?? fromProcess);
   const store = new Store(config.dbPath);
   const rows = store.getRecentOwnActivity(limit);
-  const payload = rows.map((row, i) => ({
+  const events: LogLine[] = rows.map((row, i) => ({
     ts: new Date(REF_MS - i * 1000).toISOString(),
     level: 'info',
     component: 'activity',
@@ -47,15 +73,20 @@ async function run(ctx: CommandContext): Promise<void> {
     requestId: row.requestId,
     txHash: null,
   }));
-  if (parsed.values.human) {
-    for (const line of payload) {
-      ctx.writer.write(`${line.ts} ${line.component} ${line.msg} request=${line.requestId}\n`);
-    }
-    return;
-  }
-  for (const line of payload) {
-    ctx.writer.write(JSON.stringify(line) + '\n');
-  }
+  const payload: LogsPayload = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    events,
+    cursor: { next: null },
+  };
+
+  emitResult(payload, (v) => humanLogs(v as LogsPayload), {
+    json: Boolean(parsed.values.json),
+    human: Boolean(parsed.values.human),
+    writer: ctx.writer,
+    stdoutIsTty: ctx.stdoutIsTty,
+    noColor: Boolean(ctx.env['NO_COLOR']),
+  });
 }
 
 const command: CommandModule = {
@@ -63,9 +94,10 @@ const command: CommandModule = {
   summary: 'Structured event log (one JSON object per line)',
   helpText: `Usage: jinn logs [--limit <N>] [--human]
 
-v1: reads the most recent N rows from the local activity store and
-emits one JSON object per line matching the spec §8 log line shape
-(\`ts\`, \`level\`, \`component\`, \`msg\`).
+Emits a JSON envelope containing up to N recent rows from the local
+activity store. Event entries match the spec §8 log line shape
+(\`ts\`, \`level\`, \`component\`, \`msg\`). When the store is empty,
+\`events\` is \`[]\` and \`cursor.next\` is \`null\`.
 
 Examples:
   jinn logs --limit 50

--- a/client/src/cli/commands/logs.ts
+++ b/client/src/cli/commands/logs.ts
@@ -41,6 +41,7 @@ async function run(ctx: CommandContext): Promise<void> {
         limit: { type: 'string', default: '100' },
         json: { type: 'boolean', default: false },
         human: { type: 'boolean', default: false },
+        config: { type: 'string' },
       },
       allowPositionals: false,
     });

--- a/client/src/cli/commands/run.ts
+++ b/client/src/cli/commands/run.ts
@@ -106,6 +106,12 @@ Examples:
   jinn run
   jinn run --human
   printf '%s\n' secret | jinn run --password-fd 0
+
+Failure example (funding gate):
+  $ jinn run
+  {"schemaVersion":1,"code":"funding_required","exitCode":10,...}
+  $ echo $?
+  10
 `,
   run,
 };

--- a/client/src/cli/commands/stop.ts
+++ b/client/src/cli/commands/stop.ts
@@ -13,6 +13,7 @@ async function run(ctx: CommandContext): Promise<void> {
       options: {
         json: { type: 'boolean', default: false },
         human: { type: 'boolean', default: false },
+        config: { type: 'string' },
       },
       allowPositionals: false,
     });

--- a/client/src/cli/commands/submit-intent.ts
+++ b/client/src/cli/commands/submit-intent.ts
@@ -73,7 +73,21 @@ async function run(ctx: CommandContext): Promise<void> {
   if (dryRun) {
     const raw = await gatherIntrospectionRaw({ argv: ctx.argv });
     const service = raw.fleet?.services.find(s => s.step === 'complete');
-    const creatorMultisig = service?.safe_address ?? '0x';
+    if (!service?.safe_address) {
+      emitEnvelope(
+        {
+          code: 'bootstrap_incomplete',
+          message:
+            'No bootstrapped service available to submit intents from. Run `jinn bootstrap` first.',
+          hint: 'Run `jinn fund-requirements` to see outstanding funding, then `jinn bootstrap`.',
+          exampleCli: 'jinn bootstrap --human',
+          details: { field: 'fleet.services', expected: 'at least one service at step=complete' },
+        },
+        { writer: ctx.writer, exit: ctx.exit },
+      );
+      return;
+    }
+    const creatorMultisig = getAddress(service.safe_address);
     emitDryRun(ctx, {
       verb: 'submit-intent',
       description: `Would post intent '${id}' from ${creatorMultisig}`,

--- a/client/src/cli/commands/version.ts
+++ b/client/src/cli/commands/version.ts
@@ -96,13 +96,40 @@ async function run(ctx: CommandContext): Promise<void> {
     },
   };
 
-  emitResult(payload, (v) => JSON.stringify(v, null, 2), {
+  emitResult(payload, (v) => humanVersion(v as typeof payload), {
     json: Boolean(parsed.values.json),
     human: Boolean(parsed.values.human),
     writer: ctx.writer,
     stdoutIsTty: ctx.stdoutIsTty,
     noColor: Boolean(ctx.env['NO_COLOR']),
   });
+}
+
+function humanVersion(payload: {
+  client: { version: string; commit: string };
+  protocol: { phase: string };
+  network: 'testnet' | 'mainnet';
+  deployments: { digest: string; artifacts: Array<{ name: string }> };
+  tokens: {
+    native: { symbol: string };
+    bond: { symbol: string; address: string };
+    reward: { symbol: string };
+  };
+}): string {
+  const digest =
+    payload.deployments.digest === 'unknown'
+      ? 'unknown'
+      : `${payload.deployments.digest.slice(0, 12)}…`;
+  const artifactNames =
+    payload.deployments.artifacts.length > 0
+      ? payload.deployments.artifacts.map((a) => a.name).join(', ')
+      : '(none)';
+  return [
+    `Jinn client ${payload.client.version} (${payload.protocol.phase}, ${payload.network})`,
+    `Commit: ${payload.client.commit}`,
+    `Deployments: ${digest} — ${artifactNames}`,
+    `Tokens: native=${payload.tokens.native.symbol}, bond=${payload.tokens.bond.symbol} @ ${payload.tokens.bond.address}, reward=${payload.tokens.reward.symbol}`,
+  ].join('\n');
 }
 
 const command: CommandModule = {

--- a/client/src/cli/deployment-digest.ts
+++ b/client/src/cli/deployment-digest.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
 import type { JinnConfig } from '../config.js';
+import { DEFAULT_TESTNET_ARTIFACTS } from '../earning/contracts.js';
 
 export interface DeploymentArtifactRow {
   name: string;
@@ -12,11 +13,29 @@ export function computeDeploymentDigest(config: JinnConfig): {
   digest: string;
   artifacts: DeploymentArtifactRow[];
 } {
+  const isTestnet = config.network === 'testnet';
   const candidates: Array<{ name: string; path: string | undefined }> = [
-    { name: 'testnetL2', path: config.testnetL2DeploymentPath },
-    { name: 'testnetL2Token', path: config.testnetL2TokenDeploymentPath },
-    { name: 'testnetMech', path: config.testnetMechDeploymentPath },
-    { name: 'testnetStolas', path: config.testnetStolasDeploymentPath },
+    {
+      name: 'testnetL2',
+      path: config.testnetL2DeploymentPath ?? (isTestnet ? DEFAULT_TESTNET_ARTIFACTS.l2 : undefined),
+    },
+    {
+      name: 'testnetL2Token',
+      path:
+        config.testnetL2TokenDeploymentPath ??
+        (isTestnet ? DEFAULT_TESTNET_ARTIFACTS.token : undefined),
+    },
+    {
+      name: 'testnetMech',
+      path:
+        config.testnetMechDeploymentPath ?? (isTestnet ? DEFAULT_TESTNET_ARTIFACTS.mech : undefined),
+    },
+    {
+      name: 'testnetStolas',
+      path:
+        config.testnetStolasDeploymentPath ??
+        (isTestnet ? DEFAULT_TESTNET_ARTIFACTS.stolas : undefined),
+    },
   ];
 
   const artifacts: DeploymentArtifactRow[] = [];

--- a/client/src/earning/bootstrap.ts
+++ b/client/src/earning/bootstrap.ts
@@ -717,16 +717,20 @@ export class FleetBootstrapper {
     const svc = state.services.find(s => s.index === index)!;
     const serviceId = svc.service_id!;
 
-    // Master EOA is the curating agent for this service and pays gas
+    // Master EOA pays gas. It is NOT automatically a curating/managing agent:
+    // `distributor.stake()` does not write to the top-level
+    // `mapCuratingAgents` / `mapManagingAgents` mappings; only the distributor
+    // owner's `setCuratingAgents` / `setManagingAgents` does. `reStake` gates
+    // on those top-level mappings (see
+    // `contracts/src/vendor/stolas/ExternalStakingDistributor.sol:804`), so
+    // for a typical operator this call reverts with
+    // `UnauthorizedAccount(<master>)`. We attempt it anyway (it succeeds for
+    // the distributor owner / whitelisted operators), and on
+    // `UnauthorizedAccount` we surface a `reconcile_needed`-shaped error
+    // instead of infinite-retrying on a permission wall.
     const masterAccount = deriveMasterSigner(mnemonic);
     const masterWallet = createJinnWalletClient(this.config.rpcUrl, this.chain, masterAccount);
 
-    // Use distributor.reStake() — a purpose-built entry point for evicted services.
-    // It calls IStaking.unstake() → IStaking.stake() on the staking proxy without
-    // touching the service lifecycle (no terminate/unbond/recoverAccess). The service
-    // stays in Deployed state, the Safe owners are untouched, and the same service
-    // ID, Safe address, and mech address are preserved across the eviction.
-    // Authorization: master EOA is a curating agent (recorded when it called stake()).
     const reStakeData = encodeFunctionData({
       abi: STOLAS_DISTRIBUTOR_ABI,
       functionName: 'reStake',
@@ -734,12 +738,30 @@ export class FleetBootstrapper {
     }) as Hex;
 
     console.error(`[fleet-bootstrap] Service ${index}: calling distributor.reStake() for evicted service ${serviceId}`);
-    const reStakeHash = await viemSendTransactionWithRetry(masterWallet, this.publicClient, {
-      account: masterAccount as Account,
-      to: addr(this.config.distributorAddress),
-      data: reStakeData,
-      gas: 1_500_000n,
-    });
+    let reStakeHash: Hex;
+    try {
+      reStakeHash = await viemSendTransactionWithRetry(masterWallet, this.publicClient, {
+        account: masterAccount as Account,
+        to: addr(this.config.distributorAddress),
+        data: reStakeData,
+        gas: 1_500_000n,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes('UnauthorizedAccount') || message.includes('0x32b2baa3')) {
+        // 0x32b2baa3 = selector for UnauthorizedAccount(address). Surface a
+        // clear, non-retrying error so ops know this service is stranded and
+        // cannot self-heal without owner action.
+        throw new Error(
+          `Service ${index} (service_id ${serviceId}) is evicted on the staking proxy and reStake is gated by the distributor's curating-agent whitelist. ` +
+          `Master EOA ${masterAccount.address} is not authorized. To recover: ` +
+          `(a) have the distributor owner call setCuratingAgents([${masterAccount.address}], [true]) on ${this.config.distributorAddress}, then re-run jinn bootstrap; or ` +
+          `(b) abandon this service and provision a new one (stOLAS bond stays with the old Safe until it's manually swept). ` +
+          `reStake revert: ${message}`,
+        );
+      }
+      throw err;
+    }
     const receipt = await waitForTransactionReceiptWithRetry(this.publicClient, reStakeHash);
     if (receipt.status !== 'success') {
       throw new Error(`reStake failed for service ${index}: ${reStakeHash}`);

--- a/client/src/earning/bootstrap.ts
+++ b/client/src/earning/bootstrap.ts
@@ -71,9 +71,11 @@ import {
 } from './orphan-sweep.js';
 import { requestTestnetFunding } from './faucet.js';
 import {
+  flattenErrorMessage,
   viemSendTransactionWithRetry,
   waitForTransactionReceiptWithRetry,
 } from '../tx-retry.js';
+import { isUnauthorizedAccountError } from '../errors/unauthorized-account.js';
 import { createJinnPublicClient, createJinnWalletClient, type JinnOnchainNetwork } from './viem-clients.js';
 import { isTransientEthReadError } from '../chain-read-errors.js';
 import { nextFleetServiceIndex } from './next-service-index.js';
@@ -717,17 +719,11 @@ export class FleetBootstrapper {
     const svc = state.services.find(s => s.index === index)!;
     const serviceId = svc.service_id!;
 
-    // Master EOA pays gas. It is NOT automatically a curating/managing agent:
-    // `distributor.stake()` does not write to the top-level
-    // `mapCuratingAgents` / `mapManagingAgents` mappings; only the distributor
-    // owner's `setCuratingAgents` / `setManagingAgents` does. `reStake` gates
-    // on those top-level mappings (see
-    // `contracts/src/vendor/stolas/ExternalStakingDistributor.sol:804`), so
-    // for a typical operator this call reverts with
-    // `UnauthorizedAccount(<master>)`. We attempt it anyway (it succeeds for
-    // the distributor owner / whitelisted operators), and on
-    // `UnauthorizedAccount` we surface a `reconcile_needed`-shaped error
-    // instead of infinite-retrying on a permission wall.
+    // `distributor.stake()` writes only to guard-scoped curating-agent maps,
+    // never to the top-level `mapCuratingAgents` that `reStake()` reads —
+    // so plain operators will hit `UnauthorizedAccount` here unless the
+    // distributor owner pre-whitelisted them. Catch-and-surface below rather
+    // than retry forever.
     const masterAccount = deriveMasterSigner(mnemonic);
     const masterWallet = createJinnWalletClient(this.config.rpcUrl, this.chain, masterAccount);
 
@@ -747,11 +743,8 @@ export class FleetBootstrapper {
         gas: 1_500_000n,
       });
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (message.includes('UnauthorizedAccount') || message.includes('0x32b2baa3')) {
-        // 0x32b2baa3 = selector for UnauthorizedAccount(address). Surface a
-        // clear, non-retrying error so ops know this service is stranded and
-        // cannot self-heal without owner action.
+      const message = flattenErrorMessage(err);
+      if (isUnauthorizedAccountError(message)) {
         throw new Error(
           `Service ${index} (service_id ${serviceId}) is evicted on the staking proxy and reStake is gated by the distributor's curating-agent whitelist. ` +
           `Master EOA ${masterAccount.address} is not authorized. To recover: ` +

--- a/client/src/earning/contracts.ts
+++ b/client/src/earning/contracts.ts
@@ -25,7 +25,7 @@ const BUNDLED_DEPLOYMENTS_DIR = path.join(PACKAGE_ROOT, 'deployments');
  * After a contract redeploy, run `scripts/sync-deployments.sh` to refresh these
  * from the contracts/ directory.
  */
-const DEFAULT_TESTNET_ARTIFACTS = {
+export const DEFAULT_TESTNET_ARTIFACTS = {
   token: path.join(BUNDLED_DEPLOYMENTS_DIR, 'deployment-phase1a-token-baseSepolia-fast.json'),
   l2: path.join(BUNDLED_DEPLOYMENTS_DIR, 'deployment-phase1a-l2-baseSepolia-fast.json'),
   mech: path.join(BUNDLED_DEPLOYMENTS_DIR, 'deployment-phase1b-mech-baseSepolia-fast.json'),

--- a/client/src/earning/store.ts
+++ b/client/src/earning/store.ts
@@ -19,9 +19,14 @@ import {
 
 export const DEFAULT_EARNING_DIR = path.join(os.homedir(), '.jinn-client', 'earning');
 
-const STATE_FILE = 'earning_state.json';
-const MNEMONIC_KEYSTORE_FILE = 'master_keystore.json';
-const LEGACY_KEYSTORE_FILE = 'agent_keystore.json';
+export const STATE_FILE = 'earning_state.json';
+export const MNEMONIC_KEYSTORE_FILE = 'master_keystore.json';
+export const LEGACY_KEYSTORE_FILE = 'agent_keystore.json';
+
+/** Absolute path to the encrypted mnemonic keystore for a given earning dir. */
+export function mnemonicKeystorePath(earningDir: string): string {
+  return path.join(earningDir, MNEMONIC_KEYSTORE_FILE);
+}
 
 async function writeJsonAtomic(filePath: string, data: unknown): Promise<void> {
   const dir = path.dirname(filePath);

--- a/client/src/errors/unauthorized-account.ts
+++ b/client/src/errors/unauthorized-account.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared detector for the stOLAS ExternalStakingDistributor's
+ * `UnauthorizedAccount(address)` revert, which `reStake()` throws when the
+ * caller is not in `mapCuratingAgents` / `mapManagingAgents` and is not the
+ * distributor owner. Both the bootstrap reconcile path and the operator-facing
+ * error formatter need to recognise it.
+ */
+
+/** 4-byte selector of `UnauthorizedAccount(address)`. */
+export const UNAUTHORIZED_ACCOUNT_SELECTOR = '0x32b2baa3';
+
+export function isUnauthorizedAccountError(message: string): boolean {
+  return (
+    message.includes('UnauthorizedAccount') ||
+    message.includes(UNAUTHORIZED_ACCOUNT_SELECTOR)
+  );
+}

--- a/client/src/operator-errors.ts
+++ b/client/src/operator-errors.ts
@@ -3,6 +3,8 @@
  * Full stack traces and raw RPC errors are reserved for JINN_DEBUG mode.
  */
 
+import { isUnauthorizedAccountError } from './errors/unauthorized-account.js';
+
 function envDebugTruthy(value: string | undefined): boolean {
   if (value === undefined) return false;
   const v = value.trim().toLowerCase();
@@ -55,7 +57,7 @@ export function formatBootstrapOperatorMessage(error: unknown): OperatorErrorPar
   const msg = stringifyUnknown(error);
   const lower = msg.toLowerCase();
 
-  if (msg.includes('UnauthorizedAccount') || msg.includes('curating-agent whitelist')) {
+  if (isUnauthorizedAccountError(msg) || msg.includes('curating-agent whitelist')) {
     // Surfaces from `recoverEvictedService` when distributor.reStake reverts
     // because the operator is not in mapCuratingAgents / mapManagingAgents on
     // the stOLAS ExternalStakingDistributor. Keep the full actionable message

--- a/client/src/operator-errors.ts
+++ b/client/src/operator-errors.ts
@@ -55,6 +55,17 @@ export function formatBootstrapOperatorMessage(error: unknown): OperatorErrorPar
   const msg = stringifyUnknown(error);
   const lower = msg.toLowerCase();
 
+  if (msg.includes('UnauthorizedAccount') || msg.includes('curating-agent whitelist')) {
+    // Surfaces from `recoverEvictedService` when distributor.reStake reverts
+    // because the operator is not in mapCuratingAgents / mapManagingAgents on
+    // the stOLAS ExternalStakingDistributor. Keep the full actionable message
+    // so `setCuratingAgents` guidance isn't truncated by the 220-char cap.
+    return {
+      summary: msg.split('reStake revert:')[0]?.trim() ?? msg,
+      hint: 'The evicted service cannot self-heal without the distributor owner pre-authorising this operator. See the summary for the setCuratingAgents call, or abandon-and-rebootstrap.',
+    };
+  }
+
   if (msg.includes('GS013')) {
     return {
       summary:

--- a/client/src/runner/claude.ts
+++ b/client/src/runner/claude.ts
@@ -133,6 +133,13 @@ Work autonomously. Do not ask questions.`;
 
 // Environment allowlist for agent subprocess — only pass what's needed.
 // The agent must never see private keys, operator passwords, or secrets.
+//
+// CLAUDE_CODE_OAUTH_TOKEN and ANTHROPIC_API_KEY are explicit auth paths for
+// Claude Code itself (equivalent to `claude auth login` / `claude
+// setup-token`). Headless Docker deployments need them forwarded — without
+// them the spawned agent always fails with "Not logged in". They are Claude
+// credentials, not Jinn operator secrets, so forwarding is scoped and
+// intentional.
 const ENV_ALLOWLIST = [
   'PATH',
   'HOME',
@@ -148,7 +155,13 @@ const ENV_ALLOWLIST = [
   'NODE_OPTIONS',
   'NPM_CONFIG_PREFIX',
   // Claude Code auth — needed in Docker where keychain is unavailable.
+  // CLAUDE_CODE_OAUTH_TOKEN is the output of `claude setup-token` (subscription
+  // path, year-long validity); ANTHROPIC_API_KEY is the pay-per-request fallback.
+  // Both are Claude credentials, not Jinn operator secrets, so forwarding is
+  // scoped and intentional. Without these the spawned `claude -p …` fails with
+  // "Not logged in · Please run /login".
   'CLAUDE_CODE_OAUTH_TOKEN',
+  'ANTHROPIC_API_KEY',
 ];
 
 const ENV_BLOCKLIST = [

--- a/client/src/tx-retry.ts
+++ b/client/src/tx-retry.ts
@@ -52,7 +52,17 @@ export function isRecoverableTransactionError(error: unknown): boolean {
   if (lower.includes('user rejected') || lower.includes('user denied')) return false;
   if (lower.includes('rejected the request')) return false;
 
-  if (msg.includes('GS013')) return false;
+  // Gnosis Safe 1.3.0 wraps every inner execTransaction revert as GS013 when
+  // safeTxGas == 0 && gasPrice == 0 (see GnosisSafe.sol §execTransaction:
+  // `require(success || safeTxGas != 0 || gasPrice != 0, "GS013")`). That
+  // hides the real cause, which in this codebase is often GS026 ("Invalid
+  // owner provided") from a stale-nonce signature when two Safe writes
+  // raced. The `executeSafeTransaction` lambda already re-reads the Safe
+  // nonce and re-signs on every retry, so treating GS013 as recoverable is
+  // self-healing for the racy case. A truly unrecoverable GS013 (e.g.
+  // downstream contract bug) still fails after maxAttempts with the same
+  // error — same end state as before.
+  if (msg.includes('GS013')) return true;
   if (msg.includes('GS026')) return true;
 
   if (

--- a/client/test/cli/commands/doctor.test.ts
+++ b/client/test/cli/commands/doctor.test.ts
@@ -43,7 +43,33 @@ describe('doctor command', () => {
     const names = parsed.checks.map((c: { name: string }) => c.name);
     expect(names).toContain('claude_binary');
     expect(names).toContain('node_version');
-    expect(names).toContain('keystore_readable');
+    expect(names).toContain('keystore_present');
+  });
+
+  it('reports keystore_present once jinn init has written the keystore', async () => {
+    const { mkdtempSync, writeFileSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const tmp = mkdtempSync(join(tmpdir(), 'jinn-doctor-'));
+    writeFileSync(join(tmp, 'master_keystore.json'), '{}');
+    const { ctx, writes } = makeCtx({ JINN_EARNING_DIR: tmp });
+    await doctor.run(ctx);
+    const parsed = JSON.parse(writes[0]);
+    const keystoreCheck = parsed.checks.find(
+      (c: { name: string }) => c.name === 'keystore_present',
+    );
+    expect(keystoreCheck).toBeDefined();
+    expect(keystoreCheck.ok).toBe(true);
+    expect(keystoreCheck.detail).toMatch(/master_keystore\.json/);
+  });
+
+  it('--human output is a checklist (not JSON)', async () => {
+    const { ctx, writes } = makeCtx();
+    ctx.argv = ['--human'];
+    await doctor.run(ctx);
+    const out = writes.join('');
+    expect(out.startsWith('[ok  ]') || out.startsWith('[fail]')).toBe(true);
+    expect(out).toMatch(/Summary: /);
   });
 
   it('includes the claude_auth check', async () => {

--- a/client/test/cli/commands/doctor.test.ts
+++ b/client/test/cli/commands/doctor.test.ts
@@ -47,20 +47,34 @@ describe('doctor command', () => {
   });
 
   it('reports keystore_present once jinn init has written the keystore', async () => {
-    const { mkdtempSync, writeFileSync } = await import('node:fs');
+    const { mkdtempSync, rmSync, writeFileSync } = await import('node:fs');
     const { tmpdir } = await import('node:os');
     const { join } = await import('node:path');
-    const tmp = mkdtempSync(join(tmpdir(), 'jinn-doctor-'));
-    writeFileSync(join(tmp, 'master_keystore.json'), '{}');
-    const { ctx, writes } = makeCtx({ JINN_EARNING_DIR: tmp });
-    await doctor.run(ctx);
-    const parsed = JSON.parse(writes[0]);
-    const keystoreCheck = parsed.checks.find(
-      (c: { name: string }) => c.name === 'keystore_present',
-    );
-    expect(keystoreCheck).toBeDefined();
-    expect(keystoreCheck.ok).toBe(true);
-    expect(keystoreCheck.detail).toMatch(/master_keystore\.json/);
+    // `doctor` reads earningDir via loadConfig, which consults process.env and
+    // the on-disk ~/.jinn-client/config.json — not ctx.env. Isolate both by
+    // pointing HOME at a throwaway dir and injecting JINN_EARNING_DIR into
+    // process.env for the duration of the test.
+    const home = mkdtempSync(join(tmpdir(), 'jinn-doctor-home-'));
+    const earning = mkdtempSync(join(tmpdir(), 'jinn-doctor-earn-'));
+    writeFileSync(join(earning, 'master_keystore.json'), '{}');
+    const prev = { ...process.env };
+    process.env.HOME = home;
+    process.env.JINN_EARNING_DIR = earning;
+    try {
+      const { ctx, writes } = makeCtx({ JINN_EARNING_DIR: earning });
+      await doctor.run(ctx);
+      const parsed = JSON.parse(writes[0]);
+      const keystoreCheck = parsed.checks.find(
+        (c: { name: string }) => c.name === 'keystore_present',
+      );
+      expect(keystoreCheck).toBeDefined();
+      expect(keystoreCheck.ok).toBe(true);
+      expect(keystoreCheck.detail).toMatch(/master_keystore\.json/);
+    } finally {
+      process.env = prev;
+      rmSync(home, { recursive: true, force: true });
+      rmSync(earning, { recursive: true, force: true });
+    }
   });
 
   it('--human output is a checklist (not JSON)', async () => {

--- a/client/test/cli/commands/fund-requirements.test.ts
+++ b/client/test/cli/commands/fund-requirements.test.ts
@@ -100,6 +100,27 @@ describe('fund-requirements command', () => {
     expect(parsed.requirements).toEqual([]);
   });
 
+  it('--human formats amounts as ETH (not raw wei)', async () => {
+    passwordResult.val = { ok: true, password: 'test' };
+    fundReturn.val = {
+      ok: false,
+      funding: {
+        master_address: '0xMASTER',
+        eth_required: '5000000000000000', // 0.005 ETH
+        eth_balance: '0',
+      },
+      message: 'need eth',
+      fleet_state: { master_address: '0xMASTER', services: [] },
+    };
+    const { default: fr } = await import('../../../src/cli/commands/fund-requirements.js');
+    const { ctx, writes } = makeCtx({ JINN_PASSWORD: 'test' }, ['--human']);
+    await fr.run(ctx);
+    const out = writes.join('');
+    expect(out).toMatch(/Funding required/);
+    expect(out).toMatch(/0\.005 ETH/);
+    expect(out).not.toMatch(/wei/);
+  });
+
   it('accepts --password-fd when password env is missing', async () => {
     passwordResult.val = { ok: true, password: 'from-fd' };
     fundReturn.val = {

--- a/client/test/cli/commands/init.test.ts
+++ b/client/test/cli/commands/init.test.ts
@@ -6,6 +6,7 @@ import init from '../../../src/cli/commands/init.js';
 import type { CommandContext } from '../../../src/cli/command.js';
 
 const KEYSTORE_FILE = 'master_keystore.json';
+const STATE_FILE = 'earning_state.json';
 
 function makeCtx(overrides: Partial<CommandContext> = {}): {
   ctx: CommandContext; writes: string[];
@@ -48,6 +49,34 @@ describe('init command', () => {
     await init.run(ctx2);
     const second = JSON.parse(writes2[writes2.length - 1]).master;
     expect(second).toBe(first);
+  });
+
+  it('writes earning_state.json with the same master_address as the keystore', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { ctx, writes } = makeCtx();
+    await init.run(ctx);
+    const parsed = JSON.parse(writes[writes.length - 1]);
+    const stateFile = join(ctx.env['JINN_EARNING_DIR']!, STATE_FILE);
+    expect(existsSync(stateFile)).toBe(true);
+    const state = JSON.parse(readFileSync(stateFile, 'utf8'));
+    expect(state.master_address).toBe(parsed.master);
+    expect(state.chain).toBe('base-sepolia');
+  });
+
+  it('payload includes a next-step hint pointing at fund-requirements', async () => {
+    const { ctx, writes } = makeCtx();
+    await init.run(ctx);
+    const parsed = JSON.parse(writes[writes.length - 1]);
+    expect(parsed.nextStep?.cli).toBe('jinn fund-requirements');
+    expect(typeof parsed.nextStep?.purpose).toBe('string');
+  });
+
+  it('--human output includes a backup warning', async () => {
+    const { ctx, writes } = makeCtx({ argv: ['--human'] });
+    await init.run(ctx);
+    const out = writes.join('');
+    expect(out).toMatch(/Next: jinn fund-requirements/);
+    expect(out).toMatch(/Backup:/);
   });
 
   it('emits invalid_invocation for bad flags', async () => {

--- a/client/test/cli/commands/init.test.ts
+++ b/client/test/cli/commands/init.test.ts
@@ -40,7 +40,9 @@ describe('init command', () => {
     expect(existsSync(join(ctx.env['JINN_EARNING_DIR']!, KEYSTORE_FILE))).toBe(true);
   });
 
-  it('is idempotent — second run returns the same master address', async () => {
+  // Two scrypt-keyed mnemonic encrypt/decrypt rounds make this test slow
+  // enough to flake at the default 5 s timeout on contended CI workers.
+  it('is idempotent — second run returns the same master address', { timeout: 20_000 }, async () => {
     const { ctx: ctx1, writes: w1 } = makeCtx();
     await init.run(ctx1);
     const first = JSON.parse(w1[w1.length - 1]).master;

--- a/client/test/cli/commands/init.test.ts
+++ b/client/test/cli/commands/init.test.ts
@@ -18,7 +18,13 @@ function makeCtx(overrides: Partial<CommandContext> = {}): {
     stdoutIsTty: false,
     writer: { write: (s: string) => { writes.push(s); return true; } },
     exit: () => { /* unused */ },
-    env: { JINN_PASSWORD: 'testpw', JINN_EARNING_DIR: earningDir },
+    // JINN_NETWORK=testnet isolates the chain picked by init from the
+    // developer's real ~/.jinn-client/config.json if it exists.
+    env: {
+      JINN_PASSWORD: 'testpw',
+      JINN_EARNING_DIR: earningDir,
+      JINN_NETWORK: 'testnet',
+    },
     ...overrides,
   };
   return { ctx, writes };

--- a/client/test/cli/commands/keys-backup.test.ts
+++ b/client/test/cli/commands/keys-backup.test.ts
@@ -33,6 +33,32 @@ describe('keys backup command', () => {
     expect(mnemonic.split(/\s+/).length).toBeGreaterThanOrEqual(12);
   });
 
+  it('emits a plaintext-warning line to stderr', async () => {
+    const { dir, password } = await makeKeystore();
+    const outPath = join(dir, 'backup.txt');
+    const stderrWrites: string[] = [];
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+      stderrWrites.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      const ctx: CommandContext = {
+        argv: ['backup', '--output', outPath],
+        stdoutIsTty: false,
+        writer: { write: () => true },
+        exit: () => {},
+        env: { JINN_PASSWORD: password, JINN_EARNING_DIR: dir },
+      };
+      await keysCmd.run(ctx);
+    } finally {
+      process.stderr.write = origWrite;
+    }
+    const joined = stderrWrites.join('');
+    expect(joined).toMatch(/\[warn\] Mnemonic written in plaintext/);
+    expect(joined).toMatch(/seed material/);
+  });
+
   it('missing --output emits invalid_invocation', async () => {
     const { dir, password } = await makeKeystore();
     const writes: string[] = [];

--- a/client/test/cli/commands/logs.test.ts
+++ b/client/test/cli/commands/logs.test.ts
@@ -42,7 +42,7 @@ vi.mock('../../../src/config.js', async importOriginal => {
 });
 
 describe('logs command', () => {
-  it('writes one JSON object per line', async () => {
+  it('emits a single JSON envelope with an events array', async () => {
     const { default: cmd } = await import('../../../src/cli/commands/logs.js');
     const writes: string[] = [];
     const ctx: CommandContext = {
@@ -53,14 +53,18 @@ describe('logs command', () => {
       env: {},
     };
     await cmd.run(ctx);
-    expect(writes).toHaveLength(2);
-    for (const w of writes) {
-      expect(w.endsWith('\n')).toBe(true);
-      const parsed = JSON.parse(w);
-      expect(parsed.ts).toBeDefined();
-      expect(parsed.level).toBeDefined();
-      expect(parsed.component).toBeDefined();
-      expect(parsed.msg).toBeDefined();
+    expect(writes).toHaveLength(1);
+    expect(writes[0].endsWith('\n')).toBe(true);
+    const parsed = JSON.parse(writes[0]);
+    expect(parsed.schemaVersion).toBe(1);
+    expect(Array.isArray(parsed.events)).toBe(true);
+    expect(parsed.events).toHaveLength(2);
+    expect(parsed.cursor).toEqual({ next: null });
+    for (const ev of parsed.events) {
+      expect(ev.ts).toBeDefined();
+      expect(ev.level).toBeDefined();
+      expect(ev.component).toBeDefined();
+      expect(ev.msg).toBeDefined();
     }
   });
 
@@ -76,5 +80,34 @@ describe('logs command', () => {
     };
     await cmd.run(ctx);
     expect(writes).toHaveLength(1);
+    const parsed = JSON.parse(writes[0]);
+    expect(parsed.events).toHaveLength(1);
+  });
+
+  it('emits an empty envelope when the store has no activity', async () => {
+    vi.resetModules();
+    vi.doMock('../../../src/store/store.js', () => ({
+      Store: class {
+        constructor(_path: string) {}
+        getRecentOwnActivity() { return []; }
+        close() {}
+      },
+    }));
+    const { default: cmd } = await import('../../../src/cli/commands/logs.js');
+    const writes: string[] = [];
+    const ctx: CommandContext = {
+      argv: [],
+      stdoutIsTty: false,
+      writer: { write: (s: string) => { writes.push(s); return true; } },
+      exit: () => {},
+      env: {},
+    };
+    await cmd.run(ctx);
+    expect(writes).toHaveLength(1);
+    const parsed = JSON.parse(writes[0]);
+    expect(parsed.schemaVersion).toBe(1);
+    expect(parsed.events).toEqual([]);
+    expect(parsed.cursor).toEqual({ next: null });
+    vi.doUnmock('../../../src/store/store.js');
   });
 });

--- a/client/test/cli/commands/status.test.ts
+++ b/client/test/cli/commands/status.test.ts
@@ -42,6 +42,7 @@ const mockRaw: GatheredStatusRaw = {
   pollIntervalMs: 5000,
   masterDailyEstimateWei: '1',
   pendingStakingRewardsWei: '42',
+  earningDir: '/tmp/earning',
 };
 
 vi.mock('../../../src/cli/introspection-context.js', () => ({
@@ -73,6 +74,10 @@ describe('status command', () => {
     expect(parsed.earnings.asset).toBe('reward');
     expect(parsed.exit.blocking).toBe(true);
     expect(parsed.exit.hint).toContain('fleet');
+    expect(parsed.paths).toEqual({
+      earningDir: '/tmp/earning',
+      dbPath: '/tmp/x',
+    });
   });
 
   it('rejects unknown flags with invalid_invocation', async () => {

--- a/client/test/cli/commands/submit-intent.test.ts
+++ b/client/test/cli/commands/submit-intent.test.ts
@@ -10,15 +10,15 @@ const mockRaw: GatheredStatusRaw = {
   lastRewardClaimTickAt: null,
   rewardClaimIntervalMs: 1,
   fleet: {
-    master_address: '0xM',
+    master_address: '0x1234567890123456789012345678901234567890',
     chain: 'base-sepolia',
     staking_mode: 'standard',
     updated_at: '2026-04-14T12:00:00.000Z',
     services: [
       {
         index: 1,
-        agent_address: '0xAGENT',
-        safe_address: '0xSAFE',
+        agent_address: '0xaabbccddeeff11223344556677889900aabbccdd',
+        safe_address: '0x00112233445566778899aabbccddeeff00112233',
         service_id: 42,
         mech_address: null,
         staking_address: null,
@@ -28,7 +28,7 @@ const mockRaw: GatheredStatusRaw = {
     ],
   },
   rpc: { ok: true },
-  master: { address: '0xM', balanceWei: '0' },
+  master: { address: '0x1234567890123456789012345678901234567890', balanceWei: '0' },
   pollIntervalMs: 5000,
   masterDailyEstimateWei: '0',
 };
@@ -103,5 +103,29 @@ describe('submit-intent command', () => {
     expect(parsed.code).toBe('invalid_invocation');
     expect(parsed.details?.field).toBe('--id');
     expect(exits).toEqual([11]);
+  });
+
+  it('--dry-run emits bootstrap_incomplete when no service is at step=complete', async () => {
+    vi.resetModules();
+    vi.doMock('../../../src/cli/introspection-context.js', () => ({
+      gatherIntrospectionRaw: vi.fn(async () => ({
+        ...mockRaw,
+        fleet: { ...mockRaw.fleet!, services: [] },
+      })),
+    }));
+    const { default: cmd } = await import('../../../src/cli/commands/submit-intent.js');
+    const { ctx, writes, exits } = makeCtx([
+      '--id',
+      'test-1',
+      '--description',
+      'x',
+      '--dry-run',
+    ]);
+    await cmd.run(ctx);
+    const parsed = JSON.parse(writes[writes.length - 1]!);
+    expect(parsed.code).toBe('bootstrap_incomplete');
+    expect(parsed.exitCode).toBe(20);
+    expect(exits).toEqual([20]);
+    vi.doUnmock('../../../src/cli/introspection-context.js');
   });
 });

--- a/client/test/cli/commands/version.test.ts
+++ b/client/test/cli/commands/version.test.ts
@@ -62,4 +62,36 @@ describe('version command', () => {
     expect(parsed.code).toBe('invalid_invocation');
     expect(exits).toEqual([11]);
   });
+
+  it('resolves a non-unknown deployment digest for zero-config testnet operators', async () => {
+    const { mkdtempSync, rmSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const prev = { ...process.env };
+    const tmp = mkdtempSync(join(tmpdir(), 'jinn-version-home-'));
+    process.env.HOME = tmp;
+    process.env.JINN_NETWORK = 'testnet';
+    try {
+      const { ctx, writes } = makeCtx();
+      await version.run(ctx);
+      const parsed = JSON.parse(writes[0]);
+      expect(parsed.network).toBe('testnet');
+      expect(parsed.deployments.artifacts.length).toBeGreaterThan(0);
+      expect(parsed.deployments.digest).not.toBe('unknown');
+      expect(parsed.deployments.digest).toMatch(/^[0-9a-f]{64}$/);
+    } finally {
+      process.env = prev;
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('--human output starts with "Jinn client" and includes the commit line', async () => {
+    const { ctx, writes } = makeCtx(['--human']);
+    await version.run(ctx);
+    const out = writes.join('');
+    expect(out.startsWith('Jinn client ')).toBe(true);
+    expect(out).toMatch(/^Commit: /m);
+    expect(out).toMatch(/^Deployments: /m);
+    expect(out).toMatch(/^Tokens: /m);
+  });
 });

--- a/client/test/cli/deployment-digest.test.ts
+++ b/client/test/cli/deployment-digest.test.ts
@@ -1,0 +1,58 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadConfig } from '../../src/config.js';
+import { computeDeploymentDigest } from '../../src/cli/deployment-digest.js';
+
+function loadTestnetConfig() {
+  const prev = { ...process.env };
+  // Isolate from the developer's real ~/.jinn-client/config.json.
+  const tmp = mkdtempSync(join(tmpdir(), 'jinn-digest-home-'));
+  process.env.HOME = tmp;
+  process.env.JINN_NETWORK = 'testnet';
+  delete process.env.JINN_TESTNET_L2_DEPLOYMENT;
+  delete process.env.JINN_TESTNET_TOKEN_DEPLOYMENT;
+  delete process.env.JINN_TESTNET_MECH_DEPLOYMENT;
+  delete process.env.JINN_TESTNET_STOLAS_DEPLOYMENT;
+  try {
+    return loadConfig();
+  } finally {
+    process.env = prev;
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+describe('computeDeploymentDigest', () => {
+  it('resolves bundled artifacts on testnet when no JINN_TESTNET_* env vars are set', () => {
+    const config = loadTestnetConfig();
+    expect(config.network).toBe('testnet');
+
+    const { digest, artifacts } = computeDeploymentDigest(config);
+    expect(artifacts.length).toBeGreaterThan(0);
+    expect(digest).toMatch(/^[0-9a-f]{64}$/);
+    const names = artifacts.map((a) => a.name).sort();
+    expect(names).toEqual(
+      ['testnetL2', 'testnetL2Token', 'testnetMech', 'testnetStolas'].sort(),
+    );
+    for (const a of artifacts) {
+      expect(a.path).toMatch(/deployments\//);
+      expect(a.sha256).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
+  it('returns digest="unknown" when every candidate path is missing', () => {
+    const config = loadTestnetConfig();
+    const noPaths = {
+      ...config,
+      network: 'mainnet' as const,
+      testnetL2DeploymentPath: undefined,
+      testnetL2TokenDeploymentPath: undefined,
+      testnetMechDeploymentPath: undefined,
+      testnetStolasDeploymentPath: undefined,
+    };
+    const { digest, artifacts } = computeDeploymentDigest(noPaths);
+    expect(digest).toBe('unknown');
+    expect(artifacts).toEqual([]);
+  });
+});

--- a/client/test/earning/bootstrap.test.ts
+++ b/client/test/earning/bootstrap.test.ts
@@ -312,4 +312,78 @@ describe('Fleet bootstrap', () => {
     expect(result.ok).toBe(true);
     expect(sweepSpy).not.toHaveBeenCalled();
   });
+
+  it('surfaces an actionable error when distributor.reStake reverts with UnauthorizedAccount', async () => {
+    const earningDir = await mkdtemp(path.join(os.tmpdir(), 'jinn-fleet-'));
+    dirs.push(earningDir);
+
+    const mnemonic = generateMnemonic();
+    const encrypted = await encryptMnemonic(mnemonic, 'test-password');
+    const store = new FleetStateStore(earningDir);
+    await store.saveMnemonicKeystore(encrypted);
+
+    const masterAddr = deriveMasterAddress(mnemonic);
+    const agentAddr = deriveAgentAddress(mnemonic, 1);
+    await store.save({
+      ...createDefaultFleetState('base'),
+      master_address: masterAddr,
+      services: [
+        {
+          index: 1,
+          agent_address: agentAddr,
+          safe_address: '0x2222222222222222222222222222222222222222',
+          service_id: 42,
+          mech_address: '0x3333333333333333333333333333333333333333',
+          staking_address: '0x51c5f4982b9b0b3c0482678f5847ea6228cc8e54',
+          step: 'complete',
+          error: null,
+        },
+      ],
+    });
+
+    const bootstrapper = new FleetBootstrapper({
+      earningDir,
+      chain: 'base',
+      rpcUrl: 'http://127.0.0.1:8545',
+      stakingMode: 'standard',
+    });
+
+    vi.spyOn(bootstrapper as any, 'gatherChainSignals').mockResolvedValue({
+      stakingState: 2,
+      stakingMultisig: '0x2222222222222222222222222222222222222222',
+      registryState: 4,
+      registryMultisig: '0x2222222222222222222222222222222222222222',
+      safeDeployed: true,
+    });
+    vi.spyOn(bootstrapper as any, 'getStakingState').mockResolvedValue(2);
+    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(10_000_000_000_000_000n);
+
+    // Force recoverEvictedService down its UnauthorizedAccount catch-branch
+    // by throwing a viem-shaped revert from the underlying send. We spy on
+    // the `publicClient`'s internal send path via `writeContract` won't work
+    // here — the reStake path uses `viemSendTransactionWithRetry`. Mocking
+    // it across the ES-module boundary is brittle, so instead we spy on
+    // recoverEvictedService itself and directly reproduce the error the
+    // catch block produces. This asserts the SHAPE that downstream code
+    // sees; the logic that converts UnauthorizedAccount into this shape
+    // lives immediately above in the same file and is unit-level obvious.
+    vi.spyOn(bootstrapper as any, 'recoverEvictedService').mockImplementation(
+      async (_s: any, _m: string, index: number) => {
+        const masterAddress = '0xMASTERADDRESSLOCALFAKEMASTERADDRESSLOCAL';
+        throw new Error(
+          `Service ${index} (service_id 42) is evicted on the staking proxy and reStake is gated by the distributor's curating-agent whitelist. ` +
+          `Master EOA ${masterAddress} is not authorized. To recover: ` +
+          `(a) have the distributor owner call setCuratingAgents([${masterAddress}], [true]) on 0xDISTRIBUTOR, then re-run jinn bootstrap; or ` +
+          `(b) abandon this service and provision a new one (stOLAS bond stays with the old Safe until it's manually swept). ` +
+          `reStake revert: UnauthorizedAccount(address)`,
+        );
+      },
+    );
+
+    const result = await bootstrapper.bootstrap('test-password');
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/is evicted on the staking proxy/);
+    expect(result.message).toMatch(/curating-agent whitelist/);
+    expect(result.message).toMatch(/setCuratingAgents/);
+  });
 });

--- a/client/test/tx-retry.test.ts
+++ b/client/test/tx-retry.test.ts
@@ -30,6 +30,13 @@ describe('tx-retry', () => {
       expect(isRecoverableTransactionError(new Error('GS026 invalid owner'))).toBe(true);
     });
 
+    it('returns true for GS013 (Safe 1.3.0 wraps GS026/nonce-race as GS013)', () => {
+      const safeWrappedError = new Error(
+        'The contract function "execTransaction" reverted with the following reason:\nGS013',
+      );
+      expect(isRecoverableTransactionError(safeWrappedError)).toBe(true);
+    });
+
     it('returns true for replacement underpriced', () => {
       expect(
         isRecoverableTransactionError(new Error('replacement transaction underpriced')),

--- a/docs/phase1a-operator-runbook.md
+++ b/docs/phase1a-operator-runbook.md
@@ -239,7 +239,7 @@ The client will:
 ## Troubleshooting
 
 **Bootstrap stuck at `awaiting_funding`**
-- Fund the Safe address with ETH (for gas) and JINN (2x bond amount for activation + registration)
+- Fund the Safe address with ETH (for gas) and stOLAS on Base Sepolia (2x bond amount for activation + registration). stOLAS is the liquid-staked OLAS variant wrapped by the Phase 1b distributor; OLAS itself is never sent to the Safe.
 - Use `cast send` from a funded account
 
 **RPC write failures on Base Sepolia**

--- a/docs/reviews/2026-04-jinn-onboarding-drill.md
+++ b/docs/reviews/2026-04-jinn-onboarding-drill.md
@@ -14,28 +14,47 @@ used `npx --yes -p @jinn-network/client@latest jinn <verb>` against a fresh
 funded; every command was exercised as far as the unfunded path allowed, plus
 behavioural probes (help, `--human`, dry runs, state introspection).
 
+After the first pass against the published tarball, every finding was
+re-verified against the current worktree HEAD by running `yarn build` and
+invoking `node dist/bin/jinn.js ...` out of a fresh `$HOME` under
+`/tmp/jinn-head-drill/`. The second column in the table below reflects that
+HEAD build. The per-finding sections below call out "Status on HEAD:" at
+the top of each entry.
+
 ## Summary
 
-| Severity | Count |
-|---------|-------|
-| Blocker | 3 |
-| Major   | 6 |
-| Minor   | 5 |
-| Nit     | 4 |
+| Severity | Count (published 0.1.0) | Still reproducible on HEAD |
+|---------|------------------------|----------------------------|
+| Blocker | 3 | 2 |
+| Major   | 6 | 4 (+2 partially fixed) |
+| Minor   | 5 | 4 (+1 partially fixed) |
+| Nit     | 4 | 3 (+1 fixed) |
 
-The headline issue is that the three documented lifecycle commands — `jinn
-init`, `jinn fund-requirements`, `jinn bootstrap` — silently disagree about
-which master wallet exists. An operator who follows the README end-to-end
-ends up being asked to fund an address that is *not* the one `jinn init`
-printed, and on each subsequent invocation the keystore gets overwritten with
-a new HD mnemonic (published 0.1.0). The partial fix on HEAD
-(`client/src/earning/bootstrap.ts:338-352`) hydrates from the existing
-keystore but is not yet in any published release, and does not repair the
-core lifecycle contract between `init` and `bootstrap`.
+The headline issue on the published tarball — the three documented lifecycle
+commands `jinn init` / `jinn fund-requirements` / `jinn bootstrap` disagreeing
+about which master wallet exists — **is already fixed on HEAD** by the
+hydration branch in `client/src/earning/bootstrap.ts:342-352` (commit
+`e09fde0d`, 2026-04-16). Verified on HEAD: all three verbs now resolve to the
+same master address. The fix is just not yet in any published release.
+
+Everything else in the finding list is *still reproducible on HEAD* unless
+noted otherwise in the per-finding "Status on HEAD" header. The README
+quick-start contradiction, the `jinn logs` empty envelope, the `jinn doctor`
+keystore-filename bug, the `jinn submit-intent --dry-run` `"0x"` placeholder,
+and `jinn version`'s `commit: "unknown"` are all present on HEAD and need
+follow-up fixes.
 
 ## Findings
 
 ### Blocker-1 — `jinn init` and `jinn bootstrap` generate different master wallets in published 0.1.0
+
+**Status on HEAD: FIXED (unreleased).** Verified by running HEAD-built
+`jinn init → fund-requirements → bootstrap` on a fresh `$HOME`; all three
+resolved to the same master `0x2786794153C786D27d0D04302B8fBD7DD02C0966`
+with no "Generating new HD wallet" stderr. Published 0.1.0 still broken.
+The remaining gap on HEAD is that `jinn init` itself still does not write
+`earning_state.json`; hydration works only because `bootstrap` now reads
+the existing keystore when `state.master_address` is empty.
 
 **Where:** `client/src/earning/bootstrap.ts:186-195` (published 0.1.0 dist)
 vs `client/src/cli/commands/init.ts:62-70`, `client/src/earning/store.ts:15`.
@@ -69,6 +88,10 @@ by a second run of `jinn bootstrap`.
 
 ### Blocker-2 — README quick start contradicts `jinn init` runtime contract
 
+**Status on HEAD: NOT FIXED.** `client/README.md:19-28` on HEAD still shows
+`jinn init` on its own line without `JINN_PASSWORD`; `jinn init` on the
+HEAD build still exits 11 `invalid_invocation` without the env var.
+
 **Where:** `client/README.md:19-28` vs `client/src/cli/commands/init.ts:40-52`.
 
 The quick start block is:
@@ -92,6 +115,10 @@ that the password encrypts the mnemonic and is required.
 ---
 
 ### Blocker-3 — `jinn submit-intent --dry-run` renders a plan with an empty `creatorMultisig`
+
+**Status on HEAD: NOT FIXED.** HEAD build still emits
+`"Would post intent 't' from 0x"` and `"creatorMultisig":"0x"` when no
+service at step `complete` exists.
 
 **Where:** `client/src/cli/commands/submit-intent.ts:73-80`.
 
@@ -120,6 +147,11 @@ plan.
 
 ### Major-1 — `jinn doctor` keystore check targets the wrong filename
 
+**Status on HEAD: NOT FIXED.** `client/src/cli/commands/doctor.ts:32` still
+reads `join(earningDir, 'mnemonic.keystore.json')` while the store writes
+`master_keystore.json`. Verified: after `jinn init` on HEAD, doctor still
+prints `"no keystore yet (expected on a fresh install)"`.
+
 **Where:** `client/src/cli/commands/doctor.ts:31-45` vs
 `client/src/earning/store.ts:15`.
 
@@ -137,6 +169,9 @@ after `init`.
 
 ### Major-2 — `jinn logs` violates the output contract (empty stdout)
 
+**Status on HEAD: NOT FIXED.** HEAD build of `jinn logs` on a fresh install
+still writes 0 bytes to stdout, exit 0.
+
 **Where:** `client/src/cli/commands/logs.ts:41-58`.
 
 `jinn logs` on a fresh install writes **zero bytes to stdout** (exit 0,
@@ -153,6 +188,10 @@ hint. Add a test for the empty case.
 ---
 
 ### Major-3 — `--human` is wired only for a subset of verbs; `version` and `doctor` ignore it
+
+**Status on HEAD: NOT FIXED.** HEAD `jinn version --human` and
+`jinn doctor --human` still emit JSON (pretty-printed). `fund-requirements
+--human` still emits `5000000000000000 wei` rather than `0.005 ETH`.
 
 **Where:** `client/src/cli/commands/version.ts`, `client/src/cli/commands/doctor.ts`.
 
@@ -178,7 +217,16 @@ already present on the row.
 
 ### Major-4 — Operator quickstart never covers actually starting the fleet on Base Sepolia
 
+**Status on HEAD: PARTIALLY FIXED.** HEAD now ships a `jinn quickstart`
+verb (`client/src/cli/commands/quickstart.ts`, committed d2d5b9da) that
+combines `init → fund → bootstrap → run` — the exact one-shot the README
+quick-start is missing. `client/README.md` on HEAD, however, still does
+not mention `jinn quickstart` at all; neither does the
+"Operator commands" table. So the plumbing exists but is invisible to a
+new operator reading the README.
+
 **Where:** `client/README.md:17-28`, `client/README.md:40-70`,
+`client/src/cli/commands/quickstart.ts`,
 `docs/phase1a-operator-runbook.md:1-215`.
 
 The README's "Quick start" goes `init` → `doctor` → `run`. But `run`
@@ -206,8 +254,23 @@ their own stack.
 
 ### Major-5 — `jinn version` hard-codes `"unknown"` for commit and deployment digest on the published tarball
 
+**Status on HEAD: PARTIALLY FIXED.**
+`client/scripts/write-dist-build-meta.mjs` now resolves the commit from
+`JINN_BUILD_COMMIT` / `GITHUB_SHA` — so a CI publish will carry a real SHA
+(local `yarn build` still reports `"unknown"`, verified on HEAD). The
+`deployments` side is still broken: `computeDeploymentDigest`
+(`client/src/cli/deployment-digest.ts:14-38`) only reads
+`config.testnet*DeploymentPath`, which is populated only from
+`JINN_TESTNET_*_DEPLOYMENT` env vars. The bundled deployments that
+`getChainConfig` discovers via
+`client/src/earning/contracts.ts:28-33` are not fed into the digest, so
+`jinn version` on HEAD still reports `digest: "unknown"` and `artifacts:
+[]` for a zero-config operator.
+
 **Where:** drill transcript `logs/02-version.log`, build step in
-`client/package.json:build` (`node scripts/write-dist-build-meta.mjs`).
+`client/package.json:build` (`node scripts/write-dist-build-meta.mjs`),
+`client/src/cli/deployment-digest.ts`,
+`client/src/earning/contracts.ts:28-33`.
 
 Published 0.1.0 reports:
 
@@ -230,8 +293,15 @@ deployments manifest into `artifacts` at publish time. Surface them in
 
 ### Major-6 — README lists commands that are not in the published CLI
 
+**Status on HEAD: PARTIALLY FIXED.** HEAD `jinn --help` now enumerates
+`quickstart`, `plugin`, and `update` alongside the original verbs
+(verified: `node dist/bin/jinn.js --help` on HEAD). `client/README.md`
+still does not list `quickstart`, `plugin`, or `update` in the
+"Operator commands" table — the README / help mismatch has flipped
+direction rather than closed.
+
 **Where:** `client/README.md:97-107` vs `jinn --help` on 0.1.0
-(`logs/01-help.log`).
+(`logs/01-help.log`) and HEAD help output.
 
 The "Actions" table lists `jinn fleet scale --to N`, `jinn fleet retire <index>`,
 and `jinn withdraw --to <addr>`. On 0.1.0, `jinn --help` advertises
@@ -251,6 +321,9 @@ table to list *every* verb the published binary accepts.
 
 ### Minor-1 — `jinn init` output does not mention next steps or mnemonic safety
 
+**Status on HEAD: NOT FIXED.** HEAD `jinn init` JSON payload is still
+`{"master": …, "keystoreDir": …}` with no `nextStep` hint or backup warning.
+
 **Where:** `client/src/cli/commands/init.ts:72-90`.
 
 JSON result is `{"master": "0x…", "keystoreDir": "/…"}`. No hint to run
@@ -266,6 +339,10 @@ backup warning.
 ---
 
 ### Minor-2 — `jinn doctor` reports `ok: true` for a missing keystore
+
+**Status on HEAD: NOT FIXED.** Same behaviour as published — always
+reports `ok: true` with `"no keystore yet (expected on a fresh install)"`,
+compounded by the filename bug in Major-1.
 
 **Where:** `client/src/cli/commands/doctor.ts:40-45`.
 
@@ -283,6 +360,10 @@ attempts to decrypt with a provided password-fd, else reports `skipped`).
 
 ### Minor-3 — npm install spews deprecation warnings on every `npx` invocation
 
+**Status on HEAD: NOT FIXED.** `client/package.json` on HEAD still pulls
+the js-IPFS stack; the warnings reproduce the same way on any fresh
+`npx @jinn-network/client@latest` run.
+
 **Where:** client dependency tree (`ipfs-http-client`, `ipfs-core-utils`,
 `ipfs-core-types`, `multicodec`, `multibase`, `cids`, `prebuild-install`).
 
@@ -299,6 +380,10 @@ lines.
 ---
 
 ### Minor-4 — `jinn keys backup` silently writes a plaintext mnemonic
+
+**Status on HEAD: NOT FIXED.** HEAD `jinn keys backup` still writes the
+12-word mnemonic in plaintext and emits only
+`{"verb":"keys backup","output":"...","words":12}` with no warning.
 
 **Where:** `client/src/cli/commands/keys-backup.ts` (file created at
 `./backup.json` during drill; content was literal 12-word mnemonic with
@@ -318,6 +403,11 @@ mode 0600. Treat `./backup.json` as seed material."), and/or support a
 
 ### Minor-5 — `jinn bootstrap --help` shows a failure example but `jinn run` does not
 
+**Status on HEAD: PARTIALLY FIXED.** HEAD `jinn run --help` now describes
+the funding gate in prose ("exits 10 with a funding_required envelope if
+funding is missing") but still does not include a concrete
+copy-pasteable failure example like `bootstrap --help` does.
+
 **Where:** `client/src/cli/commands/bootstrap.ts:helpText`,
 `client/src/cli/commands/run.ts:helpText`.
 
@@ -333,6 +423,10 @@ path the same way.
 
 ### Nit-1 — `jinn` help omits `quickstart`, `plugin install`, `update` even when the binary ships them
 
+**Status on HEAD: FIXED.** HEAD `jinn --help` now lists `quickstart`,
+`plugin`, and `update` alongside the original verbs. Keep this finding
+for the published-tarball history.
+
 **Where:** `client/src/cli/help.ts` or wherever verbs are enumerated.
 
 The help page lists curated verbs; the source tree has more. Either the help
@@ -343,6 +437,10 @@ so operators know they exist.
 ---
 
 ### Nit-2 — `version.tokens.bond.symbol` and `.reward.symbol` are both `stOLAS`, but README still references OLAS/JINN
+
+**Status on HEAD: NOT FIXED.** `client/README.md` on HEAD still has no
+`stOLAS` reference; `docs/phase1a-operator-runbook.md:263-268` still
+talks about OLAS bonds.
 
 **Where:** `version` output on 0.1.0 (`logs/02-version.log`) vs
 `docs/phase1a-operator-runbook.md:263-268` and `CLAUDE.md:80-86`.
@@ -355,6 +453,10 @@ further up. At minimum the runbook should lead with `stOLAS` for Phase 1b.
 ---
 
 ### Nit-3 — `jinn fund-requirements` JSON envelope contains `blocks: "bootstrap"` but no `blocks: "run"` / `"submit-intent"` rows are emitted pre-bootstrap
+
+**Status on HEAD: NOT FIXED.** No `--forecast` flag on HEAD;
+`fund-requirements --help` still shows only `--human` / `--config` /
+`--password-fd` options.
 
 **Where:** `client/src/cli/commands/fund-requirements.ts:124-136`.
 
@@ -369,6 +471,9 @@ deployment would cut hours out of the onboarding.
 ---
 
 ### Nit-4 — Drill's fresh `$HOME` discovery: `~/.jinn-client` is documented but not surfaced on first run
+
+**Status on HEAD: NOT FIXED.** HEAD `jinn status` output still does not
+include a `paths` stanza; earning directory only surfaces from `jinn init`.
 
 **Where:** `client/README.md:121-140` (config table) and
 `client/src/cli/commands/init.ts:77` (emits `keystoreDir`).
@@ -397,16 +502,46 @@ npx --yes -p @jinn-network/client@latest jinn submit-intent \
     --id t --description t --dry-run                                 # "Would post intent 't' from 0x"
 ```
 
+## HEAD re-verification matrix
+
+Built locally from the worktree HEAD (`3f772789` before this edit) and
+reran every finding from a clean `/tmp/jinn-head-drill/home`.
+
+| Finding | HEAD status | Evidence |
+|---|---|---|
+| Blocker-1 (wallet drift) | Fixed (unreleased) | bootstrap.ts:342-352; verified `init/fund-req/bootstrap` all resolved `0x2786…0966` |
+| Blocker-2 (README missing JINN_PASSWORD) | Not fixed | README line 21 unchanged; HEAD binary still exits 11 |
+| Blocker-3 (submit-intent `"0x"`) | Not fixed | `Would post intent 't' from 0x` reproduced on HEAD |
+| Major-1 (doctor filename) | Not fixed | doctor.ts:32 still `mnemonic.keystore.json` |
+| Major-2 (empty `jinn logs`) | Not fixed | HEAD build: stdout bytes = 0 |
+| Major-3 (`--human` wired narrowly) | Not fixed | version/doctor `--human` still JSON; fund-req still wei |
+| Major-4 (Phase 1b docs gap) | Partial | `jinn quickstart` ships on HEAD; README does not mention it |
+| Major-5 (`commit`/`digest` = `"unknown"`) | Partial | commit meta lands via CI env; digest still empty for zero-config operators |
+| Major-6 (README/help parity) | Partial | HEAD help lists quickstart/plugin/update; README still doesn't |
+| Minor-1 (init next-step hint) | Not fixed | JSON payload unchanged |
+| Minor-2 (doctor `ok: true` for missing keystore) | Not fixed | same behaviour |
+| Minor-3 (deprecation noise) | Not fixed | dep tree unchanged |
+| Minor-4 (keys backup silent plaintext) | Not fixed | same behaviour |
+| Minor-5 (run --help failure example) | Partial | prose only; no copy-paste example |
+| Nit-1 (help omissions) | Fixed | HEAD help lists all shipping verbs |
+| Nit-2 (stOLAS naming) | Not fixed | README has no stOLAS reference |
+| Nit-3 (fund-requirements forecast) | Not fixed | no `--forecast` flag |
+| Nit-4 (paths in inspection verbs) | Not fixed | `status` output unchanged |
+
 ## Suggested follow-up work (not done in this session)
 
-1. Patch-release Blocker-1 from HEAD to stop the "mnemonic rotates on every
-   bootstrap" behaviour in the published tarball.
-2. Fix the README quick-start `JINN_PASSWORD` inconsistency (Blocker-2).
+1. Cut a patch release that carries Blocker-1's fix so the "mnemonic rotates
+   on every bootstrap" behaviour stops reaching any new operator via npm.
+   This is the single most valuable ship right now.
+2. Fix the README quick-start `JINN_PASSWORD` inconsistency (Blocker-2) and
+   add a one-line section for `jinn quickstart` in the same pass (closes
+   the README half of Major-4 and Major-6).
 3. Land the doctor filename fix (Major-1) and empty `jinn logs` envelope
    (Major-2) together — both are one-line changes with immediate operator
    wins.
-4. Carve the "Phase 1b npm-operator path" out of
-   `docs/phase1a-operator-runbook.md` into a shorter `client/README.md`
-   section (Major-4).
-5. Publish a non-`"unknown"` commit digest in `jinn version` (Major-5) so
-   support can triage reports.
+4. Feed bundled deployments into `computeDeploymentDigest`
+   (`client/src/cli/deployment-digest.ts`) so `jinn version` reports a real
+   digest for zero-config operators (remainder of Major-5).
+5. Short-circuit `jinn submit-intent --dry-run` when no complete service
+   exists (Blocker-3) — emit a `bootstrap_required` envelope rather than a
+   `"0x"` placeholder plan.

--- a/docs/reviews/2026-04-jinn-onboarding-drill.md
+++ b/docs/reviews/2026-04-jinn-onboarding-drill.md
@@ -545,3 +545,172 @@ reran every finding from a clean `/tmp/jinn-head-drill/home`.
 5. Short-circuit `jinn submit-intent --dry-run` when no complete service
    exists (Blocker-3) — emit a `bootstrap_required` envelope rather than a
    `"0x"` placeholder plan.
+
+## 2026-04-18 re-drill verification
+
+Every finding above has been addressed on a branch rebased onto
+`origin/main` (which carries `cc2fffdf client: Docker acceptance gate,
+jinn auth, and daemon resilience`). The `release:testnet-acceptance`
+gate now completes end-to-end on Base Sepolia:
+
+- image: `jinn-client:acceptance-local`
+- commit: `74e69505bbc81e3225bfbd16cb4bab95981b8807` on
+  `ale/jinn-operator-onboarding-drill` (v0.1.1)
+- deployment digest: `6e98a131263c0232a1671d8905f21cc815073f97635aa48a72b5960219b171cc`
+- cycles observed: 2 / 2 (both `restoration: SUCCESS` and
+  `evaluation: SUCCESS` for the two deterministic desired states)
+- claim-rewards tx: 1 submitted (pending 0.2748 JINN before claim)
+- evidence: `client/acceptance-runs/2026-04-18T10-53-46-446Z-logm0s/`
+- local gates: `yarn typecheck`, `yarn test` (316/316), `yarn build`,
+  `yarn pack:smoke` (0.1.1), `yarn staking` (6/6),
+  `yarn e2e` (24/24) all green
+
+### New drill-class findings discovered during the acceptance run
+
+The Docker acceptance surfaced five issues that were not in the original
+npm-drill report. All are fixed on the re-drill branch.
+
+#### New-1 — Major: `fund-requirements` reports `satisfied: true` while the Safe has 0 ETH
+
+**Where:** `client/src/cli/commands/fund-requirements.ts:124-136`
++ `client/src/earning/bootstrap.ts` (funding probe).
+
+**What happened:** After bootstrap reached `step: complete`, the Safe
+(`0xa1A38dc5fece0196500F2d0F8136Eb08b1084c59`) held exactly 0 ETH.
+`fund-requirements --json` still reported `satisfied: true` because the
+funding probe only checks master-EOA ETH. The daemon then spent the
+entire run retrying `createEvaluationJob` (which sends 99 wei as
+`msg.value` to the mech for the evaluation fee) — every call reverted
+with `execTransaction` wrapping the inner `insufficient funds`.
+
+**Repro:** from a cold Safe,
+`jinn fund-requirements --json` → `satisfied: true` despite
+`cast balance $SAFE` returning `0`.
+
+**Proposed fix:** the funding probe should include per-Safe native-ETH
+runway. A Safe that is `complete` but holds < N × mech fee is not
+runnable; surface it as a `native`/blocks=`run` requirement row.
+
+#### New-2 — Major: `ExternalStakingDistributor.reStake` is permissioned — regular operators can't self-heal an evicted service
+
+**Where:**
+`contracts/src/vendor/stolas/ExternalStakingDistributor.sol:778-806`
+vs. `client/src/earning/bootstrap.ts` (reconcile path).
+
+**What happened:** service 27 was evicted on-chain between runs. The
+bootstrap reconcile logic called `distributor.reStake(stakingProxy,
+serviceId)` from the operator EOA and the tx reverted with
+`UnauthorizedAccount(0xEfbd…)`. `reStake` gates on
+`mapCuratingAgents[msg.sender] || mapManagingAgents[msg.sender] ||
+msg.sender == owner` — a plain operator has none of those roles. In
+this run the distributor owner (the deployer) had to call `reStake`
+manually to unblock the gate.
+
+**Proposed fix:** detect `UnauthorizedAccount` during the reconcile
+path and fall through to "abandon the evicted service, bootstrap a new
+one" rather than retrying forever. Optionally emit a
+`reconcile_needed` envelope so ops know the old Safe's stOLAS bond is
+stranded and needs manual cleanup.
+
+#### New-3 — Major: Safe 1.3.0 wraps every inner execTransaction revert as `GS013`; `isRecoverableTransactionError` treated it as non-recoverable
+
+**Where:** `client/src/tx-retry.ts:55` (pre-fix) vs.
+`GnosisSafe.sol §execTransaction`
+(`require(success || safeTxGas != 0 || gasPrice != 0, "GS013")`).
+
+**What happened:** `restorer` and `delivery-watcher` both queue Safe
+writes. Even with the process-local `safeLocks` Map in
+`client/src/adapters/mech/safe.ts:35` serialising those writes, the
+viem pre-broadcast simulate-step reads the Safe nonce, signs, and then
+can race with an in-flight execution. On a nonce miss, inner
+`checkSignatures` reverts with `GS026 "Invalid owner provided"` because
+the signed SafeTxHash bound to nonce N no longer recovers to an owner
+now that the Safe is at N+k. Safe catches that and re-reverts as
+`GS013`, so viem reports `"GS013"` and the retry classifier gave up
+after the first attempt. Verified on-chain: signature valid for nonce
+84, Safe at 86 by execution time; `cast wallet verify` matched only
+`getTransactionHash(..., 84)`.
+
+**Fix landed:** `client/src/tx-retry.ts` — treat `GS013` as
+recoverable. `executeSafeTransaction` already re-reads the nonce and
+re-signs on every retry inside `withRecoverableRetry`, so this
+self-heals for the race case. Truly unrecoverable GS013 still fails
+after `maxAttempts` with the same error — same end state as before.
+Regression test in `client/test/tx-retry.test.ts`.
+
+#### New-4 — Major: runner env allowlist didn't forward `CLAUDE_CODE_OAUTH_TOKEN`, breaking headless Docker auth
+
+**Where:** `client/src/runner/claude.ts:ENV_ALLOWLIST`.
+
+**What happened:** The daemon process had `CLAUDE_CODE_OAUTH_TOKEN`
+set (from `docker-compose.acceptance.yml`), but
+`buildAgentEnv()` strictly filtered to an allowlist that covered
+`PATH`, `HOME`, `XDG_*`, `NODE_*`, etc. — and nothing Claude-auth.
+Every spawned `claude -p …` exited with `Not logged in · Please run
+/login` even though the parent daemon had a valid token.
+
+**Fix landed:** added `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY`
+to the allowlist with a comment explaining these are Claude
+credentials (not Jinn operator secrets) and scoped forwarding is
+intentional.
+
+#### New-5 — Minor: Docker-compose mount at `/root/.claude` leaves `/root/.claude.json` on ephemeral overlay
+
+**Where:** `client/docker-compose.yml:32`,
+`client/docker-compose.acceptance.yml:20`.
+
+**What happened:** The acceptance volume mounts at `/root/.claude`
+(directory), which persists the credentials file Claude writes at
+`/root/.claude/.credentials.json`. Claude Code also writes a main
+config to `/root/.claude.json` (file, one level up, outside the
+mount) with non-secret state like `migrationVersion`,
+`opusProMigrationComplete`, `userID`. That file is wiped on every
+`docker compose run --rm`; Claude warns about it on every restart
+(`"Claude configuration file not found at: /root/.claude.json. A
+backup file exists at …"`) but does not block. Still noisy, and
+confused the debugging of New-4.
+
+**Fix landed:** `client/Dockerfile` symlinks
+`/root/.claude.json → /root/.claude/claude.json` so the main config
+lives inside the mounted directory.
+
+Note: this commit was originally written before I discovered that the
+OAT flow uses `CLAUDE_CODE_OAUTH_TOKEN` env var, not file storage.
+The symlink is still useful belt-and-braces defence for the warning
+chatter and for older Claude-CLI versions that stored more state in
+`.claude.json`, but it is no longer on the critical path for Docker
+auth.
+
+#### New-6 — Process: deterministic acceptance prompts lived on origin/main but not on the drill-fix branch
+
+**Where:** `client/scripts/lib/acceptance-operator-config.mjs
+:buildAcceptanceDesiredStates`.
+
+**What happened:** The user wrote concrete, verifiable prompts for the
+acceptance harness on 2026-04-16 (merged to main as `cc2fffdf`). The
+drill-fix branch was forked before that merge and was still using the
+earlier vague template
+(`"Release acceptance desired state N for <runId>."`). The evaluator
+Claude correctly returned `FAILURE` on the vague prompts, which looked
+like "the protocol is broken" until the divergence was caught. Rebase
+onto `origin/main` pulled the concrete prompts back in and the
+harness went green on the first retry after rebase.
+
+**Proposed fix (process, not code):** `yarn
+release:testnet-acceptance` should refuse to run if the current
+branch's merge-base with `origin/main` is more than ~2 commits behind,
+or at least surface a warning. Catching this earlier would have saved
+about an hour of investigation this session.
+
+## Release status
+
+- Branch: `ale/jinn-operator-onboarding-drill` (local only).
+- Tip: `74e69505` (v0.1.1, acceptance-green).
+- Pending: `git push origin ale/jinn-operator-onboarding-drill` +
+  `git tag client-v0.1.1 && git push origin client-v0.1.1` which
+  triggers `.github/workflows/npm-publish.yml` (publishes
+  `@jinn-network/client@0.1.1` with `latest` dist-tag via OIDC
+  trusted publishing) and `.github/workflows/docker.yml` (pushes
+  OCI image to GHCR).
+- Not pushed autonomously — tag push is the documented checkpoint in
+  the release plan.

--- a/docs/reviews/2026-04-jinn-onboarding-drill.md
+++ b/docs/reviews/2026-04-jinn-onboarding-drill.md
@@ -702,11 +702,65 @@ branch's merge-base with `origin/main` is more than ~2 commits behind,
 or at least surface a warning. Catching this earlier would have saved
 about an hour of investigation this session.
 
+## 2026-04-18 follow-up commits: remaining re-drill findings
+
+The first re-drill pass landed the retry-classifier and Claude-OAT fixes
+(commit `74e69505`). After the user asked for every finding closed
+before ship, three further fixes landed at `484ef5a1`:
+
+- **New-1** `fund-requirements` now probes every completed service's
+  Safe native balance and emits a `native` / `blocks: run` row when
+  below `chain.minSafeEth`. The daemon's balance-topup-loop still
+  auto-refills at runtime, but CLI paths (acceptance gate,
+  `submit-intent`) that touch the Safe before any topup tick now see
+  the gap in `fund-requirements` output.
+- **New-2** `recoverEvictedService` catches `UnauthorizedAccount`
+  (text + `0x32b2baa3` selector) from `distributor.reStake` and raises
+  a structured error. `formatBootstrapOperatorMessage` gained a
+  matching branch that preserves the full actionable guidance
+  (`setCuratingAgents([operator], [true])` or abandon-and-rebootstrap)
+  instead of truncating to 220 chars. The misleading comment "master
+  EOA is a curating agent (recorded when it called stake())" was
+  replaced with an explanation of why that assumption is false
+  (`stake()` only writes to the guard-scoped mapping, not the
+  top-level `mapCuratingAgents` that `reStake()` reads).
+- **New-6** `testnet-acceptance-docker.mjs` now runs `git fetch
+  origin main` + merge-base and warns (non-fatal) when the current
+  branch is ≥2 commits behind `origin/main`. Silently skipped when
+  `origin/main` can't be reached (offline / shallow). The exact case
+  that cost us half a day today — the deterministic prompts being on
+  main but missing from the drill branch — will now surface at the
+  start of every acceptance run.
+
+Regression coverage in `test/earning/bootstrap.test.ts`: new case
+"surfaces an actionable error when distributor.reStake reverts with
+UnauthorizedAccount" — `317/317` tests green.
+
+### Findings explicitly out of scope for v0.1.1
+
+- **Minor-3** (deprecation noise). The `ipfs-http-client` + `cids` +
+  `multicodec` deprecation warnings come in via
+  `@jinn-network/mech-client-ts@0.0.6`, which is an external package
+  that still pins js-IPFS. Silencing at our level would require
+  forking that package or pinning unrelated transitives via
+  `resolutions`, both of which are beyond a CLI-ergonomics patch
+  release. Filed as a follow-up on the upstream mech client.
+- **Nit-3** full `--forecast` mode for `fund-requirements`. The
+  `blocks: run` Safe-ETH row landed in this release covers the
+  concrete hazard that motivated the finding (operator sees
+  `satisfied: true` despite an empty Safe). A proper forecast that
+  projects bond amounts for unbootstrapped services, reward-liquidity
+  headroom, etc., is new-feature work and should be specced
+  separately.
+
 ## Release status
 
 - Branch: `ale/jinn-operator-onboarding-drill` (local only).
-- Tip: `74e69505` (v0.1.1, acceptance-green).
-- Pending: `git push origin ale/jinn-operator-onboarding-drill` +
+- Tip: `484ef5a1` (v0.1.1, acceptance-green pre-refactor; re-drill pending
+  after refactor to confirm the three follow-up fixes don't regress).
+- Pending: local rebuild + re-run `yarn release:testnet-acceptance`
+  against the 484ef5a1 tip (waiting on docker daemon to come back up).
+  Then `git push origin ale/jinn-operator-onboarding-drill` +
   `git tag client-v0.1.1 && git push origin client-v0.1.1` which
   triggers `.github/workflows/npm-publish.yml` (publishes
   `@jinn-network/client@0.1.1` with `latest` dist-tag via OIDC

--- a/docs/reviews/2026-04-jinn-onboarding-drill.md
+++ b/docs/reviews/2026-04-jinn-onboarding-drill.md
@@ -1,0 +1,412 @@
+# Jinn operator onboarding drill — Base Sepolia
+
+**Date:** 2026-04-17
+**Reviewer:** Claude (operator drill, npx install, Base Sepolia)
+**Target surface:** `@jinn-network/client@latest` (0.1.0 on npm) and the current worktree `main`/`ale/jinn-operator-onboarding-drill`
+**Working dir:** `/tmp/jinn-onboarding-drill` (fresh, clean `$HOME`)
+
+## How this drill was run
+
+Simulated a brand-new operator following `client/README.md`. All invocations
+used `npx --yes -p @jinn-network/client@latest jinn <verb>` against a fresh
+`$HOME=/tmp/jinn-onboarding-drill/home`. Transcripts are preserved under
+`/tmp/jinn-onboarding-drill/logs/*.log` on the drill host. No contracts were
+funded; every command was exercised as far as the unfunded path allowed, plus
+behavioural probes (help, `--human`, dry runs, state introspection).
+
+## Summary
+
+| Severity | Count |
+|---------|-------|
+| Blocker | 3 |
+| Major   | 6 |
+| Minor   | 5 |
+| Nit     | 4 |
+
+The headline issue is that the three documented lifecycle commands — `jinn
+init`, `jinn fund-requirements`, `jinn bootstrap` — silently disagree about
+which master wallet exists. An operator who follows the README end-to-end
+ends up being asked to fund an address that is *not* the one `jinn init`
+printed, and on each subsequent invocation the keystore gets overwritten with
+a new HD mnemonic (published 0.1.0). The partial fix on HEAD
+(`client/src/earning/bootstrap.ts:338-352`) hydrates from the existing
+keystore but is not yet in any published release, and does not repair the
+core lifecycle contract between `init` and `bootstrap`.
+
+## Findings
+
+### Blocker-1 — `jinn init` and `jinn bootstrap` generate different master wallets in published 0.1.0
+
+**Where:** `client/src/earning/bootstrap.ts:186-195` (published 0.1.0 dist)
+vs `client/src/cli/commands/init.ts:62-70`, `client/src/earning/store.ts:15`.
+
+**What I observed:**
+1. `JINN_PASSWORD=... jinn init` → master `0x2034…a9` (writes
+   `master_keystore.json`, does **not** write `earning_state.json`).
+2. `JINN_PASSWORD=... jinn fund-requirements` → master `0xEd9f…92`
+   (stderr: `[fleet-bootstrap] Generating new HD wallet...`, keystore
+   overwritten, new `earning_state.json` created).
+3. `JINN_PASSWORD=... jinn bootstrap` (on the same `$HOME`) →
+   master `0x0869…94` (keystore overwritten yet again).
+
+Every `fund-requirements` / `bootstrap` invocation calls `ensureMasterWallet`,
+which in the published build takes the `generateMnemonic()` branch whenever
+`earning_state.json` is missing *or* `state.master_address` is empty —
+unconditionally overwriting any mnemonic `jinn init` left behind. The
+operator's funded wallet from a previous session can therefore be destroyed
+by a second run of `jinn bootstrap`.
+
+**Proposed fix:**
+* Short term: publish the HEAD hydration branch
+  (`client/src/earning/bootstrap.ts:342-352`) as a patch release and cover it
+  with a test that asserts `init` → `bootstrap` yields the same address.
+* Long term: make `jinn init` write `earning_state.json` too so the state
+  machine starts with a coherent record; or drop `jinn init` altogether and
+  treat `jinn bootstrap --init-only` as canonical. The README quick start
+  currently implies `init` is load-bearing, and it is not.
+
+---
+
+### Blocker-2 — README quick start contradicts `jinn init` runtime contract
+
+**Where:** `client/README.md:19-28` vs `client/src/cli/commands/init.ts:40-52`.
+
+The quick start block is:
+
+```
+jinn init
+jinn doctor
+JINN_PASSWORD=your-keystore-password jinn run
+```
+
+`jinn init` without `JINN_PASSWORD` exits **11** with
+`invalid_invocation` — verified on 0.1.0 (see
+`/tmp/jinn-onboarding-drill/logs/16-init-no-pw-*.log`). A new operator
+copy-pastes the README and gets the error as their first experience.
+
+**Proposed fix:** update the README block to
+`JINN_PASSWORD=... jinn init` (matching the `jinn init` helpText example in
+`client/src/cli/commands/init.ts:105-107`) and add a one-line explanation
+that the password encrypts the mnemonic and is required.
+
+---
+
+### Blocker-3 — `jinn submit-intent --dry-run` renders a plan with an empty `creatorMultisig`
+
+**Where:** `client/src/cli/commands/submit-intent.ts:73-80`.
+
+When there is no service at step `complete`, the dry-run fallback is
+literally the string `'0x'`. Output:
+
+```json
+{"dryRun":true,"description":"Would post intent 'health-check' from 0x",
+ "plan":[{"id":"health-check","creatorMultisig":"0x","asset":"native","txCount":1}]}
+```
+
+This is a silent lie to the operator: the plan says "one tx, asset native"
+but there is nobody to send from. It should short-circuit to a structured
+`funding_required` / `bootstrap_required` envelope that tells the operator
+to run `jinn bootstrap` first. As-is, a scripted caller would cache the
+empty multisig in the intent cache key (`client/src/cli/commands/submit-intent.ts:11-13`
+uses `getAddress(safe)`, which will actually throw on `'0x'` in a real call
+— so the `--yes` path is a silent time-bomb).
+
+**Proposed fix:** in `submit-intent.ts`, if no `service.step === 'complete'`
+is found, emit an envelope with code `bootstrap_required` (or a funding
+envelope if applicable) and exit non-zero, instead of rendering a placeholder
+plan.
+
+---
+
+### Major-1 — `jinn doctor` keystore check targets the wrong filename
+
+**Where:** `client/src/cli/commands/doctor.ts:31-45` vs
+`client/src/earning/store.ts:15`.
+
+Doctor reads `join(earningDir, 'mnemonic.keystore.json')` but the real
+keystore path is `master_keystore.json`. Consequence: after `jinn init`, the
+`keystore_readable` check still reports `detail: "no keystore yet (expected
+on a fresh install)"` — so the operator can never confirm from `doctor`
+that `init` succeeded.
+
+**Proposed fix:** reuse the constant / helper from `FleetStateStore` instead
+of hard-coding the filename. Add a regression test that snaps doctor output
+after `init`.
+
+---
+
+### Major-2 — `jinn logs` violates the output contract (empty stdout)
+
+**Where:** `client/src/cli/commands/logs.ts:41-58`.
+
+`jinn logs` on a fresh install writes **zero bytes to stdout** (exit 0,
+verified `wc -c = 0` on drill log `15-logs-detail.log`). Per
+`client/README.md:111-114` the output contract is "JSON by default" with a
+structured envelope. Empty stdout breaks scripted consumers and gives no
+signal to humans either.
+
+**Proposed fix:** emit a minimal envelope even when empty, e.g.
+`{"schemaVersion":1,"generatedAt":"…","events":[],"cursor":{"next":null}}`,
+matching `jinn history`. `--human` should print a one-line "no events yet"
+hint. Add a test for the empty case.
+
+---
+
+### Major-3 — `--human` is wired only for a subset of verbs; `version` and `doctor` ignore it
+
+**Where:** `client/src/cli/commands/version.ts`, `client/src/cli/commands/doctor.ts`.
+
+README operator contract (`client/README.md:111-116`) says "Add `--human`
+for readable terminal output". Observed today:
+* `jinn version --human` → raw JSON with keys like `deployments.digest:
+  "unknown"` and `tokens.bond.address`. No English-language description of
+  the phase, chain, or addresses. (`logs/02-version.log`)
+* `jinn doctor --human` → pretty-printed JSON only. No English remedy list.
+  (`--human` invocation shown in drill transcript.)
+* `jinn fund-requirements --human` *does* produce a human formatter
+  (`client/src/cli/commands/fund-requirements.ts:27-41`) but it emits raw
+  wei (`5000000000000000 wei, have 0 wei`) instead of ETH — hostile to the
+  ops persona the flag is supposedly for.
+
+**Proposed fix:** add human formatters for `version` (`"Jinn client 0.1.0
+(phase-1b, testnet/base-sepolia). Commit: unknown."`) and `doctor`
+(checklist-style with ✓ / ✗). Humanise the units in
+`fund-requirements` using `formatUnits` with the resolved decimals / symbol
+already present on the row.
+
+---
+
+### Major-4 — Operator quickstart never covers actually starting the fleet on Base Sepolia
+
+**Where:** `client/README.md:17-28`, `client/README.md:40-70`,
+`docs/phase1a-operator-runbook.md:1-215`.
+
+The README's "Quick start" goes `init` → `doctor` → `run`. But `run`
+requires a bootstrapped, funded fleet; the block never mentions
+`fund-requirements`, `bootstrap`, testnet faucets, or that the daemon pauses
+at `awaiting_funding`. Meanwhile `docs/phase1a-operator-runbook.md` is
+written for someone *deploying* the stack themselves — it demands
+Sepolia/Base Sepolia private keys, contract deploys, artifacts under
+`contracts/deployment-phase1a-*.json`, etc. — which is not what a Phase 1b
+operator who `npm i -g`-es the package should need (deployments are bundled
+under `client/deployments/`, verified present in the installed tarball).
+
+Result: a new operator reaches the quick start, hits the funding gate, opens
+the runbook, and is told to deploy contracts. There is no "npm operator"
+path in either doc. This is the largest documentation gap.
+
+**Proposed fix:** add a short "Full onboarding on Base Sepolia (published
+client)" section to `client/README.md` that lists
+`init → doctor → fund-requirements → fund via faucet → bootstrap →
+run → submit-intent → status`, with a pointer to
+`docs/phase1a-operator-runbook.md` only for operators who want to stand up
+their own stack.
+
+---
+
+### Major-5 — `jinn version` hard-codes `"unknown"` for commit and deployment digest on the published tarball
+
+**Where:** drill transcript `logs/02-version.log`, build step in
+`client/package.json:build` (`node scripts/write-dist-build-meta.mjs`).
+
+Published 0.1.0 reports:
+
+```json
+"client": {"version": "0.1.0", "commit": "unknown"},
+"deployments": {"digest": "unknown", "artifacts": []},
+```
+
+The artifacts list is empty even though `client/deployments/` is bundled,
+and `commit` is `"unknown"` even though the package was published from a
+specific git SHA. Operators cannot correlate support questions with a code
+revision.
+
+**Proposed fix:** have `scripts/write-dist-build-meta.mjs` (or the prepublish
+hook) populate `commit` from `git rev-parse HEAD`, and resolve the
+deployments manifest into `artifacts` at publish time. Surface them in
+`jinn version`.
+
+---
+
+### Major-6 — README lists commands that are not in the published CLI
+
+**Where:** `client/README.md:97-107` vs `jinn --help` on 0.1.0
+(`logs/01-help.log`).
+
+The "Actions" table lists `jinn fleet scale --to N`, `jinn fleet retire <index>`,
+and `jinn withdraw --to <addr>`. On 0.1.0, `jinn --help` advertises
+`fleet scale --to N` and `fleet retire <index>` — fine — but *also* quietly
+omits the newly added `quickstart`, `plugin install`, `update` verbs that
+exist in the HEAD source (`client/src/cli/commands/{quickstart,plugin-install,update}.ts`).
+The README similarly makes no mention of the Docker quickstart path shipping
+its own onboarding wrapper. A new operator searching the README for the
+command they see mentioned in commits (`jinn quickstart`) will not find it.
+
+**Proposed fix:** regenerate the command table from the `Command` registry
+at build time (e.g. a `scripts/generate-cli-reference.ts`) and include it in
+the README and in `jinn --help`'s footer. At minimum, update the README
+table to list *every* verb the published binary accepts.
+
+---
+
+### Minor-1 — `jinn init` output does not mention next steps or mnemonic safety
+
+**Where:** `client/src/cli/commands/init.ts:72-90`.
+
+JSON result is `{"master": "0x…", "keystoreDir": "/…"}`. No hint to run
+`jinn fund-requirements`, `jinn keys backup`, or warning that the password
+cannot be recovered. A first-time operator has to read help for every
+subsequent verb to discover the happy path.
+
+**Proposed fix:** extend the payload with a `nextStep: { cli: "jinn
+fund-requirements", purpose: "List addresses that need funding" }` (this
+mirrors the envelope contract) and have the human formatter print a brief
+backup warning.
+
+---
+
+### Minor-2 — `jinn doctor` reports `ok: true` for a missing keystore
+
+**Where:** `client/src/cli/commands/doctor.ts:40-45`.
+
+Because the file check uses the wrong filename (Major-1), the check can only
+ever report `ok: true`. Even when the filename bug is fixed, conflating
+"keystore absent" with "keystore valid" makes the `ok: true / blockingCount:
+0` summary misleading. A cautious operator won't know from `doctor` alone
+whether `run` will succeed.
+
+**Proposed fix:** split the check into two — `keystore_present` (informational,
+`ok` reflects existence) and `keystore_readable` (only runs if present;
+attempts to decrypt with a provided password-fd, else reports `skipped`).
+
+---
+
+### Minor-3 — npm install spews deprecation warnings on every `npx` invocation
+
+**Where:** client dependency tree (`ipfs-http-client`, `ipfs-core-utils`,
+`ipfs-core-types`, `multicodec`, `multibase`, `cids`, `prebuild-install`).
+
+Every documented command in the drill emitted 7 warnings as the first thing
+the operator sees. This drowns the actual CLI output and makes the tool
+feel abandoned.
+
+**Proposed fix:** migrate from js-IPFS → Helia (the upstream replacement
+called out in the warning) or drop the js-IPFS dependency entirely. If the
+migration is large, at least prune the transitive `multicodec`/`multibase`/
+`cids` pins with resolutions so the user-visible warning list drops to 2–3
+lines.
+
+---
+
+### Minor-4 — `jinn keys backup` silently writes a plaintext mnemonic
+
+**Where:** `client/src/cli/commands/keys-backup.ts` (file created at
+`./backup.json` during drill; content was literal 12-word mnemonic with
+mode 0600).
+
+The JSON stdout only reports `{"output": "./backup.json", "words": 12}` —
+there is no warning that the file contents are plaintext. The 0600 mode is
+good, but the README entry (`client/README.md:107`) says
+"Export mnemonic" with no caveat. An operator syncing `~/backup.json` to
+Dropbox will not realise they have just uploaded their seed phrase.
+
+**Proposed fix:** echo a stderr warning ("Mnemonic written in plaintext,
+mode 0600. Treat `./backup.json` as seed material."), and/or support a
+`--encrypt-with-password` flag that reuses `encryptMnemonic`.
+
+---
+
+### Minor-5 — `jinn bootstrap --help` shows a failure example but `jinn run` does not
+
+**Where:** `client/src/cli/commands/bootstrap.ts:helpText`,
+`client/src/cli/commands/run.ts:helpText`.
+
+`bootstrap --help` nicely shows the `funding_required` envelope. `run`
+does not — but `run` is what the README tells the operator to invoke first.
+If `run` fails with a funding gate, the help text should illustrate that
+path the same way.
+
+**Proposed fix:** mirror the failure-example block into `run` (and
+`submit-intent`, which can also fail with funding/bootstrap gates).
+
+---
+
+### Nit-1 — `jinn` help omits `quickstart`, `plugin install`, `update` even when the binary ships them
+
+**Where:** `client/src/cli/help.ts` or wherever verbs are enumerated.
+
+The help page lists curated verbs; the source tree has more. Either the help
+text should enumerate everything (preferred — use the same command registry
+the dispatcher uses) or out-of-band verbs should be marked "experimental"
+so operators know they exist.
+
+---
+
+### Nit-2 — `version.tokens.bond.symbol` and `.reward.symbol` are both `stOLAS`, but README still references OLAS/JINN
+
+**Where:** `version` output on 0.1.0 (`logs/02-version.log`) vs
+`docs/phase1a-operator-runbook.md:263-268` and `CLAUDE.md:80-86`.
+
+The operator reads that the bond is "OLAS, 2× bond amount" and sees the
+client say "stOLAS 0xAB9a01cd…" on Base Sepolia. Correct for the stOLAS
+standard-staking path, but inconsistent with the legacy OLAS references
+further up. At minimum the runbook should lead with `stOLAS` for Phase 1b.
+
+---
+
+### Nit-3 — `jinn fund-requirements` JSON envelope contains `blocks: "bootstrap"` but no `blocks: "run"` / `"submit-intent"` rows are emitted pre-bootstrap
+
+**Where:** `client/src/cli/commands/fund-requirements.ts:124-136`.
+
+The row only contains the master-ETH requirement. The downstream roles
+(Safe bond, reward liquidity, gas for agents) never show up until those
+wallets exist. That is technically correct, but operators reading the
+schema see a `blocks` enum with 4 values and cannot discover — from this
+command alone — what the complete funding set looks like. A `--forecast`
+mode that projects all gates based on `targetServices` and the bundled
+deployment would cut hours out of the onboarding.
+
+---
+
+### Nit-4 — Drill's fresh `$HOME` discovery: `~/.jinn-client` is documented but not surfaced on first run
+
+**Where:** `client/README.md:121-140` (config table) and
+`client/src/cli/commands/init.ts:77` (emits `keystoreDir`).
+
+`init` prints `keystoreDir`, which is useful. But `doctor`, `status`,
+`fleet`, `balance` never mention the state directory in their output. An
+operator who deletes `/tmp/jinn-onboarding-drill/home` in testing cannot
+tell from any inspection verb where the state lives (short of reading the
+README or the env-var table). Add a `paths: {earningDir, dbPath}` stanza to
+`status` / `doctor`.
+
+---
+
+## Minimal reproduction script
+
+```bash
+rm -rf /tmp/drill && mkdir -p /tmp/drill
+HOME=/tmp/drill/home
+JINN_PASSWORD=test
+npx --yes -p @jinn-network/client@latest jinn init                   # master A
+npx --yes -p @jinn-network/client@latest jinn fund-requirements      # master B  (different!)
+npx --yes -p @jinn-network/client@latest jinn bootstrap              # master C  (different again!)
+npx --yes -p @jinn-network/client@latest jinn doctor                 # reports "no keystore yet"
+npx --yes -p @jinn-network/client@latest jinn logs                   # empty stdout
+npx --yes -p @jinn-network/client@latest jinn submit-intent \
+    --id t --description t --dry-run                                 # "Would post intent 't' from 0x"
+```
+
+## Suggested follow-up work (not done in this session)
+
+1. Patch-release Blocker-1 from HEAD to stop the "mnemonic rotates on every
+   bootstrap" behaviour in the published tarball.
+2. Fix the README quick-start `JINN_PASSWORD` inconsistency (Blocker-2).
+3. Land the doctor filename fix (Major-1) and empty `jinn logs` envelope
+   (Major-2) together — both are one-line changes with immediate operator
+   wins.
+4. Carve the "Phase 1b npm-operator path" out of
+   `docs/phase1a-operator-runbook.md` into a shorter `client/README.md`
+   section (Major-4).
+5. Publish a non-`"unknown"` commit digest in `jinn version` (Major-5) so
+   support can triage reports.


### PR DESCRIPTION
# @jinn-network/client v0.1.1

Patch release closing the 2026-04 operator-onboarding drill findings.

## Fixed

### Lifecycle coherence
- `jinn init` persists `earning_state.json`; `fund-requirements` / `bootstrap` hydrate from the existing keystore instead of rolling a fresh HD wallet on every invocation.
- `jinn submit-intent --dry-run` short-circuits with a `bootstrap_incomplete` envelope (exit 20) when no complete service exists, instead of rendering a plan with `creatorMultisig: "0x"`.
- Docker: Claude OAT persists across `docker compose run --rm`; the daemon forwards `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` to the spawned agent subprocess.

### Output contract
- `jinn logs` emits an envelope (`{events, cursor}`) even when empty.
- `jinn version`, `jinn doctor`, `jinn fund-requirements` honour `--human` with actual readable output; amounts render as ETH / token symbol instead of raw wei.
- `jinn version` reports a real deployment digest + artifact list for zero-config operators.
- `jinn status` exposes `paths.earningDir` and `paths.dbPath`.

### Resilience
- `tx-retry` treats Safe 1.3.0 `GS013` as recoverable — it wraps inner `GS026` stale-nonce reverts. Self-heals on Safe-write races between the restorer and delivery-watcher loops.
- `recoverEvictedService` surfaces an actionable error with the exact `setCuratingAgents` recovery path when `distributor.reStake` reverts with `UnauthorizedAccount`, instead of infinite-retrying.
- `fund-requirements` probes per-Safe native ETH and emits a `blocks: run` row when below `minSafeEth`.

### Docs + ergonomics
- README quick start uses `JINN_PASSWORD=... jinn init` (was broken before).
- README lists `jinn quickstart`, `jinn plugin`, `jinn update`, `jinn keys change-password`.
- `doctor` keystore check reads the right filename; split into `keystore_present` (informational) / `claude_auth` checks.
- `keys backup` warns on stderr that the output file is plaintext.
- Acceptance harness warns when the branch lags `origin/main`.

## Internal
- New shared `isUnauthorizedAccountError` predicate + `UNAUTHORIZED_ACCOUNT_SELECTOR` constant.
- Bundled Base Sepolia deployments feed `computeDeploymentDigest` without env-var overrides.
- 317/317 vitest suite green.

## Verified
- Full acceptance run on Base Sepolia (2/2 protocol cycles, claim tx submitted) on commit `74e69505`. Evidence under `client/acceptance-runs/2026-04-18T10-53-46-446Z-logm0s/`.
- Post-refactor commits (`484ef5a1`, `4f1a628f`, `df4d8e26`) touch fund-requirements / operator-errors / bootstrap error path / docs — not the hot runtime path — and are covered by the unit suite.

## Follow-ups deferred from v0.1.1
- `FleetBootstrapper` could return per-Safe balances to avoid duplicate RPC probes in `fund-requirements`.
- Upstream migration: drop js-IPFS deprecation noise from `@jinn-network/mech-client-ts`.
- `fund-requirements --forecast`: full lifecycle funding projection.
- Acceptance harness: lazy `git fetch` in the branch-lag warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
