### PR TITLE
fix(phase1a): unstick VoteWeightingFast + heartbeat

### DIFF
--- a/contracts/deployment-phase1a-sepolia-fast.json
+++ b/contracts/deployment-phase1a-sepolia-fast.json
@@ -22,7 +22,7 @@
     "Depository": "0x8c940cE1d1E68d51ca724b5A5D4121a09039A311",
     "Dispenser": "0xaFE21C6dBeF2d41A769F58CE068aa991369FB1e0",
     "GenericBondCalculator": "0xDB5e6cc6Fb4423e1899415D86e8f0B197673dd0b",
-    "VoteWeighting": "0x8eF25EEC3baC74DfA12987905D1eB2cEDf40B685",
+    "VoteWeighting": "0x73e2713B535540A3378ddA3DC62F1e75b35469c3",
     "ComponentRegistry (stub)": "0x05c083DA58aFb581382b69A25f1b3162633f7bAE",
     "AgentRegistry (stub)": "0x9f417f058C6C4334A2250A4f71B93e3D72c0F7f4",
     "ServiceRegistry (stub)": "0x72cd1f0c096C8771FeEf042456133DeF6B101d38"

--- a/contracts/scripts/phase1a-heartbeat-vote-weighting.ts
+++ b/contracts/scripts/phase1a-heartbeat-vote-weighting.ts
@@ -1,0 +1,87 @@
+/**
+ * phase1a-heartbeat-vote-weighting.ts — Keep VoteWeighting.timeSum fresh.
+ *
+ * Calls VoteWeighting.checkpoint() and checkpointNominee() so the internal
+ * _getSum() / _getWeight() walks advance timeSum / timeWeight before the
+ * _maxNumPeriods iteration cap kicks in. Skipping this for longer than
+ * _maxNumPeriods * _period permanently bricks the contract (jinn-mono-5hc).
+ *
+ * On fast-test the cap is 10_000 periods * 900s ≈ 104 days post-fix. Run
+ * at least weekly — sooner is fine, gas is trivial once timeSum is close
+ * to now (the walker only iterates the few periods that have elapsed).
+ *
+ * Usage (any signer — no access control on either function):
+ *   PHASE1A_TIMING_PROFILE=fast-test \
+ *     npx hardhat run scripts/phase1a-heartbeat-vote-weighting.ts --network sepolia
+ */
+
+import { ethers } from "hardhat";
+import {
+  BASE_SEPOLIA_CHAIN_ID,
+  buildStakingNominee,
+  loadPhase1aArtifactsFromDisk,
+} from "./lib/phase1a-rollout-helpers";
+
+const VW_ABI = [
+  "function WEEK() view returns (uint256)",
+  "function MAX_NUM_WEEKS() view returns (uint256)",
+  "function timeSum() view returns (uint256)",
+  "function checkpoint()",
+  "function checkpointNominee(bytes32 account, uint256 chainId)",
+];
+
+async function main() {
+  const artifacts = loadPhase1aArtifactsFromDisk();
+  const [signer] = await ethers.getSigners();
+  const vw = new ethers.Contract(artifacts.voteWeightingL1, VW_ABI, signer);
+
+  const now = BigInt((await ethers.provider.getBlock("latest"))!.timestamp);
+  const week = (await vw.WEEK()) as bigint;
+  const max = (await vw.MAX_NUM_WEEKS()) as bigint;
+  const before = (await vw.timeSum()) as bigint;
+  const gapBefore = now > before ? (now - before) / week : 0n;
+
+  console.log(`VoteWeighting: ${artifacts.voteWeightingL1}`);
+  console.log(`now:           ${now}`);
+  console.log(`WEEK:          ${week}s`);
+  console.log(`MAX_NUM_WEEKS: ${max}`);
+  console.log(`timeSum:       ${before} (gap=${gapBefore} periods)`);
+
+  if (gapBefore >= max) {
+    throw new Error(
+      `Gap ${gapBefore} ≥ MAX_NUM_WEEKS ${max}. The walker cannot catch up — this deployment needs a full redeploy via phase1a-redeploy-vote-weighting.ts.`,
+    );
+  }
+
+  const ckTx = await vw.checkpoint();
+  const ckReceipt = await ckTx.wait();
+  console.log(`checkpoint tx:          ${ckTx.hash} gas=${ckReceipt?.gasUsed}`);
+
+  const { stakingTarget } = buildStakingNominee(artifacts.stakingTokenL2, BASE_SEPOLIA_CHAIN_ID);
+  const cnTx = await vw.checkpointNominee(stakingTarget, BASE_SEPOLIA_CHAIN_ID);
+  const cnReceipt = await cnTx.wait();
+  console.log(`checkpointNominee tx:   ${cnTx.hash} gas=${cnReceipt?.gasUsed}`);
+
+  const after = (await vw.timeSum()) as bigint;
+  const nowAfter = BigInt((await ethers.provider.getBlock("latest"))!.timestamp);
+  const gapAfter = nowAfter > after ? (nowAfter - after) / week : 0n;
+  console.log(`timeSum after: ${after} (gap=${gapAfter} periods)`);
+
+  // Healthy: either timeSum advanced, or it was already ≥ now (nothing to do).
+  // Stuck: timeSum < now AND didn't move — iteration cap hit, redeploy required.
+  if (after < nowAfter && after <= before) {
+    throw new Error(
+      `timeSum is behind now and did not advance (before=${before}, after=${after}, now=${nowAfter}). Walker is stuck — redeploy required.`,
+    );
+  }
+  console.log(`✓ Walker healthy.`);
+}
+
+if (require.main === module) {
+  main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+}

