### PR TITLE
growth-day auto-invokes stale feed routines + freshness stamps

### DIFF
--- a/.claude/skills/cluster-model/SKILL.md
+++ b/.claude/skills/cluster-model/SKILL.md
@@ -66,10 +66,10 @@ If a search returns mostly noise after the filter, refine the vocabulary for nex
 Each cluster's §1 entry has three sub-sections:
 
 - **Frame (current):** one-paragraph synthesis of how the cluster is thinking *as of this refresh*. Replace the prior frame *only* if today's evidence shifts it; otherwise keep the prior frame and add a one-line dated note (`2026-MM-DD: no frame shift; N new evidence points added`).
-- **Evidence (cumulative, dated):** append today's verbatim quotes with handle, date, URL. Do not delete prior evidence — the historical record is the dynamic model. Group by date so a reader can see the cluster's drift over weeks.
+- **Evidence (cumulative, dated):** append today's evidence under a new `Sampled this run: YYYY-MM-DD — N handles via "<vocab>" search; M passed §7 filter` sub-heading, then list verbatim quotes with handle, date, URL beneath. Do not delete prior `Sampled this run:` blocks — the historical record is the dynamic model. The literal `Sampled this run: YYYY-MM-DD` prefix lets `growth-day` Step 0 detect freshness with a simple grep.
 - **Gap to Jinn (current + drift log):** the current synthesis of where the cluster sits relative to the THESIS frame, plus a dated change-log when the gap shifts (`2026-MM-DD: gap refined from X to Y because [evidence]`).
 
-If a cluster genuinely produced no new evidence (e.g., search returned no usable handles after the filter), say so explicitly: `2026-MM-DD: refresh attempted; 0 new evidence (filter rejected all)` — that itself is data.
+If a cluster genuinely produced no new evidence (e.g., search returned no usable handles after the filter), still write the `Sampled this run: YYYY-MM-DD` heading with `0 new evidence (filter rejected all)` underneath — that itself is data, and it keeps the freshness stamp current.
 
 ### Step 4 — Identify bridge angles
 

--- a/.claude/skills/growth-day/SKILL.md
+++ b/.claude/skills/growth-day/SKILL.md
@@ -32,6 +32,22 @@ The skill does not act on Oak's behalf. Oak picks the actions. The skill writes 
 
 Note: Oak's posting handle is `@tannedoaksprout`. The display handle `@oaksprout` is canonical-display only and is not the live X account. Use `@tannedoaksprout` for all bird CLI calls.
 
+### Step 0 — Freshness check + auto-invoke stale feeds
+
+On weekday mornings, this skill ensures the three feed routines are fresh before producing the brief. Skip Step 0 entirely on weekends, or when Oak's invocation prompt includes a `skip feeds` instruction (e.g. running growth-day in the afternoon to refresh the brief without re-pulling everything).
+
+Check each feed in this order; invoke via the Skill tool only if stale.
+
+1. **`cluster-model` (weekly).** Read `growth/.local/growth-log.md` §1 and find the most recent `Sampled this run: YYYY-MM-DD` date across all three clusters. If that date is more than 7 days ago, invoke the `cluster-model` skill and wait for it to finish before continuing. Otherwise skip.
+
+2. **`twitter-strategy` (weekly).** Check whether `growth/.local/twitter-strategy-last-run.md` exists with a timestamp within the last 7 days. If missing or stale, invoke the `twitter-strategy` skill and wait. Otherwise skip.
+
+3. **`growth-watcher` (daily on weekdays).** Check whether `growth/.local/watcher-YYYY-MM-DD.md` exists for today's UTC date. If missing and today is Mon–Fri, invoke the `growth-watcher` skill and wait. Otherwise skip.
+
+Order matters: `cluster-model` first because its output (§1 cluster snapshot) feeds `growth-watcher`'s "cluster signals" detection. `twitter-strategy` second because its drift flags feed Step 4 below. `growth-watcher` last because its output is the most time-sensitive and should reflect the freshest cluster snapshot.
+
+If a feed invocation fails (network, bird auth, rate limit), continue to Step 1 with whatever state exists, and surface the failure in the HEADS-UP section of the output: `[<feed> failed to refresh — using stale data from YYYY-MM-DD]`. Do not retry automatically.
+
 ### Step 1 — Read state
 
 Read in order:
@@ -131,11 +147,12 @@ WRITTEN TO: growth/.local/growth-log.md §5
 - **Inputs:** canonical docs, growth-log, warm-contacts CSV, today's watcher file, latest twitter-strategy output (if recent).
 - **Outputs:** chat brief, updated growth-log §5.
 - **Consumes:** `growth-watcher` outputs, `cluster-model` outputs, `twitter-strategy` outputs.
-- **Does not auto-invoke:** other skills. Oak invokes them on-demand based on the brief's recommendations.
+- **Auto-invokes stale feed routines** in Step 0: `cluster-model`, `growth-watcher`, `twitter-strategy`. Action routines (`x-post-builder`, `discover-twitter-recruits`) remain Oak-driven from the brief's recommendations.
 
 ## What this skill does not do
 
