### PR TITLE
Refactor restoration intent posting

### DIFF
--- a/client/src/cli/commands/submit-intent.ts
+++ b/client/src/cli/commands/submit-intent.ts
@@ -12,11 +12,8 @@ import { createCliExecutionContext } from '../execution-context.js';
 import { isRecoverableTransactionError } from '../../tx-retry.js';
 import type { DesiredState } from '../../types/desired-state.js';
 import { SPEC_KINDS, unknownKindMessage } from '../../intents/kinds/index.js';
+import { IntentPostingService } from '../../intents/posting-service.js';
 import { readChainlinkLatest, scaleToDecimal } from '../../venues/chainlink/client.js';
-
-function intentCacheKey(safe: string, intentId: string): string {
-  return `cli_intent:${getAddress(safe)}:${intentId}`;
-}
 
 async function run(ctx: CommandContext): Promise<void> {
   let parsed;
@@ -186,49 +183,25 @@ async function run(ctx: CommandContext): Promise<void> {
 
   const { adapter, jinnStore, primaryService } = built.ctx;
   const safe = primaryService.safe_address!;
-  const cacheKey = intentCacheKey(safe, id);
-  const cached = jinnStore.getConfigValue(cacheKey);
-  if (cached) {
-    emitResult(
-      {
-        schemaVersion: 1,
-        generatedAt: new Date().toISOString(),
-        verb: 'submit-intent',
-        id,
-        creatorMultisig: getAddress(safe),
-        requestId: cached,
-        status: 'already_submitted',
-        idempotent: true,
-      },
-      (v) => {
-        const value = v as { id: string; requestId: string; creatorMultisig: string };
-        return `Intent already submitted.\nID: ${value.id}\nRequest: ${value.requestId}\nSafe: ${value.creatorMultisig}`;
-      },
-      {
-        json: Boolean(parsed.values.json),
-        human: Boolean(parsed.values.human),
-        writer: ctx.writer,
-        stdoutIsTty: ctx.stdoutIsTty,
-        noColor: Boolean(ctx.env['NO_COLOR']),
-      },
-    );
-    return;
-  }
-
-  const attemptNumber = 1;
-  const attemptId = `${id}/${attemptNumber}`;
+  const postingService = new IntentPostingService(adapter, jinnStore);
   try {
     const desiredState: DesiredState = {
       id,
       description,
-      type: 'restoration',
-      attemptId,
-      attemptNumber,
       ...(specOverlay ?? {}),
     };
-    const requestId = await adapter.postDesiredState(desiredState);
-    jinnStore.recordOwnActivity(requestId, 'created');
-    jinnStore.setConfigValue(cacheKey, requestId);
+    const postResult = await postingService.postCandidate(
+      {
+        desiredState,
+        sourceKey: `manual:${id}`,
+        postingPolicy: { kind: 'once_per_safe' },
+        sourceMeta: { kind: desiredState.spec?.kind, note: 'manual' },
+      },
+      {
+        creatorSafeAddress: safe,
+        legacyConfigKeys: [`cli_intent:${getAddress(safe)}:${id}`],
+      },
+    );
     emitResult(
       {
         schemaVersion: 1,
@@ -236,14 +209,17 @@ async function run(ctx: CommandContext): Promise<void> {
         verb: 'submit-intent',
         id,
         creatorMultisig: getAddress(safe),
-        requestId,
-        status: 'submitted',
-        attemptId,
-        attemptNumber,
+        requestId: postResult.requestId,
+        status: postResult.idempotent ? 'already_submitted' : 'submitted',
+        attemptId: postResult.attemptId,
+        attemptNumber: postResult.attemptNumber,
+        idempotent: postResult.idempotent,
       },
       (v) => {
         const value = v as { id: string; requestId: string; creatorMultisig: string };
-        return `Intent submitted.\nID: ${value.id}\nRequest: ${value.requestId}\nSafe: ${value.creatorMultisig}`;
+        return postResult.idempotent
+          ? `Intent already submitted.\nID: ${value.id}\nRequest: ${value.requestId}\nSafe: ${value.creatorMultisig}`
+          : `Intent submitted.\nID: ${value.id}\nRequest: ${value.requestId}\nSafe: ${value.creatorMultisig}`;
       },
       {
         json: Boolean(parsed.values.json),
@@ -284,7 +260,8 @@ const command: CommandModule = {
   helpText: `Usage: jinn submit-intent --id <id> --description <text> [--spec-file <path>] [--dry-run] [--yes] [--human]
 
 Idempotent: re-posting the same (--id) from the same creator Safe returns the
-cached request id (local SQLite) without sending a new transaction.
+existing request id from the shared intent-posting store without sending a new
+transaction.
 
 Options:
   --spec-file <path>  Path to a JSON file containing typed intent fields (window, spec, eligibility).

--- a/client/src/daemon/creator.ts
+++ b/client/src/daemon/creator.ts
@@ -4,6 +4,8 @@ import type { Store } from '../store/store.js';
 import { PermanentError, TransientError } from '../types/index.js';
 import { isRecoverableTransactionError } from '../tx-retry.js';
 import { emitEvent } from '../observability/emit-event.js';
+import { IntentPostingService } from '../intents/posting-service.js';
+import type { IntentSource } from '../intents/sources.js';
 
 export interface ActiveAttempt {
   desiredState: DesiredState;
@@ -12,28 +14,14 @@ export interface ActiveAttempt {
   status: 'pending' | 'resolved';
 }
 
-/** Returns a freshly-built DesiredState for this tick, or null to skip. */
-export type IntentGenerator = () => Promise<DesiredState | null>;
-
 export class CreatorLoop {
   private stopped = false;
-  private posted = new Map<string, number>(); // stateId → timestamp of last post (in-memory fast-path)
   private attempts = new Map<string, ActiveAttempt>();
   private stopResolve: (() => void) | null = null;
   private stopPromise: Promise<void>;
-  private readonly generators: IntentGenerator[];
+  private readonly postingService: IntentPostingService;
 
-  // Minimum interval between posting the same desired state (ms).
-  // ~20 activities/day needed; each cycle = 4 activities; 5 cycles/day = 1 every ~4.8h.
-  // Use 4h to provide safety margin.
-  private static readonly REPOST_INTERVAL_MS = 4 * 60 * 60 * 1000;
   private static readonly PERMANENT_FAILURE_BACKOFF_MS = 30 * 60 * 1000;
-
-  /** SQLite config key for durable idempotency across daemon restarts. */
-  private static cacheKey(state: DesiredState, safeAddress?: string): string {
-    const prefix = safeAddress ? `created_intent:${safeAddress}` : 'created_intent';
-    return `${prefix}:${state.id}`;
-  }
 
   private static failureCacheKey(state: DesiredState, safeAddress?: string): string {
     const prefix = safeAddress ? `create_failed:${safeAddress}` : 'create_failed';
@@ -42,12 +30,11 @@ export class CreatorLoop {
 
   constructor(
     private readonly adapter: ExecutionAdapter,
-    private readonly desiredStates: DesiredState[],
+    private readonly intentSources: IntentSource[],
     private readonly store: Store,
-    generators: IntentGenerator[] = [],
     private readonly safeAddress?: string,
   ) {
-    this.generators = generators;
+    this.postingService = new IntentPostingService(adapter, store);
     this.stopPromise = new Promise(resolve => {
       this.stopResolve = resolve;
     });
@@ -55,35 +42,18 @@ export class CreatorLoop {
 
   async tick(): Promise<RequestId | null> {
     const now = Date.now();
-
-    // Compose candidates: static configured states + freshly generated ones.
-    // Generators returning null are filtered (e.g. Chainlink read failure).
-    const generated: DesiredState[] = [];
-    for (const gen of this.generators) {
+    const candidates = [];
+    for (const source of this.intentSources) {
       try {
-        const result = await gen();
-        if (result) generated.push(result);
+        const result = await source.collect(new Date(now));
+        candidates.push(...result);
       } catch (err) {
-        console.error('[creator] generator error (skipping this tick):', err);
+        console.error(`[creator] source ${source.sourceKey} error (skipping this tick):`, err);
       }
     }
-    const candidates = [...this.desiredStates, ...generated];
 
-    for (const state of candidates) {
-      // In-memory fast-path: posted within the 4h window → skip.
-      const lastPosted = this.posted.get(state.id);
-      if (lastPosted && (now - lastPosted) < CreatorLoop.REPOST_INTERVAL_MS) continue;
-
-      // Durable idempotency: SQLite cache survives daemon restarts. If we
-      // already posted this state.id before (and it's still within the repost
-      // window OR the id is stable-per-hour like auto-generators), skip.
-      const cacheKey = CreatorLoop.cacheKey(state, this.safeAddress);
-      const cachedRequestId = this.store.getConfigValue(cacheKey);
-      if (cachedRequestId) {
-        // Refresh the in-memory tracker so subsequent ticks hit the fast-path.
-        this.posted.set(state.id, now);
-        continue;
-      }
+    for (const candidate of candidates) {
+      const state = candidate.desiredState;
       const failureKey = CreatorLoop.failureCacheKey(state, this.safeAddress);
       const failedAt = this.store.getConfigValue(failureKey);
       if (failedAt) {
@@ -94,32 +64,21 @@ export class CreatorLoop {
       }
 
       try {
-        const prev = this.attempts.get(state.id);
-        const attemptNumber = prev ? prev.attemptNumber + 1 : 1;
-        const attemptId = `${state.id}/${attemptNumber}`;
-        const stateWithAttempt: DesiredState = {
-          ...state,
-          type: 'restoration',
-          attemptId,
-          attemptNumber,
-        };
-        const requestId = await this.adapter.postDesiredState(stateWithAttempt);
-        this.posted.set(state.id, now);
+        const postResult = await this.postingService.postCandidate(candidate, {
+          creatorSafeAddress: this.safeAddress,
+          legacyConfigKeys: [
+            this.safeAddress ? `created_intent:${this.safeAddress}:${state.id}` : `created_intent:${state.id}`,
+          ],
+        });
+        if (postResult.idempotent) continue;
+
+        const requestId = postResult.requestId;
         this.attempts.set(state.id, {
           desiredState: state,
-          attemptNumber,
+          attemptNumber: postResult.attemptNumber,
           restorationRequestId: requestId,
           status: 'pending',
         });
-        this.store.recordOwnActivity(requestId, 'created');
-        emitEvent(this.store, {
-          kind: 'intent_posted',
-          requestId,
-          specKind: state.spec?.kind,
-          outcome: 'ok',
-          detail: `Posted intent for desired state ${state.id}`,
-        }, 'creator');
-        this.store.setConfigValue(cacheKey, requestId);
         return requestId;
       } catch (err) {
         if (err instanceof TransientError) continue;

--- a/client/src/daemon/daemon.ts
+++ b/client/src/daemon/daemon.ts
@@ -1,8 +1,7 @@
 import type { ExecutionAdapter } from '../adapters/adapter.js';
 import type { Runner } from '../runner/runner.js';
-import type { DesiredState } from '../types/index.js';
 import { Store } from '../store/store.js';
-import { CreatorLoop, type IntentGenerator } from './creator.js';
+import { CreatorLoop } from './creator.js';
 import { DeliveryWatcherLoop } from './delivery-watcher.js';
 import { startApiServer, type ApiServer } from '../api/server.js';
 import type { StatusGatherConfig } from '../api/gather-status.js';
@@ -15,13 +14,13 @@ import { RewardClaimLoop, type RewardClaimLoopConfig } from './reward-claim-loop
 import { RestorationEngine, type RestorationEngineOptions } from '../restorer/engine/engine.js';
 import { BalanceTopupLoop, type BalanceTopupLoopConfig } from './balance-topup-loop.js';
 import { emitEvent } from '../observability/emit-event.js';
+import type { IntentSource } from '../intents/sources.js';
 
 const DEFAULT_API_PORT = 7331;
 
 export interface DaemonConfig {
   adapter: ExecutionAdapter;
   runner: Runner;
-  desiredStates: DesiredState[];
   dbPath: string;
   shutdownTimeoutMs?: number;
   /** Engine tick interval (ms) for re-driving in-flight intents. Defaults to 5000. */
@@ -50,12 +49,8 @@ export interface DaemonConfig {
   /** Passed to HTTP API for GET /v1/status (fleet + RPC hints). */
   status?: StatusGatherConfig;
 
-  /**
-   * Extra intent generators called each CreatorLoop tick. Each returns a
-   * freshly-built DesiredState (or null to skip this tick). Used e.g. for
-   * auto-posting price-aware prediction.v0 intents on testnet.
-   */
-  intentGenerators?: IntentGenerator[];
+  /** Restoration intent sources polled by CreatorLoop. */
+  intentSources?: IntentSource[];
 
   /**
    * Creator Safe address — used to scope CreatorLoop's SQLite idempotency
@@ -95,9 +90,8 @@ export class Daemon {
     this.apiPort = config.apiPort ?? parseInt(process.env['JINN_API_PORT'] ?? String(DEFAULT_API_PORT));
     this.creatorLoop = new CreatorLoop(
       this.adapter,
-      config.desiredStates,
+      config.intentSources ?? [],
       this.store,
-      config.intentGenerators ?? [],
       config.creatorSafeAddress,
     );
     this.deliveryWatcherLoop = new DeliveryWatcherLoop(this.adapter, this.store);

--- a/client/src/intents/kinds/index.ts
+++ b/client/src/intents/kinds/index.ts
@@ -2,7 +2,7 @@
  * Single dispatch table for in-repo intent kinds — jinn-mono-6q1.1.
  */
 
-import type { IntentGenerator } from '../../daemon/creator.js';
+import type { IntentGenerator } from '../sources.js';
 import { portfolioV0 } from './portfolio-v0.js';
 import { predictionV0 } from './prediction-v0.js';
 import { predictionApyV0 } from './prediction-apy-v0.js';
@@ -37,8 +37,8 @@ export function collectTestnetAutoIntentGenerators(opts: {
   rpcUrl: string;
   autoIntentsDisabled: boolean;
   env: NodeJS.ProcessEnv;
-}): { generators: IntentGenerator[]; logLines: string[] } {
-  const generators: IntentGenerator[] = [];
+}): { generators: Array<{ kind: string; generator: IntentGenerator }>; logLines: string[] } {
+  const generators: Array<{ kind: string; generator: IntentGenerator }> = [];
   const logLines: string[] = [];
   if (opts.autoIntentsDisabled || opts.network !== 'testnet') {
     return { generators, logLines };
@@ -54,7 +54,7 @@ export function collectTestnetAutoIntentGenerators(opts: {
     if (genConfig === undefined) continue;
     const g = entry.buildGenerator?.(genConfig as never);
     if (g) {
-      generators.push(g);
+      generators.push({ kind: entry.kind, generator: g });
       logLines.push(`[main] auto-intent generator enabled: ${entry.kind} (testnet)`);
     }
   }

--- a/client/src/intents/kinds/spec-kind.ts
+++ b/client/src/intents/kinds/spec-kind.ts
@@ -3,7 +3,7 @@
  * See jinn-mono-6q1.1.
  */
 
-import type { IntentGenerator } from '../../daemon/creator.js';
+import type { IntentGenerator } from '../sources.js';
 
 /** Overlay fields merged into DesiredState when posting from --spec-file. */
 export type ParsedSpecOverlay = {

--- a/client/src/intents/posting-service.ts
+++ b/client/src/intents/posting-service.ts
@@ -1,0 +1,228 @@
+import { randomUUID } from 'node:crypto';
+import { getAddress } from 'viem';
+import type { ExecutionAdapter } from '../adapters/adapter.js';
+import { emitEvent } from '../observability/emit-event.js';
+import type { Store } from '../store/store.js';
+import type { IntentPostRecord, IntentPostingPolicyType } from '../store/store.js';
+import { TransientError, type DesiredState, type RequestId } from '../types/index.js';
+import type { IntentCandidate, IntentPostingPolicy } from './sources.js';
+
+const GLOBAL_CREATOR_SCOPE = '__global__';
+const POST_LOCK_STALE_AFTER_MS = 60_000;
+
+export interface IntentPostResult {
+  requestId: RequestId;
+  desiredState: DesiredState;
+  attemptNumber: number;
+  attemptId: string;
+  idempotent: boolean;
+  source: 'store' | 'legacy_config' | 'posted';
+}
+
+export interface PostIntentCandidateOptions {
+  creatorSafeAddress?: string;
+  legacyConfigKeys?: string[];
+}
+
+function normalizeCreatorSafeAddress(safeAddress?: string): string {
+  return safeAddress ? getAddress(safeAddress) : GLOBAL_CREATOR_SCOPE;
+}
+
+function policyTypeOf(policy: IntentPostingPolicy): IntentPostingPolicyType {
+  return policy.kind;
+}
+
+function scopeKeyOf(policy: IntentPostingPolicy): string {
+  switch (policy.kind) {
+    case 'once_per_safe':
+      return '';
+    case 'once_per_bucket':
+      return policy.bucketKey;
+    case 'interval':
+      return policy.scopeKey ?? '';
+  }
+}
+
+function shouldSkipPost(record: IntentPostRecord, policy: IntentPostingPolicy, nowMs: number): boolean {
+  if (policy.kind !== 'interval') return true;
+  const lastPostedAt = Date.parse(record.lastPostedAt);
+  return Number.isFinite(lastPostedAt) && (nowMs - lastPostedAt) < policy.intervalMs;
+}
+
+export class IntentPostingService {
+  constructor(
+    private readonly adapter: ExecutionAdapter,
+    private readonly store: Store,
+  ) {}
+
+  async postCandidate(
+    candidate: IntentCandidate,
+    opts: PostIntentCandidateOptions = {},
+  ): Promise<IntentPostResult> {
+    const creatorSafeAddress = normalizeCreatorSafeAddress(opts.creatorSafeAddress);
+    const policyType = policyTypeOf(candidate.postingPolicy);
+    const scopeKey = scopeKeyOf(candidate.postingPolicy);
+    const now = new Date();
+    const nowIso = now.toISOString();
+    const nowMs = now.getTime();
+
+    const existing = this.store.getIntentPostRecord({
+      creatorSafeAddress,
+      sourceKey: candidate.sourceKey,
+      policyType,
+      scopeKey,
+    });
+    if (existing && shouldSkipPost(existing, candidate.postingPolicy, nowMs)) {
+      return this.buildIdempotentResult(candidate, existing, 'store');
+    }
+
+    const migrated = this.tryImportLegacyRecord(candidate, {
+      creatorSafeAddress,
+      policyType,
+      scopeKey,
+      nowIso,
+      legacyConfigKeys: opts.legacyConfigKeys ?? [],
+    });
+    if (migrated) {
+      return this.buildIdempotentResult(candidate, migrated, 'legacy_config');
+    }
+
+    const ownerToken = randomUUID();
+    const lockAcquired = this.store.acquireIntentPostLock({
+      creatorSafeAddress,
+      sourceKey: candidate.sourceKey,
+      policyType,
+      scopeKey,
+      ownerToken,
+      lockedAt: nowIso,
+      staleAfterMs: POST_LOCK_STALE_AFTER_MS,
+    });
+    if (!lockAcquired) {
+      throw new TransientError(
+        `Intent post already in progress for ${candidate.sourceKey} (${candidate.desiredState.id})`,
+      );
+    }
+
+    try {
+      const lockedExisting = this.store.getIntentPostRecord({
+        creatorSafeAddress,
+        sourceKey: candidate.sourceKey,
+        policyType,
+        scopeKey,
+      });
+      if (lockedExisting && shouldSkipPost(lockedExisting, candidate.postingPolicy, nowMs)) {
+        return this.buildIdempotentResult(candidate, lockedExisting, 'store');
+      }
+
+      const lockedMigrated = this.tryImportLegacyRecord(candidate, {
+        creatorSafeAddress,
+        policyType,
+        scopeKey,
+        nowIso,
+        legacyConfigKeys: opts.legacyConfigKeys ?? [],
+      });
+      if (lockedMigrated) {
+        return this.buildIdempotentResult(candidate, lockedMigrated, 'legacy_config');
+      }
+
+      const previousPostCount = lockedExisting?.postCount ?? 0;
+      const attemptNumber = previousPostCount + 1;
+      const attemptId = `${candidate.desiredState.id}/${attemptNumber}`;
+      const desiredState: DesiredState = {
+        ...candidate.desiredState,
+        type: 'restoration',
+        attemptId,
+        attemptNumber,
+      };
+      const requestId = await this.adapter.postDesiredState(desiredState);
+
+      this.store.recordOwnActivity(requestId, 'created');
+      emitEvent(this.store, {
+        kind: 'intent_posted',
+        requestId,
+        specKind: candidate.desiredState.spec?.kind,
+        outcome: 'ok',
+        detail: `Posted intent for desired state ${candidate.desiredState.id} via ${candidate.sourceKey}`,
+      }, 'creator');
+      this.store.upsertIntentPostRecord({
+        creatorSafeAddress,
+        sourceKey: candidate.sourceKey,
+        policyType,
+        scopeKey,
+        desiredStateId: candidate.desiredState.id,
+        requestId,
+        firstPostedAt: lockedExisting?.firstPostedAt ?? nowIso,
+        lastPostedAt: nowIso,
+        postCount: attemptNumber,
+      });
+      return {
+        requestId,
+        desiredState,
+        attemptNumber,
+        attemptId,
+        idempotent: false,
+        source: 'posted',
+      };
+    } finally {
+      this.store.releaseIntentPostLock({
+        creatorSafeAddress,
+        sourceKey: candidate.sourceKey,
+        policyType,
+        scopeKey,
+        ownerToken,
+      });
+    }
+  }
+
+  private tryImportLegacyRecord(
+    candidate: IntentCandidate,
+    args: {
+      creatorSafeAddress: string;
+      policyType: IntentPostingPolicyType;
+      scopeKey: string;
+      nowIso: string;
+      legacyConfigKeys: string[];
+    },
+  ): IntentPostRecord | null {
+    for (const key of args.legacyConfigKeys) {
+      const requestId = this.store.getConfigValue(key);
+      if (!requestId) continue;
+      const record: IntentPostRecord = {
+        creatorSafeAddress: args.creatorSafeAddress,
+        sourceKey: candidate.sourceKey,
+        policyType: args.policyType,
+        scopeKey: args.scopeKey,
+        desiredStateId: candidate.desiredState.id,
+        requestId,
+        firstPostedAt: args.nowIso,
+        lastPostedAt: args.nowIso,
+        postCount: 1,
+      };
+      this.store.upsertIntentPostRecord(record);
+      return record;
+    }
+    return null;
+  }
+
+  private buildIdempotentResult(
+    candidate: IntentCandidate,
+    record: IntentPostRecord,
+    source: 'store' | 'legacy_config',
+  ): IntentPostResult {
+    const attemptNumber = Math.max(1, record.postCount);
+    const attemptId = `${candidate.desiredState.id}/${attemptNumber}`;
+    return {
+      requestId: record.requestId,
+      desiredState: {
+        ...candidate.desiredState,
+        type: 'restoration',
+        attemptId,
+        attemptNumber,
+      },
+      attemptNumber,
+      attemptId,
+      idempotent: true,
+      source,
+    };
+  }
+}

--- a/client/src/intents/sources.ts
+++ b/client/src/intents/sources.ts
@@ -1,0 +1,65 @@
+import type { DesiredState } from '../types/desired-state.js';
+
+/** Returns a freshly-built DesiredState for this tick, or null to skip. */
+export type IntentGenerator = () => Promise<DesiredState | null>;
+
+export type IntentPostingPolicy =
+  | { kind: 'once_per_safe' }
+  | { kind: 'once_per_bucket'; bucketKey: string }
+  | { kind: 'interval'; intervalMs: number; scopeKey?: string };
+
+export interface IntentCandidate {
+  desiredState: DesiredState;
+  sourceKey: string;
+  postingPolicy: IntentPostingPolicy;
+  sourceMeta?: {
+    kind?: string;
+    bucketKey?: string;
+    note?: string;
+  };
+}
+
+export interface IntentSource {
+  sourceKey: string;
+  collect(now: Date): Promise<IntentCandidate[]>;
+}
+
+export class StaticConfiguredIntentSource implements IntentSource {
+  readonly sourceKey = 'configured';
+
+  constructor(private readonly desiredStates: DesiredState[]) {}
+
+  async collect(_now: Date): Promise<IntentCandidate[]> {
+    return this.desiredStates.map((desiredState) => ({
+      desiredState,
+      sourceKey: `${this.sourceKey}:${desiredState.id}`,
+      postingPolicy: { kind: 'once_per_safe' },
+      sourceMeta: { kind: desiredState.spec?.kind, note: 'configured' },
+    }));
+  }
+}
+
+export class GeneratedIntentSource implements IntentSource {
+  constructor(
+    readonly sourceKey: string,
+    private readonly generator: IntentGenerator,
+  ) {}
+
+  async collect(_now: Date): Promise<IntentCandidate[]> {
+    const desiredState = await this.generator();
+    if (!desiredState) return [];
+    const bucketKey = desiredState.window
+      ? `${desiredState.window.startTs}:${desiredState.window.endTs}`
+      : desiredState.id;
+    return [{
+      desiredState,
+      sourceKey: this.sourceKey,
+      postingPolicy: { kind: 'once_per_bucket', bucketKey },
+      sourceMeta: {
+        kind: desiredState.spec?.kind,
+        bucketKey,
+        note: 'generated',
+      },
+    }];
+  }
+}

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -40,7 +40,7 @@ import { ClaimRegistryClient } from './adapters/claim-registry/client.js';
 import { createClients } from './adapters/mech/safe.js';
 import { collectTestnetAutoIntentGenerators } from './intents/kinds/index.js';
 import { BASE_FEEDS } from './venues/chainlink/feeds.js';
-import type { IntentGenerator } from './daemon/creator.js';
+import { GeneratedIntentSource, StaticConfiguredIntentSource } from './intents/sources.js';
 import { checkRpcNetwork, logRpcLocalDevToStderr, rpcNetworkFailureHint } from './preflight/rpc-network.js';
 import { apiPortFailureMessage, checkApiPortAvailable } from './preflight/api-port.js';
 
@@ -424,7 +424,7 @@ export async function main(): Promise<DaemonStartupInfo> {
 
   // ── Auto-intent generators (testnet only, opt-out via env) ─────────────────
   const autoIntentsDisabled = process.env['JINN_DISABLE_AUTO_INTENTS'] === '1';
-  const { generators: intentGenerators, logLines: autoIntentLogLines } = collectTestnetAutoIntentGenerators({
+  const { generators: autoIntentGenerators, logLines: autoIntentLogLines } = collectTestnetAutoIntentGenerators({
     network: config.network,
     rpcUrl: config.rpcUrl,
     autoIntentsDisabled,
@@ -436,18 +436,22 @@ export async function main(): Promise<DaemonStartupInfo> {
   if (config.network === 'mainnet' && !autoIntentsDisabled && BASE_FEEDS['ETH / USD']) {
     // Mainnet auto-intent opt-in only; default is OFF. Reserved for a future flag.
   }
+  const intentSources = [
+    new StaticConfiguredIntentSource(config.desiredStates),
+    ...autoIntentGenerators.map(({ kind, generator }) =>
+      new GeneratedIntentSource(`generated:${kind}`, generator)),
+  ];
 
   const daemon = new Daemon({
     adapter,
     runner,
-    desiredStates: config.desiredStates,
+    intentSources,
     dbPath: config.dbPath,
     pollIntervalMs: config.pollIntervalMs,
     apiPort: config.apiPort,
     peers: config.peers.length > 0 ? config.peers : undefined,
     subgraphUrl: config.subgraphUrl,
     nodeEndpoint: config.nodeEndpoint,
-    intentGenerators,
     creatorSafeAddress: safeAddress,
     status: {
       earningDir: config.earningDir,

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -47,6 +47,20 @@ export interface BalanceCacheEntry {
   error?: string | null;
 }
 
+export type IntentPostingPolicyType = 'once_per_safe' | 'once_per_bucket' | 'interval';
+
+export interface IntentPostRecord {
+  creatorSafeAddress: string;
+  sourceKey: string;
+  policyType: IntentPostingPolicyType;
+  scopeKey: string;
+  desiredStateId: string;
+  requestId: string;
+  firstPostedAt: string;
+  lastPostedAt: string;
+  postCount: number;
+}
+
 const SCHEMA = `
 CREATE TABLE IF NOT EXISTS own_activity (
   request_id TEXT PRIMARY KEY,
@@ -116,6 +130,30 @@ CREATE TABLE IF NOT EXISTS balance_cache (
   error TEXT
 );
 
+CREATE TABLE IF NOT EXISTS intent_posts (
+  creator_safe_address TEXT NOT NULL,
+  source_key TEXT NOT NULL,
+  policy_type TEXT NOT NULL CHECK (policy_type IN ('once_per_safe', 'once_per_bucket', 'interval')),
+  scope_key TEXT NOT NULL DEFAULT '',
+  desired_state_id TEXT NOT NULL,
+  request_id TEXT NOT NULL,
+  first_posted_at TEXT NOT NULL,
+  last_posted_at TEXT NOT NULL,
+  post_count INTEGER NOT NULL DEFAULT 1,
+  PRIMARY KEY (creator_safe_address, source_key, policy_type, scope_key)
+);
+CREATE INDEX IF NOT EXISTS idx_intent_posts_desired_state ON intent_posts (desired_state_id);
+
+CREATE TABLE IF NOT EXISTS intent_post_locks (
+  creator_safe_address TEXT NOT NULL,
+  source_key TEXT NOT NULL,
+  policy_type TEXT NOT NULL CHECK (policy_type IN ('once_per_safe', 'once_per_bucket', 'interval')),
+  scope_key TEXT NOT NULL DEFAULT '',
+  owner_token TEXT NOT NULL,
+  locked_at TEXT NOT NULL,
+  PRIMARY KEY (creator_safe_address, source_key, policy_type, scope_key)
+);
+
 `;
 
 export class Store {
@@ -182,6 +220,131 @@ export class Store {
 
   setConfigValue(key: string, value: string): void {
     this.db.prepare('INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)').run(key, value);
+  }
+
+  getIntentPostRecord(args: {
+    creatorSafeAddress: string;
+    sourceKey: string;
+    policyType: IntentPostingPolicyType;
+    scopeKey: string;
+  }): IntentPostRecord | null {
+    const row = this.db.prepare(
+      `SELECT creator_safe_address, source_key, policy_type, scope_key, desired_state_id, request_id,
+              first_posted_at, last_posted_at, post_count
+       FROM intent_posts
+       WHERE creator_safe_address = @creatorSafeAddress
+         AND source_key = @sourceKey
+         AND policy_type = @policyType
+         AND scope_key = @scopeKey`,
+    ).get(args) as {
+      creator_safe_address: string;
+      source_key: string;
+      policy_type: IntentPostingPolicyType;
+      scope_key: string;
+      desired_state_id: string;
+      request_id: string;
+      first_posted_at: string;
+      last_posted_at: string;
+      post_count: number;
+    } | undefined;
+    if (!row) return null;
+    return {
+      creatorSafeAddress: row.creator_safe_address,
+      sourceKey: row.source_key,
+      policyType: row.policy_type,
+      scopeKey: row.scope_key,
+      desiredStateId: row.desired_state_id,
+      requestId: row.request_id,
+      firstPostedAt: row.first_posted_at,
+      lastPostedAt: row.last_posted_at,
+      postCount: row.post_count,
+    };
+  }
+
+  upsertIntentPostRecord(record: IntentPostRecord): void {
+    this.db.prepare(
+      `INSERT INTO intent_posts
+         (creator_safe_address, source_key, policy_type, scope_key, desired_state_id, request_id,
+          first_posted_at, last_posted_at, post_count)
+       VALUES
+         (@creatorSafeAddress, @sourceKey, @policyType, @scopeKey, @desiredStateId, @requestId,
+          @firstPostedAt, @lastPostedAt, @postCount)
+       ON CONFLICT(creator_safe_address, source_key, policy_type, scope_key) DO UPDATE SET
+         desired_state_id = excluded.desired_state_id,
+         request_id = excluded.request_id,
+         first_posted_at = excluded.first_posted_at,
+         last_posted_at = excluded.last_posted_at,
+         post_count = excluded.post_count`,
+    ).run(record);
+  }
+
+  acquireIntentPostLock(args: {
+    creatorSafeAddress: string;
+    sourceKey: string;
+    policyType: IntentPostingPolicyType;
+    scopeKey: string;
+    ownerToken: string;
+    lockedAt: string;
+    staleAfterMs: number;
+  }): boolean {
+    const tx = this.db.transaction((params: typeof args) => {
+      const existing = this.db.prepare(
+        `SELECT owner_token, locked_at
+         FROM intent_post_locks
+         WHERE creator_safe_address = @creatorSafeAddress
+           AND source_key = @sourceKey
+           AND policy_type = @policyType
+           AND scope_key = @scopeKey`,
+      ).get(params) as { owner_token: string; locked_at: string } | undefined;
+
+      if (!existing) {
+        this.db.prepare(
+          `INSERT INTO intent_post_locks
+             (creator_safe_address, source_key, policy_type, scope_key, owner_token, locked_at)
+           VALUES
+             (@creatorSafeAddress, @sourceKey, @policyType, @scopeKey, @ownerToken, @lockedAt)`,
+        ).run(params);
+        return true;
+      }
+
+      const lockedAtMs = Date.parse(existing.locked_at);
+      const nowMs = Date.parse(params.lockedAt);
+      const isStale = Number.isFinite(lockedAtMs)
+        && Number.isFinite(nowMs)
+        && (nowMs - lockedAtMs) >= params.staleAfterMs;
+      if (!isStale) {
+        return false;
+      }
+
+      this.db.prepare(
+        `UPDATE intent_post_locks
+         SET owner_token = @ownerToken, locked_at = @lockedAt
+         WHERE creator_safe_address = @creatorSafeAddress
+           AND source_key = @sourceKey
+           AND policy_type = @policyType
+           AND scope_key = @scopeKey`,
+      ).run(params);
+      return true;
+    });
+
+    return tx(args);
+  }
+
+  releaseIntentPostLock(args: {
+    creatorSafeAddress: string;
+    sourceKey: string;
+    policyType: IntentPostingPolicyType;
+    scopeKey: string;
+    ownerToken: string;
+  }): void {
+    this.db.prepare(
+      `DELETE FROM intent_post_locks
+       WHERE creator_safe_address = @creatorSafeAddress
+         AND source_key = @sourceKey
+         AND policy_type = @policyType
+         AND scope_key = @scopeKey
+         AND owner_token = @ownerToken`,
+    ).run(args);
   }
 
   /** Counts of protocol roles recorded for this node (best-effort activity hints). */

--- a/client/test/daemon/creator.test.ts
+++ b/client/test/daemon/creator.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
 import { CreatorLoop } from '../../src/daemon/creator.js';
 import { LocalAdapter } from '../../src/adapters/local/adapter.js';
+import { GeneratedIntentSource, StaticConfiguredIntentSource } from '../../src/intents/sources.js';
 import { Store } from '../../src/store/store.js';
 import { PermanentError, type DesiredState } from '../../src/types/index.js';
+
+const SAFE = '0x00112233445566778899aabbccddeeff00112233';
 
 describe('CreatorLoop', () => {
   it('posts desired states with type and attemptId', async () => {
@@ -15,7 +18,7 @@ describe('CreatorLoop', () => {
     ];
 
     const postSpy = vi.spyOn(adapter, 'postDesiredState');
-    const loop = new CreatorLoop(adapter, states, store);
+    const loop = new CreatorLoop(adapter, [new StaticConfiguredIntentSource(states)], store);
 
     await loop.tick();
 
@@ -42,7 +45,7 @@ describe('CreatorLoop', () => {
     ];
 
     const postSpy = vi.spyOn(adapter, 'postDesiredState');
-    const loop = new CreatorLoop(adapter, states, store);
+    const loop = new CreatorLoop(adapter, [new StaticConfiguredIntentSource(states)], store);
 
     await loop.tick();
     await loop.tick();
@@ -65,7 +68,11 @@ describe('CreatorLoop', () => {
     const generator = vi.fn(async () => generated);
 
     const postSpy = vi.spyOn(adapter, 'postDesiredState');
-    const loop = new CreatorLoop(adapter, [], store, [generator]);
+    const loop = new CreatorLoop(
+      adapter,
+      [new GeneratedIntentSource('generated:prediction.v0', generator)],
+      store,
+    );
 
     await loop.tick();
     expect(generator).toHaveBeenCalledTimes(1);
@@ -82,7 +89,11 @@ describe('CreatorLoop', () => {
 
     const generator = vi.fn(async () => null);
     const postSpy = vi.spyOn(adapter, 'postDesiredState');
-    const loop = new CreatorLoop(adapter, [], store, [generator]);
+    const loop = new CreatorLoop(
+      adapter,
+      [new GeneratedIntentSource('generated:prediction.v0', generator)],
+      store,
+    );
 
     await loop.tick();
     expect(generator).toHaveBeenCalledTimes(1);
@@ -102,12 +113,13 @@ describe('CreatorLoop', () => {
     const postSpy = vi.spyOn(adapter, 'postDesiredState');
 
     // First loop instance posts.
-    const loop1 = new CreatorLoop(adapter, states, store, [], '0xSafeAddr');
+    const source = new StaticConfiguredIntentSource(states);
+    const loop1 = new CreatorLoop(adapter, [source], store, SAFE);
     await loop1.tick();
     expect(postSpy).toHaveBeenCalledTimes(1);
 
     // New loop instance (fresh in-memory Map) reusing the same store.
-    const loop2 = new CreatorLoop(adapter, states, store, [], '0xSafeAddr');
+    const loop2 = new CreatorLoop(adapter, [source], store, SAFE);
     await loop2.tick();
     expect(postSpy).toHaveBeenCalledTimes(1); // no double-post
 
@@ -128,7 +140,11 @@ describe('CreatorLoop', () => {
     });
 
     const postSpy = vi.spyOn(adapter, 'postDesiredState');
-    const loop = new CreatorLoop(adapter, [], store, [generator]);
+    const loop = new CreatorLoop(
+      adapter,
+      [new GeneratedIntentSource('generated:prediction.v0', generator)],
+      store,
+    );
 
     await loop.tick(); // generator throws; no post
     expect(postSpy).not.toHaveBeenCalled();
@@ -149,12 +165,44 @@ describe('CreatorLoop', () => {
     const postSpy = vi
       .spyOn(adapter, 'postDesiredState')
       .mockRejectedValue(new PermanentError('No request IDs returned from router'));
-    const loop = new CreatorLoop(adapter, states, store, [], '0xSafeAddr');
+    const loop = new CreatorLoop(adapter, [new StaticConfiguredIntentSource(states)], store, SAFE);
 
     await expect(loop.tick()).rejects.toThrow(/No request IDs/);
     await loop.tick();
 
     expect(postSpy).toHaveBeenCalledTimes(1);
+    store.close();
+    await adapter.stop();
+  });
+
+  it('posts generated intents once per bucket and again in a new bucket', async () => {
+    const adapter = new LocalAdapter();
+    await adapter.initialize();
+    const store = new Store(':memory:');
+
+    let bucketStart = 0;
+    const generator = vi.fn(async () => ({
+      id: `auto-${bucketStart}`,
+      description: 'bucketed',
+      window: { startTs: bucketStart, endTs: bucketStart + 600_000 },
+    } satisfies DesiredState));
+
+    const postSpy = vi.spyOn(adapter, 'postDesiredState');
+    const loop = new CreatorLoop(
+      adapter,
+      [new GeneratedIntentSource('generated:prediction.v0', generator)],
+      store,
+      SAFE,
+    );
+
+    await loop.tick();
+    await loop.tick();
+    expect(postSpy).toHaveBeenCalledTimes(1);
+
+    bucketStart = 600_000;
+    await loop.tick();
+    expect(postSpy).toHaveBeenCalledTimes(2);
+
     store.close();
     await adapter.stop();
   });

--- a/client/test/daemon/daemon.test.ts
+++ b/client/test/daemon/daemon.test.ts
@@ -25,7 +25,7 @@ describe('Daemon', () => {
     const config: DaemonConfig = {
       adapter: new LocalAdapter(),
       runner: new SimpleRunner(async (desc) => `Done: ${desc}`),
-      desiredStates: [],
+      intentSources: [],
       dbPath: ':memory:',
       restorationEngine: minimalEngineConfig(),
     };
@@ -39,7 +39,7 @@ describe('Daemon', () => {
     const config: DaemonConfig = {
       adapter: new LocalAdapter(),
       runner: new SimpleRunner(async (desc) => `Done: ${desc}`),
-      desiredStates: [],
+      intentSources: [],
       dbPath: ':memory:',
       restorationEngine: minimalEngineConfig(),
     };

--- a/client/test/intents/kinds/index.test.ts
+++ b/client/test/intents/kinds/index.test.ts
@@ -136,6 +136,7 @@ describe('SPEC_KINDS manifest', () => {
       env: { ...process.env, JINN_ENABLE_APY_AUTO_INTENTS: '1' },
     });
     expect(generators.length).toBe(2);
+    expect(generators.map((g) => g.kind)).toEqual(['prediction.v0', 'prediction.apy.v0']);
     expect(logLines.some((l) => l.includes('prediction.v0'))).toBe(true);
     expect(logLines.some((l) => l.includes('prediction.apy.v0'))).toBe(true);
   });

--- a/client/test/intents/posting-service.test.ts
+++ b/client/test/intents/posting-service.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest';
+import { LocalAdapter } from '../../src/adapters/local/adapter.js';
+import { IntentPostingService } from '../../src/intents/posting-service.js';
+import { Store } from '../../src/store/store.js';
+import { TransientError } from '../../src/types/index.js';
+
+const SAFE_A = '0x00112233445566778899aabbccddeeff00112233';
+const SAFE_B = '0x1111222233334444555566667777888899990000';
+
+describe('IntentPostingService', () => {
+  it('returns the same request id for repeated manual submissions from the same Safe', async () => {
+    const adapter = new LocalAdapter();
+    await adapter.initialize();
+    const store = new Store(':memory:');
+    const service = new IntentPostingService(adapter, store);
+
+    const postSpy = vi.spyOn(adapter, 'postDesiredState');
+    const candidate = {
+      desiredState: { id: 'manual-1', description: 'test manual submission' },
+      sourceKey: 'manual:manual-1',
+      postingPolicy: { kind: 'once_per_safe' } as const,
+    };
+
+    const first = await service.postCandidate(candidate, { creatorSafeAddress: SAFE_A });
+    const second = await service.postCandidate(candidate, { creatorSafeAddress: SAFE_A });
+
+    expect(first.idempotent).toBe(false);
+    expect(second.idempotent).toBe(true);
+    expect(second.requestId).toBe(first.requestId);
+    expect(postSpy).toHaveBeenCalledTimes(1);
+
+    store.close();
+    await adapter.stop();
+  });
+
+  it('migrates legacy config keys into intent_posts on first lookup', async () => {
+    const adapter = new LocalAdapter();
+    await adapter.initialize();
+    const store = new Store(':memory:');
+    const service = new IntentPostingService(adapter, store);
+
+    store.setConfigValue(`cli_intent:${SAFE_A}:manual-legacy`, 'legacy-request-id');
+
+    const postSpy = vi.spyOn(adapter, 'postDesiredState');
+    const result = await service.postCandidate(
+      {
+        desiredState: { id: 'manual-legacy', description: 'legacy' },
+        sourceKey: 'manual:manual-legacy',
+        postingPolicy: { kind: 'once_per_safe' },
+      },
+      {
+        creatorSafeAddress: SAFE_A,
+        legacyConfigKeys: [`cli_intent:${SAFE_A}:manual-legacy`],
+      },
+    );
+
+    expect(result.idempotent).toBe(true);
+    expect(result.requestId).toBe('legacy-request-id');
+    expect(postSpy).not.toHaveBeenCalled();
+    expect(store.getIntentPostRecord({
+      creatorSafeAddress: '0x00112233445566778899AABbCCdDeeFf00112233',
+      sourceKey: 'manual:manual-legacy',
+      policyType: 'once_per_safe',
+      scopeKey: '',
+    })?.requestId).toBe('legacy-request-id');
+
+    store.close();
+    await adapter.stop();
+  });
+
+  it('scopes idempotency by creator Safe', async () => {
+    const adapter = new LocalAdapter();
+    await adapter.initialize();
+    const store = new Store(':memory:');
+    const service = new IntentPostingService(adapter, store);
+
+    const postSpy = vi.spyOn(adapter, 'postDesiredState');
+    const candidate = {
+      desiredState: { id: 'shared-id', description: 'same logical id' },
+      sourceKey: 'manual:shared-id',
+      postingPolicy: { kind: 'once_per_safe' } as const,
+    };
+
+    const first = await service.postCandidate(candidate, { creatorSafeAddress: SAFE_A });
+    const second = await service.postCandidate(candidate, { creatorSafeAddress: SAFE_B });
+
+    expect(first.requestId).not.toBe(second.requestId);
+    expect(postSpy).toHaveBeenCalledTimes(2);
+
+    store.close();
+    await adapter.stop();
+  });
+
+  it('prevents concurrent callers from double-posting the same candidate', async () => {
+    const adapter = new LocalAdapter();
+    await adapter.initialize();
+    const store = new Store(':memory:');
+    const service = new IntentPostingService(adapter, store);
+
+    let releasePost: (() => void) | null = null;
+    const postingGate = new Promise<void>((resolve) => {
+      releasePost = resolve;
+    });
+
+    const postSpy = vi.spyOn(adapter, 'postDesiredState').mockImplementation(async (state) => {
+      await postingGate;
+      return `req-${state.id}`;
+    });
+
+    const candidate = {
+      desiredState: { id: 'race-1', description: 'race test' },
+      sourceKey: 'manual:race-1',
+      postingPolicy: { kind: 'once_per_safe' } as const,
+    };
+
+    const first = service.postCandidate(candidate, { creatorSafeAddress: SAFE_A });
+    await Promise.resolve();
+
+    await expect(
+      service.postCandidate(candidate, { creatorSafeAddress: SAFE_A }),
+    ).rejects.toBeInstanceOf(TransientError);
+
+    releasePost?.();
+    const firstResult = await first;
+    expect(firstResult.idempotent).toBe(false);
+    expect(firstResult.requestId).toBe('req-race-1');
+    expect(postSpy).toHaveBeenCalledTimes(1);
+
+    store.close();
+    await adapter.stop();
+  });
+});

--- a/client/test/store/store.test.ts
+++ b/client/test/store/store.test.ts
@@ -32,4 +32,29 @@ describe('Store', () => {
     expect(store.getRecentOwnActivity(5)).toHaveLength(2);
     expect(store.getConfigValue('last_reward_claim_tick_at')).toBe('2026-01-02T00:00:00.000Z');
   });
+
+  it('stores durable intent post records', () => {
+    store.upsertIntentPostRecord({
+      creatorSafeAddress: '0x00112233445566778899AABbCCdDeeFf00112233',
+      sourceKey: 'manual:test-1',
+      policyType: 'once_per_safe',
+      scopeKey: '',
+      desiredStateId: 'test-1',
+      requestId: 'req-1',
+      firstPostedAt: '2026-04-23T10:00:00.000Z',
+      lastPostedAt: '2026-04-23T10:00:00.000Z',
+      postCount: 1,
+    });
+
+    expect(store.getIntentPostRecord({
+      creatorSafeAddress: '0x00112233445566778899AABbCCdDeeFf00112233',
+      sourceKey: 'manual:test-1',
+      policyType: 'once_per_safe',
+      scopeKey: '',
+    })).toMatchObject({
+      requestId: 'req-1',
+      desiredStateId: 'test-1',
+      postCount: 1,
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- unify restoration intent posting behind explicit intent sources and a shared posting service
- add durable `intent_posts` persistence with legacy cache migration and cross-process posting locks
- route both daemon posting and `jinn submit-intent` through the same backend and extend tests

## Details
This refactor introduces an internal `IntentSource` layer for restoration intents, replacing the old `desiredStates + generators` shape inside the creator loop.

`IntentPostingService` now owns:
- posting policy evaluation (`once_per_safe`, `once_per_bucket`, `interval`)
- durable idempotency via the new `intent_posts` table
- migration from legacy `created_intent:*` and `cli_intent:*` config keys
- cross-process posting locks so concurrent callers do not double-submit the same intent

The daemon now builds intent sources from:
- configured static desired states
- testnet auto-intent generators

`jinn submit-intent` keeps the same outward CLI behavior but now uses the shared posting service instead of its own cache path.

Evaluation intent creation remains unchanged in the downstream delivery path.

## Validation
- `yarn typecheck`
- `yarn test`