### PR TITLE
[codex] Add Prediction SolverNet Brier scoreboard

### DIFF
--- a/client/src/cli/commands/prediction-scoreboard.ts
+++ b/client/src/cli/commands/prediction-scoreboard.ts
@@ -1,0 +1,175 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { parseArgs } from 'node:util';
+import type { BaseCommandDeps, CommandContext, CommandModule } from '../command.js';
+import { COMMON_FLAGS } from '../command.js';
+import { emitResult } from '../output.js';
+import { emitEnvelope } from '../../errors/envelope.js';
+import {
+  getConfigPathFromArgs as defaultGetConfigPathFromArgs,
+  loadConfig as defaultLoadConfig,
+} from '../../config.js';
+import { Store } from '../../store/store.js';
+import {
+  DEFAULT_PREDICTION_BRIER_SCOREBOARD_WINDOW_DAYS,
+  DEFAULT_PREDICTION_SCOREBOARD_REPORT_PATH,
+  buildPredictionBrierScoreboard,
+  renderPredictionBrierScoreboardMarkdown,
+} from '../../corpus/index.js';
+
+interface PredictionScoreboardResult {
+  outputPath: string;
+  scoredVerdictCount: number;
+  distinctTaskCount: number;
+  activeOperatorCount: number;
+  meanBrierSpread: number | null;
+  status: 'ok' | 'insufficient_data';
+}
+
+export interface PredictionScoreboardDeps extends BaseCommandDeps {
+  storeFactory: (path: string) => Pick<Store, 'queryEnvelopeProjections' | 'close'>;
+  writeTextFile: (path: string, content: string) => void;
+  nowIso: () => string;
+}
+
+const PRODUCTION_DEPS: PredictionScoreboardDeps = {
+  loadConfig: defaultLoadConfig,
+  getConfigPathFromArgs: defaultGetConfigPathFromArgs,
+  storeFactory: (path) => new Store(path),
+  writeTextFile: (path, content) => {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, content, 'utf8');
+  },
+  nowIso: () => new Date().toISOString(),
+};
+
+function humanResult(result: PredictionScoreboardResult): string {
+  const spread = result.meanBrierSpread === null ? '-' : result.meanBrierSpread.toFixed(6);
+  return [
+    `Prediction SolverNet scoreboard written to ${result.outputPath}`,
+    `Scored Verdicts: ${result.scoredVerdictCount}`,
+    `Shared Tasks: ${result.distinctTaskCount}`,
+    `Active operators: ${result.activeOperatorCount}`,
+    `Mean Brier spread: ${spread}`,
+  ].join('\n');
+}
+
+export function createPredictionScoreboardCommand(
+  deps: PredictionScoreboardDeps = PRODUCTION_DEPS,
+): CommandModule {
+  return {
+    name: 'prediction-scoreboard',
+    summary: 'Render the Prediction SolverNet Brier scoreboard Markdown report',
+    helpText: `Usage: jinn prediction-scoreboard [--output <path>] [--as-of <ISO>] [--window-days <N>] [--limit <N>] [--json|--human]
+
+Queries local prediction.v1 envelope projections, computes the trailing Brier
+spread scoreboard, and writes a deterministic Markdown report.
+
+Examples:
+  jinn prediction-scoreboard --output docs/superpowers/reports/prediction-solvernet-scoreboard.md
+  jinn prediction-scoreboard --as-of 2026-05-03T00:00:00.000Z --human
+`,
+    async run(ctx: CommandContext): Promise<void> {
+      let parsed;
+      try {
+        parsed = parseArgs({
+          args: ctx.argv,
+          options: {
+            ...COMMON_FLAGS,
+            output: { type: 'string', default: DEFAULT_PREDICTION_SCOREBOARD_REPORT_PATH },
+            'as-of': { type: 'string' },
+            'window-days': {
+              type: 'string',
+              default: String(DEFAULT_PREDICTION_BRIER_SCOREBOARD_WINDOW_DAYS),
+            },
+            limit: { type: 'string', default: '1000' },
+          },
+          allowPositionals: false,
+        });
+      } catch (err) {
+        emitEnvelope(
+          {
+            code: 'invalid_invocation',
+            message: err instanceof Error ? err.message : String(err),
+            exampleCli: 'jinn prediction-scoreboard --output docs/superpowers/reports/prediction-solvernet-scoreboard.md',
+            details: { field: 'flags' },
+          },
+          { writer: ctx.writer, exit: ctx.exit },
+        );
+        return;
+      }
+
+      const outputPath = parsed.values.output as string;
+      const asOfGeneratedAt = parseOptionalAsOf(parsed.values['as-of'] as string | undefined);
+      if (asOfGeneratedAt === false) {
+        emitEnvelope(
+          {
+            code: 'invalid_invocation',
+            message: '--as-of must be an ISO-8601 timestamp or epoch milliseconds',
+            exampleCli: 'jinn prediction-scoreboard --as-of 2026-05-03T00:00:00.000Z',
+            details: { field: '--as-of' },
+          },
+          { writer: ctx.writer, exit: ctx.exit },
+        );
+        return;
+      }
+
+      const windowDays = parsePositiveInt(parsed.values['window-days'] as string, DEFAULT_PREDICTION_BRIER_SCOREBOARD_WINDOW_DAYS);
+      const limit = parsePositiveInt(parsed.values.limit as string, 1000);
+      const fromVerbFlags = deps.getConfigPathFromArgs(ctx.argv);
+      const fromProcess =
+        typeof process !== 'undefined' ? deps.getConfigPathFromArgs(process.argv.slice(2)) : undefined;
+      const config = deps.loadConfig(fromVerbFlags ?? fromProcess);
+      const store = deps.storeFactory(config.dbPath);
+
+      let result: PredictionScoreboardResult;
+      try {
+        const scoreboard = buildPredictionBrierScoreboard(store, {
+          asOfGeneratedAt: asOfGeneratedAt ?? undefined,
+          trailingWindowDays: windowDays,
+          projectionQuery: { limit },
+        });
+        const markdown = renderPredictionBrierScoreboardMarkdown(scoreboard, {
+          generatedAtIso: deps.nowIso(),
+        });
+        deps.writeTextFile(outputPath, markdown);
+        result = {
+          outputPath,
+          scoredVerdictCount: scoreboard.overall.scoredVerdictCount,
+          distinctTaskCount: scoreboard.overall.distinctTaskCount,
+          activeOperatorCount: scoreboard.overall.activeOperatorCount,
+          meanBrierSpread: scoreboard.overall.meanBrierSpread,
+          status: scoreboard.overall.scoredVerdictCount === 0 ? 'insufficient_data' : 'ok',
+        };
+      } finally {
+        store.close();
+      }
+
+      emitResult(result, (value) => humanResult(value as PredictionScoreboardResult), {
+        json: Boolean(parsed.values.json),
+        human: Boolean(parsed.values.human),
+        writer: ctx.writer,
+        stdoutIsTty: ctx.stdoutIsTty,
+        noColor: Boolean(ctx.env['NO_COLOR']),
+      });
+    },
+  };
+}
+
+function parseOptionalAsOf(value: string | undefined): number | null | false {
+  if (!value) return null;
+  if (/^\d+$/.test(value)) {
+    const numeric = Number(value);
+    return Number.isSafeInteger(numeric) ? numeric : false;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : false;
+}
+
+function parsePositiveInt(value: string, fallback: number): number {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+const command: CommandModule = createPredictionScoreboardCommand();
+export default command;

--- a/client/src/cli/index.ts
+++ b/client/src/cli/index.ts
@@ -43,6 +43,7 @@ import solverNetsCommand from './commands/solver-nets.js';
 import harnessesCommand from './commands/harnesses.js';
 import solverPluginsCommand from './commands/solver-plugins.js';
 import integrationsCommand from './commands/integrations.js';
+import predictionScoreboardCommand from './commands/prediction-scoreboard.js';
 
 const COMMANDS: CommandModule[] = [
   versionCommand,
@@ -72,6 +73,7 @@ const COMMANDS: CommandModule[] = [
   uiCommand,
   tasksCommand,
   solverNetsCommand,
+  predictionScoreboardCommand,
   harnessesCommand,
   solverPluginsCommand,
   integrationsCommand,

--- a/client/src/corpus/index.ts
+++ b/client/src/corpus/index.ts
@@ -36,6 +36,28 @@ export {
   queryScoreablePredictionBrierVerdicts,
   type ScoreablePredictionBrierVerdictQuery,
 } from './prediction-scoreable-verdicts.js';
+export {
+  DEFAULT_PREDICTION_BRIER_SCOREBOARD_WINDOW_DAYS,
+  aggregatePredictionBrierScoreboard,
+  type PredictionBrierExclusionCounts,
+  type PredictionBrierHarnessSummary,
+  type PredictionBrierMetricSummary,
+  type PredictionBrierOperatorSummary,
+  type PredictionBrierOverallSummary,
+  type PredictionBrierPluginSummary,
+  type PredictionBrierScoreboard,
+  type PredictionBrierScoreboardOptions,
+  type PredictionBrierWeeklySummary,
+} from './prediction-brier-scoreboard.js';
+export {
+  DEFAULT_PREDICTION_SCOREBOARD_REPORT_PATH,
+  buildPredictionBrierScoreboard,
+  queryPredictionBrierScoreboardProjections,
+  renderPredictionBrierScoreboardMarkdown,
+  type BuildPredictionBrierScoreboardOptions,
+  type PredictionBrierScoreboardMarkdownOptions,
+  type PredictionBrierScoreboardProjectionQuery,
+} from './prediction-brier-scoreboard-report.js';
 
 interface InternalDeps {
   fetch?: typeof globalThis.fetch;

--- a/client/src/corpus/prediction-brier-scoreboard-report.ts
+++ b/client/src/corpus/prediction-brier-scoreboard-report.ts
@@ -1,6 +1,7 @@
 import type { Store } from '../store/store.js';
 import type { EnvelopeProjection, EnvelopeProjectionQuery } from './types.js';
 import {
+  DEFAULT_PREDICTION_BRIER_SCOREBOARD_WINDOW_DAYS,
   aggregatePredictionBrierScoreboard,
   type PredictionBrierMetricSummary,
   type PredictionBrierScoreboard,
@@ -29,20 +30,32 @@ export function queryPredictionBrierScoreboardProjections(
   store: Pick<Store, 'queryEnvelopeProjections'>,
   query: PredictionBrierScoreboardProjectionQuery = {},
 ): EnvelopeProjection[] {
-  return store.queryEnvelopeProjections({
+  const verdicts = store.queryEnvelopeProjections({
     solverType: 'prediction.v1',
+    role: 'verdict',
     generatedAfter: query.generatedAfter,
     generatedBefore: query.generatedBefore,
     limit: query.limit ?? 1000,
   });
+  const solutionRefs = compactRefs(verdicts.flatMap(verdictSolutionRefs));
+  if (solutionRefs.length === 0) return verdicts;
+
+  const solutions = store.queryEnvelopeProjections({
+    envelopeRefs: solutionRefs,
+    solverType: 'prediction.v1',
+    role: 'restoration',
+    limit: solutionRefs.length,
+  });
+  return dedupeProjections([...verdicts, ...solutions]);
 }
 
 export function buildPredictionBrierScoreboard(
   store: Pick<Store, 'queryEnvelopeProjections'>,
   options: BuildPredictionBrierScoreboardOptions = {},
 ): PredictionBrierScoreboard {
+  const projectionQuery = windowedProjectionQuery(options);
   return aggregatePredictionBrierScoreboard(
-    queryPredictionBrierScoreboardProjections(store, options.projectionQuery),
+    queryPredictionBrierScoreboardProjections(store, projectionQuery),
     options,
   );
 }
@@ -151,10 +164,50 @@ export function renderPredictionBrierScoreboardMarkdown(
     `| Missing score rows | ${scoreboard.excluded.missingScoreRows} |`,
     `| Non-numeric score rows | ${scoreboard.excluded.nonNumericScoreRows} |`,
     `| Outside trailing window | ${scoreboard.excluded.outsideWindowRows} |`,
-    '',
   );
 
   return `${lines.join('\n')}\n`;
+}
+
+function windowedProjectionQuery(
+  options: BuildPredictionBrierScoreboardOptions,
+): PredictionBrierScoreboardProjectionQuery {
+  const projectionQuery = options.projectionQuery ?? {};
+  if (options.asOfGeneratedAt === undefined) return projectionQuery;
+
+  const trailingWindowDays = options.trailingWindowDays
+    ?? DEFAULT_PREDICTION_BRIER_SCOREBOARD_WINDOW_DAYS;
+  return {
+    ...projectionQuery,
+    generatedAfter: projectionQuery.generatedAfter
+      ?? options.asOfGeneratedAt - generatedAtSpanForDays(options.asOfGeneratedAt, trailingWindowDays),
+    generatedBefore: projectionQuery.generatedBefore ?? options.asOfGeneratedAt,
+  };
+}
+
+function generatedAtSpanForDays(asOfGeneratedAt: number, days: number): number {
+  const daySpan = Math.abs(asOfGeneratedAt) >= 10_000_000_000 ? 86_400_000 : 86_400;
+  return days * daySpan;
+}
+
+function verdictSolutionRefs(projection: EnvelopeProjection): string[] {
+  return [
+    projection.solutionEnvelopeCid,
+    projection.solutionEnvelopeSha256,
+    projection.solutionEnvelopeRef,
+    projection.metadata['solutionEnvelope.cid'],
+    projection.metadata['solutionEnvelope.sha256'],
+  ].filter((value): value is string => typeof value === 'string' && value.length > 0);
+}
+
+function compactRefs(refs: readonly string[]): string[] {
+  return [...new Set(refs)];
+}
+
+function dedupeProjections(projections: readonly EnvelopeProjection[]): EnvelopeProjection[] {
+  const byId = new Map<string, EnvelopeProjection>();
+  for (const projection of projections) byId.set(projection.envelopeId, projection);
+  return [...byId.values()];
 }
 
 function metricTable(headers: string[], rows: string[][], emptyText: string): string {

--- a/client/src/corpus/prediction-brier-scoreboard-report.ts
+++ b/client/src/corpus/prediction-brier-scoreboard-report.ts
@@ -1,0 +1,204 @@
+import type { Store } from '../store/store.js';
+import type { EnvelopeProjection, EnvelopeProjectionQuery } from './types.js';
+import {
+  aggregatePredictionBrierScoreboard,
+  type PredictionBrierMetricSummary,
+  type PredictionBrierScoreboard,
+  type PredictionBrierScoreboardOptions,
+} from './prediction-brier-scoreboard.js';
+
+export const DEFAULT_PREDICTION_SCOREBOARD_REPORT_PATH =
+  'docs/superpowers/reports/prediction-solvernet-scoreboard.md';
+
+export interface PredictionBrierScoreboardProjectionQuery extends Pick<
+  EnvelopeProjectionQuery,
+  'generatedAfter' | 'generatedBefore' | 'limit'
+> {}
+
+export interface BuildPredictionBrierScoreboardOptions extends PredictionBrierScoreboardOptions {
+  projectionQuery?: PredictionBrierScoreboardProjectionQuery;
+}
+
+export interface PredictionBrierScoreboardMarkdownOptions {
+  title?: string;
+  generatedAtIso?: string;
+  staleAfterDays?: number;
+}
+
+export function queryPredictionBrierScoreboardProjections(
+  store: Pick<Store, 'queryEnvelopeProjections'>,
+  query: PredictionBrierScoreboardProjectionQuery = {},
+): EnvelopeProjection[] {
+  return store.queryEnvelopeProjections({
+    solverType: 'prediction.v1',
+    generatedAfter: query.generatedAfter,
+    generatedBefore: query.generatedBefore,
+    limit: query.limit ?? 1000,
+  });
+}
+
+export function buildPredictionBrierScoreboard(
+  store: Pick<Store, 'queryEnvelopeProjections'>,
+  options: BuildPredictionBrierScoreboardOptions = {},
+): PredictionBrierScoreboard {
+  return aggregatePredictionBrierScoreboard(
+    queryPredictionBrierScoreboardProjections(store, options.projectionQuery),
+    options,
+  );
+}
+
+export function renderPredictionBrierScoreboardMarkdown(
+  scoreboard: PredictionBrierScoreboard,
+  options: PredictionBrierScoreboardMarkdownOptions = {},
+): string {
+  const title = options.title ?? 'Prediction SolverNet Scoreboard';
+  const generatedAtIso = options.generatedAtIso ?? new Date().toISOString();
+  const status = scoreboardStatus(scoreboard, generatedAtIso, options.staleAfterDays ?? 14);
+  const lines: string[] = [
+    `# ${title}`,
+    '',
+    `Generated: ${generatedAtIso}`,
+    `Status: ${status}`,
+    `Window: trailing ${scoreboard.trailingWindowDays} days ending ${formatGeneratedAt(scoreboard.asOfGeneratedAt)}`,
+    '',
+    '## Headline',
+    '',
+  ];
+
+  if (scoreboard.overall.scoredVerdictCount === 0) {
+    lines.push(
+      'Insufficient scoreable Verdict data. The report will populate after Prediction SolverNet evaluators emit `SCORED` Verdict envelopes with Brier metadata.',
+      '',
+    );
+  }
+
+  lines.push(
+    '| Metric | Value |',
+    '|---|---:|',
+    `| Mean Brier spread | ${formatNumber(scoreboard.overall.meanBrierSpread)} |`,
+    `| Mean solver Brier | ${formatNumber(scoreboard.overall.meanSolverBrier)} |`,
+    `| Mean consensus Brier | ${formatNumber(scoreboard.overall.meanConsensusBrier)} |`,
+    `| Scored Verdicts | ${scoreboard.overall.scoredVerdictCount} |`,
+    `| Shared Tasks | ${scoreboard.overall.distinctTaskCount} |`,
+    `| Active operators | ${scoreboard.overall.activeOperatorCount} |`,
+    '',
+    '## Weekly Trend',
+    '',
+    metricTable(
+      ['Week', 'Scored Verdicts', 'Mean Spread', 'Solver Brier', 'Consensus Brier', 'Tasks', 'Operators'],
+      scoreboard.weeklyTrend.map((summary) => [
+        summary.weekStartIso.slice(0, 10),
+        String(summary.scoredVerdictCount),
+        formatNumber(summary.meanBrierSpread),
+        formatNumber(summary.meanSolverBrier),
+        formatNumber(summary.meanConsensusBrier),
+        String(summary.distinctTaskCount),
+        String(summary.activeOperatorCount),
+      ]),
+      'No weekly trend data yet.',
+    ),
+    '',
+    '## Operators',
+    '',
+    metricTable(
+      ['Operator', 'Scored Verdicts', 'Mean Spread', 'Solver Brier', 'Consensus Brier', 'Tasks'],
+      scoreboard.perOperator.map((summary) => [
+        summary.participantSafeAddress ?? summary.participantAgentEoa ?? summary.key,
+        String(summary.scoredVerdictCount),
+        formatNumber(summary.meanBrierSpread),
+        formatNumber(summary.meanSolverBrier),
+        formatNumber(summary.meanConsensusBrier),
+        String(summary.distinctTaskCount),
+      ]),
+      'No operator rows yet.',
+    ),
+    '',
+    '## Harnesses',
+    '',
+    metricTable(
+      ['Harness', 'Runtime Digest', 'Scored Verdicts', 'Mean Spread', 'Tasks'],
+      scoreboard.perHarness.map((summary) => [
+        [summary.implName ?? 'unknown', summary.implVersion ?? 'unknown'].join('@'),
+        summary.runtimeBundleDigest ?? 'unknown',
+        String(summary.scoredVerdictCount),
+        formatNumber(summary.meanBrierSpread),
+        String(summary.distinctTaskCount),
+      ]),
+      'No Harness rows yet.',
+    ),
+    '',
+    '## Plugins',
+    '',
+    metricTable(
+      ['Plugin', 'Scored Verdicts', 'Mean Spread', 'Tasks'],
+      scoreboard.perPlugin.map((summary) => [
+        summary.plugin,
+        String(summary.scoredVerdictCount),
+        formatNumber(summary.meanBrierSpread),
+        String(summary.distinctTaskCount),
+      ]),
+      'No plugin rows yet.',
+    ),
+    '',
+    '## Exclusions',
+    '',
+    '| Reason | Count |',
+    '|---|---:|',
+    `| Total input rows | ${scoreboard.excluded.totalInputRows} |`,
+    `| Included score rows | ${scoreboard.excluded.includedRows} |`,
+    `| Non-prediction/non-Verdict rows | ${scoreboard.excluded.nonPredictionVerdictRows} |`,
+    `| Non-SCORED Verdict rows | ${scoreboard.excluded.nonScoredVerdictRows} |`,
+    `| Missing score rows | ${scoreboard.excluded.missingScoreRows} |`,
+    `| Non-numeric score rows | ${scoreboard.excluded.nonNumericScoreRows} |`,
+    `| Outside trailing window | ${scoreboard.excluded.outsideWindowRows} |`,
+    '',
+  );
+
+  return `${lines.join('\n')}\n`;
+}
+
+function metricTable(headers: string[], rows: string[][], emptyText: string): string {
+  if (rows.length === 0) return emptyText;
+  const alignment = headers.map((_, index) => (index === 0 ? '---' : '---:')).join('|');
+  const rendered = [
+    `| ${headers.map(escapeTableCell).join(' | ')} |`,
+    `|${alignment}|`,
+  ];
+  for (const row of rows) {
+    rendered.push(`| ${row.map(escapeTableCell).join(' | ')} |`);
+  }
+  return rendered.join('\n');
+}
+
+function scoreboardStatus(
+  scoreboard: PredictionBrierScoreboard,
+  generatedAtIso: string,
+  staleAfterDays: number,
+): string {
+  if (scoreboard.overall.scoredVerdictCount === 0) return 'INSUFFICIENT_DATA';
+  if (scoreboard.asOfGeneratedAt === null) return 'INSUFFICIENT_DATA';
+
+  const generatedAtMs = Date.parse(generatedAtIso);
+  if (!Number.isFinite(generatedAtMs)) return 'OK';
+  const asOfMs = generatedAtToMs(scoreboard.asOfGeneratedAt);
+  const staleAfterMs = staleAfterDays * 86_400_000;
+  if (generatedAtMs - asOfMs > staleAfterMs) return `STALE (latest scored Verdict older than ${staleAfterDays} days)`;
+  return 'OK';
+}
+
+function formatGeneratedAt(generatedAt: number | null): string {
+  if (generatedAt === null) return '-';
+  return new Date(generatedAtToMs(generatedAt)).toISOString();
+}
+
+function generatedAtToMs(generatedAt: number): number {
+  return Math.abs(generatedAt) >= 10_000_000_000 ? generatedAt : generatedAt * 1000;
+}
+
+function formatNumber(value: PredictionBrierMetricSummary['meanBrierSpread']): string {
+  return value === null ? '-' : value.toFixed(6);
+}
+
+function escapeTableCell(value: string): string {
+  return value.replace(/\|/g, '\\|');
+}

--- a/client/src/corpus/prediction-brier-scoreboard.ts
+++ b/client/src/corpus/prediction-brier-scoreboard.ts
@@ -1,0 +1,404 @@
+import type { EnvelopeProjection } from './types.js';
+
+export const DEFAULT_PREDICTION_BRIER_SCOREBOARD_WINDOW_DAYS = 84;
+
+export interface PredictionBrierScoreboardOptions {
+  asOfGeneratedAt?: number;
+  trailingWindowDays?: number;
+}
+
+export interface PredictionBrierScoreboard {
+  asOfGeneratedAt: number | null;
+  windowStartGeneratedAt: number | null;
+  trailingWindowDays: number;
+  overall: PredictionBrierOverallSummary;
+  weeklyTrend: PredictionBrierWeeklySummary[];
+  perOperator: PredictionBrierOperatorSummary[];
+  perHarness: PredictionBrierHarnessSummary[];
+  perPlugin: PredictionBrierPluginSummary[];
+  excluded: PredictionBrierExclusionCounts;
+}
+
+export interface PredictionBrierOverallSummary extends PredictionBrierMetricSummary {
+  activeOperatorCount: number;
+}
+
+export interface PredictionBrierMetricSummary {
+  scoredVerdictCount: number;
+  distinctTaskCount: number;
+  meanBrierSpread: number | null;
+  meanSolverBrier: number | null;
+  meanConsensusBrier: number | null;
+}
+
+export interface PredictionBrierOperatorSummary extends PredictionBrierMetricSummary {
+  key: string;
+  participantSafeAddress: string | null;
+  participantAgentEoa: string | null;
+}
+
+export interface PredictionBrierHarnessSummary extends PredictionBrierMetricSummary {
+  key: string;
+  implName: string | null;
+  implVersion: string | null;
+  runtimeBundleDigest: string | null;
+}
+
+export interface PredictionBrierPluginSummary extends PredictionBrierMetricSummary {
+  key: string;
+  plugin: string;
+}
+
+export interface PredictionBrierWeeklySummary extends PredictionBrierOverallSummary {
+  weekStartGeneratedAt: number;
+  weekStartIso: string;
+}
+
+export interface PredictionBrierExclusionCounts {
+  totalInputRows: number;
+  includedRows: number;
+  nonPredictionVerdictRows: number;
+  nonScoredVerdictRows: number;
+  missingScoreRows: number;
+  nonNumericScoreRows: number;
+  outsideWindowRows: number;
+}
+
+interface ScoreablePredictionBrierRow {
+  projection: EnvelopeProjection;
+  attributionProjection: EnvelopeProjection;
+  solverBrier: number;
+  consensusBrier: number;
+  brierSpread: number;
+  taskKey: string;
+  operatorKey: string;
+  harnessKey: string;
+}
+
+type TimestampUnit = 'seconds' | 'milliseconds';
+
+export function aggregatePredictionBrierScoreboard(
+  projections: readonly EnvelopeProjection[],
+  options: PredictionBrierScoreboardOptions = {},
+): PredictionBrierScoreboard {
+  const trailingWindowDays = options.trailingWindowDays
+    ?? DEFAULT_PREDICTION_BRIER_SCOREBOARD_WINDOW_DAYS;
+  const excluded: PredictionBrierExclusionCounts = {
+    totalInputRows: projections.length,
+    includedRows: 0,
+    nonPredictionVerdictRows: 0,
+    nonScoredVerdictRows: 0,
+    missingScoreRows: 0,
+    nonNumericScoreRows: 0,
+    outsideWindowRows: 0,
+  };
+  const candidates: ScoreablePredictionBrierRow[] = [];
+  const solutionProjectionByRef = indexSolutionProjections(projections);
+
+  for (const projection of projections) {
+    const parsed = parseScoreableProjection(projection, solutionProjectionByRef, excluded);
+    if (parsed) candidates.push(parsed);
+  }
+
+  const asOfGeneratedAt = options.asOfGeneratedAt ?? maxGeneratedAt(candidates.map((row) => row.projection));
+  const windowStartGeneratedAt = asOfGeneratedAt === null
+    ? null
+    : asOfGeneratedAt - generatedAtSpanForDays(asOfGeneratedAt, trailingWindowDays);
+
+  const included = windowStartGeneratedAt === null || asOfGeneratedAt === null
+    ? []
+    : candidates.filter((row) => {
+        const insideWindow = row.projection.generatedAt >= windowStartGeneratedAt
+          && row.projection.generatedAt <= asOfGeneratedAt;
+        if (!insideWindow) excluded.outsideWindowRows += 1;
+        return insideWindow;
+      });
+
+  excluded.includedRows = included.length;
+
+  return {
+    asOfGeneratedAt,
+    windowStartGeneratedAt,
+    trailingWindowDays,
+    overall: summarizeOverall(included),
+    weeklyTrend: summarizeWeeklyTrend(included),
+    perOperator: summarizeByOperator(included),
+    perHarness: summarizeByHarness(included),
+    perPlugin: summarizeByPlugin(included),
+    excluded,
+  };
+}
+
+function parseScoreableProjection(
+  projection: EnvelopeProjection,
+  solutionProjectionByRef: ReadonlyMap<string, EnvelopeProjection>,
+  excluded: PredictionBrierExclusionCounts,
+): ScoreablePredictionBrierRow | null {
+  if (projection.solverType !== 'prediction.v1' || projection.role !== 'verdict') {
+    excluded.nonPredictionVerdictRows += 1;
+    return null;
+  }
+  if (projection.metadata['verdict'] !== 'SCORED') {
+    excluded.nonScoredVerdictRows += 1;
+    return null;
+  }
+
+  const solverBrier = parseRequiredFiniteNumber(projection.metadata['scores.solverBrier']);
+  const consensusBrier = parseRequiredFiniteNumber(projection.metadata['scores.consensusBrier']);
+  const brierSpread = parseRequiredFiniteNumber(projection.metadata['scores.brierSpread']);
+  if (solverBrier.kind === 'missing' || consensusBrier.kind === 'missing' || brierSpread.kind === 'missing') {
+    excluded.missingScoreRows += 1;
+    return null;
+  }
+  if (solverBrier.kind === 'non-numeric' || consensusBrier.kind === 'non-numeric' || brierSpread.kind === 'non-numeric') {
+    excluded.nonNumericScoreRows += 1;
+    return null;
+  }
+
+  const attributionProjection = solutionAttributionProjection(projection, solutionProjectionByRef);
+
+  return {
+    projection,
+    attributionProjection,
+    solverBrier: solverBrier.value,
+    consensusBrier: consensusBrier.value,
+    brierSpread: brierSpread.value,
+    taskKey: taskKey(projection),
+    operatorKey: operatorKey(attributionProjection),
+    harnessKey: harnessKey(attributionProjection),
+  };
+}
+
+function summarizeOverall(rows: readonly ScoreablePredictionBrierRow[]): PredictionBrierOverallSummary {
+  return {
+    ...summarizeMetrics(rows),
+    activeOperatorCount: new Set(rows.map((row) => row.operatorKey)).size,
+  };
+}
+
+function summarizeMetrics(rows: readonly ScoreablePredictionBrierRow[]): PredictionBrierMetricSummary {
+  return {
+    scoredVerdictCount: rows.length,
+    distinctTaskCount: new Set(rows.map((row) => row.taskKey)).size,
+    meanBrierSpread: mean(rows.map((row) => row.brierSpread)),
+    meanSolverBrier: mean(rows.map((row) => row.solverBrier)),
+    meanConsensusBrier: mean(rows.map((row) => row.consensusBrier)),
+  };
+}
+
+function summarizeWeeklyTrend(rows: readonly ScoreablePredictionBrierRow[]): PredictionBrierWeeklySummary[] {
+  const byWeek = new Map<string, ScoreablePredictionBrierRow[]>();
+
+  for (const row of rows) {
+    const bucket = weekBucket(row.projection.generatedAt);
+    const existing = byWeek.get(bucket.key) ?? [];
+    existing.push(row);
+    byWeek.set(bucket.key, existing);
+  }
+
+  return [...byWeek.entries()]
+    .map(([key, bucketRows]) => {
+      const generatedAt = Number(key);
+      return {
+        weekStartGeneratedAt: generatedAt,
+        weekStartIso: generatedAtIso(generatedAt),
+        ...summarizeOverall(bucketRows),
+      };
+    })
+    .sort((a, b) => a.weekStartGeneratedAt - b.weekStartGeneratedAt);
+}
+
+function summarizeByOperator(rows: readonly ScoreablePredictionBrierRow[]): PredictionBrierOperatorSummary[] {
+  return summarizeGroups(
+    rows,
+    (row) => row.operatorKey,
+    (key, groupRows) => ({
+      key,
+      participantSafeAddress: firstPresent(groupRows.map((row) => row.attributionProjection.participantSafeAddress)),
+      participantAgentEoa: firstPresent(groupRows.map((row) => row.attributionProjection.participantAgentEoa)),
+    }),
+  );
+}
+
+function summarizeByHarness(rows: readonly ScoreablePredictionBrierRow[]): PredictionBrierHarnessSummary[] {
+  return summarizeGroups(
+    rows,
+    (row) => row.harnessKey,
+    (key, groupRows) => ({
+      key,
+      implName: firstPresent(groupRows.map((row) => row.attributionProjection.executorImplName)),
+      implVersion: firstPresent(groupRows.map((row) => row.attributionProjection.executorImplVersion)),
+      runtimeBundleDigest: firstPresent(groupRows.map((row) => row.attributionProjection.executorRuntimeBundleDigest)),
+    }),
+  );
+}
+
+function summarizeByPlugin(rows: readonly ScoreablePredictionBrierRow[]): PredictionBrierPluginSummary[] {
+  const expanded: Array<{ row: ScoreablePredictionBrierRow; plugin: string }> = [];
+  for (const row of rows) {
+    for (const plugin of new Set(row.attributionProjection.executorPlugins)) {
+      expanded.push({ row, plugin });
+    }
+  }
+
+  return summarizeGroups(
+    expanded,
+    (entry) => entry.plugin,
+    (key) => ({ key, plugin: key }),
+    (entry) => entry.row,
+  );
+}
+
+function summarizeGroups<T, M extends object>(
+  entries: readonly T[],
+  keyOf: (entry: T) => string,
+  metadataOf: (key: string, groupRows: ScoreablePredictionBrierRow[]) => M,
+  rowOf: (entry: T) => ScoreablePredictionBrierRow = (entry) => entry as ScoreablePredictionBrierRow,
+): Array<PredictionBrierMetricSummary & { key: string } & M> {
+  const groups = new Map<string, ScoreablePredictionBrierRow[]>();
+  for (const entry of entries) {
+    const key = keyOf(entry);
+    const existing = groups.get(key) ?? [];
+    existing.push(rowOf(entry));
+    groups.set(key, existing);
+  }
+
+  return [...groups.entries()]
+    .map(([key, groupRows]) => ({
+      key,
+      ...metadataOf(key, groupRows),
+      ...summarizeMetrics(groupRows),
+    }))
+    .sort(groupSummarySort);
+}
+
+function groupSummarySort(a: PredictionBrierMetricSummary & { key: string }, b: PredictionBrierMetricSummary & { key: string }): number {
+  if (b.scoredVerdictCount !== a.scoredVerdictCount) return b.scoredVerdictCount - a.scoredVerdictCount;
+  const aSpread = a.meanBrierSpread ?? Number.POSITIVE_INFINITY;
+  const bSpread = b.meanBrierSpread ?? Number.POSITIVE_INFINITY;
+  if (aSpread !== bSpread) return aSpread - bSpread;
+  return a.key.localeCompare(b.key);
+}
+
+type ParsedScore =
+  | { kind: 'ok'; value: number }
+  | { kind: 'missing' }
+  | { kind: 'non-numeric' };
+
+function parseRequiredFiniteNumber(value: unknown): ParsedScore {
+  if (value === undefined || value === null || value === '') return { kind: 'missing' };
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(parsed)) return { kind: 'non-numeric' };
+  return { kind: 'ok', value: parsed };
+}
+
+function indexSolutionProjections(projections: readonly EnvelopeProjection[]): Map<string, EnvelopeProjection> {
+  const byRef = new Map<string, EnvelopeProjection>();
+
+  for (const projection of projections) {
+    if (projection.solverType !== 'prediction.v1' || projection.role !== 'restoration') continue;
+    for (const ref of solutionProjectionRefs(projection)) {
+      if (!byRef.has(ref)) byRef.set(ref, projection);
+    }
+  }
+
+  return byRef;
+}
+
+function solutionAttributionProjection(
+  verdictProjection: EnvelopeProjection,
+  solutionProjectionByRef: ReadonlyMap<string, EnvelopeProjection>,
+): EnvelopeProjection {
+  for (const ref of verdictSolutionRefs(verdictProjection)) {
+    const solutionProjection = solutionProjectionByRef.get(ref);
+    if (solutionProjection) return solutionProjection;
+  }
+  return verdictProjection;
+}
+
+function solutionProjectionRefs(projection: EnvelopeProjection): string[] {
+  return compactRefs([
+    projection.envelopeCid,
+    projection.envelopeSha256,
+    projection.envelopeId,
+    projection.signatureHash,
+  ]);
+}
+
+function verdictSolutionRefs(projection: EnvelopeProjection): string[] {
+  return compactRefs([
+    projection.solutionEnvelopeCid,
+    projection.solutionEnvelopeSha256,
+    projection.solutionEnvelopeRef,
+    projection.metadata['solutionEnvelope.cid'],
+    projection.metadata['solutionEnvelope.sha256'],
+  ]);
+}
+
+function compactRefs(values: readonly unknown[]): string[] {
+  return values.filter((value): value is string => typeof value === 'string' && value.length > 0);
+}
+
+function mean(values: readonly number[]): number | null {
+  if (values.length === 0) return null;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function taskKey(projection: EnvelopeProjection): string {
+  if (projection.taskCid) return `taskCid:${projection.taskCid}`;
+  if (projection.taskId) return `taskId:${projection.taskId}`;
+  return `unknown-task:${projection.envelopeId}`;
+}
+
+function operatorKey(projection: EnvelopeProjection): string {
+  if (projection.participantSafeAddress) return `safe:${projection.participantSafeAddress.toLowerCase()}`;
+  if (projection.participantAgentEoa) return `agent:${projection.participantAgentEoa.toLowerCase()}`;
+  return 'unknown-operator';
+}
+
+function harnessKey(projection: EnvelopeProjection): string {
+  return [
+    projection.executorImplName ?? 'unknown-harness',
+    projection.executorImplVersion ?? 'unknown-version',
+    projection.executorRuntimeBundleDigest ?? 'unknown-runtime',
+  ].join('@');
+}
+
+function firstPresent(values: ReadonlyArray<string | null>): string | null {
+  return values.find((value): value is string => typeof value === 'string' && value.length > 0) ?? null;
+}
+
+function maxGeneratedAt(projections: readonly EnvelopeProjection[]): number | null {
+  if (projections.length === 0) return null;
+  return Math.max(...projections.map((projection) => projection.generatedAt));
+}
+
+function generatedAtSpanForDays(asOfGeneratedAt: number, days: number): number {
+  const unit = timestampUnit(asOfGeneratedAt);
+  const daySpan = unit === 'milliseconds' ? 86_400_000 : 86_400;
+  return days * daySpan;
+}
+
+function weekBucket(generatedAt: number): { key: string } {
+  const unit = timestampUnit(generatedAt);
+  const date = generatedAtDate(generatedAt);
+  const daysSinceMonday = (date.getUTCDay() + 6) % 7;
+  date.setUTCDate(date.getUTCDate() - daysSinceMonday);
+  date.setUTCHours(0, 0, 0, 0);
+  const weekStart = unit === 'milliseconds' ? date.getTime() : Math.floor(date.getTime() / 1000);
+  return { key: String(weekStart) };
+}
+
+function generatedAtIso(generatedAt: number): string {
+  return generatedAtDate(generatedAt).toISOString();
+}
+
+function generatedAtDate(generatedAt: number): Date {
+  return timestampUnit(generatedAt) === 'milliseconds'
+    ? new Date(generatedAt)
+    : new Date(generatedAt * 1000);
+}
+
+function timestampUnit(generatedAt: number): TimestampUnit {
+  return Math.abs(generatedAt) >= 10_000_000_000 ? 'milliseconds' : 'seconds';
+}

--- a/client/src/corpus/types.ts
+++ b/client/src/corpus/types.ts
@@ -56,6 +56,7 @@ export interface EnvelopeProjection {
 }
 
 export interface EnvelopeProjectionQuery {
+  envelopeRefs?: readonly string[];
   solverType?: string;
   role?: Role;
   taskCid?: string;

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -263,9 +263,7 @@ CREATE TABLE IF NOT EXISTS envelope_projections (
 );
 CREATE INDEX IF NOT EXISTS idx_envelope_projections_solver_role ON envelope_projections (solver_type, role);
 CREATE INDEX IF NOT EXISTS idx_envelope_projections_task_cid ON envelope_projections (task_cid);
-CREATE INDEX IF NOT EXISTS idx_envelope_projections_task_id ON envelope_projections (task_id);
 CREATE INDEX IF NOT EXISTS idx_envelope_projections_request ON envelope_projections (request_id);
-CREATE INDEX IF NOT EXISTS idx_envelope_projections_solution_ref ON envelope_projections (solution_envelope_ref);
 CREATE INDEX IF NOT EXISTS idx_envelope_projections_generated ON envelope_projections (generated_at DESC);
 
 CREATE TABLE IF NOT EXISTS envelope_projection_metadata (
@@ -308,6 +306,7 @@ export class Store {
     this.ensureRewardClaimsTxIndex();
     this.ensureNetworkArtifactsPeerCatalogId();
     this.ensureTaskPostsTaskCoordinatorColumns();
+    this.ensureEnvelopeProjectionColumns();
     this.backfillActivityEvents();
     this.recordLegacyRestorationIntentsIgnored();
   }
@@ -333,6 +332,33 @@ export class Store {
     if (!names.has('task_cid')) {
       this.db.exec(`ALTER TABLE task_posts ADD COLUMN task_cid TEXT`);
     }
+  }
+
+  /** Older local DBs may have the projection table from before Task grouping fields landed. */
+  private ensureEnvelopeProjectionColumns(): void {
+    const cols = this.db.prepare(`PRAGMA table_info(envelope_projections)`).all() as Array<{ name: string }>;
+    const names = new Set(cols.map((c) => c.name));
+    const addColumn = (name: string, ddl: string) => {
+      if (!names.has(name)) this.db.exec(`ALTER TABLE envelope_projections ADD COLUMN ${ddl}`);
+    };
+
+    addColumn('task_id', 'task_id TEXT');
+    addColumn('executor_runtime_bundle_digest', 'executor_runtime_bundle_digest TEXT');
+    addColumn('executor_plugins_json', `executor_plugins_json TEXT NOT NULL DEFAULT '[]'`);
+    addColumn('solution_envelope_cid', 'solution_envelope_cid TEXT');
+    addColumn('solution_envelope_sha256', 'solution_envelope_sha256 TEXT');
+    addColumn('solution_envelope_ref', 'solution_envelope_ref TEXT');
+    addColumn('metadata_json', `metadata_json TEXT NOT NULL DEFAULT '{}'`);
+
+    this.db.exec(
+      `CREATE INDEX IF NOT EXISTS idx_envelope_projections_task_id ON envelope_projections (task_id)`,
+    );
+    this.db.exec(
+      `CREATE INDEX IF NOT EXISTS idx_envelope_projections_solution_ref ON envelope_projections (solution_envelope_ref)`,
+    );
+    this.db.exec(
+      `CREATE INDEX IF NOT EXISTS idx_envelope_projections_generated ON envelope_projections (generated_at DESC)`,
+    );
   }
 
   /**

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -1289,6 +1289,19 @@ export class Store {
     const conditions: string[] = [];
     const params: Record<string, unknown> = {};
 
+    if (query.envelopeRefs && query.envelopeRefs.length > 0) {
+      const placeholders = query.envelopeRefs.map((ref, index) => {
+        const key = `envelopeRef${index}`;
+        params[key] = ref;
+        return `@${key}`;
+      }).join(', ');
+      conditions.push(
+        `(envelope_id IN (${placeholders})
+          OR envelope_cid IN (${placeholders})
+          OR envelope_sha256 IN (${placeholders})
+          OR signature_hash IN (${placeholders}))`,
+      );
+    }
     if (query.solverType) {
       conditions.push('solver_type = @solverType');
       params['solverType'] = query.solverType;

--- a/client/test/cli/commands/prediction-scoreboard.test.ts
+++ b/client/test/cli/commands/prediction-scoreboard.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import { createPredictionScoreboardCommand } from '@/cli/commands/prediction-scoreboard.js';
+import { runCommand } from '@test/cli.js';
+import type { EnvelopeProjection } from '@/corpus/types.js';
+
+const AS_OF = Date.parse('2026-05-03T00:00:00.000Z');
+
+describe('prediction-scoreboard command', () => {
+  it('writes a Markdown report from local prediction projections', async () => {
+    const writes = new Map<string, string>();
+    const cmd = createPredictionScoreboardCommand({
+      loadConfig: () => ({ dbPath: '/tmp/prediction-scoreboard.db' }) as any,
+      getConfigPathFromArgs: () => undefined,
+      storeFactory: () => ({
+        queryEnvelopeProjections: () => [
+          solutionProjection('a'),
+          scoredVerdictProjection('a'),
+        ],
+        close: () => {},
+      }),
+      writeTextFile: (path, content) => {
+        writes.set(path, content);
+      },
+      nowIso: () => '2026-05-03T12:00:00.000Z',
+    });
+
+    const { envelopes, exits } = await runCommand(cmd, {
+      argv: ['--output', '/tmp/prediction-scoreboard.md', '--as-of', String(AS_OF)],
+    });
+
+    expect(exits).toEqual([]);
+    expect(envelopes).toHaveLength(1);
+    expect(envelopes[0]).toMatchObject({
+      outputPath: '/tmp/prediction-scoreboard.md',
+      scoredVerdictCount: 1,
+      distinctTaskCount: 1,
+      activeOperatorCount: 1,
+      meanBrierSpread: -0.15,
+      status: 'ok',
+    });
+    expect(writes.get('/tmp/prediction-scoreboard.md')).toContain('| Mean Brier spread | -0.150000 |');
+  });
+
+  it('emits a clear error for invalid --as-of', async () => {
+    const cmd = createPredictionScoreboardCommand({
+      loadConfig: () => ({ dbPath: '/tmp/prediction-scoreboard.db' }) as any,
+      getConfigPathFromArgs: () => undefined,
+      storeFactory: () => ({
+        queryEnvelopeProjections: () => [],
+        close: () => {},
+      }),
+      writeTextFile: () => {},
+      nowIso: () => '2026-05-03T12:00:00.000Z',
+    });
+
+    const { envelopes, exits } = await runCommand(cmd, { argv: ['--as-of', 'not-a-date'] });
+
+    expect(exits).toEqual([11]);
+    expect(envelopes[0]).toMatchObject({
+      code: 'invalid_invocation',
+      details: { field: '--as-of' },
+    });
+  });
+});
+
+function solutionProjection(id: string): EnvelopeProjection {
+  return {
+    envelopeId: `solution-${id}`,
+    envelopeCid: `bafy-solution-${id}`,
+    envelopeSha256: null,
+    signatureHash: `0x${id.padEnd(64, '1').slice(0, 64)}`,
+    solverType: 'prediction.v1',
+    role: 'restoration',
+    taskCid: 'bafy-task-shared',
+    taskId: 'prediction-v1-polymarket-abc',
+    requestId: `solution-request-${id}`,
+    generatedAt: AS_OF - 1_000,
+    evidenceTier: 'self-signed',
+    participantSafeAddress: `0x${'a'.repeat(40)}`,
+    participantAgentEoa: `0x${'1'.repeat(40)}`,
+    executorImplName: 'solver-harness',
+    executorImplVersion: '1.0.0',
+    executorRuntimeBundleDigest: 'sha256:solver-runtime',
+    executorPlugins: ['solver-plugin@1.0.0'],
+    solutionEnvelopeCid: null,
+    solutionEnvelopeSha256: null,
+    solutionEnvelopeRef: null,
+    metadata: {},
+  };
+}
+
+function scoredVerdictProjection(id: string): EnvelopeProjection {
+  return {
+    envelopeId: `verdict-${id}`,
+    envelopeCid: `bafy-verdict-${id}`,
+    envelopeSha256: null,
+    signatureHash: `0x${id.padEnd(64, '2').slice(0, 64)}`,
+    solverType: 'prediction.v1',
+    role: 'verdict',
+    taskCid: 'bafy-task-shared',
+    taskId: 'prediction-v1-polymarket-abc',
+    requestId: `verdict-request-${id}`,
+    generatedAt: AS_OF,
+    evidenceTier: 'self-signed',
+    participantSafeAddress: `0x${'e'.repeat(40)}`,
+    participantAgentEoa: `0x${'3'.repeat(40)}`,
+    executorImplName: 'prediction-v1-evaluator',
+    executorImplVersion: '1.0.0',
+    executorRuntimeBundleDigest: 'sha256:evaluator-runtime',
+    executorPlugins: ['evaluator-plugin@1.0.0'],
+    solutionEnvelopeCid: `bafy-solution-${id}`,
+    solutionEnvelopeSha256: null,
+    solutionEnvelopeRef: `bafy-solution-${id}`,
+    metadata: {
+      verdict: 'SCORED',
+      'scores.solverBrier': '0.100000',
+      'scores.consensusBrier': '0.250000',
+      'scores.brierSpread': '-0.150000',
+      'solutionEnvelope.cid': `bafy-solution-${id}`,
+    },
+  };
+}

--- a/client/test/corpus/__snapshots__/prediction-brier-scoreboard-report.test.ts.snap
+++ b/client/test/corpus/__snapshots__/prediction-brier-scoreboard-report.test.ts.snap
@@ -1,0 +1,58 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`renderPredictionBrierScoreboardMarkdown > renders a deterministic Markdown report with headline, trend, attribution, and exclusions 1`] = `
+"# Prediction SolverNet Scoreboard
+
+Generated: 2026-05-03T12:00:00.000Z
+Status: OK
+Window: trailing 84 days ending 2026-05-03T00:00:00.000Z
+
+## Headline
+
+| Metric | Value |
+|---|---:|
+| Mean Brier spread | -0.070000 |
+| Mean solver Brier | 0.090000 |
+| Mean consensus Brier | 0.160000 |
+| Scored Verdicts | 1 |
+| Shared Tasks | 1 |
+| Active operators | 1 |
+
+## Weekly Trend
+
+| Week | Scored Verdicts | Mean Spread | Solver Brier | Consensus Brier | Tasks | Operators |
+|---|---:|---:|---:|---:|---:|---:|
+| 2026-04-27 | 1 | -0.070000 | 0.090000 | 0.160000 | 1 | 1 |
+
+## Operators
+
+| Operator | Scored Verdicts | Mean Spread | Solver Brier | Consensus Brier | Tasks |
+|---|---:|---:|---:|---:|---:|
+| 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa | 1 | -0.070000 | 0.090000 | 0.160000 | 1 |
+
+## Harnesses
+
+| Harness | Runtime Digest | Scored Verdicts | Mean Spread | Tasks |
+|---|---:|---:|---:|---:|
+| solver-harness@1.0.0 | sha256:solver-runtime | 1 | -0.070000 | 1 |
+
+## Plugins
+
+| Plugin | Scored Verdicts | Mean Spread | Tasks |
+|---|---:|---:|---:|
+| solver-plugin@1.0.0 | 1 | -0.070000 | 1 |
+
+## Exclusions
+
+| Reason | Count |
+|---|---:|
+| Total input rows | 3 |
+| Included score rows | 1 |
+| Non-prediction/non-Verdict rows | 1 |
+| Non-SCORED Verdict rows | 1 |
+| Missing score rows | 0 |
+| Non-numeric score rows | 0 |
+| Outside trailing window | 0 |
+
+"
+`;

--- a/client/test/corpus/__snapshots__/prediction-brier-scoreboard-report.test.ts.snap
+++ b/client/test/corpus/__snapshots__/prediction-brier-scoreboard-report.test.ts.snap
@@ -53,6 +53,5 @@ Window: trailing 84 days ending 2026-05-03T00:00:00.000Z
 | Missing score rows | 0 |
 | Non-numeric score rows | 0 |
 | Outside trailing window | 0 |
-
 "
 `;

--- a/client/test/corpus/prediction-brier-scoreboard-report.test.ts
+++ b/client/test/corpus/prediction-brier-scoreboard-report.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import {
+  aggregatePredictionBrierScoreboard,
+  renderPredictionBrierScoreboardMarkdown,
+} from '../../src/corpus/index.js';
+import type { EnvelopeProjection } from '../../src/corpus/types.js';
+
+const AS_OF = Date.parse('2026-05-03T00:00:00.000Z');
+const DAY_MS = 86_400_000;
+
+describe('renderPredictionBrierScoreboardMarkdown', () => {
+  it('renders a deterministic Markdown report with headline, trend, attribution, and exclusions', () => {
+    const scoreboard = aggregatePredictionBrierScoreboard([
+      solutionProjection('a', {
+        safe: `0x${'a'.repeat(40)}`,
+        agent: `0x${'1'.repeat(40)}`,
+        harness: 'solver-harness',
+        version: '1.0.0',
+        runtimeDigest: 'sha256:solver-runtime',
+        plugins: ['solver-plugin@1.0.0'],
+      }),
+      scoredVerdictProjection('a', {
+        generatedAt: AS_OF - DAY_MS,
+        solverBrier: '0.090000',
+        consensusBrier: '0.160000',
+        brierSpread: '-0.070000',
+      }),
+      scoredVerdictProjection('rejected', {
+        verdict: 'REJECTED',
+        generatedAt: AS_OF,
+      }),
+    ], { asOfGeneratedAt: AS_OF });
+
+    const markdown = renderPredictionBrierScoreboardMarkdown(scoreboard, {
+      generatedAtIso: '2026-05-03T12:00:00.000Z',
+    });
+
+    expect(markdown).toContain('# Prediction SolverNet Scoreboard');
+    expect(markdown).toContain('Generated: 2026-05-03T12:00:00.000Z');
+    expect(markdown).toContain('Status: OK');
+    expect(markdown).toContain('| Mean Brier spread | -0.070000 |');
+    expect(markdown).toContain('| Scored Verdicts | 1 |');
+    expect(markdown).toContain('| Active operators | 1 |');
+    expect(markdown).toContain(`| 0x${'a'.repeat(40)} | 1 | -0.070000 | 0.090000 | 0.160000 | 1 |`);
+    expect(markdown).toContain('| solver-harness@1.0.0 | sha256:solver-runtime | 1 | -0.070000 | 1 |');
+    expect(markdown).toContain('| solver-plugin@1.0.0 | 1 | -0.070000 | 1 |');
+    expect(markdown).toContain('| Non-SCORED Verdict rows | 1 |');
+    expect(markdown).toMatchSnapshot();
+  });
+
+  it('renders an insufficient-data state', () => {
+    const scoreboard = aggregatePredictionBrierScoreboard([], { asOfGeneratedAt: AS_OF });
+    const markdown = renderPredictionBrierScoreboardMarkdown(scoreboard, {
+      generatedAtIso: '2026-05-03T12:00:00.000Z',
+    });
+
+    expect(markdown).toContain('Status: INSUFFICIENT_DATA');
+    expect(markdown).toContain('Insufficient scoreable Verdict data.');
+  });
+});
+
+function solutionProjection(id: string, args: {
+  safe: string;
+  agent: string;
+  harness: string;
+  version: string;
+  runtimeDigest: string;
+  plugins: string[];
+}): EnvelopeProjection {
+  return {
+    envelopeId: `solution-${id}`,
+    envelopeCid: `bafy-solution-${id}`,
+    envelopeSha256: `sha256-solution-${id}`,
+    signatureHash: `0x${id.padEnd(64, '1').slice(0, 64)}`,
+    solverType: 'prediction.v1',
+    role: 'restoration',
+    taskCid: 'bafy-task-shared',
+    taskId: 'prediction-v1-polymarket-abc',
+    requestId: `solution-request-${id}`,
+    generatedAt: AS_OF - 2 * DAY_MS,
+    evidenceTier: 'self-signed',
+    participantSafeAddress: args.safe,
+    participantAgentEoa: args.agent,
+    executorImplName: args.harness,
+    executorImplVersion: args.version,
+    executorRuntimeBundleDigest: args.runtimeDigest,
+    executorPlugins: args.plugins,
+    solutionEnvelopeCid: null,
+    solutionEnvelopeSha256: null,
+    solutionEnvelopeRef: null,
+    metadata: {},
+  };
+}
+
+function scoredVerdictProjection(id: string, args: {
+  verdict?: string;
+  generatedAt: number;
+  solverBrier?: string;
+  consensusBrier?: string;
+  brierSpread?: string;
+}): EnvelopeProjection {
+  const metadata: EnvelopeProjection['metadata'] = {
+    verdict: args.verdict ?? 'SCORED',
+    'solutionEnvelope.cid': `bafy-solution-${id}`,
+  };
+  if (args.solverBrier !== undefined) metadata['scores.solverBrier'] = args.solverBrier;
+  if (args.consensusBrier !== undefined) metadata['scores.consensusBrier'] = args.consensusBrier;
+  if (args.brierSpread !== undefined) metadata['scores.brierSpread'] = args.brierSpread;
+
+  return {
+    envelopeId: `verdict-${id}`,
+    envelopeCid: `bafy-verdict-${id}`,
+    envelopeSha256: null,
+    signatureHash: `0x${id.padEnd(64, '2').slice(0, 64)}`,
+    solverType: 'prediction.v1',
+    role: 'verdict',
+    taskCid: 'bafy-task-shared',
+    taskId: 'prediction-v1-polymarket-abc',
+    requestId: `verdict-request-${id}`,
+    generatedAt: args.generatedAt,
+    evidenceTier: 'self-signed',
+    participantSafeAddress: `0x${'e'.repeat(40)}`,
+    participantAgentEoa: `0x${'3'.repeat(40)}`,
+    executorImplName: 'prediction-v1-evaluator',
+    executorImplVersion: '1.0.0',
+    executorRuntimeBundleDigest: 'sha256:evaluator-runtime',
+    executorPlugins: ['evaluator-plugin@1.0.0'],
+    solutionEnvelopeCid: `bafy-solution-${id}`,
+    solutionEnvelopeSha256: null,
+    solutionEnvelopeRef: `bafy-solution-${id}`,
+    metadata,
+  };
+}

--- a/client/test/corpus/prediction-brier-scoreboard-report.test.ts
+++ b/client/test/corpus/prediction-brier-scoreboard-report.test.ts
@@ -1,14 +1,67 @@
 import { describe, expect, it } from 'vitest';
 import {
   aggregatePredictionBrierScoreboard,
+  buildPredictionBrierScoreboard,
   renderPredictionBrierScoreboardMarkdown,
 } from '../../src/corpus/index.js';
 import type { EnvelopeProjection } from '../../src/corpus/types.js';
+import { Store } from '../../src/store/store.js';
 
 const AS_OF = Date.parse('2026-05-03T00:00:00.000Z');
 const DAY_MS = 86_400_000;
 
 describe('renderPredictionBrierScoreboardMarkdown', () => {
+  it('bounds historical report queries before limit and fetches Solution attribution separately', () => {
+    const store = new Store(':memory:');
+    try {
+      store.saveEnvelopeProjection(solutionProjection('a', {
+        safe: `0x${'a'.repeat(40)}`,
+        agent: `0x${'1'.repeat(40)}`,
+        harness: 'solver-harness',
+        version: '1.0.0',
+        runtimeDigest: 'sha256:solver-runtime',
+        plugins: ['solver-plugin@1.0.0'],
+        generatedAt: AS_OF - 120 * DAY_MS,
+      }));
+      store.saveEnvelopeProjection(scoredVerdictProjection('a', {
+        generatedAt: AS_OF - DAY_MS,
+        solverBrier: '0.090000',
+        consensusBrier: '0.160000',
+        brierSpread: '-0.070000',
+      }));
+      store.saveEnvelopeProjection(scoredVerdictProjection('newer', {
+        generatedAt: AS_OF + DAY_MS,
+        solverBrier: '0.990000',
+        consensusBrier: '0.010000',
+        brierSpread: '0.980000',
+      }));
+
+      const scoreboard = buildPredictionBrierScoreboard(store, {
+        asOfGeneratedAt: AS_OF,
+        projectionQuery: { limit: 1 },
+      });
+
+      expect(scoreboard.overall.scoredVerdictCount).toBe(1);
+      expect(scoreboard.overall.meanBrierSpread).toBeCloseTo(-0.07);
+      expect(scoreboard.perOperator).toMatchObject([
+        {
+          participantSafeAddress: `0x${'a'.repeat(40)}`,
+          scoredVerdictCount: 1,
+        },
+      ]);
+      expect(scoreboard.perHarness).toMatchObject([
+        {
+          implName: 'solver-harness',
+          runtimeBundleDigest: 'sha256:solver-runtime',
+          scoredVerdictCount: 1,
+        },
+      ]);
+      expect(scoreboard.perPlugin.map((summary) => summary.plugin)).toEqual(['solver-plugin@1.0.0']);
+    } finally {
+      store.close();
+    }
+  });
+
   it('renders a deterministic Markdown report with headline, trend, attribution, and exclusions', () => {
     const scoreboard = aggregatePredictionBrierScoreboard([
       solutionProjection('a', {
@@ -66,6 +119,7 @@ function solutionProjection(id: string, args: {
   version: string;
   runtimeDigest: string;
   plugins: string[];
+  generatedAt?: number;
 }): EnvelopeProjection {
   return {
     envelopeId: `solution-${id}`,
@@ -77,7 +131,7 @@ function solutionProjection(id: string, args: {
     taskCid: 'bafy-task-shared',
     taskId: 'prediction-v1-polymarket-abc',
     requestId: `solution-request-${id}`,
-    generatedAt: AS_OF - 2 * DAY_MS,
+    generatedAt: args.generatedAt ?? AS_OF - 2 * DAY_MS,
     evidenceTier: 'self-signed',
     participantSafeAddress: args.safe,
     participantAgentEoa: args.agent,

--- a/client/test/corpus/prediction-brier-scoreboard.test.ts
+++ b/client/test/corpus/prediction-brier-scoreboard.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from 'vitest';
+import {
+  aggregatePredictionBrierScoreboard,
+  queryScoreablePredictionBrierVerdicts,
+} from '../../src/corpus/index.js';
+import type { EnvelopeProjection } from '../../src/corpus/types.js';
+import { Store } from '../../src/store/store.js';
+
+const DAY_MS = 86_400_000;
+const AS_OF = Date.parse('2026-05-03T00:00:00.000Z');
+const TASK_CID = 'bafy-task-shared';
+const TASK_ID = 'prediction-v1-polymarket-abc';
+const OPERATOR_A = `0x${'a'.repeat(40)}`;
+const OPERATOR_B = `0x${'b'.repeat(40)}`;
+const EVALUATOR_OPERATOR = `0x${'e'.repeat(40)}`;
+const AGENT_A = `0x${'1'.repeat(40)}`;
+const AGENT_B = `0x${'2'.repeat(40)}`;
+const EVALUATOR_AGENT = `0x${'3'.repeat(40)}`;
+
+describe('aggregatePredictionBrierScoreboard', () => {
+  it('aggregates injected scoreable query rows by shared Task and attribution', () => {
+    const store = new Store(':memory:');
+    try {
+      store.saveEnvelopeProjection(brierProjection({
+        id: 'operator-a',
+        generatedAt: AS_OF - DAY_MS,
+        requestId: 'request-a',
+        participantSafeAddress: OPERATOR_A,
+        participantAgentEoa: AGENT_A,
+        executorImplName: 'prediction-v1-baseline',
+        executorImplVersion: '1.0.0',
+        executorRuntimeBundleDigest: 'sha256:runtime-a',
+        executorPlugins: ['prediction-baseline@1.0.0'],
+        solverBrier: '0.090000',
+        consensusBrier: '0.160000',
+        brierSpread: '-0.070000',
+      }));
+      store.saveEnvelopeProjection(brierProjection({
+        id: 'operator-b',
+        generatedAt: AS_OF - 2 * DAY_MS,
+        requestId: 'request-b',
+        participantSafeAddress: OPERATOR_B,
+        participantAgentEoa: AGENT_B,
+        executorImplName: 'prediction-v1-claude',
+        executorImplVersion: '2.1.0',
+        executorRuntimeBundleDigest: 'sha256:runtime-b',
+        executorPlugins: ['prediction-baseline@1.0.0', 'polymarket-tool@0.2.0'],
+        solverBrier: '0.250000',
+        consensusBrier: '0.160000',
+        brierSpread: '0.090000',
+      }));
+
+      const scoreableRows = queryScoreablePredictionBrierVerdicts(store, { taskCid: TASK_CID });
+      const scoreboard = aggregatePredictionBrierScoreboard(scoreableRows, { asOfGeneratedAt: AS_OF });
+
+      expect(scoreboard.overall.scoredVerdictCount).toBe(2);
+      expect(scoreboard.overall.distinctTaskCount).toBe(1);
+      expect(scoreboard.overall.activeOperatorCount).toBe(2);
+      expect(scoreboard.overall.meanBrierSpread).toBeCloseTo(0.01);
+      expect(scoreboard.overall.meanSolverBrier).toBeCloseTo(0.17);
+      expect(scoreboard.overall.meanConsensusBrier).toBeCloseTo(0.16);
+      expect(scoreboard.excluded).toMatchObject({
+        totalInputRows: 2,
+        includedRows: 2,
+        nonScoredVerdictRows: 0,
+        missingScoreRows: 0,
+        nonNumericScoreRows: 0,
+      });
+
+      expect(scoreboard.perOperator.map((summary) => summary.participantSafeAddress).sort()).toEqual([
+        OPERATOR_A,
+        OPERATOR_B,
+      ]);
+      expect(scoreboard.perHarness.map((summary) => ({
+        implName: summary.implName,
+        implVersion: summary.implVersion,
+        runtimeBundleDigest: summary.runtimeBundleDigest,
+        scoredVerdictCount: summary.scoredVerdictCount,
+      }))).toEqual([
+        {
+          implName: 'prediction-v1-baseline',
+          implVersion: '1.0.0',
+          runtimeBundleDigest: 'sha256:runtime-a',
+          scoredVerdictCount: 1,
+        },
+        {
+          implName: 'prediction-v1-claude',
+          implVersion: '2.1.0',
+          runtimeBundleDigest: 'sha256:runtime-b',
+          scoredVerdictCount: 1,
+        },
+      ]);
+      expect(scoreboard.perPlugin.map((summary) => ({
+        plugin: summary.plugin,
+        count: summary.scoredVerdictCount,
+        taskCount: summary.distinctTaskCount,
+      }))).toEqual([
+        { plugin: 'prediction-baseline@1.0.0', count: 2, taskCount: 1 },
+        { plugin: 'polymarket-tool@0.2.0', count: 1, taskCount: 1 },
+      ]);
+    } finally {
+      store.close();
+    }
+  });
+
+  it('excludes rejected, invalid, unresolved, incomplete, and non-numeric Verdict rows', () => {
+    const scoreboard = aggregatePredictionBrierScoreboard([
+      brierProjection({
+        id: 'valid',
+        generatedAt: AS_OF,
+        solverBrier: '0.100000',
+        consensusBrier: '0.250000',
+        brierSpread: '-0.150000',
+      }),
+      brierProjection({ id: 'rejected', generatedAt: AS_OF, verdict: 'REJECTED' }),
+      brierProjection({ id: 'invalid', generatedAt: AS_OF, verdict: 'INVALID' }),
+      brierProjection({ id: 'unresolved', generatedAt: AS_OF, verdict: 'INDETERMINATE' }),
+      brierProjection({
+        id: 'incomplete',
+        generatedAt: AS_OF,
+        solverBrier: '0.100000',
+        consensusBrier: '0.250000',
+        brierSpread: undefined,
+      }),
+      brierProjection({
+        id: 'non-numeric',
+        generatedAt: AS_OF,
+        solverBrier: 'not-a-number',
+        consensusBrier: '0.250000',
+        brierSpread: '0.150000',
+      }),
+      brierProjection({
+        id: 'non-prediction',
+        generatedAt: AS_OF,
+        solverType: 'portfolio.v0',
+      }),
+    ], { asOfGeneratedAt: AS_OF });
+
+    expect(scoreboard.overall.scoredVerdictCount).toBe(1);
+    expect(scoreboard.overall.meanBrierSpread).toBeCloseTo(-0.15);
+    expect(scoreboard.excluded).toMatchObject({
+      totalInputRows: 7,
+      includedRows: 1,
+      nonPredictionVerdictRows: 1,
+      nonScoredVerdictRows: 3,
+      missingScoreRows: 1,
+      nonNumericScoreRows: 1,
+      outsideWindowRows: 0,
+    });
+  });
+
+  it('uses Verdict generatedAt for trailing 84-day windowing', () => {
+    const asOf = Date.parse('2026-05-01T12:00:00.000Z');
+    const scoreboard = aggregatePredictionBrierScoreboard([
+      brierProjection({
+        id: 'inside',
+        generatedAt: asOf - 83 * DAY_MS,
+        solverBrier: '0.050000',
+        consensusBrier: '0.250000',
+        brierSpread: '-0.200000',
+      }),
+      brierProjection({
+        id: 'boundary',
+        generatedAt: asOf - 84 * DAY_MS,
+        solverBrier: '0.300000',
+        consensusBrier: '0.250000',
+        brierSpread: '0.050000',
+      }),
+      brierProjection({
+        id: 'too-old',
+        generatedAt: asOf - 84 * DAY_MS - 1,
+        solverBrier: '1.000000',
+        consensusBrier: '0.100000',
+        brierSpread: '0.900000',
+      }),
+      brierProjection({
+        id: 'future',
+        generatedAt: asOf + 1,
+        solverBrier: '0.000000',
+        consensusBrier: '0.900000',
+        brierSpread: '-0.900000',
+      }),
+    ], { asOfGeneratedAt: asOf });
+
+    expect(scoreboard.windowStartGeneratedAt).toBe(asOf - 84 * DAY_MS);
+    expect(scoreboard.overall.scoredVerdictCount).toBe(2);
+    expect(scoreboard.overall.meanBrierSpread).toBeCloseTo(-0.075);
+    expect(scoreboard.excluded.outsideWindowRows).toBe(2);
+    expect(scoreboard.weeklyTrend.reduce((count, bucket) => count + bucket.scoredVerdictCount, 0)).toBe(2);
+  });
+
+  it('joins scored Verdict rows to Solution projections for solver attribution', () => {
+    const scoreboard = aggregatePredictionBrierScoreboard([
+      solutionProjection({
+        id: 'solver-a',
+        participantSafeAddress: OPERATOR_A,
+        participantAgentEoa: AGENT_A,
+        executorImplName: 'prediction-v1-baseline',
+        executorImplVersion: '1.0.0',
+        executorRuntimeBundleDigest: 'sha256:solver-runtime',
+        executorPlugins: ['solver-plugin@1.0.0'],
+      }),
+      brierProjection({
+        id: 'solver-a',
+        generatedAt: AS_OF,
+        participantSafeAddress: EVALUATOR_OPERATOR,
+        participantAgentEoa: EVALUATOR_AGENT,
+        executorImplName: 'prediction-v1-evaluator',
+        executorImplVersion: '1.0.0',
+        executorRuntimeBundleDigest: 'sha256:evaluator-runtime',
+        executorPlugins: ['evaluator-plugin@1.0.0'],
+        solverBrier: '0.100000',
+        consensusBrier: '0.250000',
+        brierSpread: '-0.150000',
+      }),
+    ], { asOfGeneratedAt: AS_OF });
+
+    expect(scoreboard.overall.scoredVerdictCount).toBe(1);
+    expect(scoreboard.excluded.nonPredictionVerdictRows).toBe(1);
+    expect(scoreboard.perOperator).toMatchObject([
+      {
+        participantSafeAddress: OPERATOR_A,
+        participantAgentEoa: AGENT_A,
+        scoredVerdictCount: 1,
+      },
+    ]);
+    expect(scoreboard.perHarness).toMatchObject([
+      {
+        implName: 'prediction-v1-baseline',
+        implVersion: '1.0.0',
+        runtimeBundleDigest: 'sha256:solver-runtime',
+        scoredVerdictCount: 1,
+      },
+    ]);
+    expect(scoreboard.perPlugin.map((summary) => summary.plugin)).toEqual(['solver-plugin@1.0.0']);
+  });
+});
+
+function brierProjection(args: {
+  id: string;
+  generatedAt: number;
+  requestId?: string;
+  solverType?: string;
+  role?: 'restoration' | 'verdict';
+  taskCid?: string | null;
+  taskId?: string | null;
+  verdict?: string;
+  participantSafeAddress?: string | null;
+  participantAgentEoa?: string | null;
+  executorImplName?: string | null;
+  executorImplVersion?: string | null;
+  executorRuntimeBundleDigest?: string | null;
+  executorPlugins?: string[];
+  solverBrier?: string | number;
+  consensusBrier?: string | number;
+  brierSpread?: string | number;
+}): EnvelopeProjection {
+  const metadata: EnvelopeProjection['metadata'] = {
+    verdict: args.verdict ?? 'SCORED',
+  };
+  if (args.solverBrier !== undefined) metadata['scores.solverBrier'] = args.solverBrier;
+  if (args.consensusBrier !== undefined) metadata['scores.consensusBrier'] = args.consensusBrier;
+  if (args.brierSpread !== undefined) metadata['scores.brierSpread'] = args.brierSpread;
+
+  return {
+    envelopeId: `verdict-${args.id}`,
+    envelopeCid: `bafy-verdict-${args.id}`,
+    envelopeSha256: null,
+    signatureHash: `0x${args.id.padEnd(64, '0').slice(0, 64)}`,
+    solverType: args.solverType ?? 'prediction.v1',
+    role: args.role ?? 'verdict',
+    taskCid: args.taskCid === undefined ? TASK_CID : args.taskCid,
+    taskId: args.taskId === undefined ? TASK_ID : args.taskId,
+    requestId: args.requestId ?? `request-${args.id}`,
+    generatedAt: args.generatedAt,
+    evidenceTier: 'self-signed',
+    participantSafeAddress: args.participantSafeAddress === undefined ? OPERATOR_A : args.participantSafeAddress,
+    participantAgentEoa: args.participantAgentEoa === undefined ? AGENT_A : args.participantAgentEoa,
+    executorImplName: args.executorImplName === undefined ? 'prediction-v1-evaluator' : args.executorImplName,
+    executorImplVersion: args.executorImplVersion === undefined ? '1.0.0' : args.executorImplVersion,
+    executorRuntimeBundleDigest: args.executorRuntimeBundleDigest === undefined
+      ? 'sha256:runtime-default'
+      : args.executorRuntimeBundleDigest,
+    executorPlugins: args.executorPlugins ?? ['prediction-baseline@1.0.0'],
+    solutionEnvelopeCid: `bafy-solution-${args.id}`,
+    solutionEnvelopeSha256: null,
+    solutionEnvelopeRef: `bafy-solution-${args.id}`,
+    metadata,
+  };
+}
+
+function solutionProjection(args: {
+  id: string;
+  generatedAt?: number;
+  participantSafeAddress?: string | null;
+  participantAgentEoa?: string | null;
+  executorImplName?: string | null;
+  executorImplVersion?: string | null;
+  executorRuntimeBundleDigest?: string | null;
+  executorPlugins?: string[];
+}): EnvelopeProjection {
+  return {
+    envelopeId: `solution-${args.id}`,
+    envelopeCid: `bafy-solution-${args.id}`,
+    envelopeSha256: `sha256-solution-${args.id}`,
+    signatureHash: `0x${args.id.padEnd(64, '1').slice(0, 64)}`,
+    solverType: 'prediction.v1',
+    role: 'restoration',
+    taskCid: TASK_CID,
+    taskId: TASK_ID,
+    requestId: `request-${args.id}`,
+    generatedAt: args.generatedAt ?? AS_OF - DAY_MS,
+    evidenceTier: 'self-signed',
+    participantSafeAddress: args.participantSafeAddress === undefined ? OPERATOR_A : args.participantSafeAddress,
+    participantAgentEoa: args.participantAgentEoa === undefined ? AGENT_A : args.participantAgentEoa,
+    executorImplName: args.executorImplName === undefined ? 'prediction-v1-baseline' : args.executorImplName,
+    executorImplVersion: args.executorImplVersion === undefined ? '1.0.0' : args.executorImplVersion,
+    executorRuntimeBundleDigest: args.executorRuntimeBundleDigest === undefined
+      ? 'sha256:runtime-default'
+      : args.executorRuntimeBundleDigest,
+    executorPlugins: args.executorPlugins ?? ['prediction-baseline@1.0.0'],
+    solutionEnvelopeCid: null,
+    solutionEnvelopeSha256: null,
+    solutionEnvelopeRef: null,
+    metadata: {},
+  };
+}

--- a/client/test/store/envelope-projection-index.test.ts
+++ b/client/test/store/envelope-projection-index.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
 import { projectEnvelope } from '../../src/corpus/envelope-projection.js';
 import { Store } from '../../src/store/store.js';
 import type { SignedEnvelope } from '../../src/types/envelope.js';
@@ -101,6 +105,47 @@ describe('Store envelope projection index', () => {
       solutionEnvelopeRef: null,
     });
     expect(results[0].metadata['source.venue']).toBeUndefined();
+  });
+
+  it('migrates older envelope projection tables with missing Task scoreboard columns', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'jinn-projection-migration-'));
+    const dbPath = join(dir, 'store.db');
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE envelope_projections (
+        envelope_id TEXT PRIMARY KEY,
+        envelope_cid TEXT,
+        envelope_sha256 TEXT,
+        signature_hash TEXT NOT NULL,
+        solver_type TEXT NOT NULL,
+        role TEXT NOT NULL,
+        task_cid TEXT,
+        request_id TEXT,
+        generated_at INTEGER NOT NULL,
+        evidence_tier TEXT NOT NULL,
+        participant_safe_address TEXT,
+        participant_agent_eoa TEXT,
+        executor_impl_name TEXT,
+        executor_impl_version TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `);
+    db.close();
+
+    const migrated = new Store(dbPath);
+    try {
+      const cols = migrated.db.prepare(`PRAGMA table_info(envelope_projections)`).all() as Array<{ name: string }>;
+      const names = new Set(cols.map((col) => col.name));
+      expect(names.has('task_id')).toBe(true);
+      expect(names.has('executor_runtime_bundle_digest')).toBe(true);
+      expect(names.has('executor_plugins_json')).toBe(true);
+      expect(names.has('solution_envelope_ref')).toBe(true);
+      expect(names.has('metadata_json')).toBe(true);
+      expect(migrated.queryEnvelopeProjections({ solverType: 'prediction.v1' })).toEqual([]);
+    } finally {
+      migrated.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/docs/superpowers/plans/2026-04-30-brier-dashboard.md
+++ b/docs/superpowers/plans/2026-04-30-brier-dashboard.md
@@ -1,0 +1,149 @@
+# Prediction SolverNet Brier Dashboard Plan
+
+## Status
+
+Ratified implementation handoff for `jinn-mono-xp33` and `jinn-mono-l2zl.5`.
+
+The Prediction SolverNet v1 scoreboard should be built on the generic corpus/indexed envelope projection path that landed with the task-native lifecycle work. It must not introduce a Prediction-specific canonical database.
+
+## Source Of Truth
+
+The source of truth is the generic envelope corpus plus its materialized projection index:
+
+- `prediction.v1` forecast Solution envelopes.
+- `prediction.v1` evaluator Verdict envelopes.
+- Task identity from `taskCid` and `taskId`.
+- Solver operator identity from Solution-envelope `participant.safeAddress` and `participant.agentEoa`.
+- Solver Harness/runtime attribution from Solution-envelope `executor.implName`, `executor.implVersion`, and `executor.runtimeBundleDigest`.
+- Solver plugin attribution from Solution-envelope `executor.plugins`.
+
+A hosted dashboard or generated report may denormalize these fields for convenience, but those denormalized rows are derived artifacts. They are not protocol state.
+
+## Scoreable Row Definition
+
+The initial scoreboard should consume `queryScoreablePredictionBrierVerdicts()` from `client/src/corpus/prediction-scoreable-verdicts.ts`.
+
+A Verdict is scoreable only when all of the following are true:
+
+- `solverType` is `prediction.v1`.
+- `role` is `verdict`.
+- `metadata.verdict` is `SCORED`.
+- `scores.solverBrier`, `scores.consensusBrier`, and `scores.brierSpread` are present.
+
+`REJECTED`, `INVALID`, unresolved, indeterminate, and malformed Verdicts are excluded from Brier aggregates. They should still be counted separately once the report grows invalid/rejected rate sections.
+
+## Public Grouping Model
+
+Public metrics group submissions under the shared Task:
+
+- Primary Task key: `taskCid`, with `taskId` as the human/stable display key when present.
+- Submission key: `solutionEnvelopeCid`, `solutionEnvelopeSha256`, or `solutionEnvelopeRef`.
+- Verdict key: the Verdict projection `envelopeCid`, `envelopeSha256`, or `envelopeId`.
+- Operator key: Solution projection `participantSafeAddress`, then `participantAgentEoa` if Safe is absent.
+- Harness key: Solution projection `executorImplName` plus `executorImplVersion`.
+- Plugin key: entries in Solution projection `executorPlugins`.
+
+`requestId` and `attemptIndex` are trace/debug fields only. The dashboard must not treat each attempt request as a separate public Task.
+
+Score rows come from Verdict projections, but public Solver attribution should join back to the scored Solution projection using the Verdict `solutionEnvelope` reference. If only Verdict projections are available, report code may fall back to Verdict attribution, but that is an incomplete local/debug view rather than the public operator ranking.
+
+## Metrics
+
+The headline metric is trailing 84-day mean `brierSpread` across scoreable Verdicts:
+
+```text
+solverBrier = (solution.probabilityYes - outcome)^2
+consensusBrier = (task.consensusSnapshot.probabilityYes - outcome)^2
+brierSpread = solverBrier - consensusBrier
+```
+
+Smaller is better. Negative `brierSpread` means the Solver beat the Polymarket consensus snapshot for that scored forecast round.
+
+Initial supporting metrics:
+
+- Mean solver Brier.
+- Mean consensus Brier.
+- Scoreable Verdict count.
+- Distinct shared Task count.
+- Distinct active operator count.
+- Per-operator mean Brier spread and count.
+- Per-Harness mean Brier spread and count.
+- Per-plugin mean Brier spread and count.
+- Weekly trend buckets by Verdict `generatedAt`.
+
+The 84-day window should use Verdict projection `generatedAt`, because scoring happens when the evaluator emits the Verdict. Future reports may add market-resolution-time windows, but that is not required for the first scoreboard.
+
+## First Artifact
+
+The first deliverable should be a repo-rendered Markdown scoreboard, not a hosted UI:
+
+- Output: `docs/superpowers/reports/prediction-solvernet-scoreboard.md`.
+- Input: the local store's envelope projection index or an injected projection list in tests.
+- Mode: deterministic report generation with an explicit "insufficient data" state when no scoreable Verdicts exist.
+
+This keeps the next phase implementation small and validates the data model before investing in the public web surface at `https://jinn.network/solvernets/prediction`.
+
+## Implementation Slices
+
+### Slice 1: Aggregation
+
+Add a typed aggregation module that accepts scoreable `EnvelopeProjection` rows and returns:
+
+- Overall trailing 84-day summary.
+- Weekly trend buckets.
+- Per-operator, per-Harness, and per-plugin summaries.
+- Excluded/non-scoreable counters when raw projection input is supplied.
+
+The module should parse Brier metadata defensively and keep invalid numeric values out of score aggregates.
+
+### Slice 2: Report Rendering
+
+Add a report renderer/CLI path that writes the Markdown artifact. The report should show:
+
+- Headline trailing 84-day mean Brier spread.
+- Solver and consensus Brier means.
+- Counts for scored Verdicts, Tasks, and operators.
+- Weekly trend.
+- Operator, Harness, and plugin tables.
+- Insufficient-data and stale-data states.
+
+### Slice 3: Validation
+
+Add focused tests using seeded in-memory projections:
+
+- Scored Verdicts with complete Brier metadata are included.
+- Rejected, invalid, unresolved, and incomplete Verdicts are excluded from Brier aggregates.
+- Rows group by shared `taskCid`/`taskId`, not by `requestId`.
+- The 84-day window uses Verdict `generatedAt`.
+- Operator, Harness, and plugin attribution are preserved.
+- The rendered report is deterministic.
+
+## Out Of Scope
+
+- A hosted dashboard UI.
+- Prediction-specific canonical database tables.
+- Mainnet campaign launch.
+- On-chain aggregate scoring.
+- Multi-evaluator consensus.
+- Component-level contribution attribution below plugin granularity.
+- veJINN demand or economic incentive modeling.
+
+## Validation Commands
+
+Expected focused validation after implementation:
+
+```bash
+cd client
+yarn test test/corpus/prediction-scoreable-verdicts.test.ts
+yarn test test/corpus/prediction-brier-scoreboard.test.ts
+yarn test test/corpus/prediction-brier-scoreboard-report.test.ts
+yarn test test/cli/commands/prediction-scoreboard.test.ts
+yarn tsc --noEmit
+```
+
+Repo report refresh command:
+
+```bash
+cd client
+yarn jinn prediction-scoreboard --output ../docs/superpowers/reports/prediction-solvernet-scoreboard.md
+```

--- a/docs/superpowers/reports/prediction-solvernet-scoreboard.md
+++ b/docs/superpowers/reports/prediction-solvernet-scoreboard.md
@@ -44,4 +44,3 @@ No plugin rows yet.
 | Missing score rows | 0 |
 | Non-numeric score rows | 0 |
 | Outside trailing window | 0 |
-

--- a/docs/superpowers/reports/prediction-solvernet-scoreboard.md
+++ b/docs/superpowers/reports/prediction-solvernet-scoreboard.md
@@ -1,0 +1,47 @@
+# Prediction SolverNet Scoreboard
+
+Generated: 2026-05-03T16:57:09.240Z
+Status: INSUFFICIENT_DATA
+Window: trailing 84 days ending 2026-05-03T00:00:00.000Z
+
+## Headline
+
+Insufficient scoreable Verdict data. The report will populate after Prediction SolverNet evaluators emit `SCORED` Verdict envelopes with Brier metadata.
+
+| Metric | Value |
+|---|---:|
+| Mean Brier spread | - |
+| Mean solver Brier | - |
+| Mean consensus Brier | - |
+| Scored Verdicts | 0 |
+| Shared Tasks | 0 |
+| Active operators | 0 |
+
+## Weekly Trend
+
+No weekly trend data yet.
+
+## Operators
+
+No operator rows yet.
+
+## Harnesses
+
+No Harness rows yet.
+
+## Plugins
+
+No plugin rows yet.
+
+## Exclusions
+
+| Reason | Count |
+|---|---:|
+| Total input rows | 0 |
+| Included score rows | 0 |
+| Non-prediction/non-Verdict rows | 0 |
+| Non-SCORED Verdict rows | 0 |
+| Missing score rows | 0 |
+| Non-numeric score rows | 0 |
+| Outside trailing window | 0 |
+


### PR DESCRIPTION
## Summary

Adds the first repo-rendered Prediction SolverNet Brier scoreboard surface.

- Ratifies the Brier dashboard implementation plan and adds the initial report artifact.
- Adds aggregation over generic `prediction.v1` envelope projections with trailing 84-day Brier-spread metrics.
- Joins scored Verdict rows back to Solution projections for public solver operator/Harness/plugin attribution.
- Adds a `jinn prediction-scoreboard` CLI command to refresh the Markdown report from the local projection store.
- Adds an additive migration for older `envelope_projections` tables missing Task/scoreboard columns.

## Validation

- `cd client && yarn test test/corpus/prediction-brier-scoreboard.test.ts test/corpus/prediction-brier-scoreboard-report.test.ts test/corpus/prediction-scoreable-verdicts.test.ts test/store/envelope-projection-index.test.ts test/cli/commands/prediction-scoreboard.test.ts`
- `cd client && yarn tsc --noEmit`
- `git diff --check`

## Beads

Closed: `jinn-mono-xp33`, `jinn-mono-l2zl.5`, `jinn-mono-l2zl.5.1`, `jinn-mono-l2zl.5.2`, `jinn-mono-l2zl.5.3`.