--- a/contracts/scripts/phase1a-redeploy-vote-weighting.ts
+++ b/contracts/scripts/phase1a-redeploy-vote-weighting.ts
@@ -1,0 +1,260 @@
+/**
+ * phase1a-redeploy-vote-weighting.ts — Redeploy VoteWeightingFast and rewire.
+ *
+ * Recovery script for the 10.4-day quiet-tolerance stall in OLAS
+ * VoteWeightingFast (jinn-mono-5hc). Once timeSum drifts more than
+ * _maxNumPeriods * _period behind block.timestamp, _getSum() can't catch up
+ * and nomineeRelativeWeight returns 0 permanently. Since VoteWeighting is
+ * not behind a proxy and there is no admin resetTimeSum hook, recovery is
+ * a redeploy of this single contract. Everything else in the Phase 1a
+ * stack — JINN, Treasury, Tokenomics, Depository, Dispenser, veJINN,
+ * bridge, L2 — stays put.
+ *
+ * Usage:
+ *   PHASE1A_TIMING_PROFILE=fast-test \
+ *     npx hardhat run scripts/phase1a-redeploy-vote-weighting.ts --network sepolia
+ *
+ * What it does, in order (order matters — Dispenser.addNominee is gated on
+ * msg.sender == voteWeighting, so Dispenser must be pointed at the new VW
+ * before the new VW can register a nominee that calls back into Dispenser):
+ *
+ *   1. Load fast-test artifact + existing contract addresses.
+ *   2. Idempotency guard: if existing VoteWeighting already exposes
+ *      MAX_NUM_WEEKS() >= 10_000, we already ran this — exit clean.
+ *   3. Deploy VoteWeightingFast(existingVeOLAS) → VW_new.
+ *   4. Dispenser.changeManagers(0, 0, VW_new) — point Dispenser at VW_new.
+ *   5. VW_new.changeDispenser(existingDispenser) — point VW_new at Dispenser.
+ *   6. VW_new.addNomineeEVM(stakingTokenL2, BASE_SEPOLIA_CHAIN_ID). Side
+ *      effect: Dispenser.addNominee(hash) is called internally and resets
+ *      mapLastClaimedStakingEpochs[hash] to the current epochCounter,
+ *      abandoning the 137k JINN of stuck return-amount for prior epochs —
+ *      those were already permanently unreachable due to zero effective
+ *      weight during the stall.
+ *   7. Rewrite contracts.VoteWeighting in the fast-test deployment JSON.
+ *   8. Print next-step commands (vote → tick → claim).
+ *
+ * Safe to re-run: step 2 short-circuits the happy path.
+ */
+
+import { ethers } from "hardhat";
+import * as fs from "fs";
+import * as path from "path";
+import {
+  BASE_SEPOLIA_CHAIN_ID,
+  buildStakingNominee,
+  loadJson,
+  resolvePhase1aArtifactPaths,
+  resolvePhase1aTimingProfile,
+} from "./lib/phase1a-rollout-helpers";
+
+interface DeploymentArtifact {
+  contracts: Record<string, string | undefined>;
+  [key: string]: unknown;
+}
+
+const DISPENSER_ABI = [
+  "function owner() view returns (address)",
+  "function voteWeighting() view returns (address)",
+  "function tokenomics() view returns (address)",
+  "function treasury() view returns (address)",
+  "function paused() view returns (uint8)",
+  "function changeManagers(address _tokenomics, address _treasury, address _voteWeighting)",
+];
+
+const VW_ABI = [
+  "function owner() view returns (address)",
+  "function dispenser() view returns (address)",
+  "function ve() view returns (address)",
+  "function MAX_NUM_WEEKS() view returns (uint256)",
+  "function WEEK() view returns (uint256)",
+  "function timeSum() view returns (uint256)",
+  "function changeDispenser(address newDispenser)",
+  "function addNomineeEVM(address account, uint256 chainId)",
+  "function getNomineeId(bytes32,uint256) view returns (uint256)",
+];
+
+const TREASURY_ABI = ["function paused() view returns (uint8)"];
+
+function requireAddress(value: string | undefined, label: string): string {
+  if (!value || !ethers.isAddress(value)) {
+    throw new Error(`Invalid or missing address for ${label}: ${value}`);
+  }
+  return value;
+}
+
+async function main() {
+  if (resolvePhase1aTimingProfile() !== "fast-test") {
+    throw new Error(
+      "This script targets VoteWeightingFast only. Set PHASE1A_TIMING_PROFILE=fast-test.",
+    );
+  }
+
+  const paths = resolvePhase1aArtifactPaths();
+  const l1Path = path.resolve(process.cwd(), paths.l1);
+  const artifact = loadJson<DeploymentArtifact>(paths.l1);
+
+  const jinn = requireAddress(artifact.contracts.JINN, "JINN");
+  const treasury = requireAddress(artifact.contracts.Treasury, "Treasury");
+  const tokenomics = requireAddress(artifact.contracts.Tokenomics, "Tokenomics");
+  const dispenserAddr = requireAddress(artifact.contracts.Dispenser, "Dispenser");
+  const veOLAS = requireAddress(artifact.contracts.veOLAS, "veOLAS");
+  const vwOld = requireAddress(artifact.contracts.VoteWeighting, "VoteWeighting (existing)");
+  const l2Token = requireAddress(
+    // Pull from L2 artifact path since the staking-token L2 address is the nominee target.
+    loadJson<DeploymentArtifact>(paths.l2).contracts.stakingToken,
+    "stakingToken (L2)",
+  );
+
+  const [signer] = await ethers.getSigners();
+  const vwOldContract = new ethers.Contract(vwOld, VW_ABI, signer);
+  const dispenser = new ethers.Contract(dispenserAddr, DISPENSER_ABI, signer);
+  const treasuryContract = new ethers.Contract(treasury, TREASURY_ABI, signer);
+
+  console.log(`Network:       sepolia (fast-test profile)`);
+  console.log(`Signer:        ${signer.address}`);
+  console.log(`Deployer key matches:`);
+  const dispenserOwner = (await dispenser.owner()) as string;
+  console.log(`  Dispenser.owner  = ${dispenserOwner}`);
+  if (dispenserOwner.toLowerCase() !== signer.address.toLowerCase()) {
+    throw new Error(
+      `Signer ${signer.address} is not Dispenser.owner ${dispenserOwner}; cannot call changeManagers.`,
+    );
+  }
+
+  console.log();
+  console.log(`Existing addresses (from ${paths.l1}):`);
+  console.log(`  JINN:           ${jinn}`);
+  console.log(`  Treasury:       ${treasury}`);
+  console.log(`  Tokenomics:     ${tokenomics}`);
+  console.log(`  Dispenser:      ${dispenserAddr}`);
+  console.log(`  veOLAS:         ${veOLAS}`);
+  console.log(`  VoteWeighting:  ${vwOld}  (old)`);
+  console.log(`  stakingTokenL2: ${l2Token}`);
+  console.log();
+
+  // ── Step 2: Idempotency guard ─────────────────────────────────────────
+  try {
+    const existingMax = (await vwOldContract.MAX_NUM_WEEKS()) as bigint;
+    if (existingMax >= 10_000n) {
+      console.log(`Existing VoteWeighting already has MAX_NUM_WEEKS=${existingMax}.`);
+      console.log(`Nothing to do — redeploy appears to have already run.`);
+      return;
+    }
+    console.log(`Existing VoteWeighting MAX_NUM_WEEKS=${existingMax} → proceeding with redeploy.`);
+  } catch (e: any) {
+    console.log(`Could not read existing MAX_NUM_WEEKS (${e.message?.slice(0, 80)}); proceeding.`);
+  }
+
+  // ── Pause sanity ──────────────────────────────────────────────────────
+  const disPause = Number(await dispenser.paused());
+  const trePause = Number(await treasuryContract.paused());
+  console.log(`Dispenser.paused = ${disPause} (0=Unpaused,1=DevIncentivesPaused,2=StakingIncentivesPaused,3=AllPaused)`);
+  console.log(`Treasury.paused  = ${trePause} (1=Unpaused,2=Paused)`);
+  if (disPause === 2 || disPause === 3) {
+    throw new Error(
+      `Dispenser is in a paused state that blocks addNominee (paused=${disPause}). Unpause before retrying.`,
+    );
+  }
+  if (trePause === 2) {
+    throw new Error(`Treasury is paused (paused=2). Unpause before retrying.`);
+  }
+
+  // ── Step 3: Deploy new VoteWeightingFast ──────────────────────────────
+  console.log();
+  console.log(`Deploying VoteWeightingFast(${veOLAS})...`);
+  const Factory = await ethers.getContractFactory("VoteWeightingFast", signer);
+  const vwNewContract = await Factory.deploy(veOLAS);
+  const deployTx = vwNewContract.deploymentTransaction();
+  if (deployTx) {
+    console.log(`Deploy tx:     ${deployTx.hash}`);
+    await deployTx.wait();
+  }
+  await vwNewContract.waitForDeployment();
+  const vwNew = await vwNewContract.getAddress();
+  console.log(`VoteWeighting (new): ${vwNew}`);
+
+  const newVwHandle = new ethers.Contract(vwNew, VW_ABI, signer);
+  const newMax = (await newVwHandle.MAX_NUM_WEEKS()) as bigint;
+  const newWeek = (await newVwHandle.WEEK()) as bigint;
+  const newTimeSum = (await newVwHandle.timeSum()) as bigint;
+  console.log(`  MAX_NUM_WEEKS: ${newMax} (expected 10000)`);
+  console.log(`  WEEK:          ${newWeek}s (expected 900)`);
+  console.log(`  timeSum:       ${newTimeSum} (fresh — should be close to now)`);
+  if (newMax !== 10_000n || newWeek !== 900n) {
+    throw new Error(`New VoteWeighting has unexpected params; aborting before rewire.`);
+  }
+
+  // ── Step 4: Dispenser.changeManagers(0, 0, vwNew) ─────────────────────
+  console.log();
+  console.log(`Rewiring Dispenser.voteWeighting → ${vwNew}...`);
+  const cmTx = await dispenser.changeManagers(ethers.ZeroAddress, ethers.ZeroAddress, vwNew);
+  console.log(`changeManagers tx: ${cmTx.hash}`);
+  await cmTx.wait();
+  const dispenserVw = (await dispenser.voteWeighting()) as string;
+  if (dispenserVw.toLowerCase() !== vwNew.toLowerCase()) {
+    throw new Error(`Dispenser.voteWeighting = ${dispenserVw} after changeManagers; expected ${vwNew}.`);
+  }
+  console.log(`  Dispenser.voteWeighting = ${dispenserVw} ✓`);
+
+  // ── Step 5: VW_new.changeDispenser(dispenser) ─────────────────────────
+  console.log();
+  console.log(`Pointing new VoteWeighting at Dispenser ${dispenserAddr}...`);
+  const cdTx = await newVwHandle.changeDispenser(dispenserAddr);
+  console.log(`changeDispenser tx: ${cdTx.hash}`);
+  await cdTx.wait();
+  const vwDispenser = (await newVwHandle.dispenser()) as string;
+  if (vwDispenser.toLowerCase() !== dispenserAddr.toLowerCase()) {
+    throw new Error(`VW.dispenser = ${vwDispenser} after changeDispenser; expected ${dispenserAddr}.`);
+  }
+  console.log(`  VW.dispenser = ${vwDispenser} ✓`);
+
+  // ── Step 6: Register the staking nominee on the new VW ────────────────
+  console.log();
+  console.log(`Registering staking nominee (${l2Token}, chain=${BASE_SEPOLIA_CHAIN_ID}) on new VW...`);
+  const anTx = await newVwHandle.addNomineeEVM(l2Token, BASE_SEPOLIA_CHAIN_ID);
+  console.log(`addNomineeEVM tx: ${anTx.hash}`);
+  await anTx.wait();
+  const { stakingTarget, nomineeHash } = buildStakingNominee(l2Token, BASE_SEPOLIA_CHAIN_ID);
+  const nomineeId = (await newVwHandle.getNomineeId(stakingTarget, BASE_SEPOLIA_CHAIN_ID)) as bigint;
+  if (nomineeId === 0n) {
+    throw new Error(`Nominee registration failed: getNomineeId returned 0.`);
+  }
+  console.log(`  Nominee id:    ${nomineeId}`);
+  console.log(`  Nominee hash:  ${nomineeHash}`);
+
+  // ── Step 7: Rewrite the artifact JSON ─────────────────────────────────
+  console.log();
+  console.log(`Updating ${paths.l1}: contracts.VoteWeighting ${vwOld} → ${vwNew}`);
+  artifact.contracts.VoteWeighting = vwNew;
+  fs.writeFileSync(l1Path, JSON.stringify(artifact, null, 2) + "\n", "utf8");
+  console.log(`  Wrote ${l1Path}`);
+
+  // ── Step 8: Next-step cheatsheet ──────────────────────────────────────
+  console.log();
+  console.log("─── Next operator steps ─────────────────────────────────────────");
+  console.log(`  # Cast the vote from an existing veJINN locker`);
+  console.log(`  PHASE1A_TIMING_PROFILE=fast-test PHASE1A_VOTE_WEIGHT_BPS=10000 \\`);
+  console.log(`    npx hardhat run scripts/phase1a-vote-staking-weight.ts --network sepolia`);
+  console.log();
+  console.log(`  # Wait ≥ 15 min for the next WEEK boundary, then close an epoch`);
+  console.log(`  PHASE1A_TIMING_PROFILE=fast-test \\`);
+  console.log(`    npx hardhat run scripts/checkpoint-and-verify.ts --network sepolia`);
+  console.log();
+  console.log(`  # Claim — expect Claimable > 0, Return Amount much smaller`);
+  console.log(`  PHASE1A_TIMING_PROFILE=fast-test \\`);
+  console.log(`    npx hardhat run scripts/phase1a-claim-staking-incentives.ts --network sepolia`);
+  console.log();
+  console.log(`  # Schedule the heartbeat (weekly) so this doesn't recur`);
+  console.log(`  PHASE1A_TIMING_PROFILE=fast-test \\`);
+  console.log(`    npx hardhat run scripts/phase1a-heartbeat-vote-weighting.ts --network sepolia`);
+  console.log();
+}
+
+if (require.main === module) {
+  main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+}

