### PR TITLE
Fix npm publish workflow Foundry setup

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -34,6 +34,10 @@ jobs:
       - run: npm install -g npm@11.5.1
       - run: corepack enable
       - run: yarn install --immutable
+      # Keep the publish test environment aligned with CI. Some client unit
+      # tests spawn a local Anvil fork and fail with `spawn anvil ENOENT`
+      # unless Foundry is installed.
+      - uses: foundry-rs/foundry-toolchain@v1
 
       - name: Resolve publish metadata
         id: meta


### PR DESCRIPTION
## Summary
- install Foundry in the npm publish workflow before running `yarn test`
- align the publish workflow test environment with CI so Anvil-backed unit tests can spawn `anvil`

## Verification
- Parsed `.github/workflows/npm-publish.yml` with Ruby YAML loader

## Release context
The `client-v0.1.3` publish run failed in the npm workflow because `yarn test` could not find `anvil` (`spawn anvil ENOENT`).