### PR TITLE
docs(design): add root-level PRODUCT/DESIGN context and hero-mining SVG

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,3 +272,17 @@ To add a new **in-repo** `spec.kind` (typed spec, `jinn submit-intent --spec-fil
 ## Spec Conventions
 
 Spec files are named `YYYY-MM-DD-<topic>.md` and placed in `spec/`. Each has a version, date, and author in the header.
+
+## Design Context
+
+Before producing anything user-facing — essays, slides, mocks, marketing surfaces, product UI, SVG assets — read the two root-level context files:
+
+- [`PRODUCT.md`](PRODUCT.md) — strategic context. Register (`brand` by default, override to `product` inside `client/`, `ui_kits/explorer/`, or any dashboard surface), users, product purpose, brand personality, anti-references, and the five design principles. The lead principles, restated briefly:
+  1. Keep the words, loosen the visuals.
+  2. The words do the magic; the visuals stay stark.
+  3. Clarity beats mood when consequences are real.
+  4. Participants are co-authors, not users.
+  5. Protocol before narrative.
+- [`DESIGN.md`](DESIGN.md) — visual spec in [Google Stitch format](https://stitch.withgoogle.com/docs/design-md/format/). YAML frontmatter with colours, typography, radii, spacing, and component tokens; prose body with six fixed sections (Overview, Colors, Typography, Elevation, Components, Do's and Don'ts). Pair file [`DESIGN.json`](DESIGN.json) extends the frontmatter with tonal ramps, canonical OKLCH, shadows, motion, breakpoints, and drop-in component HTML/CSS.
+
+These files are the root-level precipitate of [`docs/design/jinn-design-system/`](docs/design/jinn-design-system/), which remains the canonical long-form source.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,6 +274,15 @@ Spec files are named `YYYY-MM-DD-<topic>.md` and placed in `spec/`. Each has a v
 
 ## Design System
 
+**Root-level quick reference** (for `impeccable` and other skill consumers):
+- [`PRODUCT.md`](PRODUCT.md) — register (default `brand`; override to `product` inside `client/`, `ui_kits/explorer/`, or any dashboard surface), users, brand personality, anti-references, and five strategic principles.
+- [`DESIGN.md`](DESIGN.md) — visual spec in [Google Stitch format](https://stitch.withgoogle.com/docs/design-md/format/): YAML frontmatter with colours, typography, radii, spacing, and component tokens; six-section prose body (Overview, Colors, Typography, Elevation, Components, Do's and Don'ts).
+- [`DESIGN.json`](DESIGN.json) — sidecar extending the frontmatter with tonal ramps, canonical OKLCH, shadow/motion/breakpoint tokens, and drop-in component HTML/CSS.
+
+These three files are the root-level precipitate of `docs/design/jinn-design-system/`. If you're writing marketing copy, docs, slides, or product UI, start with PRODUCT.md + DESIGN.md. If you're extending the brand itself (new sigil, new palette variant, new surface treatment), continue to the long-form source below.
+
+---
+
 Jinn's design system lives at [`docs/design/jinn-design-system/`](docs/design/jinn-design-system/). **Read it before building any UI, slide, mock, docs page, marketing surface, or other user-facing artifact** — it's the source of truth for colors, type, voice, iconography, and surface rules.
 
 Entry points, in order:

--- a/DESIGN.json
+++ b/DESIGN.json
@@ -1,0 +1,240 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-04-24T00:00:00Z",
+  "title": "Design System: Jinn",
+  "extensions": {
+    "colorMeta": {
+      "bg": {
+        "role": "neutral",
+        "displayName": "Deep Night",
+        "canonical": "oklch(17% 0.035 258)",
+        "tonalRamp": ["#070d18", "#0c1628", "#142340", "#1f3a66", "#2f5598", "#4a7bc4", "#7aa7dc", "#e4eefa"]
+      },
+      "bg-elevated": {
+        "role": "neutral",
+        "displayName": "Elevated Night",
+        "canonical": "oklch(23% 0.05 258)",
+        "tonalRamp": ["#070d18", "#0c1628", "#142340", "#1f3a66", "#2f5598", "#4a7bc4", "#7aa7dc", "#e4eefa"]
+      },
+      "bg-sunken": {
+        "role": "neutral",
+        "displayName": "Void",
+        "canonical": "oklch(13% 0.028 258)",
+        "tonalRamp": ["#070d18", "#0c1628", "#142340", "#1f3a66", "#2f5598", "#4a7bc4", "#7aa7dc", "#e4eefa"]
+      },
+      "fg": {
+        "role": "neutral",
+        "displayName": "Moon-bone",
+        "canonical": "oklch(97% 0.008 250)",
+        "tonalRamp": ["#f2f7fc", "#e4eefa", "#cbdef3", "#a8c8ea", "#7aa7dc", "#4a7bc4", "#2f5598", "#1f3a66"]
+      },
+      "fg-muted": {
+        "role": "neutral",
+        "displayName": "Smoke 300",
+        "canonical": "oklch(72% 0.02 248)",
+        "tonalRamp": ["#33394a", "#444c60", "#5c6b82", "#7d8ba3", "#a4b0c2", "#c3cbd8", "#dce1e9", "#eff2f6"]
+      },
+      "fg-dim": {
+        "role": "neutral",
+        "displayName": "Smoke 400",
+        "canonical": "oklch(60% 0.03 250)",
+        "tonalRamp": ["#33394a", "#444c60", "#5c6b82", "#7d8ba3", "#a4b0c2", "#c3cbd8", "#dce1e9", "#eff2f6"]
+      },
+      "border": {
+        "role": "neutral",
+        "displayName": "Dark Hairline",
+        "canonical": "oklch(33% 0.07 260)",
+        "tonalRamp": ["#070d18", "#0c1628", "#142340", "#1f3a66", "#2f5598", "#4a7bc4", "#7aa7dc", "#e4eefa"]
+      },
+      "border-strong": {
+        "role": "neutral",
+        "displayName": "Sky Hairline",
+        "canonical": "oklch(70% 0.10 250)",
+        "tonalRamp": ["#070d18", "#0c1628", "#142340", "#1f3a66", "#2f5598", "#4a7bc4", "#7aa7dc", "#e4eefa"]
+      },
+      "border-accent": {
+        "role": "secondary",
+        "displayName": "Gold Hairline",
+        "canonical": "oklch(73% 0.13 85)",
+        "tonalRamp": ["#6b5020", "#8d6d2b", "#a88438", "#c9a048", "#dcb866", "#ead08e", "#f3e2b0", "#faf1d8"]
+      },
+      "accent-sky": {
+        "role": "primary",
+        "displayName": "Sky",
+        "canonical": "oklch(70% 0.10 250)",
+        "tonalRamp": ["#070d18", "#0c1628", "#142340", "#1f3a66", "#2f5598", "#4a7bc4", "#7aa7dc", "#e4eefa"]
+      },
+      "accent-sky-hover": {
+        "role": "primary",
+        "displayName": "Bright Sky",
+        "canonical": "oklch(80% 0.08 248)",
+        "tonalRamp": ["#070d18", "#0c1628", "#142340", "#1f3a66", "#2f5598", "#4a7bc4", "#a8c8ea", "#e4eefa"]
+      },
+      "accent-gold": {
+        "role": "secondary",
+        "displayName": "Lamplight Gold",
+        "canonical": "oklch(79% 0.11 85)",
+        "tonalRamp": ["#6b5020", "#8d6d2b", "#a88438", "#c9a048", "#dcb866", "#ead08e", "#f3e2b0", "#faf1d8"]
+      },
+      "accent-gold-hover": {
+        "role": "secondary",
+        "displayName": "Bright Lamplight",
+        "canonical": "oklch(85% 0.10 85)",
+        "tonalRamp": ["#6b5020", "#8d6d2b", "#a88438", "#c9a048", "#dcb866", "#ead08e", "#f3e2b0", "#faf1d8"]
+      },
+      "vow-green": {
+        "role": "success",
+        "displayName": "Vow Green",
+        "canonical": "oklch(63% 0.06 180)",
+        "tonalRamp": ["#1f2f2b", "#2e4640", "#3f5e56", "#527a70", "#6a9b8f", "#8bb6ab", "#b0cdc5", "#d8e8e4"]
+      },
+      "wane": {
+        "role": "warning",
+        "displayName": "Wane",
+        "canonical": "oklch(61% 0.13 62)",
+        "tonalRamp": ["#3a2710", "#5a3c18", "#7d5521", "#9a6c28", "#b8802f", "#d0994a", "#e2b878", "#f0dcb0"]
+      },
+      "break-red": {
+        "role": "danger",
+        "displayName": "Break Red",
+        "canonical": "oklch(55% 0.10 20)",
+        "tonalRamp": ["#3a1e1e", "#5a2e2e", "#7d3f3f", "#934c4c", "#a85a5a", "#c27c7c", "#daa4a4", "#edcccc"]
+      },
+      "seer-violet": {
+        "role": "info",
+        "displayName": "Seer Violet",
+        "canonical": "oklch(55% 0.10 290)",
+        "tonalRamp": ["#26213c", "#3b3459", "#544b79", "#6a5f96", "#7a6db0", "#988dc3", "#b6add6", "#d7d0e9"]
+      }
+    },
+    "typographyMeta": {
+      "display": { "displayName": "Display", "purpose": "Marketing hero headlines only. Instrument Serif." },
+      "display-xl": { "displayName": "Display XL", "purpose": "The single biggest mark on a landing page." },
+      "headline": { "displayName": "Headline", "purpose": "Section heads in long-form content." },
+      "title": { "displayName": "Title", "purpose": "In-product section titles. JetBrains Mono." },
+      "body": { "displayName": "Body", "purpose": "Default body copy. Cap at ~72ch." },
+      "label": { "displayName": "Label", "purpose": "ALL CAPS MONO eyebrows, column headers, status chips." },
+      "wish": { "displayName": "Wish", "purpose": "The one decorative flourish, italic serif pull-quote." }
+    },
+    "shadows": [
+      { "name": "hard-sm", "value": "2px 2px 0 0 #070d18", "purpose": "Optional accent on interactive cards." },
+      { "name": "hard", "value": "4px 4px 0 0 #070d18", "purpose": "Pressed/held states on buttons or tiles." },
+      { "name": "hard-lg", "value": "6px 6px 0 0 #070d18", "purpose": "Rare. Marketing hero tiles only." },
+      { "name": "float", "value": "0 12px 32px -8px rgba(0,0,0,0.5), 0 2px 4px rgba(0,0,0,0.3)", "purpose": "The one soft blur. Overlays only (menus, toasts, modals). Never on chrome." }
+    ],
+    "motion": [
+      { "name": "dur-fast", "value": "80ms", "purpose": "Hover, focus, small state changes." },
+      { "name": "dur-base", "value": "140ms", "purpose": "Default transition duration." },
+      { "name": "dur-slow", "value": "240ms", "purpose": "Panel reveals, page transitions." },
+      { "name": "dur-wish", "value": "600ms", "purpose": "The permitted 'magical' slow fade, reserved for the .wish display element on first appearance." },
+      { "name": "ease-linear", "value": "linear", "purpose": "Default easing. Things appear." },
+      { "name": "ease-in-out", "value": "cubic-bezier(0.4, 0, 0.2, 1)", "purpose": "Rare. Never bounce, overshoot, or spring." }
+    ],
+    "breakpoints": [
+      { "name": "mobile", "value": "0px", "purpose": "Single-column mobile layout." },
+      { "name": "tablet", "value": "768px", "purpose": "4-column grid." },
+      { "name": "desktop", "value": "1200px", "purpose": "8-column grid, 24px gutters." },
+      { "name": "max-content", "value": "1440px", "purpose": "Maximum content width. Long-form copy caps at ~72ch." }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "Sky-blue call-to-action. Sentence case. The default affordance for a primary action.",
+      "html": "<button class=\"ds-btn-primary\">Bind vessel</button>",
+      "css": ".ds-btn-primary { background: #7aa7dc; color: #070d18; font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace; font-weight: 500; font-size: 14px; letter-spacing: -0.01em; padding: 10px 20px; border: 1px solid #7aa7dc; border-radius: 6px; cursor: pointer; transition: background 80ms linear, color 80ms linear; } .ds-btn-primary:hover { background: #a8c8ea; border-color: #a8c8ea; } .ds-btn-primary:focus-visible { outline: 2px solid #7aa7dc; outline-offset: 2px; } .ds-btn-primary:disabled { opacity: 0.4; cursor: not-allowed; }"
+    },
+    {
+      "name": "Ghost Button",
+      "kind": "button",
+      "refersTo": "button-ghost",
+      "description": "Transparent background, moon-bone text. Secondary action that doesn't compete with a primary.",
+      "html": "<button class=\"ds-btn-ghost\">Read the scrying</button>",
+      "css": ".ds-btn-ghost { background: transparent; color: #f2f7fc; font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace; font-weight: 500; font-size: 14px; letter-spacing: -0.01em; padding: 10px 20px; border: 1px solid #1f3a66; border-radius: 6px; cursor: pointer; transition: color 80ms linear, border-color 80ms linear; } .ds-btn-ghost:hover { color: #7aa7dc; border-color: #7aa7dc; } .ds-btn-ghost:focus-visible { outline: 2px solid #7aa7dc; outline-offset: 2px; }"
+    },
+    {
+      "name": "Status Chip (Accent)",
+      "kind": "chip",
+      "refersTo": "chip-accent",
+      "description": "ALL CAPS MONO status marker with sky border. Used for state labels in tables and headers.",
+      "html": "<span class=\"ds-chip-accent\">In smoke</span>",
+      "css": ".ds-chip-accent { display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; background: transparent; color: #7aa7dc; font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace; font-weight: 500; font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; border: 1px solid #7aa7dc; border-radius: 4px; }"
+    },
+    {
+      "name": "Panel Card",
+      "kind": "card",
+      "refersTo": "card",
+      "description": "The workhorse container. Flat elevated surface, hairline border, no shadow at rest. Hover darkens the border to sky.",
+      "html": "<article class=\"ds-card\"><h3 class=\"ds-card-title\">Vessel 0x4a7f</h3><p class=\"ds-card-body\">Bound. Three wishes in smoke. Last seer: 0x2d91.</p></article>",
+      "css": ".ds-card { background: #142340; color: #f2f7fc; border: 1px solid #1f3a66; border-radius: 10px; padding: 24px; transition: border-color 140ms linear; } .ds-card:hover { border-color: #7aa7dc; } .ds-card-title { font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace; font-weight: 500; font-size: 17px; line-height: 1.2; letter-spacing: -0.01em; margin: 0 0 12px 0; color: #f2f7fc; } .ds-card-body { font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace; font-weight: 400; font-size: 14px; line-height: 1.7; letter-spacing: -0.01em; margin: 0; color: #a4b0c2; }"
+    },
+    {
+      "name": "Text Input",
+      "kind": "input",
+      "refersTo": "input",
+      "description": "Mono-typed input with hairline border. Focus draws a 2px sky outline with 2px offset; visible, sharp, no glow.",
+      "html": "<label class=\"ds-field\"><span class=\"ds-field-label\">Outcome</span><input class=\"ds-input\" type=\"text\" placeholder=\"Speak your first wish\\u2026\"></label>",
+      "css": ".ds-field { display: flex; flex-direction: column; gap: 4px; font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace; } .ds-field-label { font-weight: 500; font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: #a4b0c2; } .ds-input { background: #0c1628; color: #f2f7fc; font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace; font-weight: 400; font-size: 14px; letter-spacing: -0.01em; padding: 10px 12px; border: 1px solid #1f3a66; border-radius: 6px; outline: none; transition: border-color 80ms linear; } .ds-input::placeholder { color: #7d8ba3; } .ds-input:focus-visible { outline: 2px solid #7aa7dc; outline-offset: 2px; }"
+    },
+    {
+      "name": "Sigil — Node",
+      "kind": "custom",
+      "refersTo": null,
+      "description": "Brand sigil for a participant vessel. ≥40px as a mark, 16/20/24 as an icon. Always currentColor.",
+      "html": "<svg class=\"ds-sigil-node\" viewBox=\"0 0 120 120\" role=\"img\" aria-label=\"Node sigil\"><rect x=\"8\" y=\"8\" width=\"104\" height=\"104\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.5\"/><circle cx=\"60\" cy=\"60\" r=\"34\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.5\"/><circle cx=\"60\" cy=\"60\" r=\"8\" fill=\"currentColor\"/></svg>",
+      "css": ".ds-sigil-node { width: 64px; height: 64px; color: #7aa7dc; display: block; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "Protocol Brutalism",
+    "overview": "Jinn is protocol brutalism. The surface is a deep night-blue (#0c1628). Hierarchy is carried by hairline 1px borders, not shadows. The type system is two voices only — Instrument Serif for feeling, JetBrains Mono for doing — with no sans anywhere. Sky-blue ink threads structure; lamplight gold is reserved for a single point of emphasis on any surface. The contrast between evocative copy (summon, bind, vow, vessel, wish, smoke, seer, wane) and stark engineering-diagram UI is the brand. The system is headless by design: palette, sigils, and wordmark are expected to be forked by node operators and community contributors. The protocol invariants — the lexicon, the two-voice type system, the no-emoji / no-gradient / no-sans rules — are fixed. The narrative layer is not.",
+    "keyCharacteristics": [
+      "Dark-first. Canonical rendering is sky-blue ink on moon-bone, touched by lamplight.",
+      "Hairline borders are the primary hierarchy. Shadows are rare; blurs are banned for UI chrome.",
+      "Two type voices: serif for feeling, mono for doing. No sans.",
+      "Softened-brutalist radii (4 / 6 / 10). Never razor-square, never pillowy.",
+      "Linear motion. No bounce, overshoot, or spring.",
+      "Emoji never. The sigils and the words are the iconography."
+    ],
+    "rules": [
+      { "name": "The Gold-as-Hint Rule", "body": "Gold is a hint, not a fill. One gold element of emphasis per surface. If a design has gold in two places, one of them is wrong.", "section": "colors" },
+      { "name": "The No-Pure-Neutral Rule", "body": "Never #000 or #fff. Every neutral carries a sky-blue tint.", "section": "colors" },
+      { "name": "The One-Voice Rule", "body": "A screen has one primary accent. Sky carries structure; gold carries emphasis. Never both loud at once.", "section": "colors" },
+      { "name": "The Two-Voices Rule", "body": "Serif for feeling, mono for doing. If a string is neither display headline nor mystical pull-quote, it is mono.", "section": "typography" },
+      { "name": "The Labels-in-Caps, Actions-in-Sentence Rule", "body": "ALL CAPS MONO is for status. Sentence case is for action.", "section": "typography" },
+      { "name": "The Hairline-over-Shadow Rule", "body": "Hierarchy is carried by more borders and less shadow than a typical system.", "section": "elevation" },
+      { "name": "The No-Float-on-Chrome Rule", "body": "--shadow-float is for overlays only. Never on cards, buttons, inputs, or any resting-state container.", "section": "elevation" },
+      { "name": "The No-Glass Rule", "body": "backdrop-filter: blur() is banned for UI chrome. If a designer feels they need glass, they need a border instead.", "section": "elevation" },
+      { "name": "The No-Emoji Rule", "body": "Never. Not in product. Not in marketing. Not in docs. The sigils, the typography, and the words are the iconography.", "section": "components" },
+      { "name": "The Sigil-before-Lucide Rule", "body": "For Jinn-native concepts (node, vow, smoke, wish, seer), use the brand sigil. Lucide at stroke 1.5 is a stand-in for generic UI affordances only.", "section": "components" }
+    ],
+    "dos": [
+      "Do use JetBrains Mono for every label, value, body line, and code block.",
+      "Do use Instrument Serif only for display headlines, section heads, and the italic pull-quote (.wish).",
+      "Do use hairline 1px borders as the primary hierarchy. More borders, less shadow.",
+      "Do use gold as a single point of emphasis per surface.",
+      "Do use sentence case for titles, headlines, and button labels (Bind vessel).",
+      "Do use ALL CAPS MONO with letter-spacing 0.14em for labels, eyebrows, and status chips; never for anything read at length.",
+      "Do use softened-brutalist radii: chip 4px, default 6px, panel 10px.",
+      "Do tint every neutral toward #0c1628. No pure gray.",
+      "Do drop the vow-language whenever money, safety, or legal consent is on the line. Clarity beats mood.",
+      "Do document any change you make. The brand is headless; you're a co-author, not a user."
+    ],
+    "donts": [
+      "Don't use emoji. Ever. Not in product. Not in marketing. Not in docs.",
+      "Don't use #000 or #fff. The darkest permitted neutral is #070d18; the lightest is #f2f7fc.",
+      "Don't use a sans font. The two-voices rule is the system.",
+      "Don't use gradients as decoration. The one exception is the top/bottom protection gradient over imagery.",
+      "Don't use backdrop-filter: blur() for UI chrome. If you want glass, use a border.",
+      "Don't use ease-out-back, ease-out-elastic, or any spring curve.",
+      "Don't use --shadow-float on cards, buttons, or inputs. Overlays only.",
+      "Don't nest cards inside cards. Ever.",
+      "Don't stack gold on gold. One gold element of emphasis per surface.",
+      "Don't use dark-mode-plus-purple-gradient crypto chrome.",
+      "Don't use Material-style filled icons or multi-color iconography.",
+      "Don't invent new vow-language without marking it as a proposal. The lexicon is protocol, not narrative."
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,314 @@
+---
+name: Jinn
+description: A decentralised network for training agentic fulfilment of outcomes.
+colors:
+  bg: "#0c1628"
+  bg-elevated: "#142340"
+  bg-sunken: "#070d18"
+  fg: "#f2f7fc"
+  fg-muted: "#a4b0c2"
+  fg-dim: "#7d8ba3"
+  border: "#1f3a66"
+  border-strong: "#7aa7dc"
+  border-accent: "#c9a048"
+  accent-sky: "#7aa7dc"
+  accent-sky-hover: "#a8c8ea"
+  accent-gold: "#dcb866"
+  accent-gold-hover: "#ead08e"
+  vow-green: "#6a9b8f"
+  wane: "#b8802f"
+  break-red: "#a85a5a"
+  seer-violet: "#7a6db0"
+typography:
+  display:
+    fontFamily: "Instrument Serif, Times New Roman, serif"
+    fontSize: "88px"
+    fontWeight: 400
+    lineHeight: 1.05
+    letterSpacing: "0"
+  display-xl:
+    fontFamily: "Instrument Serif, Times New Roman, serif"
+    fontSize: "120px"
+    fontWeight: 400
+    lineHeight: 0.95
+    letterSpacing: "0"
+  headline:
+    fontFamily: "Instrument Serif, Times New Roman, serif"
+    fontSize: "48px"
+    fontWeight: 400
+    lineHeight: 1.2
+    letterSpacing: "0"
+  title:
+    fontFamily: "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace"
+    fontSize: "17px"
+    fontWeight: 500
+    lineHeight: 1.2
+    letterSpacing: "-0.01em"
+  body:
+    fontFamily: "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace"
+    fontSize: "14px"
+    fontWeight: 400
+    lineHeight: 1.7
+    letterSpacing: "-0.01em"
+  label:
+    fontFamily: "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace"
+    fontSize: "11px"
+    fontWeight: 500
+    lineHeight: 1.5
+    letterSpacing: "0.14em"
+  wish:
+    fontFamily: "Instrument Serif, Times New Roman, serif"
+    fontSize: "26px"
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: "0"
+rounded:
+  none: "0"
+  chip: "4px"
+  default: "6px"
+  panel: "10px"
+  pill: "999px"
+spacing:
+  "1": "4px"
+  "2": "8px"
+  "3": "12px"
+  "4": "16px"
+  "5": "24px"
+  "6": "32px"
+  "7": "48px"
+  "8": "64px"
+  "9": "96px"
+  "10": "128px"
+components:
+  button-primary:
+    backgroundColor: "{colors.accent-sky}"
+    textColor: "{colors.bg-sunken}"
+    rounded: "{rounded.default}"
+    padding: "10px 20px"
+  button-primary-hover:
+    backgroundColor: "{colors.accent-sky-hover}"
+    textColor: "{colors.bg-sunken}"
+  button-ghost:
+    backgroundColor: "transparent"
+    textColor: "{colors.fg}"
+    rounded: "{rounded.default}"
+    padding: "10px 20px"
+  button-ghost-hover:
+    backgroundColor: "transparent"
+    textColor: "{colors.accent-sky}"
+  chip:
+    backgroundColor: "transparent"
+    textColor: "{colors.fg-muted}"
+    rounded: "{rounded.chip}"
+    padding: "2px 8px"
+  chip-accent:
+    backgroundColor: "transparent"
+    textColor: "{colors.accent-sky}"
+    rounded: "{rounded.chip}"
+    padding: "2px 8px"
+  chip-solid:
+    backgroundColor: "{colors.fg}"
+    textColor: "{colors.bg}"
+    rounded: "{rounded.chip}"
+    padding: "2px 8px"
+  card:
+    backgroundColor: "{colors.bg-elevated}"
+    textColor: "{colors.fg}"
+    rounded: "{rounded.panel}"
+    padding: "24px"
+  input:
+    backgroundColor: "{colors.bg}"
+    textColor: "{colors.fg}"
+    rounded: "{rounded.default}"
+    padding: "10px 12px"
+---
+
+# Design System: Jinn
+
+## 1. Overview
+
+**Creative North Star: "Protocol Brutalism"**
+
+Jinn is protocol brutalism. The surface is a deep night-blue (`#0c1628`). Hierarchy is carried by hairline 1px borders, not shadows. The type system is two voices only — Instrument Serif for *feeling*, JetBrains Mono for *doing* — with no sans anywhere. Sky-blue ink (`#7aa7dc`) threads structure; lamplight gold (`#dcb866`) is reserved for a single point of emphasis on any surface. The contrast between evocative copy (*summon, bind, vow, vessel, wish, smoke, seer, wane*) and stark, engineering-diagram UI is the brand.
+
+The system is **headless by design**. Palette, sigils, even the wordmark are expected to be forked by node operators and community contributors. The protocol invariants — the lexicon, the two-voice type system, the no-emoji / no-gradient / no-sans rules — are fixed. The narrative layer is not.
+
+This system explicitly rejects: dark-mode-plus-neon crypto aesthetics, purple-gradient SaaS chrome, glassmorphic blurred containers, emoji anywhere, bouncy springy motion, Material-style filled icons, and stock photography of people. If a render could be guessed as "crypto → neon on black" from the category alone, it has failed the system.
+
+**Key characteristics:**
+
+- Dark-first. Canonical rendering is sky-blue ink on moon-bone, touched by lamplight.
+- Hairline borders are the primary hierarchy. Shadows are rare; blurs are banned for UI chrome.
+- Two type voices: serif for feeling, mono for doing. No sans.
+- Softened-brutalist radii (4 / 6 / 10). Never razor-square, never pillowy.
+- Linear motion. No bounce, overshoot, or spring.
+- Emoji never. Ever. The sigils and the words are the iconography.
+
+## 2. Colors: Sky, Moon, Lamplight
+
+A nocturnal palette — sky-blue ink on moon-bone, touched by oil-lamp gold. Dark-first; light mode exists but the canonical rendering is the protocol in deep night.
+
+### Primary
+
+- **Sky** (`#7aa7dc`): primary accent. Links, active states, strong borders, structural emphasis in diagrams. Hover brightens to **Bright Sky** (`#a8c8ea`).
+- **Moon-bone** (`#f2f7fc`): primary foreground. All body copy, data, code, default icon fill.
+
+### Secondary
+
+- **Lamplight Gold** (`#dcb866`): secondary accent, used as a *hint* rather than a fill. Verified states, a single point of emphasis per surface, the border of a selected or primary element. Canonical static form is `#c9a048` (used for `border-accent`). Hover brightens to **Bright Lamplight** (`#ead08e`).
+
+### Tertiary (status)
+
+- **Vow Green** (`#6a9b8f`): success, bound, completed. A cool teal-green, never the sickly SaaS green.
+- **Wane** (`#b8802f`): warning, unresolved, pending. A deep lamplight, not yellow.
+- **Break Red** (`#a85a5a`): error, broken. Cool iron-red, never fire-engine.
+- **Seer Violet** (`#7a6db0`): info, reading, in-smoke. Night-watcher purple.
+
+### Neutral
+
+- **Deep Night** (`#0c1628`): primary dark surface. The canonical background.
+- **Elevated Night** (`#142340`): cards, panels, elevated surfaces.
+- **Void** (`#070d18`): sunken surfaces, vessel interior, modal scrim anchor.
+- **Smoke 300** (`#a4b0c2`): muted foreground — eyebrow labels, secondary text.
+- **Smoke 400** (`#7d8ba3`): dim foreground — tertiary text, placeholder captions.
+- **Dark Hairline** (`#1f3a66`): the default 1px border, on every container.
+
+### Named Rules
+
+**The Gold-as-Hint Rule.** Gold is a hint, not a fill. One gold element of emphasis per surface. If a design has gold in two places, one of them is wrong. The verified tick, the single selected chip, the accent border on a primary affordance — pick one.
+
+**The No-Pure-Neutral Rule.** Never `#000` or `#fff`. Every neutral carries a sky-blue tint. `#070d18` is the darkest permitted; `#f2f7fc` is the lightest.
+
+**The One-Voice Rule.** A screen has one primary accent. Sky carries structure; gold carries emphasis. Never both loud at once.
+
+## 3. Typography
+
+**Display Font:** Instrument Serif (Times New Roman, serif)
+**Body / UI / Data Font:** JetBrains Mono (ui-monospace, SF Mono, Menlo, monospace)
+**No sans. Ever.**
+
+**Character:** The serif is for *feeling* — the mystical pull-quote, the headline of an essay, the wish. The mono is for *doing* — every UI label, every data value, every line of body copy, every code block. The absence of a utility sans is deliberate: mono body text is the brutalist tell.
+
+### Hierarchy
+
+- **Display** (400, 88px, line-height 1.05): marketing hero headlines only. Instrument Serif.
+- **Display XL** (400, 120px, line-height 0.95): the single biggest mark on a landing page.
+- **Headline** (400, 48px, line-height 1.2): section heads in long-form content. Instrument Serif.
+- **Title** (500, 17px, line-height 1.2, tracking -0.01em): in-product section titles. JetBrains Mono.
+- **Body** (400, 14px, line-height 1.7, tracking -0.01em): default body copy. Cap line length at ~72ch.
+- **Label** (500, 11px, tracking 0.14em, UPPERCASE): eyebrows, column headers, status chips. Never for anything a user reads at length.
+- **Wish** (italic 400, 26px, line-height 1.5): the one decorative flourish — the pull-quote. Slow-fade entrance permitted up to 600ms.
+
+### Named Rules
+
+**The Two-Voices Rule.** Serif for feeling, mono for doing. If a string is neither display headline nor mystical pull-quote, it is mono. Period.
+
+**The Labels-in-Caps, Actions-in-Sentence Rule.** ALL CAPS MONO is for *status* — eyebrows, chips, column headers. Sentence case is for *action* — button labels, titles, headlines (`Bind vessel`, not `BIND VESSEL`).
+
+## 4. Elevation
+
+Jinn is flat by default. Hierarchy comes from **hairline borders**, not shadows. Borders do the work of depth that other systems hand to elevation.
+
+### Shadow Vocabulary (rare, used only when structurally required)
+
+- **Hard offset small** (`box-shadow: 2px 2px 0 0 #070d18`): optional accent on interactive cards or tiles.
+- **Hard offset** (`box-shadow: 4px 4px 0 0 #070d18`): pressed/held states on buttons or tiles.
+- **Hard offset large** (`box-shadow: 6px 6px 0 0 #070d18`): rare; marketing hero tiles only.
+- **Float shadow** (`box-shadow: 0 12px 32px -8px rgba(0,0,0,0.5), 0 2px 4px rgba(0,0,0,0.3)`): the only soft blur permitted. Reserved for floating overlays (menus, toasts, modals) where the container must visibly lift off the surface.
+
+### Named Rules
+
+**The Hairline-over-Shadow Rule.** Hierarchy is carried by *more borders* and *less shadow* than a typical system. If you need to separate two surfaces, add a border first; elevate second; never both.
+
+**The No-Float-on-Chrome Rule.** `--shadow-float` is for overlays only. Never on cards, buttons, inputs, or any resting-state container.
+
+**The No-Glass Rule.** `backdrop-filter: blur()` is banned for UI chrome (headers, toolbars, panels). If a designer feels they need glass, they need a border instead.
+
+## 5. Components
+
+### Buttons
+
+- **Shape:** softened-brutalist (`rounded.default`, 6px).
+- **Primary:** Sky fill (`#7aa7dc`) on Void text (`#070d18`); 10px × 20px padding; sentence case; JetBrains Mono 500.
+- **Hover:** background brightens to `#a8c8ea`. No scale, no glow.
+- **Focus:** 2px solid `#7aa7dc` outline with 2px offset.
+- **Press:** background darkens one step. No scale-down.
+- **Ghost:** transparent background, moon-bone text, hairline border. On hover, text and border both shift to sky.
+- **Disabled:** 40% opacity, `cursor: not-allowed`, no interactivity.
+
+### Chips
+
+- **Shape:** `rounded.chip` (4px) for default chips; `rounded.pill` (999px) for *status* chips only.
+- **Default:** transparent background, `#a4b0c2` text, 1px hairline border, ALL CAPS MONO, letter-spacing 0.14em.
+- **Accent:** transparent background, sky text, sky border.
+- **Solid:** moon-bone fill, deep-night text. Used rarely, for emphasised status.
+- **Status variants:** `vow-green`, `wane`, `break-red`, `seer-violet` on both border and text — never on a filled background.
+
+### Cards (Panels)
+
+- **Corner style:** `rounded.panel` (10px).
+- **Background:** `bg-elevated` (`#142340`). Flat color, never gradient.
+- **Border:** 1px hairline (`#1f3a66`).
+- **Shadow:** none at rest. Hover darkens the border from `--border` to `--border-strong` (sky). No lift, no glow.
+- **Internal padding:** 24px default (`space.5`).
+- **Never nest cards in cards.**
+
+### Inputs
+
+- **Shape:** `rounded.default` (6px).
+- **Style:** `bg` fill (`#0c1628`), 1px hairline border, mono body type.
+- **Focus:** 2px solid sky outline with 2px offset. Visible, sharp, no glow.
+- **Error:** border and helper text shift to `break-red` (`#a85a5a`).
+- **Disabled:** 40% opacity, not-allowed cursor.
+
+### Navigation
+
+- **Top nav:** fixed allowed. Flat surface, single hairline divider at base, ALL CAPS MONO labels, letter-spacing 0.14em.
+- **Hover:** label color shifts from `fg-muted` to `fg`. No underline, no pill, no color wash.
+- **Active:** label is `fg` with a 1px sky underline offset 4px below the text.
+- **Mobile:** collapses to a drawer with the same typography and hairline treatment.
+
+### Sigils (Signature Component)
+
+Five canonical brand marks ship with the system: `logo-sigil`, `logo-wordmark`, `mark-smoke`, `mark-binding`, `mark-node`.
+
+- **Color:** always `currentColor`. Monochrome only; never multi-color.
+- **Stroke:** 1.5–2px, square terminals.
+- **Sizing:** 16 / 20 / 24px as icons; ≥40px as sigils. Below 16px, drop to the solid dot variant.
+- **Style:** mono-line, square-terminal glyphs — not illustrations.
+
+### Named Rules
+
+**The No-Emoji Rule.** Never. Not in product. Not in marketing. Not in docs. The sigils, the typography, and the words are the iconography. Emoji break the spell.
+
+**The Sigil-before-Lucide Rule.** For Jinn-native concepts (node, vow, smoke, wish, seer), use the brand sigil. For generic UI affordances (chevron, search, close, copy), Lucide at `stroke-width="1.5"` is permitted as a stand-in, pending a native Jinn icon set.
+
+## 6. Do's and Don'ts
+
+### Do
+
+- **Do** use JetBrains Mono for every label, value, body line, and code block.
+- **Do** use Instrument Serif *only* for display headlines, section heads, and the italic pull-quote (`.wish`).
+- **Do** use hairline 1px borders as the primary hierarchy. More borders, less shadow.
+- **Do** use gold as a single point of emphasis per surface — the verified tick, one selected chip, one active border.
+- **Do** use sentence case for titles, headlines, and button labels (`Bind vessel`).
+- **Do** use ALL CAPS MONO with `letter-spacing: 0.14em` for labels, eyebrows, and status chips — never for anything read at length.
+- **Do** use softened-brutalist radii: chip 4px, default 6px, panel 10px.
+- **Do** tint every neutral toward `#0c1628`. If a neutral could be guessed as pure gray, add 0.005–0.01 of blue chroma.
+- **Do** drop the vow-language (*summon, bind, vow, vessel, wish, smoke, seer, wane*) whenever money, safety, or legal consent is on the line. Clarity beats mood.
+- **Do** document any change you make. The brand is headless; you're a co-author, not a user.
+
+### Don't
+
+- **Don't** use emoji. Ever. Not in product. Not in marketing. Not in docs.
+- **Don't** use `#000` or `#fff`. The darkest permitted neutral is `#070d18`; the lightest is `#f2f7fc`.
+- **Don't** use a sans font. The two-voices rule is the system.
+- **Don't** use gradients as decoration. The one exception is the top/bottom protection gradient over imagery (`.protect-top`, `.protect-bottom`).
+- **Don't** use `backdrop-filter: blur()` for UI chrome. If you want glass, use a border.
+- **Don't** use `ease-out-back`, `ease-out-elastic`, or any spring curve. Linear is default; `cubic-bezier(0.4, 0, 0.2, 1)` is the rare exception.
+- **Don't** use `--shadow-float` on cards, buttons, or inputs. Overlays only.
+- **Don't** nest cards inside cards. Ever.
+- **Don't** stack gold on gold. One gold element of emphasis per surface.
+- **Don't** use dark-mode-plus-purple-gradient crypto chrome. Jinn is night-blue on moon-bone; if a render reads as "crypto → neon on black", it has failed the system.
+- **Don't** use Material-style filled icons or multi-color iconography. Everything is `currentColor`, stroke 1.5px, square terminals.
+- **Don't** invent new vow-language without marking it as a proposal. The lexicon is protocol, not narrative.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,91 @@
+# Product
+
+## Register
+
+brand
+
+> PRODUCT.md carries one default. Jinn's default is `brand` because the primary surface is its narrative — essays, slides, sigils, wordmark, BD conversation — with product UI (explorer, daemon, dashboards) acting as reference implementations of that narrative. The register can be overridden per task: `$impeccable` commands working inside `client/`, `ui_kits/explorer/`, or any dashboard surface should treat the work as `product`.
+
+## Users
+
+Jinn's participants are **technical enough to run an agent harness**. Five overlapping roles, roughly ordered by onboarding depth:
+
+- **Creators** — teams and individuals who summon outcomes into the network. Come from engineering, research, product, or BD. Write specifications, pay fees, evaluate results.
+- **Node operators (vessels)** — engineers running the daemon against a Safe-held stake. Care about uptime, rewards economics, recovery from failure modes. Long sessions against terminals and dashboards.
+- **Seers (evaluators)** — validators who verify restoration claims. Technical enough to read evidence; economically motivated to be honest. Care about evidence schemas and challenge mechanisms.
+- **Protocol engineers** — smart-contract and client developers building on or integrating with Jinn. Care about ABIs, addresses, deployment artifacts, and ERC-8004 / ERC-8128 specifications.
+- **Community contributors** — designers, BD, writers, node operators who extend the brand surface itself. The "headless" stakeholders who fork and document variants of the system.
+
+**Context of use:** dark screens, long sessions, attention split with editors and terminals. Readers of essays are the same people later staking 500 OLAS — the marketing surface and the settings pane are visited by one person. Writing for one, writing for the other, but never assume either audience wants to be sold to.
+
+## Product Purpose
+
+Jinn is a decentralised network for training agentic fulfilment of outcomes. It defines a loop — Creation → Execution → Evaluation → Knowledge — where outcomes are published with fees, vessels attempt fulfilment, seers verify, and verified artifacts (outcome, trajectory, score triplets) accumulate as ERC-8004 knowledge.
+
+Phase 0 (complete) proved the loop on OLAS + Base. Phase 1a (complete) deployed the JINN token, DAO, and distribution contracts on testnet. Phase 1b (in progress) is hardening — anti-farming decay, challenge mechanism, ve-JINN gauge voting, evidence schema. Phase 2 is mainnet launch. Phase 3 is autonomy: USDC revenue exceeds JINN emissions and governance is fully ve-JINN.
+
+**Success looks like** a self-sustaining protocol where the economic engine (outcome fees) funds the training loop without emissions subsidy, and where the brand narrative has enough gravity that community operators ship their own variants on the shared protocol primitives.
+
+## Brand Personality
+
+**Three words: mystical, brutalist, headless.**
+
+The voice is poetic but precise. The words do the magic (*summon, bind, vow, vessel, wish, smoke, seer, wane*) so the visuals stay stark — terminal-schematic, engineering-diagram, hairline-bordered. The contrast between evocative copy and austere UI is the brand.
+
+**Emotional goals:**
+
+- **Technical confidence.** Readers should believe the people behind this can ship contracts and daemons. The way to convey it is evidence (addresses, ABIs, deployment logs), not adjectives.
+- **Reverence without preciousness.** The mystical vocabulary earns trust by being consistent, not by being florid. A jinn doesn't exclaim.
+- **Clarity on consequential actions.** The moment money moves, safety is at stake, or legal consent is asked for, the mysticism steps aside. Plain speech wins there.
+
+**Voice discipline:**
+
+- Second person (`you`) with the reader. First person plural (`we`) only in marketing, rarely.
+- Sentence case for titles, headlines, buttons (`Bind vessel`).
+- ALL CAPS MONO for status labels only — eyebrows, chips, column headers.
+- Tabular numerals with units. Commas for thousands.
+- No exclamation points. Ellipses only for in-progress states (`Binding…`) or poetic trail-off.
+- Em dashes, liberally — they match the serif's rhythm.
+- Never emoji.
+
+## Anti-references
+
+Jinn is explicitly **not** any of the following. Each is named so that when a render drifts toward it, you can call it out precisely.
+
+- **"Crypto → neon on black."** The default DeFi reflex — saturated neon green or purple accents on pure black, frosted-glass trading panels, animated candlestick heros. Most L2 front pages. Jinn is night-blue on moon-bone, not neon on black.
+- **Purple-gradient SaaS chrome.** 2020-era Stripe / Linear's early palette / Vercel's former gradient era. Dashboards that look like they were poured out of the same design-token generator. Jinn has no decorative gradients.
+- **Glassmorphic blur stacks.** VisionOS, iOS 15+ Control Centre, Glow-heavy dashboard redesigns. `backdrop-filter: blur()` as decoration. Jinn uses hairlines instead.
+- **Emoji-as-decoration landing pages.** Slack / Notion / most Y-Combinator landing pages. 🚀 and 🎉 as bullet markers. Jinn uses no emoji anywhere. Ever.
+- **Bouncy, springy motion.** iOS bounce-scrolls, `ease-out-back`, `ease-elastic`, any spring. Jinn is linear; things appear.
+- **Material-filled iconography.** Google products generally. Filled, rounded glyphs at mid-contrast. Jinn's icons are mono-line, stroke 1.5, square terminals, currentColor.
+- **Stock photography of people.** Unsplash startup tropes — smiling engineers, diverse team at whiteboard. Jinn's imagery (when used at all) is abstract, astronomical, architectural, cartographic, or documentary-technical.
+- **Sickly SaaS green, fire-engine red, mustard yellow.** Status color clichés. Jinn's status palette is muted: `vow-green` (cool teal), `wane` (deep lamplight), `break-red` (cool iron), `seer-violet` (night-watcher purple).
+
+**Category-reflex check:** if a render could be guessed as "crypto → neon on black" from the category alone, it has failed the brand.
+
+## Design Principles
+
+Five strategic lines. These override individual visual tokens if they conflict — the tokens serve the principles.
+
+1. **Keep the words, loosen the visuals.** The protocol invariants are the lexicon (*summon, bind, vow, vessel, wish, smoke, seer, wane*) and the non-negotiables (no emoji, no gradient, no sans, plain speech on money/safety/legal). Everything else — palette, sigils, type pairing, surface treatment — is narrative, and narrative is allowed to fork per operator, per surface, per community. Multiple visual dialects can coexist on the same protocol.
+
+2. **The words do the magic; the visuals stay stark.** Evocative copy is the mysticism budget. The visual system balances it by being schematic and engineering-diagram precise. If the copy leans poetic, the UI leans plain. If both lean mystical at once, the brand curdles into LARP.
+
+3. **Clarity beats mood when consequences are real.** Drop the vow-language the moment money moves, safety is on the line, or legal consent is being requested. `"Bind 500 tokens"` is fine in marketing; a transaction confirmation reads `"Stake 500 OLAS to become a seer. Funds will be locked for 90 days."` The brand survives plain speech; it does not survive a mis-worded staking confirmation.
+
+4. **Participants are co-authors, not users.** Anyone with a stake in the network — tokens, reputation, a deployed vessel — has standing to propose brand or protocol direction. Contribution to the brand is a first-class form of participation, not marketing overhead. The rule when you change something: **document what you changed**. That is the vow.
+
+5. **Protocol before narrative.** Two change classes, treated differently. A change to the loop, the lexicon, or a non-negotiable is a **protocol change** — it needs marking as a proposal, not slipped in as a design tweak. A change to a colour, a sigil, a surface treatment is a **narrative change** — just ship it and document it. Knowing which is which is the skill.
+
+## Accessibility & Inclusion
+
+Target **WCAG 2.1 AA** across product surfaces, with AAA for critical labels (focus indicators, error copy, affordance names).
+
+- **Contrast.** Body text and interactive surfaces are ≥ 4.5:1 on `#0c1628`; large text and primary accents clear AAA at ≥ 7:1. Verified in the existing palette.
+- **Motion.** Respect `prefers-reduced-motion: reduce`. The 600ms `.wish` slow-fade becomes instant; all other transitions fall back to `0ms linear`. No choreographed sequences.
+- **Color is never the sole signal.** Status always pairs colour with a label (chip text, icon, or sibling caption). Charts and diagrams label data directly, not only by hue.
+- **Keyboard.** Every interactive element is focusable. Focus outlines are 2px solid `--accent` with 2px offset, visible in both themes, never removed without replacement. Logical tab order matches visual order.
+- **Touch targets.** ≥ 44 × 44 px on any touch surface (the mobile drawer, mobile nav, mobile forms).
+- **Dark-first means contrast-first.** Light mode exists but must meet the same standards. No surface is "acceptable in dark only" and ported to light later.
+- **Copy at reading grade.** Vow-language is acceptable in marketing and long-form. Product chrome (errors, confirmations, legal) reads plain — aim for grade 8–10, not grade 16.
+- **Sigils at small sizes.** Below 16px, fall back to the solid-dot variant of each sigil. Stroke-based marks become unreadable at that scale.

--- a/growth/assets/hero-mining.svg
+++ b/growth/assets/hero-mining.svg
@@ -1,0 +1,109 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 720" role="img" aria-labelledby="title desc" preserveAspectRatio="xMidYMid meet" style="width:100%;height:auto;display:block" font-family="'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace">
+  <title id="title">Decentralised mining of outcome solutions</title>
+  <desc id="desc">Three zones read left to right: a staggered column of incoming outcome requests; a peer network of solver nodes with one actively mining; a stack of outcome-trajectory-score artifact cards, one row marked verified.</desc>
+
+  <defs>
+    <g id="solver">
+      <rect x="-20" y="-20" width="40" height="40" fill="none" stroke="#7aa7dc" stroke-width="1"/>
+      <circle cx="0" cy="0" r="12" fill="none" stroke="#7aa7dc" stroke-width="1"/>
+      <circle cx="0" cy="0" r="2.8" fill="#7aa7dc"/>
+    </g>
+    <g id="solver-active">
+      <circle cx="0" cy="0" r="28" fill="none" stroke="#dcb866" stroke-width="1" opacity="0.55"/>
+      <rect x="-20" y="-20" width="40" height="40" fill="none" stroke="#7aa7dc" stroke-width="1"/>
+      <circle cx="0" cy="0" r="12" fill="none" stroke="#7aa7dc" stroke-width="1"/>
+      <circle cx="0" cy="0" r="2.8" fill="#7aa7dc"/>
+    </g>
+  </defs>
+
+  <!-- BASELINE — broken across the solver zone and the yield column -->
+  <line x1="40"   y1="400" x2="560"  y2="400" stroke="#1f3a66" stroke-width="1"/>
+  <line x1="1060" y1="400" x2="1100" y2="400" stroke="#1f3a66" stroke-width="1"/>
+
+  <!-- LEFT ZONE — ingress ribbon -->
+  <g font-size="11" fill="#a4b0c2">
+    <g transform="translate(60,160)">
+      <rect width="160" height="28" fill="none" stroke="#1f3a66" stroke-width="1"/>
+      <text x="12" y="18">outcome#0x4a7f2e…</text>
+    </g>
+    <g transform="translate(120,230)">
+      <rect width="160" height="28" fill="none" stroke="#1f3a66" stroke-width="1"/>
+      <text x="12" y="18">outcome#0x8c13ab…</text>
+    </g>
+    <g transform="translate(70,300)">
+      <rect width="160" height="28" fill="none" stroke="#1f3a66" stroke-width="1"/>
+      <text x="12" y="18">outcome#0x2d91f4…</text>
+    </g>
+    <g transform="translate(140,430)">
+      <rect width="160" height="28" fill="none" stroke="#1f3a66" stroke-width="1"/>
+      <text x="12" y="18">outcome#0xb37e08…</text>
+    </g>
+    <g transform="translate(80,500)">
+      <rect width="160" height="28" fill="none" stroke="#1f3a66" stroke-width="1"/>
+      <text x="12" y="18">outcome#0x6a2c5d…</text>
+    </g>
+  </g>
+
+  <!-- MIDDLE ZONE — peer network -->
+  <g stroke="#1f3a66" stroke-width="1">
+    <line x1="680" y1="220" x2="780" y2="180"/>
+    <line x1="780" y1="180" x2="880" y2="260"/>
+    <line x1="680" y1="220" x2="640" y2="360"/>
+    <line x1="640" y1="360" x2="760" y2="340"/>
+    <line x1="760" y1="340" x2="880" y2="400"/>
+    <line x1="880" y1="400" x2="960" y2="320"/>
+    <line x1="760" y1="340" x2="720" y2="460"/>
+    <line x1="720" y1="460" x2="860" y2="520"/>
+  </g>
+
+  <g>
+    <use href="#solver"        x="680"  y="220"/>
+    <use href="#solver"        x="780"  y="180"/>
+    <use href="#solver"        x="880"  y="260"/>
+    <use href="#solver-active" x="640"  y="360"/>
+    <use href="#solver"        x="760"  y="340"/>
+    <use href="#solver"        x="880"  y="400"/>
+    <use href="#solver"        x="960"  y="320"/>
+    <use href="#solver"        x="720"  y="460"/>
+    <use href="#solver"        x="860"  y="520"/>
+  </g>
+
+  <!-- RIGHT ZONE — triplet artifacts -->
+  <g font-size="12">
+    <g transform="translate(1120,140)">
+      <rect width="440" height="120" fill="none" stroke="#1f3a66" stroke-width="1"/>
+      <text x="16" y="30" font-size="10" letter-spacing="1.4" fill="#7d8ba3">OUTCOME</text>
+      <text x="160" y="30" fill="#f2f7fc">0x4a7f2e8c91bb</text>
+      <text x="16" y="70" font-size="10" letter-spacing="1.4" fill="#7d8ba3">TRAJECTORY</text>
+      <text x="160" y="70" fill="#f2f7fc">0x2d91f4…e08b</text>
+      <text x="16" y="108" font-size="10" letter-spacing="1.4" fill="#7d8ba3">SCORE</text>
+      <text x="160" y="108" fill="#f2f7fc">0.92 · 0x9a44</text>
+    </g>
+
+    <g transform="translate(1120,300)">
+      <rect width="440" height="120" fill="none" stroke="#1f3a66" stroke-width="1"/>
+      <text x="16" y="30" font-size="10" letter-spacing="1.4" fill="#7d8ba3">OUTCOME</text>
+      <text x="160" y="30" fill="#f2f7fc">0x8c13abd72f04</text>
+      <text x="16" y="70" font-size="10" letter-spacing="1.4" fill="#7d8ba3">TRAJECTORY</text>
+      <text x="160" y="70" fill="#f2f7fc">0xb37e08…1c9d</text>
+      <text x="16" y="108" font-size="10" letter-spacing="1.4" fill="#7d8ba3">SCORE</text>
+      <text x="160" y="108" fill="#f2f7fc">0.97 · 0x6a2c</text>
+      <!-- the single gold hint in the frame -->
+      <g transform="translate(408,98)" stroke="#dcb866" stroke-width="1.5" fill="none" stroke-linecap="square" stroke-linejoin="miter">
+        <path d="M0,5 L5,10 L14,0"/>
+      </g>
+    </g>
+
+    <g transform="translate(1120,460)">
+      <rect width="440" height="120" fill="none" stroke="#1f3a66" stroke-width="1"/>
+      <text x="16" y="30" font-size="10" letter-spacing="1.4" fill="#7d8ba3">OUTCOME</text>
+      <text x="160" y="30" fill="#f2f7fc">0x6a2c5d1e83d7</text>
+      <text x="16" y="70" font-size="10" letter-spacing="1.4" fill="#7d8ba3">TRAJECTORY</text>
+      <text x="160" y="70" fill="#f2f7fc">0x9f44a1…c05b</text>
+      <text x="16" y="108" font-size="10" letter-spacing="1.4" fill="#7d8ba3">SCORE</text>
+      <text x="160" y="108" fill="#f2f7fc">0.84 · 0x3b72</text>
+    </g>
+  </g>
+
+  <text x="1560" y="694" text-anchor="end" font-size="10" letter-spacing="1.4" fill="#a4b0c2">ERC-8004 ARTIFACT</text>
+</svg>


### PR DESCRIPTION
## Summary
- Distill `docs/design/jinn-design-system/` into three root-level files (`PRODUCT.md`, `DESIGN.md`, `DESIGN.json`) so impeccable and other skill consumers load them directly without re-scanning the long-form source.
- Add short Design Context pointers to `CLAUDE.md` and `AGENTS.md` so Claude and Codex route to the root-level TLDR first, canonical source second.
- Ship `growth/assets/hero-mining.svg`, the first piece of growth-essay art built against the new spec (a schematic hero for a "Decentralised mining of outcome solutions" essay).

## What's in the new files

**PRODUCT.md** — register (`brand` default, per-task override pathway documented), users, brand personality, anti-references named by example (not just "modern"), and five strategic principles:
1. Keep the words, loosen the visuals.
2. The words do the magic; the visuals stay stark.
3. Clarity beats mood when consequences are real.
4. Participants are co-authors, not users.
5. Protocol before narrative.

**DESIGN.md** — [Google Stitch format](https://stitch.withgoogle.com/docs/design-md/format/). YAML frontmatter with 17 colour tokens, 7 typography roles, 5-step radii scale, 10-step spacing, and 9 component tokens; six fixed prose sections (Overview, Colors, Typography, Elevation, Components, Do's and Don'ts) with named rules (Gold-as-Hint, No-Pure-Neutral, One-Voice, Two-Voices, Hairline-over-Shadow, No-Glass, No-Emoji, Sigil-before-Lucide).

**DESIGN.json** — sidecar extending the frontmatter with tonal ramps, canonical OKLCH, four-step shadow vocabulary, six motion tokens, four breakpoints, and six drop-in components with full self-contained HTML + CSS (primary button, ghost button, accent chip, panel card, text input, node sigil).

## Test plan
- [x] `node /Users/gcd/.claude/skills/impeccable/scripts/load-context.mjs` returns `hasProduct: true` and `hasDesign: true`.
- [x] Hero SVG renders in the Launch preview panel (dark background, three-zone schematic, single gold verified tick).
- [ ] Spot-check `DESIGN.md` YAML frontmatter parses cleanly (Stitch will flag OKLCH if used in frontmatter; we used hex, so no warning expected).
- [ ] Confirm anti-references in PRODUCT.md match the project's actual stance (three assumptions flagged in-review: register default = brand, three-word personality = "mystical, brutalist, headless", a11y defaults set to WCAG AA + reduced-motion + colour-never-sole-signal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)