### PR TITLE
fix(contracts): checkpoint-and-verify uses live (fast) deployment

### DIFF
--- a/contracts/scripts/checkpoint-and-verify.ts
+++ b/contracts/scripts/checkpoint-and-verify.ts
@@ -18,11 +18,14 @@
 
 import { ethers } from "hardhat";
 
-// ─── L1 Contract Addresses (Sepolia) ───────────────────────────────────────
-const JINN = "0x95A0d0E40Ea5F85968dF9eF43e9E4a37D6C8b8a0";
-const TOKENOMICS = "0xac1D01d27dcfc377656fc728222b40DCe4b203a0";
-const TREASURY = "0x0eD61f297Ae6a9B6231818EB5055bF4002Eb99bE";
-const DISPENSER = "0xB9485266348C49918842BF7152dbE76d36bb9A3D";
+// ─── L1 Contract Addresses (Sepolia — live fast deployment) ────────────────
+// Sourced from deployment-phase1a-sepolia-fast.json (2026-04-08 redeploy).
+// TODO: replace hardcodes with loadPhase1aArtifactsFromDisk() for
+// deployment-portable checkpointing.
+const JINN = "0xc3ae831f146Eabbb8095E1EDf90a187AA4E5F408";
+const TOKENOMICS = "0x302cd1f188fCFcA64EA038aFa738D90951360739";
+const TREASURY = "0x9A0570db9a846a5114f6bFEAd75c9a820800255B";
+const DISPENSER = "0xaFE21C6dBeF2d41A769F58CE068aa991369FB1e0";
 
 // ─── Minimal ABIs ──────────────────────────────────────────────────────────
 const JINN_ABI = [


### PR DESCRIPTION
The hardcoded L1 Sepolia addresses in checkpoint-and-verify.ts pointed at a dead pre-April-8 deployment. Advancing the epoch against the dead Tokenomics was a no-op (Treasury balance 0, supply unchanged).

Updated to the live fast deployment (from \`deployment-phase1a-sepolia-fast.json\`):
- JINN: \`0xc3ae…F408\`
- Tokenomics: \`0x302c…0739\`
- Treasury: \`0x9A05…255B\`
- Dispenser: \`0xaFE2…B1e0\`

Verified end-to-end: ran \`checkpoint-and-verify.ts\` (epoch 6→7, tx \`0x5acf76b8…\`) then \`phase1a-claim-staking-incentives.ts --env PHASE1A_TIMING_PROFILE=fast-test\` (claim tx \`0x36bf6b18…\`).

Follow-up (not in this PR): replace the hardcodes with \`loadPhase1aArtifactsFromDisk()\` so the script is deployment-portable (matches the pattern already used by \`phase1a-*.ts\` scripts).