### PR TITLE
Harden operator dogfood flows

### DIFF
--- a/client/src/adapters/mech/adapter.ts
+++ b/client/src/adapters/mech/adapter.ts
@@ -38,6 +38,7 @@ import { type MechAdapterConfig, MECH_MARKETPLACE_ABI } from './types.js';
 import type { Store } from '../../store/store.js';
 import { type ClaimPolicy, AcceptAllPolicy } from './claim-policy.js';
 import { withRecoverableRetry } from '../../tx-retry.js';
+import { formatRpcError } from '../../rpc-error-context.js';
 import { computeEvidenceSimHash, type EvidenceCheckpointV1 } from '../../earning/evidence-simhash.js';
 import { RESTORATION_INTENT_CID_CONTEXT_KEY } from '../../restorer/impls/evaluation-context.js';
 
@@ -86,7 +87,14 @@ export class MechAdapter implements ExecutionAdapter {
       async () => this.publicClient.getBlockNumber(),
       {
         onRetry: ({ attempt, message }) => {
-          console.error(`[mech] getBlockNumber retry ${attempt}: ${message}`);
+          console.error(
+            `[mech] getBlockNumber retry ${attempt}: ` +
+            formatRpcError(message, {
+              operation: 'getBlockNumber',
+              chain: this.config.chainId === 84532 ? 'base-sepolia' : 'base',
+              rpcUrl: this.config.rpcUrl,
+            }),
+          );
         },
       },
     );
@@ -244,7 +252,7 @@ export class MechAdapter implements ExecutionAdapter {
     const deliveryRate = await getMechDeliveryRate(this.publicClient, this.config.mechContractAddress);
     const { max: maxTimeout } = await getTimeoutBounds(this.publicClient, this.config.mechMarketplaceAddress);
 
-    const restorationRequestIds = await submitRestorationJob(
+    const restorationJob = await submitRestorationJob(
       this.publicClient,
       this.walletClient,
       this.config.safeAddress,
@@ -254,9 +262,14 @@ export class MechAdapter implements ExecutionAdapter {
       deliveryRate,
       maxTimeout,
     );
+    const restorationRequestIds = restorationJob.requestIds;
 
     if (restorationRequestIds.length === 0) {
-      throw new PermanentError('No request IDs returned from router');
+      throw new PermanentError(
+        'No request IDs returned from router ' +
+        `(tx=${restorationJob.txHash}, router=${this.config.routerAddress}, safe=${this.config.safeAddress}, ` +
+        `mech=${this.config.mechContractAddress}, receiptLogs=${restorationJob.receiptLogCount}, chainId=${this.config.chainId})`,
+      );
     }
 
     const restorationRequestId = restorationRequestIds[0];
@@ -315,7 +328,13 @@ export class MechAdapter implements ExecutionAdapter {
           }
         }
       } catch (err) {
-        console.error('[mech] Error polling for requests:', err);
+        console.error('[mech] Error polling for requests:', formatRpcError(err, {
+          operation: 'pollMarketplaceRequests',
+          chain: this.config.chainId === 84532 ? 'base-sepolia' : 'base',
+          rpcUrl: this.config.rpcUrl,
+          contract: this.config.mechMarketplaceAddress,
+          fromBlock: this.requestBlockCursor + 1n,
+        }));
       }
 
       await new Promise(r => setTimeout(r, this.config.pollIntervalMs));
@@ -478,7 +497,13 @@ export class MechAdapter implements ExecutionAdapter {
           await this.tryCreateEvaluationJob(rid);
         }
       } catch (err) {
-        console.error('[mech] Error polling for deliveries:', err);
+        console.error('[mech] Error polling for deliveries:', formatRpcError(err, {
+          operation: 'pollDeliveries',
+          chain: this.config.chainId === 84532 ? 'base-sepolia' : 'base',
+          rpcUrl: this.config.rpcUrl,
+          contract: this.config.mechContractAddress,
+          fromBlock: this.deliveryBlockCursor + 1n,
+        }));
       }
 
       // Persist block cursor for crash recovery