--- a/contracts/src/vendor/governance/VoteWeightingFast.sol
+++ b/contracts/src/vendor/governance/VoteWeightingFast.sol
@@ -5,6 +5,13 @@ import "./VoteWeighting.sol";
 
 /// @title VoteWeightingFast
 /// @notice Fast-test timing variant of VoteWeighting for Phase 1a iteration.
+/// @dev _maxNumPeriods was raised from 1000 → 10_000 to widen the quiet-tolerance
+///      window from 10.4 days to ~104 days. With _period=900s the internal
+///      _getSum() walk can only advance timeSum if the walker reaches
+///      block.timestamp within _maxNumPeriods iterations; any longer gap leaves
+///      timeSum permanently behind. See jinn-mono-5hc for the prior Sepolia
+///      stall reproduction. Fast-test deployments should still heartbeat at
+///      least weekly — see phase1a-heartbeat-vote-weighting.ts.
 contract VoteWeightingFast is VoteWeighting {
     constructor(address _ve) VoteWeighting(_ve) {}
 
@@ -17,6 +24,6 @@ contract VoteWeightingFast is VoteWeighting {
     }
 
     function _maxNumPeriods() internal pure override returns (uint256) {
-        return 1000;
+        return 10_000;
     }
 }

--- a/docs/phase1a-operator-runbook.md
+++ b/docs/phase1a-operator-runbook.md
@@ -112,6 +112,46 @@ npx hardhat run scripts/phase1a-vote-staking-weight.ts --network sepolia
 npx hardhat run scripts/status-phase1a-live.ts --network sepolia
 ```
 
+#### Fast-test heartbeat requirement (jinn-mono-5hc)
+
+On the `fast-test` timing profile, `VoteWeightingFast._period = 900s` and
+`_maxNumPeriods = 10_000`, giving the internal `_getSum()` walker a
+quiet-tolerance window of ~104 days. If no one invokes
+`VoteWeighting.checkpoint()` (directly, or via any function that calls it)
+for longer than that window, `timeSum` falls too far behind
+`block.timestamp` for the iteration cap to catch up, and the contract
+bricks permanently — there is no admin reset. Run the heartbeat at least
+weekly on fast-test:
+
+```bash
+PHASE1A_TIMING_PROFILE=fast-test \
+  npx hardhat run scripts/phase1a-heartbeat-vote-weighting.ts --network sepolia
+```
+
+The heartbeat is gas-trivial once caught up (the walker only iterates the
+few periods that elapsed). Fold it into whatever cron already runs
+`checkpoint-and-verify.ts`, or add a dedicated scheduled workflow.
+
+#### Recovery if the gauge is already bricked
+
+If `status-phase1a-live.ts` reports the staking nominee with zero relative
+weight despite a valid on-chain vote, or `probe-timesum.ts` shows `timeSum`
+more than `MAX_NUM_WEEKS` periods behind `now`, the gauge is stuck.
+`VoteWeighting` is not behind a proxy and has no admin reset — recovery is
+a one-contract redeploy. Only `VoteWeightingFast` moves; everything else
+(JINN, Treasury, Tokenomics, Depository, Dispenser, veJINN, bridge, L2)
+stays. State lost: nominee registrations and vote history inside
+VoteWeighting (must re-register + re-vote post-redeploy).
+
+```bash
+# From the deployer key (owner of JINN/Dispenser/VoteWeighting):
+PHASE1A_TIMING_PROFILE=fast-test \
+  npx hardhat run scripts/phase1a-redeploy-vote-weighting.ts --network sepolia
+
+# The script deploys, rewires Dispenser ↔ new VW, re-registers the nominee,
+# and rewrites the fast-test artifact JSON. Next steps print on success.
+```
+
 ### Step 6: Seed L2 with JINN
 
 ```bash


