### PR TITLE
docs(spec): extension-model specs — schema versioning + executor trust boundary

### DIFF
--- a/spec/2026-04-28-restorer-architecture.md
+++ b/spec/2026-04-28-restorer-architecture.md
@@ -1,0 +1,570 @@
+# Restorer Architecture: Substrate-First vs Specialists-First — ADR
+
+> Version: 1
+> Date: 2026-04-28
+> Author: Captain (opus, dispatched on jinn-mono-bea)
+> Status: Proposed (not yet adopted)
+> Supersedes: none
+> Audit: surfaced 2026-04-27 from PR #38 review session
+> Sibling specs:
+> `spec/2026-05-restorer-plugins.md`,
+> `spec/2026-05-executor-trust-boundary.md`,
+> `spec/2026-05-schema-versioning.md`,
+> `spec/2026-05-registry-discovery.md`,
+> `spec/2026-04-21-agentic-data-substrate.md`,
+> `docs/superpowers/specs/2026-04-23-default-learning-restorer-design.md`
+
+## 1. Purpose and scope
+
+PR #38 (default-learner) introduced a wrapper-around-specialists model:
+a `DefaultLearningWrapper` first-match-claims every `(kind, type)` pair
+and delegates the inner Execute step to the specialist via a two-pass
+protocol (`IntentSessionInputs.adapterEnv`). That shape was an
+implementation choice in Plan 3 of the PR, not a deliberate
+protocol-level architectural decision. This ADR makes the call.
+
+The Captain has already separately decided that default-learner does
+not become the registry default (it ships opt-in, drops the "default"
+framing). This ADR answers the deeper question PR #38 surfaced:
+
+> Is the executor a learning **substrate** that wraps specialists, a
+> set of **specialists** with learning as an optional service, or a
+> hybrid where operators pick per kind?
+
+The four extension-model specs (`spec/2026-05-*.md`) and the audit
+output (`jinn-mono-j75`) all assume a per-impl identity. PR #38's
+wrapper assumes a substrate identity in front of those impls. Those
+two assumptions are not compatible without one of them yielding. This
+ADR picks specialists-first and routes learning as a per-impl service.
+
+### 1.1 In scope
+
+- The high-level architecture choice between substrate-first,
+  specialists-first, and hybrid.
+- The constraints the choice imposes on the engine's impl-resolution
+  rule, the trust boundary, the plug-in loader, and kind-versioning.
+- The disposition of PR #38's wrapper code given the choice.
+- The composition story for operator-supplied restorers
+  (`jinn-mono-7zz`) under the chosen model.
+
+### 1.2 Out of scope
+
+- The internal mechanics of any specific learner (Pi phases,
+  promotion gate, constitutional snapshots) — these live in the
+  default-learner design spec and are unaffected by this ADR provided
+  they are confined to one `RestorerImpl`.
+- The corpus / dataset productisation mechanics. The agentic-data
+  substrate spec is informative input; this ADR does not commit to
+  any of its tiered protocol changes.
+- Kind-major cuts, naming churn (`jinn-mono-juw` / GH#43), and CLI
+  verb shapes. Those land on their own beads.
+
+### 1.3 Non-goals
+
+- This is not a replacement for the default-learner design spec. It
+  scopes where the learner sits; it does not redesign its internals.
+- This is not a Phase 2 spec. The decision below holds the seams the
+  trust-boundary spec already opened (out-of-process plug-ins), but
+  does not pre-commit Phase 2 mechanics.
+
+## 2. The fork (recap)
+
+Three options were on the table. The framing below restates them in
+the language of the existing extension-model specs so the rejection
+or acceptance lines up with the contracts those specs already define.
+
+### 2.1 Option 1 — substrate-first
+
+A learning loop is the universal envelope around restoration.
+Specialists become Execute-step plugins inside the loop
+(Orient → Strategize → Plan → Execute → Debrief → Improve → Memory).
+The learning loop holds protocol-visible identity; specialists are
+selected by the substrate and invoked via an internal handoff.
+
+This is PR #38's current shape, just opt-in instead of default. The
+wrapper's `supports()` first-match-wins; once the wrapper claims a
+`(kind, type)`, its inner specialist runs through the wrapper's
+`adapterEnv` two-pass protocol.
+
+### 2.2 Option 2 — specialists-first
+
+Restorer impls remain the protocol-visible unit. Each kind has its own
+specialist(s) implementing the existing `RestorerImpl` interface
+(`client/src/restorer/types.ts`). Learning is a per-impl service
+layer: an impl can use a learner library or call out to a learning
+service, but it owns its own `run(ctx)` semantics and identity.
+
+A learner-style impl is one impl among many in `buildRestorerImpls`
+(or an operator-supplied plug-in via `restorers.plugins`); it does
+**not** sit between the engine and other specialists.
+
+### 2.3 Option 3 — hybrid
+
+Both shapes coexist. A wrapper substrate is one engine path;
+direct-to-specialist is another. An operator picks per kind via
+config which path applies.
+
+## 3. Decision
+
+**Option 2 — specialists-first.**
+
+The protocol's unit of identity, trust, and discovery is the
+`RestorerImpl`. Learning is a per-impl service layer that an impl
+opts into; it does not become a wrapper that sits between the engine
+and other impls. PR #38's `DefaultLearningWrapper` is repositioned
+into a kind-specific learner impl (or scope-narrowed to the kinds
+the bundled Pi harness was actually validated against), not retained
+as a first-match envelope across every kind.
+
+The status quo registration shape in
+`client/src/restorer/impls/index.ts` continues — a flat list of
+impls, each declaring `supports({ kind, type })`. The plug-in loader
+extends this list at boot from `restorers.plugins` per
+`spec/2026-05-restorer-plugins.md`. There is no second engine path.
+
+## 4. Rationale
+
+The decision is forced by four contracts the four sibling specs
+already define. Option 1 violates all four; Option 3's flexibility
+collapses to either Option 1 or Option 2 once those contracts apply.
+
+### 4.1 Trust boundary is per-impl
+
+`spec/2026-05-executor-trust-boundary.md` §3 / §4 / §5 binds:
+
+- A capability allow-list (chains, signer selectors, RPC methods,
+  rate limits) to one manifest, signed by one signer key.
+- An `implStateDir` and a per-impl `secrets/` bag to one impl name.
+- Revocation (§5.6) to one signer or one manifest CID, with cascade
+  to every impl signed by a revoked key.
+
+A substrate that interposes between the engine and a specialist
+either (a) presents its own identity to the boundary — collapsing
+many specialists' allow-lists into one wider allow-list, which is the
+exact pattern §3.5 forbids; (b) inherits the specialist's identity
+dynamically — which is not a model the boundary spec defines and
+would require redesigning §5.4's install-time review (the operator
+reviews one manifest, not "wrapper composed with specialist X");
+or (c) carries no identity and only operates inside the specialist's
+scope — at which point the substrate is a library, not a wrapper,
+which is Option 2.
+
+PR #38 implements (a) implicitly: the `DefaultLearningWrapper` runs
+under the daemon's PID with whatever credentials the engine's
+existing call site grants, and its `IntentSessionInputs.adapterEnv`
+hand-off is internal — invisible to the §3 capability scoping. The
+codex review (`jinn-mono-8dr`) flagged this in must-fix #5: the
+wrapper does not delegate gates to specialists, and its `supports()`
+is asymmetric across restoration / evaluation. Both symptoms are the
+trust-boundary mismatch surfacing.
+
+### 4.2 Plug-in loader is per-impl
+
+`spec/2026-05-restorer-plugins.md` §3.4 lifecycle:
+
+> 6. **Validate identity.** The returned `RestorerImpl.name` MUST
+>    equal `manifest.name`; `RestorerImpl.version` MUST equal
+>    `manifest.version`. Mismatch → exclude with
+>    `reason: "impl-identity-mismatch"`.
+> 7. **Validate `supportedKinds`.** Every kind the impl claims via
+>    `supports()` for the kinds in `manifest.supportedKinds` MUST
+>    match.
+
+A wrapper that announces `supports()` for a different superset than
+its manifest declares fails identity validation. A wrapper that
+declares `supportedKinds: ["*"]` (every kind) is not expressible
+under §2 of the schema-versioning spec, which requires explicit
+`<kind>>=<semver>` entries. A wrapper that wraps another impl whose
+manifest exists separately is two manifests for one runtime path —
+the loader has no model for that.
+
+The plug-in loader is the integration point an operator-supplied
+restorer goes through (`jinn-mono-7zz`). Forcing every plug-in
+through a substrate wrapper at the engine level either:
+
+- Pre-installs the substrate as a first-party impl outside the
+  plug-in flow (privileges first-party over third-party — exactly
+  what `jinn-mono-7zz`'s "first-class" goal disallows), or
+- Requires every plug-in to declare itself substrate-compatible
+  (couples third-party authors to one substrate's vocabulary).
+
+Both outcomes are worse than treating the substrate as one more
+opt-in plug-in.
+
+### 4.3 Kind-versioning is per-kind
+
+`spec/2026-05-schema-versioning.md` §2 / §4 routes consumers
+(subgraphs, evaluators, third-party readers) on `kind`, not on
+substrate. A substrate that wraps every kind has no single
+`schemaVersion` it can advertise; it has to announce its inner
+specialist's kind, which makes it indistinguishable from the
+specialist itself.
+
+The schema-versioning spec also forbids best-effort cross-kind
+parsing (§5.1, §5.2). A learning loop that promises to "improve
+across kinds" inside one envelope either fragments its trajectory
+data per kind anyway (so the cross-kind promise is illusory) or
+emits substrate-shaped envelopes that no consumer routes on (so the
+trajectories don't ingest into the existing schema-versioned
+indexers).
+
+Specialist-shaped trajectories are what every downstream consumer
+already knows how to read. That's not a coincidence — the
+agentic-data-substrate spec's Tier 1.1 ("canonical trajectory
+schema, enforced by the client") is kind-shaped because that's the
+shape buyers will actually fine-tune against (`jinn-restore-defi-v1`,
+`jinn-restore-prediction-v1`, etc., per §"What we'd sell" v2).
+
+### 4.4 jinn-mono-2zk already chose operator-side, off-chain
+
+The default-learning-restorer design spec
+(`docs/superpowers/specs/2026-04-23-default-learning-restorer-design.md`)
+resolved jinn-mono-2zk with:
+
+- **(B) operator-side for v0** (not buyer-side, not protocol-side).
+- **No protocol / engine state-machine changes.**
+- **Off-chain only**, confined to `implStateDir`.
+- **No ve-JINN tie**, no protocol-emitted training artifacts.
+
+That resolution is structurally Option 2: the learner is one impl
+running locally, with a `workingDir` (ephemeral) / `implStateDir`
+(durable) split that already follows the trust-boundary's per-impl
+filesystem rules. PR #38's wrapper-around-specialists shape goes
+**further** than that resolution committed to — it makes the learner
+visible to the engine ahead of the specialist, which is closer to a
+protocol-side change than the spec authorised.
+
+The cleanest read of PR #38: it shipped option-1 mechanics under a
+spec that authorised option-2 mechanics. This ADR realigns them.
+
+### 4.5 The corpus thesis is preserved without the wrapper
+
+The agentic-data-substrate thesis ("every operator's trajectory
+data is the corpus") is the strongest pro-Option-1 argument. It is
+preserved by Option 2:
+
+- Trajectory emission is an engine-level concern, not a substrate
+  concern. Tier 1.1 of the agentic-data-substrate spec puts the
+  canonical schema "enforced by the client" — the client is the
+  daemon, not any one impl. The daemon already constructs
+  `RestorationContext` per attempt and receives `RestorationOutput`
+  back; that envelope is the natural place to log structured turns,
+  for every impl.
+- Specialists produce kind-shaped trajectories. Cross-kind learning
+  is a downstream training-time concern (multi-task fine-tuning on
+  the corpus), not a runtime architecture concern. The corpus
+  doesn't need substrate-vocabulary trajectories to be
+  cross-task-trainable; it needs schema-versioned per-kind
+  trajectories that downstream training pipelines can mix.
+- The challenge → hard-example pipeline (Tier 2.8) routes on the
+  evaluator's verdict, which is per-(kind, attempt). It does not
+  depend on the substrate's vocabulary.
+
+In short: the corpus is the product, but the corpus is built from
+specialists' outputs, not from substrate-wrapped envelopes. Option 2
+is the architecture that lets the corpus thesis ship without forcing
+a vocabulary onto every impl author.
+
+### 4.6 Why Option 3 is not a real third choice
+
+Option 3 (hybrid) is two engine paths: direct-to-specialist for
+some kinds, substrate-wrapped for others. The cost is:
+
+- Two trust models. The trust-boundary spec already cascades
+  revocation through one signer set; a substrate adds a third layer
+  whose cascade rules are undefined.
+- Two `supports()` resolution rules. Today's first-match is already
+  fragile (the codex review's must-fix #5 lives here). Adding a
+  per-(kind, route) override doubles the cases.
+- Two trajectory shapes. Substrate-wrapped envelopes are not
+  schema-versioned the same way kind-shaped envelopes are; consumers
+  have to learn both.
+
+The only way to flatten Option 3's cost is to demote the substrate
+to a service the impl chooses to call — at which point Option 3 is
+indistinguishable from Option 2 with a learner library. That is the
+form Option 2 already names.
+
+## 5. Composition with the four sibling specs
+
+This section spells out, per spec, what changes and what does not
+under Option 2.
+
+### 5.1 With `spec/2026-05-restorer-plugins.md`
+
+No changes. The plug-in flow already assumes one impl per manifest,
+one identity per signer, one `supportedKinds` per impl. A learner is
+just one more plug-in (or one more in-repo entry in
+`buildRestorerImpls`).
+
+A plug-in author writing a learning-flavoured restorer publishes
+their own `RestorerImpl`. They MAY internally use a learner
+library — Pi, OTel-instrumented session manager, a constitutional
+snapshot helper — and the SDK package (§3.6 of the plug-in spec) MAY
+re-export those helpers for convenience. The library is opt-in at
+the impl-author level, not enforced at the engine level.
+
+### 5.2 With `spec/2026-05-executor-trust-boundary.md`
+
+No changes. The boundary stays per-impl. A learner-flavoured impl
+that uses Pi to spawn an inner agent does so inside its own
+`run(ctx)` body, using `ctx.signer` / `ctx.rpc` / `ctx.secrets` /
+`ctx.fs` capability handles. Pi spawns are subject to the same
+boundary as any other side effect the impl performs.
+
+The wrapper-vs-specialist asymmetry the codex review flagged
+(must-fix #5) goes away with the wrapper: there is no asymmetric
+gate to delegate, because there is no wrapper sitting between the
+engine and the specialist in the first place.
+
+### 5.3 With `spec/2026-05-schema-versioning.md`
+
+No changes. The grammar `<domain>.v<major>` continues to identify
+each kind. A learner-flavoured impl declares `supportedKinds`
+exactly like any other impl (§4.2 entry grammar). It MAY support
+many kinds (one entry per kind), but each entry is its own
+`<kind>>=<semver>` pair — there is no `*` or "all-kinds"
+construction.
+
+Consumer dispositions (§5.2's drop-vs-surface decision rule)
+continue to route on `kind`. A learner emits the same envelope shape
+its specialist would have emitted; downstream readers do not need to
+know an impl is learner-flavoured.
+
+### 5.4 With `spec/2026-05-registry-discovery.md`
+
+No changes. Source A (in-repo `buildRestorerImpls`) and Source B
+(`restorers.plugins`) continue to be the only two boot-time sources
+of impl candidates (§4.3). A learner is one entry in either source.
+
+The `restorers.disabled` field (§4.1) lets an operator turn off the
+in-repo learner if they want to run the bare specialists; they do
+not need a wrapper-flavoured config field to suppress substrate
+behaviour, because there is no engine-level wrapper to suppress.
+
+## 6. Where learning lives under Option 2
+
+Three plausible shapes; impl authors and operators choose. All
+three live inside one `RestorerImpl`'s `run(ctx)` and respect the
+trust boundary. None creates a second engine code path.
+
+### 6.1 Learner as library
+
+An impl imports a learner library (Pi-based session manager + OTel
+correlation + promotion gate, the shape from the default-learning
+design spec) and calls it inside `run(ctx)`. The library is
+re-exported by `@jinn-network/restorer-sdk` (`spec/2026-05-restorer-plugins.md`
+§3.6).
+
+**Trust:** library code runs with the impl's capabilities, not its
+own. Library bugs are impl bugs.
+
+**Versioning:** library version is part of the impl's
+`implVersion`. Bumping the library is a manifest minor under
+`spec/2026-05-schema-versioning.md` §3.1.
+
+**State:** library reads/writes inside `ctx.implStateDir/<sub-dir>`.
+The impl chooses the sub-dir layout.
+
+### 6.2 Learner as kind-specific specialist
+
+An operator publishes a learner-flavoured plug-in for a specific
+kind: `prediction-v0-learner`, `lending-health-v0-learner`. It
+declares `supportedKinds: ["prediction.v0>=1.0.0"]` (or whatever)
+in its manifest, and it runs alongside the baseline / claude-mcp
+specialists for the same kind.
+
+**Resolution:** the engine's first-match still applies; operators
+control ordering via `restorers.disabled` (subtractive) and a
+follow-up `restorers.preference` (additive, named in §7 below) to
+say "for this kind, prefer this impl." First-match without
+preference is the current behaviour; a preference field is the
+minimum extension this ADR requires.
+
+**Trust:** the learner-flavoured impl has its own manifest,
+signer, allow-list, and `implStateDir`. Revocation cascades
+through it like any other impl (§5.6 of the trust-boundary spec).
+
+**Corpus:** the learner emits the same kind-shaped envelope the
+baseline does; from the corpus's perspective, both impls produce
+trainable trajectories.
+
+### 6.3 Learner as out-of-process service (Phase 2)
+
+When `spec/2026-05-executor-trust-boundary.md` §6 (out-of-process
+seams) is realised in Phase 2, a learner can run as its own
+process / service that an impl calls into. The impl is still the
+trust-boundary-visible unit; the service is its dependency.
+
+This is the cleanest long-run shape for cross-impl learning: many
+specialists call into one learner service, sharing trajectory data
+across kinds, while each specialist retains its own identity and
+allow-list. The §6.2 constraints (capabilities are functions, IO is
+JSON-serialisable, no global state, no env inheritance) already
+shape the impl side of that contract.
+
+The trust-boundary spec is explicit that in-process Node is not a
+real isolation boundary; cross-kind learning that aspires to
+buyer-side packaging probably needs §6 process isolation regardless
+of which architecture this ADR picked. Option 2 inherits the §6
+upgrade path for free.
+
+## 7. PR #38 disposition
+
+The PR ships the option-1 mechanics this ADR rejects as a universal
+pattern. Concrete repositioning, in order of cost:
+
+1. **Drop `DefaultLearningWrapper` from the engine path.** The
+   first-match wrapping of every `(kind, type)` does not survive.
+   The default-learner becomes one or more kind-specific impls in
+   `buildRestorerImpls`, registered alongside the existing
+   prediction / portfolio / hyperliquid impls.
+
+2. **Lock the default-learner's `supportedKinds` to the kinds it
+   was actually validated against.** Plan 4 of PR #38 verified the
+   loop on Claude Code 2.1.119; whichever kinds were exercised in
+   that verification become the impl's `supportedKinds`. Other
+   kinds get specialist-only routing until a learner-flavoured
+   impl exists for them.
+
+3. **Remove the `IntentSessionInputs.adapterEnv` two-pass
+   protocol from the public envelope.** The wrapper-to-specialist
+   handoff stops being protocol-visible. If the default-learner's
+   internal Pi-based phases need a per-call env bag, that lives
+   inside the impl (e.g. on its constructor or in
+   `ctx.implStateDir`), not on `IntentSessionInputs`. This is the
+   schema-versioning spec's §6.1 accept-both rule applied
+   defensively: existing artifacts that referenced `adapterEnv`
+   stay parseable for one release, then the field is removed.
+
+4. **Add a `restorers.preference` config field (or equivalent).**
+   First-match without operator override is what PR #38 was
+   working around. A small additive field — `restorers.preference:
+   { "prediction.v0": "@jinn/prediction-v0-learner" }` — gives the
+   operator the same "this kind goes through the learner" choice
+   PR #38's first-match was trying to grant, without an engine-level
+   wrapper. Exact key shape is finalised by the loader bead
+   (`jinn-mono-7zz` follow-ups, §7.2).
+
+5. **Repurpose Plan 1 (the `client/plugins/default-learner/` Claude
+   plugin)** as the operator-facing harness for the default-learner
+   impl. The Claude plugin is unaffected by the engine-level
+   architecture choice; it remains the agent-side surface an
+   operator runs to author / debug / observe a learner cycle. Its
+   contract with the engine is via the kind-specific impl, not via
+   the dropped wrapper.
+
+The codex review's must-fix #5 and the supports() asymmetry both
+disappear once the wrapper is dropped: there is no longer a
+delegating layer to mis-delegate gates through, and `supports()` is
+declared per impl as it always was.
+
+## 8. How operator-supplied restorers (jinn-mono-7zz) compose
+
+`jinn-mono-7zz` already shipped `spec/2026-05-restorer-plugins.md`
+on the assumption that each plug-in is a self-contained impl. That
+assumption is what this ADR confirms.
+
+Concretely, a third-party operator publishing a learning-flavoured
+plug-in does the same things they would for any plug-in:
+
+1. Implement the `RestorerImpl` interface
+   (`client/src/restorer/types.ts`).
+2. Use the learner library if they want one
+   (`@jinn-network/restorer-sdk` re-exports per §6.1 above).
+3. Sign their `jinn.manifest.json` with their ed25519 key, declare
+   `supportedKinds`, declare `capabilities`, pin the tarball CID.
+4. Publish; operators trust the signer, install the manifest, and
+   the plug-in lights up alongside the in-repo impls.
+
+There is no "second route" they pick depending on whether they want
+learning. Learning is something the impl does internally, not
+something the protocol surface enforces.
+
+The naming pass before public ship (`jinn-mono-juw` / GH#43,
+restorer-plugins spec §7.2 step 9) applies normally; this ADR adds
+no new public-surface vocabulary.
+
+## 9. Acceptance and downstream impact
+
+### 9.1 Acceptance
+
+This ADR is accepted when:
+
+1. It is merged under `spec/`.
+2. `jinn-mono-7zz` description is updated to note that this ADR
+   confirms the per-impl assumption the plug-in spec already made,
+   and to point at this file as the architectural decision input.
+3. `jinn-mono-bea` is closed.
+
+### 9.2 Downstream tasks (informational, not committed by this ADR)
+
+The repositioning of PR #38 from §7 is the load-bearing follow-up.
+Suggested filing order if the Captain elects to land the ADR:
+
+1. **PR #38 wrapper removal / scope-narrow** — drop
+   `DefaultLearningWrapper` first-match; convert the default-learner
+   into one or more kind-specific impls registered in
+   `buildRestorerImpls`. Includes the `IntentSessionInputs.adapterEnv`
+   accept-both window per §7 step 3.
+2. **`restorers.preference` config field** — additive operator
+   override per §7 step 4. Coordinates with the in-repo disable
+   list (`spec/2026-05-registry-discovery.md` §4.1) so operators
+   have both subtractive and additive control over impl resolution.
+3. **Engine-level trajectory emission** — the canonical-trajectory
+   work (Tier 1.1 of the agentic-data-substrate spec) is now an
+   engine concern, not a substrate concern. Files at the engine /
+   `RestorationOutput` boundary, kind-shaped.
+4. **SDK learner-library re-exports** — once the per-impl learner
+   shape stabilises, the SDK package
+   (`spec/2026-05-restorer-plugins.md` §3.6) re-exports the
+   learner helpers (Pi session manager, OTel correlation,
+   promotion gate). Optional; impl authors can copy the helpers
+   if the SDK lags.
+
+### 9.3 Open questions deferred
+
+- **Cross-impl learning service.** The Phase 2 out-of-process
+  shape from §6.3 above is plausible once
+  `spec/2026-05-executor-trust-boundary.md` §6 ships, but its wire
+  protocol and trust-mediated cross-impl trajectory access are
+  unspecified. A future spec covers it; this ADR only commits that
+  the Phase 2 path stays open.
+- **Buyer-side corpus filtering / tiering.** The (C) half of
+  jinn-mono-2zk's question (deferred there) remains open. This ADR
+  is consistent with whatever buyer-side product lands, because
+  per-impl trajectories are the substrate the buyer-side product
+  reads from.
+- **Substrate-vocabulary cross-kind learning research.** The
+  Orient → Strategize → Plan → Execute → Debrief → Improve →
+  Memory loop may still be the right shape *inside* a learner-
+  flavoured impl. This ADR does not ban that vocabulary; it bans
+  the vocabulary becoming the engine-level envelope.
+
+## 10. References
+
+- `spec/2026-05-restorer-plugins.md` — plug-in loader; per-impl
+  identity, manifest, lifecycle.
+- `spec/2026-05-executor-trust-boundary.md` — per-impl credentials,
+  filesystem, provenance, revocation, out-of-process seams.
+- `spec/2026-05-schema-versioning.md` — kind grammar,
+  `supportedKinds` advertisement, consumer compatibility policy.
+- `spec/2026-05-registry-discovery.md` — Source A (in-repo) +
+  Source B (`restorers.plugins`) discovery model.
+- `spec/2026-04-21-agentic-data-substrate.md` — corpus thesis;
+  Tier 1.1 canonical trajectory schema is engine-level under this
+  ADR.
+- `docs/superpowers/specs/2026-04-23-default-learning-restorer-design.md`
+  — operator-side, off-chain, no-protocol-changes resolution that
+  this ADR realigns PR #38 with.
+- `client/src/restorer/types.ts` — `RestorerImpl` interface; the
+  per-impl unit this ADR centres on.
+- `client/src/restorer/impls/index.ts` — `buildRestorerImpls`; the
+  in-repo registry that stays as Source A.
+- `jinn-mono-bea` — this ADR's filing bead.
+- `jinn-mono-8dr` — codex review of PR #38; must-fix #5 is
+  resolved by the wrapper removal in §7.
+- `jinn-mono-2zk` — default-learner scope question; resolved
+  upstream of this ADR via the design spec above.
+- `jinn-mono-7zz` — operator-supplied restorers; this ADR
+  confirms its per-impl assumption.

--- a/spec/2026-04-28-restorer-architecture.md
+++ b/spec/2026-04-28-restorer-architecture.md
@@ -1,18 +1,30 @@
 # Restorer Architecture: Substrate-First vs Specialists-First — ADR
 
-> Version: 1
-> Date: 2026-04-28
+> Version: 1.1
+> Date: 2026-04-28 (rev 2026-04-28: vocabulary retarget — "plug-in" → "external impl"; renamed file ref)
 > Author: Captain (opus, dispatched on jinn-mono-bea)
 > Status: Proposed (not yet adopted)
-> Supersedes: none
+> Supersedes: v1 (vocabulary-only retarget; conclusion unchanged)
 > Audit: surfaced 2026-04-27 from PR #38 review session
 > Sibling specs:
-> `spec/2026-05-restorer-plugins.md`,
+> `spec/2026-05-external-restorer-impls.md`,
 > `spec/2026-05-executor-trust-boundary.md`,
 > `spec/2026-05-schema-versioning.md`,
 > `spec/2026-05-registry-discovery.md`,
 > `spec/2026-04-21-agentic-data-substrate.md`,
 > `docs/superpowers/specs/2026-04-23-default-learning-restorer-design.md`
+
+## Vocabulary note (2026-04-28)
+
+v1.1 retargets "plug-in" → "external impl" throughout (matching the
+other extension-model specs on this branch and the codebase's
+established `RestorerImpl` / `impl` vocabulary; avoiding collision
+with the unrelated existing `jinn plugin install` verb that installs
+the Jinn MCP server / skill into AI hosts). The two literal references
+to `client/plugins/default-learner/` and "the Claude plugin" in §7
+step 5 are NOT renamed — those name a real Claude Code plugin, a
+distinct surface from the operator-supplied `RestorerImpl` flow this
+ADR composes with.
 
 ## 1. Purpose and scope
 
@@ -42,7 +54,8 @@ ADR picks specialists-first and routes learning as a per-impl service.
 - The high-level architecture choice between substrate-first,
   specialists-first, and hybrid.
 - The constraints the choice imposes on the engine's impl-resolution
-  rule, the trust boundary, the plug-in loader, and kind-versioning.
+  rule, the trust boundary, the external-impl loader, and
+  kind-versioning.
 - The disposition of PR #38's wrapper code given the choice.
 - The composition story for operator-supplied restorers
   (`jinn-mono-7zz`) under the chosen model.
@@ -64,7 +77,7 @@ ADR picks specialists-first and routes learning as a per-impl service.
 - This is not a replacement for the default-learner design spec. It
   scopes where the learner sits; it does not redesign its internals.
 - This is not a Phase 2 spec. The decision below holds the seams the
-  trust-boundary spec already opened (out-of-process plug-ins), but
+  trust-boundary spec already opened (out-of-process impls), but
   does not pre-commit Phase 2 mechanics.
 
 ## 2. The fork (recap)
@@ -76,7 +89,7 @@ or acceptance lines up with the contracts those specs already define.
 ### 2.1 Option 1 — substrate-first
 
 A learning loop is the universal envelope around restoration.
-Specialists become Execute-step plugins inside the loop
+Specialists become Execute-step impls inside the loop
 (Orient → Strategize → Plan → Execute → Debrief → Improve → Memory).
 The learning loop holds protocol-visible identity; specialists are
 selected by the substrate and invoked via an internal handoff.
@@ -95,8 +108,8 @@ layer: an impl can use a learner library or call out to a learning
 service, but it owns its own `run(ctx)` semantics and identity.
 
 A learner-style impl is one impl among many in `buildRestorerImpls`
-(or an operator-supplied plug-in via `restorers.plugins`); it does
-**not** sit between the engine and other specialists.
+(or an operator-supplied external impl via `restorers.externalImpls`);
+it does **not** sit between the engine and other specialists.
 
 ### 2.3 Option 3 — hybrid
 
@@ -118,9 +131,10 @@ as a first-match envelope across every kind.
 
 The status quo registration shape in
 `client/src/restorer/impls/index.ts` continues — a flat list of
-impls, each declaring `supports({ kind, type })`. The plug-in loader
-extends this list at boot from `restorers.plugins` per
-`spec/2026-05-restorer-plugins.md`. There is no second engine path.
+impls, each declaring `supports({ kind, type })`. The external-impl
+loader extends this list at boot from `restorers.externalImpls` per
+`spec/2026-05-external-restorer-impls.md`. There is no second engine
+path.
 
 ## 4. Rationale
 
@@ -158,9 +172,9 @@ wrapper does not delegate gates to specialists, and its `supports()`
 is asymmetric across restoration / evaluation. Both symptoms are the
 trust-boundary mismatch surfacing.
 
-### 4.2 Plug-in loader is per-impl
+### 4.2 External-impl loader is per-impl
 
-`spec/2026-05-restorer-plugins.md` §3.4 lifecycle:
+`spec/2026-05-external-restorer-impls.md` §3.4 lifecycle:
 
 > 6. **Validate identity.** The returned `RestorerImpl.name` MUST
 >    equal `manifest.name`; `RestorerImpl.version` MUST equal
@@ -178,18 +192,18 @@ under §2 of the schema-versioning spec, which requires explicit
 manifest exists separately is two manifests for one runtime path —
 the loader has no model for that.
 
-The plug-in loader is the integration point an operator-supplied
-restorer goes through (`jinn-mono-7zz`). Forcing every plug-in
-through a substrate wrapper at the engine level either:
+The external-impl loader is the integration point an operator-
+supplied restorer goes through (`jinn-mono-7zz`). Forcing every
+external impl through a substrate wrapper at the engine level either:
 
 - Pre-installs the substrate as a first-party impl outside the
-  plug-in flow (privileges first-party over third-party — exactly
-  what `jinn-mono-7zz`'s "first-class" goal disallows), or
-- Requires every plug-in to declare itself substrate-compatible
+  external-impl flow (privileges first-party over third-party —
+  exactly what `jinn-mono-7zz`'s "first-class" goal disallows), or
+- Requires every external impl to declare itself substrate-compatible
   (couples third-party authors to one substrate's vocabulary).
 
 Both outcomes are worse than treating the substrate as one more
-opt-in plug-in.
+opt-in impl.
 
 ### 4.3 Kind-versioning is per-kind
 
@@ -290,19 +304,19 @@ form Option 2 already names.
 This section spells out, per spec, what changes and what does not
 under Option 2.
 
-### 5.1 With `spec/2026-05-restorer-plugins.md`
+### 5.1 With `spec/2026-05-external-restorer-impls.md`
 
-No changes. The plug-in flow already assumes one impl per manifest,
-one identity per signer, one `supportedKinds` per impl. A learner is
-just one more plug-in (or one more in-repo entry in
+No changes. The external-impl flow already assumes one impl per
+manifest, one identity per signer, one `supportedKinds` per impl. A
+learner is just one more external impl (or one more in-repo entry in
 `buildRestorerImpls`).
 
-A plug-in author writing a learning-flavoured restorer publishes
-their own `RestorerImpl`. They MAY internally use a learner
+An external-impl author writing a learning-flavoured restorer
+publishes their own `RestorerImpl`. They MAY internally use a learner
 library — Pi, OTel-instrumented session manager, a constitutional
-snapshot helper — and the SDK package (§3.6 of the plug-in spec) MAY
-re-export those helpers for convenience. The library is opt-in at
-the impl-author level, not enforced at the engine level.
+snapshot helper — and the SDK package (§3.6 of the external-impl
+spec) MAY re-export those helpers for convenience. The library is
+opt-in at the impl-author level, not enforced at the engine level.
 
 ### 5.2 With `spec/2026-05-executor-trust-boundary.md`
 
@@ -334,8 +348,9 @@ know an impl is learner-flavoured.
 ### 5.4 With `spec/2026-05-registry-discovery.md`
 
 No changes. Source A (in-repo `buildRestorerImpls`) and Source B
-(`restorers.plugins`) continue to be the only two boot-time sources
-of impl candidates (§4.3). A learner is one entry in either source.
+(`restorers.externalImpls`) continue to be the only two boot-time
+sources of impl candidates (§4.3). A learner is one entry in either
+source.
 
 The `restorers.disabled` field (§4.1) lets an operator turn off the
 in-repo learner if they want to run the bare specialists; they do
@@ -353,8 +368,8 @@ trust boundary. None creates a second engine code path.
 An impl imports a learner library (Pi-based session manager + OTel
 correlation + promotion gate, the shape from the default-learning
 design spec) and calls it inside `run(ctx)`. The library is
-re-exported by `@jinn-network/restorer-sdk` (`spec/2026-05-restorer-plugins.md`
-§3.6).
+re-exported by `@jinn-network/restorer-sdk`
+(`spec/2026-05-external-restorer-impls.md` §3.6).
 
 **Trust:** library code runs with the impl's capabilities, not its
 own. Library bugs are impl bugs.
@@ -368,9 +383,9 @@ The impl chooses the sub-dir layout.
 
 ### 6.2 Learner as kind-specific specialist
 
-An operator publishes a learner-flavoured plug-in for a specific
-kind: `prediction-v0-learner`, `lending-health-v0-learner`. It
-declares `supportedKinds: ["prediction.v0>=1.0.0"]` (or whatever)
+An operator publishes a learner-flavoured external impl for a
+specific kind: `prediction-v0-learner`, `lending-health-v0-learner`.
+It declares `supportedKinds: ["prediction.v0>=1.0.0"]` (or whatever)
 in its manifest, and it runs alongside the baseline / claude-mcp
 specialists for the same kind.
 
@@ -461,12 +476,12 @@ declared per impl as it always was.
 
 ## 8. How operator-supplied restorers (jinn-mono-7zz) compose
 
-`jinn-mono-7zz` already shipped `spec/2026-05-restorer-plugins.md`
-on the assumption that each plug-in is a self-contained impl. That
-assumption is what this ADR confirms.
+`jinn-mono-7zz` already shipped `spec/2026-05-external-restorer-impls.md`
+on the assumption that each external impl is a self-contained impl.
+That assumption is what this ADR confirms.
 
 Concretely, a third-party operator publishing a learning-flavoured
-plug-in does the same things they would for any plug-in:
+external impl does the same things they would for any external impl:
 
 1. Implement the `RestorerImpl` interface
    (`client/src/restorer/types.ts`).
@@ -475,15 +490,15 @@ plug-in does the same things they would for any plug-in:
 3. Sign their `jinn.manifest.json` with their ed25519 key, declare
    `supportedKinds`, declare `capabilities`, pin the tarball CID.
 4. Publish; operators trust the signer, install the manifest, and
-   the plug-in lights up alongside the in-repo impls.
+   the impl lights up alongside the in-repo impls.
 
 There is no "second route" they pick depending on whether they want
 learning. Learning is something the impl does internally, not
 something the protocol surface enforces.
 
 The naming pass before public ship (`jinn-mono-juw` / GH#43,
-restorer-plugins spec §7.2 step 9) applies normally; this ADR adds
-no new public-surface vocabulary.
+external-restorer-impls spec §7.2 step 9) applies normally; this ADR
+adds no new public-surface vocabulary.
 
 ## 9. Acceptance and downstream impact
 
@@ -493,8 +508,9 @@ This ADR is accepted when:
 
 1. It is merged under `spec/`.
 2. `jinn-mono-7zz` description is updated to note that this ADR
-   confirms the per-impl assumption the plug-in spec already made,
-   and to point at this file as the architectural decision input.
+   confirms the per-impl assumption the external-impl spec already
+   made, and to point at this file as the architectural decision
+   input.
 3. `jinn-mono-bea` is closed.
 
 ### 9.2 Downstream tasks (informational, not committed by this ADR)
@@ -517,7 +533,7 @@ Suggested filing order if the Captain elects to land the ADR:
    `RestorationOutput` boundary, kind-shaped.
 4. **SDK learner-library re-exports** — once the per-impl learner
    shape stabilises, the SDK package
-   (`spec/2026-05-restorer-plugins.md` §3.6) re-exports the
+   (`spec/2026-05-external-restorer-impls.md` §3.6) re-exports the
    learner helpers (Pi session manager, OTel correlation,
    promotion gate). Optional; impl authors can copy the helpers
    if the SDK lags.
@@ -543,14 +559,14 @@ Suggested filing order if the Captain elects to land the ADR:
 
 ## 10. References
 
-- `spec/2026-05-restorer-plugins.md` — plug-in loader; per-impl
-  identity, manifest, lifecycle.
+- `spec/2026-05-external-restorer-impls.md` — external-impl loader;
+  per-impl identity, manifest, lifecycle.
 - `spec/2026-05-executor-trust-boundary.md` — per-impl credentials,
   filesystem, provenance, revocation, out-of-process seams.
 - `spec/2026-05-schema-versioning.md` — kind grammar,
   `supportedKinds` advertisement, consumer compatibility policy.
 - `spec/2026-05-registry-discovery.md` — Source A (in-repo) +
-  Source B (`restorers.plugins`) discovery model.
+  Source B (`restorers.externalImpls`) discovery model.
 - `spec/2026-04-21-agentic-data-substrate.md` — corpus thesis;
   Tier 1.1 canonical trajectory schema is engine-level under this
   ADR.

--- a/spec/2026-05-executor-trust-boundary.md
+++ b/spec/2026-05-executor-trust-boundary.md
@@ -1,15 +1,24 @@
 # Executor Trust Boundary — Technical Spec
 
-> Version: 1.1
-> Date: 2026-04-27
-> Author: Ale
+> Version: 1.2
+> Date: 2026-04-27 (rev 2026-04-28: vocabulary — "plug-in" → "external impl")
+> Author: Ale (rev: opus on jinn-mono-7zz)
 > Status: Proposed (not yet adopted)
-> Supersedes: v1 (2026-05-04) — adds §5.6 revocation (signer untrust,
-> manifest revoke, maintainer revocation list, trust-pin expiry, and
-> quarantine semantics for revoked impl state)
-> Informs: `jinn-mono-7zz` (first-class operator-supplied restorers / plug-in flow)
+> Supersedes: v1.1 (vocabulary-only retarget); v1 (2026-05-04) added
+> §5.6 revocation (signer untrust, manifest revoke, maintainer
+> revocation list, trust-pin expiry, and quarantine semantics for
+> revoked impl state)
+> Informs: `jinn-mono-7zz` (first-class operator-supplied restorers / external-impl flow)
 > Audit: `jinn-mono-j75` §7.2.4, §8 decision #3
-> Sibling specs: `spec/2026-05-schema-versioning.md`, `spec/2026-05-registry-discovery.md`
+> Sibling specs: `spec/2026-05-schema-versioning.md`, `spec/2026-05-registry-discovery.md`, `spec/2026-05-external-restorer-impls.md`
+
+## Vocabulary note (2026-04-28)
+
+v1.2 retargets "plug-in" → "external impl" throughout, matching the
+codebase's `RestorerImpl` / `impl` vocabulary and avoiding collision
+with the unrelated existing `jinn plugin install` verb (which
+installs the Jinn MCP server / skill into AI hosts). The
+trust-boundary contract is unchanged.
 
 ## 1. Purpose and scope
 
@@ -26,7 +35,7 @@ read off of one document:
    place (provenance), and what is the install-time vs runtime split?
 
 The boundary established here is the contract `jinn-mono-7zz`
-(operator-supplied plug-ins) builds against. It is intentionally
+(operator-supplied external impls) builds against. It is intentionally
 conservative: a Phase 1 in-process impl is treated as **untrusted code
 running with the daemon's PID**. The seams below let us tighten that
 to out-of-process (option C in the registry-discovery spec) without
@@ -48,8 +57,9 @@ re-cutting the API.
 ### 1.2 Out of scope
 
 - Choice between dynamic-import / fork-template / out-of-process / MCP
-  for the Phase 1 plug-in mechanism — that is `jinn-mono-7zz`. This
-  spec gives that decision a constraint set, not a verdict.
+  for the Phase 1 external-impl mechanism — that is
+  `spec/2026-05-external-restorer-impls.md`. This spec gives that
+  decision a constraint set, not a verdict.
 - The schema-versioning policy for `kind` strings — that is
   `spec/2026-05-schema-versioning.md`.
 - Where impls live (in-repo vs config-declared vs on-chain registry)
@@ -64,8 +74,8 @@ re-cutting the API.
   isolation in Node is best-effort, not a security boundary. Phase 1
   treats provenance + capability narrowing as defense-in-depth, with
   process isolation deferred to Phase 2.
-- Defining a full plug-in marketplace. The provenance rules below
-  cover the **single operator install path**; a multi-operator
+- Defining a full external-impl marketplace. The provenance rules
+  below cover the **single operator install path**; a multi-operator
   registry is `spec/2026-05-registry-discovery.md` Phase 2.
 
 ## 2. Threat model
@@ -358,8 +368,8 @@ question is asked at install time (when the operator opts an impl
 into their fleet) and re-checked at runtime (when the daemon starts).
 
 This section assumes the **option (b)** registry-discovery model from
-§8 decision #1: in-repo directory + config-declared plug-ins, with no
-on-chain registry in Phase 1.
+§8 decision #1: in-repo directory + config-declared external impls,
+with no on-chain registry in Phase 1.
 
 ### 5.1 Sources of impls
 
@@ -368,15 +378,15 @@ Phase 1 has two impl sources, with different provenance requirements:
 | Source | Provenance | Verification |
 |---|---|---|
 | **In-repo** (`client/src/restorer/impls/<name>/`) | The repo's commit history; review by the Jinn maintainers. | Implicit — if the binary was built from this repo, the impl is trusted to the same level as the daemon. |
-| **Config-declared plug-in** (operator names a package + CID) | Manifest signed by a key the operator has chosen to trust. | Explicit — described in §5.2–§5.4. |
+| **Config-declared external impl** (operator names a package + CID) | Manifest signed by a key the operator has chosen to trust. | Explicit — described in §5.2–§5.4. |
 
 In-repo impls are out of scope for the rest of §5 — they ship and are
 verified with the daemon binary itself.
 
-### 5.2 Plug-in manifest
+### 5.2 External-impl manifest
 
-Every config-declared impl ships a `jinn.manifest.json` at the root
-of its package:
+Every config-declared external impl ships a `jinn.manifest.json` at
+the root of its package:
 
 ```jsonc
 {
@@ -646,7 +656,7 @@ their fleet — defense against silent decay.
 ## 6. Evolution to out-of-process (option C)
 
 The audit (`jinn-mono-j75` §8 decision #1) lists three options for
-plug-in delivery: dynamic import (in-process), fork template,
+external-impl delivery: dynamic import (in-process), fork template,
 out-of-process service (option C — MCP / HTTP). This spec does not
 pick one, but it requires that **the design we ship now does not
 foreclose option C**.
@@ -713,7 +723,8 @@ This spec is accepted when:
 2. `jinn-mono-7zz` description is updated to reference this spec as
    its trust-boundary input.
 3. The (closed) `jinn-mono-y6w` close-reason notes that the
-   trust-boundary contract for first-class plug-ins is defined here.
+   trust-boundary contract for first-class external impls is defined
+   here.
 
 ### 7.2 Downstream tasks (informational, not committed by this spec)
 

--- a/spec/2026-05-executor-trust-boundary.md
+++ b/spec/2026-05-executor-trust-boundary.md
@@ -1,0 +1,743 @@
+# Executor Trust Boundary — Technical Spec
+
+> Version: 1.1
+> Date: 2026-04-27
+> Author: Ale
+> Status: Proposed (not yet adopted)
+> Supersedes: v1 (2026-05-04) — adds §5.6 revocation (signer untrust,
+> manifest revoke, maintainer revocation list, trust-pin expiry, and
+> quarantine semantics for revoked impl state)
+> Informs: `jinn-mono-7zz` (first-class operator-supplied restorers / plug-in flow)
+> Audit: `jinn-mono-j75` §7.2.4, §8 decision #3
+> Sibling specs: `spec/2026-05-schema-versioning.md`, `spec/2026-05-registry-discovery.md`
+
+## 1. Purpose and scope
+
+This spec defines the **trust boundary between the Jinn daemon and a
+restorer/evaluator implementation** (`RestorerImpl`, `client/src/restorer/types.ts`).
+
+It answers three questions a downstream implementer must be able to
+read off of one document:
+
+1. What credentials, network access, and filesystem access does the
+   daemon hand an impl?
+2. What MUST the daemon never expose to an impl?
+3. How does the daemon decide an impl is allowed to load in the first
+   place (provenance), and what is the install-time vs runtime split?
+
+The boundary established here is the contract `jinn-mono-7zz`
+(operator-supplied plug-ins) builds against. It is intentionally
+conservative: a Phase 1 in-process impl is treated as **untrusted code
+running with the daemon's PID**. The seams below let us tighten that
+to out-of-process (option C in the registry-discovery spec) without
+re-cutting the API.
+
+### 1.1 In scope
+
+- Threat model for impls (in-process Node modules) in Phase 1.
+- Credential surface: signer, RPC client, intent-specific secrets
+  injected via `onEnable`.
+- Filesystem surface: working dir, impl-state dir, what is read-only
+  and what is writable.
+- Provenance: how impls are registered, signed, and verified at
+  install time vs run time, and how trust is **withdrawn** when a
+  signer or specific manifest must be invalidated (§5.6).
+- Forward-compatibility seams for moving impls out-of-process (MCP /
+  HTTP service) without breaking the contract.
+
+### 1.2 Out of scope
+
+- Choice between dynamic-import / fork-template / out-of-process / MCP
+  for the Phase 1 plug-in mechanism — that is `jinn-mono-7zz`. This
+  spec gives that decision a constraint set, not a verdict.
+- The schema-versioning policy for `kind` strings — that is
+  `spec/2026-05-schema-versioning.md`.
+- Where impls live (in-repo vs config-declared vs on-chain registry)
+  — that is `spec/2026-05-registry-discovery.md`.
+- Master-wallet hygiene at the daemon level (keystore encryption,
+  password handling, Safe deployment). This spec only covers what
+  crosses the daemon → impl boundary.
+
+### 1.3 Non-goals
+
+- Sandboxing Node.js against a determined attacker. In-process
+  isolation in Node is best-effort, not a security boundary. Phase 1
+  treats provenance + capability narrowing as defense-in-depth, with
+  process isolation deferred to Phase 2.
+- Defining a full plug-in marketplace. The provenance rules below
+  cover the **single operator install path**; a multi-operator
+  registry is `spec/2026-05-registry-discovery.md` Phase 2.
+
+## 2. Threat model
+
+Three failure modes drive the design. The numbering is referenced by
+later sections.
+
+### 2.1 T1 — Malicious impl
+
+An impl is authored or substituted with intent to harm. Possible
+goals: drain the master wallet, exfiltrate the keystore, exfiltrate
+other impls' API keys (e.g. Hyperliquid api-wallet keys at
+`implStateDir/<other-impl>/`), pivot to the operator's machine.
+
+**Likely vector:** an operator npm-installs a malicious package, or a
+benign package's dependency is compromised (T3 below). Less likely:
+in-repo impl reviewed by the team is malicious — code review is the
+mitigation there, not the daemon.
+
+### 2.2 T2 — Buggy impl
+
+An impl is honest but defective. It may:
+
+- Sign a transaction it shouldn't (wrong amount, wrong recipient,
+  wrong contract).
+- Burn through RPC budget in a tight loop.
+- Write outside its state dir (path traversal in a CID-derived
+  filename).
+- Leak secrets via `log()` (which the daemon persists and later may
+  publish to subgraph / IPFS).
+
+**Likely vector:** every impl at some point. Treat as the common
+case, not the exception. T2 mitigations should not depend on the impl
+being well-written.
+
+### 2.3 T3 — Dependency compromise
+
+A transitive dependency of an impl ships a malicious update (the
+`event-stream` / `node-ipc` / `xz` pattern). The impl itself is
+unchanged; the supply chain underneath it is poisoned.
+
+**Likely vector:** any npm-installed impl with a non-trivial dep
+graph. T3 is the reason provenance (§5) pins to a content hash, not a
+version range, and the reason the runtime surface (§3, §4) is narrow
+even for "trusted" impls.
+
+### 2.4 What this spec does *not* defend against
+
+- Operator-side compromise. If the operator's machine is owned, the
+  master keystore is owned; the daemon has no countermeasure and
+  shouldn't pretend otherwise.
+- A determined T1 in-process impl in Phase 1. Node has no real
+  capability isolation; a malicious in-process module can monkey-patch
+  `fs`, walk the V8 heap, or shell out. Phase 1 makes this **harder
+  and noisier**, not impossible. The §6 seams exist so Phase 2 can
+  make it actually impossible.
+
+## 3. Credential scoping
+
+The daemon owns one master signer per service (the EOA from
+`client/src/earning/`) and a Safe multisig that owns the staked
+service. The boundary rule:
+
+> An impl never sees a raw private key. An impl signs by calling
+> handles the daemon issues; the daemon decides whether each call is
+> permitted.
+
+### 3.1 What the daemon hands an impl
+
+The structured form is `RestorationContext` today
+(`client/src/restorer/types.ts`). This spec adds three capability
+handles to it. Each is a function-shaped object, not a config blob —
+so the daemon can revoke, rate-limit, or proxy without changing the
+signature.
+
+| Handle | Purpose | Phase 1 implementation |
+|---|---|---|
+| `intent` | The `DesiredState` and its IPFS CID. | Frozen object; `Object.freeze` at handoff. |
+| `workingDir`, `implStateDir` | Filesystem capability (§4). | Node `fs` paths, scoped at call sites. |
+| `log(event)` | Structured logging into the daemon event stream. | Existing function. |
+| `abort`, `msUntilEndTs()` | Window deadline. | Existing. |
+| **`signer`** (new) | Scoped signer capability (§3.2). | Wrapper around the master signer with a selector allow-list. |
+| **`rpc`** (new) | Scoped read-only RPC client (§3.3). | Wrapper around the public client with method + rate limits. |
+| **`secrets`** (new) | Per-impl secret bag, populated by the impl's own `onEnable` flow (§3.4). | Read-only `Record<string, string>`, scoped to the calling impl. |
+
+The rule, restated as a hard invariant:
+
+- An impl **must not** receive: `process.env`, the parsed `Config`
+  object, the keystore path or password, a raw `viem` `WalletClient`
+  bound to the master EOA, any other impl's `secrets` or
+  `implStateDir`.
+- An impl **may** receive: the three handles above plus the existing
+  `RestorationContext` fields. The daemon constructs these per-call
+  and discards them when the call returns.
+
+### 3.2 Scoped signer
+
+`ctx.signer` exposes only the operations an impl needs to deliver a
+restoration or evaluation result. It does **not** expose generic
+`signTransaction` / `eth_sign`.
+
+Phase 1 surface:
+
+```ts
+interface ScopedSigner {
+  /** EOA address the daemon will sign as. Read-only. */
+  readonly address: `0x${string}`;
+
+  /**
+   * Sign EIP-712 typed data for an allowed domain. The daemon
+   * validates `domain` against an allow-list (e.g. exchange-specific
+   * api-wallet approval payloads). Throws if the domain is unknown.
+   */
+  signTypedData(args: SignTypedDataArgs): Promise<`0x${string}`>;
+
+  /**
+   * Send a transaction whose `to` + 4-byte selector pair is on the
+   * impl's allow-list. The daemon constructs the tx envelope, sets
+   * gas, and signs. The impl never sees the raw key.
+   */
+  sendAllowedCall(call: {
+    to: `0x${string}`;
+    data: `0x${string}`;     // selector + ABI-encoded args
+    value?: bigint;          // 0 unless allow-list permits
+  }): Promise<`0x${string}`>; // tx hash
+}
+```
+
+Each impl declares an allow-list at registration time. The daemon
+refuses to load an impl whose allow-list isn't present and refuses
+calls that don't match. The allow-list is keyed by `(chainId, to,
+selector)` so a single impl can hold capabilities on multiple chains
+(e.g. a Hyperliquid impl with a Base-Sepolia api-wallet approval and
+an Arbitrum order-router).
+
+The allow-list lives in the impl's manifest (§5.2) and is reviewed at
+install time, not negotiated at runtime. An impl cannot expand its
+own allow-list; expansion requires reinstalling at a new manifest CID.
+
+**Open question for `jinn-mono-7zz`:** whether the scoped signer is
+implemented as
+
+  (a) a JS wrapper around the master signer (Phase 1 default — easy,
+      no on-chain change), or
+  (b) a Safe module with the selector allow-list enforced on-chain
+      (more secure, more cost, requires Safe-module governance).
+
+This spec does not require (b), but **the API above is shaped so (b)
+can replace (a) without changing impl code.** The selector allow-list
+is the integration point.
+
+### 3.3 Scoped RPC
+
+`ctx.rpc` is a read-only RPC handle. The daemon owns the upstream
+RPC connection (Base mainnet / Sepolia / etc.) and proxies impl calls
+through a wrapper that:
+
+1. Filters by JSON-RPC method. Phase 1 allow-list:
+   `eth_call`, `eth_getBlockByNumber`, `eth_getLogs`,
+   `eth_getTransactionReceipt`, `eth_chainId`, `eth_blockNumber`,
+   `eth_getBalance`, `eth_getCode`. No `eth_sendRawTransaction`,
+   `eth_sign*`, `personal_*`, `debug_*`, or provider-specific custom
+   methods. Signing goes through `ctx.signer` (§3.2).
+2. Rate-limits per impl (default: 30 requests / 10s, configurable per
+   impl in the manifest within a hard ceiling enforced by the daemon).
+3. Filters by chain. An impl declares which chains it speaks to in
+   its manifest; the daemon refuses requests for other chains.
+4. Strips multiplexed credentials. The upstream URL (which may carry
+   an Alchemy / QuickNode key in the path) is **never** observable by
+   the impl — only the parsed RPC interface is exposed.
+
+The impl-facing shape is a `viem` `PublicClient` interface (so existing
+code in `client/src/restorer/impls/` keeps working), but constructed
+by the daemon with a transport that enforces 1–4.
+
+### 3.4 Per-impl secrets
+
+Some impls need credentials the daemon doesn't own — Hyperliquid
+api-wallet private keys, an exchange API key/secret pair, an LLM
+provider token. Today these are collected by the impl's `onEnable`
+flow and persisted under `implStateDir/<impl>/`.
+
+The trust-boundary rule:
+
+- Each impl owns its own secret bag at `implStateDir/<impl>/secrets/`.
+- The daemon mediates **read** access via `ctx.secrets`, scoped to
+  the calling impl. An impl never reads another impl's secrets, even
+  though they live on the same disk.
+- Write access is via the existing `onEnable` / `onDisable` flow.
+  Writes go through the daemon, which guarantees the path is inside
+  the calling impl's `implStateDir`.
+
+Impls SHOULD NOT log secrets via `ctx.log` (which is persisted and
+may be published). The daemon's logging wrapper performs a best-effort
+redaction pass on values that match the secret bag, but this is a
+backstop, not a guarantee — see T2 above.
+
+### 3.5 What stays daemon-internal
+
+The daemon does not, under any circumstance, hand an impl:
+
+- The encrypted keystore file path or its decryption password
+  (`JINN_PASSWORD`).
+- A constructed `WalletClient` bound to the master EOA (only the
+  scoped wrappers from §3.2).
+- The full `Config` object. Specific resolved values (e.g.
+  `chainId`, `subgraphUrl`) MAY appear in `ctx`; secrets and paths
+  outside the impl's scope MUST NOT.
+- Other impls' `implStateDir`, `secrets`, or in-flight context.
+- Network handles that bypass §3.3 (e.g. raw `fetch` with the upstream
+  RPC URL, IPFS gateway tokens, evaluator-only RPC creds).
+
+This is a *daemon* invariant: the daemon enforces it at the call
+site that constructs `RestorationContext`. An impl that captures
+references via dynamic `require` / global walks defeats the
+in-process boundary; that is T1 territory and is mitigated by §5
+(provenance) and §6 (out-of-process evolution), not by this list.
+
+## 4. Filesystem scoping
+
+Two roots, set in config:
+
+| Config key | Default | Purpose |
+|---|---|---|
+| `engine.workingDirRoot` | `~/.jinn-client/engine/work` | Per-attempt scratch space. Cleared between attempts. |
+| `engine.implStateDirRoot` | `~/.jinn-client/engine/impl-state` | Durable per-impl state. Persisted across attempts. |
+
+### 4.1 Per-attempt working dir
+
+For each attempt, the engine creates `workingDirRoot/<intent-cid>/`
+(or a deterministic hash of `(intentId, attemptNonce)` when no CID is
+available). This is the only path passed as `ctx.workingDir`.
+
+Rules:
+- The engine creates and removes the directory; the impl writes
+  freely inside it.
+- The directory is cleared before re-attempts (T2: a previous attempt
+  must not leak state into the next).
+- An impl MUST NOT persist anything it expects to survive across
+  attempts here. Cross-attempt state belongs in `implStateDir`.
+
+### 4.2 Durable per-impl state dir
+
+`ctx.implStateDir = implStateDirRoot/<impl-name>/`, where `<impl-name>`
+is the manifest-declared name (§5.2). The daemon creates the dir on
+first use and chmods it 0700.
+
+Rules:
+- An impl reads/writes freely inside its own `implStateDir`.
+- The daemon does not look inside this dir except via documented
+  per-impl conventions (e.g. `secrets/`, the doctor checks in
+  `client/src/api/portfolio-v0-doctor.ts`).
+- Two impls never share an `implStateDir`. If two impls want to share
+  state, they coordinate via the daemon (intent registry, shared
+  output artifacts), not via the filesystem.
+
+### 4.3 Phase 1 enforcement: capability wrapper
+
+In-process Node has no real filesystem isolation; a determined T1
+impl can `import('node:fs')` directly. Phase 1 mitigation is a
+capability wrapper, not a sandbox:
+
+- The daemon passes `workingDir` and `implStateDir` as plain absolute
+  paths (existing behaviour).
+- A `ctx.fs` helper (new, optional) wraps `fs/promises` such that any
+  path argument is normalised and rejected if it escapes the impl's
+  two roots. Buggy impls (T2) get a clear error; honest impls get
+  a path-traversal-safe API for free.
+- Impls that use raw `node:fs` are not blocked but are **out of policy**
+  — the audit log records each impl's filesystem use; reviewers can
+  flag impls that escape their roots.
+
+Both `ctx.fs` and direct `fs` co-exist. We do not break existing impls
+to introduce the wrapper.
+
+### 4.4 Forward path: process isolation
+
+The capability wrapper is **not** a security boundary against T1.
+The full mitigation is process isolation (§6), where the impl runs as
+a separate process with its only filesystem access being the two roots
+(via OS-level controls: `chroot`, macOS sandbox-exec, Linux
+namespaces, or simply running impls as a different uid). The Phase 1
+wrapper exists so impl code that targets it works unchanged when the
+impl moves out-of-process.
+
+## 5. Provenance
+
+Provenance answers: "Should the daemon load this code at all?" The
+question is asked at install time (when the operator opts an impl
+into their fleet) and re-checked at runtime (when the daemon starts).
+
+This section assumes the **option (b)** registry-discovery model from
+§8 decision #1: in-repo directory + config-declared plug-ins, with no
+on-chain registry in Phase 1.
+
+### 5.1 Sources of impls
+
+Phase 1 has two impl sources, with different provenance requirements:
+
+| Source | Provenance | Verification |
+|---|---|---|
+| **In-repo** (`client/src/restorer/impls/<name>/`) | The repo's commit history; review by the Jinn maintainers. | Implicit — if the binary was built from this repo, the impl is trusted to the same level as the daemon. |
+| **Config-declared plug-in** (operator names a package + CID) | Manifest signed by a key the operator has chosen to trust. | Explicit — described in §5.2–§5.4. |
+
+In-repo impls are out of scope for the rest of §5 — they ship and are
+verified with the daemon binary itself.
+
+### 5.2 Plug-in manifest
+
+Every config-declared impl ships a `jinn.manifest.json` at the root
+of its package:
+
+```jsonc
+{
+  "schemaVersion": "1",
+  "name": "@some-operator/restorer-foo",   // unique; matches RestorerImpl.name
+  "version": "1.4.2",                       // semver; matches RestorerImpl.version
+  "supportedKinds": ["foo.v0>=1.0.0"],     // see schema-versioning spec
+  "entry": "./dist/index.js",               // module that default-exports a RestorerImpl factory
+  "package": {
+    "cid": "bafy...abc",                    // IPFS CID of the packed tarball; pinned at install
+    "size": 184321,                         // bytes; sanity check
+    "hash": "sha256:..."                    // sha256 of tarball; cross-check vs CID derivation
+  },
+  "capabilities": {
+    "chains": [11155111, 84532],
+    "signer": {
+      "calls": [
+        { "chainId": 84532, "to": "0xff...", "selector": "0xa9059cbb" }
+      ],
+      "typedDomains": [
+        { "name": "HyperliquidApproval", "version": "1" }
+      ]
+    },
+    "rpc": {
+      "methods": ["eth_call", "eth_getBlockByNumber"],
+      "rateLimit": { "requests": 30, "windowMs": 10000 }
+    }
+  },
+  "signer": {
+    "publicKey": "ed25519:...",             // who signed THIS manifest (see §5.3)
+    "signature": "..."                      // signature over the canonical manifest minus this field
+  }
+}
+```
+
+Notes:
+
+- `package.cid` pins **what** runs. `signer.publicKey` + `signer.signature`
+  pin **who said it's OK**. Both must verify.
+- `capabilities` is the source of truth for §3.2 / §3.3 allow-lists.
+  The daemon refuses any call outside this set. Operators reviewing a
+  manifest can read off "this impl is allowed to call selector X on
+  chain Y" without reading code.
+- `schemaVersion` is the manifest schema, distinct from the
+  `kind`-versioning policy in `spec/2026-05-schema-versioning.md`.
+
+### 5.3 Trusted signer set
+
+The operator's config declares a list of public keys the daemon will
+accept manifest signatures from:
+
+```jsonc
+// ~/.jinn-client/config.json
+{
+  "trustedImplSigners": [
+    { "publicKey": "ed25519:...", "label": "jinn-team" },
+    { "publicKey": "ed25519:...", "label": "self" }   // operator's own key, optional
+  ],
+  "impls": [
+    { "manifest": "ipfs://bafy...manifest" }
+  ]
+}
+```
+
+A signer key is added by an explicit operator action (`jinn impls
+trust <key> --label <name>`). The daemon never auto-trusts a key it
+sees in a manifest. The Jinn maintainer key is shipped as the only
+default trust anchor, distinct enough from the daemon code that an
+operator can replace or extend the set without recompiling.
+
+### 5.4 Install-time vs runtime checks
+
+| Check | Install (`jinn impls add ...`) | Runtime (every daemon boot) |
+|---|---|---|
+| Manifest signature verifies against `trustedImplSigners` | **YES** (refuse install) | YES (refuse load) |
+| Tarball CID resolves and matches `package.cid` | **YES** (pin tarball locally) | NO — local pinned copy is canonical |
+| Tarball sha256 matches `package.hash` | YES | YES (defends T3 / on-disk tamper) |
+| `supportedKinds` parses, satisfies any current intent | YES (warn if no overlap) | NO |
+| Allow-list constraints satisfiable on configured chains | YES | NO |
+| Impl factory loads without throwing | NO (lazy) | YES |
+| Allow-list does not exceed daemon-enforced ceiling (e.g. no `eth_sendRawTransaction`) | YES (refuse install) | YES (refuse load) |
+
+The split is:
+
+- **Install** is human-in-the-loop. The operator runs a CLI verb,
+  reviews the manifest's `capabilities`, and accepts. Network-bound
+  checks (CID resolution) happen here, once.
+- **Runtime** is automated. It re-verifies the locally pinned bits
+  (tarball hash + manifest signature) but does not re-fetch from
+  IPFS. This makes daemon boot offline-safe and removes IPFS gateway
+  availability from the daemon's critical path.
+
+If a runtime check fails, the daemon refuses to load the impl, logs
+to the event stream, and keeps running — other impls and the engine
+are unaffected. Failure is loud (`status.fleet.needsAttention` per
+the client-surface spec) but not fatal.
+
+### 5.5 What this does and does not buy us
+
+It buys us:
+- T3 mitigation: a poisoned dep-chain that re-publishes under the same
+  package name fails sig-check, because the tarball hash changed.
+- A reviewable surface: the operator looks at one manifest, not a
+  full audit of `node_modules`.
+- Forward compatibility: the `package.cid` field is the integration
+  point for a Phase 2 on-chain registry (see
+  `spec/2026-05-registry-discovery.md`).
+
+It does not buy us:
+- Protection against an authorised signer publishing a malicious
+  manifest. That's a key-management problem, not a protocol problem
+  — but the daemon MUST give operators a way to **withdraw** trust
+  from a compromised signer and invalidate the impls it signed. See
+  §5.6.
+- Protection against an in-process impl that, once loaded, escapes
+  the §3 / §4 wrappers via Node internals. See §6.
+
+### 5.6 Revocation
+
+The §5.3 trust-anchor list is necessary but not sufficient. An
+authorised signer's key can be lost, stolen, or burned by a
+maintainer who later turns hostile; a previously-installed impl can
+be retroactively recognised as malicious. The daemon MUST provide a
+way to **withdraw trust** from a signer and to **invalidate specific
+impl manifests** without requiring the operator to wipe their
+config or rebuild the binary.
+
+Revocation has three layers, in order of operator effort:
+
+#### 5.6.1 Operator-driven signer revocation (mandatory, Phase 1)
+
+Symmetric to `jinn impls trust` (§5.3), the daemon ships:
+
+- `jinn impls untrust <publicKey | label>` — remove an entry from
+  `trustedImplSigners`. Idempotent; succeeds even if the entry is
+  already gone.
+- `jinn impls revoke <manifestCid | implName>` — append the
+  identifier to a local **revocation list** at
+  `~/.jinn-client/impls/revoked.json`, regardless of which signer
+  signed the manifest. Use case: a specific bad release where the
+  signing key itself is still trusted (e.g. an honest maintainer who
+  pushed a buggy build).
+
+Both verbs take effect on the next runtime check (§5.4) and trigger
+an immediate engine reload — the daemon does NOT continue executing
+attempts under a now-untrusted impl. In-flight calls within the
+impl are aborted via `ctx.abort` and their results are discarded.
+
+The cascade rule: when `jinn impls untrust <signer>` runs, every
+installed impl whose manifest is signed by that key is treated as
+revoked. The operator does not need to enumerate impls.
+
+#### 5.6.2 Behaviour on a revoked impl
+
+Fail-closed semantics. When the daemon detects that a previously
+installed impl is no longer trusted (untrusted signer, revoked CID,
+or expired pin per §5.6.4):
+
+1. **Refuse to load.** The impl is excluded from `buildRestorerImpls`
+   for the current process. `status.fleet.needsAttention` flags the
+   impl with reason `"revoked"` (per the client-surface spec).
+2. **Quarantine `implStateDir`.** The daemon moves
+   `implStateDirRoot/<impl-name>/` to
+   `implStateDirRoot/.revoked/<impl-name>-<timestamp>/` and chmods it
+   0700. Secrets are NOT auto-shredded — the operator may need them
+   to migrate to a successor impl — but they are removed from the
+   live secrets path so no other impl can pick them up.
+3. **Clear in-memory state.** The capability wrappers (§3.2 / §3.3)
+   bound to the revoked impl are invalidated; subsequent calls
+   throw. Any pending tx the impl had requested but the daemon had
+   not yet broadcast is dropped.
+4. **Emit a structured event.** A single `impl.revoked` log line
+   with `{ implName, manifestCid, signerPublicKey, reason,
+   quarantinedTo }` is written to the daemon event stream and (if
+   configured) the operator's notification channel.
+
+`jinn impls forget <impl-name>` is the counterpart that finalises
+quarantine: it shreds the quarantined state dir after operator
+review. The daemon never auto-deletes secrets.
+
+#### 5.6.3 Maintainer-published revocation list (optional, Phase 1)
+
+The Jinn-team trust anchor MAY publish a signed revocation list at
+a well-known IPNS or CID, structured as:
+
+```jsonc
+{
+  "schemaVersion": "1",
+  "publishedAt": "2026-05-21T10:00:00Z",
+  "ttlSeconds": 604800,
+  "revokedSigners": [
+    { "publicKey": "ed25519:...", "reason": "key compromise", "since": "2026-05-20" }
+  ],
+  "revokedManifests": [
+    { "cid": "bafy...bad", "reason": "malicious payload", "since": "2026-05-20" }
+  ],
+  "signature": "..."   // signed by a maintainer key from trustedImplSigners
+}
+```
+
+When configured (`config.implRevocationList = "ipns://..."` or a
+fixed CID), the daemon refreshes the list:
+
+- At install time (`jinn impls add ...`) — refuse to install a
+  manifest whose CID or signer appears in the current list.
+- At runtime, opportunistically — if the local cached copy is older
+  than `ttlSeconds`, attempt a refresh in the background; failure
+  to refresh is logged but does not block engine boot (offline
+  safety).
+- On `jinn upgrade` — always refresh as part of the upgrade
+  sequence; refusal to upgrade if the list cannot be fetched and the
+  cached copy has expired (so a forked / stale daemon cannot indefinitely
+  ignore revocations after an upgrade attempt).
+
+The list signature MUST verify against a key currently in
+`trustedImplSigners`. A revocation list signed by a key the operator
+has already untrusted is itself ignored — preventing a
+post-compromise attacker from "un-revoking" their own keys.
+
+This layer is **optional** in Phase 1 (operators who self-curate may
+disable it). Phase 2 promotes the list to mandatory, with the
+on-chain registry from `spec/2026-05-registry-discovery.md` as the
+canonical publication channel.
+
+#### 5.6.4 Trust pinning expiry
+
+Manifest signatures pinned at install time are not eternal. Each
+trust-anchor entry carries an optional `maxPinAgeSeconds`:
+
+```jsonc
+{
+  "trustedImplSigners": [
+    {
+      "publicKey": "ed25519:...",
+      "label": "jinn-team",
+      "maxPinAgeSeconds": 7776000   // 90 days
+    }
+  ]
+}
+```
+
+The default for a freshly added signer is **90 days**; the operator
+may set `0` to disable expiry (long-lived pin) or any positive value
+to shorten it.
+
+When a pinned manifest's age (time since `jinn impls add`) exceeds
+`maxPinAgeSeconds`:
+
+- The impl is flagged `needsRevalidation` in
+  `status.fleet.needsAttention`.
+- Runtime continues to load the impl until age exceeds
+  `2 * maxPinAgeSeconds` (grace window). After the grace window the
+  impl is treated as revoked per §5.6.2.
+- `jinn impls revalidate <impl-name>` re-runs install-time checks
+  (§5.4): refetches the tarball CID, re-verifies the signature
+  against the current `trustedImplSigners`, re-checks the revocation
+  list (§5.6.3), and resets the pin clock. Revalidation requires
+  network and is the operator's opportunity to notice that a signer
+  they once trusted is no longer reachable, has rotated keys, or has
+  been quietly compromised.
+
+Expiry is the backstop for the case where a key is compromised but
+no revocation list is published (or the operator is not subscribed
+to one). It also forces operators to periodically re-engage with
+their fleet — defense against silent decay.
+
+## 6. Evolution to out-of-process (option C)
+
+The audit (`jinn-mono-j75` §8 decision #1) lists three options for
+plug-in delivery: dynamic import (in-process), fork template,
+out-of-process service (option C — MCP / HTTP). This spec does not
+pick one, but it requires that **the design we ship now does not
+foreclose option C**.
+
+### 6.1 What changes when impls run out-of-process
+
+In an out-of-process world (Phase 2-likely), the daemon launches each
+impl as a child process or connects to a long-running MCP / HTTP
+service. The trust model becomes:
+
+- Credentials cross a process boundary as RPC, not as JS object
+  references. The §3 capability handles become **wire protocols**;
+  every call is observable and can be authorised individually.
+- The OS enforces filesystem and network isolation. The Phase 1
+  capability wrapper (§4.3) is replaced by `chroot` / namespace /
+  sandbox-exec, with the wire protocol mediating all access.
+- The `ctx.signer` allow-list becomes a per-message authorisation
+  check on a request bus (the Safe-module variant from §3.2(b)
+  becomes more attractive because it shifts authorisation on-chain).
+
+### 6.2 Seams to design for now
+
+To keep option C cheap later, Phase 1 follows these constraints:
+
+1. **Capabilities are functions, not config.** `ctx.signer.sendAllowedCall`
+   is shaped as an async call returning a serialisable result. It can
+   become an RPC tomorrow; a property bag couldn't.
+2. **Inputs and outputs are JSON-serialisable.** `RestorationContext`
+   already passes `intent`, `intentCid`, paths, and primitive values.
+   `RestorationOutput` is JSON-serialisable per the portfolio v0
+   design. We MUST NOT add JS-only handles to either (Promises,
+   class instances with methods that aren't on the capability list,
+   `Buffer` without an explicit base64/hex contract).
+3. **Manifests describe capabilities declaratively.** §5.2's
+   `capabilities` object is the same shape an out-of-process daemon
+   would consult to provision a child process's environment. The
+   selector allow-list, RPC method allow-list, and rate-limit are all
+   "what would a reverse proxy need to enforce this?" — answerable
+   without reading impl code.
+4. **No global state.** An impl MUST NOT rely on module-level state
+   surviving across `run()` calls; durable state goes in
+   `implStateDir` (§4.2). Out-of-process impls may be cold-started
+   per call.
+5. **Logging is structured.** `ctx.log({ level, msg, data })` is the
+   only logging contract. `console.log` from an impl is unobserved
+   when out-of-process; structured logs survive the boundary.
+6. **No environment-variable inheritance.** An out-of-process child
+   inherits no env from the daemon by default. Phase 1 in-process
+   impls already MUST NOT read `process.env` for credentials or
+   config (§3.5); secrets come via `ctx.secrets`.
+
+If `jinn-mono-7zz` picks option (a) in-process dynamic import for
+Phase 1, these six constraints are the ones that keep the option C
+upgrade trivial. If it picks option C directly, these are already
+the right shape.
+
+## 7. Acceptance and downstream impact
+
+### 7.1 Acceptance
+
+This spec is accepted when:
+
+1. It is merged under `spec/`.
+2. `jinn-mono-7zz` description is updated to reference this spec as
+   its trust-boundary input.
+3. The (closed) `jinn-mono-y6w` close-reason notes that the
+   trust-boundary contract for first-class plug-ins is defined here.
+
+### 7.2 Downstream tasks (informational, not committed by this spec)
+
+- `jinn-mono-7zz` picks an in-process / fork / out-of-process model
+  for Phase 1 and references §6 constraints in its decision.
+- A follow-up bead implements `ctx.signer`, `ctx.rpc`, and `ctx.fs`
+  as additive fields on `RestorationContext` (existing in-repo impls
+  keep working unchanged; new fields are opt-in until a future spec
+  makes them mandatory).
+- A follow-up bead implements `jinn impls trust` / `jinn impls add`
+  CLI verbs per §5.3 / §5.4, and the revocation verbs `jinn impls
+  untrust` / `jinn impls revoke` / `jinn impls revalidate` / `jinn
+  impls forget` per §5.6, including the quarantine + state-clearing
+  cascade in §5.6.2.
+- A follow-up bead defines the maintainer revocation-list
+  publication channel (IPNS vs fixed-CID rotation) per §5.6.3, and
+  the `config.implRevocationList` wiring.
+
+### 7.3 Open questions deferred
+
+- Safe-module on-chain enforcement of the selector allow-list
+  (§3.2(b)) — design and gas-cost analysis is its own bead.
+- Cross-impl artefact sharing (e.g. evaluator reading restorer
+  output) — handled today via the engine, not via the filesystem; a
+  full read/write artefact model is out of scope here.
+- IPFS pinning durability for manifest CIDs — the registry-discovery
+  spec owns this.

--- a/spec/2026-05-external-restorer-impls.md
+++ b/spec/2026-05-external-restorer-impls.md
@@ -1,4 +1,4 @@
-# Operator-Supplied Restorer Plug-ins — Technical Spec
+# External Restorer Impls — Technical Spec
 
 > Version: 1
 > Date: 2026-04-28
@@ -11,11 +11,34 @@
 > `spec/2026-05-executor-trust-boundary.md`
 > Predecessor bead: `jinn-mono-y6w` (closed as merged into jinn-mono-7zz)
 
+## Vocabulary note
+
+The audit (`jinn-mono-j75`) and earlier draft language called this surface
+"plug-ins." This spec drops that word for two reasons:
+
+1. The codebase has been on `RestorerImpl` / `impl` since day one
+   (`client/src/restorer/types.ts`, `buildRestorerImpls`,
+   `client/src/restorer/impls/`, the `jinn impls *` CLI verbs proposed
+   in `spec/2026-05-executor-trust-boundary.md` §7.2 / §5.6). "Impl" is
+   the established term; "plug-in" was the audit's gloss, not the
+   codebase's.
+2. `jinn plugin install` already exists in the CLI
+   (`client/src/cli/commands/plugin-install.ts`) for a different surface
+   — it installs the Jinn MCP server / skill into AI hosts (Claude
+   Code, Codex, Cursor). Reusing "plug-in" for operator-supplied
+   restorer impls would collide with an unrelated existing verb.
+
+This spec therefore uses **"external restorer impl"** (or, where
+context disambiguates, just "external impl") for what the audit called
+a "plug-in," and **`restorers.externalImpls`** as the config field
+formerly drafted as `restorers.plugins`. Sibling specs on the same
+branch (`spec/extension-model`) carry the rename in the same merge.
+
 ## 1. Purpose and scope
 
 This spec records the **Phase 1 loader and execution model** for an
 operator-supplied `RestorerImpl` (or `EvaluatorImpl`) — i.e. the
-mechanism the daemon uses to take a config-declared plug-in entry
+mechanism the daemon uses to take a config-declared external impl entry
 from `spec/2026-05-registry-discovery.md` §4.2 and end up with a live
 `RestorerImpl` instance in the same registry the in-repo factory
 feeds.
@@ -23,18 +46,18 @@ feeds.
 The audit (`jinn-mono-j75` §7.2.1 / §8 decision #1) framed this as a
 choice between four candidates: stay-in-repo, in-process dynamic
 import, fork template, and out-of-process executor (MCP / HTTP). The
-registry-discovery spec already chose **config-declared plug-ins** as
-the *source of candidates*; this spec picks the **loader** that
-turns a candidate into a callable impl.
+registry-discovery spec already chose **config-declared external
+impls** as the *source of candidates*; this spec picks the **loader**
+that turns a candidate into a callable impl.
 
 ### 1.1 In scope
 
-- Phase 1 loader mechanism: how `restorers.plugins[<i>].entry`
+- Phase 1 loader mechanism: how `restorers.externalImpls[<i>].entry`
   becomes a constructed `RestorerImpl`.
-- The plug-in package's module contract (default export shape, factory
-  signature, lifecycle).
-- The shape of `restorers.plugins[].entry` (filesystem path; no remote
-  URL in v1).
+- The external impl package's module contract (default export shape,
+  factory signature, lifecycle).
+- The shape of `restorers.externalImpls[].entry` (filesystem path; no
+  remote URL in v1).
 - Forward-compatibility with the trust-boundary spec's §6
   out-of-process seams — the upgrade path, and what we MUST NOT do
   now to keep it cheap.
@@ -51,12 +74,12 @@ turns a candidate into a callable impl.
 - The Phase 2 out-of-process execution model itself — only its
   Phase 1 seams. A later spec covers the wire protocol, lifecycle, and
   sandbox primitive.
-- Naming. The public-facing surface this spec defines (`restorers.plugins`,
-  `RestorerImpl`, `jinn impls *`, the package contract) MAY be renamed
-  before ship per `jinn-mono-juw` / GitHub issue #43 (Restorer → Solver,
-  outcome → solution). This spec uses the current vocabulary; a single
-  rename pass will retarget the surface before any external operator
-  publishes a plug-in. See §8.1.
+- Naming. The public-facing surface this spec defines
+  (`restorers.externalImpls`, `RestorerImpl`, `jinn impls *`, the
+  package contract) MAY be renamed before ship per `jinn-mono-juw` /
+  GitHub issue #43 (Restorer → Solver, outcome → solution). This spec
+  uses the current vocabulary; a single rename pass will retarget the
+  surface before any external operator publishes an impl. See §8.1.
 
 ### 1.3 Non-goals
 
@@ -66,18 +89,18 @@ turns a candidate into a callable impl.
   (trust-boundary §3 / §5) are the Phase 1 mitigation. This spec
   preserves the seams that let process isolation slot in later, and
   nothing more.
-- This spec is not a plug-in marketplace, runtime hot-reload, or
-  cross-fleet plug-in browser. Operators install with their existing
-  package manager; the daemon resolves at boot.
+- This spec is not a marketplace, runtime hot-reload, or cross-fleet
+  impl browser. Operators install with their existing package
+  manager; the daemon resolves at boot.
 
 ## 2. The decision
 
-For Phase 1 the daemon loads each config-declared plug-in by **dynamic
-ESM import of a local filesystem path** (audit option B / §7.2.1.B).
-The same `RestorationContext` and `RestorerImpl` shape used by in-repo
-impls applies. Out-of-process execution (audit option C) is the
-Phase 2 evolution; this spec enumerates the §6 seams we must hold to
-in Phase 1 to keep that upgrade trivial.
+For Phase 1 the daemon loads each config-declared external impl by
+**dynamic ESM import of a local filesystem path** (audit option B /
+§7.2.1.B). The same `RestorationContext` and `RestorerImpl` shape used
+by in-repo impls applies. Out-of-process execution (audit option C) is
+the Phase 2 evolution; this spec enumerates the §6 seams we must hold
+to in Phase 1 to keep that upgrade trivial.
 
 The other three candidates are rejected for Phase 1:
 
@@ -85,7 +108,7 @@ The other three candidates are rejected for Phase 1:
 |---|---|
 | **Stay in-repo** (audit option A) | Already the in-repo factory (Source A in `spec/2026-05-registry-discovery.md` §4.1). Doesn't satisfy this bead's premise — operators with their own restorer would still need to maintain a long-lived fork of the daemon. |
 | **Fork template** | Same long-lived-fork problem under a different name. Surfaced as a candidate in this bead's description; rejected on the explicit user requirement ("without maintaining a long-lived fork of the repo"). |
-| **MCP-only** | MCP is a tool-protocol, not a general impl-RPC channel. Its message shape (tools / resources / prompts) does not cleanly carry `RestorationContext` or `RestorationOutput`, and committing to it would foreclose non-MCP out-of-process variants the trust-boundary spec wants to keep open. MCP remains the right *internal* transport for in-repo impls that talk to Claude (the existing `claude-mcp-*` family); it is not the right surface for third-party plug-ins. |
+| **MCP-only** | MCP is a tool-protocol, not a general impl-RPC channel. Its message shape (tools / resources / prompts) does not cleanly carry `RestorationContext` or `RestorationOutput`, and committing to it would foreclose non-MCP out-of-process variants the trust-boundary spec wants to keep open. MCP remains the right *internal* transport for in-repo impls that talk to Claude (the existing `claude-mcp-*` family); it is not the right surface for external impls. |
 | **Out-of-process executor (audit option C)** | The right Phase 2 endpoint. Not the right Phase 1 *first* step: shipping it now also requires the wire protocol, child-process lifecycle, serialisation contracts, and a port of the existing in-repo impls' assumptions. Phase 1 dynamic-import lets the manifest, trust flow, and capability handles ship first, then Phase 2 swaps the loader without changing impl-author code if §6 holds. |
 
 The case **for** dynamic import in Phase 1, in plain terms:
@@ -97,7 +120,7 @@ The case **for** dynamic import in Phase 1, in plain terms:
   authors.
 - The trust contract (manifest signing, capability handles, install /
   runtime checks) is already cut by the sibling specs and applies
-  identically to dynamic-import plug-ins.
+  identically to dynamic-import external impls.
 - The §6 seams cost nothing extra to enforce now, and they make the
   Phase 2 lift "swap the loader" rather than "redesign the contract".
 
@@ -110,11 +133,11 @@ real isolation is a Phase 2 lift; this spec inherits that posture.
 
 ## 3. Loader contract
 
-### 3.1 Plug-in package layout
+### 3.1 External impl package layout
 
-A plug-in package is an npm-style package the operator installs into
-their `node_modules` (typically with `yarn add` or as a tarball pinned
-by `package.cid`). At its root:
+An external impl is shipped as an npm-style package the operator
+installs into their `node_modules` (typically with `yarn add` or as a
+tarball pinned by `package.cid`). At its root:
 
 ```
 my-restorer/
@@ -130,12 +153,12 @@ my-restorer/
   **relative to the package root**; absolute paths and `..` segments
   are install-time refusals.
 - `package.json`'s `main` / `exports` are not consulted by the loader.
-  The manifest `entry` is the single source of truth (so a plug-in
+  The manifest `entry` is the single source of truth (so an impl
   cannot present one entrypoint to Node and a different one to
   reviewers).
 - `package.cid` from the trust-boundary manifest pins the tarball; the
   loader operates on the *unpacked* tarball at the location named by
-  `restorers.plugins[<i>].entry` in operator config.
+  `restorers.externalImpls[<i>].entry` in operator config.
 
 ### 3.2 Module shape
 
@@ -145,10 +168,10 @@ The loaded module MUST default-export a factory function:
 // my-restorer/dist/index.ts
 import type {
   RestorerImpl,
-  RestorerPluginEnv,    // new — see §3.3
+  ExternalRestorerEnv,    // new — see §3.3
 } from '@jinn-network/restorer-sdk';   // typed re-exports of client/src/restorer/types
 
-export default function createRestorer(env: RestorerPluginEnv): RestorerImpl {
+export default function createRestorer(env: ExternalRestorerEnv): RestorerImpl {
   return new MyRestorer(env);
 }
 ```
@@ -173,19 +196,19 @@ Constraints on the factory:
 
 The default export is a function (not a class) to keep the contract
 JSON-describable in Phase 2 — a factory call serialises to "spawn
-process, send `init` with `env`" without any class-instance
-plumbing. A class export would force the loader to discriminate
+process, send `init` with `env`" without any class-instance plumbing.
+A class export would force the loader to discriminate
 "constructor-ness" across language runtimes.
 
-### 3.3 `RestorerPluginEnv`
+### 3.3 `ExternalRestorerEnv`
 
-The env object passed to the factory is the plug-in-side analog of
+The env object passed to the factory is the external-impl analog of
 `RestorerEnv` (`client/src/restorer/impls/index.ts`), narrowed to
-what an operator-supplied impl is allowed to receive at construction
-time. It is **not** `RestorationContext`; that is per-call.
+what an external impl is allowed to receive at construction time. It
+is **not** `RestorationContext`; that is per-call.
 
 ```ts
-export interface RestorerPluginEnv {
+export interface ExternalRestorerEnv {
   /** Manifest-declared name (matches RestorerImpl.name). */
   readonly implName: string;
   /** Manifest-declared semver. */
@@ -210,12 +233,12 @@ export interface RestorerPluginEnv {
 
 Two notes:
 
-- `RestorerPluginEnv` is **not** `RestorerEnv`. The in-repo factory
+- `ExternalRestorerEnv` is **not** `RestorerEnv`. The in-repo factory
   takes `RestorerEnv` (which contains `pk`, `safe`, `runner`, raw
-  RPC URLs); plug-ins do not get those. A plug-in that needs RPC
-  reads or signing receives them per-call via `ctx.rpc` and
-  `ctx.signer` (trust-boundary §3.2 / §3.3); a plug-in that needs an
-  external secret receives it via `ctx.secrets` after `onEnable`.
+  RPC URLs); external impls do not get those. An external impl that
+  needs RPC reads or signing receives them per-call via `ctx.rpc` and
+  `ctx.signer` (trust-boundary §3.2 / §3.3); an external impl that
+  needs a credential receives it via `ctx.secrets` after `onEnable`.
 - The shape is **JSON-serialisable**. No functions, no class
   instances, no Buffers, no Promises (constraint §6.2.2 of the
   trust-boundary spec). `log` is the one exception, and it is the
@@ -224,11 +247,11 @@ Two notes:
 
 ### 3.4 Lifecycle
 
-The daemon resolves and constructs each plug-in at boot, in the
-following order. Failure of any step excludes that plug-in only;
-other impls and the engine are unaffected (registry-discovery §4.3).
+The daemon resolves and constructs each external impl at boot, in the
+following order. Failure of any step excludes that impl only; other
+impls and the engine are unaffected (registry-discovery §4.3).
 
-1. **Read** the operator's `restorers.plugins[<i>]`.
+1. **Read** the operator's `restorers.externalImpls[<i>]`.
 2. **Resolve manifest.** Read the locally pinned `jinn.manifest.json`
    from the install directory (registry-discovery §4.3.2a).
 3. **Trust check.** Run trust-boundary §5.4 runtime checks: tarball
@@ -239,17 +262,17 @@ other impls and the engine are unaffected (registry-discovery §4.3).
    `status.fleet.needsAttention.reason in {"impl-trust", "impl-revoked",
    "impl-needs-revalidation"}`.
 4. **Dynamic import.** `await import(<absolute path to entry>)`. The
-   path is the join of `restorers.plugins[<i>].entry` and the
+   path is the join of `restorers.externalImpls[<i>].entry` and the
    manifest's `entry` field. Failure (module not found, syntax error,
    default export missing or non-function) → exclude with
    `reason: "impl-load-failed"`.
-5. **Construct.** Call the default export with `RestorerPluginEnv`.
+5. **Construct.** Call the default export with `ExternalRestorerEnv`.
    Construction throws → exclude with `reason: "impl-construction-failed"`.
 6. **Validate identity.** The returned `RestorerImpl.name` MUST equal
    `manifest.name`; `RestorerImpl.version` MUST equal `manifest.version`.
    Mismatch → exclude with `reason: "impl-identity-mismatch"` (this
-   defends against a plug-in that signed one manifest but ships code
-   claiming a different identity).
+   defends against an external impl that signed one manifest but ships
+   code claiming a different identity).
 7. **Validate `supportedKinds`.** Every kind the impl claims via
    `supports()` for the kinds in `manifest.supportedKinds` MUST match.
    We implement this as: for each entry `<kind>>=<semver>` in the
@@ -261,24 +284,24 @@ other impls and the engine are unaffected (registry-discovery §4.3).
 8. **Register.** Insert the impl into the same in-memory registry
    `buildRestorerImpls` populates. Duplicate `name` collisions across
    sources are an operator-fixable error (registry-discovery §4.3.3);
-   the in-repo impl wins by default and the plug-in is excluded with
-   `reason: "impl-name-collision"`. Operators resolve by editing
-   `restorers.disabled` or removing the plug-in.
+   the in-repo impl wins by default and the external impl is excluded
+   with `reason: "impl-name-collision"`. Operators resolve by editing
+   `restorers.disabled` or removing the external impl.
 
-The lifecycle is **once-per-process**. A plug-in does not hot-reload;
-to swap a plug-in version, the operator runs the install verb against
-a new manifest CID and restarts the daemon. Hot-reload is a Phase 2+
-concern explicitly because revocation (trust-boundary §5.6.2) MUST
-clear in-memory capability handles — which Phase 1 does by exiting
-the impl's slot in `buildRestorerImpls` and rebuilding the registry,
-which in turn requires an engine reload anyway. Reloading the whole
-daemon is the simpler invariant.
+The lifecycle is **once-per-process**. An external impl does not
+hot-reload; to swap an impl version, the operator runs the install
+verb against a new manifest CID and restarts the daemon. Hot-reload
+is a Phase 2+ concern explicitly because revocation (trust-boundary
+§5.6.2) MUST clear in-memory capability handles — which Phase 1 does
+by exiting the impl's slot in `buildRestorerImpls` and rebuilding the
+registry, which in turn requires an engine reload anyway. Reloading
+the whole daemon is the simpler invariant.
 
 ### 3.5 What `entry` is, and is not
 
-`restorers.plugins[<i>].entry` (registry-discovery §4.2) is a **local
-filesystem path** the daemon's loader resolves with dynamic `import()`
-joined to the manifest's `entry` field. It is typically a
+`restorers.externalImpls[<i>].entry` (registry-discovery §4.2) is a
+**local filesystem path** the daemon's loader resolves with dynamic
+`import()` joined to the manifest's `entry` field. It is typically a
 `node_modules` subdirectory the operator has populated with their
 package manager.
 
@@ -291,8 +314,8 @@ It is **not**:
   `package.cid` is the canonical remote pointer, resolved at install,
   not at boot.
 - An MCP server URL. See §2; MCP is the right transport for some
-  *internal* in-repo impls, not for the third-party plug-in surface
-  this spec defines.
+  *internal* in-repo impls, not for the external-impl surface this
+  spec defines.
 - A descriptor for an out-of-process child (e.g. `{ command: '...',
   args: [...] }`). Phase 2 may extend `entry` with a discriminated-union
   shape for that, but Phase 1 keeps it a string.
@@ -307,18 +330,18 @@ follow-up bead, §7) a small `@jinn-network/restorer-sdk` package that
 re-exports the public types: `RestorerImpl`, `RestorationContext`,
 `RestorationOutput`, `ReadyStatus`, `EnableResult`, `IntentEnableMetadata`,
 `SkippableError`, the `signer` / `rpc` / `secrets` / `fs` capability
-handle types from trust-boundary §3, and `RestorerPluginEnv` from §3.3
-above.
+handle types from trust-boundary §3, and `ExternalRestorerEnv` from
+§3.3 above.
 
-Plug-in authors depend on `@jinn-network/restorer-sdk`, not on
+External-impl authors depend on `@jinn-network/restorer-sdk`, not on
 `@jinn-network/client` directly. This separation is what lets the
 daemon implementation evolve (refactors, extra in-repo glue, internal
-deps) without breaking plug-in authors. The SDK package's semver
-becomes the contract surface plug-in authors track; today, the
+deps) without breaking external-impl authors. The SDK package's semver
+becomes the contract surface external-impl authors track; today, the
 boundary is implicit in `client/src/restorer/types.ts`.
 
-The SDK package is **not** required for Phase 1 to function — a
-plug-in author can copy the relevant types or import from the
+The SDK package is **not** required for Phase 1 to function — an
+external-impl author can copy the relevant types or import from the
 unstable internal path. But shipping the SDK is part of the "feels
 first-class" goal in this bead's description and belongs in the
 follow-up.
@@ -326,17 +349,17 @@ follow-up.
 ## 4. Conformance with the trust-boundary §6 seams
 
 Trust-boundary §6.2 lists six constraints the Phase 1 design must
-satisfy to keep the option-C upgrade trivial. The plug-in flow above
-satisfies them as follows.
+satisfy to keep the option-C upgrade trivial. The external-impl flow
+above satisfies them as follows.
 
 | §6.2 constraint | How this spec satisfies it |
 |---|---|
-| 1. Capabilities are functions, not config. | `RestorationContext.signer.signTypedData / sendAllowedCall`, `ctx.rpc` (a `viem` `PublicClient` interface), and `ctx.log` are async functions in Phase 1; they become RPCs in Phase 2 with the same signatures. The plug-in factory takes `RestorerPluginEnv` (config) and returns an impl that uses capability handles only at call time — never captures a raw signer. |
-| 2. Inputs and outputs are JSON-serialisable. | `RestorerPluginEnv` (§3.3) is JSON-serialisable. `RestorationContext` already is (per portfolio v0 design). `RestorationOutput` already is. The plug-in flow adds nothing JS-only. |
-| 3. Manifests describe capabilities declaratively. | The plug-in uses `jinn.manifest.json` `capabilities` (trust-boundary §5.2) verbatim. The loader does not synthesise capabilities at runtime; the manifest is the only source. |
+| 1. Capabilities are functions, not config. | `RestorationContext.signer.signTypedData / sendAllowedCall`, `ctx.rpc` (a `viem` `PublicClient` interface), and `ctx.log` are async functions in Phase 1; they become RPCs in Phase 2 with the same signatures. The external-impl factory takes `ExternalRestorerEnv` (config) and returns an impl that uses capability handles only at call time — never captures a raw signer. |
+| 2. Inputs and outputs are JSON-serialisable. | `ExternalRestorerEnv` (§3.3) is JSON-serialisable. `RestorationContext` already is (per portfolio v0 design). `RestorationOutput` already is. The external-impl flow adds nothing JS-only. |
+| 3. Manifests describe capabilities declaratively. | The external impl uses `jinn.manifest.json` `capabilities` (trust-boundary §5.2) verbatim. The loader does not synthesise capabilities at runtime; the manifest is the only source. |
 | 4. No global state. | Factory contract §3.2 forbids module-level state across `run` calls. Per-attempt state goes in `ctx.workingDir` (cleared between attempts); durable state goes in `ctx.implStateDir`. |
-| 5. Logging is structured. | `ctx.log({ level, msg, data })` is the only logging contract surfaced to plug-ins. The SDK package (§3.6) does NOT re-export `console`. Plug-in authors who reach for `console.log` are out of policy; their output is unobserved when out-of-process. |
-| 6. No environment-variable inheritance. | `RestorerPluginEnv` (§3.3) deliberately omits `process.env`. Plug-ins MUST NOT call `process.env` for credentials or config; secrets come via `ctx.secrets` after `onEnable`. The daemon does not propagate environment to in-process impls (other than what Node itself inherits, which is invisible to a well-behaved plug-in). Out-of-process Phase 2 will spawn children with `env: {}`. |
+| 5. Logging is structured. | `ctx.log({ level, msg, data })` is the only logging contract surfaced to external impls. The SDK package (§3.6) does NOT re-export `console`. External-impl authors who reach for `console.log` are out of policy; their output is unobserved when out-of-process. |
+| 6. No environment-variable inheritance. | `ExternalRestorerEnv` (§3.3) deliberately omits `process.env`. External impls MUST NOT call `process.env` for credentials or config; secrets come via `ctx.secrets` after `onEnable`. The daemon does not propagate environment to in-process impls (other than what Node itself inherits, which is invisible to a well-behaved impl). Out-of-process Phase 2 will spawn children with `env: {}`. |
 
 The Phase 2 swap, restated: replace step §3.4(4) (`await import(...)`)
 with `spawn(<entry>)` + a wire protocol; replace step §3.4(5)
@@ -349,8 +372,8 @@ registry insertion — is unchanged.
 An operator wants to run a third-party Aave-rebalance restorer
 (`@some-operator/aave-restorer`) for kind `lending-health.v0`.
 
-1. **Author publishes.** The author packages their plug-in, computes
-   the tarball CID, writes `jinn.manifest.json` with
+1. **Author publishes.** The author packages their external impl,
+   computes the tarball CID, writes `jinn.manifest.json` with
    `name: "@some-operator/aave-restorer"`, `version: "1.0.0"`,
    `supportedKinds: ["lending-health.v0>=1.0.0"]`,
    `entry: "./dist/index.js"`, the tarball pin, and the capability
@@ -372,7 +395,7 @@ An operator wants to run a third-party Aave-rebalance restorer
    `jinn impls add` (a follow-up bead, §7) runs the install-time checks
    (trust-boundary §5.4): resolves the CID, pins the tarball, verifies
    the signature, checks the capability allow-list against the daemon
-   ceiling. On success it appends to `restorers.plugins`:
+   ceiling. On success it appends to `restorers.externalImpls`:
    ```jsonc
    {
      "name": "@some-operator/aave-restorer",
@@ -383,7 +406,7 @@ An operator wants to run a third-party Aave-rebalance restorer
 
 4. **Daemon boot.** §3.4 runs: trust check passes, dynamic import
    resolves `./node_modules/@some-operator/aave-restorer/dist/index.js`,
-   the default export is called with `RestorerPluginEnv`, the returned
+   the default export is called with `ExternalRestorerEnv`, the returned
    impl identifies as `@some-operator/aave-restorer@1.0.0` matching
    the manifest, and the impl is registered alongside the in-repo
    impls.
@@ -392,7 +415,8 @@ An operator wants to run a third-party Aave-rebalance restorer
    the engine matches via `impl.supports({ kind: 'lending-health.v0',
    type: 'restoration' })`, constructs a `RestorationContext` with
    per-call `signer` / `rpc` / `secrets` / `fs` handles, and calls
-   `impl.run(ctx)`. The plug-in does its work using only those handles.
+   `impl.run(ctx)`. The external impl does its work using only those
+   handles.
 
 6. **Operator revokes (optional path).** Two months later the operator
    reads of a bug in `@some-operator/aave-restorer@1.0.0`:
@@ -411,13 +435,13 @@ An operator wants to run a third-party Aave-rebalance restorer
 
 - The Phase 2 out-of-process wire protocol. This spec promises the
   upgrade is cheap if §4 holds; it does not prescribe the protocol.
-- Hot-reload of plug-ins inside a running daemon. Out of scope; §3.4
-  commits to once-per-process construction.
+- Hot-reload of external impls inside a running daemon. Out of scope;
+  §3.4 commits to once-per-process construction.
 - Multi-version coexistence (e.g. running `@x/foo@1` and `@x/foo@2`
   side by side). The §3.4 duplicate-name rule rejects this. If a real
   use case appears, a follow-up spec can add a `--alias` flag to the
   install verb.
-- Plug-in inter-dependencies (impl A wanting to consume impl B's
+- External-impl inter-dependencies (impl A wanting to consume impl B's
   output beyond the existing engine artifact channel). Trust-boundary
   §7.3 already calls this out as a future bead; the loader does not
   introduce a dependency graph.
@@ -454,21 +478,21 @@ hand-off list.
    `ctx.signer`, `ctx.rpc`, `ctx.secrets`, optional `ctx.fs` per
    trust-boundary §3.1. Additive — existing in-repo impls keep
    working unchanged. This is a pre-req for the loader, because the
-   plug-in flow above assumes the new fields exist.
+   external-impl flow above assumes the new fields exist.
 2. **Manifest verifier.** Implement install-time and runtime checks
    per trust-boundary §5.4: tarball CID resolution, sha256 match,
    signature verification, allow-list ceiling, revocation.
-3. **Loader.** Implement §3.4 above: read `restorers.plugins`,
+3. **Loader.** Implement §3.4 above: read `restorers.externalImpls`,
    dynamic-import, validate identity, register. Includes the
    `status.fleet.needsAttention` reason codes named in §3.4.
 4. **CLI verbs.** `jinn impls trust|untrust|add|remove|list|show`
    for the install / introspection surface; `jinn impls
    revoke|revalidate|forget` for the revocation surface
    (trust-boundary §5.6); `jinn impls update <name>` per
-   registry-discovery §6.3 for plug-in updates.
+   registry-discovery §6.3 for external-impl updates.
 5. **In-repo disable list.** `restorers.disabled: [...]` per
    registry-discovery §4.1. Small and self-contained; can land
-   independently of the plug-in flow.
+   independently of the external-impl flow.
 6. **Maintainer revocation list wiring.** `config.implRevocationList`
    per trust-boundary §5.6.3, including IPNS / fixed-CID rotation
    policy.
@@ -477,15 +501,15 @@ hand-off list.
    `RestorerImpl` template / scaffold the way `client/src/restorer/impls/prediction-v0-baseline/`
    is the in-repo template.
 8. **Extension guide.** Promote audit §5.3 ("Add a third-party
-   impl") into `docs/runbooks/publish-a-restorer.md` once the loader
-   ships, with the worked example from §5 as the spine.
+   impl") into `docs/runbooks/publish-an-external-restorer.md` once
+   the loader ships, with the worked example from §5 as the spine.
 9. **Naming pass before public ship.** Per `jinn-mono-juw` /
    GitHub issue #43 — once the Restorer → Solver decision lands,
-   apply it across `RestorerImpl`, `restorers.plugins`,
-   `restorers.disabled`, `jinn impls *`, `RestorerPluginEnv`,
-   the SDK package name, and this spec's filename. The plug-in
+   apply it across `RestorerImpl`, `restorers.externalImpls`,
+   `restorers.disabled`, `jinn impls *`, `ExternalRestorerEnv`,
+   the SDK package name, and this spec's filename. The external-impl
    surface MUST land under final names; renaming after operators
-   publish plug-ins is a much larger churn event.
+   publish external impls is a much larger churn event.
 10. **Phase 2 out-of-process spec.** A follow-on spec when the
     operator demand or threat model warrants — wire protocol, child
     lifecycle, sandbox primitive (uid / sandbox-exec / namespaces).
@@ -494,24 +518,24 @@ hand-off list.
 
 ### 7.3 Open questions deferred
 
-- Whether `RestorerPluginEnv` should carry `network` as an enum
+- Whether `ExternalRestorerEnv` should carry `network` as an enum
   (`'base-mainnet' | 'base-sepolia' | ...`) or a structured
   `{ chainId, name }`. Today it's a string; a tightening pass
   follows the §7.2.1 work landing.
-- Whether to expose a `ctx.intentRegistry` read-only handle so a
-  plug-in can introspect sibling intents (e.g. an evaluator reading
-  a restorer's prior submission). Trust-boundary §7.3 already
-  flags this; the loader does not enable it today.
-- Plug-in `peerDependencies` policy: should the SDK enforce a
+- Whether to expose a `ctx.intentRegistry` read-only handle so an
+  external impl can introspect sibling intents (e.g. an evaluator
+  reading a restorer's prior submission). Trust-boundary §7.3
+  already flags this; the loader does not enable it today.
+- External-impl `peerDependencies` policy: should the SDK enforce a
   semver range against `@jinn-network/restorer-sdk` and refuse to
-  load plug-ins built against an incompatible SDK major? Today the
+  load impls built against an incompatible SDK major? Today the
   manifest has no SDK-version field; adding one is a §3 addendum
   when the SDK ships.
-- Whether to support a `restorers.plugins[].config` field for
-  per-plug-in operator config that is *not* a secret (e.g. an
-  exchange API base URL, a feature flag the plug-in author exposes).
+- Whether to support a `restorers.externalImpls[].config` field for
+  per-impl operator config that is *not* a secret (e.g. an exchange
+  API base URL, a feature flag the impl author exposes).
   Registry-discovery §6.3 already flags this; this spec leaves it
-  out of `RestorerPluginEnv` for v1.
+  out of `ExternalRestorerEnv` for v1.
 
 ## 8. Risks and reservations
 
@@ -519,45 +543,45 @@ hand-off list.
 
 `jinn-mono-juw` was closed pending GitHub issue #43; the Restorer →
 Solver and outcome → solution renames may land before this spec's
-implementation reaches operators. The risk is that we ship plug-in
-infrastructure under one vocabulary and then have to rename the
+implementation reaches operators. The risk is that we ship external-
+impl infrastructure under one vocabulary and then have to rename the
 public surface (config keys, CLI verbs, SDK package name) on top of
-operators who have already published plug-ins.
+operators who have already published external impls.
 
 Mitigation: §7.2 step 9 names a single rename pass before any
-operator publishes a plug-in. The implementation order ensures
-naming lands BEFORE the SDK package is published to npm and BEFORE
-the worked-example runbook ships. In-repo plug-in surface (this
-spec, `client/src/restorer/`) may rename internally without external
-churn.
+operator publishes an external impl. The implementation order
+ensures naming lands BEFORE the SDK package is published to npm and
+BEFORE the worked-example runbook ships. In-repo surface (this spec,
+`client/src/restorer/`) may rename internally without external churn.
 
 ### 8.2 The "in-process is not a security boundary" reservation
 
 Trust-boundary §2.4 and §6.1 are explicit: in-process Node has no
 real isolation. This spec inherits that posture and does not pretend
 otherwise. The mitigation is the §5.6 revocation flow: a malicious
-plug-in is removed by an operator-driven `jinn impls untrust` /
+external impl is removed by an operator-driven `jinn impls untrust` /
 `revoke`, plus the maintainer-published revocation list as a
 defense-in-depth layer.
 
 The fail-loud behaviour (§5.6.2 quarantine + state clearing,
 `status.fleet.needsAttention`) is the user-visible counterpart.
-Operators MUST be able to detect that a plug-in went bad and recover
-without rebuilding. The loader does not pretend to defend against a
-plug-in that runs *before* it is recognised as malicious — that is a
-Phase 2 process-isolation problem, and §4 keeps the upgrade open.
+Operators MUST be able to detect that an external impl went bad and
+recover without rebuilding. The loader does not pretend to defend
+against an external impl that runs *before* it is recognised as
+malicious — that is a Phase 2 process-isolation problem, and §4
+keeps the upgrade open.
 
 ### 8.3 Dependency-graph surface
 
-A plug-in's transitive npm dependencies are part of its trust surface
-(trust-boundary §2.3). The manifest pins the tarball, but the
-tarball typically excludes `node_modules` — the operator's package
-manager resolves dependencies at install. This means a poisoned
-transitive dep (the `event-stream` / `node-ipc` / `xz` pattern) is
-*not* caught by `package.hash`, because `package.hash` covers the
-plug-in's own source, not the resolved dep tree.
+An external impl's transitive npm dependencies are part of its trust
+surface (trust-boundary §2.3). The manifest pins the tarball, but
+the tarball typically excludes `node_modules` — the operator's
+package manager resolves dependencies at install. This means a
+poisoned transitive dep (the `event-stream` / `node-ipc` / `xz`
+pattern) is *not* caught by `package.hash`, because `package.hash`
+covers the impl's own source, not the resolved dep tree.
 
-Phase 1 mitigation: capability narrowing (the plug-in cannot reach
+Phase 1 mitigation: capability narrowing (the impl cannot reach
 `process.env`, the keystore, sibling impls' state, etc., even
 through a poisoned dep, *if* it goes through the boundary). Phase 2
 mitigation: process isolation, so a poisoned dep cannot escape the
@@ -573,19 +597,21 @@ or successor) rather than this spec.
 
 - `docs/reviews/2026-04-22-architecture-audit-j75.md` — audit; this
   spec records the loader half of §8 decision #1 (audit option B,
-  with §6 seams toward option C).
+  with §6 seams toward option C). The audit's "plug-in" vocabulary
+  is dropped here for the reasons in the vocabulary note above.
 - `spec/2026-05-schema-versioning.md` — kind grammar, manifest
-  semver, `supportedKinds` advertisement. The plug-in's manifest
-  `supportedKinds` array follows this grammar.
+  semver, `supportedKinds` advertisement. The external impl's
+  manifest `supportedKinds` array follows this grammar.
 - `spec/2026-05-registry-discovery.md` — the source-of-candidates
-  contract this spec consumes (§4.2's `restorers.plugins` shape).
+  contract this spec consumes (§4.2's `restorers.externalImpls`
+  shape).
 - `spec/2026-05-executor-trust-boundary.md` — the trust contract
-  the plug-in flow builds against. §5.4 install/runtime split,
+  the external-impl flow builds against. §5.4 install/runtime split,
   §5.6 revocation, §6 out-of-process seams.
 - `spec/2026-04-14-client-surface.md` — `status.fleet.needsAttention`
   shape that the loader reports into.
 - `client/src/restorer/types.ts` — current `RestorerImpl` shape; the
-  plug-in module contract (§3.2) is this interface.
+  external-impl module contract (§3.2) is this interface.
 - `client/src/restorer/impls/index.ts` — `buildRestorerImpls`; the
   in-repo Source A whose registry the loader inserts into.
 - `jinn-mono-juw` — naming alignment decision (now in GitHub issue

--- a/spec/2026-05-registry-discovery.md
+++ b/spec/2026-05-registry-discovery.md
@@ -1,0 +1,370 @@
+# Plug-in Registry & Discovery — Technical Spec
+
+> Version: 1
+> Date: 2026-04-27
+> Author: Ale
+> Status: Proposed (not yet adopted)
+> Supersedes: none
+> Informs: `jinn-mono-7zz` (first-class operator-supplied restorers / plug-in flow)
+> Audit: `jinn-mono-j75` §7.2.3, §8 decision #1
+> Sibling specs: `spec/2026-05-schema-versioning.md`, `spec/2026-05-executor-trust-boundary.md`
+
+## 1. Purpose and scope
+
+This spec records the **Phase 1 decision for how a Jinn client discovers
+which `RestorerImpl` / `EvaluatorImpl` instances exist** at boot time,
+and how an operator extends the set without forking the daemon.
+
+It is a short decision record. The mechanism it commits to (in-repo
+directory + config-declared plug-ins) is shaped jointly with the two
+sibling specs:
+
+- `spec/2026-05-schema-versioning.md` — what kinds an impl claims via
+  its manifest `supportedKinds`.
+- `spec/2026-05-executor-trust-boundary.md` — what credentials and
+  filesystem an impl receives, and how its manifest is signed and
+  pinned.
+
+This spec answers the **discovery** question only: where does the list
+of impl candidates come from, and what is the rejection rule for
+sources outside that list. The trust-boundary spec owns provenance
+verification on the candidates this spec selects.
+
+### 1.1 In scope
+
+- The Phase 1 mechanism for enumerating candidate impls at daemon
+  startup.
+- The config field that declares operator-supplied plug-ins (sketch;
+  exact shape finalised by `jinn-mono-7zz`).
+- The interaction with the trust-boundary manifest from
+  `spec/2026-05-executor-trust-boundary.md` §5.2.
+- What is **explicitly excluded** for Phase 1 and what would be
+  required to reopen each excluded option.
+
+### 1.2 Out of scope
+
+- The plug-in loader's runtime mechanism (dynamic `import()` vs fork
+  vs out-of-process). That is `jinn-mono-7zz`; this spec gives it a
+  source-of-candidates contract, not an execution model.
+- Manifest signature verification, CID pinning, capability allow-lists,
+  and revocation. Those live in
+  `spec/2026-05-executor-trust-boundary.md` §5.
+- Schema versioning of intent kinds and manifests. That is
+  `spec/2026-05-schema-versioning.md`.
+- Multi-operator plug-in marketplaces, payments, or reputation. Phase
+  2+ concerns; see §5.
+
+### 1.3 Non-goals
+
+- This is not an on-chain registry spec. Phase 1 explicitly does **not**
+  publish or read impl identity from any chain. Phase 2 may; see §4.
+- This is not a package-management spec. Operators install packages
+  with their existing tooling (`yarn add`, `npm install`, container
+  base image, etc.); the daemon does not fetch or update packages.
+
+## 2. Problem
+
+A Jinn daemon at boot needs to assemble the set of `RestorerImpl` and
+`EvaluatorImpl` instances it will run. Today (per audit
+`jinn-mono-j75` §5, §7.1.1, gap #1) that set is hard-coded across two
+call sites: `client/src/main.ts` and
+`client/src/cli/intent-registry-access.ts::buildIntentsCliRegistry`.
+The 7ee close-out (audit §12) collapsed those into the single factory
+`buildRestorerImpls` (`client/src/restorer/impls/index.ts`), so today
+the answer is: "whichever impls are imported and constructed by
+`buildRestorerImpls` at compile time."
+
+That works for first-party impls reviewed in-repo. It does not work
+for:
+
+1. An operator who wants to run a third-party impl without forking the
+   daemon binary.
+2. An operator who wants to disable a first-party impl in their fleet
+   without recompiling.
+3. A maintainer who wants to publish a new impl on its own release
+   cadence (e.g. an exchange-specific restorer that tracks an
+   exchange's ABI changes faster than the daemon's release train).
+
+The audit (`jinn-mono-j75` §7.2.3, §8 decision #1) frames the question
+as four candidates, listed below. This spec picks one for Phase 1.
+
+## 3. Options considered
+
+The audit's four candidates, with the rejection or acceptance reason
+for Phase 1.
+
+### 3.1 (a) Directory scan only
+
+**Mechanism:** the daemon enumerates files under
+`client/src/restorer/impls/<name>/` (or a designated runtime path) and
+loads everything it finds.
+
+**Rejected for Phase 1.** Two problems:
+
+1. No operator-controlled disable. Anything dropped in the directory
+   runs; there is no per-fleet selection.
+2. No provenance hook. The trust-boundary spec
+   (`spec/2026-05-executor-trust-boundary.md` §5) requires a manifest
+   signed by a key in `trustedImplSigners`. A bare directory scan has
+   nothing to verify against.
+
+In-repo impls today *are* discovered by static import in
+`buildRestorerImpls`, which is functionally close to a directory scan
+but constrained at code-review time — that channel remains and is
+distinct from this option (see §4.1).
+
+### 3.2 (b) Manifest + config-declared plug-ins — **selected**
+
+**Mechanism:** two sources, unioned at boot:
+
+1. The in-repo factory `buildRestorerImpls` (existing behaviour).
+2. Config-declared plug-ins under a new `restorers.plugins` field;
+   each entry references a package + manifest the daemon loads via
+   the trust-boundary spec's install-time / runtime checks.
+
+**Selected for Phase 1.** Rationale:
+
+- Reviewable per-fleet surface. The operator's `config.json` is the
+  single source of truth for which third-party impls are active.
+- Provenance hook is direct. Each plug-in entry references a
+  `jinn.manifest.json` (`spec/2026-05-executor-trust-boundary.md`
+  §5.2), signed by a key the operator has trusted. Discovery and
+  trust use the same artifact.
+- No new infrastructure. Operators install packages with existing
+  tooling; the daemon resolves entry points at boot.
+- Forward-compatible. The `package.cid` field in the manifest is the
+  integration point for a Phase 2 on-chain or remote registry: the
+  same manifest, just delivered through a different channel.
+
+### 3.3 (c) On-chain registry
+
+**Mechanism:** a contract publishes `(name, manifestCid, signer)`
+tuples; clients read it at boot.
+
+**Deferred to Phase 2+.** Two blockers:
+
+1. No node identity primitive yet. ERC-8004 is the planned identity
+   layer (`jinn-cli-agents/docs/...`); until it lands, an on-chain
+   registry has no canonical "who is this signer" answer beyond a raw
+   pubkey, which `trustedImplSigners` already gives us off-chain.
+2. Cost and latency. Boot would gain an RPC dependency for a list
+   that, in Phase 1, has at most a handful of entries per operator.
+
+Reopening this option requires a new spec citing the ERC-8004 (or
+successor) design and a concrete fleet-size threshold above which the
+on-chain table earns its cost.
+
+### 3.4 (d) Remote registry
+
+**Mechanism:** a hosted HTTP / IPFS endpoint serves a curated index of
+manifests; clients fetch it at boot or via `jinn impls update`.
+
+**Deferred to Phase 2+.** Two reasons:
+
+1. Centralisation. A hosted index is a new trust anchor that competes
+   with `trustedImplSigners`. Operators today choose which keys to
+   trust; a remote registry would inject a maintainer-curated list
+   between operator and signer.
+2. Availability coupling. Daemon boot would depend on registry
+   availability. The trust-boundary spec deliberately keeps boot
+   offline-safe (§5.4); a remote registry undoes that guarantee
+   unless cached aggressively, at which point it is a manifest CID
+   under a different name.
+
+The maintainer-published revocation list
+(`spec/2026-05-executor-trust-boundary.md` §5.6.3) is the one
+sanctioned hosted artifact for Phase 1, and it is **subtractive only**
+(it removes trust, never grants it). A remote registry is the
+additive counterpart and is deferred.
+
+## 4. Phase 1 decision
+
+The daemon assembles its impl set at boot from two — and only two —
+sources, unioned:
+
+### 4.1 Source A: in-repo factory
+
+`buildRestorerImpls` in `client/src/restorer/impls/index.ts` continues
+to be the in-repo enumeration. Its impls are trusted to the same level
+as the daemon binary (audit §7.2.3,
+`spec/2026-05-executor-trust-boundary.md` §5.1) and do **not** carry a
+`jinn.manifest.json`. Adding, removing, or changing an in-repo impl is
+a normal code review on the daemon repo.
+
+Operators MAY disable individual in-repo impls via configuration
+(`restorers.disabled: ["legacy-claude", ...]`, exact field name
+finalised by `jinn-mono-7zz`). Disabling is purely subtractive — it
+cannot change behaviour, only suppress an impl entirely.
+
+### 4.2 Source B: config-declared plug-ins
+
+A new top-level field on the daemon config:
+
+```jsonc
+// ~/.jinn-client/config.json (sketch — exact field names finalised by jinn-mono-7zz)
+{
+  "restorers": {
+    "plugins": [
+      {
+        "name": "@some-operator/restorer-foo",   // matches jinn.manifest.json `name`
+        "package": "ipfs://bafy...manifest",      // points at the manifest, not the tarball
+        "entry": "./node_modules/@some-operator/restorer-foo"
+      }
+    ]
+  }
+}
+```
+
+The fields, in plain terms:
+
+| Field | Purpose |
+|---|---|
+| `name` | The unique impl name. MUST equal the `name` in the resolved `jinn.manifest.json`. Mismatch is an install-time refusal. |
+| `package` | A pointer to the plug-in's `jinn.manifest.json` (typically `ipfs://<cid>` or a local path during development). The manifest carries the tarball CID, signature, and capability allow-list per `spec/2026-05-executor-trust-boundary.md` §5.2. |
+| `entry` | The local filesystem path the daemon's loader resolves at boot (typically a node_modules path the operator has populated with their package manager). The chosen loader (`jinn-mono-7zz`) decides whether this is a dynamic-import path, a fork-template root, or an MCP server descriptor. |
+
+The exact key names (`plugins` vs `pluginEntries`, `package` vs
+`manifest`, etc.) are finalised by `jinn-mono-7zz` when it lands the
+implementation. This spec commits to the **shape** — name, manifest
+pointer, local entry — not the spelling.
+
+### 4.3 Discovery procedure at boot
+
+The boot sequence:
+
+1. `buildRestorerImpls` constructs the in-repo impls (§4.1). Disabled
+   names are filtered out.
+2. For each entry in `restorers.plugins`:
+   a. Resolve `package` to a local pinned `jinn.manifest.json`
+      (install-time work; the daemon does not fetch from IPFS at
+      boot — see `spec/2026-05-executor-trust-boundary.md` §5.4).
+   b. Run runtime trust checks: signature verifies against
+      `trustedImplSigners`; tarball sha256 matches `package.hash`;
+      capability allow-list is within daemon ceiling; impl is not
+      revoked (`spec/2026-05-executor-trust-boundary.md` §5.6).
+   c. Resolve `entry` to a module / process descriptor via the
+      Phase 1 loader (`jinn-mono-7zz`).
+   d. Register the constructed impl into the same `RestorerImpl`
+      registry the in-repo source feeds.
+3. Reject any duplicate `name` across both sources. Plug-in collision
+   with an in-repo name is an operator-fixable error: rename the
+   plug-in, disable the in-repo entry, or remove the plug-in.
+
+If step (2b) fails for any plug-in, that plug-in is excluded and
+`status.fleet.needsAttention` is flagged with reason `"impl-trust"`
+or `"impl-revoked"` (per the client-surface spec). The daemon does
+not abort boot — other impls remain available.
+
+### 4.4 What this rules out
+
+The decision in §4.1–§4.3 explicitly rules out, for Phase 1:
+
+- **No on-chain discovery.** The daemon does not read impl identity,
+  manifest pointers, or signer trust state from any contract. The
+  only on-chain reads at boot remain those required for staking,
+  Safe ownership, and OLAS service state (`client/src/earning/`).
+- **No remote registry HTTP fetch.** The daemon does not call out to
+  a maintainer-hosted index for impl candidates. The single permitted
+  hosted artifact is the revocation list
+  (`spec/2026-05-executor-trust-boundary.md` §5.6.3), which is
+  subtractive.
+- **No directory scan of operator-writable paths.** A future
+  `~/.jinn-client/impls/` autoload directory is **not** part of Phase
+  1. Operators add plug-ins by editing config; the daemon never picks
+  up a plug-in the operator has not explicitly listed.
+- **No bare-package plug-ins.** Every config-declared plug-in MUST
+  resolve to a `jinn.manifest.json` per the trust-boundary spec. An
+  npm package without a manifest is not a valid plug-in source.
+
+Reopening any of the above requires a new spec. The intent is that
+the next operator who proposes "let's just add a directory scan" has
+to reckon with §3.1 first.
+
+## 5. Phase 2+ outlook (informational)
+
+This section is non-binding and does not commit the protocol to any
+of the below. It exists so the §4.4 deferrals have a forward path.
+
+### 5.1 ERC-8004 node identity
+
+When ERC-8004 (or the successor identity primitive) is integrated, an
+on-chain registry becomes plausible because each signer can bind a
+pubkey to a node identity with payment / reputation context. The
+Phase 2 spec covering this would extend the `package` field with an
+on-chain pointer (e.g. a registry contract address + index) as an
+alternative to `ipfs://`.
+
+### 5.2 Maintainer-curated index
+
+A hosted additive index — symmetric to the revocation list — could
+publish "manifests the Jinn maintainers have reviewed" without
+removing the operator's `trustedImplSigners` veto. Whether this
+materialises depends on operator demand: if Phase 1 fleets routinely
+share the same five plug-ins, an index reduces config churn; if every
+fleet runs its own bespoke set, it does not.
+
+### 5.3 Cross-fleet plug-in discovery
+
+A multi-operator marketplace (browse, install, rate impls across
+fleets) is explicitly deferred. It composes on top of either §5.1 or
+§5.2 once those exist, and is not on the Phase 1 / Phase 1b roadmap.
+
+## 6. Acceptance and downstream impact
+
+### 6.1 Acceptance
+
+This spec is accepted when:
+
+1. It is merged under `spec/`.
+2. `jinn-mono-7zz` description is updated to reference this spec as
+   its discovery-source input (alongside
+   `spec/2026-05-schema-versioning.md` and
+   `spec/2026-05-executor-trust-boundary.md`).
+3. The third sibling of epic `jinn-mono-9ry` is closed by this merge.
+
+### 6.2 Downstream tasks (informational, not committed by this spec)
+
+- `jinn-mono-7zz` finalises the exact field names under `restorers`
+  (§4.2 sketch) and ships the loader implementation. It is the only
+  consumer of all three 9ry specs and is the integration point where
+  discovery, trust, and versioning meet runtime code.
+- A follow-up bead implements the in-repo disable list (§4.1) — small
+  and self-contained, but distinct from the plug-in loader work.
+- A follow-up bead defines the `jinn impls list` / `jinn impls show`
+  CLI verbs that surface the discovery state (which plug-ins
+  resolved, which were excluded by trust failure or revocation, which
+  in-repo impls are disabled). Companion to the install / trust verbs
+  in `spec/2026-05-executor-trust-boundary.md` §7.2.
+
+### 6.3 Open questions deferred
+
+- Whether the `entry` field allows a remote target (e.g. an MCP
+  server URL) directly, or only a local filesystem path resolved by
+  the operator's package manager. `jinn-mono-7zz` decides as part of
+  the loader model; the trust-boundary spec's §6 seams already
+  anticipate both.
+- Per-plug-in environment / config injection (e.g. a plug-in needs
+  an exchange API base URL). Deferred to the trust-boundary spec's
+  `ctx.secrets` flow plus a future plug-in-config field; out of scope
+  here.
+- Plug-in update semantics (how an operator moves to a newer
+  manifest CID). Conceptually a `jinn impls update <name>` verb that
+  re-runs install-time checks against a new `package` pointer; field
+  shape lives with `jinn-mono-7zz`.
+
+## 7. References
+
+- `docs/reviews/2026-04-22-architecture-audit-j75.md` — audit; this
+  spec records the policy half of §8 decision #1 and closes §7.2.3.
+- `spec/2026-05-schema-versioning.md` — sibling spec. A plug-in's
+  `jinn.manifest.json` `supportedKinds` array follows that spec's
+  grammar; this spec assumes it as the kind-routing contract.
+- `spec/2026-05-executor-trust-boundary.md` — sibling spec. §5 of
+  that spec owns manifest signing, capability allow-lists, install
+  vs runtime checks, and revocation. This spec calls into those
+  rules for every config-declared plug-in.
+- `spec/2026-04-14-client-surface.md` — `status.fleet.needsAttention`
+  and `jinn version --json` shape that the discovery surface (§4.3)
+  reports into.
+- `client/src/restorer/impls/index.ts` — the in-repo factory that is
+  Source A in §4.1.

--- a/spec/2026-05-registry-discovery.md
+++ b/spec/2026-05-registry-discovery.md
@@ -1,13 +1,26 @@
-# Plug-in Registry & Discovery — Technical Spec
+# External Impl Registry & Discovery — Technical Spec
 
-> Version: 1
-> Date: 2026-04-27
-> Author: Ale
+> Version: 1.1
+> Date: 2026-04-27 (rev 2026-04-28: vocabulary — "plug-in" → "external impl")
+> Author: Ale (rev: opus on jinn-mono-7zz)
 > Status: Proposed (not yet adopted)
 > Supersedes: none
-> Informs: `jinn-mono-7zz` (first-class operator-supplied restorers / plug-in flow)
+> Informs: `jinn-mono-7zz` (first-class operator-supplied restorers / external-impl flow)
 > Audit: `jinn-mono-j75` §7.2.3, §8 decision #1
-> Sibling specs: `spec/2026-05-schema-versioning.md`, `spec/2026-05-executor-trust-boundary.md`
+> Sibling specs: `spec/2026-05-schema-versioning.md`, `spec/2026-05-executor-trust-boundary.md`, `spec/2026-05-external-restorer-impls.md`
+
+## Vocabulary note (2026-04-28)
+
+The audit (`jinn-mono-j75`) and v1 of this spec used "plug-in" for the
+operator-supplied / config-declared variant of `RestorerImpl`. The
+codebase has been on `RestorerImpl` / `impl` throughout
+(`client/src/restorer/`, the `jinn impls *` CLI verbs); the term
+"plug-in" was the audit's gloss, not the codebase's, and it collides
+with the unrelated existing `jinn plugin install` verb (which
+installs the Jinn MCP server / skill into AI hosts). v1.1 retargets
+to **"external impl"** for prose and **`restorers.externalImpls`**
+for the config field. The decision and shape are unchanged from v1;
+only vocabulary moved.
 
 ## 1. Purpose and scope
 
@@ -16,8 +29,8 @@ which `RestorerImpl` / `EvaluatorImpl` instances exist** at boot time,
 and how an operator extends the set without forking the daemon.
 
 It is a short decision record. The mechanism it commits to (in-repo
-directory + config-declared plug-ins) is shaped jointly with the two
-sibling specs:
+directory + config-declared external impls) is shaped jointly with the
+two sibling specs:
 
 - `spec/2026-05-schema-versioning.md` — what kinds an impl claims via
   its manifest `supportedKinds`.
@@ -34,8 +47,9 @@ verification on the candidates this spec selects.
 
 - The Phase 1 mechanism for enumerating candidate impls at daemon
   startup.
-- The config field that declares operator-supplied plug-ins (sketch;
-  exact shape finalised by `jinn-mono-7zz`).
+- The config field that declares operator-supplied external impls
+  (sketch; field names finalised in
+  `spec/2026-05-external-restorer-impls.md`).
 - The interaction with the trust-boundary manifest from
   `spec/2026-05-executor-trust-boundary.md` §5.2.
 - What is **explicitly excluded** for Phase 1 and what would be
@@ -43,16 +57,17 @@ verification on the candidates this spec selects.
 
 ### 1.2 Out of scope
 
-- The plug-in loader's runtime mechanism (dynamic `import()` vs fork
-  vs out-of-process). That is `jinn-mono-7zz`; this spec gives it a
+- The external-impl loader's runtime mechanism (dynamic `import()`
+  vs fork vs out-of-process). That is
+  `spec/2026-05-external-restorer-impls.md`; this spec gives it a
   source-of-candidates contract, not an execution model.
 - Manifest signature verification, CID pinning, capability allow-lists,
   and revocation. Those live in
   `spec/2026-05-executor-trust-boundary.md` §5.
 - Schema versioning of intent kinds and manifests. That is
   `spec/2026-05-schema-versioning.md`.
-- Multi-operator plug-in marketplaces, payments, or reputation. Phase
-  2+ concerns; see §5.
+- Multi-operator external-impl marketplaces, payments, or reputation.
+  Phase 2+ concerns; see §5.
 
 ### 1.3 Non-goals
 
@@ -113,20 +128,20 @@ In-repo impls today *are* discovered by static import in
 but constrained at code-review time — that channel remains and is
 distinct from this option (see §4.1).
 
-### 3.2 (b) Manifest + config-declared plug-ins — **selected**
+### 3.2 (b) Manifest + config-declared external impls — **selected**
 
 **Mechanism:** two sources, unioned at boot:
 
 1. The in-repo factory `buildRestorerImpls` (existing behaviour).
-2. Config-declared plug-ins under a new `restorers.plugins` field;
-   each entry references a package + manifest the daemon loads via
-   the trust-boundary spec's install-time / runtime checks.
+2. Config-declared external impls under a new `restorers.externalImpls`
+   field; each entry references a package + manifest the daemon loads
+   via the trust-boundary spec's install-time / runtime checks.
 
 **Selected for Phase 1.** Rationale:
 
 - Reviewable per-fleet surface. The operator's `config.json` is the
   single source of truth for which third-party impls are active.
-- Provenance hook is direct. Each plug-in entry references a
+- Provenance hook is direct. Each external-impl entry references a
   `jinn.manifest.json` (`spec/2026-05-executor-trust-boundary.md`
   §5.2), signed by a key the operator has trusted. Discovery and
   trust use the same artifact.
@@ -192,19 +207,19 @@ as the daemon binary (audit §7.2.3,
 a normal code review on the daemon repo.
 
 Operators MAY disable individual in-repo impls via configuration
-(`restorers.disabled: ["legacy-claude", ...]`, exact field name
-finalised by `jinn-mono-7zz`). Disabling is purely subtractive — it
-cannot change behaviour, only suppress an impl entirely.
+(`restorers.disabled: ["legacy-claude", ...]`). Disabling is purely
+subtractive — it cannot change behaviour, only suppress an impl
+entirely.
 
-### 4.2 Source B: config-declared plug-ins
+### 4.2 Source B: config-declared external impls
 
 A new top-level field on the daemon config:
 
 ```jsonc
-// ~/.jinn-client/config.json (sketch — exact field names finalised by jinn-mono-7zz)
+// ~/.jinn-client/config.json
 {
   "restorers": {
-    "plugins": [
+    "externalImpls": [
       {
         "name": "@some-operator/restorer-foo",   // matches jinn.manifest.json `name`
         "package": "ipfs://bafy...manifest",      // points at the manifest, not the tarball
@@ -220,13 +235,13 @@ The fields, in plain terms:
 | Field | Purpose |
 |---|---|
 | `name` | The unique impl name. MUST equal the `name` in the resolved `jinn.manifest.json`. Mismatch is an install-time refusal. |
-| `package` | A pointer to the plug-in's `jinn.manifest.json` (typically `ipfs://<cid>` or a local path during development). The manifest carries the tarball CID, signature, and capability allow-list per `spec/2026-05-executor-trust-boundary.md` §5.2. |
-| `entry` | The local filesystem path the daemon's loader resolves at boot (typically a node_modules path the operator has populated with their package manager). The chosen loader (`jinn-mono-7zz`) decides whether this is a dynamic-import path, a fork-template root, or an MCP server descriptor. |
+| `package` | A pointer to the external impl's `jinn.manifest.json` (typically `ipfs://<cid>` or a local path during development). The manifest carries the tarball CID, signature, and capability allow-list per `spec/2026-05-executor-trust-boundary.md` §5.2. |
+| `entry` | The local filesystem path the daemon's loader resolves at boot (typically a node_modules path the operator has populated with their package manager). The Phase 1 loader (`spec/2026-05-external-restorer-impls.md` §3.4) resolves this with dynamic ESM `import()`; the field is locked to a local filesystem path for v1 (no remote URL, no MCP descriptor). |
 
-The exact key names (`plugins` vs `pluginEntries`, `package` vs
-`manifest`, etc.) are finalised by `jinn-mono-7zz` when it lands the
-implementation. This spec commits to the **shape** — name, manifest
-pointer, local entry — not the spelling.
+Field-name finalisation: `restorers.externalImpls`,
+`restorers.disabled`, and the per-entry `name` / `package` / `entry`
+shape land here. The loader spec
+(`spec/2026-05-external-restorer-impls.md`) consumes them as-is.
 
 ### 4.3 Discovery procedure at boot
 
@@ -234,7 +249,7 @@ The boot sequence:
 
 1. `buildRestorerImpls` constructs the in-repo impls (§4.1). Disabled
    names are filtered out.
-2. For each entry in `restorers.plugins`:
+2. For each entry in `restorers.externalImpls`:
    a. Resolve `package` to a local pinned `jinn.manifest.json`
       (install-time work; the daemon does not fetch from IPFS at
       boot — see `spec/2026-05-executor-trust-boundary.md` §5.4).
@@ -243,14 +258,16 @@ The boot sequence:
       capability allow-list is within daemon ceiling; impl is not
       revoked (`spec/2026-05-executor-trust-boundary.md` §5.6).
    c. Resolve `entry` to a module / process descriptor via the
-      Phase 1 loader (`jinn-mono-7zz`).
+      Phase 1 loader (`spec/2026-05-external-restorer-impls.md`
+      §3.4).
    d. Register the constructed impl into the same `RestorerImpl`
       registry the in-repo source feeds.
-3. Reject any duplicate `name` across both sources. Plug-in collision
-   with an in-repo name is an operator-fixable error: rename the
-   plug-in, disable the in-repo entry, or remove the plug-in.
+3. Reject any duplicate `name` across both sources. An external-impl
+   collision with an in-repo name is an operator-fixable error:
+   rename the external impl, disable the in-repo entry, or remove the
+   external impl.
 
-If step (2b) fails for any plug-in, that plug-in is excluded and
+If step (2b) fails for any external impl, that entry is excluded and
 `status.fleet.needsAttention` is flagged with reason `"impl-trust"`
 or `"impl-revoked"` (per the client-surface spec). The daemon does
 not abort boot — other impls remain available.
@@ -270,11 +287,12 @@ The decision in §4.1–§4.3 explicitly rules out, for Phase 1:
   subtractive.
 - **No directory scan of operator-writable paths.** A future
   `~/.jinn-client/impls/` autoload directory is **not** part of Phase
-  1. Operators add plug-ins by editing config; the daemon never picks
-  up a plug-in the operator has not explicitly listed.
-- **No bare-package plug-ins.** Every config-declared plug-in MUST
-  resolve to a `jinn.manifest.json` per the trust-boundary spec. An
-  npm package without a manifest is not a valid plug-in source.
+  1. Operators add external impls by editing config; the daemon never
+  picks up an external impl the operator has not explicitly listed.
+- **No bare-package external impls.** Every config-declared external
+  impl MUST resolve to a `jinn.manifest.json` per the trust-boundary
+  spec. An npm package without a manifest is not a valid external-impl
+  source.
 
 Reopening any of the above requires a new spec. The intent is that
 the next operator who proposes "let's just add a directory scan" has
@@ -300,10 +318,10 @@ A hosted additive index — symmetric to the revocation list — could
 publish "manifests the Jinn maintainers have reviewed" without
 removing the operator's `trustedImplSigners` veto. Whether this
 materialises depends on operator demand: if Phase 1 fleets routinely
-share the same five plug-ins, an index reduces config churn; if every
-fleet runs its own bespoke set, it does not.
+share the same five external impls, an index reduces config churn; if
+every fleet runs its own bespoke set, it does not.
 
-### 5.3 Cross-fleet plug-in discovery
+### 5.3 Cross-fleet external-impl discovery
 
 A multi-operator marketplace (browse, install, rate impls across
 fleets) is explicitly deferred. It composes on top of either §5.1 or
@@ -324,14 +342,14 @@ This spec is accepted when:
 
 ### 6.2 Downstream tasks (informational, not committed by this spec)
 
-- `jinn-mono-7zz` finalises the exact field names under `restorers`
-  (§4.2 sketch) and ships the loader implementation. It is the only
-  consumer of all three 9ry specs and is the integration point where
-  discovery, trust, and versioning meet runtime code.
+- `spec/2026-05-external-restorer-impls.md` ships the loader and
+  finalises the per-entry shape (§4.2). It is the only consumer of
+  all three 9ry specs and is the integration point where discovery,
+  trust, and versioning meet runtime code.
 - A follow-up bead implements the in-repo disable list (§4.1) — small
-  and self-contained, but distinct from the plug-in loader work.
+  and self-contained, but distinct from the external-impl loader work.
 - A follow-up bead defines the `jinn impls list` / `jinn impls show`
-  CLI verbs that surface the discovery state (which plug-ins
+  CLI verbs that surface the discovery state (which external impls
   resolved, which were excluded by trust failure or revocation, which
   in-repo impls are disabled). Companion to the install / trust verbs
   in `spec/2026-05-executor-trust-boundary.md` §7.2.
@@ -340,29 +358,33 @@ This spec is accepted when:
 
 - Whether the `entry` field allows a remote target (e.g. an MCP
   server URL) directly, or only a local filesystem path resolved by
-  the operator's package manager. `jinn-mono-7zz` decides as part of
-  the loader model; the trust-boundary spec's §6 seams already
-  anticipate both.
-- Per-plug-in environment / config injection (e.g. a plug-in needs
+  the operator's package manager. **Locked to local filesystem path
+  for v1** by `spec/2026-05-external-restorer-impls.md` §3.5; the
+  remote-target variant is deferred to Phase 2 alongside the
+  out-of-process loader (trust-boundary §6 seams keep it open).
+- Per-impl environment / config injection (e.g. an external impl needs
   an exchange API base URL). Deferred to the trust-boundary spec's
-  `ctx.secrets` flow plus a future plug-in-config field; out of scope
-  here.
-- Plug-in update semantics (how an operator moves to a newer
+  `ctx.secrets` flow plus a future external-impl-config field; out of
+  scope here.
+- External-impl update semantics (how an operator moves to a newer
   manifest CID). Conceptually a `jinn impls update <name>` verb that
   re-runs install-time checks against a new `package` pointer; field
-  shape lives with `jinn-mono-7zz`.
+  shape finalised in `spec/2026-05-external-restorer-impls.md` §7.2.
 
 ## 7. References
 
 - `docs/reviews/2026-04-22-architecture-audit-j75.md` — audit; this
   spec records the policy half of §8 decision #1 and closes §7.2.3.
-- `spec/2026-05-schema-versioning.md` — sibling spec. A plug-in's
-  `jinn.manifest.json` `supportedKinds` array follows that spec's
-  grammar; this spec assumes it as the kind-routing contract.
+- `spec/2026-05-schema-versioning.md` — sibling spec. An external
+  impl's `jinn.manifest.json` `supportedKinds` array follows that
+  spec's grammar; this spec assumes it as the kind-routing contract.
 - `spec/2026-05-executor-trust-boundary.md` — sibling spec. §5 of
   that spec owns manifest signing, capability allow-lists, install
   vs runtime checks, and revocation. This spec calls into those
-  rules for every config-declared plug-in.
+  rules for every config-declared external impl.
+- `spec/2026-05-external-restorer-impls.md` — sibling spec. Owns the
+  loader / execution model (Phase 1 dynamic ESM `import()` of a local
+  filesystem path) and the per-entry shape this spec sketches in §4.2.
 - `spec/2026-04-14-client-surface.md` — `status.fleet.needsAttention`
   and `jinn version --json` shape that the discovery surface (§4.3)
   reports into.

--- a/spec/2026-05-restorer-plugins.md
+++ b/spec/2026-05-restorer-plugins.md
@@ -1,0 +1,594 @@
+# Operator-Supplied Restorer Plug-ins — Technical Spec
+
+> Version: 1
+> Date: 2026-04-28
+> Author: Captain (opus, dispatched on jinn-mono-7zz)
+> Status: Proposed (not yet adopted)
+> Supersedes: none
+> Audit: `jinn-mono-j75` §7.2.1, §8 decision #1 (loader half)
+> Sibling specs: `spec/2026-05-schema-versioning.md`,
+> `spec/2026-05-registry-discovery.md`,
+> `spec/2026-05-executor-trust-boundary.md`
+> Predecessor bead: `jinn-mono-y6w` (closed as merged into jinn-mono-7zz)
+
+## 1. Purpose and scope
+
+This spec records the **Phase 1 loader and execution model** for an
+operator-supplied `RestorerImpl` (or `EvaluatorImpl`) — i.e. the
+mechanism the daemon uses to take a config-declared plug-in entry
+from `spec/2026-05-registry-discovery.md` §4.2 and end up with a live
+`RestorerImpl` instance in the same registry the in-repo factory
+feeds.
+
+The audit (`jinn-mono-j75` §7.2.1 / §8 decision #1) framed this as a
+choice between four candidates: stay-in-repo, in-process dynamic
+import, fork template, and out-of-process executor (MCP / HTTP). The
+registry-discovery spec already chose **config-declared plug-ins** as
+the *source of candidates*; this spec picks the **loader** that
+turns a candidate into a callable impl.
+
+### 1.1 In scope
+
+- Phase 1 loader mechanism: how `restorers.plugins[<i>].entry`
+  becomes a constructed `RestorerImpl`.
+- The plug-in package's module contract (default export shape, factory
+  signature, lifecycle).
+- The shape of `restorers.plugins[].entry` (filesystem path; no remote
+  URL in v1).
+- Forward-compatibility with the trust-boundary spec's §6
+  out-of-process seams — the upgrade path, and what we MUST NOT do
+  now to keep it cheap.
+- Hand-off into follow-up beads.
+
+### 1.2 Out of scope
+
+- The candidate-source contract (which entries the loader is fed) —
+  that is `spec/2026-05-registry-discovery.md` §4.
+- Trust verification of a manifest (CID, signature, allow-list ceiling,
+  revocation) — that is `spec/2026-05-executor-trust-boundary.md` §5.
+- The schema-versioning policy for `kind` strings and manifest
+  `schemaVersion` — that is `spec/2026-05-schema-versioning.md`.
+- The Phase 2 out-of-process execution model itself — only its
+  Phase 1 seams. A later spec covers the wire protocol, lifecycle, and
+  sandbox primitive.
+- Naming. The public-facing surface this spec defines (`restorers.plugins`,
+  `RestorerImpl`, `jinn impls *`, the package contract) MAY be renamed
+  before ship per `jinn-mono-juw` / GitHub issue #43 (Restorer → Solver,
+  outcome → solution). This spec uses the current vocabulary; a single
+  rename pass will retarget the surface before any external operator
+  publishes a plug-in. See §8.1.
+
+### 1.3 Non-goals
+
+- This spec does **not** sandbox impls. Phase 1 in-process Node has no
+  capability isolation against a determined T1 attacker
+  (trust-boundary §2.4); provenance + capability narrowing
+  (trust-boundary §3 / §5) are the Phase 1 mitigation. This spec
+  preserves the seams that let process isolation slot in later, and
+  nothing more.
+- This spec is not a plug-in marketplace, runtime hot-reload, or
+  cross-fleet plug-in browser. Operators install with their existing
+  package manager; the daemon resolves at boot.
+
+## 2. The decision
+
+For Phase 1 the daemon loads each config-declared plug-in by **dynamic
+ESM import of a local filesystem path** (audit option B / §7.2.1.B).
+The same `RestorationContext` and `RestorerImpl` shape used by in-repo
+impls applies. Out-of-process execution (audit option C) is the
+Phase 2 evolution; this spec enumerates the §6 seams we must hold to
+in Phase 1 to keep that upgrade trivial.
+
+The other three candidates are rejected for Phase 1:
+
+| Candidate | Phase 1 disposition |
+|---|---|
+| **Stay in-repo** (audit option A) | Already the in-repo factory (Source A in `spec/2026-05-registry-discovery.md` §4.1). Doesn't satisfy this bead's premise — operators with their own restorer would still need to maintain a long-lived fork of the daemon. |
+| **Fork template** | Same long-lived-fork problem under a different name. Surfaced as a candidate in this bead's description; rejected on the explicit user requirement ("without maintaining a long-lived fork of the repo"). |
+| **MCP-only** | MCP is a tool-protocol, not a general impl-RPC channel. Its message shape (tools / resources / prompts) does not cleanly carry `RestorationContext` or `RestorationOutput`, and committing to it would foreclose non-MCP out-of-process variants the trust-boundary spec wants to keep open. MCP remains the right *internal* transport for in-repo impls that talk to Claude (the existing `claude-mcp-*` family); it is not the right surface for third-party plug-ins. |
+| **Out-of-process executor (audit option C)** | The right Phase 2 endpoint. Not the right Phase 1 *first* step: shipping it now also requires the wire protocol, child-process lifecycle, serialisation contracts, and a port of the existing in-repo impls' assumptions. Phase 1 dynamic-import lets the manifest, trust flow, and capability handles ship first, then Phase 2 swaps the loader without changing impl-author code if §6 holds. |
+
+The case **for** dynamic import in Phase 1, in plain terms:
+
+- The current `RestorerImpl` interface (`client/src/restorer/types.ts`)
+  works as-is. No new ceremony for impl authors.
+- TypeScript IDE / type-checking carry through the package boundary —
+  operators publish a plain npm package and get the same DX as in-repo
+  authors.
+- The trust contract (manifest signing, capability handles, install /
+  runtime checks) is already cut by the sibling specs and applies
+  identically to dynamic-import plug-ins.
+- The §6 seams cost nothing extra to enforce now, and they make the
+  Phase 2 lift "swap the loader" rather than "redesign the contract".
+
+The case **against**, acknowledged: in-process Node grants any loaded
+module the daemon's PID. A T1 (trust-boundary §2.1) impl that escapes
+the §3 / §4 wrappers can do real harm. Phase 1 makes this **harder
+and noisier** (provenance + capability allow-lists + revocation),
+not impossible. The trust-boundary spec is explicit (§2.4, §6) that
+real isolation is a Phase 2 lift; this spec inherits that posture.
+
+## 3. Loader contract
+
+### 3.1 Plug-in package layout
+
+A plug-in package is an npm-style package the operator installs into
+their `node_modules` (typically with `yarn add` or as a tarball pinned
+by `package.cid`). At its root:
+
+```
+my-restorer/
+  package.json
+  jinn.manifest.json        # spec/2026-05-executor-trust-boundary.md §5.2
+  dist/
+    index.js                # default-exports a factory (§3.2)
+    index.d.ts              # optional TS types
+```
+
+- `jinn.manifest.json` `entry` (e.g. `./dist/index.js`) is the module
+  the loader resolves with dynamic `import()`. `entry` is a path
+  **relative to the package root**; absolute paths and `..` segments
+  are install-time refusals.
+- `package.json`'s `main` / `exports` are not consulted by the loader.
+  The manifest `entry` is the single source of truth (so a plug-in
+  cannot present one entrypoint to Node and a different one to
+  reviewers).
+- `package.cid` from the trust-boundary manifest pins the tarball; the
+  loader operates on the *unpacked* tarball at the location named by
+  `restorers.plugins[<i>].entry` in operator config.
+
+### 3.2 Module shape
+
+The loaded module MUST default-export a factory function:
+
+```ts
+// my-restorer/dist/index.ts
+import type {
+  RestorerImpl,
+  RestorerPluginEnv,    // new — see §3.3
+} from '@jinn-network/restorer-sdk';   // typed re-exports of client/src/restorer/types
+
+export default function createRestorer(env: RestorerPluginEnv): RestorerImpl {
+  return new MyRestorer(env);
+}
+```
+
+Constraints on the factory:
+
+1. **Pure construction.** The factory MAY validate `env` and throw on
+   misconfiguration. It MUST NOT perform network I/O, signer use,
+   keystore reads, filesystem writes outside `env.implStateDir`, or
+   any other side effect. Side-effecting work belongs in `onEnable` /
+   `run` / `isReady`, all of which receive scoped capability handles
+   per the trust-boundary spec.
+2. **No module-level state across `run` calls.** The returned impl
+   MAY hold state on its own instance, but per-attempt state belongs
+   in `ctx.workingDir` and durable state in `ctx.implStateDir`
+   (trust-boundary §4). This is constraint §6.2.4 of the trust-boundary
+   spec; out-of-process Phase 2 may cold-start the impl per call.
+3. **No `process.env`, no `Config` object capture, no raw signer.** The
+   factory's only inputs are `env` (described in §3.3) and the runtime
+   `RestorationContext` its returned impl receives in `run()`. See
+   trust-boundary §3.5.
+
+The default export is a function (not a class) to keep the contract
+JSON-describable in Phase 2 — a factory call serialises to "spawn
+process, send `init` with `env`" without any class-instance
+plumbing. A class export would force the loader to discriminate
+"constructor-ness" across language runtimes.
+
+### 3.3 `RestorerPluginEnv`
+
+The env object passed to the factory is the plug-in-side analog of
+`RestorerEnv` (`client/src/restorer/impls/index.ts`), narrowed to
+what an operator-supplied impl is allowed to receive at construction
+time. It is **not** `RestorationContext`; that is per-call.
+
+```ts
+export interface RestorerPluginEnv {
+  /** Manifest-declared name (matches RestorerImpl.name). */
+  readonly implName: string;
+  /** Manifest-declared semver. */
+  readonly implVersion: string;
+  /** Operator-chosen network (e.g. 'base-sepolia', 'base-mainnet'). */
+  readonly network: string;
+  /** Daemon-issued root for this impl's durable state.
+   *  Equal to implStateDirRoot/<implName>; created and chmodded by daemon. */
+  readonly implStateDir: string;
+  /** Read-only secrets bag populated by the impl's onEnable flow.
+   *  Same identity as ctx.secrets at run() time; surfaced here so
+   *  isReady / enableMetadata can answer without a full ctx. */
+  readonly secrets: Readonly<Record<string, string>>;
+  /** Daemon-side logger. Same shape as ctx.log. */
+  readonly log: (event: { level: 'info' | 'warn' | 'error'; msg: string; data?: unknown }) => void;
+  /** True when constructed under the CLI introspection path
+   *  (`jinn intents list / status`). Impls report
+   *  REQUIRES_LIVE_DAEMON_READINESS from isReady() in stub mode. */
+  readonly stub: boolean;
+}
+```
+
+Two notes:
+
+- `RestorerPluginEnv` is **not** `RestorerEnv`. The in-repo factory
+  takes `RestorerEnv` (which contains `pk`, `safe`, `runner`, raw
+  RPC URLs); plug-ins do not get those. A plug-in that needs RPC
+  reads or signing receives them per-call via `ctx.rpc` and
+  `ctx.signer` (trust-boundary §3.2 / §3.3); a plug-in that needs an
+  external secret receives it via `ctx.secrets` after `onEnable`.
+- The shape is **JSON-serialisable**. No functions, no class
+  instances, no Buffers, no Promises (constraint §6.2.2 of the
+  trust-boundary spec). `log` is the one exception, and it is the
+  exact shape an out-of-process child receives as a wire callback in
+  Phase 2.
+
+### 3.4 Lifecycle
+
+The daemon resolves and constructs each plug-in at boot, in the
+following order. Failure of any step excludes that plug-in only;
+other impls and the engine are unaffected (registry-discovery §4.3).
+
+1. **Read** the operator's `restorers.plugins[<i>]`.
+2. **Resolve manifest.** Read the locally pinned `jinn.manifest.json`
+   from the install directory (registry-discovery §4.3.2a).
+3. **Trust check.** Run trust-boundary §5.4 runtime checks: tarball
+   sha256 vs `package.hash`; manifest signature vs
+   `trustedImplSigners`; revocation status (signer untrusted?
+   manifest revoked? trust-pin within `2 * maxPinAgeSeconds`?);
+   capability allow-list within daemon ceiling. Failure → exclude with
+   `status.fleet.needsAttention.reason in {"impl-trust", "impl-revoked",
+   "impl-needs-revalidation"}`.
+4. **Dynamic import.** `await import(<absolute path to entry>)`. The
+   path is the join of `restorers.plugins[<i>].entry` and the
+   manifest's `entry` field. Failure (module not found, syntax error,
+   default export missing or non-function) → exclude with
+   `reason: "impl-load-failed"`.
+5. **Construct.** Call the default export with `RestorerPluginEnv`.
+   Construction throws → exclude with `reason: "impl-construction-failed"`.
+6. **Validate identity.** The returned `RestorerImpl.name` MUST equal
+   `manifest.name`; `RestorerImpl.version` MUST equal `manifest.version`.
+   Mismatch → exclude with `reason: "impl-identity-mismatch"` (this
+   defends against a plug-in that signed one manifest but ships code
+   claiming a different identity).
+7. **Validate `supportedKinds`.** Every kind the impl claims via
+   `supports()` for the kinds in `manifest.supportedKinds` MUST match.
+   We implement this as: for each entry `<kind>>=<semver>` in the
+   manifest, the daemon calls `impl.supports({ kind, type })` for
+   every `(kind, type)` pair the daemon knows about; the result MUST
+   be consistent with the manifest claim. Inconsistency is a defect,
+   not a security violation, but it is loud — exclude with
+   `reason: "impl-supports-mismatch"`.
+8. **Register.** Insert the impl into the same in-memory registry
+   `buildRestorerImpls` populates. Duplicate `name` collisions across
+   sources are an operator-fixable error (registry-discovery §4.3.3);
+   the in-repo impl wins by default and the plug-in is excluded with
+   `reason: "impl-name-collision"`. Operators resolve by editing
+   `restorers.disabled` or removing the plug-in.
+
+The lifecycle is **once-per-process**. A plug-in does not hot-reload;
+to swap a plug-in version, the operator runs the install verb against
+a new manifest CID and restarts the daemon. Hot-reload is a Phase 2+
+concern explicitly because revocation (trust-boundary §5.6.2) MUST
+clear in-memory capability handles — which Phase 1 does by exiting
+the impl's slot in `buildRestorerImpls` and rebuilding the registry,
+which in turn requires an engine reload anyway. Reloading the whole
+daemon is the simpler invariant.
+
+### 3.5 What `entry` is, and is not
+
+`restorers.plugins[<i>].entry` (registry-discovery §4.2) is a **local
+filesystem path** the daemon's loader resolves with dynamic `import()`
+joined to the manifest's `entry` field. It is typically a
+`node_modules` subdirectory the operator has populated with their
+package manager.
+
+It is **not**:
+
+- A remote URL (`https://...`, `ipfs://...`). The trust-boundary spec
+  keeps boot offline-safe (§5.4); a remote `entry` would couple boot to
+  network availability and inject a runtime fetch into a path that is
+  meant to operate on already-pinned local content. The manifest's
+  `package.cid` is the canonical remote pointer, resolved at install,
+  not at boot.
+- An MCP server URL. See §2; MCP is the right transport for some
+  *internal* in-repo impls, not for the third-party plug-in surface
+  this spec defines.
+- A descriptor for an out-of-process child (e.g. `{ command: '...',
+  args: [...] }`). Phase 2 may extend `entry` with a discriminated-union
+  shape for that, but Phase 1 keeps it a string.
+
+Reopening any of the above requires a new spec, the same way
+registry-discovery §4.4 reopens its deferrals.
+
+### 3.6 SDK package
+
+To make the contract discoverable, the daemon repo MAY publish (in a
+follow-up bead, §7) a small `@jinn-network/restorer-sdk` package that
+re-exports the public types: `RestorerImpl`, `RestorationContext`,
+`RestorationOutput`, `ReadyStatus`, `EnableResult`, `IntentEnableMetadata`,
+`SkippableError`, the `signer` / `rpc` / `secrets` / `fs` capability
+handle types from trust-boundary §3, and `RestorerPluginEnv` from §3.3
+above.
+
+Plug-in authors depend on `@jinn-network/restorer-sdk`, not on
+`@jinn-network/client` directly. This separation is what lets the
+daemon implementation evolve (refactors, extra in-repo glue, internal
+deps) without breaking plug-in authors. The SDK package's semver
+becomes the contract surface plug-in authors track; today, the
+boundary is implicit in `client/src/restorer/types.ts`.
+
+The SDK package is **not** required for Phase 1 to function — a
+plug-in author can copy the relevant types or import from the
+unstable internal path. But shipping the SDK is part of the "feels
+first-class" goal in this bead's description and belongs in the
+follow-up.
+
+## 4. Conformance with the trust-boundary §6 seams
+
+Trust-boundary §6.2 lists six constraints the Phase 1 design must
+satisfy to keep the option-C upgrade trivial. The plug-in flow above
+satisfies them as follows.
+
+| §6.2 constraint | How this spec satisfies it |
+|---|---|
+| 1. Capabilities are functions, not config. | `RestorationContext.signer.signTypedData / sendAllowedCall`, `ctx.rpc` (a `viem` `PublicClient` interface), and `ctx.log` are async functions in Phase 1; they become RPCs in Phase 2 with the same signatures. The plug-in factory takes `RestorerPluginEnv` (config) and returns an impl that uses capability handles only at call time — never captures a raw signer. |
+| 2. Inputs and outputs are JSON-serialisable. | `RestorerPluginEnv` (§3.3) is JSON-serialisable. `RestorationContext` already is (per portfolio v0 design). `RestorationOutput` already is. The plug-in flow adds nothing JS-only. |
+| 3. Manifests describe capabilities declaratively. | The plug-in uses `jinn.manifest.json` `capabilities` (trust-boundary §5.2) verbatim. The loader does not synthesise capabilities at runtime; the manifest is the only source. |
+| 4. No global state. | Factory contract §3.2 forbids module-level state across `run` calls. Per-attempt state goes in `ctx.workingDir` (cleared between attempts); durable state goes in `ctx.implStateDir`. |
+| 5. Logging is structured. | `ctx.log({ level, msg, data })` is the only logging contract surfaced to plug-ins. The SDK package (§3.6) does NOT re-export `console`. Plug-in authors who reach for `console.log` are out of policy; their output is unobserved when out-of-process. |
+| 6. No environment-variable inheritance. | `RestorerPluginEnv` (§3.3) deliberately omits `process.env`. Plug-ins MUST NOT call `process.env` for credentials or config; secrets come via `ctx.secrets` after `onEnable`. The daemon does not propagate environment to in-process impls (other than what Node itself inherits, which is invisible to a well-behaved plug-in). Out-of-process Phase 2 will spawn children with `env: {}`. |
+
+The Phase 2 swap, restated: replace step §3.4(4) (`await import(...)`)
+with `spawn(<entry>)` + a wire protocol; replace step §3.4(5)
+(call factory with env) with an `init` message carrying the same
+env shape; everything else — manifest, trust check, identity check,
+registry insertion — is unchanged.
+
+## 5. Worked example
+
+An operator wants to run a third-party Aave-rebalance restorer
+(`@some-operator/aave-restorer`) for kind `lending-health.v0`.
+
+1. **Author publishes.** The author packages their plug-in, computes
+   the tarball CID, writes `jinn.manifest.json` with
+   `name: "@some-operator/aave-restorer"`, `version: "1.0.0"`,
+   `supportedKinds: ["lending-health.v0>=1.0.0"]`,
+   `entry: "./dist/index.js"`, the tarball pin, and the capability
+   allow-list (chains, signer selectors, RPC methods, rate limit).
+   They sign the manifest with their `ed25519` key, pin the tarball
+   on IPFS, and publish the manifest CID.
+
+2. **Operator trusts the signer.** The operator runs:
+   ```
+   jinn impls trust ed25519:... --label some-operator
+   ```
+   The daemon adds the entry to `trustedImplSigners` (trust-boundary §5.3).
+
+3. **Operator installs.** The operator runs:
+   ```
+   yarn add @some-operator/aave-restorer
+   jinn impls add ipfs://bafy...manifest
+   ```
+   `jinn impls add` (a follow-up bead, §7) runs the install-time checks
+   (trust-boundary §5.4): resolves the CID, pins the tarball, verifies
+   the signature, checks the capability allow-list against the daemon
+   ceiling. On success it appends to `restorers.plugins`:
+   ```jsonc
+   {
+     "name": "@some-operator/aave-restorer",
+     "package": "ipfs://bafy...manifest",
+     "entry": "./node_modules/@some-operator/aave-restorer"
+   }
+   ```
+
+4. **Daemon boot.** §3.4 runs: trust check passes, dynamic import
+   resolves `./node_modules/@some-operator/aave-restorer/dist/index.js`,
+   the default export is called with `RestorerPluginEnv`, the returned
+   impl identifies as `@some-operator/aave-restorer@1.0.0` matching
+   the manifest, and the impl is registered alongside the in-repo
+   impls.
+
+5. **Engine dispatches.** When a `lending-health.v0` intent arrives,
+   the engine matches via `impl.supports({ kind: 'lending-health.v0',
+   type: 'restoration' })`, constructs a `RestorationContext` with
+   per-call `signer` / `rpc` / `secrets` / `fs` handles, and calls
+   `impl.run(ctx)`. The plug-in does its work using only those handles.
+
+6. **Operator revokes (optional path).** Two months later the operator
+   reads of a bug in `@some-operator/aave-restorer@1.0.0`:
+   ```
+   jinn impls revoke @some-operator/aave-restorer
+   ```
+   On the next runtime check the impl is excluded; `implStateDir/<impl>`
+   is moved to the quarantine path; capability handles bound to it
+   are invalidated (trust-boundary §5.6.2). The daemon continues
+   running with the rest of the fleet. Once the author ships a fix
+   at a new manifest CID, the operator runs `jinn impls add <new CID>`
+   to install the new version, and `jinn impls forget` to shred the
+   quarantined state.
+
+## 6. What is NOT decided here
+
+- The Phase 2 out-of-process wire protocol. This spec promises the
+  upgrade is cheap if §4 holds; it does not prescribe the protocol.
+- Hot-reload of plug-ins inside a running daemon. Out of scope; §3.4
+  commits to once-per-process construction.
+- Multi-version coexistence (e.g. running `@x/foo@1` and `@x/foo@2`
+  side by side). The §3.4 duplicate-name rule rejects this. If a real
+  use case appears, a follow-up spec can add a `--alias` flag to the
+  install verb.
+- Plug-in inter-dependencies (impl A wanting to consume impl B's
+  output beyond the existing engine artifact channel). Trust-boundary
+  §7.3 already calls this out as a future bead; the loader does not
+  introduce a dependency graph.
+- The CLI verb shape for `jinn impls *` beyond the verb names already
+  named by trust-boundary §7.2 / §5.6 (`trust`, `untrust`, `add`,
+  `remove`, `revoke`, `revalidate`, `forget`, `list`, `show`). Verb
+  details are a follow-up bead (§7).
+
+## 7. Acceptance and downstream impact
+
+### 7.1 Acceptance
+
+This spec is accepted when:
+
+1. It is merged under `spec/`.
+2. `spec/2026-05-registry-discovery.md` §6.3 ("Open questions
+   deferred") is updated to note that `entry` is locked to a local
+   filesystem path for Phase 1 by this spec; the remote-target
+   variant is deferred to Phase 2 alongside the out-of-process
+   loader.
+3. `client/src/restorer/types.ts` and
+   `client/src/restorer/impls/index.ts` carry doc references to this
+   spec and its sibling specs so downstream readers find the
+   contract from code.
+4. `jinn-mono-7zz` is closed.
+
+### 7.2 Downstream tasks (informational, not committed by this spec)
+
+The follow-ups, ranked roughly in dependency order. They are not
+filed in this bead per dispatch discipline; they exist here as the
+hand-off list.
+
+1. **Capability handles on `RestorationContext`.** Land
+   `ctx.signer`, `ctx.rpc`, `ctx.secrets`, optional `ctx.fs` per
+   trust-boundary §3.1. Additive — existing in-repo impls keep
+   working unchanged. This is a pre-req for the loader, because the
+   plug-in flow above assumes the new fields exist.
+2. **Manifest verifier.** Implement install-time and runtime checks
+   per trust-boundary §5.4: tarball CID resolution, sha256 match,
+   signature verification, allow-list ceiling, revocation.
+3. **Loader.** Implement §3.4 above: read `restorers.plugins`,
+   dynamic-import, validate identity, register. Includes the
+   `status.fleet.needsAttention` reason codes named in §3.4.
+4. **CLI verbs.** `jinn impls trust|untrust|add|remove|list|show`
+   for the install / introspection surface; `jinn impls
+   revoke|revalidate|forget` for the revocation surface
+   (trust-boundary §5.6); `jinn impls update <name>` per
+   registry-discovery §6.3 for plug-in updates.
+5. **In-repo disable list.** `restorers.disabled: [...]` per
+   registry-discovery §4.1. Small and self-contained; can land
+   independently of the plug-in flow.
+6. **Maintainer revocation list wiring.** `config.implRevocationList`
+   per trust-boundary §5.6.3, including IPNS / fixed-CID rotation
+   policy.
+7. **`@jinn-network/restorer-sdk` package.** §3.6 above: re-export
+   the public contract types, semver-tracked. Includes a minimal
+   `RestorerImpl` template / scaffold the way `client/src/restorer/impls/prediction-v0-baseline/`
+   is the in-repo template.
+8. **Extension guide.** Promote audit §5.3 ("Add a third-party
+   impl") into `docs/runbooks/publish-a-restorer.md` once the loader
+   ships, with the worked example from §5 as the spine.
+9. **Naming pass before public ship.** Per `jinn-mono-juw` /
+   GitHub issue #43 — once the Restorer → Solver decision lands,
+   apply it across `RestorerImpl`, `restorers.plugins`,
+   `restorers.disabled`, `jinn impls *`, `RestorerPluginEnv`,
+   the SDK package name, and this spec's filename. The plug-in
+   surface MUST land under final names; renaming after operators
+   publish plug-ins is a much larger churn event.
+10. **Phase 2 out-of-process spec.** A follow-on spec when the
+    operator demand or threat model warrants — wire protocol, child
+    lifecycle, sandbox primitive (uid / sandbox-exec / namespaces).
+    Inherits the manifest, trust flow, capability shape, and §3.5
+    `entry` extension from this spec.
+
+### 7.3 Open questions deferred
+
+- Whether `RestorerPluginEnv` should carry `network` as an enum
+  (`'base-mainnet' | 'base-sepolia' | ...`) or a structured
+  `{ chainId, name }`. Today it's a string; a tightening pass
+  follows the §7.2.1 work landing.
+- Whether to expose a `ctx.intentRegistry` read-only handle so a
+  plug-in can introspect sibling intents (e.g. an evaluator reading
+  a restorer's prior submission). Trust-boundary §7.3 already
+  flags this; the loader does not enable it today.
+- Plug-in `peerDependencies` policy: should the SDK enforce a
+  semver range against `@jinn-network/restorer-sdk` and refuse to
+  load plug-ins built against an incompatible SDK major? Today the
+  manifest has no SDK-version field; adding one is a §3 addendum
+  when the SDK ships.
+- Whether to support a `restorers.plugins[].config` field for
+  per-plug-in operator config that is *not* a secret (e.g. an
+  exchange API base URL, a feature flag the plug-in author exposes).
+  Registry-discovery §6.3 already flags this; this spec leaves it
+  out of `RestorerPluginEnv` for v1.
+
+## 8. Risks and reservations
+
+### 8.1 Naming churn
+
+`jinn-mono-juw` was closed pending GitHub issue #43; the Restorer →
+Solver and outcome → solution renames may land before this spec's
+implementation reaches operators. The risk is that we ship plug-in
+infrastructure under one vocabulary and then have to rename the
+public surface (config keys, CLI verbs, SDK package name) on top of
+operators who have already published plug-ins.
+
+Mitigation: §7.2 step 9 names a single rename pass before any
+operator publishes a plug-in. The implementation order ensures
+naming lands BEFORE the SDK package is published to npm and BEFORE
+the worked-example runbook ships. In-repo plug-in surface (this
+spec, `client/src/restorer/`) may rename internally without external
+churn.
+
+### 8.2 The "in-process is not a security boundary" reservation
+
+Trust-boundary §2.4 and §6.1 are explicit: in-process Node has no
+real isolation. This spec inherits that posture and does not pretend
+otherwise. The mitigation is the §5.6 revocation flow: a malicious
+plug-in is removed by an operator-driven `jinn impls untrust` /
+`revoke`, plus the maintainer-published revocation list as a
+defense-in-depth layer.
+
+The fail-loud behaviour (§5.6.2 quarantine + state clearing,
+`status.fleet.needsAttention`) is the user-visible counterpart.
+Operators MUST be able to detect that a plug-in went bad and recover
+without rebuilding. The loader does not pretend to defend against a
+plug-in that runs *before* it is recognised as malicious — that is a
+Phase 2 process-isolation problem, and §4 keeps the upgrade open.
+
+### 8.3 Dependency-graph surface
+
+A plug-in's transitive npm dependencies are part of its trust surface
+(trust-boundary §2.3). The manifest pins the tarball, but the
+tarball typically excludes `node_modules` — the operator's package
+manager resolves dependencies at install. This means a poisoned
+transitive dep (the `event-stream` / `node-ipc` / `xz` pattern) is
+*not* caught by `package.hash`, because `package.hash` covers the
+plug-in's own source, not the resolved dep tree.
+
+Phase 1 mitigation: capability narrowing (the plug-in cannot reach
+`process.env`, the keystore, sibling impls' state, etc., even
+through a poisoned dep, *if* it goes through the boundary). Phase 2
+mitigation: process isolation, so a poisoned dep cannot escape the
+sandbox even if it tries to.
+
+This spec does not commit a Phase 1 lockfile-pinning rule for
+dependencies. A reasonable follow-up is a manifest field
+`package.lockfileHash` that pins the resolved dep tree at publish
+time; this is left for a future trust-boundary minor revision (§5.7
+or successor) rather than this spec.
+
+## 9. References
+
+- `docs/reviews/2026-04-22-architecture-audit-j75.md` — audit; this
+  spec records the loader half of §8 decision #1 (audit option B,
+  with §6 seams toward option C).
+- `spec/2026-05-schema-versioning.md` — kind grammar, manifest
+  semver, `supportedKinds` advertisement. The plug-in's manifest
+  `supportedKinds` array follows this grammar.
+- `spec/2026-05-registry-discovery.md` — the source-of-candidates
+  contract this spec consumes (§4.2's `restorers.plugins` shape).
+- `spec/2026-05-executor-trust-boundary.md` — the trust contract
+  the plug-in flow builds against. §5.4 install/runtime split,
+  §5.6 revocation, §6 out-of-process seams.
+- `spec/2026-04-14-client-surface.md` — `status.fleet.needsAttention`
+  shape that the loader reports into.
+- `client/src/restorer/types.ts` — current `RestorerImpl` shape; the
+  plug-in module contract (§3.2) is this interface.
+- `client/src/restorer/impls/index.ts` — `buildRestorerImpls`; the
+  in-repo Source A whose registry the loader inserts into.
+- `jinn-mono-juw` — naming alignment decision (now in GitHub issue
+  #43); §7.2 step 9 lists the rename pass.
+- `jinn-mono-y6w` — closed predecessor bead, merged into
+  jinn-mono-7zz; this spec is its design output.

--- a/spec/2026-05-schema-versioning.md
+++ b/spec/2026-05-schema-versioning.md
@@ -1,0 +1,539 @@
+# Jinn Intent & Manifest Schema Versioning — Technical Spec
+
+> Version: 1.1
+> Date: 2026-04-27
+> Author: Ale
+> Status: Proposed (not yet adopted)
+> Supersedes: none
+> Informs: `docs/reviews/2026-04-22-architecture-audit-j75.md` §6 gap #5, §7.2.2, §8 decision #2
+> Extends: `spec/2026-04-14-client-surface.md`
+
+## 1. Purpose and scope
+
+This spec defines the **versioning policy** for intent kinds and their
+associated manifests across the Jinn protocol surface (intent specs,
+restoration submissions, evaluator verdicts, ERC-8004 artifact
+envelopes). It also defines how a Jinn client **advertises** the set
+of kinds and manifest versions it supports, and how downstream
+consumers (subgraphs, evaluators, third-party readers) decide
+compatibility.
+
+The audit (`docs/reviews/2026-04-22-architecture-audit-j75.md` §6
+gap #5; §7.2.2; §8 decision #2) flagged that today's kinds — `portfolio.v0`,
+`prediction.v0`, `prediction.apy.v0` — *look* like semver but carry no
+policy. Clients silently fail to parse intents written by a different
+build; subgraphs and evaluators have no rule for what `.v1` promises.
+This spec closes that gap.
+
+### 1.1 In scope
+
+- The grammar of `kind` strings.
+- The relationship between `kind` major and manifest `schemaVersion`
+  minor / patch.
+- The `supportedKinds` field added to `jinn version --json`.
+- Consumer compatibility behaviour at unknown `schemaVersion`
+  (subgraph and evaluator).
+- Migration guidance: how a kind bumps `vN → v(N+1)`, and the
+  reader-side accept-both window for additive field renames.
+
+### 1.2 Out of scope
+
+- The contents of any specific manifest (defined per-kind in
+  `client/src/types/<kind>.ts` and the kind's own spec doc).
+- Storage format on ERC-8004 / IPFS (envelope shape lives elsewhere).
+- The plugin distribution mechanism (`spec/2026-05-restorer-plugins.md`
+  or successor; audit §8 decision #1).
+- Trust boundary for third-party impls (audit §8 decision #3).
+
+### 1.3 Non-goals
+
+- This is not a hash-pinned schema registry. Audit §8 decision #2
+  considered (c) hash-pinning and rejected it for v0; semver is the
+  policy. A future spec may layer hash-pinning on top.
+- This is not a content-migration tool. Old artifacts on-chain remain
+  on-chain under their original `schemaVersion`; the policy here
+  governs how *new* code reads them.
+
+## 2. Kind grammar
+
+A `kind` is a string of the form:
+
+```
+<domain>.v<major>
+```
+
+where:
+
+- `<domain>` is one or more lowercase ASCII segments separated by
+  hyphens (`-`). Each segment matches `[a-z][a-z0-9]*`.
+- `<major>` is a non-negative decimal integer with no leading zeros
+  (`0`, `1`, `2`, …; not `01`).
+- The literal `.v` separates domain from version.
+
+### 2.1 Examples
+
+| Kind                      | Domain          | Major | Notes                                    |
+|---------------------------|-----------------|-------|------------------------------------------|
+| `prediction.v0`           | `prediction`    | 0     | Single-segment domain.                   |
+| `prediction-apy.v0`       | `prediction-apy`| 0     | Sub-domain via hyphen, **not dot**.      |
+| `portfolio.v0`            | `portfolio`     | 0     | Single-segment domain.                   |
+| `lending-health.v1`       | `lending-health`| 1     | Hyphenated sub-domain; second major.     |
+
+### 2.2 Reserved separators
+
+- **Dot (`.`)** is reserved. Exactly one dot appears in a `kind`,
+  immediately before the literal `v<major>`. A kind string therefore
+  always splits into exactly two parts on `.` — domain and version
+  token.
+- **Hyphen (`-`)** is the only valid separator inside `<domain>`.
+  Sub-domains, qualifiers, and compound names (`prediction-apy`,
+  `lending-health`, `portfolio-rebalance`) MUST use hyphens.
+- **Underscore (`_`)** and uppercase characters are forbidden.
+
+This is a deliberate change from current practice. `prediction.apy.v0`
+(dotted sub-domain, shipped as of 2026-04-22) is a **legacy form**
+retained for already-deployed artifacts; new kinds MUST use hyphens.
+See §6.3 for the migration path.
+
+### 2.3 Semantics of the major
+
+`vN → v(N+1)` is a **breaking change**. A consumer that supports
+`prediction.v0` MUST NOT assume any compatibility with `prediction.v1`.
+Specifically, a `vN+1` kind MAY:
+
+- Remove or rename required fields.
+- Change field types or units.
+- Alter loop semantics (claim → run → deliver) for that kind.
+- Replace the manifest envelope shape entirely.
+
+Conversely, a `vN+1` kind MUST be a **distinct kind string** — the
+same domain at a new major. Consumers route on the full `kind`; there
+is no implicit fallback from `v1` to `v0`.
+
+## 3. Manifest schemaVersion
+
+Every manifest emitted under a kind (intent spec, submission, verdict,
+artifact envelope) carries a `schemaVersion` field as a **semver
+string** (`MAJOR.MINOR.PATCH`).
+
+```json
+{
+  "kind": "prediction.v0",
+  "schemaVersion": "1.2.0",
+  "...": "..."
+}
+```
+
+### 3.1 Bump rules
+
+For a fixed `kind`:
+
+| Change                                                | Bump      | Reader compat                                    |
+|-------------------------------------------------------|-----------|--------------------------------------------------|
+| Add an optional field                                 | minor     | Old readers ignore unknown fields (§4.3 below).  |
+| Add a required field                                  | **major** | Old readers fail closed; treat as new kind candidate. |
+| Rename a field (with reader-side accept-both bridge)  | minor     | One release of accept-both required (§6.1).      |
+| Remove a field                                        | **major** | Treated as breaking; consider a new kind.        |
+| Tighten a constraint (range, enum subset)             | **major** | Old payloads may now fail validation.            |
+| Loosen a constraint (range, enum superset)            | minor     | Old readers may reject; reader-side accept-both. |
+| Fix a typo in a description / comment                 | patch     | No reader impact.                                |
+
+A manifest `MAJOR` reaching `2.0.0` within the same kind is an
+escalation signal: prefer minting a new kind (`prediction.v1`) over
+shipping a manifest `2.0.0` under `prediction.v0`. The kind's major is
+the user-visible breaking-change axis; manifest `MAJOR` exists for
+edge cases (e.g., field removal under regulatory pressure) where a
+full kind bump is inappropriate.
+
+### 3.2 Default schemaVersion
+
+The first manifest published under a new kind starts at `1.0.0`. There
+is no `0.x` development band; once a kind is named in code that ships,
+its manifest is `1.0.0` or higher.
+
+### 3.3 Relationship to legacy `schemaVersion` literals
+
+Existing manifests carry composed string literals like
+`prediction.v0.submission.v1` (see `client/src/types/prediction.ts`).
+Under this spec, that becomes:
+
+- `kind: "prediction.v0"` (unchanged at the spec level)
+- `schemaVersion: "1.0.0"` (semver)
+- A separate `manifestRole` discriminator (`"submission" | "verdict" |
+  "spec"`) where one is needed inside a kind.
+
+Reader-side, this spec REQUIRES that consumers accept both forms for
+one release window (see §6.1). Writer-side, new manifests SHOULD use
+the split form.
+
+## 4. Client advertisement
+
+This section extends `spec/2026-04-14-client-surface.md` §4.7
+(`jinn version`).
+
+### 4.1 `supportedKinds` field
+
+`jinn version --json` MUST emit a `supportedKinds` array on its
+top-level object:
+
+```json
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-05-04T12:00:00Z",
+  "client": { "version": "0.4.0", "commit": "..." },
+  "protocol": { "phase": "phase-1b", "specVersion": 1 },
+  "network": "testnet",
+  "deployments": { "...": "..." },
+  "tokens":      { "...": "..." },
+  "supportedKinds": [
+    "prediction.v0>=1.0.0",
+    "prediction-apy.v0>=1.1.0",
+    "portfolio.v0>=1.0.0"
+  ]
+}
+```
+
+Note: the top-level `schemaVersion: 1` here is the **client-surface**
+schema version (per `spec/2026-04-14-client-surface.md`), not a kind
+manifest version. The two namespaces are independent.
+
+### 4.2 Entry grammar
+
+Each entry in `supportedKinds` is a string:
+
+```
+<kind>>=<semver>
+```
+
+- `<kind>` follows §2.
+- `>=` is the only constraint operator in v1 of this spec. The client
+  asserts: "I can read every manifest under `<kind>` whose
+  `schemaVersion` is `>= <semver>` and `< <next-major>`, where
+  `<next-major>` is the next major after `<semver>`'s major."
+- `<semver>` is the **lowest** manifest minor.patch the client
+  guarantees to parse. Higher minors within the same major MUST also
+  parse, by the additive rule in §3.1.
+- The entry MUST contain **no whitespace** anywhere — not around the
+  `>=`, not inside `<kind>`, and not inside `<semver>`. Whitespace
+  inside an entry is a malformed advertisement and consumers MUST
+  reject the whole `supportedKinds` array.
+
+The literal `>=` immediately abutting the `v<major>` of the kind makes
+naive splitting brittle (the boundary between `<kind>` and the operator
+is `v0>=` — three characters of overlap with the kind grammar). Parsers
+MUST anchor on the §2 kind grammar, not on a substring search for `>=`.
+The full entry conforms to the regex:
+
+```
+^[a-z][a-z0-9]*(-[a-z][a-z0-9]*)*\.v(0|[1-9][0-9]*)>=(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$
+```
+
+with one exception: the legacy `prediction.apy.v0` form (§6.3) replaces
+the kind portion with the literal `prediction.apy.v0`.
+
+A client that supports multiple disjoint majors of the same kind MAY
+emit one entry per major:
+
+```
+"prediction.v0>=1.4.0"
+"prediction.v0>=2.0.0"
+```
+
+Consumers MUST treat the union of these ranges as the supported set.
+
+### 4.3 Forward-compat reading
+
+Independent of `supportedKinds`, all clients MUST:
+
+- Ignore unknown fields in any manifest they accept (additive minor
+  bumps remain backwards-compatible).
+- Treat a manifest whose `schemaVersion` major exceeds the highest
+  major in the client's `supportedKinds` entry for that kind as
+  **unreadable** (see §5).
+
+### 4.4 CLI surface (non-JSON)
+
+When `--json` is not set, `jinn version` MUST render `supportedKinds`
+as a sorted, one-per-line list under a `Supported kinds:` header.
+Wording is informative; agents MUST use the JSON form.
+
+## 5. Consumer compatibility policy
+
+This section governs subgraphs, evaluators, and any third-party reader
+that ingests intents, submissions, or verdicts published by Jinn
+clients.
+
+### 5.1 Three classes of consumer
+
+| Class             | Examples                          | Default behaviour at unknown `schemaVersion` |
+|-------------------|-----------------------------------|----------------------------------------------|
+| **Indexer**       | Subgraph, archive crawler         | **Drop** the record; emit a structured warning. |
+| **Live evaluator**| Daemon evaluator impl, attestor   | **Surface as error**: write a verdict-shaped envelope with `error.code = "unsupported_schema"` and refuse to vote. |
+| **Inspector**     | Explorer UI, `jinn intents show`  | **Surface as warning**: render the raw envelope; mark the record `unparsed: true`; do not silently hide. |
+
+The default is "drop vs surface-as-error" rather than "best-effort
+parse" because a manifest the consumer has never seen MAY have moved a
+load-bearing field. Best-effort parsing of unknown-schema records is
+explicitly forbidden.
+
+### 5.2 Decision rule
+
+For a manifest with `kind = K` and `schemaVersion = V`:
+
+1. If the consumer's supported set for `K` is empty → unsupported kind.
+   Indexers drop; evaluators surface as `error.code = "unsupported_kind"`;
+   inspectors render raw.
+2. If `V`'s major is **greater than** any supported major for `K` →
+   unsupported schema (forward-incompat). Same dispositions as (1)
+   with `error.code = "unsupported_schema"`.
+3. If `V`'s major matches a supported major and `V >= advertised
+   minimum` → **parse**.
+4. If `V`'s major matches a supported major but `V < advertised
+   minimum` → unsupported schema (backward-incompat). Same dispositions
+   as (1).
+
+Indexers MUST log the dropped record's `kind`, `schemaVersion`,
+`txHash`, and `cid` (when available) at warning level so an operator
+can trace it. Silent drops are a defect.
+
+### 5.3 Evaluator error envelope
+
+When an evaluator surfaces an unsupported manifest as an error, the
+envelope reuses the verdict shape with the error fields populated:
+
+```json
+{
+  "kind": "<K>",
+  "schemaVersion": "<V observed>",
+  "manifestRole": "verdict",
+  "error": {
+    "code": "unsupported_schema" | "unsupported_kind",
+    "evaluatorSupported": ["prediction.v0>=1.0.0", "..."]
+  }
+}
+```
+
+The evaluator MUST NOT vote pass/fail on a manifest it cannot parse.
+Subgraph indexers MUST treat such an envelope as a non-vote — it
+neither contributes to nor blocks the underlying intent's outcome.
+
+### 5.4 Configurability
+
+A consumer MAY expose a knob to switch from "drop" to "surface as
+error" for indexer-class behaviour (e.g. a subgraph can flip to
+parking unknown records in a quarantine table). The default for v1
+remains drop-with-warning.
+
+## 6. Migration guidance
+
+### 6.1 Reader-side accept-both for additive renames
+
+When a manifest field is renamed under a minor bump (§3.1), the
+producing release SHOULD ship readers that accept **both** the old
+and new field name for **at least one full release**. Concretely:
+
+- Release N: writer emits `oldName` only. Reader accepts `oldName` only.
+- Release N+1: writer emits `newName` (preferred) **and** `oldName`
+  (kept). Reader accepts both, prefers `newName`. Manifest
+  `schemaVersion` minor bumps in this release.
+- Release N+2: writer drops `oldName`. Reader still accepts both.
+  Manifest `schemaVersion` minor bumps.
+- Release N+3 or later: reader MAY drop `oldName` acceptance. This is
+  a **major** bump under §3.1 because old payloads — including any
+  still on IPFS — would now fail to parse.
+
+The accept-both window covers the case where an indexer or evaluator
+upgrades on a different cadence than the daemon emitting new
+manifests. One release of overlap is the floor; longer windows are
+preferred when older artifacts are pinned on-chain (the common case).
+
+### 6.2 Reader-side accept-both for the legacy composed `schemaVersion`
+
+Existing manifests use composed literals (`prediction.v0.submission.v1`)
+in `schemaVersion`. New manifests use semver (`1.0.0`) plus an explicit
+`manifestRole`. For at least one release after this spec is adopted,
+all readers MUST:
+
+- Parse a `schemaVersion` value matching `^\d+\.\d+\.\d+$` per §3.
+- Parse a `schemaVersion` value matching the legacy
+  `^<kind>\.(spec|submission|verdict)\.v\d+$` shape and synthesise a
+  `1.0.0` (for `v1`), `2.0.0` (for `v2`), … plus a derived
+  `manifestRole`.
+
+After the accept-both window, readers MAY drop the legacy form. That
+drop is a major bump on the affected kind's manifest.
+
+### 6.3 Sub-domain hyphenation migration
+
+The kind `prediction.apy.v0` is the only currently-shipped kind that
+violates §2.2 (dot in sub-domain). It is **grandfathered** for the
+lifetime of `v0`. Specifically:
+
+- Existing on-chain artifacts under `prediction.apy.v0` retain that
+  kind string forever.
+- Clients MUST advertise it as `prediction.apy.v0>=1.0.0` exactly
+  (the dot is part of the literal string).
+- The next major MUST use the hyphenated form: `prediction-apy.v1`.
+  At that point clients advertise both:
+  ```
+  "prediction.apy.v0>=1.0.0"
+  "prediction-apy.v1>=1.0.0"
+  ```
+  until the legacy major is retired.
+- No other kind may be minted with a dotted sub-domain.
+
+### 6.4 Announcing a kind major bump
+
+When a kind moves from `vN` to `v(N+1)`:
+
+1. A spec proposal under `spec/YYYY-MM-DD-<topic>.md` documents the
+   motivation, the field-level diff, and the reader-side migration.
+2. The new kind ships in a client release **alongside** continued
+   support for the old major. `supportedKinds` lists both:
+   ```
+   "prediction.v0>=1.4.0"
+   "prediction.v1>=1.0.0"
+   ```
+3. Writers begin emitting the new kind only after consumers
+   (subgraph, evaluator) have shipped support — verified by reading
+   their `supportedKinds` advertisement.
+4. The old major is retired in a later release. Retirement removes the
+   old entry from `supportedKinds` and is itself a breaking client
+   change (bumps the client-surface `schemaVersion` per
+   `spec/2026-04-14-client-surface.md` §9).
+
+### 6.5 Pinned-artifact graceful degradation
+
+ERC-8004 and IPFS pin artifacts indefinitely. A client running long
+after a kind retirement MAY still encounter old envelopes. The
+expected behaviour is §5.2 disposition for "unsupported kind" — drop
+or surface, never best-effort. There is no ceiling on how old an
+encountered envelope may be.
+
+## 7. Examples
+
+### 7.1 New kind, first release
+
+```
+kind:          lending-health.v0
+schemaVersion: 1.0.0
+manifestRole:  spec
+```
+
+`jinn version --json` includes:
+
+```
+"supportedKinds": ["lending-health.v0>=1.0.0", "..."]
+```
+
+### 7.2 Additive minor bump
+
+Release adds optional `targetUtilisationBps`. The writer now emits:
+
+```
+kind:          lending-health.v0
+schemaVersion: 1.1.0
+```
+
+The advertised minimum **does not change**:
+
+```
+"supportedKinds": ["lending-health.v0>=1.0.0"]
+```
+
+The reader still parses every prior `1.0.x` envelope (it just ignores
+unknown fields per §4.3) and parses the new `1.1.0` envelopes by the
+"higher minors within the same major MUST also parse" clause of §4.2.
+Bumping the advertised minimum to `1.1.0` would be wrong: the §5.2
+decision rule (rule 4) would then drop every still-pinned `1.0.x`
+artifact, even though the reader is perfectly capable of parsing it.
+
+The general rule: **the advertised minimum tracks the oldest
+`schemaVersion` the reader can still parse, not the newest one the
+writer emits.** Within a single major, the advertised minimum normally
+stays put across many writer-side minor bumps. It only advances when
+the reader drops support for an old minor — and dropping reader
+support for an old in-major minor is itself a major bump under §3.1
+(it makes pinned payloads fail), so in practice the advertised minimum
+moves only at kind-major boundaries.
+
+### 7.3 Field rename across releases
+
+`apyBps` renamed to `expectedApyBps` (audit feedback: clarity).
+
+| Release | Writer emits      | Reader accepts             | `schemaVersion` |
+|---------|-------------------|----------------------------|-----------------|
+| N       | `apyBps`          | `apyBps`                   | `1.2.0`         |
+| N+1     | `expectedApyBps`, `apyBps` | both              | `1.3.0`         |
+| N+2     | `expectedApyBps`  | both                       | `1.4.0`         |
+| N+3     | `expectedApyBps`  | both (no change)           | `1.4.0`         |
+| N+4     | `expectedApyBps`  | `expectedApyBps`           | `2.0.0`         |
+
+The drop in N+4 is a manifest **major** bump (§3.1), because old
+on-chain payloads now fail.
+
+### 7.4 Major kind bump
+
+`prediction.v0 → prediction.v1` because verdict semantics change
+(introduces partial-credit scoring incompatible with `v0`).
+
+`spec/2026-MM-DD-prediction-v1.md` documents the diff. Client release
+advertises:
+
+```
+"supportedKinds": ["prediction.v0>=1.4.0", "prediction.v1>=1.0.0"]
+```
+
+Subgraph and evaluator must ship `prediction.v1` support before
+writers begin emitting it (§6.4 step 3).
+
+## 8. Conformance checklist
+
+A client claiming conformance to this spec MUST:
+
+- [ ] Emit `supportedKinds` on `jinn version --json` per §4.
+- [ ] Validate every emitted manifest's `kind` against the §2 grammar
+      (modulo §6.3 grandfathering).
+- [ ] Validate every emitted manifest's `schemaVersion` against
+      `^\d+\.\d+\.\d+$` (or accept the legacy form per §6.2).
+- [ ] On read, apply the §5.2 decision rule. Indexer-class code drops;
+      evaluator-class code surfaces as error; never best-effort parse.
+- [ ] Log every drop / surface with `kind`, `schemaVersion`, and a
+      reference to the source record (txHash / cid / db id).
+
+A consumer (subgraph, evaluator) claiming conformance MUST additionally:
+
+- [ ] Read producers' `supportedKinds` advertisements before writers
+      begin emitting a new kind.
+- [ ] Implement §5.3's error-envelope shape for evaluator-class
+      surfaces.
+
+## 9. Open questions
+
+- Whether to allow constraint operators beyond `>=` in
+  `supportedKinds` (e.g. `~>`, `<`). Deferred until a real need
+  appears.
+- Whether to publish a machine-readable schema registry separate from
+  the in-repo `client/src/types/<kind>.ts` files. Out of scope for
+  v1; a future spec layered on top of this one MAY add it.
+- How long the §6.1 accept-both window should run by default.
+  Recommendation is "at least one release"; some kinds may need
+  multiple. Per-kind docs can name a specific window.
+- Interaction with on-chain ERC-8004 envelope shape if/when that
+  envelope itself versions independently of the inner manifest. Out
+  of scope; covered by the ERC-8004 envelope spec when written.
+
+## 10. References
+
+- `docs/reviews/2026-04-22-architecture-audit-j75.md` — audit; this
+  spec closes §6 gap #5, addresses §7.2.2, and records the policy
+  half of §8 decision #2.
+- `spec/2026-04-14-client-surface.md` — client surface this spec
+  extends (`jinn version` adds `supportedKinds`).
+- `client/src/types/prediction.ts`,
+  `client/src/types/prediction-apy.ts`,
+  `client/src/types/portfolio.ts` — current Zod schemas; targets of
+  the §6.2 / §6.3 migration.
+- `client/src/intents/kinds/index.ts` — `SPEC_KINDS` map; the
+  authoritative in-repo registry of kinds; the §8 conformance
+  checklist runs against entries here.

--- a/spec/2026-05-schema-versioning.md
+++ b/spec/2026-05-schema-versioning.md
@@ -41,8 +41,8 @@ This spec closes that gap.
 - The contents of any specific manifest (defined per-kind in
   `client/src/types/<kind>.ts` and the kind's own spec doc).
 - Storage format on ERC-8004 / IPFS (envelope shape lives elsewhere).
-- The plugin distribution mechanism (`spec/2026-05-restorer-plugins.md`
-  or successor; audit §8 decision #1).
+- The external-impl distribution mechanism
+  (`spec/2026-05-external-restorer-impls.md`; audit §8 decision #1).
 - Trust boundary for third-party impls (audit §8 decision #3).
 
 ### 1.3 Non-goals


### PR DESCRIPTION
## Summary

Two design specs from epic `jinn-mono-9ry` (Extension-model specs: versioning, registry decision, trust boundary). Both inform the implementation contract for `jinn-mono-7zz` (operator-supplied restorers / plug-ins).

### `spec/2026-05-schema-versioning.md` (jinn-mono-9ry.1 + jinn-mono-for)
539 lines. How Jinn versions intent kinds:
- `kind` semver: `<domain>.v<major>`; `vN` is breaking; additive fields bump manifest `schemaVersion` minor
- Clients advertise via `jinn version --json` → `supportedKinds: ['prediction.v0>=1.0.0', …]`
- Consumer compat policy (subgraph + evaluator behaviour at unknown `schemaVersion`)
- Migration: one release of reader-side accept-both on any field rename

Includes §7.2 self-contradiction fix + §4.2 entry-grammar tightening (jinn-mono-for).

Audit refs: §7.2.2 gap #5, §8 decision #2.

### `spec/2026-05-executor-trust-boundary.md` (jinn-mono-9ry.3 + jinn-mono-zgs)
743 lines. What the daemon gives an impl, and what an impl must not reach:
- Threat model: malicious / buggy / supply-chain-compromised impl
- Credential scoping: `ScopedSigner` (selector allow-list per `(chainId, to, selector)`), scoped RPC with method allow-list; no master pk, no keystore path, no other-impl state
- Filesystem scoping: `config.engine.workingDirRoot` + `implStateDirRoot/<impl>/`; Node capability wrapper for v0
- Provenance: IPFS CID at install, package signature, install vs runtime checks
- §5.6 (jinn-mono-zgs): signer revocation, manifest pin expiry, fail-closed runtime, state quarantine; CLI verbs `jinn impls untrust|revoke|revalidate|forget`
- §6: out-of-process evolution seams (function-shaped capabilities, JSON-serializable I/O, declarative manifest capabilities)

Direct contract for `jinn-mono-7zz` to build against.

Audit refs: §7.2.4, §8 decision #3.

## Test plan

- [ ] Both specs follow `spec/2026-04-14-client-surface.md` header convention
- [ ] Audit cross-references resolve (§7.2.2 gap #5, §8 decisions #2 + #3, §7.2.4)
- [ ] `jinn-mono-7zz` description references both specs (already updated as part of jinn-mono-zgs close)
- [ ] No code changes — pure docs/spec PR

## Open follow-ups (not blocking)

- `jinn-mono-9ry.2` — registry/discovery decision spec (the third sibling, not yet written)
- Three judgment calls flagged in spec review (filed but not yet bd issues): marketplace.json scope question, key reuse across impls, side-channel acknowledgement in threat model

🤖 Generated with [Claude Code](https://claude.com/claude-code)