### PR TITLE
[codex] Prepare client release gate fixes

### DIFF
--- a/client/scripts/ensure-forge-std.mjs
+++ b/client/scripts/ensure-forge-std.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const contractsRoot = resolve(process.cwd());
+const forgeStdRoot = join(contractsRoot, 'lib', 'forge-std');
+const sentinel = join(forgeStdRoot, 'src', 'Test.sol');
+
+if (existsSync(sentinel)) {
+  console.log(`forge-std already present at ${forgeStdRoot}`);
+  process.exit(0);
+}
+
+const result = spawnSync('forge', ['install', 'foundry-rs/forge-std', '--no-git'], {
+  cwd: contractsRoot,
+  encoding: 'utf8',
+  stdio: 'pipe',
+});
+
+if (result.stdout) process.stdout.write(result.stdout);
+if (result.stderr) process.stderr.write(result.stderr);
+
+if (result.status === 0 || existsSync(sentinel)) {
+  process.exit(0);
+}
+
+process.exit(result.status ?? 1);

--- a/client/scripts/lib/release-client.mjs
+++ b/client/scripts/lib/release-client.mjs
@@ -480,7 +480,7 @@ export function releaseGateSteps(skipAcceptance = false) {
     ['gate-operator', 'yarn release:operator-gate', 'yarn', ['release:operator-gate'], 'clientRoot'],
     ['gate-contracts-install', 'contracts: yarn install --immutable', 'yarn', ['install', '--immutable'], 'contractsRoot'],
     ['gate-contracts-test', 'contracts: yarn test', 'yarn', ['test'], 'contractsRoot'],
-    ['gate-contracts-foundry-install', 'contracts: forge install foundry-rs/forge-std --no-git', 'forge', ['install', 'foundry-rs/forge-std', '--no-git'], 'contractsRoot'],
+    ['gate-contracts-foundry-install', 'contracts: ensure forge-std', 'node', ['../client/scripts/ensure-forge-std.mjs'], 'contractsRoot'],
     ['gate-contracts-foundry-invariants', 'contracts: forge test --match-contract Invariant', 'forge', ['test', '--match-contract', 'Invariant'], 'contractsRoot'],
   ];
   if (!skipAcceptance) {

--- a/client/src/adapters/mech/adapter.ts
+++ b/client/src/adapters/mech/adapter.ts
@@ -417,27 +417,21 @@ export class MechAdapter implements ExecutionAdapter {
             const iCreatedEvaluation = this.pendingEvaluationClaims.has(requestId);
             if (!iDelivered && !iCreatedRestoration && !iCreatedEvaluation) continue;
 
-            // (a) Cross-operator claim path: we created a restoration but another
-            //     mech delivered it. The router still needs `restorationDeliveryClaimed`
-            //     flipped before `createEvaluationJob` can fire, so the creator Safe
-            //     submits the claim with an evidenceHash derived from the delivered
-            //     envelope on IPFS.
+            // (a) Creator-side claim path: we created the restoration, so the
+            //     router needs `restorationDeliveryClaimed` flipped before
+            //     `createEvaluationJob` can fire. Production engine deliveries
+            //     usually claim atomically; this call is idempotent and also
+            //     covers legacy/test adapter deliveries that only wrote to the
+            //     marketplace.
             //
-            //     Same-operator deliveries (iDelivered=true) already claimed via the
-            //     restorer engine's deliverAndClaim path — that's atomic with the
-            //     deliverToMarketplace call. Skipping here avoids a redundant Safe-tx
-            //     attempt that would log spurious `already-claimed` / `RequestNotFound`
-            //     /  V2 evidenceHash errors for our own deliveries.
-            const isCrossOperator = iCreatedRestoration && !iDelivered;
-            if (isCrossOperator) {
+            //     For V2 claims we may not have a local store entry, so derive
+            //     evidenceHash from the delivered envelope on IPFS. If derivation
+            //     fails, skip and retry on a later poll.
+            if (iCreatedRestoration) {
               try {
                 const variant = this.config.routerClaimDeliveryVariant;
                 let evidenceHash: `0x${string}` | undefined;
                 if (variant === 'v2') {
-                  // Cross-operator: we did NOT deliver, so no local store entry.
-                  // Derive evidenceHash by fetching the delivered envelope from IPFS
-                  // and recomputing keccak256(JCS(envelope - signature)).
-                  // If derivation fails, skip claim and let the next watch loop retry.
                   try {
                     const deliveryDigest = deliveryDataHex.startsWith('0x')
                       ? deliveryDataHex.slice(2)
@@ -454,14 +448,14 @@ export class MechAdapter implements ExecutionAdapter {
                     const recomputed = keccak256(jcsBytes);
                     if (recomputed !== signature.hash) {
                       console.error(
-                        `[mech] cross-operator claimDelivery skipped for ${requestId}: recomputed hash ${recomputed} !== envelope.signature.hash ${signature.hash}`,
+                        `[mech] claimDelivery skipped for ${requestId}: recomputed hash ${recomputed} !== envelope.signature.hash ${signature.hash}`,
                       );
                       continue;
                     }
                     evidenceHash = recomputed as `0x${string}`;
                   } catch (deriveErr) {
                     console.error(
-                      `[mech] cross-operator evidenceHash derivation failed for ${requestId} — skipping claim, will retry on next loop:`,
+                      `[mech] evidenceHash derivation failed for ${requestId} — skipping claim, will retry on next loop:`,
                       deriveErr,
                     );
                     continue;

--- a/client/src/daemon/daemon.ts
+++ b/client/src/daemon/daemon.ts
@@ -14,7 +14,8 @@ import { RestorationEngine, type RestorationEngineOptions } from '../restorer/en
 import { BalanceTopupLoop, type BalanceTopupLoopConfig } from './balance-topup-loop.js';
 import { JinnClaimLoop, type JinnClaimLoopConfig } from './jinn-claim-loop.js';
 import { emitEvent } from '../observability/emit-event.js';
-import type { IntentSource } from '../intents/sources.js';
+import { StaticConfiguredIntentSource, type IntentSource } from '../intents/sources.js';
+import type { RestorationJob } from '../types/index.js';
 
 const DEFAULT_API_PORT = 7331;
 
@@ -57,6 +58,8 @@ export interface DaemonConfig {
 
   /** Restoration intent sources polled by CreatorLoop. */
   intentSources?: IntentSource[];
+  /** Backwards-compatible static intents; used when intentSources is omitted. */
+  desiredStates?: RestorationJob[];
 
   /**
    * Creator Safe address — used to scope CreatorLoop's SQLite idempotency
@@ -94,9 +97,11 @@ export class Daemon {
     this.store = new Store(config.dbPath);
     this.adapter = config.adapter;
     this.apiPort = config.apiPort ?? parseInt(process.env['JINN_API_PORT'] ?? String(DEFAULT_API_PORT));
+    const intentSources = config.intentSources
+      ?? (config.desiredStates ? [new StaticConfiguredIntentSource(config.desiredStates)] : []);
     this.creatorLoop = new CreatorLoop(
       this.adapter,
-      config.intentSources ?? [],
+      intentSources,
       this.store,
       config.creatorSafeAddress,
     );

--- a/client/test/adapters/mech/adapter.test.ts
+++ b/client/test/adapters/mech/adapter.test.ts
@@ -300,12 +300,10 @@ describe('MechAdapter with JinnRouter', () => {
     await adapter.stop();
   });
 
-  it('skips adapter-side claimDelivery for same-operator deliveries (engine claims atomically)', async () => {
-    // When iDelivered=true, the restorer engine's deliverAndClaim path has
-    // already claimed via the same JinnRouter call, atomic with deliverToMarketplace.
-    // The adapter must NOT re-attempt the claim — that path is vestigial and
-    // surfaced as confusing log noise (already-claimed / RequestNotFound /
-    // ZERO_EVIDENCE) for our own deliveries before this fix.
+  it('idempotently ensures claimDelivery for same-operator creator deliveries', async () => {
+    // Engine deliveries usually claim atomically, but legacy/test adapter
+    // deliveries only write to the marketplace. The creator-side watcher must
+    // ensure the router claim before creating the evaluation job.
     const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
     const { claimDelivery, decodeDeliverLogs } = await import('../../../src/adapters/mech/contracts.js');
     const { fetchFromIpfs } = await import('../../../src/adapters/mech/ipfs.js');
@@ -321,14 +319,7 @@ describe('MechAdapter with JinnRouter', () => {
     }]);
     vi.mocked(fetchFromIpfs).mockResolvedValueOnce({ data: 'result' });
 
-    const mockStore = {
-      getLastProcessedBlock: () => null,
-      setLastProcessedBlock: vi.fn(),
-      getIntentEvidenceHash: vi.fn(),
-    };
-
-    const v2Config: MechAdapterConfig = { ...TEST_CONFIG, routerClaimDeliveryVariant: 'v2' };
-    const adapter = new MechAdapter(v2Config, mockStore as any);
+    const adapter = new MechAdapter(TEST_CONFIG);
     await adapter.initialize();
 
     (adapter as any).publicClient.getBlockNumber = vi.fn().mockResolvedValue(200n);
@@ -340,10 +331,15 @@ describe('MechAdapter with JinnRouter', () => {
     const gen = adapter.watchForDeliveries()[Symbol.asyncIterator]();
     await gen.next();
 
-    expect(claimDelivery).not.toHaveBeenCalled();
-    // Store lookup is gated on isCrossOperator now; same-operator path doesn't
-    // need the lookup either.
-    expect(mockStore.getIntentEvidenceHash).not.toHaveBeenCalled();
+    expect(claimDelivery).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      TEST_CONFIG.safeAddress,
+      TEST_CONFIG.routerAddress,
+      requestId,
+      { variant: 'v1', evidenceHash: undefined },
+      undefined,
+    );
 
     await adapter.stop();
   });

--- a/client/test/daemon/daemon.test.ts
+++ b/client/test/daemon/daemon.test.ts
@@ -49,4 +49,19 @@ describe('Daemon', () => {
     await daemon.stop();
     expect(daemon.getShutdownState()).toBe('clean');
   });
+
+  it('accepts legacy desiredStates when intentSources are omitted', async () => {
+    const config: DaemonConfig = {
+      adapter: new LocalAdapter(),
+      runner: new SimpleRunner(async (desc) => `Done: ${desc}`),
+      desiredStates: [{ id: 'legacy-static', description: 'legacy static intent' }],
+      dbPath: ':memory:',
+      restorationEngine: minimalEngineConfig(),
+    };
+
+    const daemon = new Daemon(config);
+    await daemon.start();
+    await daemon.stop();
+    expect(daemon.getShutdownState()).toBe('clean');
+  });
 });

--- a/client/test/e2e/validate.ts
+++ b/client/test/e2e/validate.ts
@@ -560,6 +560,45 @@ async function main(): Promise<void> {
 
   // API server for DAEMON_API_URL flow
   let restorerApiServer: import('../../src/api/server.js').ApiServer | undefined;
+  let e2eClaimRegistryAddress: Address | undefined;
+
+  async function deployClaimRegistryForE2e(): Promise<Address> {
+    if (e2eClaimRegistryAddress) return e2eClaimRegistryAddress;
+
+    const { createWalletClient: createWC } = await import('viem');
+    const { privateKeyToAccount } = await import('viem/accounts');
+    const { readFileSync: readFS, existsSync } = await import('node:fs');
+    const { join: joinPath } = await import('node:path');
+
+    const artifactPath = joinPath(__dirname, '..', '..', '..', 'contracts', 'artifacts', 'src', 'claiming', 'ClaimRegistry.sol', 'ClaimRegistry.json');
+    if (!existsSync(artifactPath)) {
+      throw new Error(`ClaimRegistry artifact not found (${artifactPath}); run contracts build before e2e`);
+    }
+    const artifact = JSON.parse(readFS(artifactPath, 'utf-8'));
+
+    const deployerKey = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80' as Hex;
+    const deployerAccount = privateKeyToAccount(deployerKey);
+    await anvilJsonRpc(ANVIL_RPC, 'anvil_setBalance', [deployerAccount.address, '0x56BC75E2D63100000']);
+    const deployerWallet = createWC({
+      account: deployerAccount,
+      chain: base,
+      transport: http(ANVIL_RPC),
+    });
+
+    const constructorArgs = encodeAbiParameters(
+      [{ type: 'uint256' }, { type: 'address' }],
+      [60n, deployerAccount.address],
+    );
+    const deployHash = await deployerWallet.sendTransaction({
+      data: (artifact.bytecode + constructorArgs.slice(2)) as Hex,
+      chain: base,
+    });
+    await anvilJsonRpc(ANVIL_RPC, 'evm_mine', []);
+    const deployReceipt = await publicClient.waitForTransactionReceipt({ hash: deployHash });
+    e2eClaimRegistryAddress = deployReceipt.contractAddress as Address;
+    console.log(`    E2E ClaimRegistry deployed at: ${e2eClaimRegistryAddress}`);
+    return e2eClaimRegistryAddress;
+  }
 
   try {
     // ── Phase 1: Infrastructure ──────────────────────────────────────────────
@@ -2117,7 +2156,9 @@ async function main(): Promise<void> {
         }
 
         const claimRegistryAddress = (
-          process.env['JINN_CLAIM_REGISTRY_ADDRESS'] ?? CHAIN_CONFIG.claimRegistry ?? ''
+          process.env['JINN_CLAIM_REGISTRY_ADDRESS']
+          || CHAIN_CONFIG.claimRegistry
+          || await deployClaimRegistryForE2e()
         ) as string;
         const claimDeps = claimRegistryAddress
           ? {
@@ -2146,7 +2187,7 @@ async function main(): Promise<void> {
             },
             claimDeps,
             packagingDeps: { ipfsRegistryUrl: 'https://registry.autonolas.tech' },
-            manifestDeps: {
+            envelopeDeps: {
               ipfsRegistryUrl: 'https://registry.autonolas.tech',
               agentEoaPrivateKey: agentEoaPrivateKey as `0x${string}`,
               safeAddress: safeAddress as `0x${string}`,

--- a/client/test/scripts/release-client.test.ts
+++ b/client/test/scripts/release-client.test.ts
@@ -172,9 +172,13 @@ describe('release-client runner', () => {
       .filter((call) => call.command === 'forge')
       .map((call) => call.args.join(' '));
     expect(forgeCalls).toEqual([
-      'install foundry-rs/forge-std --no-git',
       'test --match-contract Invariant',
     ]);
+    expect(calls.some((call) =>
+      call.command === 'node' &&
+      call.args.join(' ') === '../client/scripts/ensure-forge-std.mjs' &&
+      call.cwd?.endsWith('/contracts'),
+    )).toBe(true);
     expect(calls.some((call) =>
       call.command === 'yarn' &&
       call.args.join(' ') === 'test' &&


### PR DESCRIPTION
## Summary

This PR fixes the blockers found while preparing `@jinn-network/client` v0.1.3 for release.

- Ensure creator-side delivery watching idempotently calls `claimDelivery` before evaluation creation, covering legacy/test adapter deliveries that only wrote to the marketplace.
- Restore daemon e2e compatibility for static `desiredStates`, deploy a local Anvil `ClaimRegistry` when Base mainnet config has none, and update the e2e engine wiring from `manifestDeps` to `envelopeDeps`.
- Make the Foundry `forge-std` release dependency check idempotent with `client/scripts/ensure-forge-std.mjs`.

## Root Cause

The release prep gate exposed drift between older e2e wiring and the newer restoration-engine / intent-source interfaces. It also exposed a non-idempotent `forge install foundry-rs/forge-std --no-git` behavior on the current Foundry nightly when `contracts/lib/forge-std` already exists.

## Validation

- `yarn vitest run test/adapters/mech/adapter.test.ts`
- `yarn vitest run test/daemon/daemon.test.ts`
- `yarn vitest run test/scripts/release-client.test.ts`
- `yarn typecheck`
- `yarn e2e` — 29 passed, 0 failed
- `yarn release:client --prepare`

Release prep evidence report:

`client/release-runs/0.1.3-2026-04-30T14-14-42-341Z-fsnxmo/report.json`

Docker acceptance evidence:

`client/acceptance-runs/2026-04-30T14-18-58-536Z-sn5ytn`