### PR DESCRIPTION
## Summary

- Raises `VoteWeightingFast._maxNumPeriods` from 1000 → 10_000, widening the fast-test quiet-tolerance from 10.4 days → ~104 days and closes the `_getSum()` iteration-cap trap that bricks the contract permanently.
- Adds an idempotent `phase1a-redeploy-vote-weighting.ts` orchestration script (deploy → rewire Dispenser ↔ VW → re-register nominee → rewrite fast-test artifact).
- Adds a weekly `phase1a-heartbeat-vote-weighting.ts` as defense-in-depth and a runbook section naming the recovery path.
- Updates `deployment-phase1a-sepolia-fast.json` with the new VoteWeighting address post-redeploy.

Companion PR (unrelated but executed first this session): the minter-restore branch `fix/phase1a-jinn-minter-restore`.

## Root cause

Sepolia Phase 1a went idle for 16 days (2026-04-08 → 2026-04-24). `VoteWeightingFast.timeSum` got stranded because `_period=900s` × `_maxNumPeriods=1000` = 10.4 days is smaller than the idle gap. The internal `_getSum()` walker only advances `timeSum` when the walker crosses `block.timestamp` inside the loop — with the cap hit before reaching `now`, `timeSum` is never written, and every subsequent call re-reads the same stale value. Each `checkpoint()` burned 4.8M gas for zero progress (verified with three consecutive txs).

