### PR TITLE
docs: reconcile Phase 1b roadmap under Phase A umbrella

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Jinn Network monorepo. Phase 0 is complete (Base mainnet). Phase 1a (JINN token + DAO + distribution on testnet) is deployed and proven on Sepolia/Base Sepolia. Phase 1b (protocol hardening on testnet) is in progress — see `spec/2026-04-06-phase-1a-design.md` and `docs/superpowers/plans/2026-04-06-phase-1a-tokenomics.md`.
+Jinn Network monorepo. Phase 0 is complete (Base mainnet). Phase 1a (JINN token + DAO + distribution on testnet) is deployed and proven on Sepolia/Base Sepolia. Forward roadmap is the **Phase A umbrella** under the knowledge-market substrate framing — see `spec/2026-04-30-phase-a-umbrella.md`, `docs/superpowers/plans/2026-04-30-phase-a-umbrella-plan.md`, `log/decisions/2026-04-30-knowledge-market-vision-framing.md` (DR-2026-04-30), and GitHub Discussions [#59](https://github.com/Jinn-Network/mono/discussions/59) (substrate vision) + [#57](https://github.com/Jinn-Network/mono/discussions/57) (paired GTM). The original Phase 1b roadmap (`spec/2026-04-06-phase-1a-design.md` §9, `docs/superpowers/plans/2026-04-06-phase-1a-tokenomics.md`) is subsumed: anti-farming decay and ve-JINN are shipped, evidence-schema work executes through Phase A.1, the residual challenge mechanism is re-homed to Phase B.2.
 
 Jinn is a training protocol for agentic intents. It defines a loop (Creation → Execution → Evaluation → Knowledge) where intents are published with fees, participants attempt fulfillment, evaluators verify results, and knowledge accumulates to improve future attempts.
 
@@ -252,7 +252,9 @@ State persists to `~/.jinn-client/earning/earning_state.json`. Safe to interrupt
 
 - **Phase 0** (complete): Prove on OLAS ecosystem, single chain (Base), OLAS Mech Marketplace + JinnRouter, optimistic evidence, no JINN token
 - **Phase 1a** (complete): Fork OLAS contracts with minimal changes, deploy JINN token + Treasury + distribution on Sepolia/Base Sepolia, multisig governance, testnet iteration
-- **Phase 1b** (in progress): Protocol hardening on testnet — anti-farming decay, challenge mechanism, ve-JINN gauge voting, evidence schema, full client integration, extended testnet operation
+- **Phase A** (in progress): Knowledge-market substrate framing per DR-2026-04-30. A.1 operational loop (corpus library + gating leak fix + manifest hygiene + cache + MCP rewiring) shipped; A.2 plug-in surface, A.3 campaign infra, A.4 campaign-launch underway. See `spec/2026-04-30-phase-a-umbrella.md`. Subsumes the original Phase 1b roadmap; anti-farming decay + ve-JINN already shipped, residual challenge mechanism re-homed to Phase B.2.
+- **Phase B** (parallel after A.1): Trust infrastructure — B.1 verifiability tier activation, B.2 evaluator economics + signal-design (includes challenge mechanism)
+- **Phase C** (gated by community formation): Flagship marketplace API — the canonical app the team ships in-house
 - **Phase 2**: Mainnet launch — fair-launch JINN, multi-chain (Base, Arbitrum), ZK-requiring distribution contracts
 - **Phase 3**: Autonomous — full ve-JINN governance, USDC revenue exceeds JINN emissions
 

--- a/docs/superpowers/plans/2026-04-06-phase-1a-tokenomics.md
+++ b/docs/superpowers/plans/2026-04-06-phase-1a-tokenomics.md
@@ -1,5 +1,32 @@
 # Phase 1a: JINN Tokenomics Implementation Plan
 
+> **Status (2026-05-01): superseded for forward planning.** Phase 1a as
+> described shipped on Sepolia + Base Sepolia. The Phase 1b sections at
+> the tail of this plan (anti-farming decay, MechMarketplace + JinnRouterV2
+> + full daemon, "remaining Phase 1b work") are **subsumed by the Phase A
+> umbrella** under the knowledge-market substrate framing ratified in
+> DR-2026-04-30. Anti-farming decay, ve-JINN deployment, and full client
+> integration on testnet are already shipped; evidence-schema work is
+> executing through Phase A.1; the residual challenge mechanism is
+> re-homed to Phase B.2.
+>
+> **For current roadmap, read instead:**
+>
+> - `spec/2026-04-30-phase-a-umbrella.md` — Phase A.1 spec (the active
+>   operational frame)
+> - `docs/superpowers/plans/2026-04-30-phase-a-umbrella-plan.md` —
+>   implementation plan
+> - `log/decisions/2026-04-30-knowledge-market-vision-framing.md` —
+>   DR-2026-04-30 (six framing choices)
+> - GitHub Discussion [#59](https://github.com/Jinn-Network/mono/discussions/59)
+>   — *Jinn as the knowledge market — implementation roadmap proposal*
+> - GitHub Discussion [#57](https://github.com/Jinn-Network/mono/discussions/57)
+>   — *Unified GTM around the Prediction SolverNet* (paired GTM)
+>
+> The body of this plan is preserved unchanged as a historical record of
+> the Phase 1a tokenomics implementation and the Phase 1b additions made
+> through 2026-04-10.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Deploy a working JINN token → treasury → bridge → staking distribution flow on Sepolia + Base Sepolia by forking OLAS contracts with minimal modifications.

--- a/spec/2026-04-06-phase-1a-design.md
+++ b/spec/2026-04-06-phase-1a-design.md
@@ -4,6 +4,34 @@
 > Date: 2026-04-06
 > Author: Oak, Claude
 
+> **Status (2026-05-01): superseded for forward planning.** Phase 1a as
+> described here shipped on Sepolia + Base Sepolia. The Phase 1b roadmap
+> in §9 of this document is **subsumed by the Phase A umbrella** under
+> the knowledge-market substrate framing ratified in DR-2026-04-30.
+> Anti-farming decay, ve-JINN deployment, and full client integration on
+> testnet are already shipped; evidence-schema work is executing through
+> Phase A.1; the residual challenge mechanism is re-homed to Phase B.2.
+> No structural conflict — the kill criterion in DR-2026-04-30 §"Door
+> type and reversibility" does not trip.
+>
+> **For current roadmap, read instead:**
+>
+> - `spec/2026-04-30-phase-a-umbrella.md` — Phase A.1 spec (the active
+>   operational frame)
+> - `docs/superpowers/plans/2026-04-30-phase-a-umbrella-plan.md` —
+>   implementation plan
+> - `log/decisions/2026-04-30-knowledge-market-vision-framing.md` —
+>   DR-2026-04-30 (six framing choices)
+> - GitHub Discussion [#59](https://github.com/Jinn-Network/mono/discussions/59)
+>   — *Jinn as the knowledge market — implementation roadmap proposal*
+>   (substrate vision)
+> - GitHub Discussion [#57](https://github.com/Jinn-Network/mono/discussions/57)
+>   — *Unified GTM around the Prediction SolverNet* (paired GTM)
+>
+> The body of this document is preserved unchanged as a historical record
+> of the Phase 1a deployment and the Phase 1b transition plan as
+> originally framed.
+
 ## 1. Overview
 
 Phase 1a deploys the core JINN tokenomics stack on testnet (Sepolia + Base Sepolia) by forking OLAS contracts with minimal or zero modifications. The goal is a working token → treasury → bridge → distribution flow that can be stood up, torn down, and redeployed cheaply until it feels solid.


### PR DESCRIPTION
## Summary

Reconciles the Phase 1b roadmap (per `spec/2026-04-06-phase-1a-design.md` §9 and CLAUDE.md) against the Phase A umbrella ratified in DR-2026-04-30. **No structural conflict** — the kill criterion in DR-2026-04-30 §"Door type and reversibility" #6 does not trip. Phase 1b items are either already shipped, executing through Phase A.1, or re-homed to Phase B.2.

| Phase 1b item | Status | Where it lives now |
|---|---|---|
| Anti-farming LSH decay | shipped | `RestorationActivityCheckerV2` on Base Sepolia (2026-04-09) |
| ve-JINN gauge voting | shipped | veOLAS + VoteWeighting deployed; `bd jinn-mono-g9j4` is the e2e-exercise follow-up |
| Evidence schema | in flight | Phase A.1 §5–6 (gating leak fix + manifest hygiene) — `jinn-mono-vy37.1` shipped 2026-04-30 |
| Full client integration | in flight | Phase A.1 corpus library + MCP rewiring shipped |
| Extended testnet operation | reframed | Phase A.3 (Polymarket-derived intents) + A.4 (campaign launch) |
| Challenge mechanism | re-homed | Phase B.2 (evaluator economics + signal-design) |

Light-touch reconciliation per Captain direction: header notes on the two old roadmap docs pointing at the Phase A spec/plan/DR + Discussions [#57](https://github.com/Jinn-Network/mono/discussions/57) / [#59](https://github.com/Jinn-Network/mono/discussions/59); body of each preserved verbatim as historical record.

## Changes

- `spec/2026-04-06-phase-1a-design.md` — header "subsumed by" note
- `docs/superpowers/plans/2026-04-06-phase-1a-tokenomics.md` — same note
- `CLAUDE.md` — Project Overview now leads with the Phase A umbrella + DR-2026-04-30; Phased Rollout list replaces "Phase 1b (in progress)" with Phase A/B/C entries

## References

- DR-2026-04-30: `log/decisions/2026-04-30-knowledge-market-vision-framing.md`
- Phase A umbrella spec: `spec/2026-04-30-phase-a-umbrella.md`
- Phase A umbrella plan: `docs/superpowers/plans/2026-04-30-phase-a-umbrella-plan.md`
- Discussion #59 (substrate vision) — paired with #57 (GTM)

## Test plan

- [ ] Skim the three diffs to confirm tone is informational ("subsumed by", not "deprecated") and that no body content was mutated
- [ ] Confirm the new CLAUDE.md Project Overview reads as a stable steady-state framing, not a transitional one
- [ ] Optional: spot-check one of the new file references resolves (e.g. `spec/2026-04-30-phase-a-umbrella.md` exists in this branch)

Closes jinn-mono-9a4d.