### PR TITLE
[codex] Deliver Prediction SolverNet task lifecycle phase

### DIFF
--- a/client/deployments/deployment-task-coordinator-router-v3-baseSepolia-fast.json
+++ b/client/deployments/deployment-task-coordinator-router-v3-baseSepolia-fast.json
@@ -1,0 +1,38 @@
+{
+  "network": "baseSepolia",
+  "chainId": 84532,
+  "deployer": "0x15e78734481bD31F6e183dad05225505a45ACd07",
+  "owner": "0x15e78734481bD31F6e183dad05225505a45ACd07",
+  "deployedAt": "2026-05-02T12:27:26.420Z",
+  "config": {
+    "timingProfile": "fast-test",
+    "mechMarketplaceSource": "deployment-phase1b-mech-baseSepolia-fast.json",
+    "activityCheckerSource": "deployment-phase1b-router-checker-baseSepolia-fast.json",
+    "coordinatorInitialOwner": "0x15e78734481bD31F6e183dad05225505a45ACd07"
+  },
+  "contracts": {
+    "taskCoordinatorImpl": "0x830bFdBdA48D599e414c51888c8CDA6c84e67B18",
+    "taskCoordinator": "0x9ce736d3CB367cC5Db538B7962bdf416EbD7451B",
+    "jinnRouterV3Impl": "0x5f3E1e26Fd26b7A6BE4171976e555d62Bd3dcFC0",
+    "jinnRouterV3": "0xdC9BCcEB7aca21Ad4Ca2Fc5B4d7aea6b4F6CedD9",
+    "mechMarketplace": "0xD3233FdAaB51E9775f6bFCE8242B02C181D7c0e7",
+    "activityChecker": "0x0e1B5f264F4FAdcFAA950fb00c58d9A39C040f70",
+    "activityCheckerImpl": "0x9e573CFbbc52729528199005A9F3d274FE7052C4"
+  },
+  "upgrades": [
+    {
+      "upgradedAt": "2026-05-02T12:27:26.420Z",
+      "deployer": "0x15e78734481bD31F6e183dad05225505a45ACd07",
+      "previous": {
+        "taskCoordinatorImpl": "0x9707fC9681B0da32A0D4256f76f51654FCdD7125",
+        "jinnRouterV3Impl": "0x947291377b33F7F560df093a812A22128063efE1",
+        "activityCheckerImpl": null
+      },
+      "current": {
+        "taskCoordinatorImpl": "0x830bFdBdA48D599e414c51888c8CDA6c84e67B18",
+        "jinnRouterV3Impl": "0x5f3E1e26Fd26b7A6BE4171976e555d62Bd3dcFC0",
+        "activityCheckerImpl": "0x9e573CFbbc52729528199005A9F3d274FE7052C4"
+      }
+    }
+  ]
+}

--- a/client/plugins/jinn-prediction-plugin/.claude-plugin/plugin.json
+++ b/client/plugins/jinn-prediction-plugin/.claude-plugin/plugin.json
@@ -11,6 +11,8 @@
   },
   "skills": [
     "skills/base-rate-forecasting/SKILL.md",
-    "skills/calibration/SKILL.md"
+    "skills/calibration/SKILL.md",
+    "skills/common-biases/SKILL.md",
+    "skills/polymarket-task-handling/SKILL.md"
   ]
 }

--- a/client/plugins/jinn-prediction-plugin/GEMINI.md
+++ b/client/plugins/jinn-prediction-plugin/GEMINI.md
@@ -1,3 +1,5 @@
 # Jinn Prediction Reference Pack
 
 Use the Polymarket tools only to inspect the market and orderbook named by the current Task. Submit probabilities only. Do not trade, sign orders, or ask for wallet credentials.
+
+Before forecasting, check base rates, calibration, common forecasting biases, and the exact Polymarket resolution rules for the task market.

--- a/client/plugins/jinn-prediction-plugin/jinn.plugin.json
+++ b/client/plugins/jinn-prediction-plugin/jinn.plugin.json
@@ -17,7 +17,9 @@
     },
     "skills": [
       "skills/base-rate-forecasting/SKILL.md",
-      "skills/calibration/SKILL.md"
+      "skills/calibration/SKILL.md",
+      "skills/common-biases/SKILL.md",
+      "skills/polymarket-task-handling/SKILL.md"
     ]
   }
 }

--- a/client/plugins/jinn-prediction-plugin/mcp/polymarket-server.mjs
+++ b/client/plugins/jinn-prediction-plugin/mcp/polymarket-server.mjs
@@ -1,2 +1,322 @@
 #!/usr/bin/env node
-process.stdin.resume();
+import { pathToFileURL } from 'node:url';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+
+const DEFAULT_GAMMA_BASE_URL = 'https://gamma-api.polymarket.com';
+const DEFAULT_CLOB_BASE_URL = 'https://clob.polymarket.com';
+
+const MarketArgsShape = {
+  marketId: z.string().min(1).optional().describe('Exact Polymarket market id from the current prediction task.'),
+  slug: z.string().min(1).optional().describe('Exact Polymarket market slug from the current prediction task URL.'),
+  conditionId: z.string().min(1).optional().describe('Expected condition id from the current prediction task, used only to verify the returned market.'),
+};
+
+const OrderbookArgsShape = {
+  marketId: z.string().min(1).describe('Exact Polymarket market id from the current prediction task.'),
+  conditionId: z.string().min(1).describe('Exact condition id from the current prediction task.'),
+  yesTokenId: z.string().min(1).describe('YES outcome CLOB token id from the current prediction task.'),
+};
+
+const MarketArgsSchema = z.object(MarketArgsShape).strict().refine((args) => args.marketId || args.slug, {
+  message: 'marketId or slug is required',
+});
+
+const OrderbookArgsSchema = z.object(OrderbookArgsShape).strict();
+
+export function listToolDeclarations() {
+  return [
+    {
+      name: 'polymarket_get_market',
+      description:
+        'Read one exact Polymarket binary market named by the current prediction task. Requires marketId or slug and never performs broad market search.',
+      inputSchema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          marketId: { type: 'string', description: 'Exact Polymarket market id from the current prediction task.' },
+          slug: { type: 'string', description: 'Exact Polymarket market slug from the current prediction task URL.' },
+          conditionId: { type: 'string', description: 'Expected task condition id for verification.' },
+        },
+      },
+    },
+    {
+      name: 'polymarket_get_orderbook',
+      description:
+        'Read the YES orderbook for the exact market/condition/token identifiers in the current prediction task. Read-only CLOB market data only.',
+      inputSchema: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['marketId', 'conditionId', 'yesTokenId'],
+        properties: {
+          marketId: { type: 'string', description: 'Exact Polymarket market id from the current prediction task.' },
+          conditionId: { type: 'string', description: 'Exact condition id from the current prediction task.' },
+          yesTokenId: { type: 'string', description: 'YES outcome CLOB token id from the current prediction task.' },
+        },
+      },
+    },
+  ];
+}
+
+function configWithDefaults(config = {}) {
+  return {
+    gammaBaseUrl: config.gammaBaseUrl ?? process.env.POLYMARKET_GAMMA_BASE_URL ?? DEFAULT_GAMMA_BASE_URL,
+    clobBaseUrl: config.clobBaseUrl ?? process.env.POLYMARKET_CLOB_BASE_URL ?? DEFAULT_CLOB_BASE_URL,
+    fetchImpl: config.fetchImpl ?? fetch,
+  };
+}
+
+function apiUrl(baseUrl, path, params = {}) {
+  const url = new URL(path, baseUrl);
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) url.searchParams.set(key, String(value));
+  }
+  return url.toString();
+}
+
+async function readJson(url, fetchImpl) {
+  const response = await fetchImpl(url, { method: 'GET' });
+  if (!response.ok) {
+    throw new Error(`Polymarket request failed ${response.status}: ${url}`);
+  }
+  return response.json();
+}
+
+function asRecord(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function firstString(record, keys) {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+    if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  }
+  return undefined;
+}
+
+function firstBoolean(record, keys, fallback = false) {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'boolean') return value;
+    if (typeof value === 'string') {
+      if (value.toLowerCase() === 'true') return true;
+      if (value.toLowerCase() === 'false') return false;
+    }
+  }
+  return fallback;
+}
+
+function parseStringArray(value) {
+  if (Array.isArray(value)) return value.map(String);
+  if (typeof value !== 'string') return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.map(String) : [];
+  } catch {
+    return value.split(',').map((part) => part.trim()).filter(Boolean);
+  }
+}
+
+function normalizeOutcome(value) {
+  return value.trim().toUpperCase();
+}
+
+function decimalString(value, fallback = '0') {
+  if (typeof value === 'number' && Number.isFinite(value)) return value.toFixed(2);
+  if (typeof value === 'string' && value.trim()) return value.trim();
+  return fallback;
+}
+
+function buildMarketUrl(slug) {
+  return slug ? `https://polymarket.com/event/${slug}` : 'https://polymarket.com';
+}
+
+function rulesTextOf(record) {
+  return firstString(record, [
+    'rules',
+    'resolutionRules',
+    'resolution_rules',
+    'description',
+    'question',
+  ]) ?? '';
+}
+
+function endTimeOf(record) {
+  return firstString(record, ['endDateIso', 'endDate', 'end_date', 'endTime', 'end_time']) ?? '';
+}
+
+function tokenIdsFor(record, outcomes) {
+  const ids = parseStringArray(record.clobTokenIds ?? record.clob_token_ids ?? record.tokenIds);
+  if (ids.length < 2) return null;
+  const yesIndex = outcomes.findIndex((outcome) => normalizeOutcome(outcome) === 'YES');
+  const noIndex = outcomes.findIndex((outcome) => normalizeOutcome(outcome) === 'NO');
+  if (yesIndex < 0 || noIndex < 0) return null;
+  const yes = ids[yesIndex];
+  const no = ids[noIndex];
+  return yes && no ? { yes, no } : null;
+}
+
+export function normalizeMarketCandidate(raw) {
+  const record = asRecord(raw);
+  const marketId = firstString(record, ['id', 'marketId', 'market_id']);
+  const conditionId = firstString(record, ['conditionId', 'condition_id']);
+  const slug = firstString(record, ['slug', 'marketSlug', 'eventSlug']) ?? '';
+  const question = firstString(record, ['question', 'title']) ?? '';
+  const outcomes = parseStringArray(record.outcomes).map(normalizeOutcome);
+  const binary = outcomes.length === 2 && outcomes.includes('YES') && outcomes.includes('NO');
+  const tokenIds = binary ? tokenIdsFor(record, outcomes) : null;
+  const endTime = endTimeOf(record);
+
+  if (!marketId || !conditionId || !question || !binary || !tokenIds || !endTime) {
+    return null;
+  }
+
+  const description = firstString(record, ['description']);
+  return {
+    venue: 'polymarket',
+    marketId,
+    conditionId,
+    slug,
+    url: firstString(record, ['url']) ?? buildMarketUrl(slug),
+    question,
+    ...(description ? { description } : {}),
+    rulesText: rulesTextOf(record),
+    endTime,
+    active: firstBoolean(record, ['active'], true),
+    closed: firstBoolean(record, ['closed'], false),
+    archived: firstBoolean(record, ['archived'], false),
+    outcomes: ['YES', 'NO'],
+    tokenIds,
+    liquidityUsd: decimalString(record.liquidity ?? record.liquidityNum ?? record.liquidity_usd),
+    volume24hUsd: decimalString(record.volume24hr ?? record.volume24h ?? record.volume24hUsd ?? record.volume_24h),
+  };
+}
+
+export async function getMarket(args, config = {}) {
+  const parsed = MarketArgsSchema.parse(args);
+  const { gammaBaseUrl, fetchImpl } = configWithDefaults(config);
+  const raw = parsed.marketId
+    ? await readJson(apiUrl(gammaBaseUrl, `/markets/${encodeURIComponent(parsed.marketId)}`), fetchImpl)
+    : await readJson(apiUrl(gammaBaseUrl, `/markets/slug/${encodeURIComponent(parsed.slug)}`), fetchImpl);
+
+  const market = normalizeMarketCandidate(raw);
+  if (!market) throw new Error('Polymarket market response is not an eligible binary market');
+  if (parsed.conditionId && market.conditionId !== parsed.conditionId) {
+    throw new Error(`Polymarket conditionId mismatch: expected ${parsed.conditionId}, got ${market.conditionId}`);
+  }
+  return market;
+}
+
+function timestampToIso(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return new Date(value > 10_000_000_000 ? value : value * 1000).toISOString();
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return timestampToIso(numeric);
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return new Date(parsed).toISOString();
+  }
+  return new Date().toISOString();
+}
+
+function bestBidAsk(book) {
+  const bids = Array.isArray(book.bids) ? book.bids : [];
+  const asks = Array.isArray(book.asks) ? book.asks : [];
+  const bid = Math.max(...bids.map((row) => Number(asRecord(row).price)).filter(Number.isFinite));
+  const ask = Math.min(...asks.map((row) => Number(asRecord(row).price)).filter(Number.isFinite));
+  if (!Number.isFinite(bid) || !Number.isFinite(ask)) return null;
+  return { bid, ask };
+}
+
+function probability(value) {
+  return Math.max(0, Math.min(1, value)).toFixed(4);
+}
+
+export async function getOrderbook(args, config = {}) {
+  const parsed = OrderbookArgsSchema.parse(args);
+  const { clobBaseUrl, fetchImpl } = configWithDefaults(config);
+  const raw = await readJson(apiUrl(clobBaseUrl, '/book', { token_id: parsed.yesTokenId }), fetchImpl);
+  const book = asRecord(raw);
+  const best = bestBidAsk(book);
+  if (!best) {
+    throw new Error(`Polymarket orderbook has no usable YES bid/ask for token ${parsed.yesTokenId}`);
+  }
+  const midpoint = (best.bid + best.ask) / 2;
+  return {
+    venue: 'polymarket',
+    marketId: parsed.marketId,
+    conditionId: parsed.conditionId,
+    sampledAt: timestampToIso(book.timestamp),
+    bestBidYes: probability(best.bid),
+    bestAskYes: probability(best.ask),
+    midpointYes: probability(midpoint),
+    spread: probability(best.ask - best.bid),
+    source: 'polymarket-clob',
+  };
+}
+
+function ok(data) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(data, null, 2) }],
+  };
+}
+
+function toolErr(code, message) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify({ error: true, code, message }) }],
+    isError: true,
+  };
+}
+
+export function createPolymarketServer(config = {}) {
+  const server = new McpServer({ name: 'jinn-prediction-polymarket', version: '0.2.0' });
+  const registerTool = server.tool.bind(server);
+
+  registerTool(
+    'polymarket_get_market',
+    listToolDeclarations()[0].description,
+    MarketArgsShape,
+    async (args) => {
+      try {
+        return ok(await getMarket(args, config));
+      } catch (err) {
+        return toolErr('POLYMARKET_MARKET_READ_FAILED', err instanceof Error ? err.message : String(err));
+      }
+    },
+  );
+
+  registerTool(
+    'polymarket_get_orderbook',
+    listToolDeclarations()[1].description,
+    OrderbookArgsShape,
+    async (args) => {
+      try {
+        return ok(await getOrderbook(args, config));
+      } catch (err) {
+        return toolErr('POLYMARKET_ORDERBOOK_READ_FAILED', err instanceof Error ? err.message : String(err));
+      }
+    },
+  );
+
+  return server;
+}
+
+export async function startMcpServer(config = {}) {
+  const server = createPolymarketServer(config);
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  await new Promise((resolve) => {
+    process.stdin.on('close', resolve);
+    process.stdin.on('end', resolve);
+  });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  startMcpServer().catch((err) => {
+    console.error(err instanceof Error ? err.stack ?? err.message : String(err));
+    process.exit(1);
+  });
+}

--- a/client/plugins/jinn-prediction-plugin/skills/common-biases/SKILL.md
+++ b/client/plugins/jinn-prediction-plugin/skills/common-biases/SKILL.md
@@ -1,0 +1,3 @@
+# Common Forecasting Biases
+
+Check for recency bias, availability bias, anchoring on the market price, motivated reasoning, and overreaction to thin evidence. Name the adjustment only when it changes the final probability.

--- a/client/plugins/jinn-prediction-plugin/skills/polymarket-task-handling/SKILL.md
+++ b/client/plugins/jinn-prediction-plugin/skills/polymarket-task-handling/SKILL.md
@@ -1,0 +1,5 @@
+# Polymarket Task Handling
+
+Use only the market and orderbook identifiers in the current prediction task. Verify the question text, resolution rules, expected close time, spread, and liquidity before adjusting from the consensus snapshot.
+
+Do not search for unrelated markets, infer from ticker-like names alone, trade, sign orders, use wallet credentials, or post externally. The Polymarket MCP tools are read-only references for task-scoped market data.

--- a/client/src/cli/commands/doctor.ts
+++ b/client/src/cli/commands/doctor.ts
@@ -28,6 +28,10 @@ import {
   rpcNetworkFailureHint as defaultRpcNetworkFailureHint,
 } from '../../preflight/rpc-network.js';
 import { SOLVER_TYPES } from '../../solver-types/index.js';
+import {
+  resolveTaskNativeReadiness as defaultResolveTaskNativeReadiness,
+  type TaskNativeReadiness,
+} from '../task-native-readiness.js';
 
 export interface DoctorDeps extends BaseCommandDeps {
   checkClaudeBinary: typeof defaultCheckClaudeBinary;
@@ -40,6 +44,8 @@ export interface DoctorDeps extends BaseCommandDeps {
   detectAuthContext: typeof defaultDetectAuthContext;
   /** Probes claude auth status via subprocess; tests inject a fake to avoid spawning claude. */
   probeClaudeAuth: typeof defaultProbeClaudeAuth;
+  /** Local-only Task-native deployment/config readiness check. */
+  resolveTaskNativeReadiness?: (config: JinnConfig) => TaskNativeReadiness;
 }
 
 const PRODUCTION_DEPS: DoctorDeps = {
@@ -67,6 +73,18 @@ interface CheckResult {
     network: 'mainnet' | 'testnet';
     expectedChainId: number;
     actualChainId: number;
+  };
+  taskNative?: {
+    solverReady: boolean;
+    evaluatorReady: boolean;
+    source: string | null;
+    contracts: {
+      taskCoordinator?: string;
+      jinnRouterV3?: string;
+      taskActivityCheckerV3?: string;
+    };
+    routerClaimDeliveryVersion?: 'v1' | 'v2' | 'v3';
+    operatorState?: TaskNativeReadiness['operatorState'];
   };
 }
 
@@ -129,6 +147,25 @@ async function checkDeploymentLoaded(config: JinnConfig): Promise<CheckResult> {
       remedy: 'Verify deployment-related settings in your configuration file.',
     };
   }
