### PR TITLE
feat(client): generic intents enable/disable protocol + claim-time readiness gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Monorepo for the Jinn protocol — a training protocol for agentic intents.
 Operators run a headless daemon that observes marketplace requests, executes
 them via Claude Code, and earns on-chain rewards for measured work.
 
-**Current phase:** 1b (testnet) on Base Sepolia. Mainnet launch is Phase 2.
-
 ## I want to run a daemon on testnet
 
 Start here: [`docs/operator-testnet.md`](docs/operator-testnet.md) — honest

--- a/client/README.md
+++ b/client/README.md
@@ -131,6 +131,36 @@ The `jinn-operator` skill activates on mentions of "jinn", "jinn network", and
 "jinn quickstart", then walks your agent through install, auth, bootstrap, and
 daemon lifecycle. You stay in the loop for funding decisions.
 
+## Opting in to specific intent kinds
+
+After `quickstart`, your daemon participates in `legacy` (health-check) and
+`prediction.v0` intents by default. Other kinds — like `portfolio.v0`, which
+executes trades against a Hyperliquid master account — are **off by default**
+because they need credentials only you can provide. This prevents your daemon
+from claiming a request it can't actually fulfill.
+
+Inspect and toggle participation with `jinn intents`:
+
+```bash
+jinn intents list --human                          # every kind, current state
+jinn intents status portfolio.v0 --human           # details for one kind
+jinn intents enable portfolio.v0 --hl-master 0x... # start the opt-in flow
+jinn intents enable portfolio.v0 --confirm-approved
+jinn intents disable portfolio.v0                  # opt out, keep state
+```
+
+Each `enable` is an idempotent state machine. Rerun until the envelope reports
+`"status": "ready"`. When the flow needs something from you (an exchange
+approval, an API key), it returns `waiting_for_external_action` with the URL
+and the exact command to rerun next. Agents with the `jinn-operator` skill
+installed know how to walk an operator through any kind automatically — just
+paste "enable portfolio.v0 for me" and they'll take it from there.
+
+**Safety net:** before spending gas on a claim, the daemon checks whether the
+responsible impl is actually ready. If a portfolio.v0 request arrives and your
+api-wallet isn't approved, the daemon records the intent as FAILED locally
+with a clear reason instead of wasting gas claiming it.
+
 ## Docker
 
 The daemon spawns the Anthropic `claude` CLI as a subprocess for

--- a/client/skills/jinn-operator/SKILL.md
+++ b/client/skills/jinn-operator/SKILL.md
@@ -122,6 +122,91 @@ The automatic faucet may have rate-limited (1 claim per 24 hours per address). O
 - Wait 24 hours and re-run `jinn quickstart`
 - Fund manually: go to https://portal.cdp.coinbase.com/products/faucet, send testnet ETH to the printed master address, then re-run
 
+## Phase 3.5: Opting In to Intent Kinds
+
+After quickstart, the daemon participates in `legacy` (health-check) and `prediction.v0` intents by default. Other intent kinds are **off by default** because they require operator-specific credentials (exchange authorizations, API keys, etc.).
+
+### Generic flow (applies to every intent kind with external deps)
+
+**Always start with `list`.** It tells you what's enabled, what's ready, and for disabled kinds, what running `enable` would need.
+
+```bash
+jinn intents list --human
+```
+
+Example output for a fresh operator:
+```
+kind           enabled   ready   notes
+portfolio.v0   no        no      HL api-wallet not provisioned
+prediction.v0  yes       yes
+```
+
+### Enabling a kind (idempotent state machine)
+
+```bash
+jinn intents enable <kind> [--key=value ...]
+```
+
+The command is idempotent. Rerun the same command until the response has `"status": "ready"`. Intermediate states tell you exactly what to do:
+
+- `"status": "missing_args"` — the envelope lists `required` args. Re-run with them. Shape:
+  ```json
+  {
+    "status": "missing_args",
+    "required": [{"name": "hl-master", "description": "...", "required": true}],
+    "example": {"cli": "jinn intents enable portfolio.v0 --hl-master 0x..."}
+  }
+  ```
+
+- `"status": "waiting_for_external_action"` — the operator needs to do something out-of-band (e.g., approve an api-wallet on an exchange). Show the `action.description` and `action.url` to the operator. When they confirm done, run the command in `nextInvocation.cli`. Shape:
+  ```json
+  {
+    "status": "waiting_for_external_action",
+    "action": {"description": "...", "url": "https://..."},
+    "details": {"apiWalletAddress": "0x..."},
+    "nextInvocation": {"cli": "jinn intents enable <kind> --confirm-approved", "purpose": "..."}
+  }
+  ```
+
+- `"status": "ready"` — the kind is enabled. The daemon will now claim intents of this kind. No further action.
+
+- `"status": "error"` — surface `message` to the operator.
+
+### Disabling
+
+```bash
+jinn intents disable <kind>
+```
+
+Removes the kind from the operator's claim rotation. Preserves any generated key material so a later `enable` doesn't re-initialize exchange approvals.
+
+### Example: enabling portfolio.v0
+
+portfolio.v0 requires a Hyperliquid master account (holds USDC) and an approved HL api-wallet (agent key). The enable flow walks the operator through it:
+
+1. Run list to see what's needed:
+   ```bash
+   jinn intents list --human
+   jinn intents status portfolio.v0 --human
+   ```
+
+2. First invocation generates the api-wallet keypair and returns `waiting_for_external_action` with the wallet address and the HL URL:
+   ```bash
+   jinn intents enable portfolio.v0 --hl-master 0xYOUR_HL_MASTER
+   ```
+
+3. Surface the wallet address and URL to the operator. They approve the address on HL (Settings → API Wallets → Add).
+
+4. Once they confirm, re-run with `--confirm-approved`:
+   ```bash
+   jinn intents enable portfolio.v0 --confirm-approved
+   ```
+   Envelope returns `"status": "ready"`. Config is updated. Daemon will claim future portfolio.v0 requests.
+
+### Runtime guardrail
+
+The daemon checks each impl's readiness before spending gas on a claim transaction. If a portfolio.v0 request arrives and the api-wallet is missing/unapproved, the intent is marked FAILED locally with a reason pointing back to `jinn intents enable portfolio.v0 ...`. No gas wasted.
+
 ## Phase 4: Ongoing Operation
 
 ### Monitoring

