### PR TITLE
prediction.apy.v0 eval hardening and full-loop e2e

### DIFF
--- a/client/fixtures/prediction-apy-v0-intent.example.json
+++ b/client/fixtures/prediction-apy-v0-intent.example.json
@@ -21,7 +21,5 @@
       "resolveTs": 0
     }
   },
-  "eligibility": {
-    "maxSubmissionDelayMs": 60000
-  }
+  "eligibility": {}
 }

--- a/client/package.json
+++ b/client/package.json
@@ -53,6 +53,7 @@
     "status": "tsx scripts/status.ts",
     "e2e": "tsx scripts/e2e-validate.ts",
     "e2e-portfolio-v0": "tsx scripts/e2e-portfolio-v0.ts",
+    "e2e-prediction-apy-v0": "tsx scripts/e2e-prediction-apy-v0.ts",
     "e2e:prediction": "cd ../contracts && yarn compile && cd ../client && tsx scripts/e2e-prediction-v0.ts",
     "staking": "tsx scripts/staking-validate.ts",
     "stolas": "tsx scripts/stolas-validate.ts",

--- a/client/scripts/e2e-prediction-apy-v0.ts
+++ b/client/scripts/e2e-prediction-apy-v0.ts
@@ -1,0 +1,444 @@
+/**
+ * e2e-prediction-apy-v0.ts — production-shaped full loop for prediction.apy.v0.
+ *
+ * This exercises the same adapter-driven lifecycle as production:
+ * create restoration job -> watch/claim -> run baseline -> deliver ->
+ * watch delivery -> auto-create evaluation job -> watch/claim eval ->
+ * run evaluator -> deliver verdict -> watch eval delivery + cleanup.
+ */
+
+import { config as dotenvConfig } from 'dotenv';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+dotenvConfig({ path: join(dirname(fileURLToPath(import.meta.url)), '..', '.env') });
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { createPublicClient, decodeEventLog, encodeAbiParameters, getAddress, http, keccak256, numberToHex, pad, parseAbi, toHex, type Address, type Hex, type PublicClient } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { base } from 'viem/chains';
+import { MechAdapter } from '../src/adapters/mech/adapter.js';
+import { FleetBootstrapper } from '../src/earning/bootstrap.js';
+import { getChainConfig } from '../src/earning/contracts.js';
+import { decodeMarketplaceRequestLogs, getMechDeliveryRate, getTimeoutBounds, submitRestorationJob } from '../src/adapters/mech/contracts.js';
+import { buildDesiredStatePayload, uploadToIpfs, cidToDigestHex } from '../src/adapters/mech/ipfs.js';
+import { createClients } from '../src/adapters/mech/safe.js';
+import { PredictionApyV0BaselineImpl } from '../src/restorer/impls/prediction-apy-v0-baseline/index.js';
+import { PredictionApyV0Evaluator } from '../src/restorer/impls/prediction-apy-v0-evaluator/index.js';
+import { signCanonical } from '../src/restorer/engine/signing.js';
+import { RESTORATION_INTENT_CID_CONTEXT_KEY } from '../src/restorer/impls/evaluation-context.js';
+import type { DesiredState } from '../src/types/desired-state.js';
+import type { RestorationContext } from '../src/restorer/types.js';
+import type { PredictionApySubmissionManifest } from '../src/types/prediction-apy.js';
+import { JINN_ROUTER_ABI, MECH_ABI, MECH_MARKETPLACE_ABI, NATIVE_PAYMENT_TYPE } from '../src/adapters/mech/types.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BASE_RPC_URL = process.env['BASE_RPC_URL'] ?? 'https://mainnet.base.org';
+const ANVIL_PORT = 8549;
+const ANVIL_RPC = `http://127.0.0.1:${ANVIL_PORT}`;
+const PASSWORD = 'test-password-pred-apy';
+
+const CHAIN_CONFIG = getChainConfig('base');
+const OLAS_TOKEN = CHAIN_CONFIG.olasToken;
+const MARKETPLACE_ADDRESS: Address = CHAIN_CONFIG.mechMarketplace as Address;
+const ROUTER_ADDRESS: Address = '0xfFa7118A3D820cd4E820010837D65FAfF463181B';
+
+interface PhaseResult { name: string; ok: boolean; ms: number; error?: string }
+
+function sleep(ms: number): Promise<void> { return new Promise(r => setTimeout(r, ms)); }
+
+async function waitFor(description: string, check: () => Promise<boolean>, timeoutMs = 30_000, intervalMs = 500): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await check()) return;
+    await sleep(intervalMs);
+  }
+  throw new Error(`Timeout waiting for: ${description}`);
+}
+
+async function jsonRpc(url: string, method: string, params: unknown[] = []): Promise<unknown> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', method, params, id: 1 }),
+  });
+  const body = (await res.json()) as { result?: unknown; error?: { message: string } };
+  if (body.error) throw new Error(`RPC error (${method}): ${body.error.message}`);
+  return body.result;
+}
+
+async function runPhase(name: string, fn: () => Promise<void>): Promise<PhaseResult> {
+  const start = Date.now();
+  try {
+    await fn();
+    const ms = Date.now() - start;
+    console.log(`  ✓ ${name} (${ms}ms)`);
+    return { name, ok: true, ms };
+  } catch (err) {
+    const ms = Date.now() - start;
+    const error = err instanceof Error ? err.message : String(err);
+    console.error(`  ✗ ${name} (${ms}ms): ${error}`);
+    return { name, ok: false, ms, error };
+  }
+}
+
+function erc20BalanceSlot(holder: string, mappingSlot: bigint = 0n): Hex {
+  return keccak256(encodeAbiParameters([{ type: 'address' }, { type: 'uint256' }], [getAddress(holder) as Address, mappingSlot]));
+}
+
+function makeAdapter(agentPk: `0x${string}`, safe: Address, mech: Address): MechAdapter {
+  return new MechAdapter({
+    rpcUrl: ANVIL_RPC,
+    mechMarketplaceAddress: MARKETPLACE_ADDRESS as `0x${string}`,
+    routerAddress: ROUTER_ADDRESS as `0x${string}`,
+    mechContractAddress: mech as `0x${string}`,
+    safeAddress: safe as `0x${string}`,
+    agentEoaPrivateKey: agentPk,
+    ipfsRegistryUrl: 'https://registry.autonolas.tech',
+    ipfsGatewayUrl: 'https://gateway.autonolas.tech',
+    pollIntervalMs: 500,
+    chainId: base.id,
+    routerClaimDeliveryVariant: 'v1',
+  });
+}
+
+async function main(): Promise<void> {
+  console.log('\n=== Prediction.apy.v0 Full E2E (production-shaped) ===\n');
+
+  let anvil: ChildProcess | null = null;
+  let tmpDir: string | null = null;
+  const results: PhaseResult[] = [];
+
+  let publicClient!: PublicClient;
+  let agentPk!: `0x${string}`;
+  let safeAddress!: Address;
+  let mechAddress!: Address;
+  let adapter!: MechAdapter;
+  let restorationRequestId!: string;
+  let evalRequestId!: string;
+  let intent!: DesiredState;
+  let intentCid!: string;
+  let window!: { startTs: number; endTs: number };
+
+  try {
+    results.push(await runPhase('Phase 1: Spawn Anvil fork + temp dir', async () => {
+      tmpDir = await mkdtemp(join(tmpdir(), 'jinn-e2e-apy-'));
+      const forkBlock = process.env['ANVIL_FORK_BLOCK'] ?? '';
+      const args = ['--fork-url', BASE_RPC_URL, '--port', String(ANVIL_PORT), '--silent', ...(forkBlock ? ['--fork-block-number', forkBlock] : [])];
+      anvil = spawn(process.env['ANVIL_PATH'] ?? 'anvil', args, { stdio: 'ignore' });
+      await waitFor('anvil ready', async () => {
+        try { const b = await jsonRpc(ANVIL_RPC, 'eth_blockNumber'); return typeof b === 'string' && b.startsWith('0x'); }
+        catch { return false; }
+      });
+      publicClient = createPublicClient({ chain: base, transport: http(ANVIL_RPC) }) as unknown as PublicClient;
+      console.log(`    Temp dir: ${tmpDir}`);
+      console.log(`    Fork block: ${await publicClient.getBlockNumber()}`);
+    }));
+
+    results.push(await runPhase('Phase 2: Bootstrap single service', async () => {
+      if (!tmpDir) throw new Error('missing temp dir');
+      let bootstrapper = new FleetBootstrapper({ earningDir: tmpDir, chain: 'base', rpcUrl: ANVIL_RPC, targetServices: 1 });
+      const r1 = await bootstrapper.bootstrap(PASSWORD);
+      if (!r1.funding) throw new Error('expected funding requirement');
+      const master = r1.funding.master_address;
+
+      await jsonRpc(ANVIL_RPC, 'anvil_setBalance', [master, '0x56BC75E2D63100000']);
+      const slot = erc20BalanceSlot(master);
+      const olasAmount = 100000n * 10n ** 18n;
+      const { encodeFunctionData } = await import('viem');
+      await jsonRpc(ANVIL_RPC, 'anvil_setStorageAt', [OLAS_TOKEN, slot, pad(toHex(olasAmount), { size: 32 })]);
+      await jsonRpc(ANVIL_RPC, 'anvil_impersonateAccount', [master]);
+      await jsonRpc(ANVIL_RPC, 'eth_sendTransaction', [{
+        from: master,
+        to: OLAS_TOKEN,
+        data: encodeFunctionData({
+          abi: parseAbi(['function approve(address,uint256) returns (bool)']),
+          functionName: 'approve',
+          args: [CHAIN_CONFIG.stakingContract as Address, olasAmount],
+        }),
+      }]);
+      await jsonRpc(ANVIL_RPC, 'eth_sendTransaction', [{
+        from: master,
+        to: CHAIN_CONFIG.stakingContract,
+        data: encodeFunctionData({
+          abi: parseAbi(['function deposit(uint256)']),
+          functionName: 'deposit',
+          args: [olasAmount],
+        }),
+      }]);
+      await jsonRpc(ANVIL_RPC, 'anvil_stopImpersonatingAccount', [master]);
+      await jsonRpc(ANVIL_RPC, 'evm_mine', []);
+
+      bootstrapper = new FleetBootstrapper({ earningDir: tmpDir, chain: 'base', rpcUrl: ANVIL_RPC, targetServices: 1 });
+      const r2 = await bootstrapper.bootstrap(PASSWORD);
+      if (!r2.ok) throw new Error(`bootstrap failed: ${r2.message}`);
+      const svc = r2.fleet_state.services.find(s => s.step === 'complete' && s.safe_address && s.mech_address);
+      if (!svc) throw new Error('no completed service');
+
+      const { FleetStateStore } = await import('../src/earning/store.js');
+      const { decryptMnemonic, walletPrivateKeyAtIndex } = await import('../src/earning/wallet.js');
+      const store = new FleetStateStore(tmpDir);
+      const mnemonic = await decryptMnemonic(await store.loadMnemonicKeystore(), PASSWORD);
+      agentPk = walletPrivateKeyAtIndex(mnemonic, svc.index) as `0x${string}`;
+      safeAddress = getAddress(svc.safe_address!) as Address;
+      mechAddress = getAddress(svc.mech_address!) as Address;
+
+      console.log(`    Safe: ${safeAddress}`);
+      console.log(`    Mech: ${mechAddress}`);
+      await jsonRpc(ANVIL_RPC, 'anvil_setBalance', [safeAddress, '0x56BC75E2D63100000']);
+    }));
+
+    results.push(await runPhase('Phase 3: Initialize adapter', async () => {
+      adapter = makeAdapter(agentPk, safeAddress, mechAddress);
+      await adapter.initialize();
+    }));
+
+    results.push(await runPhase('Phase 4: Post prediction.apy.v0 restoration intent on-chain', async () => {
+      const now = Date.now();
+      window = { startTs: now, endTs: now + 3_600_000 };
+      intent = {
+        id: 'prediction-apy-v0-e2e',
+        description: 'APY full loop',
+        type: 'restoration',
+        window,
+        spec: {
+          kind: 'prediction.apy.v0',
+          oracle: {
+            venue: 'aave-v3-base-sepolia',
+            pool: '0x6Ae43d3271ff6888e7Fc43Fd7321a503ff738951',
+            reserve: '0x31d3A7711a10C45D72649D51E1c8D74282702572',
+            reserveSymbol: 'USDC',
+          },
+          metric: {
+            type: 'supply-apy-twa-bps',
+            twaWindowSeconds: 3600,
+            sampleCount: 12,
+            toleranceBps: 100,
+          },
+          question: { resolveTs: window.endTs + 900_000 },
+        },
+        eligibility: { maxSubmissionDelayMs: 3_600_000 },
+      } as unknown as DesiredState;
+
+      // Use the same path production uses for createRestorationJob payload.
+      const payload = buildDesiredStatePayload(intent);
+      const cid = await uploadToIpfs('https://registry.autonolas.tech', payload);
+      intentCid = `f01551220${cidToDigestHex(cid).slice(2)}`;
+      const intentDataHex = cidToDigestHex(cid) as Hex;
+      const { walletClient } = createClients(ANVIL_RPC, agentPk, base);
+      const [deliveryRate, timeoutBounds] = await Promise.all([
+        getMechDeliveryRate(publicClient, mechAddress),
+        getTimeoutBounds(publicClient, MARKETPLACE_ADDRESS),
+      ]);
+      const reqIds = await submitRestorationJob(
+        publicClient,
+        walletClient,
+        safeAddress,
+        ROUTER_ADDRESS,
+        mechAddress,
+        intentDataHex,
+        deliveryRate,
+        timeoutBounds.max,
+      );
+      if (reqIds.length === 0) throw new Error('no request id');
+      restorationRequestId = reqIds[0]!;
+      await jsonRpc(ANVIL_RPC, 'evm_mine', []);
+
+      // Ensure adapter tracks this restoration for eval creation path, just like postDesiredState.
+      (adapter as any).pendingEvaluations.set(restorationRequestId, {
+        ...intent,
+        context: { ...(intent.context ?? {}), [RESTORATION_INTENT_CID_CONTEXT_KEY]: intentCid },
+      });
+      (adapter as any).originalStates.set(restorationRequestId, { ...intent, type: 'restoration' });
+
+      const tip = await publicClient.getBlockNumber();
+      const logs = await publicClient.getLogs({ address: MARKETPLACE_ADDRESS, fromBlock: tip - 5n, toBlock: tip });
+      const found = decodeMarketplaceRequestLogs(logs).some(l => l.requestId === restorationRequestId);
+      if (!found) throw new Error('MarketplaceRequest not observed');
+      console.log(`    restorationRequestId: ${restorationRequestId}`);
+    }));
+
+    results.push(await runPhase('Phase 5: Restorer watches request, runs baseline, and delivers', async () => {
+      const iter = adapter.watchForRequests()[Symbol.asyncIterator]();
+      const req = await Promise.race([
+        iter.next(),
+        sleep(60_000).then(() => { throw new Error('watchForRequests timeout'); }),
+      ]);
+      if (req.done || !req.value) throw new Error('no restoration request');
+      await adapter.claimRequest(req.value.requestId);
+
+      const baseline = new PredictionApyV0BaselineImpl({
+        _testDeps: {
+          twApyBpsOverWindow: async () => ({ twApyBps: 250, sampleCount: 12 }),
+        },
+      });
+      const workingDir = join(tmpDir!, 'restoration', req.value.requestId);
+      const implStateDir = join(tmpDir!, 'impl-state', req.value.requestId);
+      mkdirSync(workingDir, { recursive: true });
+      mkdirSync(implStateDir, { recursive: true });
+      const out = await baseline.run({
+        intent,
+        intentCid,
+        implStateDir,
+        workingDir,
+        log: () => {},
+        abort: new AbortController().signal,
+        msUntilEndTs: () => Math.max(0, window.endTs - Date.now()),
+        _testDeps: { twApyBpsOverWindow: async () => ({ twApyBps: 250, sampleCount: 12 }) },
+      } as unknown as RestorationContext);
+
+      const account = privateKeyToAccount(agentPk);
+      const manifestBase = {
+        schemaVersion: 'prediction.apy.v0.submission.v1' as const,
+        generatedAt: Date.now(),
+        intent: {
+          cid: intentCid,
+          onchainCreationTx: req.value.onchainCreationTx ?? ('0x' + '0'.repeat(64)),
+          onchainCreationBlock: req.value.onchainCreationBlock ?? 0,
+          requestId: req.value.requestId,
+        },
+        restorer: {
+          safeAddress: safeAddress as `0x${string}`,
+          agentEoa: account.address,
+        },
+        window,
+        prediction: {
+          predictedBps: String(out.gating['predictedBps']),
+          submittedAt: Number(out.gating['submittedAt']),
+          modelId: String(out.gating['modelId']),
+        },
+      };
+      const signed = await signCanonical(manifestBase, agentPk, account.address);
+      const submission: PredictionApySubmissionManifest = {
+        ...manifestBase,
+        signature: {
+          algo: 'secp256k1',
+          signer: account.address,
+          hash: signed.hash,
+          sig: signed.sig,
+        },
+      };
+      await adapter.submitResult(req.value.requestId, { data: JSON.stringify(submission) });
+      await jsonRpc(ANVIL_RPC, 'evm_mine', []);
+      console.log('    restoration delivered');
+    }));
+
+    results.push(await runPhase('Phase 6: Adapter processes restoration delivery and auto-creates evaluation job', async () => {
+      const dIter = adapter.watchForDeliveries()[Symbol.asyncIterator]();
+      await Promise.race([
+        dIter.next(),
+        sleep(90_000).then(() => { throw new Error('watchForDeliveries timeout for restoration'); }),
+      ]);
+      const pendingClaims = (adapter as any).pendingEvaluationClaims as Set<string>;
+      if (pendingClaims.size === 0) throw new Error('no evaluation request in pendingEvaluationClaims');
+      evalRequestId = [...pendingClaims][0]!;
+      console.log(`    evalRequestId: ${evalRequestId}`);
+      const tip = await publicClient.getBlockNumber();
+      const logs = await publicClient.getLogs({ address: ROUTER_ADDRESS, fromBlock: tip - 20n, toBlock: tip });
+      const found = logs.some((log) => {
+        try {
+          const d = decodeEventLog({ abi: JINN_ROUTER_ABI, data: log.data, topics: log.topics });
+          return d.eventName === 'EvaluationJobCreated';
+        } catch { return false; }
+      });
+      if (!found) throw new Error('EvaluationJobCreated not observed');
+    }));
+
+    results.push(await runPhase('Phase 7: Watch eval request, run APY evaluator, deliver verdict', async () => {
+      const iter = adapter.watchForRequests()[Symbol.asyncIterator]();
+      let evalReq: { requestId: string; desiredState: DesiredState; intentCid?: string } | undefined;
+      const deadline = Date.now() + 60_000;
+      while (!evalReq && Date.now() < deadline) {
+        const next = await Promise.race([
+          iter.next(),
+          sleep(3_000).then(() => ({ done: true, value: undefined })),
+        ]);
+        if (!next.done && next.value?.desiredState?.type === 'evaluation') {
+          evalReq = next.value as { requestId: string; desiredState: DesiredState; intentCid?: string };
+        }
+      }
+      if (!evalReq) throw new Error('no evaluation request');
+      await adapter.claimRequest(evalReq.requestId);
+
+      const workingDir = join(tmpDir!, 'evaluation', evalReq.requestId);
+      const implStateDir = join(tmpDir!, 'eval-impl-state', evalReq.requestId);
+      mkdirSync(workingDir, { recursive: true });
+      mkdirSync(implStateDir, { recursive: true });
+      const evaluator = new PredictionApyV0Evaluator({
+        evaluatorPk: agentPk,
+        evaluatorSafeAddress: safeAddress as `0x${string}`,
+        rpcUrl: ANVIL_RPC,
+        _testDeps: {
+          twApyBpsOverWindow: async () => ({ twApyBps: 250, sampleCount: 12 }),
+        },
+      });
+      const out = await evaluator.run({
+        intent: evalReq.desiredState,
+        intentCid: evalReq.intentCid ?? '',
+        implStateDir,
+        workingDir,
+        log: () => {},
+        abort: new AbortController().signal,
+        msUntilEndTs: () => 0,
+        _testDeps: { twApyBpsOverWindow: async () => ({ twApyBps: 250, sampleCount: 12 }) },
+      } as unknown as RestorationContext);
+      const verdict = String(out.gating['verdict'] ?? 'UNKNOWN');
+      if (verdict !== 'PASS') throw new Error(`expected PASS verdict, got ${verdict}`);
+
+      await adapter.submitResult(evalReq.requestId, {
+        data: JSON.stringify({
+          protocol: 'jinn-client/prediction.apy.v0',
+          type: 'evaluation-verdict',
+          requestId: evalReq.requestId,
+          verdict,
+          gating: out.gating,
+        }),
+      });
+      await jsonRpc(ANVIL_RPC, 'evm_mine', []);
+      console.log(`    evaluator delivered verdict: ${verdict}`);
+    }));
+
+    results.push(await runPhase('Phase 8: Process evaluation delivery and cleanup tracking', async () => {
+      const iter = adapter.watchForDeliveries()[Symbol.asyncIterator]();
+      const yielded = await Promise.race([
+        iter.next(),
+        sleep(90_000).then(() => { throw new Error('watchForDeliveries timeout for evaluation'); }),
+      ]);
+      if (!yielded.done && yielded.value) {
+        const data = yielded.value.result.data;
+        try {
+          const parsed = JSON.parse(data) as { verdict?: string };
+          if (parsed.verdict !== 'PASS') throw new Error(`unexpected verdict payload ${parsed.verdict}`);
+        } catch {
+          throw new Error('failed to parse evaluation payload from delivery');
+        }
+      }
+      const pendingClaims = (adapter as any).pendingEvaluationClaims as Set<string>;
+      if (pendingClaims.has(evalRequestId)) throw new Error('pendingEvaluationClaims still contains eval request');
+    }));
+  } finally {
+    if (adapter) { try { await adapter.stop(); } catch { /**/ } }
+    if (anvil) anvil.kill('SIGTERM');
+    if (tmpDir) await rm(tmpDir, { recursive: true, force: true });
+  }
+
+  console.log('\n=== Results ===\n');
+  for (const r of results) {
+    const icon = r.ok ? '✓' : '✗';
+    console.log(`  ${icon} ${r.name} (${r.ms}ms)${r.error ? `: ${r.error}` : ''}`);
+  }
+  const failed = results.filter(r => !r.ok);
+  if (failed.length > 0) {
+    console.error(`\nE2E FAILED — ${failed.length}/${results.length} phases failed`);
+    process.exit(1);
+  }
+  console.log('\nE2E PASSED — prediction.apy.v0 production-shaped loop verified');
+}
+
+main().catch((err) => {
+  console.error('[e2e-apy] Fatal:', err);
+  process.exit(1);
+});
+