+}
+
+function taskNativeCheckForDoctor(readiness: TaskNativeReadiness): CheckResult {
+  return {
+    name: 'task_native_deployment',
+    ok: readiness.ok,
+    detail: readiness.detail,
+    ...(readiness.remedy ? { remedy: readiness.remedy } : {}),
+    taskNative: {
+      solverReady: readiness.solverReady,
+      evaluatorReady: readiness.evaluatorReady,
+      source: readiness.source,
+      contracts: readiness.contracts,
+      ...(readiness.routerClaimDeliveryVersion
+        ? { routerClaimDeliveryVersion: readiness.routerClaimDeliveryVersion }
+        : {}),
+      ...(readiness.operatorState ? { operatorState: readiness.operatorState } : {}),
+    },
+  };
 }
 
 function claudeBinaryCheckForDoctor(claudePath: string, result: ClaudeBinaryCheckResult): CheckResult {
@@ -295,6 +332,7 @@ configuration:
   - claude_auth                 Claude CLI authenticated
   - keystore_present            mnemonic keystore in configured earning directory (optional)
   - deployment_loaded           testnet/mainnet contract addresses resolved
+  - task_native_deployment      TaskCoordinator/JinnRouterV3/TaskActivityCheckerV3 local readiness
   - portfolio_impl_state_dir    HL impl state directory present and readable
   - hl_api_wallet               HL API wallet generated and approved by operator
 
@@ -340,6 +378,7 @@ Examples:
       checks.push(checkKeystorePresent(config.earningDir));
       checks.push(await checkRpcNetworkForDoctor(config));
       checks.push(await checkDeploymentLoaded(config));
+      checks.push(taskNativeCheckForDoctor((deps.resolveTaskNativeReadiness ?? defaultResolveTaskNativeReadiness)(config)));
       checks.push(checkDaemonRuntimeReady());
 
       const distributorCheck = await deps.checkDistributorReachable(config);

--- a/client/src/cli/commands/status.ts
+++ b/client/src/cli/commands/status.ts
@@ -6,17 +6,28 @@ import { gatherIntrospectionRaw as defaultGatherIntrospectionRaw } from '../intr
 import { assembleStatusRollupV1 as defaultAssembleStatusRollupV1 } from '../../api/status-rollup-build.js';
 import type { StatusRollupV1Response, StatusDetailV1 } from '../../api/status-rollup-build.js';
 import { loadConfig, getConfigPathFromArgs, buildConfigProvenance, type ConfigProvenance } from '../../config.js';
+import type { JinnConfig } from '../../config.js';
+import {
+  resolveTaskNativeReadiness,
+  type TaskNativeReadiness,
+} from '../task-native-readiness.js';
 
 export interface StatusDeps {
   gatherIntrospectionRaw: typeof defaultGatherIntrospectionRaw;
   assembleStatusRollupV1: typeof defaultAssembleStatusRollupV1;
   loadConfig?: typeof loadConfig;
   getConfigPathFromArgs?: typeof getConfigPathFromArgs;
+  resolveTaskNativeReadiness?: (config: JinnConfig) => TaskNativeReadiness;
 }
 
 const PRODUCTION_DEPS: StatusDeps = {
   gatherIntrospectionRaw: defaultGatherIntrospectionRaw,
   assembleStatusRollupV1: defaultAssembleStatusRollupV1,
+};
+
+type StatusPayload = StatusRollupV1Response & {
+  config?: ConfigProvenance;
+  taskNative?: TaskNativeReadiness;
 };
 
 function humanDetail(d: StatusDetailV1): string {
@@ -49,13 +60,16 @@ function humanDetail(d: StatusDetailV1): string {
   return lines.join('\n');
 }
 
-function humanStatus(v: StatusRollupV1Response): string {
+function humanStatus(v: StatusPayload): string {
   const health = v.exit.blocking ? `degraded: ${v.exit.hint ?? 'attention needed'}` : 'healthy';
   const parts = [
     `daemon=${v.daemon.state} network=${v.daemon.network} chain=${v.rpc.chainId} block=${v.rpc.blockNumber}`,
     `health=${health}`,
     `fleet: ${v.fleet.size} services, ${v.fleet.complete} complete, ${v.fleet.needsAttention} need attention`,
     `pending: ${v.earnings.pendingTotal} reward-wei`,
+    v.taskNative
+      ? `task-native: solver=${v.taskNative.solverReady ? 'ready' : 'not-ready'} evaluator=${v.taskNative.evaluatorReady ? 'ready' : 'not-ready'} (${v.taskNative.detail})`
+      : '',
     v.exit.blocking && v.exit.hint ? `hint: ${v.exit.hint}` : '',
   ].filter(Boolean);
   if (v.detail) {
@@ -114,9 +128,11 @@ Examples:
         (deps.getConfigPathFromArgs ?? getConfigPathFromArgs)(ctx.argv ?? []) ??
         getConfigPathFromArgs(process.argv.slice(2));
       let configProvenance: ConfigProvenance | undefined;
+      let taskNative: TaskNativeReadiness | undefined;
       try {
         const cfg = (deps.loadConfig ?? loadConfig)(configPath);
         configProvenance = buildConfigProvenance(configPath, cfg, ctx.env);
+        taskNative = (deps.resolveTaskNativeReadiness ?? resolveTaskNativeReadiness)(cfg);
       } catch {
         /* non-fatal — status works even without a valid config file */
       }
@@ -125,12 +141,14 @@ Examples:
       const rollup = deps.assembleStatusRollupV1(raw, {
         includeDetail: Boolean(parsed.values.detail),
       });
-      const payload = configProvenance !== undefined
-        ? { ...rollup, config: configProvenance }
-        : rollup;
+      const payload: StatusPayload = {
+        ...rollup,
+        ...(configProvenance !== undefined ? { config: configProvenance } : {}),
+        ...(taskNative !== undefined ? { taskNative } : {}),
+      };
       emitResult(
         payload,
-        (v) => humanStatus(v as StatusRollupV1Response),
+        (v) => humanStatus(v as StatusPayload),
         {
           json: Boolean(parsed.values.json),
           human: Boolean(parsed.values.human),

--- a/client/src/cli/commands/update.ts
+++ b/client/src/cli/commands/update.ts
@@ -1,9 +1,18 @@
 import { execSync } from 'node:child_process';
+import { copyFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { parseArgs } from 'node:util';
 import type { CommandContext, CommandModule } from '../command.js';
 import { COMMON_FLAGS } from '../command.js';
 import { emitResult } from '../output.js';
 import { emitEnvelope } from '../../errors/envelope.js';
+import {
+  DEFAULT_CONFIG_PATH,
+  loadConfig as defaultLoadConfig,
+  getConfigPathFromArgs as defaultGetConfigPathFromArgs,
+} from '../../config.js';
+import { FleetStateStore } from '../../earning/store.js';
+import type { FleetState, ServiceState } from '../../earning/types.js';
+import { Store } from '../../store/store.js';
 import integrationsCommand from './integrations.js';
 
 class StringWriter {
@@ -47,25 +56,285 @@ function summarizeIntegrationInstall(
 
 export interface UpdateDeps {
   integrationsRun: typeof integrationsCommand.run;
+  loadConfig: typeof defaultLoadConfig;
+  getConfigPathFromArgs: typeof defaultGetConfigPathFromArgs;
+  fleetStateStoreFactory: (earningDir: string) => Pick<FleetStateStore, 'dir' | 'hasStateFile' | 'tryLoadExisting' | 'save'>;
+  storeFactory: (dbPath: string) => Pick<Store, 'close'>;
 }
 
 const PRODUCTION_DEPS: UpdateDeps = {
   integrationsRun: integrationsCommand.run.bind(integrationsCommand),
+  loadConfig: defaultLoadConfig,
+  getConfigPathFromArgs: defaultGetConfigPathFromArgs,
+  fleetStateStoreFactory: (earningDir) => new FleetStateStore(earningDir),
+  storeFactory: (dbPath) => new Store(dbPath),
 };
 
-export function createUpdateCommand(deps: UpdateDeps = PRODUCTION_DEPS): CommandModule {
+type UpdateStepStatus = 'ok' | 'error' | 'skipped' | 'warning' | 'state-integrity';
+
+interface UpdateStep {
+  step: string;
+  status: UpdateStepStatus;
+  detail: string;
+}
+
+interface LocalEarningAssessment {
+  status: Extract<UpdateStepStatus, 'ok' | 'skipped' | 'warning' | 'state-integrity'>;
+  detail: string;
+}
+
+const NO_CHAIN_IO_NOTE = 'No chain readback or writes were performed.';
+const PRESERVED_FIELDS =
+  'Preserved locally recorded wallet, agent, Safe, service, Mech, and ERC-8004 binding fields.';
+const LEGACY_REQUEST_FIRST_CONFIG_KEYS = [
+  'testnetClaimRegistryDeploymentPath',
+  'claimRegistryDeploymentPath',
+  'claimRegistryAddress',
+  'claimRegistry',
+  'testnetClaimRegistry',
+  'requestRegistryDeploymentPath',
+  'requestRegistryAddress',
+  'requestRegistry',
+] as const;
+const LEGACY_REQUEST_FIRST_ENV_VARS = [
+  'JINN_TESTNET_CLAIM_REGISTRY_DEPLOYMENT',
+  'JINN_CLAIM_REGISTRY_ADDRESS',
+  'JINN_REQUEST_REGISTRY_ADDRESS',
+] as const;
+
+function isTaskReadyService(svc: ServiceState): boolean {
+  return svc.step === 'complete' || svc.step === 'safe_binding_pending';
+}
+
+function missingTaskReadyFields(svc: ServiceState): string[] {
+  const missing: string[] = [];
+  if (!svc.agent_address) missing.push('agent EOA');
+  if (!svc.safe_address) missing.push('Safe');
+  if (svc.service_id === null) missing.push('service id');
+  if (!svc.staking_address) missing.push('staking contract');
+  if (!svc.mech_address) missing.push('Mech');
+  return missing;
+}
+
+function missingOptionalErc8004Fields(svc: ServiceState): string[] {
+  const missing: string[] = [];
+  if (!svc.agent_id) missing.push('ERC-8004 agent id');
+  if (!svc.identity_registry_address) missing.push('Identity Registry');
+  return missing;
+}
+
+function assessLocalEarningState(state: FleetState): LocalEarningAssessment {
+  if (state.services.length === 0) {
+    return {
+      status: 'skipped',
+      detail: `Local earning state exists but no services are recorded yet; node is not bootstrapped. ${NO_CHAIN_IO_NOTE}`,
+    };
+  }
+
+  const readyServices = state.services.filter(isTaskReadyService);
+  const integrityIssues = readyServices
+    .map((svc) => ({ index: svc.index, missing: missingTaskReadyFields(svc) }))
+    .filter((issue) => issue.missing.length > 0);
+
+  if (integrityIssues.length > 0) {
+    const issueText = integrityIssues
+      .map((issue) => `service #${issue.index} missing ${issue.missing.join(', ')}`)
+      .join('; ');
+    return {
+      status: 'state-integrity',
+      detail:
+        `State-integrity issue: ${issueText}. Run doctor/recovery; update preserved local state and did not repair from RPC. ${NO_CHAIN_IO_NOTE}`,
+    };
+  }
+
+  const optionalErc8004Warnings = readyServices
+    .map((svc) => ({ index: svc.index, missing: missingOptionalErc8004Fields(svc) }))
+    .filter((issue) => issue.missing.length > 0);
+
+  if (readyServices.length !== state.services.length) {
+    return {
+      status: 'warning',
+      detail:
+        `Task-native local preflight found ${readyServices.length}/${state.services.length} services ready; ` +
+        `remaining services are still bootstrapping. ${PRESERVED_FIELDS} ${NO_CHAIN_IO_NOTE}`,
+    };
+  }
+
+  if (optionalErc8004Warnings.length > 0) {
+    const warningText = optionalErc8004Warnings
+      .map((issue) => `service #${issue.index} missing ${issue.missing.join(', ')}`)
+      .join('; ');
+    return {
+      status: 'warning',
+      detail:
+        `Task-native local preflight found optional ERC-8004 metadata not recorded locally: ${warningText}. ` +
+        `${PRESERVED_FIELDS} Run doctor or migrate-agent-id if participation requires agent registry metadata. ${NO_CHAIN_IO_NOTE}`,
+    };
+  }
+
+  return {
+    status: 'ok',
+    detail:
+      `Task-native local preflight passed for ${state.services.length} service${state.services.length === 1 ? '' : 's'}; ` +
+      `${PRESERVED_FIELDS} ${NO_CHAIN_IO_NOTE}`,
+  };
+}
+
+function timestampForBackup(date = new Date()): string {
+  return date.toISOString().replace(/[:.]/g, '-');
+}
+
+function runLegacyRequestFirstConfigMigration(
+  configPath: string | undefined,
+  env: NodeJS.ProcessEnv,
+): UpdateStep {
+  const effectivePath = configPath ?? DEFAULT_CONFIG_PATH;
+  const legacyEnvVars = LEGACY_REQUEST_FIRST_ENV_VARS.filter((name) => env[name] !== undefined);
+  const envNote = legacyEnvVars.length > 0
+    ? ` Legacy env var(s) ignored by runtime: ${legacyEnvVars.join(', ')}.`
+    : '';
+
+  if (!existsSync(effectivePath)) {
+    return {
+      step: 'config-migration',
+      status: legacyEnvVars.length > 0 ? 'warning' : 'skipped',
+      detail: `No config file found; no legacy ClaimRegistry/request-first fields to rewrite.${envNote}`,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(effectivePath, 'utf8'));
+  } catch (err) {
+    return {
+      step: 'config-migration',
+      status: 'error',
+      detail: `Could not parse config for legacy ClaimRegistry/request-first migration: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    };
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {
+      step: 'config-migration',
+      status: 'error',
+      detail: 'Config file root is not an object; legacy ClaimRegistry/request-first migration skipped.',
+    };
+  }
+
+  const values = parsed as Record<string, unknown>;
+  const removed = LEGACY_REQUEST_FIRST_CONFIG_KEYS.filter((key) => key in values);
+  if (removed.length === 0) {
+    return {
+      step: 'config-migration',
+      status: legacyEnvVars.length > 0 ? 'warning' : 'ok',
+      detail:
+        `No legacy ClaimRegistry/request-first config fields found; runtime ignores removed request-first knobs.${envNote}`,
+    };
+  }
+
+  const next: Record<string, unknown> = { ...values };
+  for (const key of removed) {
+    delete next[key];
+  }
+
+  const backupPath = `${effectivePath}.bak.${timestampForBackup()}`;
+  copyFileSync(effectivePath, backupPath);
+  writeFileSync(effectivePath, `${JSON.stringify(next, null, 2)}\n`, 'utf8');
+  return {
+    step: 'config-migration',
+    status: 'ok',
+    detail:
+      `Removed legacy ClaimRegistry/request-first config field(s): ${removed.join(', ')}; ` +
+      `backup written to ${backupPath}. Runtime uses TaskCoordinator/JinnRouterV3 readiness instead.${envNote}`,
+  };
+}
+
+async function runLocalTaskNativePreflight(
+  ctx: CommandContext,
+  deps: UpdateDeps,
+): Promise<UpdateStep[]> {
+  const steps: UpdateStep[] = [];
+
+  try {
+    const configPath =
+      deps.getConfigPathFromArgs(ctx.argv ?? []) ??
+      (typeof process !== 'undefined' ? deps.getConfigPathFromArgs(process.argv.slice(2)) : undefined);
+    steps.push(runLegacyRequestFirstConfigMigration(configPath, ctx.env));
+    const config = deps.loadConfig(configPath);
+
+    let localStore: Pick<Store, 'close'> | null = null;
+    try {
+      localStore = deps.storeFactory(config.dbPath);
+      steps.push({
+        step: 'task-native-store',
+        status: 'ok',
+        detail: 'Task-native local store preflight complete: task post records support protocol task ids and task CIDs.',
+      });
+    } finally {
+      localStore?.close();
+    }
+
+    const fleetStore = deps.fleetStateStoreFactory(config.earningDir);
+    if (!fleetStore.hasStateFile()) {
+      steps.push({
+        step: 'earning-state',
+        status: 'skipped',
+        detail: `No local earning state found in ${fleetStore.dir}; node is not bootstrapped. Nothing to migrate. ${NO_CHAIN_IO_NOTE}`,
+      });
+      return steps;
+    }
+
+    const state = await fleetStore.tryLoadExisting();
+    if (!state) {
+      steps.push({
+        step: 'earning-state',
+        status: 'state-integrity',
+        detail:
+          `Local earning state exists in ${fleetStore.dir} but is not readable as current fleet state. ` +
+          `Run doctor/recovery; update did not reset it or repair from RPC. ${NO_CHAIN_IO_NOTE}`,
+      });
+      return steps;
+    }
+
+    await fleetStore.save(state);
+    const assessment = assessLocalEarningState(state);
+    steps.push({
+      step: 'earning-state',
+      status: assessment.status,
+      detail: assessment.detail,
+    });
+    return steps;
+  } catch (err) {
+    steps.push({
+      step: 'task-native-preflight',
+      status: 'error',
+      detail: err instanceof Error ? err.message : String(err),
+    });
+    return steps;
+  }
+}
+
+export function createUpdateCommand(overrides: Partial<UpdateDeps> = {}): CommandModule {
+  const deps: UpdateDeps = { ...PRODUCTION_DEPS, ...overrides };
   return {
     name: 'update',
-    summary: 'Update the client package and refresh integrations in all configured AI tools',
+    summary: 'Update the client package, run local Task-native preflight, and refresh integrations',
     helpText: `Usage: jinn update [--human] [--skip-npm] [--skip-plugins]
 
-Two steps:
+Steps:
   1. npm update -g @jinn-network/client  (updates binary + MCP server + skill source)
-  2. jinn integrations install            (refreshes skills in all configured tools)
+  2. local Task-native preflight          (migrates local SQLite schema and validates earning state)
+  3. jinn integrations install            (refreshes skills in all configured tools)
 
 The MCP server updates automatically (it's a binary on PATH).
 Skills need re-installation because they are copied into each tool's
 config directory.
+
+Task-native preflight is local-only: it preserves recorded wallet/agent/Safe/
+service/Mech/ERC-8004 fields and reports state-integrity issues for
+doctor/recovery. It does not read from or write to chain.
 
 Flags:
   --skip-npm        Skip the npm update step
@@ -104,7 +373,7 @@ Examples:
       const skipNpm = parsed.values['skip-npm'] as boolean;
       const skipPlugins = parsed.values['skip-plugins'] as boolean;
 
-      const steps: Array<{ step: string; status: string; detail: string }> = [];
+      const steps: UpdateStep[] = [];
 
       // ── Step 1: Update the npm package ──
       if (!skipNpm) {
@@ -126,7 +395,17 @@ Examples:
         steps.push({ step: 'npm-update', status: 'skipped', detail: '--skip-npm' });
       }
 
-      // ── Step 2: Re-install integrations (propagates skill updates) ──
+      // ── Step 2: Local-only Task-native migration/preflight ──
+      console.error('[update] Running local Task-native preflight...');
+      const localSteps = await runLocalTaskNativePreflight(ctx, deps);
+      steps.push(...localSteps);
+      if (localSteps.some((step) => step.status === 'error' || step.status === 'state-integrity')) {
+        console.error('[update] Local Task-native preflight found issues.');
+      } else {
+        console.error('[update] Local Task-native preflight complete.');
+      }
+
+      // ── Step 3: Re-install integrations (propagates skill updates) ──
       if (!skipPlugins) {
         console.error('[update] Updating integrations...');
         const integrationWriter = new StringWriter();
@@ -152,7 +431,7 @@ Examples:
         steps.push({ step: 'integrations-install', status: 'skipped', detail: '--skip-plugins' });
       }
 
-      const allOk = steps.every((s) => s.status === 'ok' || s.status === 'skipped');
+      const allOk = steps.every((s) => s.status === 'ok' || s.status === 'skipped' || s.status === 'warning');
 
       emitResult(
         {
@@ -163,9 +442,9 @@ Examples:
           steps,
         },
         (v) => {
-          const value = v as { ok: boolean; steps: Array<{ step: string; status: string; detail: string }> };
+          const value = v as { ok: boolean; steps: UpdateStep[] };
           const lines = value.steps.map(
-            (s) => `  ${s.step.padEnd(16)} ${s.status}${s.status === 'error' ? `: ${s.detail}` : ''}`,
+            (s) => `  ${s.step.padEnd(20)} ${s.status}: ${s.detail}`,
           );
           return `Update ${value.ok ? 'complete' : 'completed with errors'}:\n${lines.join('\n')}`;
         },

--- a/client/src/cli/task-native-readiness.ts
+++ b/client/src/cli/task-native-readiness.ts
@@ -1,0 +1,216 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { JinnConfig } from '../config.js';
+import { DEFAULT_TESTNET_ARTIFACTS, getChainConfig } from '../earning/contracts.js';
+import { parseFleetStateJson, STATE_FILE } from '../earning/store.js';
+import { isOperationalServiceStep, type FleetState, type ServiceState } from '../earning/types.js';
+
+export interface TaskNativeReadiness {
+  ok: boolean;
+  solverReady: boolean;
+  evaluatorReady: boolean;
+  detail: string;
+  remedy?: string;
+  source: string | null;
+  contracts: {
+    taskCoordinator?: string;
+    jinnRouterV3?: string;
+    taskActivityCheckerV3?: string;
+  };
+  routerClaimDeliveryVersion?: 'v1' | 'v2' | 'v3';
+  operatorState?: {
+    statePath: string;
+    chain?: 'base' | 'base-sepolia';
+    services: number;
+    taskNativeServices: number;
+    activeSafe?: string;
+    activeMech?: string;
+    evaluatorSafe?: string;
+    evaluatorMech?: string;
+    selfEvaluationAllowed: boolean;
+  };
+}
+
+function isNonZeroAddress(value: unknown): value is string {
+  return typeof value === 'string' &&
+    /^0x[0-9a-fA-F]{40}$/.test(value) &&
+    value.toLowerCase() !== '0x0000000000000000000000000000000000000000';
+}
+
+function bundledTaskNativeDeploymentPath(): string {
+  return process.env['JINN_TESTNET_TASK_COORDINATOR_ROUTER_V3_DEPLOYMENT'] ??
+    DEFAULT_TESTNET_ARTIFACTS.taskCoordinatorRouterV3;
+}
+
+function taskNativeStatePath(config: JinnConfig): string {
+  return join(config.earningDir, STATE_FILE);
+}
+
+function isTaskNativeService(service: ServiceState): boolean {
+  return isOperationalServiceStep(service.step) &&
+    service.service_id !== null &&
+    isNonZeroAddress(service.safe_address) &&
+    isNonZeroAddress(service.mech_address);
+}
+
+function loadFleetState(config: JinnConfig): { path: string; state: FleetState | null; error?: string } {
+  const path = taskNativeStatePath(config);
+  if (!existsSync(path)) {
+    return { path, state: null, error: 'earning state file is missing' };
+  }
+  try {
+    const state = parseFleetStateJson(readFileSync(path, 'utf8'));
+    return state
+      ? { path, state }
+      : { path, state: null, error: 'earning state file is not a current fleet-state schema' };
+  } catch (err) {
+    return {
+      path,
+      state: null,
+      error: `earning state file could not be read: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+export function resolveTaskNativeReadiness(config: JinnConfig): TaskNativeReadiness {
+  const chain = config.network === 'testnet' ? 'base-sepolia' : 'base';
+  const source = config.network === 'testnet' ? bundledTaskNativeDeploymentPath() : null;
+  if (!source || !existsSync(source)) {
+    return {
+      ok: false,
+      solverReady: false,
+      evaluatorReady: false,
+      detail:
+        source
+          ? `Task-native deployment artifact is not bundled at ${source}`
+          : `Task-native deployment artifact is not bundled for ${chain}`,
+      remedy:
+        'Bundle deployment-task-coordinator-router-v3-baseSepolia-fast.json or configure a network release with TaskCoordinator/JinnRouterV3/TaskActivityCheckerV3.',
+      source,
+      contracts: {},
+    };
+  }
+
+  let chainCfg: ReturnType<typeof getChainConfig>;
+  try {
+    chainCfg = getChainConfig(chain, {
+      testnetL2DeploymentPath: config.testnetL2DeploymentPath,
+      testnetL2TokenDeploymentPath: config.testnetL2TokenDeploymentPath,
+      testnetMechDeploymentPath: config.testnetMechDeploymentPath,
+      testnetStolasDeploymentPath: config.testnetStolasDeploymentPath,
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      solverReady: false,
+      evaluatorReady: false,
+      detail: `Task-native deployment config could not be resolved: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      remedy: 'Verify bundled deployment artifacts and deployment path overrides.',
+      source,
+      contracts: {},
+    };
+  }
+
+  let artifact: { contracts?: Record<string, unknown> };
+  try {
+    artifact = JSON.parse(readFileSync(source, 'utf8')) as {
+      contracts?: Record<string, unknown>;
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      solverReady: false,
+      evaluatorReady: false,
+      detail: `Task-native deployment artifact could not be parsed at ${source}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      remedy: 'Refresh the bundled TaskCoordinator/JinnRouterV3 deployment artifact.',
+      source,
+      contracts: {},
+      routerClaimDeliveryVersion: chainCfg.routerClaimDeliveryVersion,
+    };
+  }
+
+  const contracts = artifact.contracts ?? {};
+  const taskCoordinator = contracts['taskCoordinator'];
+  const jinnRouterV3 = contracts['jinnRouterV3'];
+  const taskActivityCheckerV3 = contracts['activityChecker'];
+  const resolvedContracts = {
+    ...(isNonZeroAddress(taskCoordinator) ? { taskCoordinator } : {}),
+    ...(isNonZeroAddress(jinnRouterV3) ? { jinnRouterV3 } : {}),
+    ...(isNonZeroAddress(taskActivityCheckerV3) ? { taskActivityCheckerV3 } : {}),
+  };
+  const missingContracts = [
+    isNonZeroAddress(taskCoordinator) ? null : 'TaskCoordinator',
+    isNonZeroAddress(jinnRouterV3) ? null : 'JinnRouterV3',
+    isNonZeroAddress(taskActivityCheckerV3) ? null : 'TaskActivityCheckerV3',
+  ].filter((part): part is string => part !== null);
+  const routerMatchesConfig =
+    isNonZeroAddress(jinnRouterV3) &&
+    isNonZeroAddress(chainCfg.jinnRouter) &&
+    chainCfg.jinnRouter.toLowerCase() === jinnRouterV3.toLowerCase();
+  const claimVariantReady = chainCfg.routerClaimDeliveryVersion === 'v3';
+  const deploymentReady = missingContracts.length === 0 && routerMatchesConfig && claimVariantReady;
+
+  const stateLoad = loadFleetState(config);
+  const expectedFleetChain = chain;
+  const state = stateLoad.state;
+  const taskNativeServices = state?.services.filter(isTaskNativeService) ?? [];
+  const active = taskNativeServices[0];
+  const evaluator = active
+    ? taskNativeServices.find((svc) => svc.safe_address!.toLowerCase() !== active.safe_address!.toLowerCase())
+    : undefined;
+  const stateChainReady = state?.chain === expectedFleetChain;
+  const operatorState = {
+    statePath: stateLoad.path,
+    ...(state?.chain ? { chain: state.chain } : {}),
+    services: state?.services.length ?? 0,
+    taskNativeServices: taskNativeServices.length,
+    ...(active?.safe_address ? { activeSafe: active.safe_address } : {}),
+    ...(active?.mech_address ? { activeMech: active.mech_address } : {}),
+    ...(evaluator?.safe_address ? { evaluatorSafe: evaluator.safe_address } : {}),
+    ...(evaluator?.mech_address ? { evaluatorMech: evaluator.mech_address } : {}),
+    selfEvaluationAllowed: false,
+  };
+
+  const stateIssues = [
+    stateLoad.error ?? null,
+    state && !stateChainReady ? `earning state chain is ${state.chain}, expected ${expectedFleetChain}` : null,
+    state && taskNativeServices.length === 0
+      ? 'no operational service has service_id, Safe, and Mech addresses'
+      : null,
+  ].filter((part): part is string => part !== null);
+  const deploymentIssues = [
+    missingContracts.length > 0 ? `missing ${missingContracts.join(', ')}` : null,
+    routerMatchesConfig ? null : 'resolved chain config does not point at bundled JinnRouterV3',
+    claimVariantReady ? null : `router claim variant is ${chainCfg.routerClaimDeliveryVersion}, expected v3`,
+  ].filter((part): part is string => part !== null);
+
+  const solverReady = deploymentReady && stateChainReady && Boolean(active);
+  const evaluatorReady = solverReady && Boolean(evaluator);
+  const evaluatorDetail = evaluatorReady
+    ? `evaluator-ready=true evaluatorSafe=${evaluator!.safe_address} evaluatorMech=${evaluator!.mech_address}`
+    : 'evaluator-ready=false (self-evaluation is disabled and no distinct evaluator Safe/Mech is configured)';
+  const detail = solverReady
+    ? `Task-native solver-ready=true ${evaluatorDetail} on ${chain}: TaskCoordinator=${taskCoordinator}, JinnRouterV3=${jinnRouterV3}, TaskActivityCheckerV3=${taskActivityCheckerV3}; activeSafe=${active!.safe_address} activeMech=${active!.mech_address}`
+    : `Task-native not ready on ${chain}: ${[...deploymentIssues, ...stateIssues].join('; ')}`;
+
+  return {
+    ok: solverReady,
+    solverReady,
+    evaluatorReady,
+    detail,
+    ...(solverReady
+      ? {}
+      : {
+          remedy:
+            'Use bundled TaskCoordinator/JinnRouterV3/TaskActivityCheckerV3 artifacts and an existing operational service with Safe and Mech addresses before Task-native participation.',
+        }),
+    source,
+    contracts: resolvedContracts,
+    routerClaimDeliveryVersion: chainCfg.routerClaimDeliveryVersion,
+    operatorState,
+  };
+}

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -279,6 +279,43 @@ export const JinnConfigSchema = z.object({
   predictionV1ResolveGapMs: z.number().int().positive().optional(),
 
   /**
+   * Enables launcher-owned Polymarket prediction.v1 Task generation.
+   * Default false: ordinary operator daemons do not create Polymarket rounds.
+   * Env: JINN_PREDICTION_V1_LAUNCHER_ENABLED
+   */
+  predictionV1LauncherEnabled: z.boolean().default(false),
+
+  /**
+   * prediction.v1 Polymarket generator cadence (ms). Default 21600000 (6h).
+   * Set to 0 only for launcher/test loops that intentionally poll every tick.
+   * Env: JINN_PREDICTION_V1_CADENCE_MS
+   */
+  predictionV1CadenceMs: z.number().int().nonnegative().optional(),
+
+  /**
+   * prediction.v1 Polymarket generator safety caps.
+   * Defaults live in the generator: per-poll 25, per-day 100, open 250.
+   * Env:
+   *   JINN_PREDICTION_V1_MAX_NEW_ROUNDS_PER_POLL
+   *   JINN_PREDICTION_V1_MAX_NEW_ROUNDS_PER_DAY
+   *   JINN_PREDICTION_V1_MAX_OPEN_ROUNDS
+   */
+  predictionV1MaxNewRoundsPerPoll: z.number().int().nonnegative().optional(),
+  predictionV1MaxNewRoundsPerDay: z.number().int().nonnegative().optional(),
+  predictionV1MaxOpenRounds: z.number().int().nonnegative().optional(),
+
+  /**
+   * Manual prediction.v1 Polymarket conditionId controls.
+   * Allowlist prioritizes consideration but never bypasses eligibility checks;
+   * blocklist always wins.
+   * Env:
+   *   JINN_PREDICTION_V1_ALLOWLIST_CONDITION_IDS
+   *   JINN_PREDICTION_V1_BLOCKLIST_CONDITION_IDS
+   */
+  predictionV1AllowlistConditionIds: z.array(z.string()).optional(),
+  predictionV1BlocklistConditionIds: z.array(z.string()).optional(),
+
+  /**
    * Operator-controlled Harness inventory.
    */
   harnesses: z
@@ -718,6 +755,38 @@ export function loadConfig(configPath?: string): JinnConfig {
     const parsed = Number(env['JINN_PREDICTION_V1_RESOLVE_GAP_MS'].trim());
     if (Number.isFinite(parsed) && parsed > 0) merged.predictionV1ResolveGapMs = parsed;
   }
+  if (env['JINN_PREDICTION_V1_LAUNCHER_ENABLED'] !== undefined) {
+    const v = env['JINN_PREDICTION_V1_LAUNCHER_ENABLED'].trim().toLowerCase();
+    merged.predictionV1LauncherEnabled = v === '1' || v === 'true' || v === 'yes';
+  }
+  if (env['JINN_PREDICTION_V1_CADENCE_MS']) {
+    const parsed = Number(env['JINN_PREDICTION_V1_CADENCE_MS'].trim());
+    if (Number.isFinite(parsed) && parsed >= 0) merged.predictionV1CadenceMs = parsed;
+  }
+  if (env['JINN_PREDICTION_V1_MAX_NEW_ROUNDS_PER_POLL']) {
+    const parsed = Number(env['JINN_PREDICTION_V1_MAX_NEW_ROUNDS_PER_POLL'].trim());
+    if (Number.isFinite(parsed) && parsed >= 0) merged.predictionV1MaxNewRoundsPerPoll = parsed;
+  }
+  if (env['JINN_PREDICTION_V1_MAX_NEW_ROUNDS_PER_DAY']) {
+    const parsed = Number(env['JINN_PREDICTION_V1_MAX_NEW_ROUNDS_PER_DAY'].trim());
+    if (Number.isFinite(parsed) && parsed >= 0) merged.predictionV1MaxNewRoundsPerDay = parsed;
+  }
+  if (env['JINN_PREDICTION_V1_MAX_OPEN_ROUNDS']) {
+    const parsed = Number(env['JINN_PREDICTION_V1_MAX_OPEN_ROUNDS'].trim());
+    if (Number.isFinite(parsed) && parsed >= 0) merged.predictionV1MaxOpenRounds = parsed;
+  }
+  if (env['JINN_PREDICTION_V1_ALLOWLIST_CONDITION_IDS'] !== undefined) {
+    merged.predictionV1AllowlistConditionIds = env['JINN_PREDICTION_V1_ALLOWLIST_CONDITION_IDS']
+      .split(',')
+      .map((part) => part.trim())
+      .filter(Boolean);
+  }
+  if (env['JINN_PREDICTION_V1_BLOCKLIST_CONDITION_IDS'] !== undefined) {
+    merged.predictionV1BlocklistConditionIds = env['JINN_PREDICTION_V1_BLOCKLIST_CONDITION_IDS']
+      .split(',')
+      .map((part) => part.trim())
+      .filter(Boolean);
+  }
 
   if (env['JINN_IDENTITY_REGISTRY_ADDRESS'])   merged.identityRegistryAddress = env['JINN_IDENTITY_REGISTRY_ADDRESS'];
   if (env['JINN_VALIDATION_REGISTRY_ADDRESS']) merged.validationRegistryAddress = env['JINN_VALIDATION_REGISTRY_ADDRESS'];
@@ -907,6 +976,13 @@ const TRACKED_ENV_VARS = [
   'JINN_MIN_SAFE_ETH_WEI',
   'JINN_PREDICTION_V1_WINDOW_MS',
   'JINN_PREDICTION_V1_RESOLVE_GAP_MS',
+  'JINN_PREDICTION_V1_LAUNCHER_ENABLED',
+  'JINN_PREDICTION_V1_CADENCE_MS',
+  'JINN_PREDICTION_V1_MAX_NEW_ROUNDS_PER_POLL',
+  'JINN_PREDICTION_V1_MAX_NEW_ROUNDS_PER_DAY',
+  'JINN_PREDICTION_V1_MAX_OPEN_ROUNDS',
+  'JINN_PREDICTION_V1_ALLOWLIST_CONDITION_IDS',
+  'JINN_PREDICTION_V1_BLOCKLIST_CONDITION_IDS',
   'JINN_IDENTITY_REGISTRY_ADDRESS',
   'JINN_VALIDATION_REGISTRY_ADDRESS',
   'JINN_REPUTATION_ENABLED',

--- a/client/src/corpus/envelope-projection.ts
+++ b/client/src/corpus/envelope-projection.ts
@@ -1,0 +1,160 @@
+import type {
+  EnvelopeProjection,
+  EnvelopeProjectionMetadata,
+  EnvelopeProjectionMetadataValue,
+} from './types.js';
+import type { SignedEnvelope } from '../types/envelope.js';
+import type { Task } from '../types/task.js';
+
+const RESTORATION_TASK_CID_CONTEXT_KEY = 'restorationTaskCid';
+
+export interface ProjectEnvelopeOptions {
+  envelopeCid?: string | null;
+  envelopeSha256?: string | null;
+  task?: Task | null;
+  taskCid?: string | null;
+  taskId?: string | null;
+  metadata?: EnvelopeProjectionMetadata;
+}
+
+export function projectEnvelope(
+  envelope: SignedEnvelope,
+  options: ProjectEnvelopeOptions = {},
+): EnvelopeProjection {
+  const metadata: EnvelopeProjectionMetadata = {};
+
+  setMetadata(metadata, 'participant.safeAddress', envelope.participant.safeAddress);
+  setMetadata(metadata, 'participant.agentEoa', envelope.participant.agentEoa);
+  setMetadata(metadata, 'executor.implName', envelope.executor.implName);
+  setMetadata(metadata, 'executor.implVersion', envelope.executor.implVersion);
+  setMetadata(metadata, 'executor.runtimeBundleDigest', envelope.executor.runtimeBundleDigest);
+  setMetadata(
+    metadata,
+    'executor.plugins',
+    JSON.stringify(envelope.executor.plugins.map((plugin) => ({
+      name: plugin.name,
+      version: plugin.version,
+      cid: plugin.cid ?? null,
+      sha256: plugin.sha256,
+    }))),
+  );
+
+  const projectedTaskCid = resolveProjectedTaskCid(envelope, options);
+  const projectedTaskId = options.taskId ?? options.task?.id ?? null;
+  setMetadata(metadata, 'taskCid', projectedTaskCid);
+  setMetadata(metadata, 'requestId', envelope.task.requestId);
+  setMetadata(metadata, 'taskId', projectedTaskId);
+
+  if (envelope.solverType === 'prediction.v1') {
+    projectPredictionV1Fields(metadata, envelope, options.task);
+  }
+
+  for (const [key, value] of Object.entries(options.metadata ?? {})) {
+    setMetadata(metadata, key, value);
+  }
+
+  const solutionEnvelopeCid = stringFromMetadata(metadata, 'solutionEnvelope.cid');
+  const solutionEnvelopeSha256 = stringFromMetadata(metadata, 'solutionEnvelope.sha256');
+  const solutionEnvelopeRef = solutionEnvelopeCid
+    ?? solutionEnvelopeSha256
+    ?? (envelope.role === 'verdict' ? envelope.signature.hash : null);
+  const envelopeCid = options.envelopeCid ?? null;
+  const envelopeSha256 = options.envelopeSha256 ?? null;
+  const envelopeId = envelopeCid ?? envelopeSha256 ?? envelope.signature.hash;
+
+  return {
+    envelopeId,
+    envelopeCid,
+    envelopeSha256,
+    signatureHash: envelope.signature.hash,
+    solverType: envelope.solverType,
+    role: envelope.role,
+    taskCid: projectedTaskCid,
+    taskId: projectedTaskId,
+    requestId: envelope.task.requestId,
+    generatedAt: envelope.generatedAt,
+    evidenceTier: envelope.evidenceTier,
+    participantSafeAddress: envelope.participant.safeAddress,
+    participantAgentEoa: envelope.participant.agentEoa,
+    executorImplName: envelope.executor.implName,
+    executorImplVersion: envelope.executor.implVersion,
+    executorRuntimeBundleDigest: envelope.executor.runtimeBundleDigest,
+    executorPlugins: envelope.executor.plugins.map((plugin) => plugin.name),
+    solutionEnvelopeCid,
+    solutionEnvelopeSha256,
+    solutionEnvelopeRef,
+    metadata,
+  };
+}
+
+function projectPredictionV1Fields(
+  metadata: EnvelopeProjectionMetadata,
+  envelope: SignedEnvelope,
+  task?: Task | null,
+): void {
+  const taskSpec = record(task?.spec);
+  const taskSource = record(taskSpec?.source);
+  const taskIdentifiers = record(taskSource?.identifiers);
+  const taskQuestion = record(taskSpec?.question);
+  const payload = record(envelope.payload);
+  const resolutionSource = record(payload?.resolutionSource);
+  const payloadTask = record(payload?.task);
+  const scores = record(payload?.scores);
+  const solutionEnvelope = record(payload?.solutionEnvelope);
+
+  setMetadata(metadata, 'solverType', envelope.solverType);
+  setMetadata(metadata, 'role', envelope.role);
+  setMetadata(metadata, 'source.venue', stringValue(taskSource?.venue) ?? stringValue(resolutionSource?.venue));
+  setMetadata(metadata, 'source.marketId', stringValue(taskIdentifiers?.marketId) ?? stringValue(resolutionSource?.marketId));
+  setMetadata(
+    metadata,
+    'source.conditionId',
+    stringValue(taskIdentifiers?.conditionId) ?? stringValue(resolutionSource?.conditionId),
+  );
+  setMetadata(metadata, 'question.kind', stringValue(taskQuestion?.kind));
+  setMetadata(metadata, 'verdict', stringValue(payload?.verdict));
+  setMetadata(metadata, 'scores.solverBrier', stringValue(scores?.solverBrier));
+  setMetadata(metadata, 'scores.consensusBrier', stringValue(scores?.consensusBrier));
+  setMetadata(metadata, 'scores.brierSpread', stringValue(scores?.brierSpread));
+  setMetadata(metadata, 'solutionEnvelope.cid', stringValue(solutionEnvelope?.cid));
+  setMetadata(metadata, 'solutionEnvelope.sha256', stringValue(solutionEnvelope?.sha256));
+  setMetadata(metadata, 'payload.task.cid', stringValue(payloadTask?.cid));
+}
+
+function resolveProjectedTaskCid(
+  envelope: SignedEnvelope,
+  options: ProjectEnvelopeOptions,
+): string | null {
+  if (options.taskCid) return options.taskCid;
+  const contextTaskCid = options.task?.context?.[RESTORATION_TASK_CID_CONTEXT_KEY];
+  if (typeof contextTaskCid === 'string' && contextTaskCid.length > 0) {
+    return contextTaskCid;
+  }
+  const payloadTask = record(record(envelope.payload)?.task);
+  const payloadTaskCid = stringValue(payloadTask?.cid);
+  return payloadTaskCid ?? envelope.task.cid ?? null;
+}
+
+function setMetadata(
+  metadata: EnvelopeProjectionMetadata,
+  key: string,
+  value: EnvelopeProjectionMetadataValue | null | undefined,
+): void {
+  if (value === undefined || value === null) return;
+  metadata[key] = value;
+}
+
+function stringFromMetadata(metadata: EnvelopeProjectionMetadata, key: string): string | null {
+  const value = metadata[key];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}

--- a/client/src/corpus/index.ts
+++ b/client/src/corpus/index.ts
@@ -32,6 +32,10 @@ export type {
 export { CorpusQueryError, ManifestFetchError, AcquireError, HashMismatchError } from './types.js';
 export { noopRouteResolver } from './route-resolver.js';
 export { getCachedArtifact, hasCachedArtifact } from './cache.js';
+export {
+  queryScoreablePredictionBrierVerdicts,
+  type ScoreablePredictionBrierVerdictQuery,
+} from './prediction-scoreable-verdicts.js';
 
 interface InternalDeps {
   fetch?: typeof globalThis.fetch;

--- a/client/src/corpus/prediction-scoreable-verdicts.ts
+++ b/client/src/corpus/prediction-scoreable-verdicts.ts
@@ -1,0 +1,35 @@
+import type { Store } from '../store/store.js';
+import type { EnvelopeProjection, EnvelopeProjectionQuery } from './types.js';
+
+export type ScoreablePredictionBrierVerdictQuery = Omit<
+  EnvelopeProjectionQuery,
+  'solverType' | 'role' | 'metadata'
+>;
+
+export function queryScoreablePredictionBrierVerdicts(
+  store: Pick<Store, 'queryEnvelopeProjections'>,
+  query: ScoreablePredictionBrierVerdictQuery = {},
+): EnvelopeProjection[] {
+  const { limit, ...projectionQuery } = query;
+  const scoreable = store.queryEnvelopeProjections({
+    ...projectionQuery,
+    limit: 1000,
+    solverType: 'prediction.v1',
+    role: 'verdict',
+    metadata: { verdict: 'SCORED' },
+  }).filter(hasBrierScoreMetadata);
+
+  if (limit === undefined) return scoreable;
+  return scoreable.slice(0, Math.max(0, limit));
+}
+
+function hasBrierScoreMetadata(projection: EnvelopeProjection): boolean {
+  return hasStringMetadata(projection, 'scores.solverBrier')
+    && hasStringMetadata(projection, 'scores.consensusBrier')
+    && hasStringMetadata(projection, 'scores.brierSpread');
+}
+
+function hasStringMetadata(projection: EnvelopeProjection, key: string): boolean {
+  const value = projection.metadata[key];
+  return typeof value === 'string' && value.length > 0;
+}

--- a/client/src/corpus/types.ts
+++ b/client/src/corpus/types.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Store } from '../store/store.js';
-import type { SignedEnvelope } from '../types/envelope.js';
+import type { EvidenceTier, Role, SignedEnvelope } from '../types/envelope.js';
 
 export interface CorpusOptions {
   subgraphUrl: string;
@@ -23,6 +23,47 @@ export interface CorpusQuery {
   taskCid?: string;
   participant?: { safeAddress?: string };
   evidenceTier?: 'self-signed' | 'committed' | 'attested';
+  generatedAfter?: number;
+  generatedBefore?: number;
+  limit?: number;
+}
+
+export type EnvelopeProjectionMetadataValue = string | number | boolean;
+export type EnvelopeProjectionMetadata = Record<string, EnvelopeProjectionMetadataValue>;
+
+export interface EnvelopeProjection {
+  envelopeId: string;
+  envelopeCid: string | null;
+  envelopeSha256: string | null;
+  signatureHash: string;
+  solverType: string;
+  role: Role;
+  taskCid: string | null;
+  taskId: string | null;
+  requestId: string | null;
+  generatedAt: number;
+  evidenceTier: EvidenceTier;
+  participantSafeAddress: string | null;
+  participantAgentEoa: string | null;
+  executorImplName: string | null;
+  executorImplVersion: string | null;
+  executorRuntimeBundleDigest: string | null;
+  executorPlugins: string[];
+  solutionEnvelopeCid: string | null;
+  solutionEnvelopeSha256: string | null;
+  solutionEnvelopeRef: string | null;
+  metadata: EnvelopeProjectionMetadata;
+}
+
+export interface EnvelopeProjectionQuery {
+  solverType?: string;
+  role?: Role;
+  taskCid?: string;
+  taskId?: string;
+  requestId?: string;
+  participant?: { safeAddress?: string; agentEoa?: string };
+  solutionEnvelopeRef?: string;
+  metadata?: EnvelopeProjectionMetadata;
   generatedAfter?: number;
   generatedBefore?: number;
   limit?: number;

--- a/client/src/daemon/daemon.ts
+++ b/client/src/daemon/daemon.ts
@@ -428,7 +428,7 @@ export class Daemon {
 
       const solverType = taskAnnouncement.task.solverType ?? undefined;
       const taskRole = (taskAnnouncement.task.role ?? 'restoration') as 'restoration' | 'evaluation';
-      const accept = await engine.canAcceptTask({ solverType, taskRole });
+      const accept = await engine.canAcceptTask({ solverType, taskRole, task: taskAnnouncement.task });
       if (!accept.ok) {
         console.log(`[daemon] skipping task ${taskAnnouncement.taskId} — ${accept.reason}`);
         continue;

--- a/client/src/earning/contracts.ts
+++ b/client/src/earning/contracts.ts
@@ -29,6 +29,7 @@ export const DEFAULT_TESTNET_ARTIFACTS = {
   token: path.join(BUNDLED_DEPLOYMENTS_DIR, 'deployment-phase1a-token-baseSepolia-fast.json'),
   l2: path.join(BUNDLED_DEPLOYMENTS_DIR, 'deployment-phase1a-l2-baseSepolia-fast.json'),
   mech: path.join(BUNDLED_DEPLOYMENTS_DIR, 'deployment-phase1b-mech-baseSepolia-fast.json'),
+  taskCoordinatorRouterV3: path.join(BUNDLED_DEPLOYMENTS_DIR, 'deployment-task-coordinator-router-v3-baseSepolia-fast.json'),
   stolas: path.join(BUNDLED_DEPLOYMENTS_DIR, 'deployment-stolas-l2-baseSepolia-fast.json'),
   faucet: path.join(BUNDLED_DEPLOYMENTS_DIR, 'deployment-jinn-testnet-faucet-baseSepolia-fast.json'),
   /** v0 MVI L1 stack (JINN, Timelock, Governor, Distributor, Messenger) on Sepolia. */
@@ -313,6 +314,9 @@ function resolveBaseSepoliaConfig(overrides: ChainConfigOverrides = {}): ChainCo
     overrides.testnetMechDeploymentPath
     ?? process.env['JINN_TESTNET_MECH_DEPLOYMENT']
     ?? DEFAULT_TESTNET_ARTIFACTS.mech;
+  const taskCoordinatorRouterV3ArtifactPath =
+    process.env['JINN_TESTNET_TASK_COORDINATOR_ROUTER_V3_DEPLOYMENT']
+    ?? DEFAULT_TESTNET_ARTIFACTS.taskCoordinatorRouterV3;
 
   const resolved: ChainConfig = { ...BASE_SEPOLIA_CONFIG };
 
@@ -376,6 +380,22 @@ function resolveBaseSepoliaConfig(overrides: ChainConfigOverrides = {}): ChainCo
     if (stakingToken) {
       resolved.stakingContract = stakingToken;
     }
+  }
+
+  if (taskCoordinatorRouterV3ArtifactPath) {
+    const taskArtifact = loadArtifact(taskCoordinatorRouterV3ArtifactPath);
+    const jinnRouterV3 = taskArtifact.contracts?.jinnRouterV3;
+    const mechMarketplace = taskArtifact.contracts?.mechMarketplace;
+    if (!jinnRouterV3) {
+      throw new Error(
+        `TaskCoordinator/JinnRouterV3 artifact ${path.resolve(taskCoordinatorRouterV3ArtifactPath)} is missing contracts.jinnRouterV3`,
+      );
+    }
+    resolved.jinnRouter = jinnRouterV3;
+    if (mechMarketplace) {
+      resolved.mechMarketplace = mechMarketplace;
+    }
+    resolved.routerClaimDeliveryVersion = 'v3';
   }
 
   const stolasArtifactPath =

--- a/client/src/earning/store.ts
+++ b/client/src/earning/store.ts
@@ -117,6 +117,10 @@ export class FleetStateStore {
     return this.earningDir;
   }
 
+  hasStateFile(): boolean {
+    return existsSync(this.statePath);
+  }
+
   // ── Mnemonic keystore ──────────────────────────────────────────────────
 
   hasMnemonicKeystore(): boolean {

--- a/client/src/harnesses/engine/engine.ts
+++ b/client/src/harnesses/engine/engine.ts
@@ -41,8 +41,10 @@ import type {
 } from '../../erc8004/index.js';
 import { submitEvaluatorFeedback } from '../../erc8004/index.js';
 import type { Role } from '../../types/envelope.js';
+import type { Task } from '../../types/task.js';
 import { TrajectoryCollector, emitTrajectory } from '../../trajectory/index.js';
 import { buildInfo } from '../../build-info.js';
+import { getSolverNetContract, validateTask } from '@jinn-network/sdk/solvernets';
 
 // ── Sentinel error ────────────────────────────────────────────────────────────
 
@@ -249,8 +251,9 @@ export class TaskEngine {
   async canAcceptTask(input: {
     solverType?: string;
     taskRole?: 'restoration' | 'evaluation';
+    task?: Task;
   }): Promise<{ ok: true } | { ok: false; reason: string }> {
-    const reason = await this.runnableFailureReason(input.solverType, input.taskRole ?? 'restoration');
+    const reason = await this.runnableFailureReason(input.solverType, input.taskRole ?? 'restoration', input.task);
     return reason ? { ok: false, reason } : { ok: true };
   }
 
@@ -442,7 +445,11 @@ export class TaskEngine {
    * the operator has an enabled, ready Harness and advances DISCOVERED → CLAIMED.
    */
   protected async claim(task: PersistedTaskRun): Promise<void> {
-    const reason = await this.runnableFailureReason(task.solverType ?? undefined, task.taskRole ?? 'restoration');
+    const reason = await this.runnableFailureReason(
+      task.solverType ?? undefined,
+      task.taskRole ?? 'restoration',
+      task.task as Task | undefined,
+    );
     if (reason) {
       this.persistence.markFailed(task.requestId, reason);
       console.log(`[harness-engine] ${task.requestId}: skipping claimed task — ${reason}`);
@@ -473,12 +480,19 @@ export class TaskEngine {
   private async runnableFailureReason(
     solverType: string | undefined,
     role: 'restoration' | 'evaluation',
+    task?: Task,
   ): Promise<string | null> {
     const solverNet = this.solverNetRegistry && solverType
       ? this.solverNetRegistry.forSolverType(solverType)
       : undefined;
     if (this.solverNetRegistry && solverType && !solverNet) {
       return `no enabled SolverNet for solverType '${solverType}'; run \`jinn solver-nets enable <name>\``;
+    }
+    if (solverType && task && getSolverNetContract(solverType)) {
+      const validation = validateTask(solverType, task);
+      if (!validation.ok) {
+        return validation.error.message;
+      }
     }
     if (!this.implRegistry || !solverType) return null;
 
@@ -488,6 +502,14 @@ export class TaskEngine {
         ? `jinn solver-nets set-harness ${solverNet.name} <harness>`
         : 'jinn solver-nets set-harness <name> <harness>';
       return `no Harness registered or enabled for solverType '${solverType}'; run \`${setHarnessHint}\``;
+    }
+    if (task) {
+      if (impl.canAttempt) {
+        const attempt = await impl.canAttempt(task);
+        if (!attempt.ok) {
+          return `impl '${impl.name}' cannot attempt task: ${attempt.reason}`;
+        }
+      }
     }
     if (impl.isReady) {
       const status = await impl.isReady({ solverType, role });

--- a/client/src/harnesses/impls/index.ts
+++ b/client/src/harnesses/impls/index.ts
@@ -8,8 +8,8 @@ import type { Harness } from '../types.js';
 import { LegacyClaudeImpl } from './legacy-claude/index.js';
 import { ClaudeMcpHyperliquidImpl } from './claude-mcp-hyperliquid/index.js';
 import { PortfolioV0Evaluator } from './portfolio-v0-evaluator/index.js';
-import { PredictionV1BaselineImpl } from './prediction-v0-baseline/index.js';
-import { PredictionV1Evaluator } from './prediction-v0-evaluator/index.js';
+import { PredictionV1BaselineImpl } from './prediction-v1-baseline/index.js';
+import { PredictionV1Evaluator } from './prediction-v1-evaluator/index.js';
 import { ClaudeMcpPredictionImpl } from './claude-mcp-prediction/index.js';
 import { PredictionApyV0BaselineImpl } from './prediction-apy-v0-baseline/index.js';
 import { ClaudeMcpPredictionApyImpl } from './claude-mcp-prediction-apy/index.js';
@@ -130,7 +130,6 @@ export function buildHarnesses(env: HarnessEnv): Harness[] {
   );
   out.push(
     new PredictionV1BaselineImpl({
-      rpcUrl: env.rpcUrl,
       stub: isStub,
     }),
   );
@@ -144,12 +143,8 @@ export function buildHarnesses(env: HarnessEnv): Harness[] {
   );
   out.push(
     isStub
-      ? new PredictionV1Evaluator({ stub: true, rpcUrl: env.rpcUrl })
-      : new PredictionV1Evaluator({
-          evaluatorPk: env.pk!,
-          evaluatorSafeAddress: env.safe!,
-          rpcUrl: env.rpcUrl,
-        }),
+      ? new PredictionV1Evaluator({ stub: true })
+      : new PredictionV1Evaluator(),
   );
   out.push(
     new PredictionApyV0BaselineImpl({

--- a/client/src/harnesses/impls/prediction-v1-evaluator/index.ts
+++ b/client/src/harnesses/impls/prediction-v1-evaluator/index.ts
@@ -20,6 +20,12 @@ import {
   RESTORATION_TASK_CID_CONTEXT_KEY,
 } from '../evaluation-context.js';
 import {
+  checkManifestSignature,
+  checkTaskRef,
+  checkTaskRefMissingExpected,
+  recomputeTopLevelSignatureHash,
+} from '../prediction-v0-evaluator/checks/integrity.js';
+import {
   getResolution,
   type ResolutionSnapshot,
 } from '../../../venues/polymarket/client.js';
@@ -58,6 +64,9 @@ export class PredictionV1Evaluator implements Harness {
     if (typeof task.context?.['restorationResult'] !== 'string') {
       return { ok: false, reason: 'context.restorationResult required' };
     }
+    if (typeof task.context?.[RESTORATION_TASK_CID_CONTEXT_KEY] !== 'string') {
+      return { ok: false, reason: `context.${RESTORATION_TASK_CID_CONTEXT_KEY} required` };
+    }
     return { ok: true };
   }
 
@@ -89,15 +98,12 @@ export class PredictionV1Evaluator implements Harness {
       } else {
         checks.push({ name: 'solution.envelope', status: 'PASS' });
       }
+      checks.push(await checkManifestSignature(recomputeTopLevelSignatureHash(rawEnvelope), envelope.signature));
       const expectedTaskCid = ctx.task.context?.[RESTORATION_TASK_CID_CONTEXT_KEY] as string | undefined;
-      if (expectedTaskCid && envelope.task.cid !== expectedTaskCid) {
-        checks.push({
-          name: 'task.identity',
-          status: 'FAIL',
-          detail: { expectedTaskCid, actualTaskCid: envelope.task.cid },
-        });
+      if (expectedTaskCid) {
+        checks.push(checkTaskRef(envelope.task.cid, expectedTaskCid));
       } else {
-        checks.push({ name: 'task.identity', status: expectedTaskCid ? 'PASS' : 'SKIP' });
+        checks.push(checkTaskRefMissingExpected());
       }
       solution = PredictionV1RestorationPayloadSchema.parse(envelope.payload);
       checks.push({ name: 'solution.schema', status: 'PASS' });
@@ -123,10 +129,7 @@ export class PredictionV1Evaluator implements Harness {
     }
 
     const resolution = await this.readResolution(ids.marketId, ids.conditionId, task.spec.source.url);
-    const verdict = deriveVerdict(checks, resolution);
-    const scores = verdict === 'SCORED' && solution && resolution.outcome
-      ? scoreBrier(solution.probabilityYes, task.spec.consensusSnapshot.probabilityYes, resolution.outcome)
-      : undefined;
+    checks.push(checkResolutionIdentity(resolution, ids));
     if (resolution.status === 'resolved') {
       checks.push({ name: 'market.resolution', status: 'PASS' });
     } else if (resolution.status === 'unresolved') {
@@ -134,6 +137,10 @@ export class PredictionV1Evaluator implements Harness {
     } else {
       checks.push({ name: 'market.resolution', status: 'FAIL', detail: resolution.status });
     }
+    const verdict = deriveVerdict(checks, resolution);
+    const scores = verdict === 'SCORED' && solution && resolution.outcome
+      ? scoreBrier(solution.probabilityYes, task.spec.consensusSnapshot.probabilityYes, resolution.outcome)
+      : undefined;
 
     const payload: Record<string, unknown> = {
       verdict,
@@ -206,10 +213,32 @@ export class PredictionV1Evaluator implements Harness {
 }
 
 function deriveVerdict(checks: Check[], resolution: ResolutionSnapshot): 'SCORED' | 'REJECTED' | 'INVALID' | 'INDETERMINATE' {
-  if (checks.some((check) => check.status === 'FAIL')) return 'REJECTED';
+  if (checks.some((check) => check.status === 'FAIL' && check.name !== 'market.resolution')) return 'REJECTED';
+  if (checks.some((check) => check.status === 'INDETERMINATE')) return 'INDETERMINATE';
   if (resolution.status === 'resolved' && resolution.outcome) return 'SCORED';
   if (resolution.status === 'unresolved') return 'INDETERMINATE';
   return 'INVALID';
+}
+
+function checkResolutionIdentity(
+  resolution: ResolutionSnapshot,
+  ids: { marketId: string; conditionId: string },
+): Check {
+  const marketMatches = resolution.marketId === ids.marketId;
+  const conditionMatches = resolution.conditionId.toLowerCase() === ids.conditionId.toLowerCase();
+  if (marketMatches && conditionMatches) {
+    return { name: 'market.identity', status: 'PASS' };
+  }
+  return {
+    name: 'market.identity',
+    status: 'FAIL',
+    detail: {
+      expectedMarketId: ids.marketId,
+      actualMarketId: resolution.marketId,
+      expectedConditionId: ids.conditionId,
+      actualConditionId: resolution.conditionId,
+    },
+  };
 }
 
 function scoreBrier(

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1162,7 +1162,14 @@ export async function main(): Promise<DaemonStartupInfo | void> {
     agentEoa: agentEoaAddress,
     safeAddress,
     agentPrivateKey,
+    predictionV1LauncherEnabled: config.predictionV1LauncherEnabled,
     predictionV1WindowMs: config.predictionV1WindowMs,
+    predictionV1CadenceMs: config.predictionV1CadenceMs,
+    predictionV1MaxNewRoundsPerPoll: config.predictionV1MaxNewRoundsPerPoll,
+    predictionV1MaxNewRoundsPerDay: config.predictionV1MaxNewRoundsPerDay,
+    predictionV1MaxOpenRounds: config.predictionV1MaxOpenRounds,
+    predictionV1AllowlistConditionIds: config.predictionV1AllowlistConditionIds,
+    predictionV1BlocklistConditionIds: config.predictionV1BlocklistConditionIds,
     predictionV1ResolveGapMs: config.predictionV1ResolveGapMs,
   });
   for (const line of autoTaskLogLines) {

--- a/client/src/solver-types/index.ts
+++ b/client/src/solver-types/index.ts
@@ -4,7 +4,7 @@
 
 import type { TaskGenerator } from '../tasks/sources.js';
 import { portfolioV0 } from './portfolio-v0.js';
-import { predictionV1 } from './prediction-v0.js';
+import { predictionV1 } from './prediction-v1.js';
 import { predictionApyV0 } from './prediction-apy-v0.js';
 import { learnerLoopTest } from './learner-loop-test.js';
 import type { SolverTypeDefinition, TestnetAutoContext } from './solver-type.js';
@@ -45,8 +45,19 @@ export function collectTestnetAutoTaskGenerators(opts: {
   safeAddress?: `0x${string}`;
   /** Agent EOA private key — passed to generator configs that sign tasks. */
   agentPrivateKey?: `0x${string}`;
+  /** Explicit launcher opt-in for Polymarket prediction.v1 Task generation. */
+  predictionV1LauncherEnabled?: boolean;
   /** Override prediction.v1 submission window (ms). */
   predictionV1WindowMs?: number;
+  /** Override prediction.v1 Polymarket generator cadence (ms). */
+  predictionV1CadenceMs?: number;
+  /** Override prediction.v1 Polymarket generator safety caps. */
+  predictionV1MaxNewRoundsPerPoll?: number;
+  predictionV1MaxNewRoundsPerDay?: number;
+  predictionV1MaxOpenRounds?: number;
+  /** Override prediction.v1 Polymarket manual conditionId controls. */
+  predictionV1AllowlistConditionIds?: string[];
+  predictionV1BlocklistConditionIds?: string[];
   /** Override prediction.v1 window→resolveTs gap (ms). */
   predictionV1ResolveGapMs?: number;
 }): { generators: Array<{ solverType: string; generator: TaskGenerator }>; logLines: string[] } {
@@ -62,7 +73,14 @@ export function collectTestnetAutoTaskGenerators(opts: {
     agentEoa: opts.agentEoa,
     safeAddress: opts.safeAddress,
     agentPrivateKey: opts.agentPrivateKey,
+    predictionV1LauncherEnabled: opts.predictionV1LauncherEnabled,
     predictionV1WindowMs: opts.predictionV1WindowMs,
+    predictionV1CadenceMs: opts.predictionV1CadenceMs,
+    predictionV1MaxNewRoundsPerPoll: opts.predictionV1MaxNewRoundsPerPoll,
+    predictionV1MaxNewRoundsPerDay: opts.predictionV1MaxNewRoundsPerDay,
+    predictionV1MaxOpenRounds: opts.predictionV1MaxOpenRounds,
+    predictionV1AllowlistConditionIds: opts.predictionV1AllowlistConditionIds,
+    predictionV1BlocklistConditionIds: opts.predictionV1BlocklistConditionIds,
     predictionV1ResolveGapMs: opts.predictionV1ResolveGapMs,
   };
   for (const kind of knownSolverTypes()) {

--- a/client/src/solver-types/prediction-v0.ts
+++ b/client/src/solver-types/prediction-v0.ts
@@ -7,7 +7,7 @@ import { makePredictionV1Generator, type PredictionV1AutoConfig } from './predic
 import type { SolverTypeDefinition } from './solver-type.js';
 import { PREDICTION_V1_KIND } from './constants.js';
 
-export const predictionV1: SolverTypeDefinition<PredictionV1AutoConfig> = {
+export const legacyChainlinkPredictionV1: SolverTypeDefinition<PredictionV1AutoConfig> = {
   solverType: PREDICTION_V1_KIND,
   async parseSpec(raw, deps) {
     if (predictionV1TemplateNeedsReadCurrent(raw) && !deps?.readCurrent) {

--- a/client/src/solver-types/prediction-v1-auto.ts
+++ b/client/src/solver-types/prediction-v1-auto.ts
@@ -7,6 +7,7 @@ import type { Task } from '../types/task.js';
 import type { TaskV1, SignedTaskV1 } from '../types/task-document.js';
 import { signTaskV1 } from '../tasks/signing.js';
 import {
+  getResolution,
   getOrderbook,
   listMarketCandidates,
   type MarketCandidate,
@@ -21,6 +22,7 @@ export interface PredictionV1AutoConfig extends PolymarketClientConfig {
   minVolume24hUsd?: string;
   maxYesSpread?: string;
   maxOrderbookAgeSeconds?: number;
+  cadenceMs?: number;
   maxNewRoundsPerPoll?: number;
   maxNewRoundsPerDay?: number;
   maxOpenRounds?: number;
@@ -28,6 +30,7 @@ export interface PredictionV1AutoConfig extends PolymarketClientConfig {
   agentEoa?: `0x${string}`;
   safeAddress?: `0x${string}`;
   agentPrivateKey?: `0x${string}`;
+  allowlistConditionIds?: string[];
   blocklistConditionIds?: string[];
 }
 
@@ -45,6 +48,7 @@ const DEFAULTS = {
   minVolume24hUsd: '2500',
   maxYesSpread: '0.10',
   maxOrderbookAgeSeconds: 60,
+  cadenceMs: 6 * 60 * 60 * 1000,
   maxNewRoundsPerPoll: 25,
   maxNewRoundsPerDay: 100,
   maxOpenRounds: 250,
@@ -54,10 +58,18 @@ const DEFAULTS = {
 export function makePredictionV1Generator(config: PredictionV1AutoConfig = {}) {
   const postedAtByCondition = new Map<string, number>();
   const postedCountByDay = new Map<string, number>();
-  const blocklist = new Set(config.blocklistConditionIds ?? []);
+  const allowlist = conditionIdSet(config.allowlistConditionIds);
+  const blocklist = conditionIdSet(config.blocklistConditionIds);
+  let lastPollStartedAt = 0;
 
   return async (): Promise<Task[] | null> => {
     const now = Date.now();
+    const cadenceMs = config.cadenceMs ?? DEFAULTS.cadenceMs;
+    if (cadenceMs > 0 && lastPollStartedAt > 0 && now - lastPollStartedAt < cadenceMs) {
+      return null;
+    }
+    lastPollStartedAt = now;
+
     pruneOpenRounds(postedAtByCondition, now);
     const dayKey = new Date(now).toISOString().slice(0, 10);
     const todayCount = postedCountByDay.get(dayKey) ?? 0;
@@ -74,14 +86,19 @@ export function makePredictionV1Generator(config: PredictionV1AutoConfig = {}) {
     }
 
     const eligible: EligibleMarket[] = [];
-    for (const market of candidates) {
+    for (const market of prioritizeAllowlisted(candidates, allowlist)) {
       if (eligible.length >= pollLimit * 3) break;
-      if (postedAtByCondition.has(market.conditionId) || blocklist.has(market.conditionId)) continue;
+      const conditionId = normalizeConditionId(market.conditionId);
+      if (postedAtByCondition.has(conditionId) || blocklist.has(conditionId)) continue;
       const checked = await checkMarketEligibility(market, config, now);
       if (checked) eligible.push(checked);
     }
 
     eligible.sort((a, b) => {
+      const allowDelta =
+        Number(allowlist.has(normalizeConditionId(b.market.conditionId))) -
+        Number(allowlist.has(normalizeConditionId(a.market.conditionId)));
+      if (allowDelta !== 0) return allowDelta;
       const liquidityDelta = Number(b.market.liquidityUsd) - Number(a.market.liquidityUsd);
       if (Number.isFinite(liquidityDelta) && liquidityDelta !== 0) return liquidityDelta;
       const spreadDelta = Number(a.orderbook.spread) - Number(b.orderbook.spread);
@@ -93,7 +110,7 @@ export function makePredictionV1Generator(config: PredictionV1AutoConfig = {}) {
     const tasks: Task[] = [];
     for (const entry of selected) {
       const task = await buildTask(entry, config, now);
-      postedAtByCondition.set(entry.market.conditionId, Date.parse(entry.market.endTime));
+      postedAtByCondition.set(normalizeConditionId(entry.market.conditionId), Date.parse(entry.market.endTime));
       tasks.push(task);
     }
     if (tasks.length > 0) {
@@ -108,7 +125,6 @@ async function checkMarketEligibility(
   config: PredictionV1AutoConfig,
   now: number,
 ): Promise<EligibleMarket | null> {
-  if (!market.active || market.closed || market.archived) return null;
   if (!market.rulesText.trim()) return null;
   if (Number(market.liquidityUsd) < Number(config.minLiquidityUsd ?? DEFAULTS.minLiquidityUsd)) return null;
   if (Number(market.volume24hUsd) < Number(config.minVolume24hUsd ?? DEFAULTS.minVolume24hUsd)) return null;
@@ -118,6 +134,20 @@ async function checkMarketEligibility(
   const timeToResolutionHours = (resolutionMs - now) / 3_600_000;
   if (timeToResolutionHours < (config.minTimeToResolutionHours ?? DEFAULTS.minTimeToResolutionHours)) return null;
   if (timeToResolutionHours > (config.maxTimeToResolutionHours ?? DEFAULTS.maxTimeToResolutionHours)) return null;
+
+  let resolutionStatus: string;
+  try {
+    const resolution = await getResolution({
+      ...config,
+      marketId: market.marketId,
+      sourceUrl: market.url,
+    });
+    resolutionStatus = resolution.status;
+  } catch {
+    return null;
+  }
+  if (resolutionStatus !== 'unresolved') return null;
+  if (!market.active || market.closed || market.archived) return null;
 
   let orderbook: OrderbookSnapshot;
   try {
@@ -204,6 +234,11 @@ async function buildTask(
     minVolume24hUsd: config.minVolume24hUsd ?? DEFAULTS.minVolume24hUsd,
     maxYesSpread: config.maxYesSpread ?? DEFAULTS.maxYesSpread,
     maxOrderbookAgeSeconds: config.maxOrderbookAgeSeconds ?? DEFAULTS.maxOrderbookAgeSeconds,
+    generatorCadenceMs: config.cadenceMs ?? DEFAULTS.cadenceMs,
+    maxNewRoundsPerPoll: config.maxNewRoundsPerPoll ?? DEFAULTS.maxNewRoundsPerPoll,
+    maxNewRoundsPerDay: config.maxNewRoundsPerDay ?? DEFAULTS.maxNewRoundsPerDay,
+    maxOpenRounds: config.maxOpenRounds ?? DEFAULTS.maxOpenRounds,
+    manualAllowlistHit: conditionIdSet(config.allowlistConditionIds).has(normalizeConditionId(market.conditionId)),
   };
   const baseTask: Task = {
     id,
@@ -246,4 +281,26 @@ function pruneOpenRounds(postedAtByCondition: Map<string, number>, now: number):
       postedAtByCondition.delete(conditionId);
     }
   }
+}
+
+function normalizeConditionId(conditionId: string): string {
+  return conditionId.trim().toLowerCase();
+}
+
+function conditionIdSet(values?: string[]): Set<string> {
+  return new Set(
+    (values ?? [])
+      .map((value) => normalizeConditionId(value))
+      .filter(Boolean),
+  );
+}
+
+function prioritizeAllowlisted(markets: MarketCandidate[], allowlist: Set<string>): MarketCandidate[] {
+  if (allowlist.size === 0) return markets;
+  return [...markets].sort((a, b) => {
+    const allowDelta =
+      Number(allowlist.has(normalizeConditionId(b.conditionId))) -
+      Number(allowlist.has(normalizeConditionId(a.conditionId)));
+    return allowDelta;
+  });
 }

--- a/client/src/solver-types/prediction-v1.ts
+++ b/client/src/solver-types/prediction-v1.ts
@@ -18,11 +18,18 @@ export const predictionV1: SolverTypeDefinition<PredictionV1AutoConfig> = {
   },
   buildGenerator: (config) => makePredictionV1Generator(config),
   getTestnetAutoConfig: (ctx) => {
-    if (ctx.network !== 'testnet') return undefined;
+    if (ctx.network !== 'testnet' || !ctx.predictionV1LauncherEnabled) return undefined;
     return {
       agentEoa: ctx.agentEoa,
       safeAddress: ctx.safeAddress,
       agentPrivateKey: ctx.agentPrivateKey,
+      submissionWindowMs: ctx.predictionV1WindowMs ?? nonNegativeNumberEnv(ctx.env, 'JINN_PREDICTION_V1_WINDOW_MS'),
+      cadenceMs: ctx.predictionV1CadenceMs ?? nonNegativeNumberEnv(ctx.env, 'JINN_PREDICTION_V1_CADENCE_MS'),
+      maxNewRoundsPerPoll: ctx.predictionV1MaxNewRoundsPerPoll ?? nonNegativeNumberEnv(ctx.env, 'JINN_PREDICTION_V1_MAX_NEW_ROUNDS_PER_POLL'),
+      maxNewRoundsPerDay: ctx.predictionV1MaxNewRoundsPerDay ?? nonNegativeNumberEnv(ctx.env, 'JINN_PREDICTION_V1_MAX_NEW_ROUNDS_PER_DAY'),
+      maxOpenRounds: ctx.predictionV1MaxOpenRounds ?? nonNegativeNumberEnv(ctx.env, 'JINN_PREDICTION_V1_MAX_OPEN_ROUNDS'),
+      allowlistConditionIds: ctx.predictionV1AllowlistConditionIds ?? csvEnv(ctx.env, 'JINN_PREDICTION_V1_ALLOWLIST_CONDITION_IDS'),
+      blocklistConditionIds: ctx.predictionV1BlocklistConditionIds ?? csvEnv(ctx.env, 'JINN_PREDICTION_V1_BLOCKLIST_CONDITION_IDS'),
     };
   },
   ui: {
@@ -30,3 +37,20 @@ export const predictionV1: SolverTypeDefinition<PredictionV1AutoConfig> = {
     category: 'prediction',
   },
 };
+
+function nonNegativeNumberEnv(env: NodeJS.ProcessEnv, name: string): number | undefined {
+  const value = env[name]?.trim();
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function csvEnv(env: NodeJS.ProcessEnv, name: string): string[] | undefined {
+  const value = env[name];
+  if (value === undefined) return undefined;
+  const parts = value
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean);
+  return parts.length > 0 ? parts : undefined;
+}

--- a/client/src/solver-types/solver-type.ts
+++ b/client/src/solver-types/solver-type.ts
@@ -33,14 +33,27 @@ export interface TestnetAutoContext {
   /** Agent EOA private key — threaded into auto-gen configs so generators can sign SignedTaskV1. */
   agentPrivateKey?: `0x${string}`;
   /**
-   * Override the prediction.v1 auto-generator submission window (ms). Used by the
-   * docker acceptance gate to keep the protocol loop tight (gate sets 120000).
-   * Default 600000 (10 min) when unset.
+   * Explicit opt-in for the launcher-owned Polymarket prediction.v1 generator.
+   * Ordinary operator daemons leave this unset/false and do not create rounds.
+   */
+  predictionV1LauncherEnabled?: boolean;
+  /**
+   * Override the prediction.v1 Polymarket submission window (ms).
+   * The generator default applies when unset.
    */
   predictionV1WindowMs?: number;
+  /** Launcher-owned Polymarket generator cadence (ms). */
+  predictionV1CadenceMs?: number;
+  /** Launcher-owned Polymarket generator safety caps. */
+  predictionV1MaxNewRoundsPerPoll?: number;
+  predictionV1MaxNewRoundsPerDay?: number;
+  predictionV1MaxOpenRounds?: number;
+  /** Launcher-owned Polymarket manual conditionId controls. */
+  predictionV1AllowlistConditionIds?: string[];
+  predictionV1BlocklistConditionIds?: string[];
   /**
-   * Override the prediction.v1 auto-generator gap from window end → resolveTs (ms).
-   * Default 300000 (5 min) when unset; gate sets 60000.
+   * Legacy Chainlink prediction.v1 gap from window end → resolveTs (ms).
+   * Retained for direct legacy generator tests; unused by Polymarket prediction.v1.
    */
   predictionV1ResolveGapMs?: number;
 }

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -1,6 +1,11 @@
 import Database from 'better-sqlite3';
 import { mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
+import type {
+  EnvelopeProjection,
+  EnvelopeProjectionMetadataValue,
+  EnvelopeProjectionQuery,
+} from '../corpus/types.js';
 import { TASK_RUNS_SCHEMA } from '../harnesses/engine/persistence.js';
 
 export interface ActivityEventInput {
@@ -232,6 +237,48 @@ CREATE INDEX IF NOT EXISTS idx_network_artifacts_envelope ON network_artifacts (
 CREATE INDEX IF NOT EXISTS idx_network_artifacts_artifact_type ON network_artifacts (artifact_type);
 CREATE INDEX IF NOT EXISTS idx_network_artifacts_last_used ON network_artifacts (last_used_at DESC);
 
+CREATE TABLE IF NOT EXISTS envelope_projections (
+  envelope_id TEXT PRIMARY KEY,
+  envelope_cid TEXT,
+  envelope_sha256 TEXT,
+  signature_hash TEXT NOT NULL,
+  solver_type TEXT NOT NULL,
+  role TEXT NOT NULL,
+  task_cid TEXT,
+  task_id TEXT,
+  request_id TEXT,
+  generated_at INTEGER NOT NULL,
+  evidence_tier TEXT NOT NULL,
+  participant_safe_address TEXT,
+  participant_agent_eoa TEXT,
+  executor_impl_name TEXT,
+  executor_impl_version TEXT,
+  executor_runtime_bundle_digest TEXT,
+  executor_plugins_json TEXT NOT NULL DEFAULT '[]',
+  solution_envelope_cid TEXT,
+  solution_envelope_sha256 TEXT,
+  solution_envelope_ref TEXT,
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_envelope_projections_solver_role ON envelope_projections (solver_type, role);
+CREATE INDEX IF NOT EXISTS idx_envelope_projections_task_cid ON envelope_projections (task_cid);
+CREATE INDEX IF NOT EXISTS idx_envelope_projections_task_id ON envelope_projections (task_id);
+CREATE INDEX IF NOT EXISTS idx_envelope_projections_request ON envelope_projections (request_id);
+CREATE INDEX IF NOT EXISTS idx_envelope_projections_solution_ref ON envelope_projections (solution_envelope_ref);
+CREATE INDEX IF NOT EXISTS idx_envelope_projections_generated ON envelope_projections (generated_at DESC);
+
+CREATE TABLE IF NOT EXISTS envelope_projection_metadata (
+  envelope_id TEXT NOT NULL,
+  key TEXT NOT NULL,
+  value_text TEXT NOT NULL,
+  value_type TEXT NOT NULL CHECK (value_type IN ('string', 'number', 'boolean')),
+  PRIMARY KEY (envelope_id, key),
+  FOREIGN KEY (envelope_id) REFERENCES envelope_projections(envelope_id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_envelope_projection_metadata_key_value
+  ON envelope_projection_metadata (key, value_text);
+
 CREATE TABLE IF NOT EXISTS task_post_locks (
   creator_safe_address TEXT NOT NULL,
   source_key TEXT NOT NULL,
@@ -262,6 +309,7 @@ export class Store {
     this.ensureNetworkArtifactsPeerCatalogId();
     this.ensureTaskPostsTaskCoordinatorColumns();
     this.backfillActivityEvents();
+    this.recordLegacyRestorationIntentsIgnored();
   }
 
   /** Older on-disk DBs predate `peer_catalog_id` on network_artifacts. */
@@ -284,6 +332,61 @@ export class Store {
     }
     if (!names.has('task_cid')) {
       this.db.exec(`ALTER TABLE task_posts ADD COLUMN task_cid TEXT`);
+    }
+  }
+
+  /**
+   * Task-native startup ignores the retired request-first `restoration_intents`
+   * table. Keep a one-time local marker when old in-flight rows are present so
+   * operators can see why they were not resumed without blocking Store startup.
+   */
+  private recordLegacyRestorationIntentsIgnored(): void {
+    const table = this.db.prepare(
+      `SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'restoration_intents'`,
+    ).get() as { name: string } | undefined;
+    if (!table) return;
+
+    const cols = this.db.prepare(`PRAGMA table_info(restoration_intents)`).all() as Array<{ name: string }>;
+    const names = new Set(cols.map((c) => c.name));
+    if (!names.has('state')) return;
+
+    try {
+      const row = this.db.prepare(
+        `SELECT COUNT(*) AS count
+         FROM restoration_intents
+         WHERE state NOT IN ('COMPLETE', 'FAILED')`,
+      ).get() as { count: number } | undefined;
+      const count = row?.count ?? 0;
+      if (count <= 0) return;
+
+      const detail =
+        `Ignored ${count} legacy request-first restoration_intents row${count === 1 ? '' : 's'}; ` +
+        'Task-native recovery does not resume ClaimRegistry/request-first jobs.';
+      const ts = new Date().toISOString();
+      const marker = {
+        schemaVersion: 1,
+        ignoredAt: ts,
+        table: 'restoration_intents',
+        inFlightRows: count,
+        reason: 'legacy_request_first_task_native_update',
+      };
+
+      const tx = this.db.transaction(() => {
+        this.db.prepare(
+          `INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)`,
+        ).run('legacy_restoration_intents_ignored_v1', JSON.stringify(marker));
+        this.db.prepare(
+          `INSERT INTO activity_events (ts, kind, outcome, detail)
+           SELECT @ts, 'legacy_ignored', 'ignored', @detail
+           WHERE NOT EXISTS (
+             SELECT 1 FROM activity_events
+             WHERE kind = 'legacy_ignored' AND detail = @detail
+           )`,
+        ).run({ ts, detail });
+      });
+      tx();
+    } catch {
+      // Legacy schemas varied. Never let stale request-first state block Store startup.
     }
   }
 
@@ -1077,7 +1180,246 @@ export class Store {
     ];
   }
 
+  saveEnvelopeProjection(projection: EnvelopeProjection): void {
+    const tx = this.db.transaction((p: EnvelopeProjection) => {
+      this.db.prepare(
+        `INSERT INTO envelope_projections
+           (envelope_id, envelope_cid, envelope_sha256, signature_hash, solver_type, role,
+            task_cid, task_id, request_id, generated_at, evidence_tier,
+            participant_safe_address, participant_agent_eoa,
+            executor_impl_name, executor_impl_version, executor_runtime_bundle_digest,
+            executor_plugins_json, solution_envelope_cid, solution_envelope_sha256,
+            solution_envelope_ref, metadata_json)
+         VALUES
+           (@envelopeId, @envelopeCid, @envelopeSha256, @signatureHash, @solverType, @role,
+            @taskCid, @taskId, @requestId, @generatedAt, @evidenceTier,
+            @participantSafeAddress, @participantAgentEoa,
+            @executorImplName, @executorImplVersion, @executorRuntimeBundleDigest,
+            @executorPluginsJson, @solutionEnvelopeCid, @solutionEnvelopeSha256,
+            @solutionEnvelopeRef, @metadataJson)
+         ON CONFLICT(envelope_id) DO UPDATE SET
+           envelope_cid = excluded.envelope_cid,
+           envelope_sha256 = excluded.envelope_sha256,
+           signature_hash = excluded.signature_hash,
+           solver_type = excluded.solver_type,
+           role = excluded.role,
+           task_cid = excluded.task_cid,
+           task_id = excluded.task_id,
+           request_id = excluded.request_id,
+           generated_at = excluded.generated_at,
+           evidence_tier = excluded.evidence_tier,
+           participant_safe_address = excluded.participant_safe_address,
+           participant_agent_eoa = excluded.participant_agent_eoa,
+           executor_impl_name = excluded.executor_impl_name,
+           executor_impl_version = excluded.executor_impl_version,
+           executor_runtime_bundle_digest = excluded.executor_runtime_bundle_digest,
+           executor_plugins_json = excluded.executor_plugins_json,
+           solution_envelope_cid = excluded.solution_envelope_cid,
+           solution_envelope_sha256 = excluded.solution_envelope_sha256,
+           solution_envelope_ref = excluded.solution_envelope_ref,
+           metadata_json = excluded.metadata_json`,
+      ).run({
+        envelopeId: p.envelopeId,
+        envelopeCid: p.envelopeCid,
+        envelopeSha256: p.envelopeSha256,
+        signatureHash: p.signatureHash,
+        solverType: p.solverType,
+        role: p.role,
+        taskCid: p.taskCid,
+        taskId: p.taskId,
+        requestId: p.requestId,
+        generatedAt: p.generatedAt,
+        evidenceTier: p.evidenceTier,
+        participantSafeAddress: p.participantSafeAddress,
+        participantAgentEoa: p.participantAgentEoa,
+        executorImplName: p.executorImplName,
+        executorImplVersion: p.executorImplVersion,
+        executorRuntimeBundleDigest: p.executorRuntimeBundleDigest,
+        executorPluginsJson: JSON.stringify(p.executorPlugins),
+        solutionEnvelopeCid: p.solutionEnvelopeCid,
+        solutionEnvelopeSha256: p.solutionEnvelopeSha256,
+        solutionEnvelopeRef: p.solutionEnvelopeRef,
+        metadataJson: JSON.stringify(p.metadata),
+      });
+
+      this.db.prepare(`DELETE FROM envelope_projection_metadata WHERE envelope_id = ?`).run(p.envelopeId);
+      const insertMetadata = this.db.prepare(
+        `INSERT INTO envelope_projection_metadata (envelope_id, key, value_text, value_type)
+         VALUES (@envelopeId, @key, @valueText, @valueType)`,
+      );
+      for (const [key, value] of Object.entries(p.metadata)) {
+        insertMetadata.run({
+          envelopeId: p.envelopeId,
+          key,
+          valueText: metadataValueText(value),
+          valueType: typeof value,
+        });
+      }
+    });
+    tx(projection);
+  }
+
+  queryEnvelopeProjections(query: EnvelopeProjectionQuery = {}): EnvelopeProjection[] {
+    const conditions: string[] = [];
+    const params: Record<string, unknown> = {};
+
+    if (query.solverType) {
+      conditions.push('solver_type = @solverType');
+      params['solverType'] = query.solverType;
+    }
+    if (query.role) {
+      conditions.push('role = @role');
+      params['role'] = query.role;
+    }
+    if (query.taskCid) {
+      conditions.push('task_cid = @taskCid');
+      params['taskCid'] = query.taskCid;
+    }
+    if (query.taskId) {
+      conditions.push('task_id = @taskId');
+      params['taskId'] = query.taskId;
+    }
+    if (query.requestId) {
+      conditions.push('request_id = @requestId');
+      params['requestId'] = query.requestId;
+    }
+    if (query.participant?.safeAddress) {
+      conditions.push('participant_safe_address = @participantSafeAddress');
+      params['participantSafeAddress'] = query.participant.safeAddress;
+    }
+    if (query.participant?.agentEoa) {
+      conditions.push('participant_agent_eoa = @participantAgentEoa');
+      params['participantAgentEoa'] = query.participant.agentEoa;
+    }
+    if (query.solutionEnvelopeRef) {
+      conditions.push('solution_envelope_ref = @solutionEnvelopeRef');
+      params['solutionEnvelopeRef'] = query.solutionEnvelopeRef;
+    }
+    if (query.generatedAfter !== undefined) {
+      conditions.push('generated_at >= @generatedAfter');
+      params['generatedAfter'] = query.generatedAfter;
+    }
+    if (query.generatedBefore !== undefined) {
+      conditions.push('generated_at <= @generatedBefore');
+      params['generatedBefore'] = query.generatedBefore;
+    }
+
+    let metadataIndex = 0;
+    for (const [key, value] of Object.entries(query.metadata ?? {})) {
+      const keyParam = `metadataKey${metadataIndex}`;
+      const valueParam = `metadataValue${metadataIndex}`;
+      conditions.push(
+        `EXISTS (
+          SELECT 1 FROM envelope_projection_metadata m${metadataIndex}
+          WHERE m${metadataIndex}.envelope_id = envelope_projections.envelope_id
+            AND m${metadataIndex}.key = @${keyParam}
+            AND m${metadataIndex}.value_text = @${valueParam}
+        )`,
+      );
+      params[keyParam] = key;
+      params[valueParam] = metadataValueText(value);
+      metadataIndex += 1;
+    }
+
+    const limit = Math.max(0, Math.min(query.limit ?? 100, 1000));
+    params['limit'] = limit;
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    const rows = this.db.prepare(
+      `SELECT envelope_id, envelope_cid, envelope_sha256, signature_hash, solver_type, role,
+              task_cid, task_id, request_id, generated_at, evidence_tier,
+              participant_safe_address, participant_agent_eoa,
+              executor_impl_name, executor_impl_version, executor_runtime_bundle_digest,
+              executor_plugins_json, solution_envelope_cid, solution_envelope_sha256,
+              solution_envelope_ref, metadata_json
+       FROM envelope_projections
+       ${where}
+       ORDER BY generated_at DESC, envelope_id ASC
+       LIMIT @limit`,
+    ).all(params) as EnvelopeProjectionRow[];
+
+    return rows.map(rowToEnvelopeProjection);
+  }
+
   close(): void {
     this.db.close();
+  }
+}
+
+interface EnvelopeProjectionRow {
+  envelope_id: string;
+  envelope_cid: string | null;
+  envelope_sha256: string | null;
+  signature_hash: string;
+  solver_type: string;
+  role: 'restoration' | 'verdict';
+  task_cid: string | null;
+  task_id: string | null;
+  request_id: string | null;
+  generated_at: number;
+  evidence_tier: 'self-signed' | 'committed' | 'attested';
+  participant_safe_address: string | null;
+  participant_agent_eoa: string | null;
+  executor_impl_name: string | null;
+  executor_impl_version: string | null;
+  executor_runtime_bundle_digest: string | null;
+  executor_plugins_json: string;
+  solution_envelope_cid: string | null;
+  solution_envelope_sha256: string | null;
+  solution_envelope_ref: string | null;
+  metadata_json: string;
+}
+
+function rowToEnvelopeProjection(row: EnvelopeProjectionRow): EnvelopeProjection {
+  return {
+    envelopeId: row.envelope_id,
+    envelopeCid: row.envelope_cid,
+    envelopeSha256: row.envelope_sha256,
+    signatureHash: row.signature_hash,
+    solverType: row.solver_type,
+    role: row.role,
+    taskCid: row.task_cid,
+    taskId: row.task_id,
+    requestId: row.request_id,
+    generatedAt: row.generated_at,
+    evidenceTier: row.evidence_tier,
+    participantSafeAddress: row.participant_safe_address,
+    participantAgentEoa: row.participant_agent_eoa,
+    executorImplName: row.executor_impl_name,
+    executorImplVersion: row.executor_impl_version,
+    executorRuntimeBundleDigest: row.executor_runtime_bundle_digest,
+    executorPlugins: parseStringArray(row.executor_plugins_json),
+    solutionEnvelopeCid: row.solution_envelope_cid,
+    solutionEnvelopeSha256: row.solution_envelope_sha256,
+    solutionEnvelopeRef: row.solution_envelope_ref,
+    metadata: parseMetadata(row.metadata_json),
+  };
+}
+
+function metadataValueText(value: EnvelopeProjectionMetadataValue): string {
+  return String(value);
+}
+
+function parseStringArray(json: string): string[] {
+  try {
+    const parsed = JSON.parse(json) as unknown;
+    return Array.isArray(parsed) ? parsed.filter((value): value is string => typeof value === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function parseMetadata(json: string): Record<string, EnvelopeProjectionMetadataValue> {
+  try {
+    const parsed = JSON.parse(json) as unknown;
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const out: Record<string, EnvelopeProjectionMetadataValue> = {};
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+        out[key] = value;
+      }
+    }
+    return out;
+  } catch {
+    return {};
   }
 }

--- a/client/test/cli/commands/doctor.test.ts
+++ b/client/test/cli/commands/doctor.test.ts
@@ -1,6 +1,42 @@
 import { describe, it, expect } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { createDoctorCommand } from '@/cli/commands/doctor.js';
 import { runCommand } from '@test/cli.js';
+
+function writeFleetState(earningDir: string, services: unknown[]): void {
+  mkdirSync(earningDir, { recursive: true });
+  writeFileSync(
+    join(earningDir, 'earning_state.json'),
+    JSON.stringify({
+      master_address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      chain: 'base-sepolia',
+      staking_mode: 'standard',
+      services,
+      updated_at: '2026-05-03T00:00:00.000Z',
+    }),
+    'utf8',
+  );
+}
+
+function service(index: number, safe: string, mech: string): unknown {
+  return {
+    index,
+    agent_address: `0x${String(index).repeat(40)}`,
+    safe_address: safe,
+    service_id: 100 + index,
+    mech_address: mech,
+    staking_address: '0x5555555555555555555555555555555555555555',
+    step: 'complete',
+    error: null,
+    agent_id: String(index),
+    agent_uri: null,
+    identity_registry_address: '0x8004A818BFB912233c491871b3d84c89A494BD9e',
+    agent_registered_tx: null,
+    safe_bound_to_agent: false,
+  };
+}
 
 const fakeDeps = {
   loadConfig: () => ({
@@ -31,6 +67,19 @@ const fakeDeps = {
     authenticated: true,
     context: 'bare' as const,
     detail: 'fake claude auth',
+  }),
+  resolveTaskNativeReadiness: () => ({
+    ok: true,
+    solverReady: true,
+    evaluatorReady: true,
+    detail: 'fake Task-native deployment ready; solver-ready=true evaluator-ready=true',
+    source: '/tmp/deployment-task-coordinator-router-v3-baseSepolia-fast.json',
+    contracts: {
+      taskCoordinator: '0x1111111111111111111111111111111111111111',
+      jinnRouterV3: '0x2222222222222222222222222222222222222222',
+      taskActivityCheckerV3: '0x3333333333333333333333333333333333333333',
+    },
+    routerClaimDeliveryVersion: 'v3' as const,
   }),
 } as const;
 
@@ -88,6 +137,76 @@ describe('doctor command (DI integration)', () => {
     expect(typeof env.config!.earningDir).toBe('string');
     expect(typeof env.config!.dbPath).toBe('string');
     expect(env.config!.envOverrides).toBeDefined();
+  });
+
+  it('reports Task-native solver and evaluator readiness from local deployment config', async () => {
+    const cmd = createDoctorCommand(fakeDeps);
+    const { envelopes } = await runCommand(cmd);
+    const env = envelopes[0] as {
+      checks: Array<{
+        name: string;
+        ok: boolean;
+        taskNative?: {
+          solverReady: boolean;
+          evaluatorReady: boolean;
+          contracts: Record<string, string>;
+          routerClaimDeliveryVersion?: string;
+        };
+      }>;
+    };
+    const check = env.checks.find((c) => c.name === 'task_native_deployment');
+    expect(check).toBeDefined();
+    expect(check?.ok).toBe(true);
+    expect(check?.taskNative?.solverReady).toBe(true);
+    expect(check?.taskNative?.evaluatorReady).toBe(true);
+    expect(check?.taskNative?.contracts.jinnRouterV3).toBe('0x2222222222222222222222222222222222222222');
+    expect(check?.taskNative?.routerClaimDeliveryVersion).toBe('v3');
+  });
+
+  it('flags stale legacy router claim config in the real Task-native readiness check', async () => {
+    const earningDir = mkdtempSync(join(tmpdir(), 'jinn-doctor-task-native-'));
+    const prevClaimVersion = process.env['JINN_ROUTER_CLAIM_DELIVERY_VERSION'];
+    process.env['JINN_ROUTER_CLAIM_DELIVERY_VERSION'] = 'v2';
+    try {
+      writeFleetState(earningDir, [
+        service(
+          1,
+          '0x1111111111111111111111111111111111111111',
+          '0x2222222222222222222222222222222222222222',
+        ),
+      ]);
+      const { resolveTaskNativeReadiness: _unused, ...deps } = fakeDeps;
+      const cmd = createDoctorCommand({
+        ...deps,
+        loadConfig: () => ({
+          network: 'testnet' as const,
+          rpcUrl: 'http://fake',
+          apiPort: 7331,
+          claudePath: 'claude',
+          tasks: [],
+          engine: { implStateDirRoot: '/tmp/fake-impl-state', workingDirRoot: '/tmp/fake-work' },
+          earningDir,
+          dbPath: '/tmp/fake.db',
+          runtimeMode: undefined,
+        } as any),
+      });
+      const { envelopes } = await runCommand(cmd);
+      const env = envelopes[0] as {
+        checks: Array<{ name: string; ok: boolean; detail: string; taskNative?: { solverReady: boolean; evaluatorReady: boolean } }>;
+      };
+      const check = env.checks.find((c) => c.name === 'task_native_deployment');
+      expect(check?.ok).toBe(false);
+      expect(check?.detail).toContain('router claim variant is v2, expected v3');
+      expect(check?.taskNative?.solverReady).toBe(false);
+      expect(check?.taskNative?.evaluatorReady).toBe(false);
+    } finally {
+      if (prevClaimVersion === undefined) {
+        delete process.env['JINN_ROUTER_CLAIM_DELIVERY_VERSION'];
+      } else {
+        process.env['JINN_ROUTER_CLAIM_DELIVERY_VERSION'] = prevClaimVersion;
+      }
+      rmSync(earningDir, { recursive: true, force: true });
+    }
   });
 
   it('does not include JINN_PASSWORD in config.envOverrides even when set in ctx.env', async () => {

--- a/client/test/cli/commands/status.test.ts
+++ b/client/test/cli/commands/status.test.ts
@@ -1,8 +1,57 @@
 import { describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { GatheredStatusRaw } from '../../../src/api/status-build.js';
 import { createStatusCommand } from '@/cli/commands/status.js';
 import { assembleStatusRollupV1 } from '@/api/status-rollup-build.js';
 import { runCommand } from '@test/cli.js';
+
+function writeFleetState(earningDir: string, services: unknown[]): void {
+  mkdirSync(earningDir, { recursive: true });
+  writeFileSync(
+    join(earningDir, 'earning_state.json'),
+    JSON.stringify({
+      master_address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      chain: 'base-sepolia',
+      staking_mode: 'standard',
+      services,
+      updated_at: '2026-05-03T00:00:00.000Z',
+    }),
+    'utf8',
+  );
+}
+
+function service(index: number, safe: string, mech: string): unknown {
+  return {
+    index,
+    agent_address: `0x${String(index).repeat(40)}`,
+    safe_address: safe,
+    service_id: 100 + index,
+    mech_address: mech,
+    staking_address: '0x5555555555555555555555555555555555555555',
+    step: 'complete',
+    error: null,
+    agent_id: String(index),
+    agent_uri: null,
+    identity_registry_address: '0x8004A818BFB912233c491871b3d84c89A494BD9e',
+    agent_registered_tx: null,
+    safe_bound_to_agent: false,
+  };
+}
+
+function realReadinessDeps(earningDir: string) {
+  const { resolveTaskNativeReadiness: _unused, ...deps } = fakeDeps;
+  return {
+    ...deps,
+    loadConfig: () => ({
+      network: 'testnet' as const,
+      earningDir,
+      dbPath: '/tmp/x',
+      runtimeMode: undefined,
+    } as any),
+  };
+}
 
 const mockRaw: GatheredStatusRaw = {
   shutdownState: 'running',
@@ -51,6 +100,26 @@ const mockRaw: GatheredStatusRaw = {
 const fakeDeps = {
   gatherIntrospectionRaw: async () => mockRaw as GatheredStatusRaw,
   assembleStatusRollupV1,
+  loadConfig: () => ({
+    network: 'testnet' as const,
+    earningDir: '/tmp/earning',
+    dbPath: '/tmp/x',
+    runtimeMode: undefined,
+  } as any),
+  getConfigPathFromArgs: () => undefined,
+  resolveTaskNativeReadiness: () => ({
+    ok: true,
+    solverReady: true,
+    evaluatorReady: true,
+    detail: 'fake Task-native deployment ready',
+    source: '/tmp/deployment-task-coordinator-router-v3-baseSepolia-fast.json',
+    contracts: {
+      taskCoordinator: '0x1111111111111111111111111111111111111111',
+      jinnRouterV3: '0x2222222222222222222222222222222222222222',
+      taskActivityCheckerV3: '0x3333333333333333333333333333333333333333',
+    },
+    routerClaimDeliveryVersion: 'v3' as const,
+  }),
 };
 
 describe('status command', () => {
@@ -67,6 +136,7 @@ describe('status command', () => {
       earnings: { pendingTotal: string; asset: string };
       exit: { blocking: boolean; hint: string };
       paths: { earningDir: string; dbPath: string };
+      taskNative: { solverReady: boolean; evaluatorReady: boolean; contracts: Record<string, string> };
     };
     expect(parsed.schemaVersion).toBe(1);
     expect(parsed.daemon.state).toBe('running');
@@ -85,6 +155,9 @@ describe('status command', () => {
       earningDir: '/tmp/earning',
       dbPath: '/tmp/x',
     });
+    expect(parsed.taskNative.solverReady).toBe(true);
+    expect(parsed.taskNative.evaluatorReady).toBe(true);
+    expect(parsed.taskNative.contracts.jinnRouterV3).toBe('0x2222222222222222222222222222222222222222');
   });
 
   it('rejects unknown flags with invalid_invocation', async () => {
@@ -100,8 +173,112 @@ describe('status command', () => {
     const { raw, exits } = await runCommand(cmd, { argv: ['--human'], tty: true });
     const out = raw.join('');
     expect(out).toContain('daemon=running');
+    expect(out).toContain('task-native: solver=ready evaluator=ready');
     expect(out).not.toMatch(/^\{/);
     expect(exits).toEqual([]);
+  });
+
+  it('reports Task-native solver and evaluator ready from bundled config plus distinct local services', async () => {
+    const earningDir = mkdtempSync(join(tmpdir(), 'jinn-status-task-native-'));
+    try {
+      writeFleetState(earningDir, [
+        service(
+          1,
+          '0x1111111111111111111111111111111111111111',
+          '0x2222222222222222222222222222222222222222',
+        ),
+        service(
+          2,
+          '0x3333333333333333333333333333333333333333',
+          '0x4444444444444444444444444444444444444444',
+        ),
+      ]);
+      const cmd = createStatusCommand(realReadinessDeps(earningDir));
+      const { envelopes } = await runCommand(cmd);
+      const payload = envelopes[0] as {
+        taskNative: {
+          ok: boolean;
+          solverReady: boolean;
+          evaluatorReady: boolean;
+          contracts: Record<string, string>;
+          operatorState?: { taskNativeServices: number; activeSafe?: string; evaluatorSafe?: string };
+        };
+      };
+      expect(payload.taskNative.ok).toBe(true);
+      expect(payload.taskNative.solverReady).toBe(true);
+      expect(payload.taskNative.evaluatorReady).toBe(true);
+      expect(payload.taskNative.contracts.taskCoordinator).toMatch(/^0x[0-9a-fA-F]{40}$/);
+      expect(payload.taskNative.contracts.jinnRouterV3).toMatch(/^0x[0-9a-fA-F]{40}$/);
+      expect(payload.taskNative.contracts.taskActivityCheckerV3).toMatch(/^0x[0-9a-fA-F]{40}$/);
+      expect(payload.taskNative.operatorState?.taskNativeServices).toBe(2);
+      expect(payload.taskNative.operatorState?.activeSafe).toBe('0x1111111111111111111111111111111111111111');
+      expect(payload.taskNative.operatorState?.evaluatorSafe).toBe('0x3333333333333333333333333333333333333333');
+    } finally {
+      rmSync(earningDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports solver-only when self-evaluation is disallowed and no distinct evaluator service exists', async () => {
+    const earningDir = mkdtempSync(join(tmpdir(), 'jinn-status-task-native-'));
+    try {
+      writeFleetState(earningDir, [
+        service(
+          1,
+          '0x1111111111111111111111111111111111111111',
+          '0x2222222222222222222222222222222222222222',
+        ),
+      ]);
+      const cmd = createStatusCommand(realReadinessDeps(earningDir));
+      const { envelopes, raw } = await runCommand(cmd, { argv: ['--human'], tty: true });
+      expect(envelopes).toEqual([]);
+      const out = raw.join('');
+      expect(out).toContain('task-native: solver=ready evaluator=not-ready');
+      expect(out).toContain('self-evaluation is disabled');
+
+      const jsonCmd = createStatusCommand(realReadinessDeps(earningDir));
+      const jsonResult = await runCommand(jsonCmd);
+      const payload = jsonResult.envelopes[0] as {
+        taskNative: { ok: boolean; solverReady: boolean; evaluatorReady: boolean; detail: string };
+      };
+      expect(payload.taskNative.ok).toBe(true);
+      expect(payload.taskNative.solverReady).toBe(true);
+      expect(payload.taskNative.evaluatorReady).toBe(false);
+      expect(payload.taskNative.detail).toContain('no distinct evaluator Safe/Mech is configured');
+    } finally {
+      rmSync(earningDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports missing Task-native artifact without chain readback', async () => {
+    const earningDir = mkdtempSync(join(tmpdir(), 'jinn-status-task-native-'));
+    const prevArtifact = process.env['JINN_TESTNET_TASK_COORDINATOR_ROUTER_V3_DEPLOYMENT'];
+    process.env['JINN_TESTNET_TASK_COORDINATOR_ROUTER_V3_DEPLOYMENT'] = join(earningDir, 'missing-task-native.json');
+    try {
+      writeFleetState(earningDir, [
+        service(
+          1,
+          '0x1111111111111111111111111111111111111111',
+          '0x2222222222222222222222222222222222222222',
+        ),
+      ]);
+      const cmd = createStatusCommand(realReadinessDeps(earningDir));
+      const { envelopes } = await runCommand(cmd);
+      const payload = envelopes[0] as {
+        taskNative: { ok: boolean; solverReady: boolean; evaluatorReady: boolean; detail: string; contracts: Record<string, string> };
+      };
+      expect(payload.taskNative.ok).toBe(false);
+      expect(payload.taskNative.solverReady).toBe(false);
+      expect(payload.taskNative.evaluatorReady).toBe(false);
+      expect(payload.taskNative.detail).toContain('Task-native deployment artifact is not bundled');
+      expect(payload.taskNative.contracts).toEqual({});
+    } finally {
+      if (prevArtifact === undefined) {
+        delete process.env['JINN_TESTNET_TASK_COORDINATOR_ROUTER_V3_DEPLOYMENT'];
+      } else {
+        process.env['JINN_TESTNET_TASK_COORDINATOR_ROUTER_V3_DEPLOYMENT'] = prevArtifact;
+      }
+      rmSync(earningDir, { recursive: true, force: true });
+    }
   });
 
   // ── --detail flag (audit U4) ─────────────────────────────────────────────

--- a/client/test/cli/commands/update.test.ts
+++ b/client/test/cli/commands/update.test.ts
@@ -1,7 +1,17 @@
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'fs/promises';
+import Database from 'better-sqlite3';
+import os from 'os';
+import path from 'path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createUpdateCommand } from '@/cli/commands/update.js';
 import { runCommand } from '@test/cli.js';
 import type { CommandContext } from '@/cli/command.js';
+import { FleetStateStore } from '@/earning/store.js';
+import { createDefaultFleetState, createDefaultServiceState } from '@/earning/types.js';
+import type { FleetState, ServiceState } from '@/earning/types.js';
+import { DEFAULT_TESTNET_ARTIFACTS, getChainConfig } from '@/earning/contracts.js';
+import { resolveTaskNativeReadiness } from '@/cli/task-native-readiness.js';
+import { Store } from '@/store/store.js';
 
 // MOCK_JUSTIFICATION: node:child_process is a leaf Node built-in; execSync is a syscall and cannot be DI'd without a shim module we don't own.
 vi.mock('node:child_process', async (importOriginal) => {
@@ -13,11 +23,99 @@ vi.mock('node:child_process', async (importOriginal) => {
 });
 
 describe('update command', () => {
+  const dirs: string[] = [];
+
   afterEach(() => {
     vi.clearAllMocks();
+    return Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
   });
 
+  async function makeEarningDir(): Promise<string> {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'jinn-update-'));
+    dirs.push(dir);
+    return dir;
+  }
+
+  function makeUpdateCommand(
+    earningDir: string,
+    integrationsRun = vi.fn(async () => {}),
+    opts: {
+      dbPath?: string;
+      storeFactory?: (dbPath: string) => Pick<Store, 'close'>;
+    } = {},
+  ) {
+    return createUpdateCommand({
+      integrationsRun,
+      loadConfig: () => ({ earningDir, dbPath: opts.dbPath ?? ':memory:' }) as any,
+      getConfigPathFromArgs: (argv = []) => {
+        const idx = argv.indexOf('--config');
+        return idx >= 0 ? argv[idx + 1] : undefined;
+      },
+      fleetStateStoreFactory: (dir) => new FleetStateStore(dir),
+      storeFactory: opts.storeFactory ?? (() => ({ close: () => {} })),
+    });
+  }
+
+  function completeService(): ServiceState {
+    return {
+      ...createDefaultServiceState(1, '0x1111111111111111111111111111111111111111'),
+      safe_address: '0x2222222222222222222222222222222222222222',
+      service_id: 42,
+      mech_address: '0x3333333333333333333333333333333333333333',
+      staking_address: '0x4444444444444444444444444444444444444444',
+      step: 'complete',
+      agent_id: '12345',
+      agent_uri: 'ipfs://agent',
+      identity_registry_address: '0x5555555555555555555555555555555555555555',
+      agent_registered_tx: `0x${'aa'.repeat(32)}`,
+      safe_bound_to_agent: true,
+    };
+  }
+
+  function baseSepoliaCompleteService(
+    index: number,
+    ids: {
+      agent: string;
+      safe: string;
+      serviceId: number;
+      mech: string;
+      staking: string;
+      agentId: string;
+    },
+  ): ServiceState {
+    return {
+      ...createDefaultServiceState(index, ids.agent),
+      safe_address: ids.safe,
+      service_id: ids.serviceId,
+      mech_address: ids.mech,
+      staking_address: ids.staking,
+      step: 'complete',
+      agent_id: ids.agentId,
+      agent_uri: `ipfs://agent-${ids.agentId}`,
+      identity_registry_address: '0x8004A818BFB912233c491871b3d84c89A494BD9e',
+      agent_registered_tx: `0x${String(index).repeat(64)}`,
+      safe_bound_to_agent: true,
+    };
+  }
+
+  function preservedIdentifiers(state: FleetState) {
+    return {
+      master: state.master_address,
+      services: state.services.map((svc) => ({
+        index: svc.index,
+        wallet: svc.agent_address,
+        agentId: svc.agent_id,
+        safe: svc.safe_address,
+        serviceId: svc.service_id,
+        mech: svc.mech_address,
+        staking: svc.staking_address,
+        identityRegistry: svc.identity_registry_address,
+      })),
+    };
+  }
+
   it('reports integration refresh errors even when integrations install does not set an exit code', async () => {
+    const earningDir = await makeEarningDir();
     const integrationsRunMock = vi.fn(async (ctx: CommandContext) => {
       ctx.writer.write(JSON.stringify({
         results: [
@@ -30,7 +128,7 @@ describe('update command', () => {
       }));
     });
 
-    const cmd = createUpdateCommand({ integrationsRun: integrationsRunMock });
+    const cmd = makeUpdateCommand(earningDir, integrationsRunMock);
     const { envelopes, exits } = await runCommand(cmd, { argv: ['--json', '--skip-npm'] });
 
     const payload = envelopes[envelopes.length - 1] as {
@@ -47,5 +145,327 @@ describe('update command', () => {
     expect(payload.steps.find((step) => step.step === 'integrations-install')?.detail)
       .toContain('claude-code');
     expect(exits).toEqual([]);
+  });
+
+  it('preserves complete local earning fields during Task-native preflight', async () => {
+    const earningDir = await makeEarningDir();
+    const store = new FleetStateStore(earningDir);
+    const initial = {
+      ...createDefaultFleetState('base'),
+      master_address: '0x9999999999999999999999999999999999999999',
+      services: [completeService()],
+    };
+    await store.save(initial);
+
+    const cmd = makeUpdateCommand(earningDir);
+    const { envelopes } = await runCommand(cmd, { argv: ['--json', '--skip-npm', '--skip-plugins'] });
+    const payload = envelopes[envelopes.length - 1] as {
+      ok: boolean;
+      steps: Array<{ step: string; status: string; detail: string }>;
+    };
+
+    expect(payload.ok).toBe(true);
+    expect(payload.steps.find((step) => step.step === 'earning-state')).toMatchObject({
+      status: 'ok',
+    });
+    expect(payload.steps.find((step) => step.step === 'earning-state')?.detail)
+      .toContain('No chain readback or writes were performed');
+
+    const persisted = await store.tryLoadExisting();
+    expect(persisted?.master_address).toBe(initial.master_address);
+    expect(persisted?.services[0]).toMatchObject({
+      agent_address: '0x1111111111111111111111111111111111111111',
+      safe_address: '0x2222222222222222222222222222222222222222',
+      service_id: 42,
+      mech_address: '0x3333333333333333333333333333333333333333',
+      staking_address: '0x4444444444444444444444444444444444444444',
+      agent_id: '12345',
+      identity_registry_address: '0x5555555555555555555555555555555555555555',
+      agent_registered_tx: `0x${'aa'.repeat(32)}`,
+      safe_bound_to_agent: true,
+    });
+  });
+
+  it('upgrades a pre-upgrade Base Sepolia fixture without rebootstrap and resolves bundled V3 runtime metadata', async () => {
+    const earningDir = await makeEarningDir();
+    const prevV3Artifact = process.env['JINN_TESTNET_TASK_COORDINATOR_ROUTER_V3_DEPLOYMENT'];
+    process.env['JINN_TESTNET_TASK_COORDINATOR_ROUTER_V3_DEPLOYMENT'] =
+      DEFAULT_TESTNET_ARTIFACTS.taskCoordinatorRouterV3;
+
+    try {
+      const chainCfg = getChainConfig('base-sepolia');
+      const store = new FleetStateStore(earningDir);
+      const preUpgrade: FleetState = {
+        ...createDefaultFleetState('base-sepolia'),
+        master_address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        staking_mode: 'standard',
+        services: [
+          baseSepoliaCompleteService(1, {
+            agent: '0x1111111111111111111111111111111111111111',
+            safe: '0x2222222222222222222222222222222222222222',
+            serviceId: 7001,
+            mech: '0x3333333333333333333333333333333333333333',
+            staking: chainCfg.stakingContract,
+            agentId: '800401',
+          }),
+          baseSepoliaCompleteService(2, {
+            agent: '0x4444444444444444444444444444444444444444',
+            safe: '0x5555555555555555555555555555555555555555',
+            serviceId: 7002,
+            mech: '0x6666666666666666666666666666666666666666',
+            staking: chainCfg.stakingContract,
+            agentId: '800402',
+          }),
+        ],
+      };
+      await store.save(preUpgrade);
+      const before = await store.tryLoadExisting();
+      expect(before).not.toBeNull();
+      const beforeIdentifiers = preservedIdentifiers(before!);
+
+      const cmd = makeUpdateCommand(earningDir);
+      const { envelopes } = await runCommand(cmd, { argv: ['--json', '--skip-npm', '--skip-plugins'] });
+      const payload = envelopes[envelopes.length - 1] as {
+        ok: boolean;
+        steps: Array<{ step: string; status: string; detail: string }>;
+      };
+      const earningStep = payload.steps.find((step) => step.step === 'earning-state');
+
+      expect(payload.ok).toBe(true);
+      expect(earningStep).toMatchObject({ status: 'ok' });
+      expect(earningStep?.detail).toContain('Preserved locally recorded wallet, agent, Safe, service, Mech');
+      expect(earningStep?.detail).toContain('No chain readback or writes were performed');
+
+      const after = await store.tryLoadExisting();
+      expect(after).not.toBeNull();
+      expect(after!.chain).toBe('base-sepolia');
+      expect(after!.services).toHaveLength(2);
+      expect(preservedIdentifiers(after!)).toEqual(beforeIdentifiers);
+
+      const artifact = JSON.parse(
+        await readFile(DEFAULT_TESTNET_ARTIFACTS.taskCoordinatorRouterV3, 'utf8'),
+      ) as {
+        contracts: {
+          taskCoordinator: string;
+          jinnRouterV3: string;
+          activityChecker: string;
+        };
+      };
+      const readiness = resolveTaskNativeReadiness({
+        network: 'testnet',
+        earningDir,
+        dbPath: ':memory:',
+      } as any);
+      expect(readiness.ok).toBe(true);
+      expect(readiness.solverReady).toBe(true);
+      expect(readiness.evaluatorReady).toBe(true);
+      expect(readiness.source).toBe(DEFAULT_TESTNET_ARTIFACTS.taskCoordinatorRouterV3);
+      expect(readiness.contracts).toEqual({
+        taskCoordinator: artifact.contracts.taskCoordinator,
+        jinnRouterV3: artifact.contracts.jinnRouterV3,
+        taskActivityCheckerV3: artifact.contracts.activityChecker,
+      });
+      expect(readiness.routerClaimDeliveryVersion).toBe('v3');
+      expect(readiness.operatorState?.activeSafe).toBe(beforeIdentifiers.services[0]?.safe);
+      expect(readiness.operatorState?.evaluatorSafe).toBe(beforeIdentifiers.services[1]?.safe);
+      expect(chainCfg.jinnRouter).toBe(artifact.contracts.jinnRouterV3);
+      expect(chainCfg.routerClaimDeliveryVersion).toBe('v3');
+    } finally {
+      if (prevV3Artifact === undefined) {
+        delete process.env['JINN_TESTNET_TASK_COORDINATOR_ROUTER_V3_DEPLOYMENT'];
+      } else {
+        process.env['JINN_TESTNET_TASK_COORDINATOR_ROUTER_V3_DEPLOYMENT'] = prevV3Artifact;
+      }
+    }
+  });
+
+  it('removes legacy ClaimRegistry/request-first config fields with a migration note', async () => {
+    const earningDir = await makeEarningDir();
+    const configPath = path.join(earningDir, 'config.json');
+    await writeFile(configPath, JSON.stringify({
+      network: 'testnet',
+      testnetClaimRegistryDeploymentPath: '/tmp/claim-registry.json',
+      claimRegistryAddress: '0x1111111111111111111111111111111111111111',
+      solverNets: {
+        prediction: {
+          enabled: true,
+          solverType: 'prediction.v1',
+          canonicalPlugin: 'bundled:jinn-prediction-plugin',
+          harness: 'claude-code-learner',
+          plugins: [],
+          taskGenerator: { enabled: true },
+        },
+      },
+    }, null, 2));
+
+    const cmd = makeUpdateCommand(earningDir);
+    const { envelopes } = await runCommand(cmd, {
+      argv: ['--json', '--skip-npm', '--skip-plugins', '--config', configPath],
+    });
+    const payload = envelopes[envelopes.length - 1] as {
+      ok: boolean;
+      steps: Array<{ step: string; status: string; detail: string }>;
+    };
+    const configStep = payload.steps.find((step) => step.step === 'config-migration');
+
+    expect(payload.ok).toBe(true);
+    expect(configStep).toMatchObject({ status: 'ok' });
+    expect(configStep?.detail).toContain('Removed legacy ClaimRegistry/request-first config field');
+    expect(configStep?.detail).toContain('TaskCoordinator/JinnRouterV3');
+
+    const migrated = JSON.parse(await readFile(configPath, 'utf8')) as Record<string, unknown>;
+    expect('testnetClaimRegistryDeploymentPath' in migrated).toBe(false);
+    expect('claimRegistryAddress' in migrated).toBe(false);
+    const files = await readdir(earningDir);
+    expect(files.some((file) => file.startsWith('config.json.bak.'))).toBe(true);
+  });
+
+  it('records legacy request-first in-flight jobs as ignored without blocking local store preflight', async () => {
+    const earningDir = await makeEarningDir();
+    const dbPath = path.join(earningDir, 'jinn.db');
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE restoration_intents (
+        request_id TEXT PRIMARY KEY,
+        state TEXT NOT NULL,
+        window_start_ts INTEGER NOT NULL
+      );
+      INSERT INTO restoration_intents (request_id, state, window_start_ts)
+      VALUES ('legacy-req-1', 'CLAIMED', 1);
+    `);
+    db.close();
+
+    const cmd = makeUpdateCommand(earningDir, vi.fn(async () => {}), {
+      dbPath,
+      storeFactory: (path) => new Store(path),
+    });
+    const { envelopes } = await runCommand(cmd, { argv: ['--json', '--skip-npm', '--skip-plugins'] });
+    const payload = envelopes[envelopes.length - 1] as {
+      ok: boolean;
+      steps: Array<{ step: string; status: string; detail: string }>;
+    };
+
+    expect(payload.ok).toBe(true);
+    expect(payload.steps.find((step) => step.step === 'task-native-store')).toMatchObject({ status: 'ok' });
+
+    const store = new Store(dbPath);
+    try {
+      const markerRaw = store.getConfigValue('legacy_restoration_intents_ignored_v1');
+      expect(markerRaw).not.toBeNull();
+      const marker = JSON.parse(markerRaw!) as { inFlightRows: number; reason: string };
+      expect(marker.inFlightRows).toBe(1);
+      expect(marker.reason).toBe('legacy_request_first_task_native_update');
+      const events = store.getRecentActivityEvents(10);
+      expect(events.some((event) =>
+        event.kind === 'legacy_ignored' &&
+        event.detail?.includes('legacy request-first restoration_intents row')
+      )).toBe(true);
+    } finally {
+      store.close();
+    }
+  });
+
+  it('reports partial local earning state as bootstrapping without repairing it', async () => {
+    const earningDir = await makeEarningDir();
+    const store = new FleetStateStore(earningDir);
+    await store.save({
+      ...createDefaultFleetState('base'),
+      master_address: '0x9999999999999999999999999999999999999999',
+      services: [
+        createDefaultServiceState(1, '0x1111111111111111111111111111111111111111'),
+      ],
+    });
+
+    const cmd = makeUpdateCommand(earningDir);
+    const { envelopes } = await runCommand(cmd, { argv: ['--json', '--skip-npm', '--skip-plugins'] });
+    const payload = envelopes[envelopes.length - 1] as {
+      ok: boolean;
+      steps: Array<{ step: string; status: string; detail: string }>;
+    };
+    const earningStep = payload.steps.find((step) => step.step === 'earning-state');
+
+    expect(payload.ok).toBe(true);
+    expect(earningStep).toMatchObject({ status: 'warning' });
+    expect(earningStep?.detail).toContain('still bootstrapping');
+    expect(earningStep?.detail).toContain('No chain readback or writes were performed');
+
+    const persisted = await store.tryLoadExisting();
+    expect(persisted?.services[0]).toMatchObject({
+      safe_address: null,
+      service_id: null,
+      mech_address: null,
+      agent_id: null,
+    });
+  });
+
+  it('reports ready-looking local state with missing Task-native fields as state-integrity', async () => {
+    const earningDir = await makeEarningDir();
+    const store = new FleetStateStore(earningDir);
+    await store.save({
+      ...createDefaultFleetState('base'),
+      master_address: '0x9999999999999999999999999999999999999999',
+      services: [{
+        ...completeService(),
+        mech_address: null,
+      }],
+    });
+
+    const cmd = makeUpdateCommand(earningDir);
+    const { envelopes } = await runCommand(cmd, { argv: ['--json', '--skip-npm', '--skip-plugins'] });
+    const payload = envelopes[envelopes.length - 1] as {
+      ok: boolean;
+      steps: Array<{ step: string; status: string; detail: string }>;
+    };
+    const earningStep = payload.steps.find((step) => step.step === 'earning-state');
+
+    expect(payload.ok).toBe(false);
+    expect(earningStep).toMatchObject({ status: 'state-integrity' });
+    expect(earningStep?.detail).toContain('Mech');
+    expect(earningStep?.detail).toContain('Run doctor/recovery');
+    expect(earningStep?.detail).toContain('did not repair from RPC');
+  });
+
+  it('warns but does not fail when optional ERC-8004 metadata is not locally recorded', async () => {
+    const earningDir = await makeEarningDir();
+    const store = new FleetStateStore(earningDir);
+    await store.save({
+      ...createDefaultFleetState('base'),
+      master_address: '0x9999999999999999999999999999999999999999',
+      services: [{
+        ...completeService(),
+        agent_id: null,
+        identity_registry_address: null,
+      }],
+    });
+
+    const cmd = makeUpdateCommand(earningDir);
+    const { envelopes } = await runCommand(cmd, { argv: ['--json', '--skip-npm', '--skip-plugins'] });
+    const payload = envelopes[envelopes.length - 1] as {
+      ok: boolean;
+      steps: Array<{ step: string; status: string; detail: string }>;
+    };
+    const earningStep = payload.steps.find((step) => step.step === 'earning-state');
+
+    expect(payload.ok).toBe(true);
+    expect(earningStep).toMatchObject({ status: 'warning' });
+    expect(earningStep?.detail).toContain('optional ERC-8004 metadata');
+    expect(earningStep?.detail).toContain('migrate-agent-id');
+    expect(earningStep?.detail).toContain('No chain readback or writes were performed');
+  });
+
+  it('reports not-bootstrapped local state without creating earning state', async () => {
+    const earningDir = await makeEarningDir();
+    const cmd = makeUpdateCommand(earningDir);
+    const { envelopes } = await runCommand(cmd, { argv: ['--json', '--skip-npm', '--skip-plugins'] });
+    const payload = envelopes[envelopes.length - 1] as {
+      ok: boolean;
+      steps: Array<{ step: string; status: string; detail: string }>;
+    };
+    const earningStep = payload.steps.find((step) => step.step === 'earning-state');
+
+    expect(payload.ok).toBe(true);
+    expect(earningStep).toMatchObject({ status: 'skipped' });
+    expect(earningStep?.detail).toContain('not bootstrapped');
+    expect(await new FleetStateStore(earningDir).tryLoadExisting()).toBeNull();
   });
 });

--- a/client/test/corpus/envelope-projection.test.ts
+++ b/client/test/corpus/envelope-projection.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest';
+import { projectEnvelope } from '../../src/corpus/envelope-projection.js';
+import type { SignedEnvelope } from '../../src/types/envelope.js';
+import type { Task } from '../../src/types/task.js';
+
+const TASK_CID = 'bafy-task-shared';
+const TASK_ID = '42';
+const REQUEST_ID = `0x${'1'.repeat(64)}`;
+
+describe('projectEnvelope', () => {
+  it('projects prediction.v1 Solution metadata from envelope and Task context', () => {
+    const task = makePredictionTask();
+    const projection = projectEnvelope(makeEnvelope({
+      role: 'restoration',
+      taskCid: TASK_CID,
+      requestId: REQUEST_ID,
+      signatureHash: `0x${'a'.repeat(64)}`,
+      payload: {
+        probabilityYes: '0.5700',
+        submittedAt: '2026-05-02T01:00:00.000Z',
+        format: 'decimal',
+        modelId: 'solver-a',
+      },
+    }), {
+      envelopeCid: 'bafy-solution-envelope',
+      envelopeSha256: '2'.repeat(64),
+      task,
+      taskId: TASK_ID,
+    });
+
+    expect(projection).toMatchObject({
+      envelopeId: 'bafy-solution-envelope',
+      solverType: 'prediction.v1',
+      role: 'restoration',
+      taskCid: TASK_CID,
+      taskId: TASK_ID,
+      requestId: REQUEST_ID,
+      participantSafeAddress: `0x${'2'.repeat(40)}`,
+      participantAgentEoa: `0x${'3'.repeat(40)}`,
+      executorImplName: 'prediction-v1-baseline',
+      executorRuntimeBundleDigest: `sha256:${'1'.repeat(64)}`,
+      solutionEnvelopeRef: null,
+    });
+    expect(projection.metadata).toMatchObject({
+      'source.venue': 'polymarket',
+      'source.marketId': 'mkt-1',
+      'source.conditionId': '0xabc',
+      'question.kind': 'binary',
+      'participant.safeAddress': `0x${'2'.repeat(40)}`,
+      'participant.agentEoa': `0x${'3'.repeat(40)}`,
+      'executor.implName': 'prediction-v1-baseline',
+      'executor.runtimeBundleDigest': `sha256:${'1'.repeat(64)}`,
+    });
+    expect(projection.metadata.verdict).toBeUndefined();
+  });
+
+  it('projects prediction.v1 Verdict metadata and solution backref', () => {
+    const projection = projectEnvelope(makeEnvelope({
+      role: 'verdict',
+      taskCid: 'bafy-eval-task',
+      requestId: `0x${'4'.repeat(64)}`,
+      signatureHash: `0x${'b'.repeat(64)}`,
+      payload: {
+        verdict: 'SCORED',
+        resolutionSource: {
+          venue: 'polymarket',
+          marketId: 'mkt-1',
+          conditionId: '0xabc',
+        },
+        task: {
+          cid: TASK_CID,
+          id: TASK_ID,
+        },
+        solutionEnvelope: {
+          cid: 'bafy-solution-envelope',
+          sha256: '2'.repeat(64),
+        },
+        scores: {
+          solverBrier: '0.184900',
+          consensusBrier: '0.144400',
+          brierSpread: '0.040500',
+        },
+      },
+    }), {
+      task: {
+        ...makePredictionTask(),
+        id: 'eval-task-local',
+        role: 'evaluation',
+        context: { restorationTaskCid: TASK_CID },
+      },
+      taskId: TASK_ID,
+    });
+
+    expect(projection.taskCid).toBe(TASK_CID);
+    expect(projection.taskId).toBe(TASK_ID);
+    expect(projection.solutionEnvelopeCid).toBe('bafy-solution-envelope');
+    expect(projection.solutionEnvelopeSha256).toBe('2'.repeat(64));
+    expect(projection.solutionEnvelopeRef).toBe('bafy-solution-envelope');
+    expect(projection.metadata).toMatchObject({
+      'source.venue': 'polymarket',
+      'source.marketId': 'mkt-1',
+      'source.conditionId': '0xabc',
+      verdict: 'SCORED',
+      'scores.solverBrier': '0.184900',
+      'scores.consensusBrier': '0.144400',
+      'scores.brierSpread': '0.040500',
+      'solutionEnvelope.cid': 'bafy-solution-envelope',
+      'solutionEnvelope.sha256': '2'.repeat(64),
+    });
+  });
+
+  it('projects generic non-prediction envelopes without prediction metadata', () => {
+    const projection = projectEnvelope(makeEnvelope({
+      solverType: 'portfolio.v0',
+      role: 'restoration',
+      taskCid: 'bafy-portfolio-task',
+      requestId: `0x${'5'.repeat(64)}`,
+      signatureHash: `0x${'c'.repeat(64)}`,
+      payload: {
+        preSnapshot: { capturedAt: 1, payload: {} },
+        postSnapshot: { capturedAt: 2, payload: {} },
+      },
+    }));
+
+    expect(projection.solverType).toBe('portfolio.v0');
+    expect(projection.taskCid).toBe('bafy-portfolio-task');
+    expect(projection.metadata['source.venue']).toBeUndefined();
+    expect(projection.metadata.verdict).toBeUndefined();
+    expect(projection.metadata['executor.implName']).toBe('prediction-v1-baseline');
+  });
+});
+
+function makePredictionTask(): Task {
+  return {
+    id: 'prediction-v1-polymarket-abc',
+    description: 'Forecast a binary externally resolved prediction market.',
+    solverType: 'prediction.v1',
+    role: 'restoration',
+    window: { startTs: 1000, endTs: 2000 },
+    spec: {
+      question: { kind: 'binary', text: 'Will test pass?', yesLabel: 'YES', noLabel: 'NO' },
+      source: {
+        type: 'prediction-market',
+        venue: 'polymarket',
+        url: 'https://polymarket.com/event/test-market',
+        identifiers: {
+          marketId: 'mkt-1',
+          conditionId: '0xabc',
+          yesTokenId: 'yes-token',
+          noTokenId: 'no-token',
+        },
+      },
+      consensusSnapshot: {
+        sampledAt: '2026-05-02T00:00:00.000Z',
+        probabilityYes: '0.6200',
+        method: 'best-bid-ask-midpoint',
+      },
+    },
+    eligibility: { dedupKey: 'polymarket:0xabc' },
+  };
+}
+
+function makeEnvelope(overrides: {
+  solverType?: string;
+  role: 'restoration' | 'verdict';
+  taskCid: string;
+  requestId: string;
+  signatureHash: `0x${string}`;
+  payload: Record<string, unknown>;
+}): SignedEnvelope {
+  return {
+    schemaVersion: 'jinn.execution.v1',
+    solverType: overrides.solverType ?? 'prediction.v1',
+    role: overrides.role,
+    generatedAt: 1_777_680_000_000,
+    task: {
+      cid: overrides.taskCid,
+      onchainCreationTx: `0x${'0'.repeat(64)}`,
+      onchainCreationBlock: 123,
+      requestId: overrides.requestId,
+    },
+    participant: {
+      safeAddress: `0x${'2'.repeat(40)}`,
+      agentEoa: `0x${'3'.repeat(40)}`,
+    },
+    window: { startTs: 1000, endTs: 2000 },
+    executor: {
+      implName: 'prediction-v1-baseline',
+      implVersion: '1.0.0',
+      clientGitSha: 'dev',
+      codeDigest: `sha256:${'0'.repeat(64)}`,
+      runtimeBundleDigest: `sha256:${'1'.repeat(64)}`,
+      plugins: [{ name: 'polymarket', version: '1.0.0', sha256: '9'.repeat(64) }],
+      signingKey: { kind: 'agent-eoa', pubkey: `0x${'3'.repeat(40)}` },
+    },
+    evidenceTier: 'self-signed',
+    attestation: null,
+    trajectory: null,
+    artifacts: [],
+    payload: overrides.payload,
+    signature: {
+      algo: 'secp256k1',
+      signer: `0x${'3'.repeat(40)}`,
+      hash: overrides.signatureHash,
+      sig: `0x${'4'.repeat(130)}`,
+    },
+  } as SignedEnvelope;
+}

--- a/client/test/corpus/prediction-scoreable-verdicts.test.ts
+++ b/client/test/corpus/prediction-scoreable-verdicts.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { projectEnvelope } from '../../src/corpus/envelope-projection.js';
+import { queryScoreablePredictionBrierVerdicts } from '../../src/corpus/index.js';
+import { Store } from '../../src/store/store.js';
+import type { SignedEnvelope } from '../../src/types/envelope.js';
+import type { Task } from '../../src/types/task.js';
+
+const TASK_CID = 'bafy-task-shared';
+const TASK_ID = 'prediction-v1-polymarket-abc';
+
+describe('queryScoreablePredictionBrierVerdicts', () => {
+  let store: Store;
+
+  beforeEach(() => {
+    store = new Store(':memory:');
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  it('includes only SCORED prediction Verdict projections with Brier score metadata', () => {
+    for (const projection of [
+      verdictProjection({
+        generatedAt: 4000,
+        signatureHash: `0x${'a'.repeat(64)}`,
+        requestId: `0x${'1'.repeat(64)}`,
+        solutionCid: 'bafy-scoreable-a',
+        verdict: 'SCORED',
+        scores: true,
+      }),
+      verdictProjection({
+        generatedAt: 3000,
+        signatureHash: `0x${'b'.repeat(64)}`,
+        requestId: `0x${'2'.repeat(64)}`,
+        solutionCid: 'bafy-invalid',
+        verdict: 'INVALID',
+        scores: false,
+      }),
+      verdictProjection({
+        generatedAt: 2000,
+        signatureHash: `0x${'c'.repeat(64)}`,
+        requestId: `0x${'3'.repeat(64)}`,
+        solutionCid: 'bafy-rejected',
+        verdict: 'REJECTED',
+        scores: false,
+      }),
+      verdictProjection({
+        generatedAt: 5000,
+        signatureHash: `0x${'d'.repeat(64)}`,
+        requestId: `0x${'4'.repeat(64)}`,
+        solutionCid: 'bafy-scored-no-brier',
+        verdict: 'SCORED',
+        scores: false,
+      }),
+    ]) {
+      store.saveEnvelopeProjection(projection);
+    }
+
+    const results = queryScoreablePredictionBrierVerdicts(store, { taskCid: TASK_CID });
+
+    expect(results.map((projection) => projection.solutionEnvelopeRef)).toEqual(['bafy-scoreable-a']);
+    expect(results[0]?.metadata).toMatchObject({
+      verdict: 'SCORED',
+      'scores.solverBrier': '0.184900',
+      'scores.consensusBrier': '0.144400',
+      'scores.brierSpread': '0.040500',
+    });
+
+    expect(queryScoreablePredictionBrierVerdicts(store, { taskCid: TASK_CID, limit: 1 })).toHaveLength(1);
+  });
+});
+
+function verdictProjection(args: {
+  generatedAt: number;
+  signatureHash: `0x${string}`;
+  requestId: `0x${string}`;
+  solutionCid: string;
+  verdict: 'SCORED' | 'INVALID' | 'REJECTED' | 'INDETERMINATE';
+  scores: boolean;
+}) {
+  return projectEnvelope(makeEnvelope({
+    generatedAt: args.generatedAt,
+    signatureHash: args.signatureHash,
+    requestId: args.requestId,
+    payload: {
+      verdict: args.verdict,
+      resolutionSource: {
+        venue: 'polymarket',
+        marketId: 'mkt-1',
+        conditionId: '0xabc',
+      },
+      task: { cid: TASK_CID, id: TASK_ID },
+      solutionEnvelope: { cid: args.solutionCid, sha256: '2'.repeat(64) },
+      ...(args.scores
+        ? {
+            scores: {
+              solverBrier: '0.184900',
+              consensusBrier: '0.144400',
+              brierSpread: '0.040500',
+            },
+          }
+        : {}),
+    },
+  }), {
+    task: makeEvaluationTask(),
+    taskId: TASK_ID,
+  });
+}
+
+function makeEvaluationTask(): Task {
+  return {
+    id: 'prediction-v1-eval',
+    description: 'Evaluate a binary externally resolved prediction market.',
+    solverType: 'prediction.v1',
+    role: 'evaluation',
+    window: { startTs: 1000, endTs: 2000 },
+    context: { restorationTaskCid: TASK_CID },
+    spec: {
+      question: { kind: 'binary', text: 'Will test pass?', yesLabel: 'YES', noLabel: 'NO' },
+      source: {
+        type: 'prediction-market',
+        venue: 'polymarket',
+        url: 'https://polymarket.com/event/test-market',
+        identifiers: {
+          marketId: 'mkt-1',
+          conditionId: '0xabc',
+          yesTokenId: 'yes-token',
+          noTokenId: 'no-token',
+        },
+      },
+      consensusSnapshot: {
+        sampledAt: '2026-05-02T00:00:00.000Z',
+        probabilityYes: '0.6200',
+        method: 'best-bid-ask-midpoint',
+      },
+    },
+    eligibility: { dedupKey: 'polymarket:0xabc' },
+  };
+}
+
+function makeEnvelope(overrides: {
+  generatedAt: number;
+  requestId: `0x${string}`;
+  signatureHash: `0x${string}`;
+  payload: Record<string, unknown>;
+}): SignedEnvelope {
+  return {
+    schemaVersion: 'jinn.execution.v1',
+    solverType: 'prediction.v1',
+    role: 'verdict',
+    generatedAt: overrides.generatedAt,
+    task: {
+      cid: 'bafy-eval-task',
+      onchainCreationTx: `0x${'0'.repeat(64)}`,
+      onchainCreationBlock: 123,
+      requestId: overrides.requestId,
+    },
+    participant: {
+      safeAddress: `0x${'2'.repeat(40)}`,
+      agentEoa: `0x${'3'.repeat(40)}`,
+    },
+    window: { startTs: 1000, endTs: 2000 },
+    executor: {
+      implName: 'prediction-v1-evaluator',
+      implVersion: '1.0.0',
+      clientGitSha: 'dev',
+      codeDigest: `sha256:${'0'.repeat(64)}`,
+      runtimeBundleDigest: `sha256:${'1'.repeat(64)}`,
+      plugins: [],
+      signingKey: { kind: 'agent-eoa', pubkey: `0x${'3'.repeat(40)}` },
+    },
+    evidenceTier: 'self-signed',
+    attestation: null,
+    trajectory: null,
+    artifacts: [],
+    payload: overrides.payload,
+    signature: {
+      algo: 'secp256k1',
+      signer: `0x${'3'.repeat(40)}`,
+      hash: overrides.signatureHash,
+      sig: `0x${'4'.repeat(130)}`,
+    },
+  } as SignedEnvelope;
+}

--- a/client/test/e2e/prediction-v1.ts
+++ b/client/test/e2e/prediction-v1.ts
@@ -23,7 +23,9 @@ async function main(): Promise<void> {
   results.push(await runPhase('Prediction v1 Task-first local lifecycle', async () => {
     const result = await runLocalTaskFirstLifecycle();
     process.stdout.write(
-      `taskId=${result.postedTaskId} attempts=0:${result.request.requestId} 1:${result.secondRequest.requestId}\n`,
+      `taskId=${result.postedTaskId} taskCid=${result.postedTaskCid} ` +
+      `attempts=${result.attempts.map((a) => `${a.request.attemptIndex}:${a.request.requestId}`).join(',')} ` +
+      `verdicts=${result.attempts.map((a) => `${a.verdictRequest.requestId}:${a.verdict}`).join(',')}\n`,
     );
   }));
 

--- a/client/test/e2e/task-first-helpers.ts
+++ b/client/test/e2e/task-first-helpers.ts
@@ -1,6 +1,6 @@
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -42,14 +42,14 @@ import { TaskEngine } from '../../src/harnesses/engine/engine.js';
 import { signCanonical } from '../../src/harnesses/engine/signing.js';
 import { TaskRunPersistence } from '../../src/harnesses/engine/persistence.js';
 import { TaskRunState } from '../../src/harnesses/engine/state.js';
-import { PredictionV1Evaluator } from '../../src/harnesses/impls/prediction-v0-evaluator/index.js';
+import { PredictionV1Evaluator } from '../../src/harnesses/impls/prediction-v1-evaluator/index.js';
 import { RESTORATION_ENVELOPE_CID_CONTEXT_KEY, RESTORATION_TASK_CID_CONTEXT_KEY } from '../../src/harnesses/impls/evaluation-context.js';
 import type { Harness, Solution } from '../../src/harnesses/types.js';
 import { Store } from '../../src/store/store.js';
 import { TaskPostingService } from '../../src/tasks/posting-service.js';
 import { SignedEnvelopeSchema, type SignedEnvelope } from '../../src/types/envelope.js';
-import { PredictionV1TaskSchema } from '../../src/types/index.js';
-import type { Task, TaskRequest } from '../../src/types/index.js';
+import type { DeliveredResult, Task, TaskRequest } from '../../src/types/index.js';
+import { PredictionV1TaskSchema } from '../../src/types/prediction-v1.js';
 import { validatePayload } from '../../src/types/payloads/index.js';
 import { TrajectoryCollector } from '../../src/trajectory/index.js';
 import { allocateAnvilPort } from '../_support/chain/port-allocator.js';
@@ -416,31 +416,55 @@ export function makePredictionV1Task(now = Date.now()): Task {
     startTs: now - 1_000,
     endTs: now + 60_000,
   };
+  const sampledAt = new Date(now - 10_000).toISOString();
+  const expectedResolutionTime = new Date(now + 120_000).toISOString();
   const core = {
     id: 'prediction-v1-e2e',
-    description: 'Will ETH/USD be above 3000 at the test resolution timestamp?',
+    description: 'Will the test prediction market resolve YES?',
     solverType: 'prediction.v1' as const,
     window,
     spec: {
-      oracle: {
-        venue: 'chainlink-base-sepolia' as const,
-        feed: '0x0000000000000000000000000000000000000001',
-        feedDescription: 'ETH / USD',
-      },
       question: {
-        kind: 'threshold' as const,
-        operator: 'GT' as const,
-        threshold: '3000',
-        resolveTs: window.endTs + 60_000,
+        kind: 'binary' as const,
+        text: 'Will the test prediction market resolve YES?',
+        yesLabel: 'YES' as const,
+        noLabel: 'NO' as const,
+      },
+      source: {
+        type: 'prediction-market' as const,
+        venue: 'polymarket' as const,
+        url: 'https://polymarket.com/event/jinn-task-first-e2e',
+        identifiers: {
+          marketId: 'jinn-task-first-e2e',
+          conditionId: '0xcondition-task-first-e2e',
+          yesTokenId: 'yes-token-task-first-e2e',
+          noTokenId: 'no-token-task-first-e2e',
+        },
+      },
+      resolution: {
+        expectedResolutionTime,
+        rulesText: 'Test fixture resolves YES.',
+        rulesUrl: 'https://example.com/jinn-task-first-e2e-rules',
+      },
+      consensusSnapshot: {
+        sampledAt,
+        probabilityYes: '0.68',
+        method: 'best-bid-ask-midpoint' as const,
+        bestBidYes: '0.67',
+        bestAskYes: '0.69',
+        spread: '0.02',
+        source: 'polymarket-clob' as const,
+      },
+      eligibilitySnapshot: {
+        sampledAt,
+        timeToResolutionHours: 24,
+        liquidityUsd: '10000',
+        volume24hUsd: '5000',
+        orderbookAgeSeconds: 10,
+        selectionReason: 'deterministic Task-first e2e fixture',
       },
     },
-    eligibility: {
-      maxSubmissionDelayMs: 60_000,
-    },
-  };
-  PredictionV1TaskSchema.parse(core);
-  return {
-    ...core,
+    eligibility: {},
     claimPolicy: {
       mode: 'parallel',
       maxClaims: 25,
@@ -451,57 +475,73 @@ export function makePredictionV1Task(now = Date.now()): Task {
       submissionDeadlineTs: Math.floor((now + 10 * 60_000) / 1000),
     },
   };
+  PredictionV1TaskSchema.parse(core);
+  return core;
 }
 
-export function makePredictionV1SolutionPayload(now = Date.now()): Record<string, unknown> {
+export function makePredictionV1SolutionPayload(
+  now = Date.now(),
+  overrides: Partial<{
+    probabilityYes: string;
+    submittedAt: string;
+    format: string;
+    modelId: string;
+    confidence: string;
+    methodology: string;
+  }> = {},
+): Record<string, unknown> {
   const payload = {
-    prediction: {
-      probability: '0.72',
-      submittedAt: now,
-      modelId: 'task-first-e2e-baseline',
-    },
-    rationale: [
-      { ts: now, note: 'Task-first e2e smoke payload.' },
-    ],
+    probabilityYes: '0.72',
+    submittedAt: new Date(now).toISOString(),
+    format: 'decimal',
+    modelId: 'task-first-e2e-baseline',
+    confidence: 'medium',
+    methodology: 'Deterministic Task-first e2e smoke payload.',
+    ...overrides,
   };
   validatePayload('prediction.v1', 'restoration', payload);
   return payload;
 }
 
 export function makePredictionV1VerdictPayload(now = Date.now()): Record<string, unknown> {
+  const sampledAt = new Date(now - 10_000).toISOString();
   const payload = {
-    restorationEnvelope: {
+    verdict: 'SCORED',
+    outcome: 'YES',
+    resolvedAt: new Date(now).toISOString(),
+    resolutionSource: {
+      venue: 'polymarket',
+      url: 'https://polymarket.com/event/jinn-task-first-e2e',
+      marketId: 'jinn-task-first-e2e',
+      conditionId: '0xcondition-task-first-e2e',
+    },
+    task: {
+      cid: 'local-1',
+      id: 'prediction-v1-e2e',
+    },
+    solutionEnvelope: {
       cid: 'bafy-restoration-envelope',
       sha256: 'a'.repeat(64),
     },
-    verificationOfRestoration: {
-      claimedTier: 'committed',
-      sdkVersion: 'task-first-e2e',
-      timestamp: now,
-      checks: [
-        { name: 'schema', passed: true, detail: 'prediction.v1 restoration payload parsed' },
-      ],
-      overall: 'valid',
-    },
-    verdict: 'PASS',
-    score: '0.0784',
-    scoreBasis: 'brier.v1',
-    scoreVersion: 'task-first-e2e',
-    oracleReading: {
-      feed: '0x0000000000000000000000000000000000000001',
-      roundId: '1',
-      answer: '3200',
-      updatedAt: now,
-    },
     claimed: {
-      probability: '0.72',
-      submittedAt: now,
+      probabilityYes: '0.72',
+      submittedAt: new Date(now - 1_000).toISOString(),
       modelId: 'task-first-e2e-baseline',
-      submissionManifestCid: 'bafy-restoration-envelope',
     },
-    groundTruth: 'YES',
+    benchmark: {
+      probabilityYes: '0.68',
+      sampledAt,
+      method: 'best-bid-ask-midpoint',
+    },
+    scores: {
+      scoreBasis: 'brier-loss.v1',
+      solverBrier: '0.0784',
+      consensusBrier: '0.1024',
+      brierSpread: '0.024',
+    },
     checks: [
-      { name: 'brier', status: 'PASS', detail: 'score=(1-0.72)^2' },
+      { name: 'solution.envelope', status: 'PASS' },
+      { name: 'solution.schema', status: 'PASS' },
     ],
   };
   validatePayload('prediction.v1', 'verdict', payload);
@@ -521,10 +561,57 @@ function predictionHarness(): Harness {
   };
 }
 
+function makeResolvedPolymarketSnapshot(task: Task) {
+  const parsed = PredictionV1TaskSchema.parse(task);
+  return {
+    venue: 'polymarket' as const,
+    marketId: parsed.spec.source.identifiers.marketId,
+    conditionId: parsed.spec.source.identifiers.conditionId,
+    status: 'resolved' as const,
+    outcome: 'YES' as const,
+    resolvedAt: parsed.spec.resolution.expectedResolutionTime,
+    sourceUrl: parsed.spec.source.url,
+  };
+}
+
+function verdictScoreSummary(payload: Record<string, unknown>): string {
+  const scores = payload['scores'];
+  if (scores && typeof scores === 'object' && !Array.isArray(scores)) {
+    const record = scores as Record<string, unknown>;
+    return String(record['solverBrier'] ?? record['brierSpread'] ?? '');
+  }
+  return String(payload['score'] ?? '');
+}
+
+export interface LocalTaskFirstAttemptResult {
+  sharedTaskId: string;
+  sharedTaskCid: string;
+  conditionId: string;
+  solverSafeAddress: Address;
+  request: TaskRequest;
+  solutionPayload: Record<string, unknown>;
+  solutionEnvelope: SignedEnvelope;
+  solutionDelivery: DeliveredResult;
+  verdictRequest: TaskRequest;
+  verdictPayload: Record<string, unknown>;
+  verdictDelivery: DeliveredResult;
+  verdict: string;
+  score: string;
+}
+
 export interface LocalTaskFirstResult {
   postedTaskId: string;
+  postedTaskCid: string;
+  conditionId: string;
+  consensusSnapshot: Record<string, unknown>;
+  attempts: LocalTaskFirstAttemptResult[];
   request: TaskRequest;
+  solutionDelivery: DeliveredResult;
+  verdictRequest: TaskRequest;
+  verdictDelivery: DeliveredResult;
   secondRequest: TaskRequest;
+  verdict: string;
+  score: string;
 }
 
 export async function runLocalTaskFirstLifecycle(): Promise<LocalTaskFirstResult> {
@@ -533,7 +620,9 @@ export async function runLocalTaskFirstLifecycle(): Promise<LocalTaskFirstResult
   const adapter = new LocalAdapter();
   await adapter.initialize();
   try {
-    const task = makePredictionV1Task();
+    const now = Date.now();
+    const task = makePredictionV1Task(now);
+    const predictionTask = PredictionV1TaskSchema.parse(task);
     const posting = new TaskPostingService(adapter, store);
     const posted = await posting.postCandidate(
       {
@@ -550,11 +639,6 @@ export async function runLocalTaskFirstLifecycle(): Promise<LocalTaskFirstResult
     assert(announcement.taskId === posted.taskId, 'watchForTasks yielded the wrong taskId');
     assert(announcement.task.solverType === 'prediction.v1', 'announcement solverType mismatch');
 
-    const request = await adapter.claimTask(announcement.taskId);
-    assert(request.taskId === posted.taskId, 'claimTask did not preserve taskId');
-    assert(request.attemptIndex === 0, 'first claim did not produce attemptIndex=0');
-    assert(request.requestId.length > 0, 'claimTask did not return requestId');
-
     const engine = new TaskEngine({
       store,
       paths: {
@@ -565,48 +649,175 @@ export async function runLocalTaskFirstLifecycle(): Promise<LocalTaskFirstResult
         findFor: (ctx) => predictionHarness().supports(ctx) ? predictionHarness() : undefined,
       },
     });
-    await engine.observe({
-      requestId: request.requestId,
-      taskId: request.taskId,
-      attemptIndex: request.attemptIndex,
-      taskCid: request.taskCid ?? posted.taskCid,
-      onchainCreationTx: request.onchainCreationTx ?? '0x' + '00'.repeat(32),
-      onchainCreationBlock: request.onchainCreationBlock ?? 1,
-      solverType: announcement.task.solverType,
-      taskRole: 'restoration',
-      windowStartTs: announcement.task.window?.startTs ?? Date.now() - 1_000,
-      windowEndTs: announcement.task.window?.endTs ?? Date.now() + 60_000,
-      task: announcement.task,
-    });
-    await engine.process(request.requestId);
-    await engine.process(request.requestId);
-    await engine.process(request.requestId);
-
     const persistence = new TaskRunPersistence(store.db);
-    const row = persistence.getByRequestId(request.requestId);
-    assert(row?.state === TaskRunState.POST_SNAPSHOT, `engine did not run harness; state=${row?.state}`);
-    assert(row.taskId === posted.taskId, 'engine row missing task_id grouping field');
-    assert(row.attemptIndex === 0, 'engine row missing attempt_index grouping field');
-    assert(row.taskCid === posted.taskCid, 'engine row missing task_cid grouping field');
-    assert(row.solverType === 'prediction.v1', 'engine row missing solver_type grouping field');
+    const evaluatorSafe = privateKeyToAccount(ANVIL_PRIVATE_KEYS[3]).address as Address;
+    const evaluatorHarness = new PredictionV1Evaluator({
+      _testDeps: {
+        getResolution: async () => makeResolvedPolymarketSnapshot(announcement.task),
+      },
+    });
+    const runAttempt = async (
+      attemptIndex: number,
+      privateKey: Hex,
+      probabilityYes: string,
+    ): Promise<LocalTaskFirstAttemptResult> => {
+      const request = await adapter.claimTask(announcement.taskId);
+      assert(request.taskId === posted.taskId, 'claimTask did not preserve taskId');
+      assert(request.attemptIndex === attemptIndex, `claimTask did not produce attemptIndex=${attemptIndex}`);
+      assert(request.requestId.length > 0, 'claimTask did not return requestId');
 
-    await adapter.submitResult(request.requestId, {
-      data: JSON.stringify({
+      await engine.observe({
+        requestId: request.requestId,
+        taskId: request.taskId,
+        attemptIndex: request.attemptIndex,
+        taskCid: request.taskCid ?? posted.taskCid,
+        onchainCreationTx: request.onchainCreationTx ?? '0x' + '00'.repeat(32),
+        onchainCreationBlock: request.onchainCreationBlock ?? 1,
+        solverType: announcement.task.solverType,
+        taskRole: 'restoration',
+        windowStartTs: announcement.task.window?.startTs ?? Date.now() - 1_000,
+        windowEndTs: announcement.task.window?.endTs ?? Date.now() + 60_000,
+        task: announcement.task,
+      });
+      await engine.process(request.requestId);
+      await engine.process(request.requestId);
+      await engine.process(request.requestId);
+
+      const row = persistence.getByRequestId(request.requestId);
+      assert(row?.state === TaskRunState.POST_SNAPSHOT, `engine did not run harness; state=${row?.state}`);
+      assert(row.taskId === posted.taskId, 'engine row missing task_id grouping field');
+      assert(row.attemptIndex === attemptIndex, 'engine row missing attempt_index grouping field');
+      assert(row.taskCid === posted.taskCid, 'engine row missing task_cid grouping field');
+      assert(row.solverType === 'prediction.v1', 'engine row missing solver_type grouping field');
+
+      const taskCid = request.taskCid ?? posted.taskCid;
+      const solverSafeAddress = privateKeyToAccount(privateKey).address as Address;
+      const solutionPayload = makePredictionV1SolutionPayload(now + 1_000 + attemptIndex, {
+        probabilityYes,
+        modelId: `task-first-e2e-baseline-${attemptIndex + 1}`,
+      });
+      const solutionEnvelope = await signedExecutionEnvelope({
         solverType: 'prediction.v1',
         role: 'restoration',
-        payload: makePredictionV1SolutionPayload(),
-      }),
-    });
-    const delivery = await takeOne(adapter.watchForDeliveries(), 'watchForDeliveries');
-    assert(delivery.requestId === request.requestId, 'delivery requestId mismatch');
-    assert(delivery.task.solverType === 'prediction.v1', 'delivery task solverType mismatch');
+        taskCid,
+        requestId: keccak256(toBytes(request.requestId)),
+        onchainCreationTx: request.onchainCreationTx ?? '0x' + '00'.repeat(32),
+        onchainCreationBlock: request.onchainCreationBlock ?? 1,
+        safeAddress: solverSafeAddress,
+        privateKey,
+        window: announcement.task.window!,
+        payload: solutionPayload,
+      });
+      await adapter.submitResult(request.requestId, {
+        data: JSON.stringify(solutionEnvelope),
+      });
+      const solutionDelivery = await takeOne(adapter.watchForDeliveries(), 'watchForDeliveries');
+      assert(solutionDelivery.requestId === request.requestId, 'delivery requestId mismatch');
+      assert(solutionDelivery.task.solverType === 'prediction.v1', 'delivery task solverType mismatch');
 
-    const secondRequest = await adapter.claimTask(announcement.taskId);
-    assert(secondRequest.taskId === posted.taskId, 'second claim did not preserve taskId');
-    assert(secondRequest.attemptIndex === 1, 'second claim did not produce attemptIndex=1');
-    assert(secondRequest.requestId !== request.requestId, 'second claim reused requestId');
+      const evaluationTask: Task = {
+        ...announcement.task,
+        id: `${announcement.task.id}:evaluation:${request.attemptIndex}`,
+        role: 'evaluation',
+        restorationRequestId: request.requestId,
+        attemptId: request.requestId,
+        attemptNumber: request.attemptIndex,
+        context: {
+          ...(announcement.task.context ?? {}),
+          restorationResult: JSON.stringify(solutionEnvelope),
+          [RESTORATION_TASK_CID_CONTEXT_KEY]: taskCid,
+          [RESTORATION_ENVELOPE_CID_CONTEXT_KEY]: `bafy-restoration-local-${attemptIndex}`,
+        },
+      };
+      const verdictPosted = await adapter.postTask(evaluationTask);
+      const verdictAnnouncement = await takeOne(adapter.watchForTasks(), 'watchForEvaluationTasks');
+      assert(verdictAnnouncement.task.role === 'evaluation', 'evaluation announcement did not preserve role');
+      assert(
+        verdictAnnouncement.task.restorationRequestId === request.requestId,
+        'evaluation task did not link restoration request',
+      );
+      const verdictRequest = await adapter.claimTask(verdictAnnouncement.taskId);
+      assert(verdictRequest.task.role === 'evaluation', 'verdict request did not preserve evaluation role');
+      assert(
+        verdictRequest.task.restorationRequestId === request.requestId,
+        'verdict request did not preserve restorationRequestId',
+      );
 
-    return { postedTaskId: posted.taskId, request, secondRequest };
+      const verdictWorkDir = join(tmp, `verdict-work-${attemptIndex}`);
+      await mkdir(verdictWorkDir, { recursive: true });
+      const verdictSolution = await evaluatorHarness.run({
+        task: verdictAnnouncement.task,
+        taskCid: verdictPosted.taskCid,
+        workingDir: verdictWorkDir,
+        implStateDir: join(tmp, `verdict-state-${attemptIndex}`),
+        log: () => {},
+        abort: new AbortController().signal,
+        msUntilEndTs: () => 0,
+        trajectory: new TrajectoryCollector({ taskCid, runId: verdictRequest.requestId }),
+      });
+      assert(verdictSolution.verdictPayload, 'local evaluator did not return a verdictPayload');
+      validatePayload('prediction.v1', 'verdict', verdictSolution.verdictPayload);
+      const verdictEnvelope = await signedExecutionEnvelope({
+        solverType: 'prediction.v1',
+        role: 'verdict',
+        taskCid,
+        requestId: keccak256(toBytes(verdictRequest.requestId)),
+        onchainCreationTx: verdictRequest.onchainCreationTx ?? '0x' + '00'.repeat(32),
+        onchainCreationBlock: verdictRequest.onchainCreationBlock ?? 1,
+        safeAddress: evaluatorSafe,
+        privateKey: ANVIL_PRIVATE_KEYS[3],
+        window: announcement.task.window!,
+        payload: verdictSolution.verdictPayload,
+      });
+      await adapter.submitResult(verdictRequest.requestId, {
+        data: JSON.stringify(verdictEnvelope),
+      });
+      const verdictDelivery = await takeOne(adapter.watchForDeliveries(), 'watchForVerdictDeliveries');
+      assert(verdictDelivery.requestId === verdictRequest.requestId, 'verdict delivery requestId mismatch');
+      assert(verdictDelivery.task.role === 'evaluation', 'verdict delivery task role mismatch');
+
+      return {
+        sharedTaskId: posted.taskId,
+        sharedTaskCid: posted.taskCid,
+        conditionId: predictionTask.spec.source.identifiers.conditionId,
+        solverSafeAddress,
+        request,
+        solutionPayload,
+        solutionEnvelope,
+        solutionDelivery,
+        verdictRequest,
+        verdictPayload: verdictSolution.verdictPayload,
+        verdictDelivery,
+        verdict: String(verdictSolution.verdictPayload['verdict']),
+        score: verdictScoreSummary(verdictSolution.verdictPayload),
+      };
+    };
+
+    const attempts = [
+      await runAttempt(0, ANVIL_PRIVATE_KEYS[1], '0.72'),
+      await runAttempt(1, ANVIL_PRIVATE_KEYS[2], '0.61'),
+    ];
+
+    assert(attempts[0]!.request.requestId !== attempts[1]!.request.requestId, 'second claim reused requestId');
+    assert(
+      attempts[0]!.solverSafeAddress !== attempts[1]!.solverSafeAddress,
+      'two solver attempts used the same solver identity',
+    );
+
+    return {
+      postedTaskId: posted.taskId,
+      postedTaskCid: posted.taskCid,
+      conditionId: predictionTask.spec.source.identifiers.conditionId,
+      consensusSnapshot: predictionTask.spec.consensusSnapshot,
+      attempts,
+      request: attempts[0]!.request,
+      solutionDelivery: attempts[0]!.solutionDelivery,
+      verdictRequest: attempts[0]!.verdictRequest,
+      verdictDelivery: attempts[0]!.verdictDelivery,
+      secondRequest: attempts[1]!.request,
+      verdict: attempts[0]!.verdict,
+      score: attempts[0]!.score,
+    };
   } finally {
     await adapter.stop();
     store.close();
@@ -935,7 +1146,7 @@ async function signedExecutionEnvelope(params: {
     },
     window: params.window,
     executor: {
-      implName: params.role === 'verdict' ? 'prediction-v0-evaluator' : 'prediction-v1-e2e-harness',
+      implName: params.role === 'verdict' ? 'prediction-v1-evaluator' : 'prediction-v1-e2e-harness',
       implVersion: '1.0.0',
       clientGitSha: 'dev-e2e',
       codeDigest: `sha256:${'11'.repeat(32)}`,
@@ -1683,29 +1894,8 @@ export async function runBaseSepoliaForkTaskFirstFullLoop(): Promise<AnvilTaskFi
     const verdictRequestId = verdictClaim.requestId as Hex;
 
     const evaluatorHarness = new PredictionV1Evaluator({
-      evaluatorPk: evaluatorOperator.agentPrivateKey,
-      evaluatorSafeAddress: evaluatorOperator.safeAddress,
       _testDeps: {
-        expectedTaskCid: taskCid,
-        oraclePriceAtResolveTs: async () => ({
-          round: {
-            roundId: 1n,
-            answer: 3200n,
-            startedAt: predictionTask.window.endTs - 10_000,
-            updatedAt: predictionTask.spec.question.resolveTs - 1_000,
-            answeredInRound: 1n,
-            decimals: 0,
-          },
-          nextRound: {
-            roundId: 2n,
-            answer: 3210n,
-            startedAt: predictionTask.spec.question.resolveTs + 1_000,
-            updatedAt: predictionTask.spec.question.resolveTs + 1_000,
-            answeredInRound: 2n,
-            decimals: 0,
-          },
-          spanning: true,
-        }),
+        getResolution: async () => makeResolvedPolymarketSnapshot(task),
       },
     });
     const evaluationTmp = await mkdtemp(join(tmpdir(), 'jinn-prediction-fork-eval-e2e-'));
@@ -1865,7 +2055,7 @@ export async function runBaseSepoliaForkTaskFirstFullLoop(): Promise<AnvilTaskFi
         { operator: operator.safeAddress, attemptIndex: claim.attemptIndex, requestId },
       ],
       verdict: String(verdictPayload['verdict']),
-      score: String(verdictPayload['score']),
+      score: verdictScoreSummary(verdictPayload),
       submittedCount,
       refundedUnusedBudget,
     };
@@ -2040,29 +2230,8 @@ export async function runAnvilTaskFirstFullLoop(): Promise<AnvilTaskFirstFullLoo
     assert(verdictIndex === 0, `first verdict index was ${verdictIndex}`);
 
     const evaluatorHarness = new PredictionV1Evaluator({
-      evaluatorPk: ANVIL_PRIVATE_KEYS[3],
-      evaluatorSafeAddress: evaluator.address,
       _testDeps: {
-        expectedTaskCid: taskCid,
-        oraclePriceAtResolveTs: async () => ({
-          round: {
-            roundId: 1n,
-            answer: 3200n,
-            startedAt: predictionTask.window.endTs - 10_000,
-            updatedAt: predictionTask.spec.question.resolveTs - 1_000,
-            answeredInRound: 1n,
-            decimals: 0,
-          },
-          nextRound: {
-            roundId: 2n,
-            answer: 3210n,
-            startedAt: predictionTask.spec.question.resolveTs + 1_000,
-            updatedAt: predictionTask.spec.question.resolveTs + 1_000,
-            answeredInRound: 2n,
-            decimals: 0,
-          },
-          spanning: true,
-        }),
+        getResolution: async () => makeResolvedPolymarketSnapshot(task),
       },
     });
     const evaluationTmp = await mkdtemp(join(tmpdir(), 'jinn-prediction-eval-e2e-'));
@@ -2221,7 +2390,7 @@ export async function runAnvilTaskFirstFullLoop(): Promise<AnvilTaskFirstFullLoo
         { operator: operatorB.address, attemptIndex: attemptIndexB, requestId: requestIdB },
       ],
       verdict: String(verdictPayload['verdict']),
-      score: String(verdictPayload['score']),
+      score: verdictScoreSummary(verdictPayload),
       submittedCount,
       refundedUnusedBudget,
     };

--- a/client/test/e2e/task-first-local.ts
+++ b/client/test/e2e/task-first-local.ts
@@ -26,7 +26,9 @@ async function main(): Promise<void> {
   results.push(await runPhase('Client Task-first lifecycle', async () => {
     const result = await runLocalTaskFirstLifecycle();
     process.stdout.write(
-      `taskId=${result.postedTaskId} requestIds=${result.request.requestId},${result.secondRequest.requestId}\n`,
+      `taskId=${result.postedTaskId} taskCid=${result.postedTaskCid} ` +
+      `attempts=${result.attempts.map((a) => `${a.request.attemptIndex}:${a.request.requestId}`).join(',')} ` +
+      `verdicts=${result.attempts.map((a) => `${a.verdictRequest.requestId}:${a.verdict}:${a.score}`).join(',')}\n`,
     );
   }));
 

--- a/client/test/e2e/validate.ts
+++ b/client/test/e2e/validate.ts
@@ -29,7 +29,8 @@ async function main(): Promise<void> {
   results.push(await runPhase('Client Task-first lifecycle', async () => {
     const result = await runLocalTaskFirstLifecycle();
     process.stdout.write(
-      `taskId=${result.postedTaskId} requestIds=${result.request.requestId},${result.secondRequest.requestId}\n`,
+      `taskId=${result.postedTaskId} requestIds=${result.request.requestId},${result.secondRequest.requestId} ` +
+      `verdictRequest=${result.verdictRequest.requestId} verdict=${result.verdict} score=${result.score}\n`,
     );
   }));
 

--- a/client/test/earning/contracts.test.ts
+++ b/client/test/earning/contracts.test.ts
@@ -11,6 +11,14 @@ describe('getChainConfig', () => {
     expect('claimRegistry' in cfg).toBe(false);
   });
 
+  it('resolves Base Sepolia runtime to bundled Task-native router metadata', () => {
+    const cfg = getChainConfig('base-sepolia');
+
+    expect(cfg.jinnRouter).toBe('0xdC9BCcEB7aca21Ad4Ca2Fc5B4d7aea6b4F6CedD9');
+    expect(cfg.mechMarketplace).toBe('0xD3233FdAaB51E9775f6bFCE8242B02C181D7c0e7');
+    expect(cfg.routerClaimDeliveryVersion).toBe('v3');
+  });
+
   it('does not expose legacy claim coordination on Base mainnet clean-break config', () => {
     const cfg = getChainConfig('base');
 

--- a/client/test/harnesses/engine/prediction-v1-runtime-gate.test.ts
+++ b/client/test/harnesses/engine/prediction-v1-runtime-gate.test.ts
@@ -1,0 +1,107 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Store } from '../../../src/store/store.js';
+import { TaskEngine } from '../../../src/harnesses/engine/engine.js';
+import { buildHarnesses } from '../../../src/harnesses/impls/index.js';
+import type { Harness, Solution } from '../../../src/harnesses/types.js';
+import type { Task } from '../../../src/types/task.js';
+import { makePredictionV1Task } from '../impls/prediction-v1-test-helpers.js';
+
+function stubHarness(overrides: Partial<Harness> = {}): Harness {
+  return {
+    name: 'prediction-v1-test-harness',
+    version: '1.0.0',
+    supports: ({ solverType, role }) => solverType === 'prediction.v1' && role !== 'evaluation',
+    run: async (): Promise<Solution> => ({ venueRef: { name: 'stub' }, gating: {} }),
+    ...overrides,
+  };
+}
+
+describe('prediction.v1 runtime gate', () => {
+  let dir: string;
+  let store: Store;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'jinn-prediction-v1-gate-'));
+    store = new Store(join(dir, 'jinn.db'));
+  });
+
+  afterEach(() => {
+    store.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('buildHarnesses wires prediction.v1 to the Polymarket v1 baseline and evaluator', () => {
+    const harnesses = buildHarnesses({
+      stub: true,
+      rpcUrl: 'http://127.0.0.1:8545',
+      claudePath: 'claude',
+      claudeModel: 'test-model',
+    });
+
+    const restoration = harnesses.find((harness) => harness.supports({
+      solverType: 'prediction.v1',
+      role: 'restoration',
+    }));
+    const evaluation = harnesses.find((harness) => harness.supports({
+      solverType: 'prediction.v1',
+      role: 'evaluation',
+    }));
+
+    expect(restoration?.name).toBe('prediction-v1-baseline');
+    expect(evaluation?.name).toBe('prediction-v1-evaluator');
+    expect(harnesses.map((harness) => harness.name)).not.toContain('prediction-v0-baseline');
+    expect(harnesses.map((harness) => harness.name)).not.toContain('prediction-v0-evaluator');
+  });
+
+  it('rejects schema-invalid prediction.v1 Tasks before a harness attempt', async () => {
+    const canAttempt = vi.fn(async () => ({ ok: true as const }));
+    const engine = new TaskEngine({
+      store,
+      paths: { workingDirRoot: join(dir, 'work'), implStateDirRoot: join(dir, 'impl-state') },
+      implRegistry: { findFor: () => stubHarness({ canAttempt }) },
+    });
+    const task = {
+      ...makePredictionV1Task(),
+      spec: { source: { venue: 'polymarket' } },
+    } as unknown as Task;
+
+    const accept = await engine.canAcceptTask({
+      solverType: 'prediction.v1',
+      taskRole: 'restoration',
+      task,
+    });
+
+    expect(accept.ok).toBe(false);
+    if (!accept.ok) {
+      expect(accept.reason).toMatch(/prediction\.v1 task failed validation/);
+      expect(accept.reason).toMatch(/spec\.question/);
+    }
+    expect(canAttempt).not.toHaveBeenCalled();
+  });
+
+  it('passes a schema-valid prediction.v1 Task through harness canAttempt', async () => {
+    const canAttempt = vi.fn(async () => ({ ok: false as const, reason: 'operator policy declined' }));
+    const engine = new TaskEngine({
+      store,
+      paths: { workingDirRoot: join(dir, 'work'), implStateDirRoot: join(dir, 'impl-state') },
+      implRegistry: { findFor: () => stubHarness({ canAttempt }) },
+    });
+    const task = makePredictionV1Task();
+
+    const accept = await engine.canAcceptTask({
+      solverType: 'prediction.v1',
+      taskRole: 'restoration',
+      task,
+    });
+
+    expect(accept).toEqual({
+      ok: false,
+      reason: "impl 'prediction-v1-test-harness' cannot attempt task: operator policy declined",
+    });
+    expect(canAttempt).toHaveBeenCalledWith(task);
+  });
+});

--- a/client/test/harnesses/impls/prediction-v1-evaluator/index.test.ts
+++ b/client/test/harnesses/impls/prediction-v1-evaluator/index.test.ts
@@ -7,6 +7,7 @@ import {
   makePredictionV1Task,
   makeSignedSolutionEnvelope,
 } from '../prediction-v1-test-helpers.js';
+import { RESTORATION_TASK_CID_CONTEXT_KEY } from '../../../../src/harnesses/impls/evaluation-context.js';
 
 describe('PredictionV1Evaluator', () => {
   it('scores valid YES resolutions with Brier loss against consensus', async () => {
@@ -82,6 +83,98 @@ describe('PredictionV1Evaluator', () => {
     expect(out.gating).not.toHaveProperty('solverBrier');
     expect(payload.checks).toContainEqual(expect.objectContaining({
       name: 'solution.schema',
+      status: 'FAIL',
+    }));
+  });
+
+  it('rejects forged solution envelopes before scoring', async () => {
+    const task = makePredictionV1Task();
+    const envelope = await makeSignedSolutionEnvelope(task);
+    const tamperedEnvelope = {
+      ...envelope,
+      payload: {
+        ...envelope.payload,
+        probabilityYes: '0.0100',
+      },
+    };
+
+    const out = await new PredictionV1Evaluator({
+      _testDeps: {
+        getResolution: async () => ({
+          venue: 'polymarket',
+          marketId: 'mkt-1',
+          conditionId: '0xabc',
+          status: 'resolved',
+          outcome: 'YES',
+          sourceUrl: 'https://polymarket.com/event/test-market',
+        }),
+      },
+    }).run(makeHarnessCtx({ task: makeEvalTask(task, tamperedEnvelope as typeof envelope) }));
+    const payload = PredictionV1VerdictPayloadSchema.parse(out.verdictPayload);
+
+    expect(payload.verdict).toBe('REJECTED');
+    expect(payload.scores).toBeUndefined();
+    expect(payload.checks).toContainEqual(expect.objectContaining({
+      name: 'integrity.manifest_signature',
+      status: 'FAIL',
+    }));
+  });
+
+  it('does not score when restoration task CID context is missing', async () => {
+    const task = makePredictionV1Task();
+    const envelope = await makeSignedSolutionEnvelope(task);
+    const evalTask = makeEvalTask(task, envelope);
+    delete evalTask.context![RESTORATION_TASK_CID_CONTEXT_KEY];
+    const evaluator = new PredictionV1Evaluator({
+      _testDeps: {
+        getResolution: async () => ({
+          venue: 'polymarket',
+          marketId: 'mkt-1',
+          conditionId: '0xabc',
+          status: 'resolved',
+          outcome: 'YES',
+          sourceUrl: 'https://polymarket.com/event/test-market',
+        }),
+      },
+    });
+
+    await expect(evaluator.canAttempt(evalTask)).resolves.toEqual({
+      ok: false,
+      reason: 'context.restorationTaskCid required',
+    });
+    const out = await evaluator.run(makeHarnessCtx({ task: evalTask }));
+    const payload = PredictionV1VerdictPayloadSchema.parse(out.verdictPayload);
+
+    expect(payload.verdict).toBe('INDETERMINATE');
+    expect(payload.scores).toBeUndefined();
+    expect(payload.checks).toContainEqual(expect.objectContaining({
+      name: 'integrity.signedTask_ref',
+      status: 'INDETERMINATE',
+    }));
+  });
+
+  it('rejects resolution snapshots that do not match task market identifiers', async () => {
+    const task = makePredictionV1Task();
+    const envelope = await makeSignedSolutionEnvelope(task);
+
+    const out = await new PredictionV1Evaluator({
+      _testDeps: {
+        getResolution: async () => ({
+          venue: 'polymarket',
+          marketId: 'mkt-1',
+          conditionId: '0xother',
+          status: 'resolved',
+          outcome: 'YES',
+          sourceUrl: 'https://polymarket.com/event/test-market',
+        }),
+      },
+    }).run(makeHarnessCtx({ task: makeEvalTask(task, envelope) }));
+    const payload = PredictionV1VerdictPayloadSchema.parse(out.verdictPayload);
+
+    expect(payload.verdict).toBe('REJECTED');
+    expect(payload.scores).toBeUndefined();
+    expect(payload.checks).toContainEqual(expect.objectContaining({
+      name: 'market.identity',
       status: 'FAIL',
     }));
   });

--- a/client/test/harnesses/impls/prediction-v1-evaluator/index.test.ts
+++ b/client/test/harnesses/impls/prediction-v1-evaluator/index.test.ts
@@ -53,7 +53,7 @@ describe('PredictionV1Evaluator', () => {
     expect(payload.solutionEnvelope.cid).toBe('bafy-solution-envelope');
   });
 
-  it('rejects malformed probabilities without scoring', async () => {
+  it('rejects invalid parseable probabilities without scoring', async () => {
     const task = makePredictionV1Task();
     const envelope = await makeSignedSolutionEnvelope(task, {
       probabilityYes: '1.2',
@@ -79,25 +79,16 @@ describe('PredictionV1Evaluator', () => {
 
     expect(payload.verdict).toBe('REJECTED');
     expect(payload.scores).toBeUndefined();
-    expect(payload.checks.some((check) => check.status === 'FAIL')).toBe(true);
+    expect(out.gating).not.toHaveProperty('solverBrier');
+    expect(payload.checks).toContainEqual(expect.objectContaining({
+      name: 'solution.schema',
+      status: 'FAIL',
+    }));
   });
 
-  it('marks invalid and unresolved markets as non-scored verdicts', async () => {
+  it('marks unresolved markets INDETERMINATE without scores', async () => {
     const task = makePredictionV1Task();
     const envelope = await makeSignedSolutionEnvelope(task);
-
-    const invalid = await new PredictionV1Evaluator({
-      _testDeps: {
-        getResolution: async () => ({
-          venue: 'polymarket',
-          marketId: 'mkt-1',
-          conditionId: '0xabc',
-          status: 'invalid',
-          sourceUrl: 'https://polymarket.com/event/test-market',
-        }),
-      },
-    }).run(makeHarnessCtx({ task: makeEvalTask(task, envelope) }));
-    expect(PredictionV1VerdictPayloadSchema.parse(invalid.verdictPayload).verdict).toBe('INVALID');
 
     const unresolved = await new PredictionV1Evaluator({
       _testDeps: {
@@ -110,6 +101,44 @@ describe('PredictionV1Evaluator', () => {
         }),
       },
     }).run(makeHarnessCtx({ task: makeEvalTask(task, envelope) }));
-    expect(PredictionV1VerdictPayloadSchema.parse(unresolved.verdictPayload).verdict).toBe('INDETERMINATE');
+    const payload = PredictionV1VerdictPayloadSchema.parse(unresolved.verdictPayload);
+
+    expect(payload.verdict).toBe('INDETERMINATE');
+    expect(payload.scores).toBeUndefined();
+    expect(unresolved.gating).not.toHaveProperty('solverBrier');
+    expect(payload.checks).toContainEqual({
+      name: 'market.resolution',
+      status: 'INDETERMINATE',
+    });
   });
+
+  it.each(['invalid', 'cancelled', 'ambiguous'] as const)(
+    'marks %s market resolutions INVALID without scores and records a failed check',
+    async (status) => {
+      const task = makePredictionV1Task();
+      const envelope = await makeSignedSolutionEnvelope(task);
+
+      const out = await new PredictionV1Evaluator({
+        _testDeps: {
+          getResolution: async () => ({
+            venue: 'polymarket',
+            marketId: 'mkt-1',
+            conditionId: '0xabc',
+            status,
+            sourceUrl: 'https://polymarket.com/event/test-market',
+          }),
+        },
+      }).run(makeHarnessCtx({ task: makeEvalTask(task, envelope) }));
+      const payload = PredictionV1VerdictPayloadSchema.parse(out.verdictPayload);
+
+      expect(payload.verdict).toBe('INVALID');
+      expect(payload.scores).toBeUndefined();
+      expect(out.gating).not.toHaveProperty('solverBrier');
+      expect(payload.checks).toContainEqual({
+        name: 'market.resolution',
+        status: 'FAIL',
+        detail: status,
+      });
+    },
+  );
 });

--- a/client/test/plugins/prediction-plugin.test.ts
+++ b/client/test/plugins/prediction-plugin.test.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { describe, expect, it } from 'vitest';
 import {
   loadSolverPluginManifest,
@@ -10,8 +12,18 @@ import { SOLVER_NET_CONTRACTS } from '../../src/solver-nets/contracts.js';
 
 const pluginRoot = fileURLToPath(new URL('../../plugins/jinn-prediction-plugin/', import.meta.url));
 
+interface PredictionMcpServerModule {
+  listToolDeclarations(): Array<{ name: string }>;
+  getMarket(args: unknown, config: unknown): Promise<Record<string, unknown>>;
+  getOrderbook(args: unknown, config: unknown): Promise<Record<string, unknown>>;
+}
+
 function readJson(rel: string): Record<string, unknown> {
   return JSON.parse(readFileSync(join(pluginRoot, rel), 'utf-8')) as Record<string, unknown>;
+}
+
+async function readMcpServerModule(): Promise<PredictionMcpServerModule> {
+  return import(pathToFileURL(join(pluginRoot, 'mcp/polymarket-server.mjs')).href) as Promise<PredictionMcpServerModule>;
 }
 
 function sampleTask() {
@@ -153,6 +165,99 @@ describe('jinn prediction reference pack manifests', () => {
     expect(skills).toEqual([
       'skills/base-rate-forecasting/SKILL.md',
       'skills/calibration/SKILL.md',
+      'skills/common-biases/SKILL.md',
+      'skills/polymarket-task-handling/SKILL.md',
+    ]);
+  });
+
+  it('declares only read-only task-scoped Polymarket MCP tools', async () => {
+    const mcp = await readMcpServerModule();
+    const declarations = mcp.listToolDeclarations();
+    const names = declarations.map((tool: { name: string }) => tool.name);
+
+    expect(names).toEqual(['polymarket_get_market', 'polymarket_get_orderbook']);
+    expect(names.join(' ')).not.toMatch(/submit|trade|order_place|sign|wallet|post|search/i);
+    expect(JSON.stringify(declarations)).toContain('Read-only CLOB market data only');
+    expect(JSON.stringify(declarations)).toContain('current prediction task');
+  });
+
+  it('serves the Polymarket tool list from the stdio MCP entrypoint', async () => {
+    const client = new Client({ name: 'prediction-plugin-test', version: '1.0.0' });
+    const transport = new StdioClientTransport({
+      command: 'node',
+      args: [join(pluginRoot, 'mcp/polymarket-server.mjs')],
+      cwd: pluginRoot,
+    });
+
+    try {
+      await client.connect(transport);
+      const tools = await client.listTools();
+      expect(tools.tools.map((tool) => tool.name)).toEqual([
+        'polymarket_get_market',
+        'polymarket_get_orderbook',
+      ]);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('reads exact Polymarket market and orderbook identifiers without network search', async () => {
+    const mcp = await readMcpServerModule();
+    const requested: string[] = [];
+    const fetchImpl = async (url: string | URL) => {
+      const href = String(url);
+      requested.push(href);
+      if (href === 'https://gamma.test/markets/mkt-1') {
+        return new Response(JSON.stringify({
+          id: 'mkt-1',
+          conditionId: '0xabc',
+          slug: 'test-market',
+          question: 'Will test pass?',
+          description: 'A test market.',
+          outcomes: '["YES","NO"]',
+          clobTokenIds: '["yes-token","no-token"]',
+          endDate: '2026-05-04T00:00:00.000Z',
+          active: true,
+          closed: false,
+          archived: false,
+          liquidity: 12000,
+          volume24hr: 2600,
+        }), { status: 200 });
+      }
+      if (href === 'https://clob.test/book?token_id=yes-token') {
+        return new Response(JSON.stringify({
+          timestamp: 1777852800,
+          bids: [{ price: '0.60' }, { price: '0.58' }],
+          asks: [{ price: '0.64' }, { price: '0.66' }],
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: 'unexpected url' }), { status: 404 });
+    };
+
+    const market = await mcp.getMarket(
+      { marketId: 'mkt-1', conditionId: '0xabc' },
+      { gammaBaseUrl: 'https://gamma.test', fetchImpl },
+    );
+    const orderbook = await mcp.getOrderbook(
+      { marketId: 'mkt-1', conditionId: '0xabc', yesTokenId: 'yes-token' },
+      { clobBaseUrl: 'https://clob.test', fetchImpl },
+    );
+
+    expect(market.marketId).toBe('mkt-1');
+    expect(market.conditionId).toBe('0xabc');
+    expect(market.tokenIds).toEqual({ yes: 'yes-token', no: 'no-token' });
+    expect(orderbook).toMatchObject({
+      marketId: 'mkt-1',
+      conditionId: '0xabc',
+      bestBidYes: '0.6000',
+      bestAskYes: '0.6400',
+      midpointYes: '0.6200',
+      spread: '0.0400',
+      source: 'polymarket-clob',
+    });
+    expect(requested).toEqual([
+      'https://gamma.test/markets/mkt-1',
+      'https://clob.test/book?token_id=yes-token',
     ]);
   });
 

--- a/client/test/solver-nets/contracts.test.ts
+++ b/client/test/solver-nets/contracts.test.ts
@@ -56,4 +56,23 @@ describe('SolverNet contracts', () => {
       }),
     ).rejects.toThrow(/no registered SolverNetContract/);
   });
+
+  it('reports a clear error when the canonical prediction plugin is not available', async () => {
+    await expect(
+      loadSolverNets({
+        solverNets: {
+          prediction: {
+            enabled: true,
+            solverType: 'prediction.v1',
+            canonicalPlugin: 'npm:@jinn-network/definitely-missing-prediction-canonical-plugin',
+            harness: 'prediction-v1-baseline',
+            plugins: [],
+            taskGenerator: { enabled: true },
+          },
+        },
+      }),
+    ).rejects.toThrow(
+      /SolverPlugin source npm:@jinn-network\/definitely-missing-prediction-canonical-plugin is not vendored/,
+    );
+  });
 });

--- a/client/test/solver-types/prediction-v1-auto.test.ts
+++ b/client/test/solver-types/prediction-v1-auto.test.ts
@@ -39,9 +39,16 @@ function book(bid: string, ask: string, timestamp = NOW) {
 }
 
 function fetchFixture(markets: unknown[], books: Record<string, unknown>) {
+  const marketById = new Map(
+    markets.map((row) => [String((row as Record<string, unknown>)['id'] ?? ''), row]),
+  );
   return vi.fn(async (input: RequestInfo | URL) => {
     const url = new URL(String(input));
     if (url.pathname === '/markets') return jsonResponse(markets);
+    if (url.pathname.startsWith('/markets/')) {
+      const id = decodeURIComponent(url.pathname.slice('/markets/'.length));
+      return jsonResponse(marketById.get(id) ?? {});
+    }
     if (url.pathname === '/book') {
       const token = url.searchParams.get('token_id') ?? '';
       return jsonResponse(books[token] ?? { bids: [], asks: [] });
@@ -71,7 +78,7 @@ describe('prediction.v1 auto-generator', () => {
       },
     );
 
-    const generator = makePredictionV1Generator({ fetchImpl, maxNewRoundsPerPoll: 25 });
+    const generator = makePredictionV1Generator({ fetchImpl, cadenceMs: 0, maxNewRoundsPerPoll: 25 });
     const tasks = await generator();
 
     expect(tasks).toHaveLength(1);
@@ -116,7 +123,7 @@ describe('prediction.v1 auto-generator', () => {
       },
     );
 
-    const generator = makePredictionV1Generator({ fetchImpl, maxNewRoundsPerPoll: 1 });
+    const generator = makePredictionV1Generator({ fetchImpl, cadenceMs: 0, maxNewRoundsPerPoll: 1 });
     const first = await generator();
     const second = await generator();
 
@@ -134,11 +141,125 @@ describe('prediction.v1 auto-generator', () => {
       { 'yes-abc': book('0.60', '0.64') },
     );
 
-    const generator = makePredictionV1Generator({ fetchImpl });
+    const generator = makePredictionV1Generator({ fetchImpl, cadenceMs: 0 });
     await generator();
 
     const calls = (fetchImpl as any).mock.calls.map((call: unknown[]) => String(call[0]));
     expect(calls.every((url: string) => url.includes('/markets') || url.includes('/book'))).toBe(true);
     expect(calls.some((url: string) => /order|trade|auth|wallet|sign/i.test(url))).toBe(false);
+  });
+
+  it('honors generator cadence independently from daemon poll frequency', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const fetchImpl = fetchFixture(
+      [market('abc', 'yes-abc')],
+      { 'yes-abc': book('0.60', '0.64') },
+    );
+
+    const generator = makePredictionV1Generator({ fetchImpl, cadenceMs: 6 * 60 * 60 * 1000 });
+    const first = await generator();
+    const second = await generator();
+
+    expect(first).toHaveLength(1);
+    expect(second).toBeNull();
+    expect((fetchImpl as any).mock.calls).toHaveLength(3);
+
+    vi.setSystemTime(NOW + 6 * 60 * 60 * 1000 + 1);
+    await generator();
+
+    expect((fetchImpl as any).mock.calls.filter((call: unknown[]) => String(call[0]).includes('/markets'))).toHaveLength(3);
+  });
+
+  it('prioritizes valid allowlisted markets when per-poll caps bind', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const fetchImpl = fetchFixture(
+      [
+        market('liquid', 'yes-liquid', { liquidity: '90000' }),
+        market('manual', 'yes-manual', { liquidity: '12000' }),
+      ],
+      {
+        'yes-liquid': book('0.60', '0.64'),
+        'yes-manual': book('0.51', '0.55'),
+      },
+    );
+
+    const generator = makePredictionV1Generator({
+      fetchImpl,
+      cadenceMs: 0,
+      maxNewRoundsPerPoll: 1,
+      allowlistConditionIds: ['0xmanual'],
+    });
+    const tasks = await generator();
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks![0].spec?.source).toMatchObject({ identifiers: { conditionId: '0xmanual' } });
+    expect(tasks![0].eligibility).toMatchObject({ manualAllowlistHit: true });
+  });
+
+  it('keeps blocklist above allowlist and does not let allowlist bypass validation', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const fetchImpl = fetchFixture(
+      [
+        market('blocked', 'yes-blocked', { liquidity: '99000' }),
+        market('ambiguous-schema', 'yes-ambiguous', { outcomes: '["Yes","Maybe"]' }),
+        market('too-soon', 'yes-too-soon', { endDateIso: new Date(NOW + 2 * 3_600_000).toISOString() }),
+        market('stale', 'yes-stale'),
+        market('valid', 'yes-valid'),
+      ],
+      {
+        'yes-blocked': book('0.60', '0.64'),
+        'yes-too-soon': book('0.60', '0.64'),
+        'yes-stale': book('0.50', '0.54', NOW - 120_000),
+        'yes-valid': book('0.51', '0.55'),
+      },
+    );
+
+    const generator = makePredictionV1Generator({
+      fetchImpl,
+      cadenceMs: 0,
+      maxNewRoundsPerPoll: 1,
+      allowlistConditionIds: ['0xblocked', '0xambiguous-schema', '0xtoo-soon', '0xstale'],
+      blocklistConditionIds: ['0xblocked'],
+    });
+    const tasks = await generator();
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks![0].spec?.source).toMatchObject({ identifiers: { conditionId: '0xvalid' } });
+    const calledUrls = (fetchImpl as any).mock.calls.map((call: unknown[]) => String(call[0]));
+    expect(calledUrls.some((url: string) => url.includes('yes-blocked'))).toBe(false);
+    expect(calledUrls.some((url: string) => url.includes('yes-too-soon'))).toBe(false);
+    expect(calledUrls.some((url: string) => url.includes('yes-stale'))).toBe(true);
+  });
+
+  it('skips invalid, cancelled, and ambiguous Polymarket statuses', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const fetchImpl = fetchFixture(
+      [
+        market('invalid', 'yes-invalid', { resolutionStatus: 'invalid' }),
+        market('cancelled', 'yes-cancelled', { resolutionStatus: 'cancelled' }),
+        market('ambiguous', 'yes-ambiguous', { closed: true }),
+        market('valid', 'yes-valid'),
+      ],
+      {
+        'yes-invalid': book('0.60', '0.64'),
+        'yes-cancelled': book('0.60', '0.64'),
+        'yes-ambiguous': book('0.60', '0.64'),
+        'yes-valid': book('0.51', '0.55'),
+      },
+    );
+
+    const generator = makePredictionV1Generator({ fetchImpl, cadenceMs: 0 });
+    const tasks = await generator();
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks![0].spec?.source).toMatchObject({ identifiers: { conditionId: '0xvalid' } });
+    const calledUrls = (fetchImpl as any).mock.calls.map((call: unknown[]) => String(call[0]));
+    expect(calledUrls.some((url: string) => url.includes('yes-invalid'))).toBe(false);
+    expect(calledUrls.some((url: string) => url.includes('yes-cancelled'))).toBe(false);
+    expect(calledUrls.some((url: string) => url.includes('yes-ambiguous'))).toBe(false);
   });
 });

--- a/client/test/solver-types/registry.test.ts
+++ b/client/test/solver-types/registry.test.ts
@@ -1,13 +1,137 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+import { LocalAdapter } from '../../src/adapters/local/adapter.js';
+import { TaskPostingService } from '../../src/tasks/posting-service.js';
+import { GeneratedTaskSource } from '../../src/tasks/sources.js';
+import { PredictionV1TaskSchema } from '../../src/types/prediction-v1.js';
 import {
   SOLVER_TYPES,
   knownSolverTypes,
   unknownSolverTypeMessage,
-  PREDICTION_V1_KIND,
   collectTestnetAutoTaskGenerators,
 } from '../../src/solver-types/index.js';
 
+const NOW = Date.parse('2026-05-02T00:00:00.000Z');
+
+function polymarketTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'prediction-v1-polymarket-abc',
+    description: 'Forecast a binary externally resolved prediction market.',
+    solverType: 'prediction.v1',
+    role: 'restoration',
+    window: {
+      startTs: NOW,
+      endTs: NOW + 6 * 60 * 60 * 1000,
+    },
+    claimPolicy: {
+      mode: 'parallel',
+      maxClaims: 25,
+      maxClaimsPerOperator: 1,
+      claimLeaseTtlSeconds: 30 * 60,
+    },
+    spec: {
+      question: { kind: 'binary', text: 'Will test pass?', yesLabel: 'YES', noLabel: 'NO' },
+      source: {
+        type: 'prediction-market',
+        venue: 'polymarket',
+        url: 'https://polymarket.com/event/test-market',
+        identifiers: {
+          marketId: 'mkt-1',
+          conditionId: '0xabc',
+          yesTokenId: 'yes-token',
+          noTokenId: 'no-token',
+        },
+      },
+      resolution: {
+        expectedResolutionTime: '2026-05-04T00:00:00.000Z',
+        rulesText: 'Resolve according to UMA final market resolution.',
+        rulesUrl: 'https://polymarket.com/event/test-market',
+        timezone: 'UTC',
+      },
+      consensusSnapshot: {
+        sampledAt: '2026-05-02T00:00:00.000Z',
+        probabilityYes: '0.6200',
+        method: 'best-bid-ask-midpoint',
+        bestBidYes: '0.6000',
+        bestAskYes: '0.6400',
+        spread: '0.0400',
+        source: 'polymarket-clob',
+      },
+      eligibilitySnapshot: {
+        sampledAt: '2026-05-02T00:00:00.000Z',
+        timeToResolutionHours: 48,
+        liquidityUsd: '12000',
+        volume24hUsd: '2600',
+        orderbookAgeSeconds: 1,
+        selectionReason: 'weekly-binary-liquid-clear-rules',
+      },
+    },
+    eligibility: {
+      dedupKey: 'polymarket:0xabc',
+    },
+    ...overrides,
+  };
+}
+
+function market(id: string, token: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    conditionId: `0x${id}`,
+    slug: `${id}-slug`,
+    question: `Will ${id} resolve yes?`,
+    description: `Resolution rules for ${id}.`,
+    outcomes: '["Yes","No"]',
+    clobTokenIds: `["${token}","${token}-no"]`,
+    endDateIso: new Date(NOW + 48 * 3_600_000).toISOString(),
+    active: true,
+    closed: false,
+    archived: false,
+    liquidity: '12000',
+    volume24hr: '2600',
+    ...overrides,
+  };
+}
+
+function book(bid: string, ask: string, timestamp = NOW) {
+  return {
+    timestamp,
+    bids: [{ price: bid, size: '10' }],
+    asks: [{ price: ask, size: '10' }],
+  };
+}
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function fetchFixture(markets: unknown[], books: Record<string, unknown>) {
+  const marketById = new Map(
+    markets.map((row) => [String((row as Record<string, unknown>)['id'] ?? ''), row]),
+  );
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = new URL(String(input));
+    if (url.pathname === '/markets') return jsonResponse(markets);
+    if (url.pathname.startsWith('/markets/')) {
+      const id = decodeURIComponent(url.pathname.slice('/markets/'.length));
+      return jsonResponse(marketById.get(id) ?? {});
+    }
+    if (url.pathname === '/book') {
+      const token = url.searchParams.get('token_id') ?? '';
+      return jsonResponse(books[token] ?? { bids: [], asks: [] });
+    }
+    throw new Error(`unexpected Polymarket endpoint: ${url.toString()}`);
+  }) as unknown as typeof fetch;
+}
+
 describe('SOLVER_TYPES manifest', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
   it('knownSolverTypes returns stable insertion order', () => {
     expect(knownSolverTypes()).toEqual([
       'portfolio.v0',
@@ -72,52 +196,26 @@ describe('SOLVER_TYPES manifest', () => {
     expect(out.spec).not.toHaveProperty('kind');
   });
 
-  it('prediction.v1 parseSpec works without readCurrent when threshold is not a current[±…] sentinel', async () => {
-    const raw = {
-      id: 'p-1',
-      description: 'x',
-      window: { startTs: 1, endTs: 120_000 },
-      spec: {
-        kind: PREDICTION_V1_KIND,
-        oracle: {
-          venue: 'chainlink-base-sepolia',
-          feed: '0x4aDC67696bA383F43DD60A9e78F2C97Fbbfc7cb1',
-          feedDescription: 'ETH / USD',
-        },
-        question: { kind: 'threshold', operator: 'GT', threshold: '1', resolveTs: 200_000 },
-      },
-      eligibility: {},
-    };
+  it('prediction.v1 parseSpec accepts canonical Polymarket tasks', async () => {
+    const raw = polymarketTask();
     const out = await SOLVER_TYPES['prediction.v1']!.parseSpec(raw);
-    expect(out.spec).not.toHaveProperty('kind');
-  });
-
-  it('prediction.v1 parseSpec requires readCurrent for current[±…] threshold sentinel', async () => {
-    const raw = {
-      id: 'p-1',
-      description: 'x',
-      window: { startTs: 1, endTs: 120_000 },
-      spec: {
-        kind: PREDICTION_V1_KIND,
-        oracle: {
-          venue: 'chainlink-base-sepolia',
-          feed: '0x4aDC67696bA383F43DD60A9e78F2C97Fbbfc7cb1',
-          feedDescription: 'ETH / USD',
-        },
-        question: { kind: 'threshold', operator: 'GT', threshold: 'current+0.5%', resolveTs: 200_000 },
+    expect(out.window).toEqual((raw as any).window);
+    expect(out.claimPolicy).toMatchObject({ mode: 'parallel', maxClaims: 25 });
+    expect(out.spec).toMatchObject({
+      source: {
+        venue: 'polymarket',
+        identifiers: { conditionId: '0xabc' },
       },
-      eligibility: {},
-    };
-    await expect(SOLVER_TYPES['prediction.v1']!.parseSpec(raw)).rejects.toThrow(/readCurrent/);
+    });
   });
 
-  it('prediction.v1 parseSpec resolves with readCurrent', async () => {
+  it('prediction.v1 parseSpec rejects legacy Chainlink threshold templates', async () => {
     const raw = {
       id: 'p-1',
       description: 'x',
       window: { startTs: 1, endTs: 120_000 },
       spec: {
-        kind: PREDICTION_V1_KIND,
+        kind: 'prediction.v1',
         oracle: {
           venue: 'chainlink-base-sepolia',
           feed: '0x4aDC67696bA383F43DD60A9e78F2C97Fbbfc7cb1',
@@ -127,10 +225,30 @@ describe('SOLVER_TYPES manifest', () => {
       },
       eligibility: {},
     };
-    const out = await SOLVER_TYPES['prediction.v1']!.parseSpec(raw, {
-      readCurrent: vi.fn(async () => '999'),
+    await expect(SOLVER_TYPES['prediction.v1']!.parseSpec(raw)).rejects.toThrow();
+  });
+
+  it('collectTestnetAutoTaskGenerators leaves Polymarket disabled for ordinary operators', () => {
+    const { generators, logLines } = collectTestnetAutoTaskGenerators({
+      network: 'testnet',
+      rpcUrl: 'https://sepolia.base.org',
+      autoTasksDisabled: false,
+      env: {},
     });
-    expect(out.spec).not.toHaveProperty('kind');
+    expect(generators.map((g) => g.solverType)).not.toContain('prediction.v1');
+    expect(logLines.some((l) => l.includes('prediction.v1'))).toBe(false);
+  });
+
+  it('collectTestnetAutoTaskGenerators keeps disable-all ahead of launcher opt-in', () => {
+    const { generators, logLines } = collectTestnetAutoTaskGenerators({
+      network: 'testnet',
+      rpcUrl: 'https://sepolia.base.org',
+      autoTasksDisabled: true,
+      env: { JINN_ENABLE_APY_AUTO_TASKS: '1' },
+      predictionV1LauncherEnabled: true,
+    });
+    expect(generators).toEqual([]);
+    expect(logLines).toEqual([]);
   });
 
   it('collectTestnetAutoTaskGenerators registers kinds via getTestnetAutoConfig', () => {
@@ -138,11 +256,144 @@ describe('SOLVER_TYPES manifest', () => {
       network: 'testnet',
       rpcUrl: 'https://sepolia.base.org',
       autoTasksDisabled: false,
-      env: { ...process.env, JINN_ENABLE_APY_AUTO_TASKS: '1' },
+      env: { JINN_ENABLE_APY_AUTO_TASKS: '1' },
+      predictionV1LauncherEnabled: true,
     });
     expect(generators.length).toBe(2);
     expect(generators.map((g) => g.solverType)).toEqual(['prediction.v1', 'prediction.apy.v0']);
     expect(logLines.some((l) => l.includes('prediction.v1'))).toBe(true);
     expect(logLines.some((l) => l.includes('prediction.apy.v0'))).toBe(true);
+  });
+
+  it('launcher-enabled testnet generator emits signed shared Polymarket prediction.v1 tasks', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    vi.stubGlobal('fetch', fetchFixture(
+      [market('abc', 'yes-abc')],
+      { 'yes-abc': book('0.60', '0.64') },
+    ));
+    const pk = generatePrivateKey();
+    const account = privateKeyToAccount(pk);
+    const safeAddress = '0x1111111111111111111111111111111111111111' as `0x${string}`;
+
+    const { generators } = collectTestnetAutoTaskGenerators({
+      network: 'testnet',
+      rpcUrl: 'https://sepolia.base.org',
+      autoTasksDisabled: false,
+      env: {
+        JINN_PREDICTION_V1_CADENCE_MS: '12345',
+        JINN_PREDICTION_V1_MAX_NEW_ROUNDS_PER_POLL: '7',
+        JINN_PREDICTION_V1_MAX_NEW_ROUNDS_PER_DAY: '11',
+        JINN_PREDICTION_V1_MAX_OPEN_ROUNDS: '13',
+        JINN_PREDICTION_V1_ALLOWLIST_CONDITION_IDS: '0xabc',
+      },
+      agentEoa: account.address as `0x${string}`,
+      safeAddress,
+      agentPrivateKey: pk,
+      predictionV1LauncherEnabled: true,
+      predictionV1WindowMs: 60 * 60 * 1000,
+    });
+    const prediction = generators.find((g) => g.solverType === 'prediction.v1');
+    expect(prediction).toBeDefined();
+
+    const source = new GeneratedTaskSource('generated:prediction.v1', prediction!.generator);
+    const [candidate] = await source.collect(new Date(NOW));
+    const task = PredictionV1TaskSchema.parse(candidate.task);
+
+    expect(candidate.sourceKey).toBe('generated:prediction.v1');
+    expect(candidate.postingPolicy.kind).toBe('once_per_bucket');
+    expect(task.claimPolicy).toMatchObject({
+      mode: 'parallel',
+      maxClaims: 25,
+      maxClaimsPerOperator: 1,
+    });
+    expect(task.window.endTs - task.window.startTs).toBe(60 * 60 * 1000);
+    expect(task.spec.source).toMatchObject({
+      venue: 'polymarket',
+      identifiers: { conditionId: '0xabc' },
+    });
+    expect(task.eligibility).toMatchObject({
+      generatorCadenceMs: 12345,
+      maxNewRoundsPerPoll: 7,
+      maxNewRoundsPerDay: 11,
+      maxOpenRounds: 13,
+      manualAllowlistHit: true,
+    });
+    expect(candidate.task.signedTask?.creator.safeAddress).toBe(safeAddress);
+    expect(candidate.task.signedTask?.creator.agentEoa.toLowerCase()).toBe(account.address.toLowerCase());
+
+    const adapter = new LocalAdapter();
+    await adapter.initialize();
+    const records = new Map<string, any>();
+    const store = {
+      getTaskPostRecord: vi.fn((key: any) => records.get(JSON.stringify(key))),
+      acquireTaskPostLock: vi.fn(() => true),
+      releaseTaskPostLock: vi.fn(),
+      upsertTaskPostRecord: vi.fn((record: any) => {
+        records.set(JSON.stringify({
+          creatorSafeAddress: record.creatorSafeAddress,
+          sourceKey: record.sourceKey,
+          policyType: record.policyType,
+          scopeKey: record.scopeKey,
+        }), record);
+      }),
+      recordOwnActivity: vi.fn(),
+      recordActivityEvent: vi.fn(),
+    };
+    try {
+      const posting = new TaskPostingService(adapter, store as any);
+      const posted = await posting.postCandidate(candidate, { creatorSafeAddress: safeAddress });
+      expect(posted.idempotent).toBe(false);
+      expect(posted.taskId).toBeTruthy();
+      expect(posted.task.solverType).toBe('prediction.v1');
+      expect(posted.task.signedTask?.creator.safeAddress).toBe(safeAddress);
+      expect(store.upsertTaskPostRecord).toHaveBeenCalledWith(expect.objectContaining({
+        creatorSafeAddress: safeAddress,
+        sourceKey: 'generated:prediction.v1',
+        taskId: candidate.task.id,
+      }));
+    } finally {
+      await adapter.stop();
+    }
+  });
+
+  it('passes launcher generator knobs from config fields, not only env', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    vi.stubGlobal('fetch', fetchFixture(
+      [market('cfg', 'yes-cfg')],
+      { 'yes-cfg': book('0.58', '0.62') },
+    ));
+
+    const { generators } = collectTestnetAutoTaskGenerators({
+      network: 'testnet',
+      rpcUrl: 'https://sepolia.base.org',
+      autoTasksDisabled: false,
+      env: {},
+      predictionV1LauncherEnabled: true,
+      predictionV1WindowMs: 30 * 60 * 1000,
+      predictionV1CadenceMs: 67890,
+      predictionV1MaxNewRoundsPerPoll: 3,
+      predictionV1MaxNewRoundsPerDay: 5,
+      predictionV1MaxOpenRounds: 8,
+      predictionV1AllowlistConditionIds: ['0xcfg'],
+      predictionV1BlocklistConditionIds: ['0xother'],
+    });
+    const prediction = generators.find((g) => g.solverType === 'prediction.v1');
+    expect(prediction).toBeDefined();
+
+    const source = new GeneratedTaskSource('generated:prediction.v1', prediction!.generator);
+    const [candidate] = await source.collect(new Date(NOW));
+    const task = PredictionV1TaskSchema.parse(candidate.task);
+
+    expect(task.window.endTs - task.window.startTs).toBe(30 * 60 * 1000);
+    expect(task.spec.source.identifiers.conditionId).toBe('0xcfg');
+    expect(task.eligibility).toMatchObject({
+      generatorCadenceMs: 67890,
+      maxNewRoundsPerPoll: 3,
+      maxNewRoundsPerDay: 5,
+      maxOpenRounds: 8,
+      manualAllowlistHit: true,
+    });
   });
 });

--- a/client/test/store/envelope-projection-index.test.ts
+++ b/client/test/store/envelope-projection-index.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { projectEnvelope } from '../../src/corpus/envelope-projection.js';
+import { Store } from '../../src/store/store.js';
+import type { SignedEnvelope } from '../../src/types/envelope.js';
+import type { Task } from '../../src/types/task.js';
+
+const TASK_CID = 'bafy-task-shared';
+const TASK_ID = '42';
+
+describe('Store envelope projection index', () => {
+  let store: Store;
+
+  beforeEach(() => {
+    store = new Store(':memory:');
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  it('queries Solution and Verdict projections grouped under one Task projection', () => {
+    const task = makePredictionTask();
+    const solutionA = projectEnvelope(makeEnvelope({
+      role: 'restoration',
+      generatedAt: 1000,
+      taskCid: TASK_CID,
+      requestId: `0x${'1'.repeat(64)}`,
+      signatureHash: `0x${'a'.repeat(64)}`,
+      payload: { probabilityYes: '0.5700', submittedAt: '2026-05-02T01:00:00.000Z', modelId: 'solver-a' },
+    }), { envelopeCid: 'bafy-solution-a', task, taskId: TASK_ID });
+    const solutionB = projectEnvelope(makeEnvelope({
+      role: 'restoration',
+      generatedAt: 1100,
+      taskCid: TASK_CID,
+      requestId: `0x${'2'.repeat(64)}`,
+      signatureHash: `0x${'b'.repeat(64)}`,
+      payload: { probabilityYes: '0.6300', submittedAt: '2026-05-02T01:01:00.000Z', modelId: 'solver-b' },
+    }), { envelopeCid: 'bafy-solution-b', task, taskId: TASK_ID });
+    const verdictA = projectEnvelope(makeEnvelope({
+      role: 'verdict',
+      generatedAt: 2000,
+      taskCid: 'bafy-eval-a',
+      requestId: `0x${'3'.repeat(64)}`,
+      signatureHash: `0x${'c'.repeat(64)}`,
+      payload: verdictPayload('bafy-solution-a', '3'.repeat(64), 'SCORED'),
+    }), { task: makeEvaluationTask(), taskId: TASK_ID });
+    const verdictB = projectEnvelope(makeEnvelope({
+      role: 'verdict',
+      generatedAt: 2100,
+      taskCid: 'bafy-eval-b',
+      requestId: `0x${'4'.repeat(64)}`,
+      signatureHash: `0x${'d'.repeat(64)}`,
+      payload: verdictPayload('bafy-solution-b', '4'.repeat(64), 'SCORED'),
+    }), { task: makeEvaluationTask(), taskId: TASK_ID });
+
+    for (const projection of [solutionA, solutionB, verdictA, verdictB]) {
+      store.saveEnvelopeProjection(projection);
+    }
+
+    const solutions = store.queryEnvelopeProjections({
+      solverType: 'prediction.v1',
+      role: 'restoration',
+      taskCid: TASK_CID,
+    });
+    const verdicts = store.queryEnvelopeProjections({
+      solverType: 'prediction.v1',
+      role: 'verdict',
+      taskCid: TASK_CID,
+      metadata: { verdict: 'SCORED' },
+    });
+    const all = store.queryEnvelopeProjections({ solverType: 'prediction.v1', taskId: TASK_ID });
+
+    expect(solutions.map((p) => p.envelopeCid).sort()).toEqual(['bafy-solution-a', 'bafy-solution-b']);
+    expect(verdicts).toHaveLength(2);
+    expect(verdicts.map((p) => p.solutionEnvelopeRef).sort()).toEqual(['bafy-solution-a', 'bafy-solution-b']);
+    expect(all).toHaveLength(4);
+
+    const groupKeys = new Set(all.map((p) => `${p.taskCid}:${p.taskId}`));
+    expect(groupKeys).toEqual(new Set([`${TASK_CID}:${TASK_ID}`]));
+  });
+
+  it('persists generic envelope projections without prediction metadata', () => {
+    const projection = projectEnvelope(makeEnvelope({
+      solverType: 'legacy.v0',
+      role: 'restoration',
+      generatedAt: 1000,
+      taskCid: 'bafy-generic-task',
+      requestId: `0x${'5'.repeat(64)}`,
+      signatureHash: `0x${'e'.repeat(64)}`,
+      payload: { text: 'generic' },
+    }));
+
+    store.saveEnvelopeProjection(projection);
+    const results = store.queryEnvelopeProjections({ solverType: 'legacy.v0' });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      solverType: 'legacy.v0',
+      role: 'restoration',
+      taskCid: 'bafy-generic-task',
+      solutionEnvelopeRef: null,
+    });
+    expect(results[0].metadata['source.venue']).toBeUndefined();
+  });
+});
+
+function makePredictionTask(): Task {
+  return {
+    id: 'prediction-v1-polymarket-abc',
+    description: 'Forecast a binary externally resolved prediction market.',
+    solverType: 'prediction.v1',
+    role: 'restoration',
+    window: { startTs: 1000, endTs: 2000 },
+    spec: {
+      question: { kind: 'binary', text: 'Will test pass?', yesLabel: 'YES', noLabel: 'NO' },
+      source: {
+        type: 'prediction-market',
+        venue: 'polymarket',
+        url: 'https://polymarket.com/event/test-market',
+        identifiers: {
+          marketId: 'mkt-1',
+          conditionId: '0xabc',
+          yesTokenId: 'yes-token',
+          noTokenId: 'no-token',
+        },
+      },
+      consensusSnapshot: {
+        sampledAt: '2026-05-02T00:00:00.000Z',
+        probabilityYes: '0.6200',
+        method: 'best-bid-ask-midpoint',
+      },
+    },
+    eligibility: { dedupKey: 'polymarket:0xabc' },
+  };
+}
+
+function makeEvaluationTask(): Task {
+  return {
+    ...makePredictionTask(),
+    id: 'prediction-v1-eval',
+    role: 'evaluation',
+    context: { restorationTaskCid: TASK_CID },
+  };
+}
+
+function verdictPayload(solutionCid: string, solutionSha256: string, verdict: string): Record<string, unknown> {
+  return {
+    verdict,
+    resolutionSource: {
+      venue: 'polymarket',
+      marketId: 'mkt-1',
+      conditionId: '0xabc',
+    },
+    task: { cid: TASK_CID, id: TASK_ID },
+    solutionEnvelope: { cid: solutionCid, sha256: solutionSha256 },
+    scores: {
+      solverBrier: '0.184900',
+      consensusBrier: '0.144400',
+      brierSpread: '0.040500',
+    },
+  };
+}
+
+function makeEnvelope(overrides: {
+  solverType?: string;
+  role: 'restoration' | 'verdict';
+  generatedAt: number;
+  taskCid: string;
+  requestId: string;
+  signatureHash: `0x${string}`;
+  payload: Record<string, unknown>;
+}): SignedEnvelope {
+  return {
+    schemaVersion: 'jinn.execution.v1',
+    solverType: overrides.solverType ?? 'prediction.v1',
+    role: overrides.role,
+    generatedAt: overrides.generatedAt,
+    task: {
+      cid: overrides.taskCid,
+      onchainCreationTx: `0x${'0'.repeat(64)}`,
+      onchainCreationBlock: 123,
+      requestId: overrides.requestId,
+    },
+    participant: {
+      safeAddress: `0x${'2'.repeat(40)}`,
+      agentEoa: `0x${'3'.repeat(40)}`,
+    },
+    window: { startTs: 1000, endTs: 2000 },
+    executor: {
+      implName: 'prediction-v1-baseline',
+      implVersion: '1.0.0',
+      clientGitSha: 'dev',
+      codeDigest: `sha256:${'0'.repeat(64)}`,
+      runtimeBundleDigest: `sha256:${'1'.repeat(64)}`,
+      plugins: [],
+      signingKey: { kind: 'agent-eoa', pubkey: `0x${'3'.repeat(40)}` },
+    },
+    evidenceTier: 'self-signed',
+    attestation: null,
+    trajectory: null,
+    artifacts: [],
+    payload: overrides.payload,
+    signature: {
+      algo: 'secp256k1',
+      signer: `0x${'3'.repeat(40)}`,
+      hash: overrides.signatureHash,
+      sig: `0x${'4'.repeat(130)}`,
+    },
+  } as SignedEnvelope;
+}

--- a/client/test/task-first-local.test.ts
+++ b/client/test/task-first-local.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { runLocalTaskFirstLifecycle } from './e2e/task-first-helpers.js';
+
+describe('Task-first local lifecycle', () => {
+  it('runs Task -> Solution -> Verdict through the local Task-native adapter/store path', async () => {
+    const result = await runLocalTaskFirstLifecycle();
+
+    expect(result.postedTaskId).toBe(result.request.taskId);
+    expect(result.request.attemptIndex).toBe(0);
+    expect(result.solutionDelivery.requestId).toBe(result.request.requestId);
+    expect(result.solutionDelivery.task.role).toBe('restoration');
+
+    expect(result.verdictRequest.task.role).toBe('evaluation');
+    expect(result.verdictRequest.task.restorationRequestId).toBe(result.request.requestId);
+    expect(result.verdictDelivery.requestId).toBe(result.verdictRequest.requestId);
+    expect(result.verdictDelivery.task.role).toBe('evaluation');
+    expect(result.verdict).toBe('SCORED');
+    expect(result.score).toMatch(/^-?\d+(\.\d+)?$/);
+
+    expect(result.conditionId).toBe('0xcondition-task-first-e2e');
+    expect(result.attempts).toHaveLength(2);
+    expect(new Set(result.attempts.map((attempt) => attempt.sharedTaskId))).toEqual(new Set([result.postedTaskId]));
+    expect(new Set(result.attempts.map((attempt) => attempt.sharedTaskCid))).toEqual(new Set([result.postedTaskCid]));
+    expect(new Set(result.attempts.map((attempt) => attempt.conditionId))).toEqual(new Set([result.conditionId]));
+    expect(new Set(result.attempts.map((attempt) => attempt.solverSafeAddress)).size).toBe(2);
+    expect(new Set(result.attempts.map((attempt) => attempt.request.requestId)).size).toBe(2);
+    expect(result.attempts.map((attempt) => attempt.request.attemptIndex)).toEqual([0, 1]);
+    for (const attempt of result.attempts) {
+      expect(attempt.solutionPayload).toHaveProperty('probabilityYes');
+      expect(attempt.solutionEnvelope.payload).toEqual(attempt.solutionPayload);
+      expect(attempt.verdict).toBe('SCORED');
+      expect(attempt.verdictPayload).toMatchObject({
+        verdict: 'SCORED',
+        outcome: 'YES',
+        benchmark: {
+          probabilityYes: result.consensusSnapshot['probabilityYes'],
+          sampledAt: result.consensusSnapshot['sampledAt'],
+          method: result.consensusSnapshot['method'],
+        },
+      });
+      expect(attempt.verdictRequest.task.restorationRequestId).toBe(attempt.request.requestId);
+      expect(attempt.verdictDelivery.requestId).toBe(attempt.verdictRequest.requestId);
+    }
+
+    expect(result.secondRequest.taskId).toBe(result.postedTaskId);
+    expect(result.secondRequest.attemptIndex).toBe(1);
+    expect(result.secondRequest.requestId).not.toBe(result.request.requestId);
+  });
+});


### PR DESCRIPTION
## Summary

This PR delivers the next Prediction SolverNet phase as a four-commit stack:

- wires the Prediction SolverNet plugin/generator surface for Polymarket-derived `prediction.v1` Tasks
- adds Task-native operator migration/readiness checks for `jinn update`, `doctor`, and `status`
- adds a fast local Task-first Prediction e2e: one shared Task, two solver Solution attempts, and one scored Verdict per Solution
- adds generic corpus/store envelope projections, scoreable Brier Verdict queries, runtime pre-claim Task validation, and evaluator failure-path coverage

## Beads

Closed in the stewardship pass:

- `jinn-mono-l2zl.9`
- `jinn-mono-l2zl.4`
- `jinn-mono-l2zl.4.1`
- `jinn-mono-l2zl.4.2`
- `jinn-mono-l2zl.4.3`

Also updates the parent Prediction SolverNet notes so the next sequence is scoreboard planning/implementation, then operator UX, then learner/onboarding work.

## Validation

Passed locally after committing:

```bash
yarn vitest run test/cli/commands/update.test.ts test/cli/commands/doctor.test.ts test/cli/commands/status.test.ts test/corpus/envelope-projection.test.ts test/store/envelope-projection-index.test.ts test/corpus/prediction-scoreable-verdicts.test.ts test/harnesses/engine/prediction-v1-runtime-gate.test.ts test/harnesses/impls/prediction-v1-evaluator/index.test.ts test/plugins/prediction-plugin.test.ts test/solver-nets/contracts.test.ts test/task-first-local.test.ts
yarn tsc --noEmit
JINN_E2E_SKIP_ANVIL=1 JINN_E2E_SKIP_CONTRACTS=1 yarn e2e:task-first-local
yarn e2e:task-first-local
BASE_SEPOLIA_RPC_URL=https://sepolia.base.org yarn e2e
git diff --check
```

The unskipped `yarn e2e:task-first-local` passed the schema smoke, local client Task-first lifecycle, local Anvil Task-first full loop with evaluator, and TaskCoordinator/JinnRouterV3 contract integration.

The Base Sepolia fork validation passed against the public Base Sepolia RPC, including the fork Task-first full loop with real Mech and TaskCoordinator/JinnRouterV3 contract integration.

## Next

Before merging, I recommend using CI as the final confidence gate. After that, update/ratify `jinn-mono-xp33` and split `jinn-mono-l2zl.5` into scoreboard implementation slices.