--- a/client/src/adapters/mech/contracts.ts
+++ b/client/src/adapters/mech/contracts.ts
@@ -32,7 +32,7 @@ export async function submitRestorationJob(
   requestDataHex: Hex,
   priceWei: bigint,
   responseTimeout: bigint,
-): Promise<string[]> {
+): Promise<{ requestIds: string[]; txHash: Hex; receiptLogCount: number }> {
   const calldata = encodeFunctionData({
     abi: JINN_ROUTER_ABI,
     functionName: 'createRestorationJob',
@@ -69,7 +69,7 @@ export async function submitRestorationJob(
     }
   }
 
-  return requestIds;
+  return { requestIds, txHash, receiptLogCount: receipt.logs.length };
 }
 
 export async function submitEvaluationJob(

--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -240,6 +240,7 @@ export async function gatherGatheredStatusRaw(
   status: StatusGatherConfig | undefined,
 ): Promise<GatheredStatusRaw> {
   const shutdownState = store.getShutdownState();
+  const daemonStartedAt = store.getDaemonStartedAt();
   const activityCounts = store.getActivityCountsByKind();
   const recentActivity = store.getRecentActivityEvents(12).map((row) => ({
     id: row.id,
@@ -267,6 +268,7 @@ export async function gatherGatheredStatusRaw(
 
   const baseRaw: GatheredStatusRaw = {
     shutdownState,
+    daemonStartedAt,
     dbPath: store.path,
     earningDir: status?.earningDir,
     activityCounts,

--- a/client/src/api/status-build.ts
+++ b/client/src/api/status-build.ts
@@ -18,6 +18,7 @@ export interface GatheredStatusRaw {
   /** sqlite_only: only SQLite-backed fields (e2e / API without fleet context). */
   hintsScope?: StatusHintsScope;
   shutdownState: string | null;
+  daemonStartedAt?: string | null;
   dbPath: string;
   earningDir?: string;
   activityCounts: Record<string, number>;
@@ -65,6 +66,7 @@ export interface StatusV1Response {
   statusMode: 'full' | 'sqlite_only';
   daemon: {
     shutdownState: string | null;
+    startedAt: string | null;
     dbPath: string;
     timestamp: string;
   };
@@ -245,7 +247,7 @@ function buildNextActions(raw: GatheredStatusRaw, fleetSum: StatusV1Response['fl
     const excess = bal > min ? bal - min : 0n;
     const days = excess / daily;
     if (days < 3n && raw.rpc.ok) {
-      actions.push('Master ETH runway is low — consider topping up the master wallet.');
+      actions.push('Master ETH runway is low; top up the master wallet soon.');
     }
   }
 
@@ -276,6 +278,7 @@ export function assembleStatusV1(raw: GatheredStatusRaw): StatusV1Response {
     statusMode: mode,
     daemon: {
       shutdownState: raw.shutdownState,
+      startedAt: raw.daemonStartedAt ?? null,
       dbPath: raw.dbPath,
       timestamp: new Date().toISOString(),
     },

--- a/client/src/api/status-rollup-build.ts
+++ b/client/src/api/status-rollup-build.ts
@@ -48,8 +48,8 @@ function buildExitRollup(
     try {
       if (BigInt(raw.master.balanceWei) < BigInt(raw.minMasterEthWei)) {
         return {
-          blocking: true,
-          hint: 'Master ETH is below the configured minimum runway threshold.',
+          blocking: false,
+          hint: 'Master ETH runway is low; top up the master wallet soon.',
         };
       }
     } catch {
@@ -96,7 +96,7 @@ export function assembleStatusRollupV1(raw: GatheredStatusRaw): StatusRollupV1Re
     generatedAt: new Date().toISOString(),
     daemon: {
       state: daemonState(raw.shutdownState),
-      startedAt: null,
+      startedAt: raw.daemonStartedAt ?? null,
       phase,
       network,
       version,

--- a/client/src/cli/commands/auth.ts
+++ b/client/src/cli/commands/auth.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from 'node:child_process';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
 import { parseArgs } from 'node:util';
 import { createInterface } from 'node:readline';
@@ -13,7 +13,7 @@ import {
   buildLoginCommand,
   type AuthContext,
 } from '../../preflight/claude-auth.js';
-import { loadConfig } from '../../config.js';
+import { ConfigLoadError, loadConfig } from '../../config.js';
 
 const CONTEXT_LABELS: Record<string, string> = {
   container: 'inside this container',
@@ -38,7 +38,16 @@ function persistRuntimeMode(mode: AuthContext, configPath: string = DEFAULT_CONF
       current = {};
     }
   }
+  const envNetwork = process.env['JINN_NETWORK'] === 'mainnet' ? 'mainnet' : 'testnet';
+  if (current['network'] === undefined) {
+    current['network'] = envNetwork;
+  }
+  const network = current['network'] === 'mainnet' ? 'mainnet' : 'testnet';
+  if (current['rpcUrl'] === undefined) {
+    current['rpcUrl'] = network === 'testnet' ? 'https://sepolia.base.org' : 'https://mainnet.base.org';
+  }
   current['runtimeMode'] = mode;
+  mkdirSync(dirname(configPath), { recursive: true, mode: 0o700 });
   writeFileSync(configPath, JSON.stringify(current, null, 2) + '\n', { encoding: 'utf-8' });
 }
 
@@ -98,13 +107,26 @@ async function run(ctx: CommandContext): Promise<void> {
     typeof parsed.values.config === 'string' && parsed.values.config.length > 0
       ? parsed.values.config
       : undefined;
-  const config = loadConfig(configPath);
+  const modeFlag = typeof parsed.values.mode === 'string' ? parsed.values.mode : undefined;
+  let config: ReturnType<typeof loadConfig> | { runtimeMode?: AuthContext };
+  try {
+    config = loadConfig(configPath);
+  } catch (error) {
+    if (
+      error instanceof ConfigLoadError &&
+      error.code === 'config_file_not_found' &&
+      modeFlag !== undefined
+    ) {
+      config = {};
+    } else {
+      throw error;
+    }
+  }
 
   // ── Resolve runtime mode ─────────────────────────────────────────────────
   // Order: --mode flag > config.runtimeMode > (interactive prompt if TTY)
   // > filesystem-based auto-detect (legacy fallback).
   let runtimeMode: AuthContext | undefined;
-  const modeFlag = typeof parsed.values.mode === 'string' ? parsed.values.mode : undefined;
   if (modeFlag) {
     if (modeFlag !== 'bare' && modeFlag !== 'docker-compose' && modeFlag !== 'container') {
       emitEnvelope(

--- a/client/src/cli/commands/bootstrap.ts
+++ b/client/src/cli/commands/bootstrap.ts
@@ -5,6 +5,7 @@ import { emitEnvelope } from '../../errors/envelope.js';
 import { loadConfig } from '../../config.js';
 import { FleetBootstrapper } from '../../earning/bootstrap.js';
 import { resolveCliPassword } from '../password.js';
+import { checkRpcNetwork, rpcNetworkFailureHint } from '../../preflight/rpc-network.js';
 
 /** §6.2 — `stack` only when `JINN_DEBUG=1` (exact string). */
 function envelopeDebug(env: NodeJS.ProcessEnv): boolean {
@@ -71,6 +72,27 @@ async function run(ctx: CommandContext): Promise<void> {
   }
 
   const config = loadConfig(configPath);
+  const rpcPreflight = await checkRpcNetwork(config);
+  if (!rpcPreflight.ok) {
+    emitEnvelope(
+      {
+        code: 'invalid_invocation',
+        message: rpcPreflight.message,
+        hint: rpcNetworkFailureHint(rpcPreflight),
+        exampleCli: 'jinn doctor --human',
+        details: {
+          field: 'rpcUrl',
+          network: rpcPreflight.network,
+          expectedChainId: rpcPreflight.expectedChainId,
+          actualChainId: rpcPreflight.actualChainId ?? null,
+          rpcHost: rpcPreflight.rpcHost,
+          reason: rpcPreflight.reason,
+        },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
   const bootstrapper = new FleetBootstrapper({
     earningDir: config.earningDir,
     chain: config.network === 'testnet' ? 'base-sepolia' : 'base',

--- a/client/src/cli/commands/doctor.ts
+++ b/client/src/cli/commands/doctor.ts
@@ -15,6 +15,7 @@ import { getConfigPathFromArgs, loadConfig, type JinnConfig } from '../../config
 import { getChainConfig, ERC20_ABI } from '../../earning/contracts.js';
 import { runPortfolioV0DoctorChecks } from '../../api/portfolio-v0-doctor.js';
 import { mnemonicKeystorePath } from '../../earning/store.js';
+import { checkRpcNetwork, rpcNetworkFailureHint } from '../../preflight/rpc-network.js';
 
 interface CheckResult {
   name: string;
@@ -166,7 +167,7 @@ async function checkDistributorReachable(config: JinnConfig): Promise<CheckResul
         detail: 'distributor address not configured (standard mode staking disabled)',
       };
     }
-    const client = createPublicClient({ chain: baseSepolia, transport: http(cfg.rpcUrl) });
+    const client = createPublicClient({ chain: baseSepolia, transport: http(config.rpcUrl) });
     const balance = await client.readContract({
       address: cfg.olasToken as Address,
       abi: ERC20_ABI,
@@ -198,6 +199,23 @@ async function checkDistributorReachable(config: JinnConfig): Promise<CheckResul
       detail: `distributor probe failed: ${err instanceof Error ? err.message : String(err)}`,
     };
   }
+}
+
+async function checkRpcNetworkForDoctor(config: JinnConfig): Promise<CheckResult> {
+  const result = await checkRpcNetwork(config);
+  if (result.ok) {
+    return {
+      name: 'rpc_network',
+      ok: true,
+      detail: `${result.rpcHost} reports chain ${result.actualChainId} for ${result.network}`,
+    };
+  }
+  return {
+    name: 'rpc_network',
+    ok: false,
+    detail: result.message,
+    remedy: rpcNetworkFailureHint(result),
+  };
 }
 
 async function checkClaudeAuth(config: JinnConfig): Promise<CheckResult> {
@@ -248,6 +266,7 @@ async function run(ctx: CommandContext): Promise<void> {
   checks.push(await checkClaudeAuth(config));
 
   checks.push(checkKeystorePresent(config.earningDir));
+  checks.push(await checkRpcNetworkForDoctor(config));
   checks.push(await checkDeploymentLoaded(config));
   checks.push(checkDaemonRuntimeReady());
 

--- a/client/src/cli/commands/quickstart.ts
+++ b/client/src/cli/commands/quickstart.ts
@@ -10,6 +10,8 @@ import { loadConfig } from '../../config.js';
 import initCommand from './init.js';
 import bootstrapCommand from './bootstrap.js';
 import doctorCommand from './doctor.js';
+import { checkRpcNetwork, rpcNetworkFailureHint } from '../../preflight/rpc-network.js';
+import { apiPortFailureMessage, checkApiPortAvailable } from '../../preflight/api-port.js';
 
 // StringWriter to capture sub-command output
 class StringWriter {
@@ -67,6 +69,44 @@ async function run(ctx: CommandContext): Promise<void> {
   }
 
   const subEnv = { ...ctx.env, JINN_PASSWORD: password };
+  const config = loadConfig(configPath);
+
+  const rpcPreflight = await checkRpcNetwork(config);
+  if (!rpcPreflight.ok) {
+    emitEnvelope({
+      code: 'invalid_invocation',
+      message: rpcPreflight.message,
+      hint: rpcNetworkFailureHint(rpcPreflight),
+      exampleCli: 'jinn doctor --human',
+      details: {
+        field: 'rpcUrl',
+        network: rpcPreflight.network,
+        expectedChainId: rpcPreflight.expectedChainId,
+        actualChainId: rpcPreflight.actualChainId ?? null,
+        rpcHost: rpcPreflight.rpcHost,
+        reason: rpcPreflight.reason,
+      },
+    }, { writer: ctx.writer, exit: ctx.exit });
+    return;
+  }
+
+  if (!noDaemon) {
+    const portPreflight = await checkApiPortAvailable(config.apiPort);
+    if (!portPreflight.ok) {
+      emitEnvelope({
+        code: 'invalid_invocation',
+        message: apiPortFailureMessage(portPreflight),
+        hint: 'Stop the other daemon or set JINN_API_PORT / apiPort to a free port before running quickstart.',
+        exampleCli: 'JINN_API_PORT=7332 jinn quickstart',
+        details: {
+          field: 'apiPort',
+          port: portPreflight.port,
+          reason: portPreflight.code ?? 'unavailable',
+        },
+      }, { writer: ctx.writer, exit: ctx.exit });
+      return;
+    }
+  }
 
   // ── Step 1.5: Doctor preflight ──
   // Run doctor before touching any wallet state so blocking problems (missing
@@ -223,7 +263,7 @@ async function run(ctx: CommandContext): Promise<void> {
   }
 
   // ── Step 4: Print summary ──
-  const apiPort = String(loadConfig(configPath).apiPort);
+  const apiPort = String(config.apiPort);
   const keystoreFile = join(jinnDir, 'earning', 'master_keystore.json');
   console.error('');
   if (passwordGenerated) {

--- a/client/src/cli/commands/run.ts
+++ b/client/src/cli/commands/run.ts
@@ -4,6 +4,9 @@ import { COMMON_FLAGS } from '../command.js';
 import { emitResult } from '../output.js';
 import { emitEnvelope } from '../../errors/envelope.js';
 import { resolveCliPassword } from '../password.js';
+import { getConfigPathFromArgs, loadConfig } from '../../config.js';
+import { checkRpcNetwork, rpcNetworkFailureHint } from '../../preflight/rpc-network.js';
+import { apiPortFailureMessage, checkApiPortAvailable } from '../../preflight/api-port.js';
 
 function routeConsoleToStderr(): void {
   const writer = (line: string): void => {
@@ -72,6 +75,47 @@ async function run(ctx: CommandContext): Promise<void> {
     return;
   }
   process.env['JINN_PASSWORD'] = password.password;
+  const configPath = getConfigPathFromArgs(ctx.argv);
+  const config = loadConfig(configPath);
+  const rpcPreflight = await checkRpcNetwork(config);
+  if (!rpcPreflight.ok) {
+    emitEnvelope(
+      {
+        code: 'invalid_invocation',
+        message: rpcPreflight.message,
+        hint: rpcNetworkFailureHint(rpcPreflight),
+        exampleCli: 'jinn doctor --human',
+        details: {
+          field: 'rpcUrl',
+          network: rpcPreflight.network,
+          expectedChainId: rpcPreflight.expectedChainId,
+          actualChainId: rpcPreflight.actualChainId ?? null,
+          rpcHost: rpcPreflight.rpcHost,
+          reason: rpcPreflight.reason,
+        },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
+  const portPreflight = await checkApiPortAvailable(config.apiPort);
+  if (!portPreflight.ok) {
+    emitEnvelope(
+      {
+        code: 'invalid_invocation',
+        message: apiPortFailureMessage(portPreflight),
+        hint: `Use --config with apiPort or set JINN_API_PORT to a free port before running jinn run.`,
+        exampleCli: 'JINN_API_PORT=7332 jinn run',
+        details: {
+          field: 'apiPort',
+          port: portPreflight.port,
+          reason: portPreflight.code ?? 'unavailable',
+        },
+      },
+      { writer: ctx.writer, exit: ctx.exit },
+    );
+    return;
+  }
   if (!(parsed.values.human as boolean)) {
     routeConsoleToStderr();
   }

--- a/client/src/cli/introspection-context.ts
+++ b/client/src/cli/introspection-context.ts
@@ -22,17 +22,20 @@ async function tryMergeStatusFromHttp(
     const res = await fetch(url, { signal: ac.signal });
     if (!res.ok) return local;
     const remote = (await res.json()) as StatusV1Response;
+    const next: GatheredStatusRaw = {
+      ...local,
+      shutdownState: remote.daemon?.shutdownState ?? local.shutdownState,
+      daemonStartedAt: remote.daemon?.startedAt ?? local.daemonStartedAt,
+    };
     if (remote.rpc?.ok && !local.rpc.ok) {
-      return {
-        ...local,
-        rpc: {
-          ok: remote.rpc.ok,
-          chainId: remote.rpc.chainId,
-          blockNumber: remote.rpc.blockNumber,
-          ...(remote.rpc.error ? { error: remote.rpc.error } : {}),
-        },
+      next.rpc = {
+        ok: remote.rpc.ok,
+        chainId: remote.rpc.chainId,
+        blockNumber: remote.rpc.blockNumber,
+        ...(remote.rpc.error ? { error: remote.rpc.error } : {}),
       };
     }
+    return next;
   } catch {
     /* ignore — local gather is authoritative */
   } finally {

--- a/client/src/daemon/creator.ts
+++ b/client/src/daemon/creator.ts
@@ -1,7 +1,7 @@
 import type { ExecutionAdapter } from '../adapters/adapter.js';
 import type { DesiredState, RequestId } from '../types/index.js';
 import type { Store } from '../store/store.js';
-import { TransientError } from '../types/index.js';
+import { PermanentError, TransientError } from '../types/index.js';
 import { isRecoverableTransactionError } from '../tx-retry.js';
 import { emitEvent } from '../observability/emit-event.js';
 
@@ -27,10 +27,16 @@ export class CreatorLoop {
   // ~20 activities/day needed; each cycle = 4 activities; 5 cycles/day = 1 every ~4.8h.
   // Use 4h to provide safety margin.
   private static readonly REPOST_INTERVAL_MS = 4 * 60 * 60 * 1000;
+  private static readonly PERMANENT_FAILURE_BACKOFF_MS = 30 * 60 * 1000;
 
   /** SQLite config key for durable idempotency across daemon restarts. */
   private static cacheKey(state: DesiredState, safeAddress?: string): string {
     const prefix = safeAddress ? `created_intent:${safeAddress}` : 'created_intent';
+    return `${prefix}:${state.id}`;
+  }
+
+  private static failureCacheKey(state: DesiredState, safeAddress?: string): string {
+    const prefix = safeAddress ? `create_failed:${safeAddress}` : 'create_failed';
     return `${prefix}:${state.id}`;
   }
 
@@ -78,6 +84,14 @@ export class CreatorLoop {
         this.posted.set(state.id, now);
         continue;
       }
+      const failureKey = CreatorLoop.failureCacheKey(state, this.safeAddress);
+      const failedAt = this.store.getConfigValue(failureKey);
+      if (failedAt) {
+        const ts = Number(failedAt);
+        if (Number.isFinite(ts) && now - ts < CreatorLoop.PERMANENT_FAILURE_BACKOFF_MS) {
+          continue;
+        }
+      }
 
       try {
         const prev = this.attempts.get(state.id);
@@ -109,6 +123,13 @@ export class CreatorLoop {
         return requestId;
       } catch (err) {
         if (err instanceof TransientError) continue;
+        if (err instanceof PermanentError) {
+          this.store.setConfigValue(failureKey, String(now));
+          console.error(
+            `[creator] Permanent create failure for ${state.id}; backing off for ` +
+            `${Math.round(CreatorLoop.PERMANENT_FAILURE_BACKOFF_MS / 60000)} min: ${err.message}`,
+          );
+        }
         throw err;
       }
     }

--- a/client/src/daemon/daemon.ts
+++ b/client/src/daemon/daemon.ts
@@ -133,6 +133,7 @@ export class Daemon {
   async start(): Promise<void> {
     await this.adapter.initialize();
     this.store.setShutdownState('running');
+    this.store.setDaemonStartedAt(new Date().toISOString());
     this.cachedShutdownState = 'running';
     emitEvent(this.store, { kind: 'startup', outcome: 'ok', detail: 'Daemon started' }, 'daemon');
 

--- a/client/src/earning/bootstrap.ts
+++ b/client/src/earning/bootstrap.ts
@@ -79,6 +79,7 @@ import { isUnauthorizedAccountError } from '../errors/unauthorized-account.js';
 import { createJinnPublicClient, createJinnWalletClient, type JinnOnchainNetwork } from './viem-clients.js';
 import { isTransientEthReadError } from '../chain-read-errors.js';
 import { nextFleetServiceIndex } from './next-service-index.js';
+import { rpcHostForDisplay } from '../preflight/rpc-network.js';
 import type { Account } from 'viem/accounts';
 
 const addr = (value: string): Address => getAddress(value) as Address;
@@ -241,7 +242,8 @@ export class FleetBootstrapper {
         const INTER_DRIP_PAUSE_MS = 1_000;
         console.error(
           `[fleet-bootstrap] Master has ${formatEther(systemEth)} ETH; need ${formatEther(requiredMasterEth)} ETH. ` +
-          `Draining CDP faucet (each drip ≈ 0.0001 ETH, up to ${MAX_FAUCET_ITERS} drips; expect ~30-60 s on first run).`,
+          `Draining CDP faucet on ${this.chain} via ${rpcHostForDisplay(this.config.rpcUrl)} ` +
+          `(each drip ≈ 0.0001 ETH, up to ${MAX_FAUCET_ITERS} drips; expect ~30-60 s on first run).`,
         );
         for (let i = 0; i < MAX_FAUCET_ITERS; i++) {
           const faucetResult = await requestTestnetFunding(masterAddress, 'base-sepolia');
@@ -259,7 +261,8 @@ export class FleetBootstrapper {
           masterBalance = refreshed.master;
           if ((i + 1) % 5 === 0) {
             console.error(
-              `[fleet-bootstrap] drip ${i + 1}/${MAX_FAUCET_ITERS} · master=${formatEther(masterBalance)} ETH · target=${formatEther(requiredMasterEth)} ETH`,
+              `[fleet-bootstrap] drip ${i + 1}/${MAX_FAUCET_ITERS} · chain=${this.chain} · rpc=${rpcHostForDisplay(this.config.rpcUrl)} · ` +
+              `master=${formatEther(masterBalance)} ETH · target=${formatEther(requiredMasterEth)} ETH`,
             );
           }
           if (systemEth >= requiredMasterEth) {
@@ -272,41 +275,11 @@ export class FleetBootstrapper {
         }
       }
 
-      if (systemEth < requiredMasterEth) {
-        // On testnet, attempt automatic faucet funding before giving up
-        if (this.chain === 'base-sepolia') {
-          console.error('[fleet-bootstrap] Attempting automatic faucet funding via Coinbase CDP...');
-          const faucetResult = await requestTestnetFunding(masterAddress, 'base-sepolia');
-          if (faucetResult.ok) {
-            console.error(`[fleet-bootstrap] Faucet funded successfully (tx: ${faucetResult.txHash}). Rechecking balance...`);
-            // Wait for tx propagation
-            await new Promise(r => setTimeout(r, 3000));
-            // Re-read balance and continue if sufficient
-            const refreshedBalance = await this.publicClient.getBalance({ address: masterAddress as Address });
-            let refreshedSystemEth = refreshedBalance;
-            if (this.stakingMode === 'self-bond') {
-              for (const svc of state.services) {
-                if (svc.agent_address) {
-                  refreshedSystemEth += await this.publicClient.getBalance({
-                    address: getAddress(svc.agent_address) as Address,
-                  });
-                }
-                if (svc.safe_address) {
-                  refreshedSystemEth += await this.publicClient.getBalance({
-                    address: getAddress(svc.safe_address) as Address,
-                  });
-                }
-              }
-            }
-            if (refreshedSystemEth >= requiredMasterEth) {
-              console.error('[fleet-bootstrap] Faucet funding sufficient. Continuing bootstrap...');
-              // Update systemEth/masterBalance for the runway check below
-              systemEth = refreshedSystemEth;
-            }
-          } else {
-            console.error(`[fleet-bootstrap] Faucet unavailable: ${faucetResult.reason}`);
-          }
-        }
+      if (systemEth < requiredMasterEth && this.chain === 'base-sepolia' && autoFaucetEnabled) {
+        console.error(
+          '[fleet-bootstrap] Automatic faucet funding did not reach the target. ' +
+          'Switching to manual funding only; no more faucet requests will be sent in this run.',
+        );
       }
 
       if (systemEth < requiredMasterEth) {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -50,6 +50,8 @@ import { makePredictionV0Generator } from './intents/prediction-v0-auto.js';
 import { makePredictionApyV0Generator } from './intents/prediction-apy-v0-auto.js';
 import { BASE_SEPOLIA_FEEDS, BASE_FEEDS } from './venues/chainlink/feeds.js';
 import type { IntentGenerator } from './daemon/creator.js';
+import { checkRpcNetwork, rpcNetworkFailureHint } from './preflight/rpc-network.js';
+import { apiPortFailureMessage, checkApiPortAvailable } from './preflight/api-port.js';
 
 dotenvConfig({ path: join(dirname(fileURLToPath(import.meta.url)), '..', '.env') });
 
@@ -239,6 +241,39 @@ export interface DaemonStartupInfo {
 
 export async function main(): Promise<DaemonStartupInfo> {
   console.log(`[main] jinn-client starting on ${NETWORK_CHAIN}`);
+
+  const rpcPreflight = await checkRpcNetwork(config);
+  if (!rpcPreflight.ok) {
+    emitEnvelope({
+      code: 'invalid_invocation',
+      message: rpcPreflight.message,
+      hint: rpcNetworkFailureHint(rpcPreflight),
+      exampleCli: 'jinn doctor --human',
+      details: {
+        field: 'rpcUrl',
+        network: rpcPreflight.network,
+        expectedChainId: rpcPreflight.expectedChainId,
+        actualChainId: rpcPreflight.actualChainId ?? null,
+        rpcHost: rpcPreflight.rpcHost,
+        reason: rpcPreflight.reason,
+      },
+    });
+  }
+
+  const portPreflight = await checkApiPortAvailable(config.apiPort);
+  if (!portPreflight.ok) {
+    emitEnvelope({
+      code: 'invalid_invocation',
+      message: apiPortFailureMessage(portPreflight),
+      hint: 'Stop the other daemon or set JINN_API_PORT / apiPort to a free port.',
+      exampleCli: 'JINN_API_PORT=7332 jinn run',
+      details: {
+        field: 'apiPort',
+        port: portPreflight.port,
+        reason: portPreflight.code ?? 'unavailable',
+      },
+    });
+  }
 
   const { agentPrivateKey, masterAddress, safeAddress, mechAddress, serviceIndex, serviceId } =
     await bootstrap();
@@ -543,7 +578,25 @@ export async function main(): Promise<DaemonStartupInfo> {
   };
   process.on('exit', removePidfile);
 
-  await daemon.start();
+  try {
+    await daemon.start();
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err?.code === 'EADDRINUSE') {
+      emitEnvelope({
+        code: 'invalid_invocation',
+        message: `Port ${config.apiPort} is already in use. Stop the other daemon or set JINN_API_PORT / apiPort to another port.`,
+        hint: 'Set JINN_API_PORT to a free port, or stop the process currently listening on the dashboard/API port.',
+        exampleCli: 'JINN_API_PORT=7332 jinn run',
+        details: {
+          field: 'apiPort',
+          port: config.apiPort,
+          reason: 'EADDRINUSE',
+        },
+      });
+    }
+    throw error;
+  }
   console.log(`[main] Daemon running. Dashboard: http://127.0.0.1:${config.apiPort}`);
   return {
     schemaVersion: 1,

--- a/client/src/preflight/api-port.ts
+++ b/client/src/preflight/api-port.ts
@@ -1,0 +1,49 @@
+import { createServer } from 'node:net';
+
+export interface ApiPortPreflightOk {
+  ok: true;
+  port: number;
+}
+
+export interface ApiPortPreflightFail {
+  ok: false;
+  port: number;
+  code?: string;
+  message: string;
+}
+
+export type ApiPortPreflightResult = ApiPortPreflightOk | ApiPortPreflightFail;
+
+export async function checkApiPortAvailable(port: number): Promise<ApiPortPreflightResult> {
+  return new Promise((resolve) => {
+    const server = createServer();
+    let settled = false;
+
+    const finish = (result: ApiPortPreflightResult) => {
+      if (settled) return;
+      settled = true;
+      server.removeAllListeners();
+      resolve(result);
+    };
+
+    server.once('error', (error: NodeJS.ErrnoException) => {
+      finish({
+        ok: false,
+        port,
+        code: error.code,
+        message: error.message,
+      });
+    });
+
+    server.listen({ port, host: '0.0.0.0', exclusive: true }, () => {
+      server.close(() => finish({ ok: true, port }));
+    });
+  });
+}
+
+export function apiPortFailureMessage(result: ApiPortPreflightFail): string {
+  if (result.code === 'EADDRINUSE') {
+    return `Port ${result.port} is already in use. Stop the other daemon or set JINN_API_PORT / apiPort to another port.`;
+  }
+  return `Port ${result.port} is not available: ${result.message}`;
+}

--- a/client/src/preflight/rpc-network.ts
+++ b/client/src/preflight/rpc-network.ts
@@ -1,0 +1,101 @@
+import { createPublicClient, http } from 'viem';
+import { base, baseSepolia } from 'viem/chains';
+import type { JinnConfig } from '../config.js';
+
+export type ExpectedRpcNetwork = 'mainnet' | 'testnet';
+
+export interface RpcNetworkPreflightOk {
+  ok: true;
+  network: ExpectedRpcNetwork;
+  expectedChainId: number;
+  actualChainId: number;
+  rpcHost: string;
+}
+
+export interface RpcNetworkPreflightFail {
+  ok: false;
+  network: ExpectedRpcNetwork;
+  expectedChainId: number;
+  actualChainId?: number;
+  rpcHost: string;
+  reason: 'chain_mismatch' | 'unreachable';
+  message: string;
+}
+
+export type RpcNetworkPreflightResult = RpcNetworkPreflightOk | RpcNetworkPreflightFail;
+
+export function expectedChainIdForNetwork(network: ExpectedRpcNetwork): number {
+  return network === 'testnet' ? 84532 : 8453;
+}
+
+export function rpcHostForDisplay(rpcUrl: string): string {
+  try {
+    const parsed = new URL(rpcUrl);
+    return parsed.host || parsed.hostname || '(unknown host)';
+  } catch {
+    return '(invalid rpc url)';
+  }
+}
+
+function expectedChainForNetwork(network: ExpectedRpcNetwork) {
+  return network === 'testnet' ? baseSepolia : base;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) return error.message;
+  return String(error);
+}
+
+export async function checkRpcNetwork(
+  config: Pick<JinnConfig, 'network' | 'rpcUrl'>,
+): Promise<RpcNetworkPreflightResult> {
+  const expectedChainId = expectedChainIdForNetwork(config.network);
+  const rpcHost = rpcHostForDisplay(config.rpcUrl);
+  const client = createPublicClient({
+    chain: expectedChainForNetwork(config.network),
+    transport: http(config.rpcUrl),
+  });
+
+  let actualChainId: number;
+  try {
+    actualChainId = await client.getChainId();
+  } catch (error) {
+    return {
+      ok: false,
+      network: config.network,
+      expectedChainId,
+      rpcHost,
+      reason: 'unreachable',
+      message: `RPC preflight failed for ${config.network} via ${rpcHost}: ${errorMessage(error)}`,
+    };
+  }
+
+  if (actualChainId !== expectedChainId) {
+    return {
+      ok: false,
+      network: config.network,
+      expectedChainId,
+      actualChainId,
+      rpcHost,
+      reason: 'chain_mismatch',
+      message:
+        `RPC chain mismatch for ${config.network}: expected chain ${expectedChainId}, ` +
+        `got ${actualChainId} from ${rpcHost}.`,
+    };
+  }
+
+  return {
+    ok: true,
+    network: config.network,
+    expectedChainId,
+    actualChainId,
+    rpcHost,
+  };
+}
+
+export function rpcNetworkFailureHint(result: RpcNetworkPreflightFail): string {
+  if (result.network === 'testnet') {
+    return 'Set rpcUrl to a Base Sepolia endpoint such as https://sepolia.base.org, or set BASE_SEPOLIA_RPC_URL.';
+  }
+  return 'Set rpcUrl to a Base mainnet endpoint such as https://mainnet.base.org, or set BASE_RPC_URL.';
+}

--- a/client/src/rpc-error-context.ts
+++ b/client/src/rpc-error-context.ts
@@ -1,0 +1,32 @@
+import { flattenErrorMessage } from './tx-retry.js';
+import { rpcHostForDisplay } from './preflight/rpc-network.js';
+
+export interface RpcErrorContext {
+  operation: string;
+  rpcUrl?: string;
+  chain?: 'base' | 'base-sepolia' | string;
+  address?: string;
+  contract?: string;
+  fromBlock?: bigint | number | string;
+  toBlock?: bigint | number | string;
+}
+
+function blockValue(value: bigint | number | string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return String(value);
+}
+
+export function formatRpcError(error: unknown, context: RpcErrorContext): string {
+  const parts = [`operation=${context.operation}`];
+  if (context.chain) parts.push(`chain=${context.chain}`);
+  if (context.rpcUrl) parts.push(`rpc=${rpcHostForDisplay(context.rpcUrl)}`);
+  if (context.contract) parts.push(`contract=${context.contract}`);
+  if (context.address) parts.push(`address=${context.address}`);
+  const from = blockValue(context.fromBlock);
+  const to = blockValue(context.toBlock);
+  if (from !== undefined || to !== undefined) {
+    parts.push(`blocks=${from ?? '?'}..${to ?? '?'}`);
+  }
+  parts.push(`cause=${flattenErrorMessage(error)}`);
+  return parts.join(' ');
+}

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -165,6 +165,15 @@ export class Store {
     return row?.value ?? null;
   }
 
+  setDaemonStartedAt(value: string): void {
+    this.db.prepare('INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)').run('daemon_started_at', value);
+  }
+
+  getDaemonStartedAt(): string | null {
+    const row = this.db.prepare('SELECT value FROM config WHERE key = ?').get('daemon_started_at') as { value: string } | undefined;
+    return row?.value ?? null;
+  }
+
   /** Generic config row (e.g. last_reward_claim_tick_at). */
   getConfigValue(key: string): string | null {
     const row = this.db.prepare('SELECT value FROM config WHERE key = ?').get(key) as { value: string } | undefined;

--- a/client/test/adapters/mech/adapter.test.ts
+++ b/client/test/adapters/mech/adapter.test.ts
@@ -4,7 +4,11 @@ import { RESTORATION_INTENT_CID_CONTEXT_KEY } from '../../../src/restorer/impls/
 
 // Mock contract helpers
 vi.mock('../../../src/adapters/mech/contracts.js', () => ({
-  submitRestorationJob: vi.fn().mockResolvedValue(['0x' + 'aa'.repeat(32)]),
+  submitRestorationJob: vi.fn().mockResolvedValue({
+    requestIds: ['0x' + 'aa'.repeat(32)],
+    txHash: '0x' + '12'.repeat(32),
+    receiptLogCount: 1,
+  }),
   submitEvaluationJob: vi.fn().mockResolvedValue(['0x' + 'bb'.repeat(32)]),
   claimDelivery: vi.fn().mockResolvedValue('0x1234'),
   getMechDeliveryRate: vi.fn().mockResolvedValue(1000000n),
@@ -82,6 +86,26 @@ describe('MechAdapter with JinnRouter', () => {
       expect.any(String),
       expect.any(BigInt),
       expect.any(BigInt),
+    );
+
+    await adapter.stop();
+  });
+
+  it('includes router context when create returns no request ids', async () => {
+    const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+    const { submitRestorationJob } = await import('../../../src/adapters/mech/contracts.js');
+
+    vi.mocked(submitRestorationJob).mockResolvedValueOnce({
+      requestIds: [],
+      txHash: ('0x' + '99'.repeat(32)) as `0x${string}`,
+      receiptLogCount: 3,
+    });
+
+    const adapter = new MechAdapter(TEST_CONFIG);
+    await adapter.initialize();
+
+    await expect(adapter.postDesiredState({ id: 'ds-1', description: 'test' })).rejects.toThrow(
+      new RegExp(`tx=0x9999.*router=${TEST_CONFIG.routerAddress}.*receiptLogs=3`),
     );
 
     await adapter.stop();

--- a/client/test/api/status-rollup-build.test.ts
+++ b/client/test/api/status-rollup-build.test.ts
@@ -79,4 +79,14 @@ describe('assembleStatusRollupV1', () => {
     const parsed = assembleStatusRollupV1(raw);
     expect(parsed.exit.blocking).toBe(false);
   });
+
+  it('low master ETH is a warning hint, not a blocking exit', () => {
+    const raw = makeRaw();
+    raw.fleet!.services = raw.fleet!.services.map(s => ({ ...s, step: 'complete' as const }));
+    raw.minMasterEthWei = '100';
+    raw.master.balanceWei = '1';
+    const parsed = assembleStatusRollupV1(raw);
+    expect(parsed.exit.blocking).toBe(false);
+    expect(parsed.exit.hint).toContain('runway is low');
+  });
 });

--- a/client/test/cli/commands/auth.test.ts
+++ b/client/test/cli/commands/auth.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import auth from '../../../src/cli/commands/auth.js';
 import type { CommandContext } from '../../../src/cli/command.js';
@@ -58,6 +61,33 @@ describe('auth command', () => {
       // Not authenticated on non-TTY: invalid_invocation
       expect(parsed.code).toBe('invalid_invocation');
       expect(exits).toEqual([11]);
+    }
+  });
+
+  it('persists a testnet rpcUrl when JINN_NETWORK=testnet and config is fresh', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'jinn-auth-config-'));
+    const configPath = join(dir, 'config.json');
+    const prev = process.env.JINN_NETWORK;
+    process.env.JINN_NETWORK = 'testnet';
+    try {
+      const { ctx } = makeCtx({
+        argv: ['--mode', 'bare', '--config', configPath],
+        stdoutIsTty: false,
+      });
+      await auth.run(ctx);
+      const persisted = JSON.parse(readFileSync(configPath, 'utf-8'));
+      expect(persisted).toMatchObject({
+        network: 'testnet',
+        rpcUrl: 'https://sepolia.base.org',
+        runtimeMode: 'bare',
+      });
+    } finally {
+      if (prev === undefined) {
+        delete process.env.JINN_NETWORK;
+      } else {
+        process.env.JINN_NETWORK = prev;
+      }
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/client/test/cli/commands/bootstrap.test.ts
+++ b/client/test/cli/commands/bootstrap.test.ts
@@ -22,10 +22,16 @@ const passwordResult = vi.hoisted(() => ({
 }));
 
 const loadConfigMock = vi.fn();
+const checkRpcNetworkMock = vi.fn();
 let constructorOptions: Record<string, unknown> | undefined;
 
 vi.mock('../../../src/config.js', () => ({
   loadConfig: loadConfigMock,
+}));
+
+vi.mock('../../../src/preflight/rpc-network.js', () => ({
+  checkRpcNetwork: checkRpcNetworkMock,
+  rpcNetworkFailureHint: () => 'fix rpc',
 }));
 
 vi.mock('../../../src/earning/bootstrap.js', () => ({
@@ -64,6 +70,13 @@ function makeCtx(
 
 describe('bootstrap command', () => {
   beforeEach(() => {
+    checkRpcNetworkMock.mockResolvedValue({
+      ok: true,
+      network: 'testnet',
+      expectedChainId: 84532,
+      actualChainId: 84532,
+      rpcHost: '127.0.0.1:8545',
+    });
     loadConfigMock.mockReturnValue({
       earningDir: '/tmp/earning',
       network: 'testnet',
@@ -225,5 +238,34 @@ describe('bootstrap command', () => {
       }),
     }));
     expect(exits).toEqual([0]);
+  });
+
+  it('fails before constructing bootstrapper when rpc chain is mismatched', async () => {
+    passwordResult.val = { ok: true, password: 'test' };
+    checkRpcNetworkMock.mockResolvedValueOnce({
+      ok: false,
+      network: 'testnet',
+      expectedChainId: 84532,
+      actualChainId: 8453,
+      rpcHost: 'mainnet.base.org',
+      reason: 'chain_mismatch',
+      message: 'RPC chain mismatch for testnet',
+    });
+    const { default: bootstrap } = await import('../../../src/cli/commands/bootstrap.js');
+    const { ctx, writes, exits } = makeCtx();
+
+    await bootstrap.run(ctx);
+
+    const parsed = JSON.parse(writes[writes.length - 1]);
+    expect(parsed.code).toBe('invalid_invocation');
+    expect(parsed.details).toMatchObject({
+      field: 'rpcUrl',
+      network: 'testnet',
+      expectedChainId: 84532,
+      actualChainId: 8453,
+      rpcHost: 'mainnet.base.org',
+    });
+    expect(constructorOptions).toBeUndefined();
+    expect(exits).toEqual([11]);
   });
 });

--- a/client/test/cli/commands/doctor.test.ts
+++ b/client/test/cli/commands/doctor.test.ts
@@ -1,6 +1,17 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import doctor from '../../../src/cli/commands/doctor.js';
 import type { CommandContext } from '../../../src/cli/command.js';
+
+vi.mock('../../../src/preflight/rpc-network.js', () => ({
+  checkRpcNetwork: vi.fn(async () => ({
+    ok: true,
+    network: 'mainnet',
+    expectedChainId: 8453,
+    actualChainId: 8453,
+    rpcHost: 'mainnet.base.org',
+  })),
+  rpcNetworkFailureHint: vi.fn(() => 'Set rpcUrl to a matching Base RPC endpoint.'),
+}));
 
 function makeCtx(env: Record<string, string> = {}): {
   ctx: CommandContext; writes: string[]; exits: number[];

--- a/client/test/cli/commands/quickstart.test.ts
+++ b/client/test/cli/commands/quickstart.test.ts
@@ -6,6 +6,8 @@ const runBootstrapMock = vi.fn();
 const runDoctorMock = vi.fn();
 const loadConfigMock = vi.fn();
 const mainMock = vi.fn();
+const checkRpcNetworkMock = vi.fn();
+const checkApiPortAvailableMock = vi.fn();
 
 vi.mock('../../../src/cli/commands/init.js', () => ({
   default: {
@@ -36,6 +38,16 @@ vi.mock('../../../src/cli/commands/doctor.js', () => ({
 
 vi.mock('../../../src/config.js', () => ({
   loadConfig: loadConfigMock,
+}));
+
+vi.mock('../../../src/preflight/rpc-network.js', () => ({
+  checkRpcNetwork: checkRpcNetworkMock,
+  rpcNetworkFailureHint: () => 'fix rpc',
+}));
+
+vi.mock('../../../src/preflight/api-port.js', () => ({
+  checkApiPortAvailable: checkApiPortAvailableMock,
+  apiPortFailureMessage: (r: { port: number }) => `Port ${r.port} is already in use.`,
 }));
 
 vi.mock('../../../src/main.js', () => ({
@@ -94,7 +106,9 @@ describe('quickstart command', () => {
         ctx.exit(0);
       });
 
-    loadConfigMock.mockReturnValue({ apiPort: 9555 });
+    loadConfigMock.mockReturnValue({ apiPort: 9555, network: 'testnet', rpcUrl: 'https://sepolia.base.org' });
+    checkRpcNetworkMock.mockResolvedValue({ ok: true });
+    checkApiPortAvailableMock.mockResolvedValue({ ok: true, port: 9555 });
 
     const { default: quickstart } = await import('../../../src/cli/commands/quickstart.js');
     const { ctx, writes, exits } = makeCtx(['--config', '/tmp/custom.json', '--no-daemon']);
@@ -104,6 +118,7 @@ describe('quickstart command', () => {
     await runPromise;
 
     expect(runBootstrapMock).toHaveBeenCalledTimes(2);
+    expect(checkApiPortAvailableMock).not.toHaveBeenCalled();
     expect(runBootstrapMock.mock.calls[0]?.[0]).toMatchObject({
       argv: ['--json', '--config', '/tmp/custom.json'],
       env: expect.objectContaining({ JINN_PASSWORD: 'test-password' }),
@@ -120,5 +135,21 @@ describe('quickstart command', () => {
     const payload = JSON.parse(writes[writes.length - 1] ?? '{}');
     expect(payload.status).toBe('ready');
     expect(payload.dashboardUrl).toBe('http://127.0.0.1:9555');
+  });
+
+  it('fails before bootstrap when daemon mode needs an occupied api port', async () => {
+    loadConfigMock.mockReturnValue({ apiPort: 7331, network: 'testnet', rpcUrl: 'https://sepolia.base.org' });
+    checkRpcNetworkMock.mockResolvedValue({ ok: true });
+    checkApiPortAvailableMock.mockResolvedValue({ ok: false, port: 7331, code: 'EADDRINUSE', message: 'in use' });
+
+    const { default: quickstart } = await import('../../../src/cli/commands/quickstart.js');
+    const { ctx, writes, exits } = makeCtx([]);
+    await quickstart.run(ctx);
+
+    const parsed = JSON.parse(writes[writes.length - 1] ?? '{}');
+    expect(parsed.code).toBe('invalid_invocation');
+    expect(parsed.details).toMatchObject({ field: 'apiPort', port: 7331 });
+    expect(runBootstrapMock).not.toHaveBeenCalled();
+    expect(exits).toEqual([11]);
   });
 });

--- a/client/test/cli/commands/run.test.ts
+++ b/client/test/cli/commands/run.test.ts
@@ -1,5 +1,28 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CommandContext } from '../../../src/cli/command.js';
+
+const loadConfigMock = vi.fn(() => ({
+  network: 'testnet',
+  rpcUrl: 'https://sepolia.base.org',
+  apiPort: 7331,
+}));
+const checkRpcNetworkMock = vi.fn(async () => ({ ok: true }));
+const checkApiPortAvailableMock = vi.fn(async () => ({ ok: true, port: 7331 }));
+
+vi.mock('../../../src/config.js', () => ({
+  loadConfig: loadConfigMock,
+  getConfigPathFromArgs: vi.fn(() => undefined),
+}));
+
+vi.mock('../../../src/preflight/rpc-network.js', () => ({
+  checkRpcNetwork: checkRpcNetworkMock,
+  rpcNetworkFailureHint: () => 'fix rpc',
+}));
+
+vi.mock('../../../src/preflight/api-port.js', () => ({
+  checkApiPortAvailable: checkApiPortAvailableMock,
+  apiPortFailureMessage: (r: { port: number }) => `Port ${r.port} is already in use.`,
+}));
 
 vi.mock('../../../src/main.js', () => ({
   main: vi.fn(async () => ({
@@ -36,6 +59,17 @@ function makeCtx(env: Record<string, string> = { JINN_PASSWORD: 'test' }): {
 }
 
 describe('run command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadConfigMock.mockReturnValue({
+      network: 'testnet',
+      rpcUrl: 'https://sepolia.base.org',
+      apiPort: 7331,
+    });
+    checkRpcNetworkMock.mockResolvedValue({ ok: true });
+    checkApiPortAvailableMock.mockResolvedValue({ ok: true, port: 7331 });
+  });
+
   it('requires JINN_PASSWORD', async () => {
     const { default: run } = await import('../../../src/cli/commands/run.js');
     const { ctx, writes, exits } = makeCtx({});
@@ -53,5 +87,18 @@ describe('run command', () => {
     expect(main).toHaveBeenCalled();
     const parsed = JSON.parse(writes[writes.length - 1]);
     expect(parsed.kind).toBe('daemon_started');
+  });
+
+  it('fails before main() when api port is occupied', async () => {
+    checkApiPortAvailableMock.mockResolvedValueOnce({ ok: false, port: 7331, code: 'EADDRINUSE', message: 'in use' });
+    const { default: run } = await import('../../../src/cli/commands/run.js');
+    const { main } = await import('../../../src/main.js');
+    const { ctx, writes, exits } = makeCtx();
+    await run.run(ctx);
+    const parsed = JSON.parse(writes[writes.length - 1]);
+    expect(parsed.code).toBe('invalid_invocation');
+    expect(parsed.details).toMatchObject({ field: 'apiPort', port: 7331 });
+    expect(main).not.toHaveBeenCalled();
+    expect(exits).toEqual([11]);
   });
 });

--- a/client/test/cli/commands/status.test.ts
+++ b/client/test/cli/commands/status.test.ts
@@ -39,6 +39,7 @@ const mockRaw: GatheredStatusRaw = {
   },
   rpc: { ok: true, chainId: 84532, blockNumber: '999' },
   master: { address: '0xM', balanceWei: '1' },
+  daemonStartedAt: '2026-04-14T12:00:00.000Z',
   pollIntervalMs: 5000,
   masterDailyEstimateWei: '1',
   pendingStakingRewardsWei: '42',
@@ -64,6 +65,7 @@ describe('status command', () => {
     const parsed = JSON.parse(writes[writes.length - 1]!);
     expect(parsed.schemaVersion).toBe(1);
     expect(parsed.daemon.state).toBe('running');
+    expect(parsed.daemon.startedAt).toBe('2026-04-14T12:00:00.000Z');
     expect(parsed.daemon.network).toBe('testnet');
     expect(parsed.rpc.ok).toBe(true);
     expect(parsed.rpc.chainId).toBe(84532);
@@ -95,5 +97,21 @@ describe('status command', () => {
     const parsed = JSON.parse(writes[writes.length - 1]!);
     expect(parsed.code).toBe('invalid_invocation');
     expect(exits).toEqual([11]);
+  });
+
+  it('renders human output through the CLI dispatcher', async () => {
+    const { runCli } = await import('../../../src/cli/index.js');
+    const writes: string[] = [];
+    const exits: number[] = [];
+    await runCli(['status', '--human'], {
+      stdoutIsTty: true,
+      writer: { write: (s: string) => { writes.push(s); return true; } },
+      exit: (code: number) => { exits.push(code); },
+    });
+
+    const out = writes.join('');
+    expect(out).toContain('daemon=running');
+    expect(out).not.toMatch(/^\{/);
+    expect(exits).toEqual([]);
   });
 });

--- a/client/test/config.test.ts
+++ b/client/test/config.test.ts
@@ -143,6 +143,18 @@ describe('loadConfig RPC override handling', () => {
     expect(config.stakingMode).toBe('standard');
   });
 
+  it('defaults testnet to Base Sepolia rpcUrl', async () => {
+    const configPath = await writeConfigFile({ network: 'testnet' });
+    delete process.env['BASE_RPC_URL'];
+    delete process.env['BASE_SEPOLIA_RPC_URL'];
+    delete process.env['JINN_RPC_URL'];
+    delete process.env['JINN_NETWORK'];
+
+    const config = loadConfig(configPath);
+
+    expect(config.rpcUrl).toBe('https://sepolia.base.org');
+  });
+
   it('accepts self-bond stakingMode from env', () => {
     process.env['JINN_STAKING_MODE'] = 'self-bond';
     const config = loadConfig();

--- a/client/test/daemon/creator.test.ts
+++ b/client/test/daemon/creator.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { CreatorLoop } from '../../src/daemon/creator.js';
 import { LocalAdapter } from '../../src/adapters/local/adapter.js';
 import { Store } from '../../src/store/store.js';
-import type { DesiredState } from '../../src/types/index.js';
+import { PermanentError, type DesiredState } from '../../src/types/index.js';
 
 describe('CreatorLoop', () => {
   it('posts desired states with type and attemptId', async () => {
@@ -136,6 +136,25 @@ describe('CreatorLoop', () => {
     await loop.tick(); // generator succeeds; posts
     expect(postSpy).toHaveBeenCalledTimes(1);
 
+    store.close();
+    await adapter.stop();
+  });
+
+  it('backs off permanent create failures for the same intent', async () => {
+    const adapter = new LocalAdapter();
+    await adapter.initialize();
+    const store = new Store(':memory:');
+
+    const states: DesiredState[] = [{ id: 'gated', description: 'router-gated' }];
+    const postSpy = vi
+      .spyOn(adapter, 'postDesiredState')
+      .mockRejectedValue(new PermanentError('No request IDs returned from router'));
+    const loop = new CreatorLoop(adapter, states, store, [], '0xSafeAddr');
+
+    await expect(loop.tick()).rejects.toThrow(/No request IDs/);
+    await loop.tick();
+
+    expect(postSpy).toHaveBeenCalledTimes(1);
     store.close();
     await adapter.stop();
   });

--- a/client/test/earning/bootstrap-faucet.test.ts
+++ b/client/test/earning/bootstrap-faucet.test.ts
@@ -1,0 +1,49 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const requestTestnetFundingMock = vi.fn(async () => ({
+  ok: true,
+  txHash: '0x' + '12'.repeat(32),
+}));
+
+vi.mock('../../src/earning/faucet.js', () => ({
+  requestTestnetFunding: requestTestnetFundingMock,
+}));
+
+describe('Fleet bootstrap faucet cap', () => {
+  const dirs: string[] = [];
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    requestTestnetFundingMock.mockClear();
+    await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it('does not send an extra faucet request after the drip cap', async () => {
+    const earningDir = await mkdtemp(join(tmpdir(), 'jinn-faucet-cap-'));
+    dirs.push(earningDir);
+
+    const { FleetBootstrapper } = await import('../../src/earning/bootstrap.js');
+    const bootstrapper = new FleetBootstrapper({
+      earningDir,
+      chain: 'base-sepolia',
+      rpcUrl: 'https://sepolia.base.org',
+      env: {},
+      stakingMode: 'standard',
+    });
+
+    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(0n);
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation((cb: (...args: unknown[]) => void) => {
+      queueMicrotask(cb);
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    });
+
+    const result = await bootstrapper.bootstrap('test-password');
+
+    expect(result.ok).toBe(false);
+    expect(result.funding).toBeDefined();
+    expect(requestTestnetFundingMock).toHaveBeenCalledTimes(60);
+  });
+});

--- a/client/test/preflight/api-port.test.ts
+++ b/client/test/preflight/api-port.test.ts
@@ -1,0 +1,21 @@
+import { createServer } from 'node:net';
+import { describe, expect, it } from 'vitest';
+import { apiPortFailureMessage, checkApiPortAvailable } from '../../src/preflight/api-port.js';
+
+describe('api port preflight', () => {
+  it('reports an occupied port before daemon startup', async () => {
+    const holder = createServer();
+    await new Promise<void>((resolve) => holder.listen(0, '0.0.0.0', () => resolve()));
+    const addr = holder.address();
+    if (!addr || typeof addr === 'string') throw new Error('missing address');
+    try {
+      const result = await checkApiPortAvailable(addr.port);
+      expect(result).toMatchObject({ ok: false, port: addr.port, code: 'EADDRINUSE' });
+      if (!result.ok) {
+        expect(apiPortFailureMessage(result)).toContain(String(addr.port));
+      }
+    } finally {
+      await new Promise<void>((resolve) => holder.close(() => resolve()));
+    }
+  });
+});

--- a/client/test/preflight/rpc-network.test.ts
+++ b/client/test/preflight/rpc-network.test.ts
@@ -1,0 +1,72 @@
+import { createServer, type Server } from 'node:http';
+import { afterEach, describe, expect, it } from 'vitest';
+import { checkRpcNetwork, rpcHostForDisplay } from '../../src/preflight/rpc-network.js';
+
+const servers: Server[] = [];
+
+function startRpc(chainIdHex: string): Promise<{ url: string; close: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      let body = '';
+      req.on('data', (chunk) => { body += String(chunk); });
+      req.on('end', () => {
+        const parsed = JSON.parse(body) as { id?: number };
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ jsonrpc: '2.0', id: parsed.id ?? 1, result: chainIdHex }));
+      });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      servers.push(server);
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') throw new Error('missing address');
+      resolve({
+        url: `http://127.0.0.1:${addr.port}`,
+        close: () => new Promise<void>((res) => server.close(() => res())),
+      });
+    });
+  });
+}
+
+describe('rpc network preflight', () => {
+  afterEach(async () => {
+    await Promise.all(servers.splice(0).map((server) => new Promise<void>((resolve) => server.close(() => resolve()))));
+  });
+
+  it('accepts expected Base Sepolia chain id', async () => {
+    const rpc = await startRpc('0x14a34');
+    const result = await checkRpcNetwork({ network: 'testnet', rpcUrl: rpc.url });
+    expect(result).toMatchObject({
+      ok: true,
+      network: 'testnet',
+      expectedChainId: 84532,
+      actualChainId: 84532,
+    });
+  });
+
+  it('rejects a mainnet chain id for testnet config', async () => {
+    const rpc = await startRpc('0x2105');
+    const result = await checkRpcNetwork({ network: 'testnet', rpcUrl: rpc.url });
+    expect(result).toMatchObject({
+      ok: false,
+      network: 'testnet',
+      expectedChainId: 84532,
+      actualChainId: 8453,
+      reason: 'chain_mismatch',
+    });
+    expect(result.message).toContain('expected chain 84532');
+  });
+
+  it('reports unreachable RPCs', async () => {
+    const result = await checkRpcNetwork({ network: 'testnet', rpcUrl: 'http://127.0.0.1:9' });
+    expect(result).toMatchObject({
+      ok: false,
+      network: 'testnet',
+      expectedChainId: 84532,
+      reason: 'unreachable',
+    });
+  });
+
+  it('reports only the host for display', () => {
+    expect(rpcHostForDisplay('https://user:secret@example.com/path?key=abc')).toBe('example.com');
+  });
+});

--- a/client/test/rpc-error-context.test.ts
+++ b/client/test/rpc-error-context.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { formatRpcError } from '../src/rpc-error-context.js';
+
+describe('formatRpcError', () => {
+  it('adds operation, rpc host, chain, contract, block range, and cause', () => {
+    const error = new Error('Version: viem@2.48.4 | RPC Request failed.');
+    const formatted = formatRpcError(error, {
+      operation: 'getLogs',
+      chain: 'base-sepolia',
+      rpcUrl: 'https://user:secret@sepolia.base.org/path',
+      contract: '0xabc',
+      fromBlock: 10n,
+      toBlock: 20n,
+    });
+
+    expect(formatted).toContain('operation=getLogs');
+    expect(formatted).toContain('chain=base-sepolia');
+    expect(formatted).toContain('rpc=sepolia.base.org');
+    expect(formatted).toContain('contract=0xabc');
+    expect(formatted).toContain('blocks=10..20');
+    expect(formatted).toContain('RPC Request failed');
+    expect(formatted).not.toContain('secret');
+  });
+});


### PR DESCRIPTION
## Summary
- add shared RPC/network and API port preflights for doctor/bootstrap/run/quickstart/main startup
- fix testnet config persistence, faucet cap behavior, live daemon status reporting, and low-runway warning semantics
- improve creator/router/RPC diagnostics and add retry backoff for permanent create failures

## Tests
- `PATH=/Users/adrianobradley/.nvm/versions/node/v22.22.2/bin:$PATH yarn typecheck`
- `PATH=/Users/adrianobradley/.nvm/versions/node/v22.22.2/bin:$PATH yarn build`
- `PATH=/Users/adrianobradley/.nvm/versions/node/v22.22.2/bin:$PATH yarn test`
- `PATH=/Users/adrianobradley/.nvm/versions/node/v22.22.2/bin:$PATH yarn pack:smoke`
- `PATH=/Users/adrianobradley/.nvm/versions/node/v22.22.2/bin:$PATH yarn release:operator-gate`

## Notes
- `doctor` unit tests mock only the RPC preflight to avoid real network IO; production `jinn doctor` still uses the real preflight.
- Untracked docs files were intentionally left out of this PR.