--- a/client/src/cli/commands/intents.ts
+++ b/client/src/cli/commands/intents.ts
@@ -1,0 +1,456 @@
+/**
+ * jinn intents — operator entrypoint for opting in/out of specific intent kinds.
+ *
+ * Four subverbs:
+ *   list    — every known (kind → impl) pair with enable state + readiness
+ *   status  — detailed envelope for one kind
+ *   enable  — idempotent opt-in; dispatches to impl.onEnable
+ *   disable — opt-out; removes impl from restorers.disabled in user config
+ *
+ * JSON by default (agent-friendly). `--human` gives a readable table / prose.
+ * Never blocks on TTY input — opt-in flows that need external operator action
+ * return `waiting_for_external_action` envelopes the agent surfaces back to
+ * the operator.
+ */
+
+import { parseArgs } from 'node:util';
+import type { CommandContext, CommandModule } from '../command.js';
+import { emitResult } from '../output.js';
+import { emitEnvelope } from '../../errors/envelope.js';
+import { loadConfig, getConfigPathFromArgs } from '../../config.js';
+import type { RestorerImpl, EnableResult, ReadyStatus } from '../../restorer/types.js';
+import {
+  buildIntentsCliRegistry,
+  isImplDisabled,
+  resolveConfigPath,
+  setImplEnabledInConfig,
+} from '../intent-registry-access.js';
+
+// ── Kind/impl surface helpers ─────────────────────────────────────────────────
+
+/**
+ * Static map of intent kind → responsible impl name. Must stay in sync with
+ * the `byKind` map hard-coded in `main.ts` and `intent-registry-access.ts`.
+ * Centralised so `jinn intents list` enumerates kinds even when the operator
+ * has no active registry. The `legacy` pseudo-kind is not listed because
+ * legacy-claude is always-on and operators don't toggle it.
+ */
+const KIND_TO_IMPL: Record<string, string> = {
+  'portfolio.v0': 'claude-mcp-hyperliquid',
+  'prediction.v0': 'prediction-v0-baseline',
+};
+
+function implFor(kind: string, registry: ReturnType<typeof buildIntentsCliRegistry>): RestorerImpl | null {
+  const implName = KIND_TO_IMPL[kind];
+  if (!implName) return null;
+  return registry.list().find((i) => i.name === implName) ?? null;
+}
+
+async function readinessOrDefault(impl: RestorerImpl): Promise<ReadyStatus> {
+  if (!impl.isReady) return { ready: true };
+  try {
+    return await impl.isReady();
+  } catch (err) {
+    return { ready: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// ── args helper ───────────────────────────────────────────────────────────────
+
+/**
+ * Parse `--key=value` / `--flag` positional-free args into a string record.
+ * Known CLI flags (`--json`, `--human`, `--config`) are stripped before
+ * parsing, and the kind is captured as the first positional.
+ */
+function splitSubverbArgs(argv: string[]): { kind?: string; rawArgs: Record<string, string | undefined>; flags: { json: boolean; human: boolean; configPath?: string } } {
+  const flags = { json: false, human: false, configPath: undefined as string | undefined };
+  const rawArgs: Record<string, string | undefined> = {};
+  const positionals: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!;
+    if (a === '--json') { flags.json = true; continue; }
+    if (a === '--human') { flags.human = true; continue; }
+    if (a === '--config') { flags.configPath = argv[++i]; continue; }
+    if (a.startsWith('--')) {
+      const eq = a.indexOf('=');
+      if (eq >= 0) {
+        rawArgs[a.slice(2, eq)] = a.slice(eq + 1);
+      } else {
+        // Bare flag — allow `--confirm-approved` without a value.
+        // If the next token exists and isn't another flag, use it as the value.
+        const next = argv[i + 1];
+        if (next !== undefined && !next.startsWith('--')) {
+          rawArgs[a.slice(2)] = next;
+          i++;
+        } else {
+          rawArgs[a.slice(2)] = '';
+        }
+      }
+      continue;
+    }
+    positionals.push(a);
+  }
+
+  return { kind: positionals[0], rawArgs, flags };
+}
+
+// ── Subverbs ──────────────────────────────────────────────────────────────────
+
+interface KindRow {
+  kind: string;
+  impl: string;
+  enabled: boolean;
+  ready: boolean;
+  reason?: string;
+  description?: string;
+}
+
+async function runList(ctx: CommandContext, rest: string[]): Promise<void> {
+  const { flags } = splitSubverbArgs(rest);
+  const config = loadConfig(flags.configPath ?? getConfigPathFromArgs(ctx.argv));
+  const registry = buildIntentsCliRegistry(config);
+
+  const rows: KindRow[] = [];
+  for (const kind of Object.keys(KIND_TO_IMPL)) {
+    const impl = implFor(kind, registry);
+    if (!impl) continue;
+    const enabled = !isImplDisabled(impl.name, config);
+    const readyStatus = await readinessOrDefault(impl);
+    const description = impl.enableMetadata?.().description;
+    rows.push({
+      kind,
+      impl: impl.name,
+      enabled,
+      ready: readyStatus.ready,
+      reason: readyStatus.reason,
+      ...(description ? { description } : {}),
+    });
+  }
+
+  emitResult(
+    {
+      schemaVersion: 1 as const,
+      generatedAt: new Date().toISOString(),
+      verb: 'intents list',
+      intents: rows,
+    },
+    (_) => renderListHuman(rows),
+    {
+      json: flags.json,
+      human: flags.human,
+      writer: ctx.writer,
+      stdoutIsTty: ctx.stdoutIsTty,
+      noColor: Boolean(ctx.env['NO_COLOR']),
+    },
+  );
+}
+
+function renderListHuman(rows: KindRow[]): string {
+  if (rows.length === 0) return 'No intent kinds registered.';
+  const lines: string[] = [];
+  const maxKindLen = Math.max(...rows.map((r) => r.kind.length));
+  lines.push(`${'kind'.padEnd(maxKindLen + 2)}${'enabled'.padEnd(10)}${'ready'.padEnd(8)}notes`);
+  for (const r of rows) {
+    const note = r.ready ? (r.enabled ? '' : 'disabled — run `jinn intents enable <kind>` to opt in') : (r.reason ?? 'not ready');
+    lines.push(`${r.kind.padEnd(maxKindLen + 2)}${(r.enabled ? 'yes' : 'no').padEnd(10)}${(r.ready ? 'yes' : 'no').padEnd(8)}${note}`);
+  }
+  return lines.join('\n');
+}
+
+async function runStatus(ctx: CommandContext, rest: string[]): Promise<void> {
+  const { kind, flags } = splitSubverbArgs(rest);
+  if (!kind) {
+    emitEnvelope(
+      {
+        code: 'invalid_invocation',
+        message: 'jinn intents status requires a kind argument.',
+        exampleCli: 'jinn intents status portfolio.v0',
+        details: { field: 'kind', expected: Object.keys(KIND_TO_IMPL).join('|') },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
+
+  const config = loadConfig(flags.configPath ?? getConfigPathFromArgs(ctx.argv));
+  const registry = buildIntentsCliRegistry(config);
+  const impl = implFor(kind, registry);
+  if (!impl) {
+    emitEnvelope(
+      {
+        code: 'invalid_invocation',
+        message: `Unknown intent kind: ${kind}`,
+        exampleCli: 'jinn intents list',
+        details: { field: 'kind', expected: Object.keys(KIND_TO_IMPL).join('|') },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
+
+  const enabled = !isImplDisabled(impl.name, config);
+  const readyStatus = await readinessOrDefault(impl);
+  const metadata = impl.enableMetadata?.();
+
+  emitResult(
+    {
+      schemaVersion: 1 as const,
+      generatedAt: new Date().toISOString(),
+      verb: 'intents status',
+      kind,
+      impl: impl.name,
+      enabled,
+      ready: readyStatus.ready,
+      ...(readyStatus.reason ? { reason: readyStatus.reason } : {}),
+      ...(readyStatus.nextStep ? { nextStep: readyStatus.nextStep } : {}),
+      ...(metadata ? { metadata } : {}),
+    },
+    (v) => JSON.stringify(v, null, 2),
+    {
+      json: flags.json,
+      human: flags.human,
+      writer: ctx.writer,
+      stdoutIsTty: ctx.stdoutIsTty,
+      noColor: Boolean(ctx.env['NO_COLOR']),
+    },
+  );
+}
+
+async function runEnable(ctx: CommandContext, rest: string[]): Promise<void> {
+  const { kind, rawArgs, flags } = splitSubverbArgs(rest);
+  if (!kind) {
+    emitEnvelope(
+      {
+        code: 'invalid_invocation',
+        message: 'jinn intents enable requires a kind argument.',
+        exampleCli: 'jinn intents enable portfolio.v0 --hl-master 0x...',
+        details: { field: 'kind', expected: Object.keys(KIND_TO_IMPL).join('|') },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
+
+  const configPath = resolveConfigPath(flags.configPath ?? getConfigPathFromArgs(ctx.argv));
+  const config = loadConfig(flags.configPath ?? getConfigPathFromArgs(ctx.argv));
+  const registry = buildIntentsCliRegistry(config);
+  const impl = implFor(kind, registry);
+  if (!impl) {
+    emitEnvelope(
+      {
+        code: 'invalid_invocation',
+        message: `Unknown intent kind: ${kind}`,
+        exampleCli: 'jinn intents list',
+        details: { field: 'kind', expected: Object.keys(KIND_TO_IMPL).join('|') },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
+
+  if (!impl.onEnable) {
+    emitEnvelope(
+      {
+        code: 'invalid_invocation',
+        message: `Impl '${impl.name}' does not support enable via this command. Edit config.restorers.disabled[] manually.`,
+        exampleCli: 'jinn intents list',
+        details: { field: 'impl', impl: impl.name },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
+
+  let result: EnableResult;
+  try {
+    result = await impl.onEnable(rawArgs);
+  } catch (err) {
+    emitEnvelope(
+      {
+        code: 'fatal',
+        message: err instanceof Error ? err.message : String(err),
+        exampleCli: `jinn intents status ${kind}`,
+        details: { impl: impl.name, kind },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
+
+  if (result.status === 'ready') {
+    // Flip config to remove the impl from disabled[], if it was disabled.
+    const wasDisabled = isImplDisabled(impl.name, config);
+    if (wasDisabled) {
+      setImplEnabledInConfig(impl.name, true, configPath);
+    }
+    emitResult(
+      {
+        schemaVersion: 1 as const,
+        generatedAt: new Date().toISOString(),
+        verb: 'intents enable',
+        kind,
+        impl: impl.name,
+        status: 'ready',
+        configUpdated: wasDisabled,
+        ...(result.details ? { details: result.details } : {}),
+      },
+      (v) => JSON.stringify(v, null, 2),
+      {
+        json: flags.json,
+        human: flags.human,
+        writer: ctx.writer,
+        stdoutIsTty: ctx.stdoutIsTty,
+        noColor: Boolean(ctx.env['NO_COLOR']),
+      },
+    );
+    return;
+  }
+
+  // Non-ready: emit the impl's result verbatim under the envelope. Agents
+  // parse `status` and act on `action` / `nextInvocation` / `required`.
+  ctx.writer.write(JSON.stringify({
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    verb: 'intents enable',
+    kind,
+    impl: impl.name,
+    ...result,
+  }) + '\n');
+}
+
+async function runDisable(ctx: CommandContext, rest: string[]): Promise<void> {
+  const { kind, flags } = splitSubverbArgs(rest);
+  if (!kind) {
+    emitEnvelope(
+      {
+        code: 'invalid_invocation',
+        message: 'jinn intents disable requires a kind argument.',
+        exampleCli: 'jinn intents disable portfolio.v0',
+        details: { field: 'kind', expected: Object.keys(KIND_TO_IMPL).join('|') },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
+
+  const configPath = resolveConfigPath(flags.configPath ?? getConfigPathFromArgs(ctx.argv));
+  const config = loadConfig(flags.configPath ?? getConfigPathFromArgs(ctx.argv));
+  const registry = buildIntentsCliRegistry(config);
+  const impl = implFor(kind, registry);
+  if (!impl) {
+    emitEnvelope(
+      {
+        code: 'invalid_invocation',
+        message: `Unknown intent kind: ${kind}`,
+        exampleCli: 'jinn intents list',
+        details: { field: 'kind', expected: Object.keys(KIND_TO_IMPL).join('|') },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
+
+  const wasEnabled = !isImplDisabled(impl.name, config);
+  if (wasEnabled) {
+    setImplEnabledInConfig(impl.name, false, configPath);
+  }
+  if (impl.onDisable) {
+    try {
+      await impl.onDisable();
+    } catch (err) {
+      // Non-fatal: config was updated; impl-local cleanup problems shouldn't block.
+      console.error(`[intents] ${impl.name}.onDisable threw: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
+  emitResult(
+    {
+      schemaVersion: 1 as const,
+      generatedAt: new Date().toISOString(),
+      verb: 'intents disable',
+      kind,
+      impl: impl.name,
+      status: 'disabled',
+      configUpdated: wasEnabled,
+    },
+    (v) => JSON.stringify(v, null, 2),
+    {
+      json: flags.json,
+      human: flags.human,
+      writer: ctx.writer,
+      stdoutIsTty: ctx.stdoutIsTty,
+      noColor: Boolean(ctx.env['NO_COLOR']),
+    },
+  );
+}
+
+// ── Dispatcher ────────────────────────────────────────────────────────────────
+
+async function run(ctx: CommandContext): Promise<void> {
+  // Tolerate `--json` / `--human` appearing before or after the subverb.
+  let args = ctx.argv;
+  // Don't use parseArgs up front; we need to preserve unknown flags (like
+  // `--hl-master`, `--confirm-approved`) for impl.onEnable to consume.
+  // parseArgs rejects unknown flags by default and isn't flexible enough.
+  try {
+    parseArgs({ args: [], options: {}, allowPositionals: true });
+  } catch { /* unreachable */ }
+
+  const [subverb, ...rest] = args;
+  if (!subverb) {
+    emitEnvelope(
+      {
+        code: 'invalid_invocation',
+        message: 'jinn intents requires a subverb: list, status, enable, disable',
+        exampleCli: 'jinn intents list',
+        details: { field: 'subverb', expected: 'list|status|enable|disable' },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
+
+  switch (subverb) {
+    case 'list':     return runList(ctx, rest);
+    case 'status':   return runStatus(ctx, rest);
+    case 'enable':   return runEnable(ctx, rest);
+    case 'disable':  return runDisable(ctx, rest);
+    default:
+      emitEnvelope(
+        {
+          code: 'invalid_invocation',
+          message: `Unknown intents subverb: ${subverb}`,
+          exampleCli: 'jinn intents list',
+          details: { field: 'subverb', expected: 'list|status|enable|disable' },
+        },
+        { writer: ctx.writer, exit: ctx.exit },
+      );
+  }
+}
+
+const command: CommandModule = {
+  name: 'intents',
+  summary: 'List, enable, or disable restoration of specific intent kinds.',
+  helpText: `Usage:
+  jinn intents list                          Show every intent kind and its enable/ready state
+  jinn intents status <kind>                 Detailed status for one kind
+  jinn intents enable <kind> [--key=value…]  Idempotent opt-in flow; dispatches to impl.onEnable
+  jinn intents disable <kind>                Opt out; preserves any generated state
+
+Intent kinds are resolved to impls via the hard-coded byKind map in main.ts.
+Each impl controls its own enable flow — see \`jinn intents list\` for
+kind-specific arg requirements.
+
+Examples:
+  jinn intents list --human
+  jinn intents status portfolio.v0 --human
+  jinn intents enable prediction.v0
+  jinn intents enable portfolio.v0 --hl-master 0xYOUR_HL_MASTER
+  jinn intents enable portfolio.v0 --confirm-approved
+  jinn intents disable portfolio.v0
+`,
+  run,
+};
+
+export default command;

--- a/client/src/cli/index.ts
+++ b/client/src/cli/index.ts
@@ -35,6 +35,7 @@ import withdrawCommand from './commands/withdraw.js';
 import keysCommand from './commands/keys-backup.js';
 import pluginCommand from './commands/plugin-install.js';
 import updateCommand from './commands/update.js';
+import intentsCommand from './commands/intents.js';
 
 const COMMANDS: CommandModule[] = [
   versionCommand,
@@ -59,6 +60,7 @@ const COMMANDS: CommandModule[] = [
   keysCommand,
   pluginCommand,
   updateCommand,
+  intentsCommand,
 ];
 
 function publicCommandNames(commands: CommandModule[]): string[] {

--- a/client/src/cli/intent-registry-access.ts
+++ b/client/src/cli/intent-registry-access.ts
@@ -1,0 +1,147 @@
+/**
+ * Shared helpers for the `jinn intents` CLI surface.
+ *
+ * - Builds a RestorerImplRegistry populated with the same impls the daemon
+ *   registers at boot (minus the ones that need live dependencies like a
+ *   running master wallet). The generic `intents list/status/enable/disable`
+ *   verbs use this to dispatch to per-impl onEnable / isReady logic without
+ *   standing up the full daemon.
+ *
+ * - Reads/writes the `restorers.disabled[]` list in the operator's config
+ *   file so `enable` / `disable` can flip per-impl participation.
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+
+import { RestorerImplRegistry } from '../restorer/engine/registry.js';
+import { PredictionV0BaselineImpl } from '../restorer/impls/prediction-v0-baseline/index.js';
+import { PredictionV0Evaluator } from '../restorer/impls/prediction-v0-evaluator/index.js';
+import { ClaudeMcpHyperliquidImpl } from '../restorer/impls/claude-mcp-hyperliquid/index.js';
+import { PortfolioV0Evaluator } from '../restorer/impls/portfolio-v0-evaluator/index.js';
+import type { JinnConfig } from '../config.js';
+
+/**
+ * Impls that ship default-disabled because they require external dependencies
+ * (credentials, exchange approvals, etc.) the operator must opt into. Kept in
+ * one place so `main.ts` and the `intents` CLI share a single source of truth.
+ */
+export const DEFAULT_DISABLED_IMPLS = ['claude-mcp-hyperliquid'] as const;
+
+const DEFAULT_CONFIG_PATH = join(homedir(), '.jinn-client', 'config.json');
+
+export function resolveConfigPath(explicit?: string): string {
+  return explicit ?? DEFAULT_CONFIG_PATH;
+}
+
+/**
+ * Construct the same impl registry main.ts uses, populated with the subset
+ * of impls that can answer `isReady` / `onEnable` without live chain/runner
+ * dependencies. Evaluators and the legacy-claude impl are omitted because
+ * they don't expose enable-level UX (legacy-claude is always-on; evaluators
+ * dispatch by type='evaluation' rather than by kind).
+ */
+export function buildIntentsCliRegistry(config: JinnConfig): RestorerImplRegistry {
+  const registry = new RestorerImplRegistry({
+    byKind: {
+      'portfolio.v0': 'claude-mcp-hyperliquid',
+      'prediction.v0': 'prediction-v0-baseline',
+    },
+    default: 'legacy-claude',
+    disabled: resolveEffectiveDisabled(config),
+  });
+
+  registry.register(new PredictionV0BaselineImpl({ rpcUrl: config.rpcUrl }));
+  registry.register(new PredictionV0Evaluator({
+    evaluatorPk: '0x' + '00'.repeat(32) as `0x${string}`,
+    evaluatorSafeAddress: '0x0000000000000000000000000000000000000000',
+    rpcUrl: config.rpcUrl,
+  }));
+  registry.register(new ClaudeMcpHyperliquidImpl({
+    claudePath: config.claudePath,
+    claudeModel: config.claudeModel,
+  }));
+  registry.register(new PortfolioV0Evaluator());
+
+  return registry;
+}
+
+/**
+ * Resolve the effective disabled list, applying the ship-default plus any
+ * operator overrides. Semantics match main.ts: user config fully replaces
+ * the default, so operators who have already curated a list aren't
+ * surprised by new defaults sneaking in.
+ */
+export function resolveEffectiveDisabled(config: JinnConfig): string[] {
+  const userDisabled = config.restorers?.disabled;
+  if (userDisabled !== undefined) return [...userDisabled];
+  return [...DEFAULT_DISABLED_IMPLS];
+}
+
+/** Is an impl currently disabled in the effective config? */
+export function isImplDisabled(implName: string, config: JinnConfig): boolean {
+  return resolveEffectiveDisabled(config).includes(implName);
+}
+
+interface RestorersPatch {
+  byKind?: Record<string, string>;
+  default?: string;
+  disabled?: string[];
+}
+
+/**
+ * Patch the user's config file to add/remove an impl from the `restorers.disabled[]`
+ * list.
+ *
+ * Semantics (important): since user config fully replaces the default list,
+ * we always rebuild `disabled` from `DEFAULT_DISABLED_IMPLS ∪ user additions`
+ * minus the currently-enabled impl, not from whatever list the user last
+ * wrote. Concretely: if we later add a new default-disabled impl, an operator
+ * who previously enabled X won't silently auto-enable the new one — their
+ * written list always reflects "every current default off, minus what I've
+ * explicitly enabled." Extra operator-added disables are preserved verbatim.
+ *
+ * Returns the new disabled list for the caller to surface.
+ */
+export function setImplEnabledInConfig(
+  implName: string,
+  enabled: boolean,
+  configPath: string = DEFAULT_CONFIG_PATH,
+): string[] {
+  let current: Record<string, unknown> = {};
+  if (existsSync(configPath)) {
+    try {
+      current = JSON.parse(readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+    } catch {
+      current = {};
+    }
+  }
+
+  const restorers = (current['restorers'] ?? {}) as RestorersPatch;
+  const existing = new Set(restorers.disabled ?? []);
+  // Operator-added extras: anything they've explicitly disabled that isn't a ship default.
+  const defaults = new Set(DEFAULT_DISABLED_IMPLS as readonly string[]);
+  const operatorExtras = new Set(
+    [...existing].filter((n) => !defaults.has(n)),
+  );
+
+  // Rebuild from first principles so future default additions stay disabled
+  // unless the operator explicitly enables them too.
+  const rebuilt = new Set<string>([...defaults, ...operatorExtras]);
+
+  if (enabled) {
+    rebuilt.delete(implName);
+  } else {
+    rebuilt.add(implName);
+  }
+
+  const next = [...rebuilt];
+  restorers.disabled = next;
+  current['restorers'] = restorers;
+
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(configPath, JSON.stringify(current, null, 2) + '\n', { encoding: 'utf-8' });
+
+  return next;
+}

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -309,12 +309,19 @@ export async function main(): Promise<DaemonStartupInfo> {
 
   // ── Impl registry ────────────────────────────────────────────────────────────
 
+  // Default-disable impls with external dependencies the operator must opt
+  // into (see cli/intent-registry-access.ts). The user's
+  // `config.restorers.disabled[]` fully overrides this default when present,
+  // so `jinn intents enable <kind>` persists the opt-in by writing to that
+  // list in ~/.jinn-client/config.json.
+  const { DEFAULT_DISABLED_IMPLS } = await import('./cli/intent-registry-access.js');
   const implRegistry = new RestorerImplRegistry({
     byKind: {
       'portfolio.v0': 'claude-mcp-hyperliquid',
       'prediction.v0': 'prediction-v0-baseline',
     },
     default: 'legacy-claude',
+    disabled: [...DEFAULT_DISABLED_IMPLS],
     ...(config.restorers ?? {}),
   });
 

--- a/client/src/restorer/engine/engine.ts
+++ b/client/src/restorer/engine/engine.ts
@@ -347,6 +347,38 @@ export class RestorationEngine {
       throw new NotImplementedError('claim');
     }
 
+    // ── Pre-claim impl gate ─────────────────────────────────────────────────
+    // Refuse to claim intents whose impl is either unregistered (operator has
+    // opted out via config.restorers.disabled[]) or not ready (external deps
+    // missing — e.g. HL api-wallet not approved for portfolio.v0). Marking
+    // FAILED is terminal so we don't re-attempt; another operator can still
+    // claim from the marketplace.
+    //
+    // Only fires when an implRegistry is wired in (production); tests that
+    // inject claimDeps without a registry intentionally exercise the raw
+    // claim path and are not gated.
+    if (this.implRegistry && intent.specKind) {
+      const impl = this.implRegistry.findFor({
+        kind: intent.specKind,
+        type: intent.intentType ?? 'restoration',
+      });
+      if (!impl) {
+        const reason = `no impl registered or enabled for kind '${intent.specKind}'; run \`jinn intents enable ${intent.specKind}\` to opt in`;
+        this.persistence.markFailed(intent.requestId, reason);
+        console.log(`[restorer-engine] ${intent.requestId}: skipping claim — ${reason}`);
+        throw new Error(reason);
+      }
+      if (impl.isReady) {
+        const status = await impl.isReady();
+        if (!status.ready) {
+          const reason = `impl '${impl.name}' not ready: ${status.reason ?? 'unknown'}${status.nextStep?.cli ? ` — run \`${status.nextStep.cli}\`` : ''}`;
+          this.persistence.markFailed(intent.requestId, reason);
+          console.log(`[restorer-engine] ${intent.requestId}: skipping claim — ${reason}`);
+          throw new Error(reason);
+        }
+      }
+    }
+
     const { registryClient, marketplaceClaimer } = this.claimDeps;
 
     await executeTwoLayerClaim(

--- a/client/src/restorer/impls/claude-mcp-hyperliquid/index.ts
+++ b/client/src/restorer/impls/claude-mcp-hyperliquid/index.ts
@@ -19,12 +19,19 @@
  *   Programmatic approval is a §8.5 future item.
  */
 
-import { writeFileSync, mkdirSync, chmodSync } from 'node:fs';
+import { writeFileSync, mkdirSync, chmodSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 
-import type { RestorerImpl, RestorationContext, RestorationOutput } from '../../types.js';
+import type {
+  RestorerImpl,
+  RestorationContext,
+  RestorationOutput,
+  ReadyStatus,
+  EnableResult,
+  IntentEnableMetadata,
+} from '../../types.js';
 import type { DesiredState } from '../../../types/desired-state.js';
 import type { RationaleEntry } from '../../../types/portfolio.js';
 import { HyperliquidClient, HL_MAINNET_BASE_URL, HL_TESTNET_BASE_URL } from '../../../venues/hyperliquid/client.js';
@@ -43,7 +50,13 @@ import {
   tradedNotionalMultiple,
 } from '../portfolio-v0-evaluator/canonical-metrics.js';
 
-import { provisionApiWallet } from './api-wallet.js';
+import {
+  provisionApiWallet,
+  loadApiWalletState,
+  markApiWalletApproved,
+  saveApiWalletState,
+  walletStatePath,
+} from './api-wallet.js';
 import { buildHlTools } from './mcp-tools.js';
 import { createRateLimitState, DEFAULT_SAFETY_CONFIG as DEFAULT_SAFETY_CONFIG_IMPORTED } from './safety-rails.js';
 import type { SafetyConfig } from './safety-rails.js';
@@ -63,9 +76,18 @@ export interface ClaudeMcpHyperliquidConfig {
   cadenceMs?: number;
   /** Max session wall time in ms. Default: 8 min */
   sessionMaxMs?: number;
+  /**
+   * Impl state directory root — used by `isReady` and `onEnable` to locate
+   * the api-wallet file outside of a running intent context. Defaults to
+   * `/tmp/jinn-engine-impl-state/claude-mcp-hyperliquid` to match the
+   * convention the engine uses in `main.ts`.
+   */
+  implStateDir?: string;
   /** Injected deps for testing */
   _testDeps?: TestDeps;
 }
+
+const DEFAULT_IMPL_STATE_DIR = '/tmp/jinn-engine-impl-state/claude-mcp-hyperliquid';
 
 export interface TestDeps {
   /** Mock runner — called instead of spawning Claude */
@@ -106,6 +128,170 @@ export class ClaudeMcpHyperliquidImpl implements RestorerImpl {
     // implStateDir is not available in canAttempt — we can only check
     // if the intent is structurally valid. API wallet check is done at run() time.
     return { ok: true };
+  }
+
+  /** Resolve the impl state directory used by enable / readiness flows. */
+  private resolveImplStateDir(): string {
+    return this.config.implStateDir ?? DEFAULT_IMPL_STATE_DIR;
+  }
+
+  async isReady(): Promise<ReadyStatus> {
+    const implStateDir = this.resolveImplStateDir();
+    const wallet = loadApiWalletState(implStateDir);
+    if (!wallet) {
+      return {
+        ready: false,
+        reason: 'HL api-wallet not provisioned',
+        nextStep: {
+          description: 'Run `jinn intents enable portfolio.v0 --hl-master <your-HL-master-address>` to generate the api-wallet and complete HL approval.',
+          cli: 'jinn intents enable portfolio.v0 --hl-master 0x...',
+        },
+      };
+    }
+    if (!wallet.approved) {
+      return {
+        ready: false,
+        reason: 'HL api-wallet generated but not approved on HL',
+        nextStep: {
+          description: `Approve address ${wallet.address} on Hyperliquid (Settings → API Wallets → Add), then re-run \`jinn intents enable portfolio.v0 --confirm-approved\`.`,
+          cli: 'jinn intents enable portfolio.v0 --confirm-approved',
+          url: 'https://app.hyperliquid-testnet.xyz/API',
+        },
+      };
+    }
+    if (!wallet.masterAddress) {
+      return {
+        ready: false,
+        reason: 'HL master address not recorded in api-wallet state',
+        nextStep: {
+          description: 'Re-run enable with the master address to record it: `jinn intents enable portfolio.v0 --hl-master 0x...`.',
+          cli: 'jinn intents enable portfolio.v0 --hl-master 0x...',
+        },
+      };
+    }
+    return { ready: true };
+  }
+
+  enableMetadata(): IntentEnableMetadata {
+    return {
+      description:
+        'portfolio.v0 — 24h managed-trading intent executed against a Hyperliquid master account. Requires you to (1) bring an HL master with USDC, and (2) approve a generated api-wallet as an HL agent.',
+      requiredArgs: [
+        { name: 'hl-master', description: 'Your Hyperliquid master address (holds USDC; approves the api-wallet).', required: true },
+      ],
+      externalResources: [
+        { name: 'HL Testnet Settings → API Wallets', url: 'https://app.hyperliquid-testnet.xyz/API' },
+        { name: 'HL Mainnet Settings → API Wallets', url: 'https://app.hyperliquid.xyz/API' },
+      ],
+    };
+  }
+
+  async onEnable(args: Record<string, string | undefined>): Promise<EnableResult> {
+    const implStateDir = this.resolveImplStateDir();
+    const hlMaster = args['hl-master'];
+    const confirmApproved = args['confirm-approved'] !== undefined;
+
+    // Ensure the impl state directory exists so we can write the wallet file.
+    if (!existsSync(implStateDir)) {
+      mkdirSync(implStateDir, { recursive: true, mode: 0o700 });
+    }
+
+    const existing = loadApiWalletState(implStateDir);
+
+    // Already enabled: idempotent no-op.
+    if (existing && existing.approved && existing.masterAddress) {
+      return {
+        status: 'ready',
+        details: {
+          apiWalletAddress: existing.address,
+          masterAddress: existing.masterAddress,
+        },
+      };
+    }
+
+    // First invocation: need --hl-master to know which account this wallet belongs to.
+    if (!existing && !hlMaster) {
+      return {
+        status: 'missing_args',
+        required: [
+          { name: 'hl-master', description: 'Your Hyperliquid master address (holds USDC).', required: true },
+        ],
+        example: { cli: 'jinn intents enable portfolio.v0 --hl-master 0x...' },
+      };
+    }
+
+    // State transition 1: no wallet yet — generate it and tell the agent to have the operator approve on HL.
+    if (!existing) {
+      const wallet = provisionApiWallet(implStateDir);
+      // Record the master so we don't re-ask on the next invocation.
+      saveApiWalletState(implStateDir, { ...wallet, masterAddress: hlMaster });
+      return {
+        status: 'waiting_for_external_action',
+        action: {
+          description: `API wallet ${wallet.address} generated. Open the Hyperliquid UI, go to Settings → API Wallets → Add, and approve this address under your master ${hlMaster}. Once done, re-run this command with --confirm-approved.`,
+          url: 'https://app.hyperliquid-testnet.xyz/API',
+        },
+        details: {
+          apiWalletAddress: wallet.address,
+          masterAddress: hlMaster,
+          walletStatePath: walletStatePath(implStateDir),
+        },
+        nextInvocation: {
+          cli: 'jinn intents enable portfolio.v0 --confirm-approved',
+          purpose: 'Record the operator-confirmed HL approval and enable portfolio.v0 claims.',
+        },
+      };
+    }
+
+    // State transition 2: wallet exists, not yet confirmed — if --confirm-approved is passed, flip the flag.
+    if (!existing.approved && !confirmApproved) {
+      return {
+        status: 'waiting_for_external_action',
+        action: {
+          description: `Approve api-wallet address ${existing.address} on Hyperliquid under master ${existing.masterAddress ?? hlMaster ?? '<set via --hl-master>'}, then re-run with --confirm-approved.`,
+          url: 'https://app.hyperliquid-testnet.xyz/API',
+        },
+        details: {
+          apiWalletAddress: existing.address,
+          masterAddress: existing.masterAddress ?? hlMaster,
+        },
+        nextInvocation: {
+          cli: 'jinn intents enable portfolio.v0 --confirm-approved',
+          purpose: 'Record the operator-confirmed HL approval.',
+        },
+      };
+    }
+
+    // State transition 3: --confirm-approved passed — persist approval and optionally update the master.
+    const updated = markApiWalletApproved(implStateDir);
+    const resolvedMaster = hlMaster ?? updated.masterAddress;
+    if (!resolvedMaster) {
+      return {
+        status: 'missing_args',
+        required: [
+          { name: 'hl-master', description: 'Master address was never recorded; pass --hl-master now.', required: true },
+        ],
+        example: { cli: 'jinn intents enable portfolio.v0 --hl-master 0x... --confirm-approved' },
+      };
+    }
+    if (updated.masterAddress !== resolvedMaster) {
+      saveApiWalletState(implStateDir, { ...updated, masterAddress: resolvedMaster });
+    }
+
+    return {
+      status: 'ready',
+      details: {
+        apiWalletAddress: updated.address,
+        masterAddress: resolvedMaster,
+      },
+    };
+  }
+
+  async onDisable(): Promise<void> {
+    // Intentionally no-op on key material: operators may re-enable later
+    // and re-generating the wallet would force a fresh HL approval round-trip.
+    // The config-level disable (removing the impl from `restorers.disabled`)
+    // is handled by the `jinn intents disable` verb, not the impl itself.
   }
 
   async run(ctx: RestorationContext): Promise<RestorationOutput> {
@@ -708,7 +894,6 @@ await startMcpServer(config);
 
 // ── Jinn MCP launcher resolution ──────────────────────────────────────────────
 
-import { existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 

--- a/client/src/restorer/impls/legacy-claude/index.ts
+++ b/client/src/restorer/impls/legacy-claude/index.ts
@@ -10,7 +10,14 @@
  */
 
 import { type Runner, type RunnerContext } from '../../../runner/runner.js';
-import type { RestorerImpl, RestorationContext, RestorationOutput } from '../../types.js';
+import type {
+  RestorerImpl,
+  RestorationContext,
+  RestorationOutput,
+  ReadyStatus,
+  EnableResult,
+  IntentEnableMetadata,
+} from '../../types.js';
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -47,6 +54,21 @@ export class LegacyClaudeImpl implements RestorerImpl {
 
   async canAttempt(): Promise<{ ok: true }> {
     return { ok: true };
+  }
+
+  async isReady(): Promise<ReadyStatus> {
+    return { ready: true };
+  }
+
+  enableMetadata(): IntentEnableMetadata {
+    return {
+      description:
+        'legacy-claude — handles health-check intents (no spec.kind). Always enabled.',
+    };
+  }
+
+  async onEnable(_args: Record<string, string | undefined>): Promise<EnableResult> {
+    return { status: 'ready' };
   }
 
   async run(ctx: RestorationContext): Promise<RestorationOutput> {

--- a/client/src/restorer/impls/prediction-v0-baseline/index.ts
+++ b/client/src/restorer/impls/prediction-v0-baseline/index.ts
@@ -8,7 +8,14 @@ import { join } from 'node:path';
 import { createPublicClient, http } from 'viem';
 import { baseSepolia, base } from 'viem/chains';
 
-import type { RestorerImpl, RestorationContext, RestorationOutput } from '../../types.js';
+import type {
+  RestorerImpl,
+  RestorationContext,
+  RestorationOutput,
+  ReadyStatus,
+  EnableResult,
+  IntentEnableMetadata,
+} from '../../types.js';
 import type { PublicClient } from 'viem';
 import { PredictionV0IntentSchema } from '../../../types/prediction.js';
 import {
@@ -33,6 +40,22 @@ export class PredictionV0BaselineImpl implements RestorerImpl {
 
   supports(ctx: { kind: string; type?: 'restoration' | 'evaluation' }): boolean {
     return ctx.kind === 'prediction.v0' && ctx.type !== 'evaluation';
+  }
+
+  async isReady(): Promise<ReadyStatus> {
+    // Zero external deps — prediction.v0 runs against on-chain oracles only.
+    return { ready: true };
+  }
+
+  enableMetadata(): IntentEnableMetadata {
+    return {
+      description:
+        'prediction.v0 — submit probability predictions against on-chain price feeds. No external credentials required.',
+    };
+  }
+
+  async onEnable(_args: Record<string, string | undefined>): Promise<EnableResult> {
+    return { status: 'ready' };
   }
 
   async canAttempt(intent: import('../../../types/desired-state.js').DesiredState):

--- a/client/src/restorer/types.ts
+++ b/client/src/restorer/types.ts
@@ -39,6 +39,77 @@ export interface RestorationOutput {
   rationale?: RationaleEntry[];
 }
 
+// ── Enable / readiness types ──────────────────────────────────────────────────
+
+/**
+ * Context-free readiness probe. "Are this impl's external dependencies
+ * satisfied right now, regardless of any specific intent?" Used by
+ * `jinn intents list|status` and by the claim-policy gate that refuses
+ * to spend gas claiming an intent whose impl cannot execute.
+ */
+export interface ReadyStatus {
+  ready: boolean;
+  reason?: string;
+  /** Optional hint for the operator/agent on how to become ready. */
+  nextStep?: { description: string; cli?: string; url?: string };
+}
+
+/**
+ * Argument a kind-specific enable flow wants from the operator, surfaced
+ * via `enableMetadata()`. The generic `jinn intents enable <kind>` verb
+ * parses these from `--key=value` flags without caring what they mean.
+ */
+export interface EnableArgDef {
+  name: string;
+  description: string;
+  required: boolean;
+}
+
+/**
+ * Metadata that `jinn intents list` uses to teach the operator (or agent)
+ * what's needed to enable a kind. Returned without running the flow.
+ */
+export interface IntentEnableMetadata {
+  /** Human-readable summary of what opting in to this kind entails. */
+  description: string;
+  requiredArgs?: EnableArgDef[];
+  /** External URLs the operator/agent will need (e.g. exchange UI). */
+  externalResources?: Array<{ name: string; url: string }>;
+}
+
+/**
+ * Outcome of a single `jinn intents enable <kind>` invocation.
+ *
+ * The flow is idempotent: the agent reruns the same command until
+ * `status === 'ready'`. Each intermediate state carries enough info for
+ * the agent to know what to do next (show a URL, collect more args,
+ * surface an error).
+ */
+export type EnableResult =
+  | {
+      status: 'ready';
+      /** Anything the impl wants to surface (e.g. master address, wallet address). */
+      details?: Record<string, unknown>;
+    }
+  | {
+      status: 'waiting_for_external_action';
+      /** What the operator has to do out-of-band (e.g. approve an api-wallet). */
+      action: { description: string; url?: string };
+      details?: Record<string, unknown>;
+      /** The exact CLI the agent should re-run once the action is done. */
+      nextInvocation: { cli: string; purpose: string };
+    }
+  | {
+      status: 'missing_args';
+      required: EnableArgDef[];
+      example: { cli: string };
+    }
+  | {
+      status: 'error';
+      message: string;
+      details?: Record<string, unknown>;
+    };
+
 // ── RestorerImpl ──────────────────────────────────────────────────────────────
 
 export interface RestorerImpl {
@@ -58,4 +129,47 @@ export interface RestorerImpl {
   supports(ctx: { kind: string; type?: 'restoration' | 'evaluation' }): boolean;
   canAttempt?(intent: DesiredState): Promise<{ ok: true } | { ok: false; reason: string }>;
   run(ctx: RestorationContext): Promise<RestorationOutput>;
+
+  /**
+   * Context-free readiness probe. Zero-dep impls can omit this (treated
+   * as `{ ready: true }`). Impls with external deps (credentials, files,
+   * exchange approvals) report current readiness plus a `nextStep` hint.
+   */
+  isReady?(): Promise<ReadyStatus>;
+
+  /**
+   * Describes what `onEnable` wants from the caller. Consumed by
+   * `jinn intents list` so the agent can tell the operator what a
+   * specific kind's enable flow needs without triggering it first.
+   */
+  enableMetadata?(): IntentEnableMetadata;
+
+  /**
+   * Idempotent enable-state machine. Called by `jinn intents enable <kind>`.
+   *
+   * Contract:
+   *   - Zero-dep impls return `{ status: 'ready' }` on every call.
+   *   - Impls with external deps advance as far as they can without
+   *     blocking, then return a `waiting_for_external_action` envelope
+   *     the agent surfaces to the operator.
+   *   - Subsequent invocations pick up where the previous left off.
+   *   - Calling after already-enabled is a no-op that returns `ready`.
+   *
+   * `args` is the raw `--key=value` map parsed from the CLI. Impls
+   * validate and coerce as needed; missing required args should return
+   * `{ status: 'missing_args', required: [...], example: {...} }`.
+   *
+   * Impls that omit this method cannot be enabled by the generic CLI;
+   * they are either always-on (zero-dep) or require manual config.
+   */
+  onEnable?(args: Record<string, string | undefined>): Promise<EnableResult>;
+
+  /**
+   * Optional inverse of `onEnable`. Invoked when the operator runs
+   * `jinn intents disable <kind>`. Should NOT destroy unrecoverable
+   * state (generated key material, on-chain registrations); reserve
+   * that for explicit `jinn intents purge` or similar (out of scope
+   * for this interface).
+   */
+  onDisable?(): Promise<void>;
 }

--- a/client/test/cli/intent-registry-access.test.ts
+++ b/client/test/cli/intent-registry-access.test.ts
@@ -1,0 +1,99 @@
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_DISABLED_IMPLS,
+  setImplEnabledInConfig,
+  resolveEffectiveDisabled,
+  isImplDisabled,
+} from '../../src/cli/intent-registry-access.js';
+import type { JinnConfig } from '../../src/config.js';
+
+describe('setImplEnabledInConfig', () => {
+  let dir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'jinn-intent-cfg-'));
+    configPath = join(dir, 'config.json');
+  });
+
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('creates config with default-disabled set when file absent', () => {
+    const result = setImplEnabledInConfig('claude-mcp-hyperliquid', false, configPath);
+    expect(result).toEqual(expect.arrayContaining([...DEFAULT_DISABLED_IMPLS]));
+    const written = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(written.restorers.disabled).toEqual(expect.arrayContaining([...DEFAULT_DISABLED_IMPLS]));
+  });
+
+  it('removes impl from disabled[] when enabled=true', () => {
+    // Seed with full default.
+    setImplEnabledInConfig('claude-mcp-hyperliquid', false, configPath);
+    const result = setImplEnabledInConfig('claude-mcp-hyperliquid', true, configPath);
+    expect(result).not.toContain('claude-mcp-hyperliquid');
+  });
+
+  it('re-adds impl to disabled[] when enabled=false after enable', () => {
+    setImplEnabledInConfig('claude-mcp-hyperliquid', true, configPath);
+    const result = setImplEnabledInConfig('claude-mcp-hyperliquid', false, configPath);
+    expect(result).toContain('claude-mcp-hyperliquid');
+  });
+
+  it('preserves operator-added non-default disabled impls across enable flips', () => {
+    // Operator hand-disables something that isn't a ship default.
+    writeFileSync(configPath, JSON.stringify({
+      restorers: { disabled: ['claude-mcp-hyperliquid', 'custom-evil-impl'] },
+    }));
+    const result = setImplEnabledInConfig('claude-mcp-hyperliquid', true, configPath);
+    expect(result).not.toContain('claude-mcp-hyperliquid');
+    expect(result).toContain('custom-evil-impl');
+  });
+
+  it('rebuilds from defaults, not from the user\'s last list, so future default-disables stay off', () => {
+    // Operator had previously enabled the one default impl.
+    writeFileSync(configPath, JSON.stringify({ restorers: { disabled: [] } }));
+    // Suppose we add a new default-disabled impl in code. We simulate by
+    // re-invoking setImplEnabledInConfig for a DIFFERENT impl — the rebuild
+    // path must include every current default.
+    const result = setImplEnabledInConfig('claude-mcp-hyperliquid', false, configPath);
+    expect(result).toEqual(expect.arrayContaining([...DEFAULT_DISABLED_IMPLS]));
+  });
+
+  it('preserves unrelated top-level config keys', () => {
+    writeFileSync(configPath, JSON.stringify({
+      network: 'testnet',
+      rpcUrl: 'http://example.com',
+      restorers: { disabled: [...DEFAULT_DISABLED_IMPLS] },
+    }));
+    setImplEnabledInConfig('claude-mcp-hyperliquid', true, configPath);
+    const after = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(after.network).toBe('testnet');
+    expect(after.rpcUrl).toBe('http://example.com');
+  });
+});
+
+describe('resolveEffectiveDisabled', () => {
+  it('returns defaults when user has not set restorers.disabled', () => {
+    const config = {} as JinnConfig;
+    expect(resolveEffectiveDisabled(config)).toEqual([...DEFAULT_DISABLED_IMPLS]);
+  });
+
+  it('returns user list when restorers.disabled is set (full replace)', () => {
+    const config = { restorers: { disabled: [] } } as unknown as JinnConfig;
+    expect(resolveEffectiveDisabled(config)).toEqual([]);
+  });
+});
+
+describe('isImplDisabled', () => {
+  it('returns true when impl is in effective disabled list', () => {
+    expect(isImplDisabled('claude-mcp-hyperliquid', {} as JinnConfig)).toBe(true);
+  });
+
+  it('returns false after operator enables impl via config', () => {
+    const config = { restorers: { disabled: [] } } as unknown as JinnConfig;
+    expect(isImplDisabled('claude-mcp-hyperliquid', config)).toBe(false);
+  });
+});

--- a/client/test/restorer/engine/claim-gate.test.ts
+++ b/client/test/restorer/engine/claim-gate.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { Store } from '../../../src/store/store.js';
+import {
+  RestorationEngine,
+  type RestorerImplRegistry as EngineRegistry,
+} from '../../../src/restorer/engine/engine.js';
+import type { PersistedIntent, PersistedIntentInput } from '../../../src/restorer/engine/persistence.js';
+import { IntentState } from '../../../src/restorer/engine/state.js';
+import type { RestorerImpl, RestorationOutput, ReadyStatus } from '../../../src/restorer/types.js';
+import type { ClaimRegistryClient } from '../../../src/adapters/claim-registry/client.js';
+import type { MarketplaceClaimer } from '../../../src/restorer/engine/claim.js';
+
+const noopResolver: EngineRegistry = { resolveImplName: () => null };
+
+function stubImpl(overrides: Partial<RestorerImpl> & { isReady?: () => Promise<ReadyStatus> } = {}): RestorerImpl {
+  return {
+    name: 'stub-impl',
+    version: '1.0.0',
+    supports: () => true,
+    run: async (): Promise<RestorationOutput> => ({ venueRef: { name: 'stub' }, gating: {} }),
+    ...overrides,
+  };
+}
+
+function makeClaimDeps() {
+  const registryClient: ClaimRegistryClient = {
+    weAlreadyClaimed: async () => false,
+    claimJob: async () => ({ claimed: true, txHash: '0xabc' as `0x${string}` }),
+    releaseClaim: async () => ({ released: true }),
+  } as unknown as ClaimRegistryClient;
+  const marketplaceClaimer: MarketplaceClaimer = {
+    claimRequest: async () => {},
+  } as unknown as MarketplaceClaimer;
+  return { registryClient, marketplaceClaimer };
+}
+
+function makeInput(id = 'req-gate'): PersistedIntentInput {
+  const now = Date.now();
+  return {
+    requestId: id,
+    intentCid: 'bafy',
+    onchainCreationTx: '0xtx' as `0x${string}`,
+    onchainCreationBlock: 1,
+    specKind: 'portfolio.v0',
+    windowStartTs: now + 1000,
+    windowEndTs: now + 60_000,
+    desiredState: { id, description: 'test' },
+  };
+}
+
+class TestEngine extends RestorationEngine {
+  async callClaim(intent: PersistedIntent): Promise<void> {
+    return this.claim(intent);
+  }
+  get db(): import('../../../src/restorer/engine/persistence.js').IntentPersistence {
+    return this.persistence;
+  }
+}
+
+describe('RestorationEngine.claim — impl gate', () => {
+  let dir: string;
+  let store: Store;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'jinn-claim-gate-'));
+    store = new Store(join(dir, 'jinn.db'));
+  });
+
+  afterEach(() => {
+    store.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('refuses to claim when no impl is registered for the intent\'s kind', async () => {
+    const engine = new TestEngine({
+      store,
+      registry: noopResolver,
+      paths: { workingDirRoot: '/tmp', implStateDirRoot: '/tmp' },
+      claimDeps: makeClaimDeps(),
+      implRegistry: { findFor: () => undefined },
+    });
+    const input = makeInput();
+    engine.db.insertDiscovered(input);
+
+    const persisted = engine.db.getByRequestId(input.requestId)!;
+    await expect(engine.callClaim(persisted)).rejects.toThrow(/no impl registered or enabled/);
+    const after = engine.db.getByRequestId(input.requestId)!;
+    expect(after.state).toBe(IntentState.FAILED);
+    expect(after.failureReason).toMatch(/jinn intents enable portfolio.v0/);
+  });
+
+  it('refuses to claim when impl reports not-ready', async () => {
+    const notReadyImpl = stubImpl({
+      isReady: async () => ({ ready: false, reason: 'api-wallet not approved', nextStep: { description: 'do the thing', cli: 'jinn intents enable portfolio.v0 --confirm-approved' } }),
+    });
+    const engine = new TestEngine({
+      store,
+      registry: noopResolver,
+      paths: { workingDirRoot: '/tmp', implStateDirRoot: '/tmp' },
+      claimDeps: makeClaimDeps(),
+      implRegistry: { findFor: () => notReadyImpl },
+    });
+    const input = makeInput();
+    engine.db.insertDiscovered(input);
+
+    const persisted = engine.db.getByRequestId(input.requestId)!;
+    await expect(engine.callClaim(persisted)).rejects.toThrow(/not ready/);
+    const after = engine.db.getByRequestId(input.requestId)!;
+    expect(after.state).toBe(IntentState.FAILED);
+    expect(after.failureReason).toMatch(/api-wallet not approved/);
+    expect(after.failureReason).toMatch(/jinn intents enable portfolio.v0 --confirm-approved/);
+  });
+
+  it('proceeds with claim when impl is registered and ready', async () => {
+    const readyImpl = stubImpl({ isReady: async () => ({ ready: true }) });
+    const engine = new TestEngine({
+      store,
+      registry: noopResolver,
+      paths: { workingDirRoot: '/tmp', implStateDirRoot: '/tmp' },
+      claimDeps: makeClaimDeps(),
+      implRegistry: { findFor: () => readyImpl },
+    });
+    const input = makeInput();
+    engine.db.insertDiscovered(input);
+
+    const persisted = engine.db.getByRequestId(input.requestId)!;
+    await engine.callClaim(persisted);
+    const after = engine.db.getByRequestId(input.requestId)!;
+    expect(after.state).toBe(IntentState.CLAIMED);
+  });
+
+  it('does not gate when implRegistry is absent (legacy test-mode path)', async () => {
+    const engine = new TestEngine({
+      store,
+      registry: noopResolver,
+      paths: { workingDirRoot: '/tmp', implStateDirRoot: '/tmp' },
+      claimDeps: makeClaimDeps(),
+      // No implRegistry — gate must no-op so raw claim path works.
+    });
+    const input = makeInput();
+    engine.db.insertDiscovered(input);
+
+    const persisted = engine.db.getByRequestId(input.requestId)!;
+    await engine.callClaim(persisted);
+    const after = engine.db.getByRequestId(input.requestId)!;
+    expect(after.state).toBe(IntentState.CLAIMED);
+  });
+});

--- a/client/test/restorer/impls/claude-mcp-hyperliquid/on-enable.test.ts
+++ b/client/test/restorer/impls/claude-mcp-hyperliquid/on-enable.test.ts
@@ -1,0 +1,107 @@
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { ClaudeMcpHyperliquidImpl } from '../../../../src/restorer/impls/claude-mcp-hyperliquid/index.js';
+import { loadApiWalletState } from '../../../../src/restorer/impls/claude-mcp-hyperliquid/api-wallet.js';
+
+describe('ClaudeMcpHyperliquidImpl.onEnable + isReady state machine', () => {
+  let implStateDir: string;
+
+  beforeEach(() => {
+    implStateDir = mkdtempSync(join(tmpdir(), 'jinn-hl-enable-'));
+  });
+
+  afterEach(() => rmSync(implStateDir, { recursive: true, force: true }));
+
+  function makeImpl(): ClaudeMcpHyperliquidImpl {
+    return new ClaudeMcpHyperliquidImpl({ implStateDir });
+  }
+
+  it('isReady returns not-ready when api-wallet absent', async () => {
+    const impl = makeImpl();
+    const status = await impl.isReady();
+    expect(status.ready).toBe(false);
+    expect(status.reason).toMatch(/api-wallet not provisioned/);
+  });
+
+  it('onEnable without --hl-master returns missing_args', async () => {
+    const impl = makeImpl();
+    const result = await impl.onEnable({});
+    expect(result.status).toBe('missing_args');
+  });
+
+  it('onEnable with --hl-master generates wallet and returns waiting_for_external_action', async () => {
+    const impl = makeImpl();
+    const result = await impl.onEnable({ 'hl-master': '0xABC' });
+    expect(result.status).toBe('waiting_for_external_action');
+    if (result.status !== 'waiting_for_external_action') throw new Error('unreachable');
+    expect(result.details?.['apiWalletAddress']).toMatch(/^0x[a-fA-F0-9]{40}$/);
+    expect(result.details?.['masterAddress']).toBe('0xABC');
+    expect(result.nextInvocation.cli).toContain('--confirm-approved');
+
+    // Wallet persisted as not-approved with master recorded.
+    const persisted = loadApiWalletState(implStateDir);
+    expect(persisted).not.toBeNull();
+    expect(persisted!.approved).toBe(false);
+    expect(persisted!.masterAddress).toBe('0xABC');
+  });
+
+  it('re-invoking onEnable without --confirm-approved stays in waiting state (no regen)', async () => {
+    const impl = makeImpl();
+    const first = await impl.onEnable({ 'hl-master': '0xABC' });
+    if (first.status !== 'waiting_for_external_action') throw new Error('unreachable');
+    const firstAddress = first.details?.['apiWalletAddress'];
+
+    const second = await impl.onEnable({});
+    if (second.status !== 'waiting_for_external_action') throw new Error('unreachable');
+    expect(second.details?.['apiWalletAddress']).toBe(firstAddress);
+  });
+
+  it('onEnable with --confirm-approved flips approved and returns ready', async () => {
+    const impl = makeImpl();
+    await impl.onEnable({ 'hl-master': '0xABC' });
+    const result = await impl.onEnable({ 'confirm-approved': '' });
+    expect(result.status).toBe('ready');
+
+    const persisted = loadApiWalletState(implStateDir);
+    expect(persisted!.approved).toBe(true);
+    expect(persisted!.masterAddress).toBe('0xABC');
+
+    const status = await impl.isReady();
+    expect(status.ready).toBe(true);
+  });
+
+  it('onEnable on an already-ready impl is a no-op returning ready', async () => {
+    const impl = makeImpl();
+    await impl.onEnable({ 'hl-master': '0xABC' });
+    await impl.onEnable({ 'confirm-approved': '' });
+    const repeat = await impl.onEnable({ 'hl-master': '0xOTHER' });
+    expect(repeat.status).toBe('ready');
+
+    // Master not overwritten by idempotent no-op.
+    const persisted = loadApiWalletState(implStateDir);
+    expect(persisted!.masterAddress).toBe('0xABC');
+  });
+
+  it('isReady surfaces missing masterAddress as not-ready with nextStep', async () => {
+    // Set up a wallet file with approved:true but no master (simulate an
+    // old hand-crafted file).
+    const impl = makeImpl();
+    await impl.onEnable({ 'hl-master': '0xABC' });
+    // Manually rewrite to strip masterAddress but keep approved.
+    const persisted = loadApiWalletState(implStateDir)!;
+    const { masterAddress: _m, ...rest } = persisted;
+    const { writeFileSync } = await import('node:fs');
+    writeFileSync(
+      join(implStateDir, 'api-wallet.json'),
+      JSON.stringify({ ...rest, approved: true }),
+      'utf-8',
+    );
+
+    const status = await impl.isReady();
+    expect(status.ready).toBe(false);
+    expect(status.reason).toMatch(/master address not recorded/i);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the ad-hoc portfolio.v0 opt-in plan with a generic mechanism that scales to any number of intent kinds. Default-off for impls with external dependencies, CLI-driven opt-in that walks the operator (or their agent) through kind-specific setup, and a runtime gate that refuses to spend gas on claims the daemon can't actually fulfill.

Resolves jinn-mono-26s.

## New CLI surface — `jinn intents`

```
jinn intents list                              every kind, enabled state, readiness
jinn intents status <kind>                     detailed envelope for one kind
jinn intents enable <kind> [--key=value ...]   idempotent opt-in; dispatches to impl.onEnable
jinn intents disable <kind>                    opt out, preserve generated state
```

JSON by default. Each `enable` invocation is an idempotent state machine — agents rerun the same command until `status === "ready"`. Intermediate states:

- `missing_args` — envelope lists `required` args and shows example `cli`
- `waiting_for_external_action` — URL + `nextInvocation.cli` to run after the external step (e.g. exchange-side approval)
- `ready` — kind enabled; config updated
- `error` — surfaces `message` to the agent

## RestorerImpl interface extensions

Four new optional methods — zero-dep impls can omit them:
- `isReady()` — context-free readiness probe used by claim gate + `list`/`status`
- `enableMetadata()` — describes what `onEnable` wants (surfaced by `list`)
- `onEnable(args)` — idempotent enable state machine
- `onDisable()` — inverse hook; must NOT destroy unrecoverable state

## Impls

- **prediction-v0-baseline**: `onEnable` returns `ready` immediately (zero deps)
- **legacy-claude**: always-ready zero-dep stub
- **claude-mcp-hyperliquid**: full three-state machine for HL api-wallet provisioning + operator-confirmed approval

## Default-off + config semantics

`DEFAULT_DISABLED_IMPLS = ['claude-mcp-hyperliquid']` shared between `main.ts` and `intent-registry-access.ts`. The config writer rebuilds `restorers.disabled[]` from first principles on every toggle so future default-disables stay disabled for operators who've only opted in to one kind.

## Claim-time gate (belt and suspenders)

`RestorationEngine.claim()` consults `impl.isReady()` before spending gas on the on-chain claim transaction. Not-ready intents are marked FAILED locally with a reason pointing back at `jinn intents enable <kind>`. Gate only fires when an `implRegistry` is wired (production); engine tests that inject `claimDeps` without a registry aren't affected.

## Docs

- `client/README.md` — new "Opting in to specific intent kinds" section after the agent-path quickstart
- `skills/jinn-operator/SKILL.md` — Phase 3.5 teaches the agent the generic flow so any agent with the skill installed knows how to guide operators through enabling any new kind, today and in the future

## Test plan

- [x] `yarn typecheck` exit 0
- [x] `yarn test` — 983/984 tests pass (1 skipped, same as main); new coverage in:
  - `test/cli/intent-registry-access.test.ts` — config round-trip + default-disable rebuild semantics
  - `test/restorer/impls/claude-mcp-hyperliquid/on-enable.test.ts` — full state machine + idempotent re-entry + stale-master recovery
  - `test/restorer/engine/claim-gate.test.ts` — gate fires on unregistered impl, on not-ready impl, passes on ready impl, no-ops without registry
- [x] Manual CLI dry-run in /tmp: list → enable (missing_args) → enable --hl-master (waiting_for_external_action) → enable (idempotent waiting) → enable --confirm-approved (ready) → list → disable → list; config round-trips correctly in `restorers.disabled[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)