### PR TITLE
fix(contracts/scripts): withdraw expired veJINN lock before createLock

### DIFF
--- a/contracts/scripts/phase1a-vote-staking-weight.ts
+++ b/contracts/scripts/phase1a-vote-staking-weight.ts
@@ -16,6 +16,7 @@ const VE_ABI = [
   "function lockedEnd(address account) view returns (uint256)",
   "function createLock(uint256 amount, uint256 unlockTime)",
   "function increaseAmount(uint256 amount)",
+  "function withdraw()",
 ];
 
 const VOTE_WEIGHTING_ABI = [
@@ -127,6 +128,15 @@ async function main() {
       throw new Error(
         "No active veJINN lock found. Set PHASE1A_VOTE_LOCK_AMOUNT so the script can create one.",
       );
+    }
+
+    // If the signer has an expired lock with unwithdrawn JINN in veJINN, createLock
+    // reverts with LockedValueNotZero. Withdraw first, then create a fresh lock.
+    if (lockEnd > 0n) {
+      console.log(`Withdrawing expired lock (ended ${formatTs(lockEnd)})...`);
+      const withdrawTx = await veOLAS.withdraw();
+      console.log(`Withdraw tx:               ${withdrawTx.hash}`);
+      await withdrawTx.wait();
     }
 
     const balance = (await jinn.balanceOf(signerAddress)) as bigint;


### PR DESCRIPTION
## Problem

\`phase1a-vote-staking-weight.ts\` reverts on second run for the same deployer with \`LockedValueNotZero\`. The first run creates a lock (e.g. for the fast-test profile's 7-day default). After that lock expires, calling \`createLock\` again reverts because the JINN is still locked inside veJINN awaiting \`withdraw()\`.

Hit this while bootstrapping vote-weight for the Base Sepolia staking nominee: our deployer had an expired April-9 lock with 100 JINN still parked in veJINN. The script's \`lockEnd <= now + 1\` branch treats expired and never-locked as equivalent and goes straight to \`createLock\` — which fails.

## Fix

Add a conditional \`withdraw()\` inside the no-active-lock branch when \`lockEnd > 0\` (i.e. there WAS a prior lock, just now expired). Added \`function withdraw()\` to \`VE_ABI\`.

Verified end-to-end: manually ran \`withdraw()\` (tx \`0x07bec855510285a904ff9401d22bb6aa2f55b7201e9af39d86f76fe878940b40\`), then re-ran the script which successfully \`createLock\`-ed 1000 JINN (tx \`0x576c92adb44d40370fc4b5ecd921b7743bbed461aa063ee710074178eeeb54bf\`) and voted (tx \`0xf058d31692be8645c24c28ad5e9b642b6e0070f0fa865b2070489227165ead10\`).

## No test added

The script is a one-off rollout helper with no existing unit tests. Verified manually on live Sepolia state.