--- a/client/scripts/e2e-validate.ts
+++ b/client/scripts/e2e-validate.ts
@@ -122,6 +122,63 @@ async function waitFor(
   throw new Error(`Timeout waiting for: ${description}`);
 }
 
+/**
+ * `watchForDeliveries` can yield a restoration delivery before
+ * `tryCreateEvaluationJob` has observed `restorationDeliveryClaimed` on the
+ * router (stale RPC). The eval tx may post on a later `watchForDeliveries`
+ * poll. Operator B's `processOne` must not start until
+ * `EvaluationJobCreated` for this restoration is on chain.
+ */
+async function waitForRouterEvaluationJobForRestoration(
+  publicClient: PublicClient,
+  routerAddress: Address,
+  restorationRequestId: Hex,
+  anvilRpc: string,
+  fromBlock: bigint,
+): Promise<void> {
+  const want = restorationRequestId.toLowerCase();
+  await waitFor(
+    `router EvaluationJobCreated (restorationRequestId ${restorationRequestId})`,
+    async () => {
+      try {
+        await jsonRpc(anvilRpc, 'evm_mine', []);
+      } catch {
+        /* ignore */
+      }
+      const tip = await publicClient.getBlockNumber();
+      if (tip < fromBlock) {
+        return false;
+      }
+      const logs = await publicClient.getLogs({
+        address: routerAddress,
+        fromBlock,
+        toBlock: tip,
+      });
+      for (const log of logs) {
+        try {
+          const decoded = decodeEventLog({
+            abi: JINN_ROUTER_ABI,
+            data: log.data,
+            topics: log.topics,
+          });
+          if (decoded.eventName === 'EvaluationJobCreated') {
+            const args = decoded.args as { restorationRequestId: Hex };
+            if (String(args.restorationRequestId).toLowerCase() === want) {
+              return true;
+            }
+          }
+        } catch {
+          /* not a router event */
+        }
+      }
+      return false;
+    },
+    120_000,
+    500,
+  );
+  console.log('    Evaluation job on chain (EvaluationJobCreated) — proceeding to operator B eval');
+}
+
 async function jsonRpc(url: string, method: string, params: unknown[] = []): Promise<unknown> {
   const res = await fetch(url, {
     method: 'POST',
@@ -215,6 +272,9 @@ async function runPhase(name: string, fn: () => Promise<void>): Promise<PhaseRes
     const ms = Date.now() - start;
     const error = err instanceof Error ? err.message : String(err);
     console.error(`  ✗ ${name} (${ms}ms): ${error}`);
+    if (err instanceof Error && err.stack) {
+      console.error(err.stack);
+    }
     return { name, ok: false, ms, error };
   }
 }
@@ -1507,6 +1567,9 @@ async function main(): Promise<void> {
           try { await jsonRpc(ANVIL_RPC, 'evm_mine', []); } catch {}
         }, 1000);
 