-- Run the routines (`cluster-model`, `growth-watcher`, `twitter-strategy`, `discover-twitter-recruits`). Oak runs those separately.
+- Run *action* routines (`x-post-builder`, `discover-twitter-recruits`). Those have side-effects in the world (publish posts, change recruit lists) and require Oak's explicit invocation from the brief.
+- *Feed* routines (`cluster-model`, `growth-watcher`, `twitter-strategy`) are auto-invoked in Step 0 when stale. They are read-only refreshes of the data plane.
 - Draft reply text or posts. (That is `x-post-builder`.)
 - Score posts. (That is `x-algorithm-grader`.)
 - Make recruitment decisions. (Oak picks the actions; this skill ranks options.)
@@ -146,3 +163,5 @@ WRITTEN TO: growth/.local/growth-log.md §5
 - **Growth-log §5 missing yesterday's plan.** Mark each loop bucket `[no plan]` and skip the compliance check. Still propose today's top-3.
 - **Warm-contacts CSV missing.** Note: `[warm contacts not available — direct-offer compliance unchecked]`. Continue with what's readable.
 - **No active threads in §3.** Note: `[no active threads — propose discovery round]` and surface a `discover-twitter-recruits` invocation as a Tier B action.
+- **Feed routine fails mid-run** (Step 0). Continue with whatever stale state exists. Surface in HEADS-UP as `[<feed> failed: <one-line cause>]`. Do not retry automatically.
+- **Skip-feeds override.** If Oak's invocation prompt contains "skip feeds" or "feeds already fresh", skip Step 0 entirely and proceed to Step 1.

--- a/.claude/skills/twitter-strategy/SKILL.md
+++ b/.claude/skills/twitter-strategy/SKILL.md
@@ -76,9 +76,23 @@ Flag drift in either direction:
 
 ### Step 6 — Output
 
-Print the structured review (format below) inline in chat. Do not write to disk — this skill is a lens, not a state file.
+Print the structured review (format below) inline in chat. Do not write the review itself to disk — this skill is a lens, not a state file. The freshness stamp in Step 7 is the only persisted artefact.
 
 If `growth-day` invokes this skill, the review feeds the day's drift flag.
+
+### Step 7 — Write the freshness stamp
+
+After printing the review, write a freshness stamp to `growth/.local/twitter-strategy-last-run.md`. Overwrite each run; do not append. Format:
+
+```
+# Twitter strategy — last run
+
+YYYY-MM-DDTHH:MM:SSZ
+Window: 7d / 30d
+Drift flags: N
+```
+
+This file is read by `growth-day` Step 0 to detect freshness without re-running the lens.
 
 ## Output format
 


### PR DESCRIPTION
## Summary

Follow-up to #70. The `growth-day` orchestrator previously had a deliberate "does not auto-invoke other skills" rule. In practice that forces Oak to chain four skills manually each morning. The corrected boundary is **feeds-yes / actions-no**:

- **Feeds** (`cluster-model`, `growth-watcher`, `twitter-strategy`) auto-fire from `growth-day` Step 0 when stale.
- **Actions** (`x-post-builder`, `discover-twitter-recruits`) stay manual because they have side-effects in the world (publish posts, change recruit lists).

This solves the scheduling blocker in #70 (remote sandbox has no bird CLI / X cookies) without needing a scheduler at all — feeds run in Oak's local session with his auth, when he runs `growth-day` at the start of his deep block.

## Changes

- **`growth-day` SKILL.md**: new Step 0 (freshness check + auto-invoke order: cluster-model → twitter-strategy → growth-watcher); updated Composition + "What this skill does not do" + Failure modes (feed-fail-mid-run, skip-feeds override).
- **`twitter-strategy` SKILL.md**: new Step 7 writes `growth/.local/twitter-strategy-last-run.md` so `growth-day` can detect freshness without re-running the lens. Closes follow-up I-2 from #70.
- **`cluster-model` SKILL.md**: Step 3 evidence sub-section now opens with a literal `Sampled this run: YYYY-MM-DD — N handles via "<vocab>" search; M passed §7 filter` heading, making the freshness date grep-stable for `growth-day` Step 0 without needing a separate stamp file.

## Plan

`/Users/gcd/.claude/plans/what-i-would-suggest-ticklish-cat.md` (local, not in repo). Full design rationale, files to modify, verification steps. Approved before implementation.

## Test plan

- [ ] From a fresh Claude Code session, invoke `growth-day` (trigger phrase *"growth day"* or *"morning growth standup"*).
- [ ] Verify Step 0 fires when stale: detects today's watcher-file missing → invokes `growth-watcher`; detects no `Sampled this run:` ≤7 days old in §1 → invokes `cluster-model`; detects no `twitter-strategy-last-run.md` ≤7 days old → invokes `twitter-strategy`.
- [ ] Re-invoke `growth-day` immediately afterwards — Step 0 should detect all three feeds fresh, skip invocations, jump straight to Step 1.
- [ ] Run with prompt *"growth day skip feeds"* — Step 0 should honour the override.
- [ ] Force a feed failure (e.g. simulate `bird` auth issue) — `growth-day` continues, surfaces the failure in HEADS-UP, doesn't crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)