### PR TITLE
ci(docker): fix cd-client typo blocking release workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,7 +34,8 @@ jobs:
               ;;
           esac
 
-          PACKAGE_VERSION=$(cd client && node -e "console.log(JSON.parse(require('fs').readFileSync('package.json','utf8')).version)")
+          # working-directory default is `client/`, no extra cd.
+          PACKAGE_VERSION=$(node -e "console.log(JSON.parse(require('fs').readFileSync('package.json','utf8')).version)")
           if [ "${VERSION}" != "${PACKAGE_VERSION}" ]; then
             echo "::error::Release tag version ${VERSION} does not match client/package.json version ${PACKAGE_VERSION}"
             exit 1


### PR DESCRIPTION
## Summary
- `defaults.run.working-directory: client` already scopes every step to `client/`.
- The metadata resolver's `cd client && node -e …` therefore tried to hop to `client/client/` and failed with `cd: client: No such file or directory`.
- Blocked the Docker release workflow on `client-v0.1.1` (the npm workflow was fine).

## Test plan
- [ ] Merge this, then delete-and-recreate the `client-v0.1.1` GitHub Release so `release.published` fires again; confirm Docker workflow completes and publishes to `ghcr.io/jinn-network/client:0.1.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)