+        // Scan for EvaluationJobCreated from this point; the event may land after the first
+        // watchForDeliveries yield (restorationDeliveryClaimed retry / next poll).
+        const crossEvalScanFromBlock = await publicClient.getBlockNumber();
         const crossDeliveryIter = creatorAdapter.watchForDeliveries()[Symbol.asyncIterator]();
         const crossDelivery = await Promise.race([
           crossDeliveryIter.next().then(r => r.value),
@@ -1514,7 +1577,15 @@ async function main(): Promise<void> {
         ]);
         console.log(`    A claimed restoration, type: ${crossDelivery?.desiredState?.type}`);
 
-        // B delivers evaluation
+        await waitForRouterEvaluationJobForRestoration(
+          publicClient,
+          ROUTER_ADDRESS,
+          crossRequestId as Hex,
+          ANVIL_RPC,
+          crossEvalScanFromBlock,
+        );
+
+        // B delivers evaluation (only after eval request is guaranteed on chain for B's mech)
         await Promise.race([
           restorerB.processOne(),
           sleep(agentTimeoutMs + 30000).then(() => { throw new Error(`Operator B eval processOne timed out after ${(agentTimeoutMs + 30000) / 1000}s`); }),
@@ -1668,7 +1739,8 @@ async function main(): Promise<void> {
     // ── Phase 13b: On-Chain ClaimRegistry ──────────────────────────────────
 
     const { OnChainClaimPolicy } = await import('../src/adapters/mech/claim-policy.js');
-    const { CLAIM_REGISTRY_ABI } = await import('../src/adapters/mech/types.js');
+    // Canonical ABI — do not import from adapters/mech/types (CLAIM_REGISTRY_ABI was removed there).
+    const { CLAIM_REGISTRY_ABI } = await import('../src/adapters/claim-registry/abi.js');
 
     results.push(
       await runPhase('Phase 13b: On-Chain ClaimRegistry — deploy, claim, reject, expire, reclaim', async () => {

--- a/client/src/adapters/mech/adapter.ts
+++ b/client/src/adapters/mech/adapter.ts
@@ -36,6 +36,7 @@ import type { Store } from '../../store/store.js';
 import { type ClaimPolicy, AcceptAllPolicy } from './claim-policy.js';
 import { withRecoverableRetry } from '../../tx-retry.js';
 import { computeEvidenceSimHash, type EvidenceCheckpointV1 } from '../../earning/evidence-simhash.js';
+import { RESTORATION_INTENT_CID_CONTEXT_KEY } from '../../restorer/impls/evaluation-context.js';
 
 export class MechAdapter implements ExecutionAdapter {
   readonly name = 'mech';
@@ -185,6 +186,8 @@ export class MechAdapter implements ExecutionAdapter {
     const restorationPayload = buildDesiredStatePayload(restorationState);
     const restorationCid = await uploadToIpfs(this.config.ipfsRegistryUrl, restorationPayload);
     const restorationDataHex = cidToDigestHex(restorationCid);
+    const digestNo0x = restorationDataHex.startsWith('0x') ? restorationDataHex.slice(2) : restorationDataHex;
+    const restorationIntentCid = `f01551220${digestNo0x}`;
 
     const deliveryRate = await getMechDeliveryRate(this.publicClient, this.config.mechContractAddress);
     const { max: maxTimeout } = await getTimeoutBounds(this.publicClient, this.config.mechMarketplaceAddress);
@@ -206,9 +209,15 @@ export class MechAdapter implements ExecutionAdapter {
 
     const restorationRequestId = restorationRequestIds[0];
 
-    // Store for evaluation creation after delivery is claimed
-    this.pendingEvaluations.set(restorationRequestId, state);
-    this.originalStates.set(restorationRequestId, { ...state, type: 'restoration' });
+    // Store for evaluation creation after delivery is claimed. The evaluation
+    // job’s IPFS CID is different from the restoration intended-state CID; evaluators
+    // need the latter to verify submission.intent.cid (see context.restorationIntentCid).
+    const stateForEval: DesiredState = {
+      ...state,
+      context: { ...(state.context ?? {}), [RESTORATION_INTENT_CID_CONTEXT_KEY]: restorationIntentCid },
+    };
+    this.pendingEvaluations.set(restorationRequestId, stateForEval);
+    this.originalStates.set(restorationRequestId, { ...stateForEval, type: 'restoration' });
 
     return restorationRequestId;
   }
@@ -314,8 +323,15 @@ export class MechAdapter implements ExecutionAdapter {
             const iCreatedEvaluation = this.pendingEvaluationClaims.has(requestId);
             if (!iDelivered && !iCreatedRestoration && !iCreatedEvaluation) continue;
 
-            // (a) If I delivered, claim delivery → msg.sender = my Safe → correct role credit.
-            if (iDelivered) {
+            // (a) Claim delivery on the router so `restorationDeliveryClaimed[requestId]` is set
+            // (required before createEvaluationJob can run).
+            // - Same-operator: we delivered (iDelivered) → our Safe claims and gets counter credit.
+            // - Cross-operator: we created the request (iCreatedRestoration) but another mech
+            //   delivered (iDelivered is false) → the creator Safe must still call claimDelivery
+            //   so the router flips `restorationDeliveryClaimed` for this requestId. Otherwise
+            //   tryCreateEvaluationJob never unblocks. See JinnRouter.claimDelivery in contracts.
+            const shouldClaimDelivery = iDelivered || (iCreatedRestoration && !iDelivered);
+            if (shouldClaimDelivery) {
               try {
                 const variant = this.config.routerClaimDeliveryVariant;
                 let evidenceHash: `0x${string}` | undefined;
@@ -487,8 +503,10 @@ export class MechAdapter implements ExecutionAdapter {
   }
 
   private async verifyRestorationClaimed(requestId: `0x${string}`): Promise<boolean> {
-    const MAX_POLLS = 5;
-    const POLL_DELAY_MS = 2_000;
+    // RPC / fork can lag right after claimDelivery; give more room than 5×2s so
+    // tryCreateEvaluationJob succeeds on the first watchForDeliveries pass when possible.
+    const MAX_POLLS = 12;
+    const POLL_DELAY_MS = 1_500;
     const abi = [{
       type: 'function' as const,
       name: 'restorationDeliveryClaimed' as const,

--- a/client/src/adapters/mech/adapter.ts
+++ b/client/src/adapters/mech/adapter.ts
@@ -30,6 +30,8 @@ import {
   callDeliverToMarketplace,
   scanRestorationJobs,
   scanEvaluationJobs,
+  findLatestRequestDataHexForMarketplaceRequest,
+  findLatestDeliveryDataHexForRequest,
 } from './contracts.js';
 import { type MechAdapterConfig, MECH_MARKETPLACE_ABI } from './types.js';
 import type { Store } from '../../store/store.js';
@@ -60,6 +62,9 @@ export class MechAdapter implements ExecutionAdapter {
   private originalStates = new Map<string, DesiredState>();
   private store?: Store;
   private claimPolicy: ClaimPolicy;
+
+  /** On-demand Deliver scan so evaluation creation can find IPFS even if `pendingEvaluationResults` is cold. */
+  private static readonly DELIVER_LOOKBACK_BLOCKS = 500_000n;
 
   constructor(config: MechAdapterConfig, store?: Store) {
     this.config = config;
@@ -169,6 +174,51 @@ export class MechAdapter implements ExecutionAdapter {
 
     // Set delivery block cursor to scan from recovery point
     this.deliveryBlockCursor = fromBlock;
+
+    for (const { requestId } of restorations) {
+      const pe = this.pendingEvaluations.get(requestId);
+      if (!pe) continue;
+
+      const requestDataHex = await findLatestRequestDataHexForMarketplaceRequest(
+        this.publicClient,
+        this.config.mechMarketplaceAddress,
+        requestId,
+        fromBlock,
+        currentBlock,
+      );
+      if (requestDataHex) {
+        const d = String(requestDataHex);
+        const digest = d.startsWith('0x') ? d.slice(2) : d;
+        this.pendingEvaluations.set(requestId, {
+          ...pe,
+          context: { ...pe.context, [RESTORATION_INTENT_CID_CONTEXT_KEY]: `f01551220${digest}` },
+        });
+      }
+
+      const deliveryDataHex = await findLatestDeliveryDataHexForRequest(
+        this.publicClient,
+        this.config.mechContractAddress,
+        requestId,
+        fromBlock,
+        currentBlock,
+      );
+      if (deliveryDataHex) {
+        try {
+          const d = String(deliveryDataHex);
+          const dig = d.startsWith('0x') ? d.slice(2) : d;
+          const payload = (await fetchFromIpfs(
+            this.config.ipfsGatewayUrl,
+            `f01551220${dig}`,
+          )) as Record<string, unknown>;
+          this.pendingEvaluationResults.set(
+            requestId,
+            (payload.data as string) ?? JSON.stringify(payload),
+          );
+        } catch (err) {
+          console.error(`[mech] recovery: could not load restoration result IPFS for ${requestId}:`, err);
+        }
+      }
+    }
 
     const recovered = this.pendingEvaluations.size + this.pendingEvaluationClaims.size + this.claimedButNotEvaluated.size;
     if (recovered > 0) {
@@ -296,11 +346,6 @@ export class MechAdapter implements ExecutionAdapter {
   async *watchForDeliveries(): AsyncIterable<DeliveredResult> {
     while (!this.stopped) {
       try {
-        // Retry evaluation creation for claimed restorations that failed previously
-        for (const rid of [...this.claimedButNotEvaluated]) {
-          await this.tryCreateEvaluationJob(rid);
-        }
-
         const currentBlock = await this.publicClient.getBlockNumber();
         if (currentBlock > this.deliveryBlockCursor) {
           const logs = await this.publicClient.getLogs({
@@ -422,6 +467,13 @@ export class MechAdapter implements ExecutionAdapter {
             }
           }
         }
+
+        // After new Deliver events are processed (and `pendingEvaluationResults` may be warm),
+        // retry evaluation creation. Doing this *before* deliver processing can upload an
+        // evaluation desired state without `restorationResult` in context.
+        for (const rid of [...this.claimedButNotEvaluated]) {
+          await this.tryCreateEvaluationJob(rid);
+        }
       } catch (err) {
         console.error('[mech] Error polling for deliveries:', err);
       }
@@ -435,13 +487,54 @@ export class MechAdapter implements ExecutionAdapter {
     }
   }
 
+  private async backfillRestorationResultFromChain(requestId: string): Promise<string | undefined> {
+    if (this.pendingEvaluationResults.has(requestId)) {
+      return this.pendingEvaluationResults.get(requestId);
+    }
+    const currentBlock = await this.publicClient.getBlockNumber();
+    const from = currentBlock > MechAdapter.DELIVER_LOOKBACK_BLOCKS
+      ? currentBlock - MechAdapter.DELIVER_LOOKBACK_BLOCKS
+      : 1n;
+    const dhex = await findLatestDeliveryDataHexForRequest(
+      this.publicClient,
+      this.config.mechContractAddress,
+      requestId,
+      from,
+      currentBlock,
+    );
+    if (!dhex) return undefined;
+    try {
+      const d = String(dhex);
+      const dig = d.startsWith('0x') ? d.slice(2) : d;
+      const payload = (await fetchFromIpfs(
+        this.config.ipfsGatewayUrl,
+        `f01551220${dig}`,
+      )) as Record<string, unknown>;
+      const data = (payload.data as string) ?? JSON.stringify(payload);
+      this.pendingEvaluationResults.set(requestId, data);
+      return data;
+    } catch (err) {
+      console.error(`[mech] backfill: failed to load restoration result for ${requestId}:`, err);
+      return undefined;
+    }
+  }
+
   private async tryCreateEvaluationJob(requestId: string, restorationResultData?: string): Promise<void> {
     if (!this.pendingEvaluations.has(requestId)) return;
     const originalState = this.pendingEvaluations.get(requestId)!;
     if (restorationResultData) {
       this.pendingEvaluationResults.set(requestId, restorationResultData);
     }
-    const cachedRestorationResultData = restorationResultData ?? this.pendingEvaluationResults.get(requestId);
+    let cachedRestorationResultData = restorationResultData ?? this.pendingEvaluationResults.get(requestId);
+    if (cachedRestorationResultData == null) {
+      cachedRestorationResultData = await this.backfillRestorationResultFromChain(requestId);
+    }
+    if (cachedRestorationResultData == null) {
+      console.error(
+        `[mech] no restoration result yet for ${requestId} (evaluation job and IPFS upload deferred until Deliver or backfill)`,
+      );
+      return;
+    }
     try {
       const evaluationState: DesiredState = {
         ...originalState,
@@ -449,7 +542,7 @@ export class MechAdapter implements ExecutionAdapter {
         restorationRequestId: requestId,
         context: {
           ...originalState.context,
-          ...(cachedRestorationResultData ? { restorationResult: cachedRestorationResultData } : {}),
+          restorationResult: cachedRestorationResultData,
         },
       };
       const evaluationPayload = buildDesiredStatePayload(evaluationState);

--- a/client/src/adapters/mech/adapter.ts
+++ b/client/src/adapters/mech/adapter.ts
@@ -30,7 +30,8 @@ import {
   callDeliverToMarketplace,
   scanRestorationJobs,
   scanEvaluationJobs,
-  findLatestRequestDataHexForMarketplaceRequest,
+  scanLatestRequestDataByRid,
+  scanLatestDeliveryDataByRid,
   findLatestDeliveryDataHexForRequest,
 } from './contracts.js';
 import { type MechAdapterConfig, MECH_MARKETPLACE_ABI } from './types.js';
@@ -57,14 +58,13 @@ export class MechAdapter implements ExecutionAdapter {
   // Restoration result content cached across evaluation-job retries so a transient
   // Safe/router failure does not silently strip evaluator context on the next poll.
   private pendingEvaluationResults = new Map<string, string>();
+  // RIDs with no delivery found in backfill window; avoids repeated 500k-block rescans.
+  private backfillMissRids = new Set<string>();
   // Original desired states keyed by request ID (restoration and evaluation)
   // so we can yield accurate desiredState in DeliveredResult
   private originalStates = new Map<string, DesiredState>();
   private store?: Store;
   private claimPolicy: ClaimPolicy;
-
-  /** On-demand Deliver scan so evaluation creation can find IPFS even if `pendingEvaluationResults` is cold. */
-  private static readonly DELIVER_LOOKBACK_BLOCKS = 500_000n;
 
   constructor(config: MechAdapterConfig, store?: Store) {
     this.config = config;
@@ -175,17 +175,24 @@ export class MechAdapter implements ExecutionAdapter {
     // Set delivery block cursor to scan from recovery point
     this.deliveryBlockCursor = fromBlock;
 
+    const latestRequestDataByRid = await scanLatestRequestDataByRid(
+      this.publicClient,
+      this.config.mechMarketplaceAddress,
+      fromBlock,
+      currentBlock,
+    );
+    const latestDeliveryDataByRid = await scanLatestDeliveryDataByRid(
+      this.publicClient,
+      this.config.mechContractAddress,
+      fromBlock,
+      currentBlock,
+    );
+
     for (const { requestId } of restorations) {
       const pe = this.pendingEvaluations.get(requestId);
       if (!pe) continue;
 
-      const requestDataHex = await findLatestRequestDataHexForMarketplaceRequest(
-        this.publicClient,
-        this.config.mechMarketplaceAddress,
-        requestId,
-        fromBlock,
-        currentBlock,
-      );
+      const requestDataHex = latestRequestDataByRid.get(requestId.toLowerCase());
       if (requestDataHex) {
         const d = String(requestDataHex);
         const digest = d.startsWith('0x') ? d.slice(2) : d;
@@ -195,13 +202,7 @@ export class MechAdapter implements ExecutionAdapter {
         });
       }
 
-      const deliveryDataHex = await findLatestDeliveryDataHexForRequest(
-        this.publicClient,
-        this.config.mechContractAddress,
-        requestId,
-        fromBlock,
-        currentBlock,
-      );
+      const deliveryDataHex = latestDeliveryDataByRid.get(requestId.toLowerCase());
       if (deliveryDataHex) {
         try {
           const d = String(deliveryDataHex);
@@ -214,6 +215,7 @@ export class MechAdapter implements ExecutionAdapter {
             requestId,
             (payload.data as string) ?? JSON.stringify(payload),
           );
+          this.backfillMissRids.delete(requestId);
         } catch (err) {
           console.error(`[mech] recovery: could not load restoration result IPFS for ${requestId}:`, err);
         }
@@ -426,6 +428,7 @@ export class MechAdapter implements ExecutionAdapter {
                 const digest = deliveryDataHex.startsWith('0x') ? deliveryDataHex.slice(2) : deliveryDataHex;
                 const payload = await fetchFromIpfs(this.config.ipfsGatewayUrl, `f01551220${digest}`) as Record<string, unknown>;
                 restorationResultData = (payload.data as string) ?? JSON.stringify(payload);
+                this.backfillMissRids.delete(requestId);
               } catch (err) {
                 console.error(`[mech] Failed to fetch restoration result for evaluation: ${requestId}`, err);
               }
@@ -491,9 +494,13 @@ export class MechAdapter implements ExecutionAdapter {
     if (this.pendingEvaluationResults.has(requestId)) {
       return this.pendingEvaluationResults.get(requestId);
     }
+    if (this.backfillMissRids.has(requestId)) {
+      return undefined;
+    }
     const currentBlock = await this.publicClient.getBlockNumber();
-    const from = currentBlock > MechAdapter.DELIVER_LOOKBACK_BLOCKS
-      ? currentBlock - MechAdapter.DELIVER_LOOKBACK_BLOCKS
+    const lookbackBlocks = this.config.mechDeliverBackfillLookbackBlocks ?? 500_000n;
+    const from = currentBlock > lookbackBlocks
+      ? currentBlock - lookbackBlocks
       : 1n;
     const dhex = await findLatestDeliveryDataHexForRequest(
       this.publicClient,
@@ -502,7 +509,10 @@ export class MechAdapter implements ExecutionAdapter {
       from,
       currentBlock,
     );
-    if (!dhex) return undefined;
+    if (!dhex) {
+      this.backfillMissRids.add(requestId);
+      return undefined;
+    }
     try {
       const d = String(dhex);
       const dig = d.startsWith('0x') ? d.slice(2) : d;
@@ -512,6 +522,7 @@ export class MechAdapter implements ExecutionAdapter {
       )) as Record<string, unknown>;
       const data = (payload.data as string) ?? JSON.stringify(payload);
       this.pendingEvaluationResults.set(requestId, data);
+      this.backfillMissRids.delete(requestId);
       return data;
     } catch (err) {
       console.error(`[mech] backfill: failed to load restoration result for ${requestId}:`, err);
@@ -524,12 +535,14 @@ export class MechAdapter implements ExecutionAdapter {
     const originalState = this.pendingEvaluations.get(requestId)!;
     if (restorationResultData) {
       this.pendingEvaluationResults.set(requestId, restorationResultData);
+      this.backfillMissRids.delete(requestId);
     }
     let cachedRestorationResultData = restorationResultData ?? this.pendingEvaluationResults.get(requestId);
     if (cachedRestorationResultData == null) {
       cachedRestorationResultData = await this.backfillRestorationResultFromChain(requestId);
     }
     if (cachedRestorationResultData == null) {
+      this.claimedButNotEvaluated.add(requestId);
       console.error(
         `[mech] no restoration result yet for ${requestId} (evaluation job and IPFS upload deferred until Deliver or backfill)`,
       );

--- a/client/src/adapters/mech/contracts.ts
+++ b/client/src/adapters/mech/contracts.ts
@@ -443,9 +443,16 @@ export function decodeMarketplaceRequestLogs(logs: Log[]): DecodedMarketplaceReq
       if (decoded.eventName === 'MarketplaceRequest') {
         const args = decoded.args as {
           priorityMech: string;
-          requestIds: readonly Hex[];
-          requestDatas: readonly Hex[];
+          requestIds: readonly Hex[] | undefined;
+          requestDatas: readonly Hex[] | undefined;
         };
+        if (!args.requestIds?.length || !args.requestDatas?.length) {
+          console.error('[mech] MarketplaceRequest decode missing requestIds/requestDatas', {
+            hasRequestIds: args.requestIds != null,
+            hasRequestDatas: args.requestDatas != null,
+          });
+          continue;
+        }
         for (let i = 0; i < args.requestIds.length; i++) {
           results.push({
             requestId: String(args.requestIds[i]),

--- a/client/src/adapters/mech/contracts.ts
+++ b/client/src/adapters/mech/contracts.ts
@@ -508,6 +508,48 @@ export function decodeDeliverLogs(logs: Log[]): DecodedDeliverEvent[] {
 
 const LOG_SCAN_CHUNK = 9999n;
 
+export async function scanLatestRequestDataByRid(
+  publicClient: PublicClient,
+  marketplaceAddress: Address,
+  fromBlock: bigint,
+  toBlock: bigint,
+): Promise<Map<string, Hex>> {
+  const results = new Map<string, Hex>();
+  for (let start = fromBlock; start <= toBlock; start += LOG_SCAN_CHUNK + 1n) {
+    const end = start + LOG_SCAN_CHUNK > toBlock ? toBlock : start + LOG_SCAN_CHUNK;
+    const logs = await publicClient.getLogs({
+      address: marketplaceAddress,
+      fromBlock: start,
+      toBlock: end,
+    });
+    for (const decoded of decodeMarketplaceRequestLogs(logs)) {
+      results.set(decoded.requestId.toLowerCase(), decoded.requestDataHex as Hex);
+    }
+  }
+  return results;
+}
+
+export async function scanLatestDeliveryDataByRid(
+  publicClient: PublicClient,
+  mechContractAddress: Address,
+  fromBlock: bigint,
+  toBlock: bigint,
+): Promise<Map<string, Hex>> {
+  const results = new Map<string, Hex>();
+  for (let start = fromBlock; start <= toBlock; start += LOG_SCAN_CHUNK + 1n) {
+    const end = start + LOG_SCAN_CHUNK > toBlock ? toBlock : start + LOG_SCAN_CHUNK;
+    const logs = await publicClient.getLogs({
+      address: mechContractAddress,
+      fromBlock: start,
+      toBlock: end,
+    });
+    for (const decoded of decodeDeliverLogs(logs)) {
+      results.set(decoded.requestId.toLowerCase(), decoded.deliveryDataHex as Hex);
+    }
+  }
+  return results;
+}
+
 /**
  * Most recent `requestData` for `requestId` from MarketplaceRequest events on
  * `marketplaceAddress` in [fromBlock, toBlock] (inclusive), by block then log index.
@@ -519,49 +561,13 @@ export async function findLatestRequestDataHexForMarketplaceRequest(
   fromBlock: bigint,
   toBlock: bigint,
 ): Promise<Hex | null> {
-  const rid = requestId.toLowerCase();
-  let best: { bn: number; li: number; sub: number; data: Hex } | null = null;
-
-  for (let start = fromBlock; start <= toBlock; start += LOG_SCAN_CHUNK + 1n) {
-    const end = start + LOG_SCAN_CHUNK > toBlock ? toBlock : start + LOG_SCAN_CHUNK;
-    const logs = await publicClient.getLogs({
-      address: marketplaceAddress,
-      fromBlock: start,
-      toBlock: end,
-    });
-    for (const log of logs) {
-      try {
-        const decoded = decodeEventLog({
-          abi: MECH_MARKETPLACE_ABI,
-          data: log.data,
-          topics: log.topics,
-        });
-        if (decoded.eventName !== 'MarketplaceRequest') continue;
-        const args = decoded.args as {
-          requestIds: readonly Hex[] | undefined;
-          requestDatas: readonly Hex[] | undefined;
-        };
-        if (!args.requestIds?.length || !args.requestDatas?.length) continue;
-        const bn = log.blockNumber != null ? Number(log.blockNumber) : 0;
-        const li = log.logIndex != null ? Number(log.logIndex) : 0;
-        for (let i = 0; i < args.requestIds.length; i++) {
-          if (String(args.requestIds[i]).toLowerCase() !== rid) continue;
-          const data = args.requestDatas[i]!;
-          if (
-            !best ||
-            bn > best.bn ||
-            (bn === best.bn && li > best.li) ||
-            (bn === best.bn && li === best.li && i > best.sub)
-          ) {
-            best = { bn, li, sub: i, data };
-          }
-        }
-      } catch {
-        // skip
-      }
-    }
-  }
-  return best?.data ?? null;
+  const dataByRid = await scanLatestRequestDataByRid(
+    publicClient,
+    marketplaceAddress,
+    fromBlock,
+    toBlock,
+  );
+  return dataByRid.get(requestId.toLowerCase()) ?? null;
 }
 
 /**
@@ -575,38 +581,13 @@ export async function findLatestDeliveryDataHexForRequest(
   fromBlock: bigint,
   toBlock: bigint,
 ): Promise<Hex | null> {
-  const rid = requestId.toLowerCase();
-  let best: { bn: number; li: number; data: Hex } | null = null;
-
-  for (let start = fromBlock; start <= toBlock; start += LOG_SCAN_CHUNK + 1n) {
-    const end = start + LOG_SCAN_CHUNK > toBlock ? toBlock : start + LOG_SCAN_CHUNK;
-    const logs = await publicClient.getLogs({
-      address: mechContractAddress,
-      fromBlock: start,
-      toBlock: end,
-    });
-    for (const log of logs) {
-      try {
-        const decoded = decodeEventLog({
-          abi: MECH_ABI,
-          data: log.data,
-          topics: log.topics,
-        });
-        if (decoded.eventName !== 'Deliver') continue;
-        const args = decoded.args as { requestId: Hex; data: Hex };
-        if (String(args.requestId).toLowerCase() !== rid) continue;
-        const bn = log.blockNumber != null ? Number(log.blockNumber) : 0;
-        const li = log.logIndex != null ? Number(log.logIndex) : 0;
-        const data = args.data;
-        if (!best || bn > best.bn || (bn === best.bn && li > best.li)) {
-          best = { bn, li, data };
-        }
-      } catch {
-        // skip
-      }
-    }
-  }
-  return best?.data ?? null;
+  const dataByRid = await scanLatestDeliveryDataByRid(
+    publicClient,
+    mechContractAddress,
+    fromBlock,
+    toBlock,
+  );
+  return dataByRid.get(requestId.toLowerCase()) ?? null;
 }
 
 // ── Delivery ─────────────────────────────────────────────────────────────────

--- a/client/src/adapters/mech/contracts.ts
+++ b/client/src/adapters/mech/contracts.ts
@@ -506,6 +506,109 @@ export function decodeDeliverLogs(logs: Log[]): DecodedDeliverEvent[] {
   return results;
 }
 
+const LOG_SCAN_CHUNK = 9999n;
+
+/**
+ * Most recent `requestData` for `requestId` from MarketplaceRequest events on
+ * `marketplaceAddress` in [fromBlock, toBlock] (inclusive), by block then log index.
+ */
+export async function findLatestRequestDataHexForMarketplaceRequest(
+  publicClient: PublicClient,
+  marketplaceAddress: Address,
+  requestId: string,
+  fromBlock: bigint,
+  toBlock: bigint,
+): Promise<Hex | null> {
+  const rid = requestId.toLowerCase();
+  let best: { bn: number; li: number; sub: number; data: Hex } | null = null;
+
+  for (let start = fromBlock; start <= toBlock; start += LOG_SCAN_CHUNK + 1n) {
+    const end = start + LOG_SCAN_CHUNK > toBlock ? toBlock : start + LOG_SCAN_CHUNK;
+    const logs = await publicClient.getLogs({
+      address: marketplaceAddress,
+      fromBlock: start,
+      toBlock: end,
+    });
+    for (const log of logs) {
+      try {
+        const decoded = decodeEventLog({
+          abi: MECH_MARKETPLACE_ABI,
+          data: log.data,
+          topics: log.topics,
+        });
+        if (decoded.eventName !== 'MarketplaceRequest') continue;
+        const args = decoded.args as {
+          requestIds: readonly Hex[] | undefined;
+          requestDatas: readonly Hex[] | undefined;
+        };
+        if (!args.requestIds?.length || !args.requestDatas?.length) continue;
+        const bn = log.blockNumber != null ? Number(log.blockNumber) : 0;
+        const li = log.logIndex != null ? Number(log.logIndex) : 0;
+        for (let i = 0; i < args.requestIds.length; i++) {
+          if (String(args.requestIds[i]).toLowerCase() !== rid) continue;
+          const data = args.requestDatas[i]!;
+          if (
+            !best ||
+            bn > best.bn ||
+            (bn === best.bn && li > best.li) ||
+            (bn === best.bn && li === best.li && i > best.sub)
+          ) {
+            best = { bn, li, sub: i, data };
+          }
+        }
+      } catch {
+        // skip
+      }
+    }
+  }
+  return best?.data ?? null;
+}
+
+/**
+ * `data` field of the most recent Deliver event for `requestId` on the mech contract
+ * in [fromBlock, toBlock] (inclusive).
+ */
+export async function findLatestDeliveryDataHexForRequest(
+  publicClient: PublicClient,
+  mechContractAddress: Address,
+  requestId: string,
+  fromBlock: bigint,
+  toBlock: bigint,
+): Promise<Hex | null> {
+  const rid = requestId.toLowerCase();
+  let best: { bn: number; li: number; data: Hex } | null = null;
+
+  for (let start = fromBlock; start <= toBlock; start += LOG_SCAN_CHUNK + 1n) {
+    const end = start + LOG_SCAN_CHUNK > toBlock ? toBlock : start + LOG_SCAN_CHUNK;
+    const logs = await publicClient.getLogs({
+      address: mechContractAddress,
+      fromBlock: start,
+      toBlock: end,
+    });
+    for (const log of logs) {
+      try {
+        const decoded = decodeEventLog({
+          abi: MECH_ABI,
+          data: log.data,
+          topics: log.topics,
+        });
+        if (decoded.eventName !== 'Deliver') continue;
+        const args = decoded.args as { requestId: Hex; data: Hex };
+        if (String(args.requestId).toLowerCase() !== rid) continue;
+        const bn = log.blockNumber != null ? Number(log.blockNumber) : 0;
+        const li = log.logIndex != null ? Number(log.logIndex) : 0;
+        const data = args.data;
+        if (!best || bn > best.bn || (bn === best.bn && li > best.li)) {
+          best = { bn, li, data };
+        }
+      } catch {
+        // skip
+      }
+    }
+  }
+  return best?.data ?? null;
+}
+
 // ── Delivery ─────────────────────────────────────────────────────────────────
 
 // Error names reported by the Mech Marketplace contract for duplicate delivery.

--- a/client/src/adapters/mech/ipfs.ts
+++ b/client/src/adapters/mech/ipfs.ts
@@ -69,9 +69,89 @@ export function buildResultPayload(requestId: string, result: RestorationResult)
 }
 
 /**
- * Upload JSON to IPFS via the Autonolas registry.
- * Uses pushJsonToIpfs from mech-client-ts — the same function jinn-node uses.
- * Returns [digestHex, cidString].
+ * Default per-request timeout (ms) when fetching from a gateway.
+ * jinn-node uses 7–10s; we allow a bit more for slow public gateways.
+ */
+const IPFS_FETCH_TIMEOUT_MS = 15_000;
+
+const FALLBACK_IPFS_GATEWAY_BASE = 'https://ipfs.io/ipfs/';
+
+/**
+ * Normalizes operator-configured `ipfsGatewayUrl` into a base that ends with `/ipfs/`
+ * so we can append a CID path without double `/ipfs/ipfs/`.
+ *
+ * jinn-node defaults to `https://gateway.autonolas.tech/ipfs/`; operators sometimes set
+ * the origin only (`https://gateway.autonolas.tech`) or paste the full `/ipfs/` URL.
+ * See: jinn-node `fetchIpfsMetadata` / `shared/ipfs` gateway joining.
+ */
+export function normalizeIpfsGatewayBase(gatewayUrl: string): string {
+  let t = gatewayUrl.trim();
+  if (t === '') t = 'https://gateway.autonolas.tech';
+  t = t.replace(/\/+$/, '');
+  if (!t.toLowerCase().endsWith('/ipfs')) {
+    t = `${t}/ipfs`;
+  }
+  return `${t}/`;
+}
+
+/**
+ * For the same 32-byte on-chain digest, Autonolas may address content as CIDv1 **raw** (`f01551220…`)
+ * or **dag-pb** (`f01701220…`). Gateways can 404/500 on the wrong codec — jinn-node always tries both.
+ * See: `jinn-node/src/worker/metadata/fetchIpfsMetadata.ts` (buildIpfsHashCandidates).
+ */
+export function buildIpfsHexCidCandidatesFromPartialHex(hex: string): string[] {
+  const h = (hex.startsWith('0x') ? hex.slice(2) : hex).toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(h)) {
+    return [hex];
+  }
+  // Raw (registry file JSON) first — matches mech `pushJsonToIpfs` / on-chain requestData
+  return [`f01551220${h}`, `f01701220${h}`];
+}
+
+/**
+ * Build CID path segments to try for `fetchFromIpfs`. Accepts on-chain f01… hex, or full base32 (bafy…, Qm…).
+ */
+export function buildIpfsFetchCidPathCandidates(cidOrPath: string): string[] {
+  const s = cidOrPath.trim();
+  const lower = s.toLowerCase();
+  // Prefixes are CIDv1 multibase+version+codec (9 hex chars for f015 / f017 forms we use)
+  if (lower.startsWith('f01551220') && lower.length > 9) {
+    return buildIpfsHexCidCandidatesFromPartialHex(lower.slice(9));
+  }
+  if (lower.startsWith('f01701220') && lower.length > 9) {
+    return buildIpfsHexCidCandidatesFromPartialHex(lower.slice(9));
+  }
+  if (/^[0-9a-f]+$/i.test(s) && s.length === 64) {
+    return buildIpfsHexCidCandidatesFromPartialHex(s);
+  }
+  return [s];
+}
+
+async function fetchJsonFromUrl(url: string, signal: AbortSignal): Promise<unknown> {
+  const response = await fetch(url, { method: 'GET', signal });
+  if (!response.ok) {
+    throw new Error(`IPFS fetch failed: ${response.status} ${response.statusText} (${url.slice(0, 80)}…)`);
+  }
+  const contentType = response.headers.get('content-type') || '';
+  if (contentType.includes('application/json')) {
+    return response.json();
+  }
+  const text = await response.text();
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new Error(`IPFS response is not JSON (content-type: ${contentType || 'none'})`);
+  }
+}
+
+/**
+ * Fetch JSON from IPFS gateways, mirroring jinn-node:
+ * 1) Normalize base URL (avoid `/ipfs//ipfs/` when env already includes `/ipfs/`).
+ * 2) Try raw then dag-pb hex CIDs for the same digest.
+ * 3) Retry on primary gateway then public ipfs.io fallback.
+ *
+ * Upload path stays `pushJsonToIpfs` from mech-client-ts (axios, same as jinn-node) — it already
+ * enforces a registry timeout; we do not wrap it again here.
  */
 export async function uploadToIpfs(_registryUrl: string, data: unknown): Promise<string> {
   const { pushJsonToIpfs } = await import('@jinn-network/mech-client-ts/dist/ipfs.js');
@@ -80,9 +160,28 @@ export async function uploadToIpfs(_registryUrl: string, data: unknown): Promise
 }
 
 export async function fetchFromIpfs(gatewayUrl: string, cid: string): Promise<unknown> {
-  const response = await fetch(`${gatewayUrl}/ipfs/${cid}`);
-  if (!response.ok) throw new Error(`IPFS fetch failed: ${response.statusText}`);
-  return response.json();
+  const base = normalizeIpfsGatewayBase(gatewayUrl);
+  const candidates = buildIpfsFetchCidPathCandidates(cid);
+  const errors: string[] = [];
+  for (const cidPath of candidates) {
+    for (const [name, baseUrl] of [
+      ['primary', base] as const,
+      ['fallback', FALLBACK_IPFS_GATEWAY_BASE] as const,
+    ]) {
+      const url = `${baseUrl}${cidPath}`;
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), IPFS_FETCH_TIMEOUT_MS);
+      try {
+        return await fetchJsonFromUrl(url, controller.signal);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        errors.push(`${name}:${url.slice(0, 100)}: ${message}`);
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+  }
+  throw new Error(`IPFS JSON fetch failed after all candidates: ${errors.join(' | ')}`);
 }
 
 /**
@@ -130,13 +229,12 @@ export function digestHexToGatewayUrl(digestHex: string): string {
 }
 
 /**
- * Fetch content from IPFS using a raw SHA256 digest hex.
+ * Fetch content from IPFS using a raw SHA256 digest hex (with or without `0x`).
+ * Uses the same multi-codec and multi-gateway path as `fetchFromIpfs`.
  */
 export async function fetchFromDigest(digestHex: string): Promise<unknown> {
-  const url = digestHexToGatewayUrl(digestHex);
-  const response = await fetch(url);
-  if (!response.ok) throw new Error(`IPFS fetch failed: ${response.statusText}`);
-  return response.json();
+  const hex = (digestHex.startsWith('0x') ? digestHex.slice(2) : digestHex).toLowerCase();
+  return fetchFromIpfs('https://gateway.autonolas.tech', `f01551220${hex}`);
 }
 
 // ── Base encoding helpers ────────────────────────────────────────────────────

--- a/client/src/adapters/mech/types.ts
+++ b/client/src/adapters/mech/types.ts
@@ -10,6 +10,8 @@ export interface MechAdapterConfig {
   ipfsRegistryUrl: string;  // Upload endpoint (e.g., https://registry.autonolas.tech)
   ipfsGatewayUrl: string;   // Read endpoint (e.g., https://gateway.autonolas.tech)
   pollIntervalMs: number;
+  /** Optional delivery backfill horizon for late evaluation creation retries. */
+  mechDeliverBackfillLookbackBlocks?: bigint;
   chainId: number;
   /** Base mainnet V1 vs Phase 1b V2 `claimDelivery` — align with `ChainConfig.routerClaimDeliveryVersion`. */
   routerClaimDeliveryVariant: 'v1' | 'v2';

--- a/client/src/intents/prediction-apy-v0-auto.ts
+++ b/client/src/intents/prediction-apy-v0-auto.ts
@@ -48,7 +48,7 @@ export function makePredictionApyV0Generator(config: PredictionApyV0AutoConfig =
           },
           question: { resolveTs },
         },
-        eligibility: { maxSubmissionDelayMs: 60_000 },
+        eligibility: { maxSubmissionDelayMs: windowDurationMs },
       });
       return intent as unknown as DesiredState;
     } catch {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -46,6 +46,7 @@ import { PredictionApyV0Evaluator } from './restorer/impls/prediction-apy-v0-eva
 import { ClaimRegistryClient } from './adapters/claim-registry/client.js';
 import { createClients } from './adapters/mech/safe.js';
 import { makePredictionV0Generator } from './intents/prediction-v0-auto.js';
+import { makePredictionApyV0Generator } from './intents/prediction-apy-v0-auto.js';
 import { BASE_SEPOLIA_FEEDS, BASE_FEEDS } from './venues/chainlink/feeds.js';
 import type { IntentGenerator } from './daemon/creator.js';
 
@@ -437,6 +438,10 @@ export async function main(): Promise<DaemonStartupInfo> {
       rpcUrl: config.rpcUrl,
     }));
     console.log('[main] auto-intent generator enabled: prediction.v0 (testnet, ETH/USD coin-flip+0.5%)');
+    if (process.env['JINN_ENABLE_APY_AUTO_INTENTS'] === '1') {
+      intentGenerators.push(makePredictionApyV0Generator());
+      console.log('[main] auto-intent generator enabled: prediction.apy.v0 (JINN_ENABLE_APY_AUTO_INTENTS=1)');
+    }
   } else if (config.network === 'mainnet' && !autoIntentsDisabled && BASE_FEEDS['ETH / USD']) {
     // Mainnet opt-in only; default is OFF. Reserved for a future flag.
   }

--- a/client/src/restorer/engine/engine.ts
+++ b/client/src/restorer/engine/engine.ts
@@ -517,6 +517,7 @@ export class RestorationEngine {
           ...(intent.specKind ? { spec: { kind: intent.specKind } } : {}),
           window: { startTs: intent.windowStartTs, endTs: intent.windowEndTs },
         }) as import('../../types/desired-state.js').DesiredState,
+        intentCid: intent.intentCid,
         implStateDir,
         workingDir,
         log: (event: { level: string; msg: string; data?: unknown }) => {

--- a/client/src/restorer/impls/evaluation-context.ts
+++ b/client/src/restorer/impls/evaluation-context.ts
@@ -1,0 +1,23 @@
+import type { DesiredState } from '../../types/desired-state.js';
+
+/** Eval `DesiredState.context` key for the restoration job’s intended-state IPFS CID (not the eval job’s). */
+export const RESTORATION_INTENT_CID_CONTEXT_KEY = 'restorationIntentCid' as const;
+
+/**
+ * Resolve the expected restoration intent CID for `integrity.intent_ref`.
+ * Test-only overrides win; otherwise the value must be present in `context`.
+ * There is no fallback to the evaluation job’s `intentCid` (wrong reference).
+ */
+export function resolveExpectedRestorationIntentCid(
+  intent: DesiredState,
+  testDeps?: { expectedIntentCid?: string },
+): { kind: 'resolved'; cid: string } | { kind: 'missing' } {
+  if (testDeps?.expectedIntentCid) {
+    return { kind: 'resolved', cid: testDeps.expectedIntentCid };
+  }
+  const v = intent.context?.[RESTORATION_INTENT_CID_CONTEXT_KEY];
+  if (typeof v === 'string' && v.length > 0) {
+    return { kind: 'resolved', cid: v };
+  }
+  return { kind: 'missing' };
+}

--- a/client/src/restorer/impls/prediction-apy-v0-baseline/index.ts
+++ b/client/src/restorer/impls/prediction-apy-v0-baseline/index.ts
@@ -70,14 +70,17 @@ export class PredictionApyV0BaselineImpl implements RestorerImpl {
     const parsed = PredictionApyV0IntentSchema.parse(ctx.intent);
     const { venue, pool, reserve } = parsed.spec.oracle;
     const { chain, chainId } = chainForVenue(venue);
-    const rpcUrl = this.config.rpcUrl ?? this.config.archiveRpcUrl;
+    const rpcUrl = this.config.archiveRpcUrl ?? this.config.rpcUrl;
+    // At submission time, resolveTs is usually in the future — cap the TWA
+    // window end at "now" so we only sample historical state (persistence baseline).
+    const windowEndForTwa = Math.min(parsed.spec.question.resolveTs, Date.now());
     let twApyBps: number;
     let sampleCount: number;
     if (this.config._testDeps?.twApyBpsOverWindow) {
       const result = await this.config._testDeps.twApyBpsOverWindow({
         pool: pool as `0x${string}`,
         reserve: reserve as `0x${string}`,
-        windowEndTs: parsed.spec.question.resolveTs,
+        windowEndTs: windowEndForTwa,
         twaWindowSeconds: parsed.spec.metric.twaWindowSeconds,
         sampleCount: parsed.spec.metric.sampleCount,
       });
@@ -93,7 +96,7 @@ export class PredictionApyV0BaselineImpl implements RestorerImpl {
         publicClient,
         pool: pool as `0x${string}`,
         reserve: reserve as `0x${string}`,
-        windowEndTs: parsed.spec.question.resolveTs,
+        windowEndTs: windowEndForTwa,
         twaWindowSeconds: parsed.spec.metric.twaWindowSeconds,
         sampleCount: parsed.spec.metric.sampleCount,
       });

--- a/client/src/restorer/impls/prediction-apy-v0-evaluator/canonical-metrics.ts
+++ b/client/src/restorer/impls/prediction-apy-v0-evaluator/canonical-metrics.ts
@@ -1,5 +1,9 @@
 import type { PredictionApyV0Intent } from '../../../types/prediction-apy.js';
 
+/**
+ * Shell for future metric kinds: today `twApyBps` is already integer-rounded
+ * from the Aave client; this keeps a single hook if we add more `metric.type`s.
+ */
 export function deriveGroundTruthBps(intent: PredictionApyV0Intent, twApyBps: number): string {
   if (intent.spec.metric.type !== 'supply-apy-twa-bps') {
     throw new Error(`unsupported metric: ${intent.spec.metric.type}`);

--- a/client/src/restorer/impls/prediction-apy-v0-evaluator/index.ts
+++ b/client/src/restorer/impls/prediction-apy-v0-evaluator/index.ts
@@ -6,14 +6,17 @@ import { privateKeyToAccount } from 'viem/accounts';
 import type { PublicClient } from 'viem';
 import type { RestorerImpl, RestorationContext, RestorationOutput } from '../../types.js';
 import type { DesiredState } from '../../../types/desired-state.js';
-import {
-  PredictionApyV0IntentSchema,
-  PredictionApySubmissionManifestSchema,
-  type PredictionApySubmissionManifest,
-  type PredictionApyVerdictManifest,
-} from '../../../types/prediction-apy.js';
+import { PredictionApyV0IntentSchema, type PredictionApyVerdictManifest } from '../../../types/prediction-apy.js';
 import { twApyBpsOverWindow } from '../../../venues/aave-v3/client.js';
+import {
+  checkIntentRef,
+  checkIntentRefMissingExpected,
+  checkManifestSignature,
+  recomputeTopLevelSignatureHash,
+} from '../prediction-v0-evaluator/checks/integrity.js';
+import { resolveExpectedRestorationIntentCid } from '../evaluation-context.js';
 import { deriveGroundTruthBps } from './canonical-metrics.js';
+import { parsePredictionApySubmissionManifest } from './parse-submission.js';
 import { computeScore } from './score.js';
 import type { Check, Verdict } from './types.js';
 
@@ -32,26 +35,6 @@ export interface PredictionApyV0EvaluatorConfig {
     }) => Promise<{ twApyBps: number; sampleCount: number }>;
     expectedIntentCid?: string;
   };
-}
-
-function parseSubmissionManifest(manifestJson: string): PredictionApySubmissionManifest {
-  const raw = JSON.parse(manifestJson) as Record<string, unknown>;
-  const direct = PredictionApySubmissionManifestSchema.safeParse(raw);
-  if (direct.success) return direct.data;
-  const normalized = {
-    schemaVersion: 'prediction.apy.v0.submission.v1',
-    generatedAt: raw['generatedAt'],
-    intent: raw['intent'],
-    restorer: raw['restorer'],
-    window: raw['window'],
-    prediction: {
-      predictedBps: String((raw['gating'] as Record<string, unknown> | undefined)?.['predictedBps'] ?? ''),
-      submittedAt: Number((raw['gating'] as Record<string, unknown> | undefined)?.['submittedAt'] ?? 0),
-      modelId: String((raw['gating'] as Record<string, unknown> | undefined)?.['modelId'] ?? ''),
-    },
-    signature: raw['signature'],
-  };
-  return PredictionApySubmissionManifestSchema.parse(normalized);
 }
 
 function chainForVenue(venue: 'aave-v3-base-sepolia' | 'aave-v3-base' | 'aave-v3-mainnet') {
@@ -80,8 +63,14 @@ export class PredictionApyV0Evaluator implements RestorerImpl {
   }
 
   async run(ctx: RestorationContext): Promise<RestorationOutput> {
+    const testDeps = (ctx as RestorationContext & { _testDeps?: PredictionApyV0EvaluatorConfig['_testDeps'] })._testDeps
+      ?? this.config._testDeps;
+    const expectedRef = resolveExpectedRestorationIntentCid(ctx.intent, testDeps);
+
     const intent = PredictionApyV0IntentSchema.parse(ctx.intent);
-    const submission = parseSubmissionManifest(ctx.intent.context!['restorationResult'] as string);
+    const manifestJson = ctx.intent.context!['restorationResult'] as string;
+    const rawPayload = JSON.parse(manifestJson) as Record<string, unknown>;
+    const submission = parsePredictionApySubmissionManifest(manifestJson);
     const checks: Check[] = [];
     const { venue, pool, reserve } = intent.spec.oracle;
     const { chain, chainId } = chainForVenue(venue);
@@ -89,8 +78,8 @@ export class PredictionApyV0Evaluator implements RestorerImpl {
     let twApyBps: number;
     let sampleCount: number;
     try {
-      if (this.config._testDeps?.twApyBpsOverWindow) {
-        const result = await this.config._testDeps.twApyBpsOverWindow({
+      if (testDeps?.twApyBpsOverWindow) {
+        const result = await testDeps.twApyBpsOverWindow({
           pool: pool as `0x${string}`,
           reserve: reserve as `0x${string}`,
           windowEndTs: intent.spec.question.resolveTs,
@@ -124,19 +113,38 @@ export class PredictionApyV0Evaluator implements RestorerImpl {
       sampleCount = 0;
     }
 
-    if (
-      submission.prediction.submittedAt >= intent.window.startTs &&
-      submission.prediction.submittedAt <= intent.window.endTs
-    ) {
-      checks.push({ name: 'eligibility.submission_within_window', status: 'PASS' });
-    } else {
-      checks.push({ name: 'eligibility.submission_within_window', status: 'FAIL' });
+    {
+      const sa = submission.prediction.submittedAt;
+      const w = intent.window;
+      const within = sa >= w.startTs && sa < w.endTs;
+      checks.push({
+        name: 'eligibility.submission_within_window',
+        status: within ? 'PASS' : 'FAIL',
+        detail: within ? undefined : { submittedAt: sa, startTs: w.startTs, endTs: w.endTs },
+      });
+    }
+    {
+      const sa = submission.prediction.submittedAt;
+      const w = intent.window;
+      const maxDelay = intent.eligibility.maxSubmissionDelayMs;
+      const within = sa <= w.startTs + maxDelay;
+      checks.push({
+        name: 'eligibility.submission_within_max_delay',
+        status: within ? 'PASS' : 'FAIL',
+        detail: within
+          ? undefined
+          : { submittedAt: sa, startTs: w.startTs, maxSubmissionDelayMs: maxDelay },
+      });
     }
 
-    if (submission.intent.cid === (this.config._testDeps?.expectedIntentCid ?? submission.intent.cid)) {
-      checks.push({ name: 'integrity.intent_ref', status: 'PASS' });
+    {
+      const recomputed = recomputeTopLevelSignatureHash(rawPayload);
+      checks.push(await checkManifestSignature(recomputed, submission.signature));
+    }
+    if (expectedRef.kind === 'missing') {
+      checks.push(checkIntentRefMissingExpected());
     } else {
-      checks.push({ name: 'integrity.intent_ref', status: 'FAIL' });
+      checks.push(checkIntentRef(submission.intent.cid, expectedRef.cid));
     }
 
     if (intent.spec.metric.toleranceBps > 0) {
@@ -171,7 +179,6 @@ export class PredictionApyV0Evaluator implements RestorerImpl {
         predictedBps: submission.prediction.predictedBps,
         submittedAt: submission.prediction.submittedAt,
         modelId: submission.prediction.modelId,
-        submissionManifestCid: 'inline',
       },
       groundTruth: {
         twApyBps: groundTruthBps,
@@ -205,9 +212,11 @@ export class PredictionApyV0Evaluator implements RestorerImpl {
 
 function deriveVerdict(checks: Check[]): Verdict {
   if (checks.some((c) => c.name.startsWith('availability.') && c.status !== 'PASS')) return 'INDETERMINATE';
+  if (checks.some((c) => c.name.startsWith('integrity.') && c.status === 'INDETERMINATE')) return 'INDETERMINATE';
   if (checks.some((c) => c.name.startsWith('eligibility.') && c.status === 'FAIL')) return 'REJECTED';
   if (checks.some((c) => (c.name.startsWith('integrity.') || c.name.startsWith('spec.')) && c.status === 'FAIL')) return 'FAIL';
   return 'PASS';
 }
 
+export { parsePredictionApySubmissionManifest } from './parse-submission.js';
 export default PredictionApyV0Evaluator;

--- a/client/src/restorer/impls/prediction-apy-v0-evaluator/parse-submission.ts
+++ b/client/src/restorer/impls/prediction-apy-v0-evaluator/parse-submission.ts
@@ -1,0 +1,32 @@
+import {
+  PredictionApySubmissionManifestSchema,
+  type PredictionApySubmissionManifest,
+} from '../../../types/prediction-apy.js';
+
+/**
+ * Parse a restoration submission for prediction.apy.v0. Engine-wrapped jobs store
+ * the prediction under `gating` (see manifest assembly); direct IPFS manifests
+ * use `prediction` per schema.
+ */
+export function parsePredictionApySubmissionManifest(manifestJson: string): PredictionApySubmissionManifest {
+  const raw = JSON.parse(manifestJson) as Record<string, unknown>;
+  const gating = raw['gating'] as Record<string, unknown> | undefined;
+  const gatingBps = gating?.['predictedBps'];
+  if (gating && (typeof gatingBps === 'string' || typeof gatingBps === 'number')) {
+    const normalized = {
+      schemaVersion: 'prediction.apy.v0.submission.v1',
+      generatedAt: raw['generatedAt'] ?? Date.now(),
+      intent: raw['intent'],
+      restorer: raw['restorer'],
+      window: raw['window'],
+      prediction: {
+        predictedBps: String(gatingBps),
+        submittedAt: Number(gating['submittedAt'] ?? 0),
+        modelId: String(gating['modelId'] ?? ''),
+      },
+      signature: raw['signature'],
+    };
+    return PredictionApySubmissionManifestSchema.parse(normalized);
+  }
+  return PredictionApySubmissionManifestSchema.parse(raw);
+}

--- a/client/src/restorer/impls/prediction-apy-v0-evaluator/types.ts
+++ b/client/src/restorer/impls/prediction-apy-v0-evaluator/types.ts
@@ -1,4 +1,4 @@
-export type CheckStatus = 'PASS' | 'FAIL' | 'SKIP';
+export type CheckStatus = 'PASS' | 'FAIL' | 'SKIP' | 'INDETERMINATE';
 
 export interface Check {
   name: string;

--- a/client/src/restorer/impls/prediction-v0-evaluator/checks/integrity.ts
+++ b/client/src/restorer/impls/prediction-v0-evaluator/checks/integrity.ts
@@ -1,4 +1,5 @@
-import { recoverAddress } from 'viem';
+import { keccak256, recoverAddress } from 'viem';
+import { canonicalJson } from '../../../engine/canonical-json.js';
 import type { Check } from '../types.js';
 import type { PredictionV0Intent, PredictionSubmissionManifest } from '../../../../types/prediction.js';
 
@@ -70,6 +71,15 @@ export function checkManifestFieldsPresent(
   return { name: 'integrity.manifest_fields_present', status: 'PASS' };
 }
 
+/**
+ * Recompute keccak256 over the canonical JSON of the top-level object after
+ * removing `signature` — the same pre-image the restorer `signCanonical` hashes.
+ */
+export function recomputeTopLevelSignatureHash(manifest: Record<string, unknown>): `0x${string}` {
+  const { signature: _sig, ...unsigned } = manifest;
+  return keccak256(new TextEncoder().encode(canonicalJson(unsigned))) as `0x${string}`;
+}
+
 export async function checkManifestSignature(
   canonicalHash: `0x${string}`,
   signature: PredictionSubmissionManifest['signature'],
@@ -99,5 +109,16 @@ export function checkIntentRef(manifestIntentCid: string, expectedIntentCid: str
     name: 'integrity.intent_ref',
     status: manifestIntentCid === expectedIntentCid ? 'PASS' : 'FAIL',
     detail: manifestIntentCid === expectedIntentCid ? undefined : { manifestIntentCid, expectedIntentCid },
+  };
+}
+
+export function checkIntentRefMissingExpected(): Check {
+  return {
+    name: 'integrity.intent_ref',
+    status: 'INDETERMINATE',
+    detail: {
+      reason:
+        'context.restorationIntentCid missing; cannot verify submission.intent.cid trustlessly',
+    },
   };
 }

--- a/client/src/restorer/impls/prediction-v0-evaluator/index.ts
+++ b/client/src/restorer/impls/prediction-v0-evaluator/index.ts
@@ -36,7 +36,10 @@ import {
   checkManifestFieldsPresent,
   checkManifestSignature,
   checkIntentRef,
+  checkIntentRefMissingExpected,
+  recomputeTopLevelSignatureHash,
 } from './checks/integrity.js';
+import { resolveExpectedRestorationIntentCid } from '../evaluation-context.js';
 import { checkQuestionKindSupported } from './checks/spec.js';
 
 export interface PredictionV0EvaluatorConfig {
@@ -108,6 +111,7 @@ export class PredictionV0Evaluator implements RestorerImpl {
     const { intent, workingDir, log } = ctx;
     // Support _testDeps injection from ctx (test) or config (constructor).
     const testDeps = (ctx as any)._testDeps ?? this.config._testDeps;
+    const expectedRef = resolveExpectedRestorationIntentCid(intent, testDeps);
 
     // 1. Parse intent — same spec the restorer ran under
     const predictionIntent = PredictionV0IntentSchema.parse(intent);
@@ -115,6 +119,7 @@ export class PredictionV0Evaluator implements RestorerImpl {
 
     // 2. Parse restorer's manifest from inlined context
     const manifestJson = intent.context!['restorationResult'] as string;
+    const rawPayload = JSON.parse(manifestJson) as Record<string, unknown>;
     const manifest = parseRestorationSubmissionManifest(manifestJson);
 
     // 3. Fetch Chainlink spanning round
@@ -154,8 +159,15 @@ export class PredictionV0Evaluator implements RestorerImpl {
     // integrity
     checks.push(checkWindowBounds(predictionIntent));
     checks.push(checkManifestFieldsPresent(manifest.prediction));
-    checks.push(await checkManifestSignature(manifest.signature.hash as `0x${string}`, manifest.signature));
-    checks.push(checkIntentRef(manifest.intent.cid, testDeps?.expectedIntentCid ?? manifest.intent.cid));
+    {
+      const recomputed = recomputeTopLevelSignatureHash(rawPayload);
+      checks.push(await checkManifestSignature(recomputed, manifest.signature));
+    }
+    if (expectedRef.kind === 'missing') {
+      checks.push(checkIntentRefMissingExpected());
+    } else {
+      checks.push(checkIntentRef(manifest.intent.cid, expectedRef.cid));
+    }
 
     // spec
     checks.push(checkQuestionKindSupported(predictionIntent.spec.question));
@@ -191,7 +203,7 @@ export class PredictionV0Evaluator implements RestorerImpl {
         probability: manifest.prediction.probability,
         submittedAt: manifest.prediction.submittedAt,
         modelId: manifest.prediction.modelId,
-        submissionManifestCid: 'inline',
+        // Omitted when no IPFS submission CID is available (inline / dev).
       },
       groundTruth,
       checks,
@@ -245,6 +257,8 @@ function deriveVerdict(checks: Check[]): Verdict {
   if (checks.some(c => c.name.startsWith('availability.') && c.status === 'FAIL')) return 'INDETERMINATE';
   // Any availability SKIP → INDETERMINATE (oracle not yet spanning)
   if (checks.some(c => c.name.startsWith('availability.') && c.status === 'SKIP')) return 'INDETERMINATE';
+  // Missing trust anchor for intent CID (e.g. legacy eval payload) → INDETERMINATE
+  if (checks.some(c => c.name.startsWith('integrity.') && c.status === 'INDETERMINATE')) return 'INDETERMINATE';
   // Any eligibility FAIL → REJECTED
   if (checks.some(c => c.name.startsWith('eligibility.') && c.status === 'FAIL')) return 'REJECTED';
   // Any integrity or spec FAIL → FAIL

--- a/client/src/restorer/impls/prediction-v0-evaluator/types.ts
+++ b/client/src/restorer/impls/prediction-v0-evaluator/types.ts
@@ -1,4 +1,4 @@
-export type CheckStatus = 'PASS' | 'FAIL' | 'SKIP';
+export type CheckStatus = 'PASS' | 'FAIL' | 'SKIP' | 'INDETERMINATE';
 
 export interface Check {
   name: string;

--- a/client/src/restorer/types.ts
+++ b/client/src/restorer/types.ts
@@ -11,6 +11,13 @@ import type { OutputArtifact, RationaleEntry, Snapshot } from '../types/portfoli
 
 export interface RestorationContext {
   intent: DesiredState;
+  /**
+   * IPFS CID of this job's desired state (from Marketplace / observe).
+   * Restorers' submission manifests should reference the same CID; evaluators
+   * compare it via integrity.intent_ref. May be an empty string when
+   * provenance is missing (dev / legacy).
+   */
+  intentCid?: string;
   /** Persistent directory for impl-specific state. */
   implStateDir: string;
   /** Ephemeral working directory (cleared between attempts). */

--- a/client/src/types/prediction-apy.ts
+++ b/client/src/types/prediction-apy.ts
@@ -46,7 +46,12 @@ export const PredictionApyV0SpecSchema = z.object({
 export type PredictionApyV0Spec = z.infer<typeof PredictionApyV0SpecSchema>;
 
 export const PredictionApyV0EligibilitySchema = z.object({
-  maxSubmissionDelayMs: z.number().int().default(60_000),
+  /**
+   * Latest time after window start for a valid submission: submittedAt ≤
+   * startTs + maxSubmissionDelayMs. Default 72h so it does not cut off
+   * late-in-window posts on long windows; tighten per market.
+   */
+  maxSubmissionDelayMs: z.number().int().min(1).default(72 * 3_600_000),
 });
 
 export type PredictionApyV0Eligibility = z.infer<typeof PredictionApyV0EligibilitySchema>;
@@ -79,10 +84,18 @@ export const PredictionApyV0IntentSchema = z
     message: 'resolve gap must be ≤ 8 days',
     path: ['spec', 'question', 'resolveTs'],
   })
-  .refine((d) => d.spec.metric.sampleCount <= d.spec.metric.twaWindowSeconds, {
-    message: 'sampleCount must be <= twaWindowSeconds',
-    path: ['spec', 'metric', 'sampleCount'],
-  });
+  .refine(
+    (d) => {
+      const { twaWindowSeconds, sampleCount } = d.spec.metric;
+      if (sampleCount < 2) return true;
+      const stepMs = Math.floor((twaWindowSeconds * 1000) / (sampleCount - 1));
+      return stepMs >= 1000;
+    },
+    {
+      message: 'TWA sample spacing must be at least 1 second (increase window or reduce sampleCount)',
+      path: ['spec', 'metric', 'sampleCount'],
+    },
+  );
 
 export type PredictionApyV0Intent = z.infer<typeof PredictionApyV0IntentSchema>;
 
@@ -123,7 +136,8 @@ export const PredictionApyVerdictManifestSchema = z.object({
     predictedBps: IntegerStringSchema,
     submittedAt: z.number().int(),
     modelId: z.string(),
-    submissionManifestCid: z.string(),
+    /** Present when the submission was registered on IPFS; omitted for inline/dev. */
+    submissionManifestCid: z.string().min(1).optional(),
   }),
   groundTruth: z.object({
     twApyBps: IntegerStringSchema,
@@ -132,7 +146,7 @@ export const PredictionApyVerdictManifestSchema = z.object({
   checks: z.array(
     z.object({
       name: z.string(),
-      status: z.enum(['PASS', 'FAIL', 'SKIP']),
+      status: z.enum(['PASS', 'FAIL', 'SKIP', 'INDETERMINATE']),
       detail: z.union([z.string(), z.record(z.unknown())]).optional(),
     }),
   ),

--- a/client/src/types/prediction.ts
+++ b/client/src/types/prediction.ts
@@ -132,7 +132,7 @@ export type PredictionSubmissionManifest = z.infer<typeof PredictionSubmissionMa
 
 const CheckSchema = z.object({
   name: z.string(),
-  status: z.enum(['PASS', 'FAIL', 'SKIP']),
+  status: z.enum(['PASS', 'FAIL', 'SKIP', 'INDETERMINATE']),
   detail: z.union([z.string(), z.record(z.unknown())]).optional(),
 });
 
@@ -157,7 +157,8 @@ export const PredictionVerdictManifestSchema = z.object({
     probability: z.string(),
     submittedAt: z.number().int(),
     modelId: z.string(),
-    submissionManifestCid: z.string(),
+    /** Present when the submission was registered on IPFS; omitted for inline/dev. */
+    submissionManifestCid: z.string().min(1).optional(),
   }),
   groundTruth: z.enum(['YES', 'NO']),
   checks: z.array(CheckSchema),

--- a/client/src/venues/aave-v3/client.ts
+++ b/client/src/venues/aave-v3/client.ts
@@ -63,9 +63,13 @@ export function liquidityRateRayToApyBps(rateRay: bigint): number {
 export async function findBlockAtOrBeforeTimestamp(
   publicClient: PublicClient,
   targetTsMs: number,
+  options?: { minBlock?: bigint },
 ): Promise<{ number: bigint; timestampMs: number }> {
   const latest = await publicClient.getBlock({ blockTag: 'latest' });
-  let lo = 0n;
+  let lo = options?.minBlock ?? 0n;
+  if (lo > latest.number) {
+    lo = 0n;
+  }
   let hi = latest.number;
   let best = 0n;
   while (lo <= hi) {
@@ -88,8 +92,11 @@ export async function readReserveRateAtTimestamp(
   pool: `0x${string}`,
   reserve: `0x${string}`,
   timestampMs: number,
+  options?: { minBlockForSearch?: bigint },
 ): Promise<ReserveRateReading> {
-  const block = await findBlockAtOrBeforeTimestamp(publicClient, timestampMs);
+  const block = await findBlockAtOrBeforeTimestamp(publicClient, timestampMs, {
+    minBlock: options?.minBlockForSearch,
+  });
   const reserveData = await publicClient.readContract({
     address: pool,
     abi: AAVE_POOL_ABI,
@@ -114,8 +121,12 @@ export async function twApyBpsOverWindow(params: {
 }): Promise<TwaApyBpsResult> {
   const sampleTs = scheduleSampleTimestamps(params.windowEndTs, params.twaWindowSeconds, params.sampleCount);
   let sum = 0;
+  let minBlock: bigint | undefined;
   for (const ts of sampleTs) {
-    const r = await readReserveRateAtTimestamp(params.publicClient, params.pool, params.reserve, ts);
+    const r = await readReserveRateAtTimestamp(params.publicClient, params.pool, params.reserve, ts, {
+      minBlockForSearch: minBlock,
+    });
+    minBlock = r.blockNumber;
     sum += liquidityRateRayToApyBps(r.currentLiquidityRateRay);
   }
   return {

--- a/client/test/adapters/mech/adapter.test.ts
+++ b/client/test/adapters/mech/adapter.test.ts
@@ -11,6 +11,10 @@ vi.mock('../../../src/adapters/mech/contracts.js', () => ({
   decodeMarketplaceRequestLogs: vi.fn().mockReturnValue([]),
   decodeDeliverLogs: vi.fn().mockReturnValue([]),
   callDeliverToMarketplace: vi.fn(),
+  findLatestRequestDataHexForMarketplaceRequest: vi.fn().mockResolvedValue(null),
+  findLatestDeliveryDataHexForRequest: vi.fn().mockResolvedValue(null),
+  scanRestorationJobs: vi.fn().mockResolvedValue([]),
+  scanEvaluationJobs: vi.fn().mockResolvedValue([]),
 }));
 
 // Mock IPFS
@@ -165,6 +169,30 @@ describe('MechAdapter with JinnRouter', () => {
         restorationResult: 'restoration output',
       },
     });
+
+    await adapter.stop();
+  });
+
+  it('defers evaluation job when restoration result is not in cache and chain backfill finds nothing', async () => {
+    const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+    const { submitEvaluationJob, findLatestDeliveryDataHexForRequest } = await import('../../../src/adapters/mech/contracts.js');
+    const { buildDesiredStatePayload } = await import('../../../src/adapters/mech/ipfs.js');
+
+    vi.mocked(findLatestDeliveryDataHexForRequest).mockResolvedValue(null);
+
+    const adapter = new MechAdapter(TEST_CONFIG);
+    await adapter.initialize();
+
+    const requestId = '0x' + 'aa'.repeat(32);
+    (adapter as any).pendingEvaluations.set(requestId, {
+      id: 'ds-1',
+      description: 'test',
+    });
+
+    await (adapter as any).tryCreateEvaluationJob(requestId);
+
+    expect(vi.mocked(buildDesiredStatePayload)).not.toHaveBeenCalled();
+    expect(submitEvaluationJob).not.toHaveBeenCalled();
 
     await adapter.stop();
   });

--- a/client/test/adapters/mech/adapter.test.ts
+++ b/client/test/adapters/mech/adapter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { MechAdapterConfig } from '../../../src/adapters/mech/types.js';
+import { RESTORATION_INTENT_CID_CONTEXT_KEY } from '../../../src/restorer/impls/evaluation-context.js';
 
 // Mock contract helpers
 vi.mock('../../../src/adapters/mech/contracts.js', () => ({
@@ -11,6 +12,8 @@ vi.mock('../../../src/adapters/mech/contracts.js', () => ({
   decodeMarketplaceRequestLogs: vi.fn().mockReturnValue([]),
   decodeDeliverLogs: vi.fn().mockReturnValue([]),
   callDeliverToMarketplace: vi.fn(),
+  scanLatestRequestDataByRid: vi.fn().mockResolvedValue(new Map()),
+  scanLatestDeliveryDataByRid: vi.fn().mockResolvedValue(new Map()),
   findLatestRequestDataHexForMarketplaceRequest: vi.fn().mockResolvedValue(null),
   findLatestDeliveryDataHexForRequest: vi.fn().mockResolvedValue(null),
   scanRestorationJobs: vi.fn().mockResolvedValue([]),
@@ -193,6 +196,82 @@ describe('MechAdapter with JinnRouter', () => {
 
     expect(vi.mocked(buildDesiredStatePayload)).not.toHaveBeenCalled();
     expect(submitEvaluationJob).not.toHaveBeenCalled();
+    expect((adapter as any).claimedButNotEvaluated.has(requestId)).toBe(true);
+
+    await adapter.stop();
+  });
+
+  it('recoverPendingState backfills restorationIntentCid from marketplace logs', async () => {
+    const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+    const {
+      scanRestorationJobs,
+      scanEvaluationJobs,
+      scanLatestRequestDataByRid,
+      scanLatestDeliveryDataByRid,
+    } = await import('../../../src/adapters/mech/contracts.js');
+
+    vi.mocked(scanRestorationJobs).mockResolvedValueOnce([{ requestId: '0x' + 'aa'.repeat(32), creator: TEST_CONFIG.safeAddress }]);
+    vi.mocked(scanEvaluationJobs).mockResolvedValueOnce([]);
+    vi.mocked(scanLatestRequestDataByRid).mockResolvedValueOnce(new Map([
+      [('0x' + 'aa'.repeat(32)).toLowerCase(), ('0x' + 'dd'.repeat(32)) as `0x${string}`],
+    ]));
+    vi.mocked(scanLatestDeliveryDataByRid).mockResolvedValueOnce(new Map());
+
+    const adapter = new MechAdapter(TEST_CONFIG);
+    await adapter.initialize();
+    (adapter as any).store = {
+      getLastProcessedBlock: () => 50n,
+      setLastProcessedBlock: vi.fn(),
+      savePendingEvaluation: vi.fn(),
+      getPendingEvaluations: vi.fn().mockReturnValue([]),
+      deletePendingEvaluation: vi.fn(),
+      saveDeliveryStatus: vi.fn(),
+      getDeliveryStatus: vi.fn(),
+      saveAttemptToResolveClaim: vi.fn(),
+      hasAttemptedToResolveClaim: vi.fn(),
+    };
+
+    (adapter as any).publicClient.readContract = vi.fn().mockResolvedValue([
+      '0x' + '00'.repeat(20),
+      '0x' + '00'.repeat(20),
+      TEST_CONFIG.safeAddress,
+      0n,
+      0n,
+      '0x' + '00'.repeat(32),
+    ]);
+
+    await (adapter as any).recoverPendingState(100n);
+
+    const pending = (adapter as any).pendingEvaluations.get('0x' + 'aa'.repeat(32));
+    expect(pending.context[RESTORATION_INTENT_CID_CONTEXT_KEY]).toBe(`f01551220${'dd'.repeat(32)}`);
+
+    await adapter.stop();
+  });
+
+  it('tryCreateEvaluationJob uses chain backfill result when cache is cold', async () => {
+    const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+    const { submitEvaluationJob, findLatestDeliveryDataHexForRequest } = await import('../../../src/adapters/mech/contracts.js');
+    const { buildDesiredStatePayload, fetchFromIpfs } = await import('../../../src/adapters/mech/ipfs.js');
+
+    vi.mocked(findLatestDeliveryDataHexForRequest).mockResolvedValueOnce(('0x' + 'ef'.repeat(32)) as `0x${string}`);
+    vi.mocked(fetchFromIpfs).mockResolvedValueOnce({ data: 'backfilled restoration output' });
+
+    const adapter = new MechAdapter(TEST_CONFIG);
+    await adapter.initialize();
+    (adapter as any).publicClient.readContract = vi.fn().mockResolvedValue(true);
+
+    const requestId = '0x' + 'aa'.repeat(32);
+    (adapter as any).pendingEvaluations.set(requestId, {
+      id: 'ds-1',
+      description: 'test',
+    });
+
+    await (adapter as any).tryCreateEvaluationJob(requestId);
+
+    expect(vi.mocked(buildDesiredStatePayload).mock.calls.at(-1)?.[0]).toMatchObject({
+      context: { restorationResult: 'backfilled restoration output' },
+    });
+    expect(submitEvaluationJob).toHaveBeenCalled();
 
     await adapter.stop();
   });

--- a/client/test/adapters/mech/ipfs.test.ts
+++ b/client/test/adapters/mech/ipfs.test.ts
@@ -1,96 +1,40 @@
-import { describe, it, expect } from 'vitest';
-import { buildDesiredStatePayload, parseDesiredStateFromPayload, cidToDigestHex, digestHexToGatewayUrl } from '../../../src/adapters/mech/ipfs.js';
+import { describe, expect, it } from 'vitest';
+import {
+  buildIpfsFetchCidPathCandidates,
+  buildIpfsHexCidCandidatesFromPartialHex,
+  normalizeIpfsGatewayBase,
+} from '../../../src/adapters/mech/ipfs.js';
 
-describe('IPFS utilities', () => {
-  it('serializes a desired state to IPFS payload', () => {
-    const payload = buildDesiredStatePayload({
-      id: 'ds-1',
-      description: 'Test state',
-      context: { key: 'value' },
-    });
-    expect(payload.description).toBe('Test state');
-    expect(payload.desiredStateId).toBe('ds-1');
-    expect(payload.context).toEqual({ key: 'value' });
-  });
-
-  it('deserializes an IPFS payload back to a desired state', () => {
-    const payload = { desiredStateId: 'ds-1', description: 'Test', context: { key: 'value' } };
-    const state = parseDesiredStateFromPayload(payload);
-    expect(state.id).toBe('ds-1');
-    expect(state.description).toBe('Test');
-  });
-
-  it('round-trips a portfolio.v0 intent through JSON with spec/window/eligibility intact', () => {
-    const intent = {
-      id: 'portfolio-v0-roundtrip',
-      description: 'Grow HL testnet portfolio 5% in 24h with 10% max drawdown.',
-      window: { startTs: 1_776_495_469_000, endTs: 1_776_581_869_000 },
-      spec: {
-        kind: 'portfolio.v0',
-        account: {
-          venue: 'hyperliquid-testnet',
-          masterAddress: '0xc7B5aB63dfd2B1d8b7CD1761465aFB316aFA03dF',
-        },
-        target: { metric: 'equity_return_pct', minReturnPct: 5.0 },
-        constraint: { maxDrawdownPct: 10.0 },
-      },
-      eligibility: { minClosedTrades: 20, minTradedNotionalMultiple: 5.0 },
-    };
-
-    const payload = buildDesiredStatePayload(intent);
-    expect(payload.spec).toEqual(intent.spec);
-    expect(payload.window).toEqual(intent.window);
-    expect(payload.eligibility).toEqual(intent.eligibility);
-
-    // Full JSON round-trip — what actually happens on the IPFS wire.
-    const roundTripped = parseDesiredStateFromPayload(
-      JSON.parse(JSON.stringify(payload)) as Record<string, unknown>,
+describe('ipfs gateway + CID helpers (jinn-node parity)', () => {
+  it('normalizeIpfsGatewayBase handles origin-only, /ipfs suffix, and trailing slashes', () => {
+    expect(normalizeIpfsGatewayBase('https://gateway.autonolas.tech')).toBe(
+      'https://gateway.autonolas.tech/ipfs/',
     );
-
-    expect(roundTripped.id).toBe(intent.id);
-    expect(roundTripped.description).toBe(intent.description);
-    expect(roundTripped.spec).toEqual(intent.spec);
-    expect(roundTripped.window).toEqual(intent.window);
-    expect(roundTripped.eligibility).toEqual(intent.eligibility);
-    expect((roundTripped.spec as { kind: string }).kind).toBe('portfolio.v0');
-    expect(roundTripped.window?.endTs! - roundTripped.window?.startTs!).toBe(86_400_000);
+    expect(normalizeIpfsGatewayBase('https://gateway.autonolas.tech/ipfs')).toBe(
+      'https://gateway.autonolas.tech/ipfs/',
+    );
+    expect(normalizeIpfsGatewayBase('https://gateway.autonolas.tech/ipfs/')).toBe(
+      'https://gateway.autonolas.tech/ipfs/',
+    );
   });
 
-  it('parses a legacy payload (no spec/window/eligibility) with those fields undefined', () => {
-    const legacyPayload = {
-      desiredStateId: 'legacy-health-check',
-      description: 'The service is running.',
-      type: 'restoration' as const,
-      attemptId: 'legacy-health-check/1',
-      attemptNumber: 1,
-    };
-
-    const state = parseDesiredStateFromPayload(legacyPayload);
-    expect(state.id).toBe('legacy-health-check');
-    expect(state.attemptNumber).toBe(1);
-    expect(state.spec).toBeUndefined();
-    expect(state.window).toBeUndefined();
-    expect(state.eligibility).toBeUndefined();
+  it('buildIpfsHexCidCandidatesFromPartialHex returns raw then dag-pb for 32-byte digest', () => {
+    const d = 'a'.repeat(64);
+    expect(buildIpfsHexCidCandidatesFromPartialHex(d)).toEqual([
+      `f01551220${d}`,
+      `f01701220${d}`,
+    ]);
   });
 
-  it('extracts a 32-byte SHA256 digest from a CIDv0', () => {
-    // CIDv0: QmYwAPJzv5CZsnN625s3Xf2nemtYgPpHdWEz79ojWnPbdG
-    // This is a well-known IPFS CID (empty directory)
-    const cid = 'QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn';
-    const digest = cidToDigestHex(cid);
-    expect(digest).toMatch(/^0x[0-9a-f]{64}$/);
-    expect(digest.length).toBe(66); // 0x + 64 hex chars = 32 bytes
+  it('buildIpfsFetchCidPathCandidates expands f015 full hex to both codecs', () => {
+    const d = 'b'.repeat(64);
+    const f015 = `f01551220${d}`;
+    expect(buildIpfsFetchCidPathCandidates(f015)).toEqual([`f01551220${d}`, `f01701220${d}`]);
   });
 
-  it('constructs a gateway URL from a digest hex', () => {
-    const digest = '0x' + 'ab'.repeat(32);
-    const url = digestHexToGatewayUrl(digest);
-    expect(url).toBe('https://gateway.autonolas.tech/ipfs/f01551220' + 'ab'.repeat(32));
-  });
-
-  it('constructs a gateway URL without 0x prefix', () => {
-    const digest = 'cd'.repeat(32);
-    const url = digestHexToGatewayUrl(digest);
-    expect(url).toBe('https://gateway.autonolas.tech/ipfs/f01551220' + 'cd'.repeat(32));
+  it('buildIpfsFetchCidPathCandidates passes through base32 CIDs unchanged', () => {
+    const bafy =
+      'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi';
+    expect(buildIpfsFetchCidPathCandidates(bafy)).toEqual([bafy]);
   });
 });

--- a/client/test/restorer/impls/prediction-apy-v0-evaluator/index.test.ts
+++ b/client/test/restorer/impls/prediction-apy-v0-evaluator/index.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { privateKeyToAccount } from 'viem/accounts';
+import { PredictionApyV0Evaluator } from '../../../../src/restorer/impls/prediction-apy-v0-evaluator/index.js';
+import { signCanonical } from '../../../../src/restorer/engine/signing.js';
+import { RESTORATION_INTENT_CID_CONTEXT_KEY } from '../../../../src/restorer/impls/evaluation-context.js';
+import type { DesiredState } from '../../../../src/types/desired-state.js';
+import type { RestorationContext } from '../../../../src/restorer/types.js';
+
+const PK = ('0x' + 'e'.repeat(64)) as `0x${string}`;
+const AGENT_PK = ('0x' + '1'.repeat(64)) as `0x${string}`;
+
+const intentProv = (cid: string) => ({
+  cid,
+  onchainCreationTx: '0x' + 'ab'.repeat(32),
+  onchainCreationBlock: 1,
+  requestId: '0x' + 'cd'.repeat(32),
+});
+
+async function makeSignedApyManifestJson(overrides: { submittedAt?: number; intentCid?: string; corruptSignature?: boolean } = {}) {
+  const account = privateKeyToAccount(AGENT_PK);
+  const unsigned: Record<string, unknown> = {
+    schemaVersion: 'prediction.apy.v0.submission.v1',
+    generatedAt: 1_000,
+    intent: intentProv(overrides.intentCid ?? 'expected-cid'),
+    restorer: { safeAddress: '0x' + '44'.repeat(20), agentEoa: account.address },
+    window: { startTs: 0, endTs: 600_000 },
+    prediction: {
+      predictedBps: '100',
+      submittedAt: overrides.submittedAt ?? 100_000,
+      modelId: 'apy-persistence.v1',
+    },
+  };
+  const s = await signCanonical(unsigned, AGENT_PK, account.address);
+  const full = {
+    ...unsigned,
+    signature: {
+      algo: 'secp256k1' as const,
+      signer: account.address,
+      hash: s.hash,
+      sig: overrides.corruptSignature ? (('0x' + 'a'.repeat(130)) as `0x${string}`) : s.sig,
+    },
+  };
+  return JSON.stringify(full);
+}
+
+function makeEvalIntent(
+  manifestJson: string,
+  options?: { omitRestorationIntentCid?: boolean; restorationIntentCid?: string },
+): DesiredState {
+  return {
+    id: 'eval-apy',
+    description: 'e',
+    type: 'evaluation',
+    window: { startTs: 0, endTs: 600_000 },
+    spec: {
+      kind: 'prediction.apy.v0',
+      oracle: {
+        venue: 'aave-v3-base-sepolia',
+        pool: '0x6Ae43d3271ff6888e7Fc43Fd7321a503ff738951',
+        reserve: '0x31d3A7711a10C45D72649D51E1c8D74282702572',
+        reserveSymbol: 'USDC',
+      },
+      metric: { type: 'supply-apy-twa-bps', twaWindowSeconds: 3600, sampleCount: 12, toleranceBps: 100 },
+      question: { resolveTs: 900_000 },
+    },
+    eligibility: {},
+    context: {
+      restorationResult: manifestJson,
+      ...(options?.omitRestorationIntentCid
+        ? {}
+        : { [RESTORATION_INTENT_CID_CONTEXT_KEY]: options?.restorationIntentCid ?? 'expected-cid' }),
+    },
+  } as unknown as DesiredState;
+}
+
+function makeCtx(intent: DesiredState, intentCid: string, testDeps: Record<string, unknown> = {}): RestorationContext {
+  const d = mkdtempSync(join(tmpdir(), 'apy-eval-'));
+  return {
+    intent,
+    intentCid,
+    implStateDir: d,
+    workingDir: d,
+    log: () => {},
+    abort: new AbortController().signal,
+    msUntilEndTs: () => 0,
+    _testDeps: testDeps,
+  } as unknown as RestorationContext;
+}
+
+describe('PredictionApyV0Evaluator', () => {
+  it('PASS with stubbed TWA and matching intentCid', async () => {
+    const manifest = await makeSignedApyManifestJson();
+    const evalIntent = makeEvalIntent(manifest);
+    const ev = new PredictionApyV0Evaluator({
+      evaluatorPk: PK,
+      evaluatorSafeAddress: '0x0000000000000000000000000000000000000003',
+    });
+    const out = await ev.run(
+      makeCtx(evalIntent, 'expected-cid', {
+        twApyBpsOverWindow: async () => ({ twApyBps: 100, sampleCount: 12 }),
+      }),
+    );
+    expect(out.gating.verdict).toBe('PASS');
+  });
+
+  it('REJECTED when submitted after window', async () => {
+    const manifest = await makeSignedApyManifestJson({ submittedAt: 700_000 });
+    const evalIntent = makeEvalIntent(manifest);
+    const ev = new PredictionApyV0Evaluator({
+      evaluatorPk: PK,
+      evaluatorSafeAddress: '0x0000000000000000000000000000000000000003',
+    });
+    const out = await ev.run(
+      makeCtx(evalIntent, 'expected-cid', {
+        twApyBpsOverWindow: async () => ({ twApyBps: 100, sampleCount: 12 }),
+      }),
+    );
+    expect(out.gating.verdict).toBe('REJECTED');
+  });
+
+  it('FAIL when manifest intent cid does not match context.restorationIntentCid', async () => {
+    const manifest = await makeSignedApyManifestJson({ intentCid: 'wrong' });
+    const evalIntent = makeEvalIntent(manifest);
+    const ev = new PredictionApyV0Evaluator({
+      evaluatorPk: PK,
+      evaluatorSafeAddress: '0x0000000000000000000000000000000000000003',
+    });
+    const out = await ev.run(
+      makeCtx(evalIntent, 'expected-cid', {
+        twApyBpsOverWindow: async () => ({ twApyBps: 100, sampleCount: 12 }),
+      }),
+    );
+    expect(out.gating.verdict).toBe('FAIL');
+  });
+
+  it('uses context.restorationIntentCid when it differs from ctx.intentCid (eval job vs restoration)', async () => {
+    const manifest = await makeSignedApyManifestJson({ intentCid: 'restoration-cid' });
+    const evalIntent = makeEvalIntent(manifest, { restorationIntentCid: 'restoration-cid' });
+    const ev = new PredictionApyV0Evaluator({
+      evaluatorPk: PK,
+      evaluatorSafeAddress: '0x0000000000000000000000000000000000000003',
+    });
+    const out = await ev.run(
+      makeCtx(evalIntent, 'evaluation-desired-state-cid', {
+        twApyBpsOverWindow: async () => ({ twApyBps: 100, sampleCount: 12 }),
+      }),
+    );
+    expect(out.gating.verdict).toBe('PASS');
+  });
+
+  it('INDETERMINATE when context.restorationIntentCid is missing (legacy eval payload)', async () => {
+    const manifest = await makeSignedApyManifestJson();
+    const evalIntent = makeEvalIntent(manifest, { omitRestorationIntentCid: true });
+    const ev = new PredictionApyV0Evaluator({
+      evaluatorPk: PK,
+      evaluatorSafeAddress: '0x0000000000000000000000000000000000000003',
+    });
+    const out = await ev.run(
+      makeCtx(evalIntent, 'any-eval-cid', {
+        twApyBpsOverWindow: async () => ({ twApyBps: 100, sampleCount: 12 }),
+      }),
+    );
+    expect(out.gating.verdict).toBe('INDETERMINATE');
+  });
+
+  it('FAIL on bad signature', async () => {
+    const manifest = await makeSignedApyManifestJson({ corruptSignature: true });
+    const evalIntent = makeEvalIntent(manifest);
+    const ev = new PredictionApyV0Evaluator({
+      evaluatorPk: PK,
+      evaluatorSafeAddress: '0x0000000000000000000000000000000000000003',
+    });
+    const out = await ev.run(
+      makeCtx(evalIntent, 'expected-cid', {
+        twApyBpsOverWindow: async () => ({ twApyBps: 100, sampleCount: 12 }),
+      }),
+    );
+    expect(out.gating.verdict).toBe('FAIL');
+  });
+});

--- a/client/test/restorer/impls/prediction-apy-v0-evaluator/parse-submission.test.ts
+++ b/client/test/restorer/impls/prediction-apy-v0-evaluator/parse-submission.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { parsePredictionApySubmissionManifest } from '../../../../src/restorer/impls/prediction-apy-v0-evaluator/parse-submission.js';
+
+const intentProv = {
+  cid: 'bafytest',
+  onchainCreationTx: '0x' + 'ab'.repeat(32),
+  onchainCreationBlock: 1,
+  requestId: '0x' + 'cd'.repeat(32),
+};
+
+function sigStub() {
+  return {
+    algo: 'secp256k1' as const,
+    signer: '0x' + '11'.repeat(20),
+    hash: '0x' + '22'.repeat(32),
+    sig: '0x' + '33'.repeat(65),
+  };
+}
+
+describe('parsePredictionApySubmissionManifest', () => {
+  it('normalizes engine gating shape', () => {
+    const raw = {
+      schemaVersion: 'prediction.apy.v0.submission.v1',
+      generatedAt: 1_000,
+      intent: intentProv,
+      restorer: { safeAddress: '0x' + '44'.repeat(20), agentEoa: '0x' + '55'.repeat(20) },
+      window: { startTs: 0, endTs: 600_000 },
+      gating: { predictedBps: '42', submittedAt: 100_000, modelId: 'apy-persistence.v1' },
+      signature: sigStub(),
+    };
+    const m = parsePredictionApySubmissionManifest(JSON.stringify(raw));
+    expect(m.prediction.predictedBps).toBe('42');
+    expect(m.prediction.submittedAt).toBe(100_000);
+  });
+
+  it('accepts direct schema-shaped manifest', () => {
+    const raw = {
+      schemaVersion: 'prediction.apy.v0.submission.v1',
+      generatedAt: 1_000,
+      intent: intentProv,
+      restorer: { safeAddress: '0x' + '44'.repeat(20), agentEoa: '0x' + '55'.repeat(20) },
+      window: { startTs: 0, endTs: 600_000 },
+      prediction: { predictedBps: '7', submittedAt: 200_000, modelId: 'm' },
+      signature: sigStub(),
+    };
+    const m = parsePredictionApySubmissionManifest(JSON.stringify(raw));
+    expect(m.prediction.modelId).toBe('m');
+  });
+
+  it('throws on invalid json', () => {
+    expect(() => parsePredictionApySubmissionManifest('not json')).toThrow();
+  });
+});

--- a/client/test/restorer/impls/prediction-apy-v0-evaluator/score.test.ts
+++ b/client/test/restorer/impls/prediction-apy-v0-evaluator/score.test.ts
@@ -12,4 +12,21 @@ describe('prediction-apy-v0 evaluator score', () => {
     const out = computeScore('REJECTED', '450', '430', 50);
     expect(out.score).toBe('0');
   });
+
+  it('returns zero when error meets tolerance (boundary)', () => {
+    const out = computeScore('PASS', '500', '450', 50);
+    expect(out.errorBps).toBe('50');
+    expect(out.score).toBe('0');
+  });
+
+  it('returns partial score inside band', () => {
+    const out = computeScore('PASS', '470', '450', 100);
+    expect(out.errorBps).toBe('20');
+    expect(out.score).toBe('800000000000000000');
+  });
+
+  it('returns zero for INDETERMINATE even with low error', () => {
+    const out = computeScore('INDETERMINATE', '100', '100', 50);
+    expect(out.score).toBe('0');
+  });
 });

--- a/client/test/restorer/impls/prediction-v0-evaluator/index.test.ts
+++ b/client/test/restorer/impls/prediction-v0-evaluator/index.test.ts
@@ -2,13 +2,16 @@ import { describe, it, expect } from 'vitest';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { privateKeyToAccount } from 'viem/accounts';
 import { PredictionV0Evaluator } from '../../../../src/restorer/impls/prediction-v0-evaluator/index.js';
+import { signCanonical } from '../../../../src/restorer/engine/signing.js';
 import { makeValidIntent, makeSignedManifest, makeEvalDesiredState } from './test-helpers.js';
 
 function makeCtx(intent: any, deps: any) {
   const tmp = mkdtempSync(join(tmpdir(), 'pred-eval-'));
   return {
     intent,
+    intentCid: 'intent-cid',
     implStateDir: tmp,
     workingDir: tmp,
     log: () => {},
@@ -26,7 +29,6 @@ function spanningDeps(priceAtResolve: string) {
       nextRound: { roundId: 2n, answer: 0n, startedAt: 4_500_001, updatedAt: 4_500_001, answeredInRound: 2n, decimals: 8 },
       spanning: true,
     }),
-    expectedIntentCid: 'intent-cid',
   };
 }
 
@@ -50,7 +52,9 @@ describe('PredictionV0Evaluator — verdict pipeline', () => {
   it('accepts the engine outer manifest produced by prediction restorations', async () => {
     const intent = makeValidIntent();
     const manifest = await makeSignedManifest({ probability: '0.55', submittedAt: 100, intentCid: 'intent-cid' });
-    const outerManifest = {
+    const pk = ('0x' + '1'.repeat(64)) as `0x${string}`;
+    const account = privateKeyToAccount(pk);
+    const unsignedOuter: Record<string, unknown> = {
       schemaVersion: 'portfolio.v0.manifest.v1',
       generatedAt: manifest.generatedAt,
       intent: manifest.intent,
@@ -61,9 +65,13 @@ describe('PredictionV0Evaluator — verdict pipeline', () => {
       fills: [],
       gating: manifest.prediction,
       artifacts: [],
-      signature: manifest.signature,
     };
-    const evalIntent = makeEvalDesiredState(outerManifest as any, intent);
+    const s = await signCanonical(unsignedOuter, pk, account.address);
+    const outerManifest = {
+      ...unsignedOuter,
+      signature: { algo: 'secp256k1' as const, signer: account.address, hash: s.hash, sig: s.sig },
+    };
+    const evalIntent = makeEvalDesiredState(outerManifest, intent);
     const evaluator = new PredictionV0Evaluator({
       evaluatorPk,
       evaluatorSafeAddress: '0x0000000000000000000000000000000000000003',
@@ -95,6 +103,15 @@ describe('PredictionV0Evaluator — verdict pipeline', () => {
     expect(out.gating.score).toBe('0');
   });
 
+  it('INDETERMINATE when context.restorationIntentCid is missing (legacy eval payload)', async () => {
+    const intent = makeValidIntent();
+    const manifest = await makeSignedManifest({ intentCid: 'intent-cid' });
+    const evalIntent = makeEvalDesiredState(manifest, intent, { omitRestorationIntentCid: true });
+    const evaluator = new PredictionV0Evaluator({ evaluatorPk, evaluatorSafeAddress: '0x0000000000000000000000000000000000000003' });
+    const out = await evaluator.run(makeCtx(evalIntent, spanningDeps('3501')));
+    expect(out.gating.verdict).toBe('INDETERMINATE');
+  });
+
   it('INDETERMINATE when oracle has no spanning round', async () => {
     const intent = makeValidIntent();
     const manifest = await makeSignedManifest({ intentCid: 'intent-cid' });
@@ -106,7 +123,6 @@ describe('PredictionV0Evaluator — verdict pipeline', () => {
         nextRound: null,
         spanning: false,
       }),
-      expectedIntentCid: 'intent-cid',
     }));
     expect(out.gating.verdict).toBe('INDETERMINATE');
   });

--- a/client/test/restorer/impls/prediction-v0-evaluator/test-helpers.ts
+++ b/client/test/restorer/impls/prediction-v0-evaluator/test-helpers.ts
@@ -1,7 +1,8 @@
 import { privateKeyToAccount } from 'viem/accounts';
-import { keccak256, stringToHex } from 'viem';
 import type { PredictionSubmissionManifest, PredictionV0Intent } from '../../../../src/types/prediction.js';
 import type { DesiredState } from '../../../../src/types/desired-state.js';
+import { signCanonical } from '../../../../src/restorer/engine/signing.js';
+import { RESTORATION_INTENT_CID_CONTEXT_KEY } from '../../../../src/restorer/impls/evaluation-context.js';
 
 export function makeValidIntent(overrides: Partial<PredictionV0Intent> = {}): PredictionV0Intent {
   return {
@@ -47,15 +48,17 @@ export async function makeSignedManifest(overrides: {
       modelId: 'spot-carry.v1',
     },
   };
-  const canonical = JSON.stringify(base);
-  const hash = keccak256(stringToHex(canonical));
-  // account.sign({hash}) is raw ECDSA (no EIP-191). recoverAddress in
-  // checkManifestSignature must use the same semantic.
-  const sig = overrides.corruptSignature ? ('0x' + 'a'.repeat(130)) as `0x${string}` : await account.sign({ hash });
-  return { ...base, signature: { algo: 'secp256k1' as const, signer: account.address, hash, sig } };
+  const s = await signCanonical(base, pk, account.address);
+  const sig = overrides.corruptSignature ? (('0x' + 'a'.repeat(130)) as `0x${string}`) : s.sig;
+  return { ...base, signature: { algo: 'secp256k1' as const, signer: account.address, hash: s.hash, sig } };
 }
 
-export function makeEvalDesiredState(manifest: PredictionSubmissionManifest, intent: PredictionV0Intent): DesiredState {
+export function makeEvalDesiredState(
+  manifest: PredictionSubmissionManifest | Record<string, unknown>,
+  intent: PredictionV0Intent,
+  options?: { omitRestorationIntentCid?: boolean },
+): DesiredState {
+  const m = manifest as { intent: { cid: string } };
   return {
     id: 'eval',
     description: 'evaluate',
@@ -64,6 +67,11 @@ export function makeEvalDesiredState(manifest: PredictionSubmissionManifest, int
     window: intent.window,
     spec: intent.spec,
     eligibility: intent.eligibility,
-    context: { restorationResult: JSON.stringify(manifest) },
+    context: {
+      restorationResult: JSON.stringify(manifest),
+      ...(options?.omitRestorationIntentCid
+        ? {}
+        : { [RESTORATION_INTENT_CID_CONTEXT_KEY]: m.intent.cid }),
+    },
   } as unknown as DesiredState;
 }

--- a/client/test/types/prediction-apy.test.ts
+++ b/client/test/types/prediction-apy.test.ts
@@ -25,8 +25,36 @@ describe('PredictionApyV0IntentSchema', () => {
           resolveTs: 1_700_000_900_000,
         },
       },
-      eligibility: { maxSubmissionDelayMs: 60_000 },
+      eligibility: {},
     });
     expect(parsed.spec.metric.sampleCount).toBe(12);
+    expect(parsed.eligibility.maxSubmissionDelayMs).toBe(72 * 3_600_000);
+  });
+
+  it('rejects TWA sample spacing under 1 second', () => {
+    expect(() =>
+      PredictionApyV0IntentSchema.parse({
+        id: 'x',
+        description: 'd',
+        window: { startTs: 0, endTs: 3_600_000 },
+        spec: {
+          kind: 'prediction.apy.v0',
+          oracle: {
+            venue: 'aave-v3-base-sepolia',
+            pool: '0x6Ae43d3271ff6888e7Fc43Fd7321a503ff738951',
+            reserve: '0x31d3A7711a10C45D72649D51E1c8D74282702572',
+            reserveSymbol: 'USDC',
+          },
+          metric: {
+            type: 'supply-apy-twa-bps',
+            twaWindowSeconds: 100,
+            sampleCount: 102,
+            toleranceBps: 50,
+          },
+          question: { resolveTs: 3_600_000 },
+        },
+        eligibility: {},
+      }),
+    ).toThrow();
   });
 });

--- a/spec/2026-04-22-prediction-apy-v0-design.md
+++ b/spec/2026-04-22-prediction-apy-v0-design.md
@@ -25,6 +25,8 @@ Status: draft
 - Intent window: 10 minutes (`windowDurationMs = 600_000`).
 - Resolve gap: 5 minutes (`resolveGapMs = 300_000`).
 - TWA: 1 hour (`twaWindowSeconds = 3600`) with 12 samples.
+- Baseline restorer: TWA `windowEnd` is `min(resolveTs, now)` at submission time so samples stay in the past. Evaluator at resolution uses `resolveTs` as the window end.
+- Testnet: optional `prediction.apy.v0` auto-intents when `JINN_ENABLE_APY_AUTO_INTENTS=1` (off by default; `prediction.v0` auto remains the default loop activity).
 
 ## Mainnet profile defaults
 
@@ -41,17 +43,26 @@ Status: draft
 - Score basis: `absolute-error-linear.v1`.
 - Formula: `score = max(0, 1 - error/toleranceBps)` scaled to 1e18.
 
+## Verdict manifest
+
+- `claimed.submissionManifestCid` is optional (omit when no IPFS child CID; do not use a placeholder string).
+
 ## Checks
 
 1. availability: Aave pool/reserve data readable for every sample point.
-2. eligibility: submission timestamp is inside intent window.
-3. integrity: signed submission manifest + intent CID linkage.
-4. spec: valid sample/twa parameters and positive tolerance.
+2. eligibility: `submittedAt` in `[window.startTs, window.endTs)`; and `submittedAt ≤ window.startTs + eligibility.maxSubmissionDelayMs` (default 72h in schema so short windows are not accidentally cut off by a 60s default).
+3. integrity:
+   - `integrity.manifest_signature`: recompute the keccak256 over the canonical unsigned JSON (same as restorer `signCanonical`) and verify the secp256k1 signature.
+   - `integrity.intent_ref`: compare the submission manifest’s `intent.cid` to the **restoration** job’s intended-state IPFS CID. The evaluation job’s `DesiredState` is a different IPFS object; the protocol therefore requires `context.restorationIntentCid` on the **evaluation** `DesiredState` (set by Jinn’s mech adapter when it creates the eval job from a delivered restoration). If that key is missing (e.g. legacy or third-party eval jobs), the check is `INDETERMINATE` — the evaluator does **not** fall back to the evaluation job’s `intentCid` (which would be the wrong reference and cause false `FAIL` / false `PASS` bugs).
+4. spec: valid TWA sample spacing (≥1s between samples), and positive tolerance.
 
-Failures map to verdicts:
+Verdicts:
 
-- availability fail/skip -> `INDETERMINATE`
+- availability fail -> `INDETERMINATE`
+- any `integrity.*` with status `INDETERMINATE` (e.g. missing `context.restorationIntentCid`) -> `INDETERMINATE`
 - eligibility fail -> `REJECTED`
-- integrity/spec fail -> `FAIL`
+- other integrity or spec fail -> `FAIL`
 - all pass -> `PASS`
+
+`prediction.v0` evaluation uses the same `context.restorationIntentCid` rule and the same `integrity.*` / `INDETERMINATE` ordering.
 


### PR DESCRIPTION
## Summary
- harden Mech adapter evaluation-job recovery by preserving restoration context, deferring eval creation until restoration results exist, and reducing repeated recovery log scans
- add APY evaluator integrity and schema alignment updates (intent-ref behavior, signature verification flow, INDETERMINATE check status wiring)
- add and verify a production-shaped `prediction.apy.v0` full-loop e2e runner (`yarn e2e-prediction-apy-v0`) and expose it via package scripts

## Test plan
- [x] `cd client && yarn typecheck`
- [x] `cd client && yarn test`
- [x] `cd client && yarn e2e`
- [x] `cd client && yarn e2e-prediction-apy-v0`
- [x] `cd client && yarn vitest run test/restorer/impls/prediction-apy-v0-evaluator test/restorer/impls/prediction-apy-v0-baseline test/venues/aave-v3`

Made with [Cursor](https://cursor.com)