Downstream: `nomineeRelativeWeight` returned 0 regardless of valid votes; Dispenser routed 137k JINN to return-to-Treasury on every claim. No admin hook to reset `timeSum` → redeploy was the only recovery.

## Sepolia verification (2026-04-24)

- New VW: `0x73e2713B535540A3378ddA3DC62F1e75b35469c3` (`MAX_NUM_WEEKS=10000`)
- Full sequence executed — all txs in the commit body.
- Claim on epoch 18 delivered 3.67 JINN to L2 via bridge, 468.7 JINN returned to Treasury. Pre-fix this path returned 100% to Treasury due to the stall.
- Heartbeat txs cost 29,914 and 42,837 gas respectively (walker near `now`).

## Test plan

- [x] Contract compile clean (`hardhat compile`).
- [x] Redeploy script idempotency guard short-circuits when existing VW already has `MAX_NUM_WEEKS ≥ 10_000`.
- [x] End-to-end on Sepolia: vote → checkpoint → claim path yields non-zero `Claimable JINN`.
- [x] Heartbeat runs with tiny gas when walker is healthy.
- [ ] L2 bridge settlement — the 3.67 JINN will land on `0x2c286651590b4DdC6d58d1270069B43183a851D1` after Sepolia bridge relay (operational, not blocking).
- [ ] Weekly heartbeat cron — see `jinn-mono-5hc` follow-up for GH Actions workflow.

## Notes

Re-registering the nominee on the new VW reset `Dispenser.mapLastClaimedStakingEpochs` to the current epoch, permanently abandoning ~137k JINN of return-amount from epochs 9-16. That allocation was already unreachable (nominee had zero effective weight during the stall), so nothing is lost in practice — worth naming explicitly.

Closes jinn-mono-5hc; unblocks jinn-mono-vvo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)