### PR TITLE
[codex] Surface Prediction dashboard status

### DIFF
--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -26,9 +26,12 @@ import {
   gatherPortfolioV0Status,
   DEFAULT_ENGINE_WORKING_DIR_ROOT,
 } from './portfolio-v0-build.js';
-import { gatherPredictionV1Status } from './prediction-v1-build.js';
+import { gatherPredictionV1Status, type PredictionV1Status } from './prediction-v1-build.js';
 import type { BalanceCacheEntry } from '../store/store.js';
-import { buildPredictionOperatorStatus } from '../solver-nets/prediction-operator-ux.js';
+import {
+  buildPredictionOperatorStatus,
+  type PredictionOperatorStatus,
+} from '../solver-nets/prediction-operator-ux.js';
 
 const ERC20_BALANCE_OF_ABI = [
   {
@@ -41,6 +44,7 @@ const ERC20_BALANCE_OF_ABI = [
 ] as const;
 
 const STANDARD_MASTER_BOOTSTRAP_MULTIPLIER = 2n;
+const predictionOperatorStatusCache = new WeakMap<JinnConfig, Map<string, Promise<PredictionOperatorStatus>>>();
 
 export interface StatusGatherConfig {
   earningDir: string;
@@ -62,6 +66,94 @@ export interface StatusGatherConfig {
 
 function chainKey(network: 'mainnet' | 'testnet'): 'base' | 'base-sepolia' {
   return network === 'testnet' ? 'base-sepolia' : 'base';
+}
+
+function predictionOperatorCacheKey(configPath: string, name: string): string {
+  return `${configPath}\0${name}`;
+}
+
+async function getCachedPredictionOperatorStatus(
+  config: JinnConfig,
+  configPath: string,
+  name: string,
+): Promise<PredictionOperatorStatus> {
+  let byKey = predictionOperatorStatusCache.get(config);
+  if (!byKey) {
+    byKey = new Map();
+    predictionOperatorStatusCache.set(config, byKey);
+  }
+
+  const key = predictionOperatorCacheKey(configPath, name);
+  let cached = byKey.get(key);
+  if (!cached) {
+    cached = buildPredictionOperatorStatus({ config, configPath, name })
+      .catch((error) => predictionOperatorUnavailable(config, configPath, name, errorMessage(error)));
+    byKey.set(key, cached);
+  }
+  return cached;
+}
+
+function predictionOperatorUnavailable(
+  config: JinnConfig,
+  configPath: string,
+  name: string,
+  message: string,
+): PredictionOperatorStatus {
+  const net = config.solverNets[name];
+  const diagnostic = {
+    code: 'prediction_operator_status_unavailable',
+    severity: 'error' as const,
+    message,
+    nextAction: {
+      description: 'Inspect Prediction SolverNet configuration and restart the daemon after fixing it.',
+      cli: `jinn solver-nets show ${name}`,
+    },
+  };
+
+  return {
+    kind: 'prediction.v1.operatorStatus',
+    ok: false,
+    configPath,
+    solverNet: {
+      name,
+      enabled: net?.enabled ?? false,
+      solverType: net?.solverType ?? 'prediction.v1',
+      harness: net?.harness,
+      taskGeneratorEnabled: net?.taskGenerator.enabled ?? false,
+    },
+    extraPlugins: [],
+    diagnostics: [diagnostic],
+    nextAction: diagnostic.nextAction,
+  };
+}
+
+function predictionV1Unavailable(
+  operator: PredictionOperatorStatus | null,
+  operatorError: string,
+): PredictionV1Status {
+  return {
+    operator,
+    operatorError,
+    totals: {
+      observedTasks: 0,
+      activeTaskRuns: 0,
+      solutions: 0,
+      verdicts: 0,
+      failed: 0,
+    },
+    latest: {
+      taskAt: null,
+      solutionAt: null,
+      verdictAt: null,
+    },
+    recentTasks: [],
+    recentSolutions: [],
+    recentVerdicts: [],
+  };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 async function sumPendingStakingRewards(
@@ -281,21 +373,34 @@ export async function gatherGatheredStatusRaw(
     portfolioV0 = undefined;
   }
 
-  let predictionV1: ReturnType<typeof gatherPredictionV1Status> | undefined;
+  let predictionOperator: PredictionOperatorStatus | null = null;
+  let predictionOperatorError: string | undefined;
+  if (status?.config) {
+    try {
+      predictionOperator = await getCachedPredictionOperatorStatus(
+        status.config,
+        status.configPath ?? '<default>',
+        'prediction',
+      );
+    } catch (error) {
+      predictionOperatorError = errorMessage(error);
+    }
+  }
+
+  let predictionV1: PredictionV1Status | undefined;
   try {
-    const operator = status?.config
-      ? await buildPredictionOperatorStatus({
-          config: status.config,
-          configPath: status.configPath ?? '<default>',
-          name: 'prediction',
-        })
-      : null;
-    predictionV1 = gatherPredictionV1Status(store, { operator });
-  } catch (error) {
     predictionV1 = gatherPredictionV1Status(store, {
-      operator: null,
-      operatorError: error instanceof Error ? error.message : String(error),
+      operator: predictionOperator,
+      operatorError: predictionOperatorError,
     });
+  } catch (error) {
+    const lifecycleError = errorMessage(error);
+    predictionV1 = predictionV1Unavailable(
+      predictionOperator,
+      predictionOperatorError
+        ? `${predictionOperatorError}; prediction lifecycle unavailable: ${lifecycleError}`
+        : `Prediction lifecycle unavailable: ${lifecycleError}`,
+    );
   }
 
   const baseRaw: GatheredStatusRaw = {

--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -8,6 +8,7 @@ import { createPublicClient, http, type PublicClient } from 'viem';
 type StatusBalanceRpc = Pick<PublicClient, 'getBalance' | 'readContract'>;
 import { base, baseSepolia } from 'viem/chains';
 import type { Store } from '../store/store.js';
+import type { JinnConfig } from '../config.js';
 import { FleetStateStore } from '../earning/store.js';
 import { getChainConfig } from '../earning/contracts.js';
 import { JINN_STAKING_ABI } from '../earning/jinn-rewards.js';
@@ -25,7 +26,9 @@ import {
   gatherPortfolioV0Status,
   DEFAULT_ENGINE_WORKING_DIR_ROOT,
 } from './portfolio-v0-build.js';
+import { gatherPredictionV1Status } from './prediction-v1-build.js';
 import type { BalanceCacheEntry } from '../store/store.js';
+import { buildPredictionOperatorStatus } from '../solver-nets/prediction-operator-ux.js';
 
 const ERC20_BALANCE_OF_ABI = [
   {
@@ -52,6 +55,9 @@ export interface StatusGatherConfig {
   testnetStolasDeploymentPath?: string;
   /** Engine paths — used for portfolio.v0 Claude outcome scan, etc. */
   engine?: { workingDirRoot: string; implStateDirRoot: string };
+  /** Full config enables SolverNet/plugin/Harness diagnostics in /v1/status. */
+  config?: JinnConfig;
+  configPath?: string;
 }
 
 function chainKey(network: 'mainnet' | 'testnet'): 'base' | 'base-sepolia' {
@@ -275,6 +281,23 @@ export async function gatherGatheredStatusRaw(
     portfolioV0 = undefined;
   }
 
+  let predictionV1: ReturnType<typeof gatherPredictionV1Status> | undefined;
+  try {
+    const operator = status?.config
+      ? await buildPredictionOperatorStatus({
+          config: status.config,
+          configPath: status.configPath ?? '<default>',
+          name: 'prediction',
+        })
+      : null;
+    predictionV1 = gatherPredictionV1Status(store, { operator });
+  } catch (error) {
+    predictionV1 = gatherPredictionV1Status(store, {
+      operator: null,
+      operatorError: error instanceof Error ? error.message : String(error),
+    });
+  }
+
   const baseRaw: GatheredStatusRaw = {
     shutdownState,
     daemonStartedAt,
@@ -290,6 +313,7 @@ export async function gatherGatheredStatusRaw(
     pollIntervalMs: status?.pollIntervalMs ?? 5000,
     masterDailyEstimateWei: daily.toString(),
     portfolioV0,
+    predictionV1,
     serviceBalances: {},
     pendingByService: {},
     claimedByService: store.getClaimedRewardsByService(),

--- a/client/src/api/prediction-v1-build.ts
+++ b/client/src/api/prediction-v1-build.ts
@@ -1,0 +1,125 @@
+/**
+ * prediction.v1 dashboard data assembly.
+ *
+ * Uses the generic task_runs table as the first operator-visible lifecycle
+ * source. Envelope projections remain the richer corpus source once production
+ * writes them, but task_runs is available in the daemon today.
+ */
+
+import type { Store } from '../store/store.js';
+import { TaskRunPersistence, type PersistedTaskRun } from '../harnesses/engine/persistence.js';
+import type { PredictionOperatorStatus } from '../solver-nets/prediction-operator-ux.js';
+
+const RECENT_LIMIT = 5;
+
+export interface PredictionV1TaskRunSummary {
+  requestId: string;
+  taskId: string | null;
+  taskCid: string;
+  state: string;
+  taskRole: 'restoration' | 'evaluation' | null;
+  implName: string | null;
+  windowStartTs: number;
+  windowEndTs: number;
+  stateUpdatedAt: number;
+  manifestCid: string | null;
+  deliveryTxHash: string | null;
+  failureReason: string | null;
+}
+
+export interface PredictionV1Status {
+  operator: PredictionOperatorStatus | null;
+  operatorError?: string;
+  totals: {
+    observedTasks: number;
+    activeTaskRuns: number;
+    solutions: number;
+    verdicts: number;
+    failed: number;
+  };
+  latest: {
+    taskAt: number | null;
+    solutionAt: number | null;
+    verdictAt: number | null;
+  };
+  recentTasks: PredictionV1TaskRunSummary[];
+  recentSolutions: PredictionV1TaskRunSummary[];
+  recentVerdicts: PredictionV1TaskRunSummary[];
+}
+
+export interface GatherPredictionV1StatusOptions {
+  operator?: PredictionOperatorStatus | null;
+  operatorError?: string;
+}
+
+export function gatherPredictionV1Status(
+  store: Store,
+  options: GatherPredictionV1StatusOptions = {},
+): PredictionV1Status {
+  const persistence = new TaskRunPersistence(store.db);
+  const inFlight = persistence.getInFlight().filter(isPredictionV1Run);
+  const complete = persistence.getByState('COMPLETE').filter(isPredictionV1Run);
+  const failed = persistence.getByState('FAILED').filter(isPredictionV1Run);
+  const allRuns = [...inFlight, ...complete, ...failed];
+  const allRecent = [...allRuns].sort((a, b) => b.stateUpdatedAt - a.stateUpdatedAt);
+  const solutions = complete
+    .filter((run) => run.taskRole !== 'evaluation')
+    .sort((a, b) => b.stateUpdatedAt - a.stateUpdatedAt);
+  const verdicts = complete
+    .filter((run) => run.taskRole === 'evaluation')
+    .sort((a, b) => b.stateUpdatedAt - a.stateUpdatedAt);
+
+  return {
+    operator: options.operator ?? null,
+    ...(options.operatorError ? { operatorError: options.operatorError } : {}),
+    totals: {
+      observedTasks: distinctTaskCount(allRuns),
+      activeTaskRuns: inFlight.length,
+      solutions: solutions.length,
+      verdicts: verdicts.length,
+      failed: failed.length,
+    },
+    latest: {
+      taskAt: latestAt(allRuns),
+      solutionAt: latestAt(solutions),
+      verdictAt: latestAt(verdicts),
+    },
+    recentTasks: allRecent.slice(0, RECENT_LIMIT).map(toSummary),
+    recentSolutions: solutions.slice(0, RECENT_LIMIT).map(toSummary),
+    recentVerdicts: verdicts.slice(0, RECENT_LIMIT).map(toSummary),
+  };
+}
+
+function isPredictionV1Run(run: PersistedTaskRun): boolean {
+  return run.solverType === 'prediction.v1';
+}
+
+function taskIdentity(run: PersistedTaskRun): string {
+  return run.taskId ?? run.taskCid;
+}
+
+function distinctTaskCount(runs: readonly PersistedTaskRun[]): number {
+  return new Set(runs.map(taskIdentity)).size;
+}
+
+function latestAt(runs: readonly PersistedTaskRun[]): number | null {
+  if (runs.length === 0) return null;
+  return Math.max(...runs.map((run) => run.stateUpdatedAt));
+}
+
+function toSummary(run: PersistedTaskRun): PredictionV1TaskRunSummary {
+  return {
+    requestId: run.requestId,
+    taskId: run.taskId,
+    taskCid: run.taskCid,
+    state: run.state,
+    taskRole: run.taskRole,
+    implName: run.implName,
+    windowStartTs: run.windowStartTs,
+    windowEndTs: run.windowEndTs,
+    stateUpdatedAt: run.stateUpdatedAt,
+    manifestCid: run.manifestCid,
+    deliveryTxHash: run.deliveryTxHash,
+    failureReason: run.failureReason,
+  };
+}

--- a/client/src/api/status-build.ts
+++ b/client/src/api/status-build.ts
@@ -9,6 +9,7 @@ import {
 } from '../earning/types.js';
 import type { EarningMigrationArchive } from '../earning/store.js';
 import type { PortfolioV0Status } from './portfolio-v0-build.js';
+import type { PredictionV1Status } from './prediction-v1-build.js';
 
 const DEFAULT_MASTER_ETH_DAILY_WEI = 1_000_000_000_000_000n;
 
@@ -56,6 +57,8 @@ export interface GatheredStatusRaw {
   minMasterEthWei?: string;
   /** portfolio.v0 lifecycle data — populated by gather-status from the SQLite store. */
   portfolioV0?: PortfolioV0Status;
+  /** prediction.v1 operator/lifecycle data — populated by gather-status from the SQLite store. */
+  predictionV1?: PredictionV1Status;
   serviceBalances?: Record<number, { agentNativeWei: string; safeNativeWei: string; safeBondWei: string }>;
   /** Last balance fetch error per service (display index). Present when a fetch failed. */
   serviceBalanceErrors?: Record<number, ServiceBalanceErrorEntry>;
@@ -124,6 +127,8 @@ export interface StatusV1Response {
   nextActions: string[];
   /** portfolio.v0 lifecycle data — optional, absent when not available. */
   portfolioV0?: PortfolioV0Status;
+  /** prediction.v1 operator/lifecycle data — optional, absent when not available. */
+  predictionV1?: PredictionV1Status;
 }
 
 /**
@@ -354,5 +359,6 @@ export function assembleStatusV1(raw: GatheredStatusRaw): StatusV1Response {
     },
     nextActions: buildNextActions(raw, fleetSum),
     ...(raw.portfolioV0 !== undefined ? { portfolioV0: raw.portfolioV0 } : {}),
+    ...(raw.predictionV1 !== undefined ? { predictionV1: raw.predictionV1 } : {}),
   };
 }

--- a/client/src/dashboard/spa/src/regions/Operating.tsx
+++ b/client/src/dashboard/spa/src/regions/Operating.tsx
@@ -66,6 +66,63 @@ interface StatusV1 {
     }>;
     recentVerdicts?: Array<{ state: 'COMPLETE' | 'FAILED'; deliveryTxHash?: string | null }>;
   };
+  predictionV1?: {
+    operator?: {
+      ok: boolean;
+      solverNet?: {
+        name?: string;
+        enabled?: boolean;
+        solverType?: string;
+        harness?: string;
+        taskGeneratorEnabled?: boolean;
+      };
+      canonicalPlugin?: {
+        name?: string;
+        version?: string;
+        source?: string | null;
+      };
+      harness?: {
+        name: string;
+        version: string;
+        readiness?: {
+          ready: boolean;
+          reason?: string;
+        };
+      };
+      diagnostics?: Array<{
+        code: string;
+        severity: 'error' | 'warning' | 'info';
+        message: string;
+        configField?: string;
+      }>;
+      nextAction?: {
+        description: string;
+        cli?: string;
+      };
+    } | null;
+    operatorError?: string;
+    totals?: {
+      observedTasks?: number;
+      activeTaskRuns?: number;
+      solutions?: number;
+      verdicts?: number;
+      failed?: number;
+    };
+    latest?: {
+      taskAt?: number | null;
+      solutionAt?: number | null;
+      verdictAt?: number | null;
+    };
+    recentTasks?: Array<{
+      requestId: string;
+      taskId?: string | null;
+      state: string;
+      taskRole?: 'restoration' | 'evaluation' | null;
+      implName?: string | null;
+      stateUpdatedAt: number;
+      failureReason?: string | null;
+    }>;
+  };
 }
 
 const truncAddr = (s?: string): string =>
@@ -97,6 +154,13 @@ const formatOperatorStep = (step?: string): string => {
     default:
       return formatStep(step);
   }
+};
+
+const formatTimestamp = (ts?: number | null): string => {
+  if (ts === null || ts === undefined) return '—';
+  const ms = Math.abs(ts) >= 10_000_000_000 ? ts : ts * 1000;
+  const date = new Date(ms);
+  return Number.isNaN(date.getTime()) ? '—' : date.toLocaleString();
 };
 
 const sumWei = (values: Array<string | undefined>): string => {
@@ -142,6 +206,7 @@ export function Operating(): JSX.Element {
             masterAddress={status?.masterGas?.address ?? undefined}
             chain={status?.fleet?.chain}
           />
+          <PredictionPanel status={status} />
           <Actions status={status} onRefresh={() => { void refetch(); }} />
           <FleetWalletDetails status={status} />
           <Activity />
@@ -232,6 +297,157 @@ function Header({
         </div>
       </div>
     </header>
+  );
+}
+
+function PredictionPanel({ status }: { status?: StatusV1 }): JSX.Element {
+  const prediction = status?.predictionV1;
+  const operator = prediction?.operator;
+  const diagnostics = operator?.diagnostics ?? [];
+  const blockers = diagnostics.filter((diagnostic) => diagnostic.severity === 'error');
+  const warnings = diagnostics.filter((diagnostic) => diagnostic.severity === 'warning');
+  const ready = operator?.ok === true && !prediction?.operatorError;
+  const statusLabel = prediction
+    ? ready
+      ? 'Ready'
+      : 'Needs attention'
+    : 'Loading';
+  const statusColor = ready
+    ? 'var(--vow-green)'
+    : prediction
+      ? 'var(--wane)'
+      : 'var(--fg-dim)';
+  const pluginLabel = operator?.canonicalPlugin?.name
+    ? `${operator.canonicalPlugin.name}@${operator.canonicalPlugin.version ?? 'unknown'}`
+    : operator?.canonicalPlugin?.source ?? '—';
+  const harnessLabel = operator?.harness
+    ? `${operator.harness.name}@${operator.harness.version}`
+    : operator?.solverNet?.harness ?? '—';
+  const recentTasks = prediction?.recentTasks ?? [];
+
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <span className="j-label">Prediction SolverNet</span>
+        <span className="j-mono text-[10px]" style={{ color: statusColor }}>
+          {statusLabel}
+        </span>
+      </div>
+      <div className="j-card-bare overflow-hidden" style={{ background: 'var(--bg-elevated)' }}>
+        <div
+          className="px-5 py-4 grid grid-cols-2 md:grid-cols-5 gap-4"
+          style={{ borderBottom: '1px solid var(--border)' }}
+        >
+          <PredictionStat label="tasks" value={prediction?.totals?.observedTasks ?? 0} />
+          <PredictionStat label="active" value={prediction?.totals?.activeTaskRuns ?? 0} />
+          <PredictionStat label="solutions" value={prediction?.totals?.solutions ?? 0} />
+          <PredictionStat label="verdicts" value={prediction?.totals?.verdicts ?? 0} />
+          <PredictionStat label="failed" value={prediction?.totals?.failed ?? 0} tone="warn" />
+        </div>
+        <div
+          className="px-5 py-4 grid grid-cols-1 md:grid-cols-3 gap-4"
+          style={{ borderBottom: '1px solid var(--border)' }}
+        >
+          <PredictionDetail label="solver net" value={operator?.solverNet?.name ?? 'prediction'} />
+          <PredictionDetail label="harness" value={harnessLabel} />
+          <PredictionDetail label="plugin" value={pluginLabel} />
+          <PredictionDetail label="task generator" value={operator?.solverNet?.taskGeneratorEnabled ? 'enabled' : 'disabled'} />
+          <PredictionDetail label="latest solution" value={formatTimestamp(prediction?.latest?.solutionAt)} />
+          <PredictionDetail label="latest verdict" value={formatTimestamp(prediction?.latest?.verdictAt)} />
+        </div>
+        <div className="px-5 py-4 flex flex-col gap-3">
+          {prediction?.operatorError && (
+            <span className="j-mono text-xs" style={{ color: 'var(--break-red)' }}>
+              {prediction.operatorError}
+            </span>
+          )}
+          {blockers.length > 0 || warnings.length > 0 ? (
+            <div className="flex flex-col gap-2">
+              {[...blockers, ...warnings].slice(0, 3).map((diagnostic) => (
+                <div key={diagnostic.code} className="grid grid-cols-[88px_1fr] gap-3">
+                  <span
+                    className="j-label"
+                    style={{ color: diagnostic.severity === 'error' ? 'var(--break-red)' : 'var(--wane)' }}
+                  >
+                    {diagnostic.severity}
+                  </span>
+                  <span className="j-mono text-xs" style={{ color: 'var(--fg-muted)' }}>
+                    {diagnostic.message}
+                  </span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <span className="j-mono text-xs" style={{ color: 'var(--fg-muted)' }}>
+              {operator?.nextAction?.description ?? 'No Prediction task runs recorded yet.'}
+            </span>
+          )}
+          {operator?.nextAction?.cli && (
+            <span className="j-mono text-[11px]" style={{ color: 'var(--accent-sky)' }}>
+              {operator.nextAction.cli}
+            </span>
+          )}
+          {recentTasks.length > 0 && (
+            <div className="flex flex-col gap-2 pt-1">
+              {recentTasks.slice(0, 3).map((task) => (
+                <div
+                  key={task.requestId}
+                  className="grid grid-cols-[88px_1fr_auto] gap-3 items-baseline"
+                  style={{ color: 'var(--fg-muted)' }}
+                >
+                  <span className="j-label">{task.taskRole === 'evaluation' ? 'verdict' : 'solution'}</span>
+                  <span className="j-mono text-xs truncate">{task.taskId ?? task.requestId}</span>
+                  <span className="j-mono text-[10px]">{task.state.toLowerCase()}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function PredictionStat({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone?: 'default' | 'warn';
+}): JSX.Element {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="j-label">{label}</span>
+      <span
+        className="j-display tabular-nums"
+        style={{
+          fontSize: '28px',
+          lineHeight: 1,
+          color: tone === 'warn' && value > 0 ? 'var(--wane)' : 'var(--fg)',
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function PredictionDetail({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}): JSX.Element {
+  return (
+    <div className="flex flex-col gap-1 min-w-0">
+      <span className="j-label">{label}</span>
+      <span className="j-mono text-xs truncate" style={{ color: 'var(--fg)' }} title={value}>
+        {value}
+      </span>
+    </div>
   );
 }
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -25,7 +25,7 @@ import { homedir } from 'node:os';
 import { randomBytes as cryptoRandomBytes } from 'node:crypto';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import { loadConfig, getConfigPathFromArgs } from './config.js';
+import { loadConfig, getConfigPathFromArgs, DEFAULT_CONFIG_PATH } from './config.js';
 import { Store } from './store/store.js';
 import { startApiServer, type ApiServer } from './api/server.js';
 import { ensureUiToken } from './api/ui-token.js';
@@ -646,6 +646,8 @@ export async function main(): Promise<DaemonStartupInfo | void> {
         testnetMechDeploymentPath: config.testnetMechDeploymentPath,
         testnetStolasDeploymentPath: config.testnetStolasDeploymentPath,
         engine: config.engine,
+        config,
+        configPath: CONFIG_PATH ?? DEFAULT_CONFIG_PATH,
       },
     });
   } catch (error) {
@@ -1238,6 +1240,8 @@ export async function main(): Promise<DaemonStartupInfo | void> {
       testnetMechDeploymentPath: config.testnetMechDeploymentPath,
       testnetStolasDeploymentPath: config.testnetStolasDeploymentPath,
       engine: config.engine,
+      config,
+      configPath: CONFIG_PATH ?? DEFAULT_CONFIG_PATH,
     },
     rewardClaim:
       config.rewardClaimIntervalMs > 0

--- a/client/test/api/gather-status.test.ts
+++ b/client/test/api/gather-status.test.ts
@@ -1,0 +1,169 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { JinnConfig } from '../../src/config.js';
+import { TaskRunPersistence } from '../../src/harnesses/engine/persistence.js';
+import type { PredictionOperatorStatus } from '../../src/solver-nets/prediction-operator-ux.js';
+import { withTempStore } from '@test/store.js';
+
+describe('gatherStatusForApi', () => {
+  afterEach(() => {
+    vi.doUnmock('viem');
+    vi.doUnmock('../../src/solver-nets/prediction-operator-ux.js');
+    vi.resetModules();
+  });
+
+  function mockStatusRpc(): void {
+    vi.doMock('viem', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('viem')>();
+      return {
+        ...actual,
+        createPublicClient: () => ({
+          getBlockNumber: async () => {
+            throw new Error('rpc unavailable');
+          },
+          getChainId: async () => 84532,
+          getBalance: async () => 0n,
+          readContract: async () => 0n,
+        }),
+        http: () => ({}),
+      };
+    });
+  }
+
+  it('keeps core status available when prediction lifecycle rows cannot be read', async () => {
+    const { gatherStatusForApi } = await import('../../src/api/gather-status.js');
+
+    await withTempStore(async (store) => {
+      const persistence = new TaskRunPersistence(store.db);
+      persistence.insertDiscovered({
+        requestId: 'bad-prediction-row',
+        taskId: 'prediction-task',
+        taskCid: 'bafy-bad-prediction-row',
+        onchainCreationTx: '0xbad',
+        onchainCreationBlock: 1,
+        solverType: 'prediction.v1',
+        taskRole: 'restoration',
+        windowStartTs: 1_000,
+        windowEndTs: 2_000,
+        task: {
+          id: 'prediction-task',
+          description: 'bad prediction row',
+          solverType: 'prediction.v1',
+          role: 'restoration',
+        },
+      });
+      store.db.prepare(
+        `UPDATE task_runs
+         SET task_payload = ?
+         WHERE request_id = ?`,
+      ).run('{', 'bad-prediction-row');
+
+      const status = await gatherStatusForApi(store, undefined);
+
+      expect(status.statusMode).toBe('sqlite_only');
+      expect(status.predictionV1?.operator).toBeNull();
+      expect(status.predictionV1?.operatorError).toMatch(/Prediction lifecycle unavailable/);
+      expect(status.predictionV1?.totals).toEqual({
+        observedTasks: 0,
+        activeTaskRuns: 0,
+        solutions: 0,
+        verdicts: 0,
+        failed: 0,
+      });
+    });
+  });
+
+  it('reuses cached Prediction operator diagnostics for repeated status polls', async () => {
+    mockStatusRpc();
+    const buildPredictionOperatorStatus = vi.fn(async (): Promise<PredictionOperatorStatus> => ({
+      kind: 'prediction.v1.operatorStatus',
+      ok: true,
+      configPath: '/tmp/config.json',
+      solverNet: {
+        name: 'prediction',
+        enabled: true,
+        solverType: 'prediction.v1',
+        harness: 'prediction-v1-baseline',
+        taskGeneratorEnabled: true,
+      },
+      extraPlugins: [],
+      diagnostics: [],
+      nextAction: { description: 'Run', cli: 'jinn run' },
+    }));
+    vi.doMock('../../src/solver-nets/prediction-operator-ux.js', () => ({
+      buildPredictionOperatorStatus,
+    }));
+    const { gatherStatusForApi } = await import('../../src/api/gather-status.js');
+    const config = {
+      solverNets: {
+        prediction: {
+          enabled: true,
+          solverType: 'prediction.v1',
+          harness: 'prediction-v1-baseline',
+          taskGenerator: { enabled: true },
+        },
+      },
+    } as unknown as JinnConfig;
+
+    await withTempStore(async (store) => {
+      const status = {
+        earningDir: mkdtempSync(join(tmpdir(), 'jinn-status-test-')),
+        rpcUrl: 'http://127.0.0.1:0',
+        network: 'testnet' as const,
+        pollIntervalMs: 5000,
+        rewardClaimIntervalMs: 0,
+        config,
+        configPath: '/tmp/config.json',
+      };
+
+      await gatherStatusForApi(store, status);
+      await gatherStatusForApi(store, status);
+    });
+
+    expect(buildPredictionOperatorStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches Prediction operator diagnostic failures for repeated status polls', async () => {
+    mockStatusRpc();
+    const buildPredictionOperatorStatus = vi.fn(async () => {
+      throw new Error('plugin hash failed');
+    });
+    vi.doMock('../../src/solver-nets/prediction-operator-ux.js', () => ({
+      buildPredictionOperatorStatus,
+    }));
+    const { gatherStatusForApi } = await import('../../src/api/gather-status.js');
+    const config = {
+      solverNets: {
+        prediction: {
+          enabled: true,
+          solverType: 'prediction.v1',
+          harness: 'prediction-v1-baseline',
+          taskGenerator: { enabled: true },
+        },
+      },
+    } as unknown as JinnConfig;
+
+    await withTempStore(async (store) => {
+      const status = {
+        earningDir: mkdtempSync(join(tmpdir(), 'jinn-status-test-')),
+        rpcUrl: 'http://127.0.0.1:0',
+        network: 'testnet' as const,
+        pollIntervalMs: 5000,
+        rewardClaimIntervalMs: 0,
+        config,
+        configPath: '/tmp/config.json',
+      };
+
+      const first = await gatherStatusForApi(store, status);
+      const second = await gatherStatusForApi(store, status);
+
+      expect(first.predictionV1?.operator?.ok).toBe(false);
+      expect(first.predictionV1?.operator?.diagnostics[0]?.message).toBe('plugin hash failed');
+      expect(second.predictionV1?.operator?.diagnostics[0]?.message).toBe('plugin hash failed');
+    });
+
+    expect(buildPredictionOperatorStatus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/test/api/prediction-v1-build.test.ts
+++ b/client/test/api/prediction-v1-build.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import { withTempStore } from '@test/store.js';
+import { gatherPredictionV1Status } from '../../src/api/prediction-v1-build.js';
+import { TaskRunPersistence } from '../../src/harnesses/engine/persistence.js';
+import type { Store } from '../../src/store/store.js';
+
+function seedPredictionRun(
+  store: Store,
+  persistence: TaskRunPersistence,
+  input: {
+    requestId: string;
+    taskId?: string;
+    taskRole?: 'restoration' | 'evaluation';
+    state?: 'DISCOVERED' | 'COMPLETE' | 'FAILED';
+    stateUpdatedAt?: number;
+    solverType?: string;
+  },
+): void {
+  persistence.insertDiscovered({
+    requestId: input.requestId,
+    taskId: input.taskId ?? 'prediction-task-1',
+    taskCid: `bafy-${input.requestId}`,
+    onchainCreationTx: `0xtx-${input.requestId}`,
+    onchainCreationBlock: 1,
+    solverType: input.solverType ?? 'prediction.v1',
+    taskRole: input.taskRole ?? 'restoration',
+    windowStartTs: 1_000,
+    windowEndTs: 2_000,
+    task: {
+      id: input.taskId ?? 'prediction-task-1',
+      description: 'prediction test task',
+      solverType: input.solverType ?? 'prediction.v1',
+      role: input.taskRole ?? 'restoration',
+    },
+  });
+  if (input.state && input.state !== 'DISCOVERED') {
+    persistence.markFailed(input.requestId, 'temporary');
+    if (input.state === 'COMPLETE') {
+      store.db.prepare(
+        `UPDATE task_runs
+         SET state = 'COMPLETE',
+             state_updated_at = ?,
+             failure_reason = NULL,
+             failure_at = NULL,
+             manifest_cid = ?,
+             delivery_tx_hash = ?
+         WHERE request_id = ?`,
+      ).run(input.stateUpdatedAt ?? Date.now(), `bafy-manifest-${input.requestId}`, `0xdelivery-${input.requestId}`, input.requestId);
+    } else {
+      store.db.prepare(
+        `UPDATE task_runs
+         SET state_updated_at = ?
+         WHERE request_id = ?`,
+      ).run(input.stateUpdatedAt ?? Date.now(), input.requestId);
+    }
+  } else if (input.stateUpdatedAt !== undefined) {
+    store.db.prepare(
+      `UPDATE task_runs SET state_updated_at = ? WHERE request_id = ?`,
+    ).run(input.stateUpdatedAt, input.requestId);
+  }
+}
+
+describe('gatherPredictionV1Status', () => {
+  it('returns empty lifecycle rows when no prediction tasks exist', async () => {
+    await withTempStore(async (store) => {
+      const result = gatherPredictionV1Status(store);
+      expect(result.operator).toBeNull();
+      expect(result.totals).toEqual({
+        observedTasks: 0,
+        activeTaskRuns: 0,
+        solutions: 0,
+        verdicts: 0,
+        failed: 0,
+      });
+      expect(result.recentTasks).toEqual([]);
+    });
+  });
+
+  it('counts prediction Tasks, Solutions, Verdicts, and failures from task_runs', async () => {
+    await withTempStore(async (store) => {
+      const persistence = new TaskRunPersistence(store.db);
+      seedPredictionRun(store, persistence, {
+        requestId: 'solution-a',
+        taskId: 'shared-task',
+        state: 'COMPLETE',
+        stateUpdatedAt: 10,
+      });
+      seedPredictionRun(store, persistence, {
+        requestId: 'solution-b',
+        taskId: 'shared-task',
+        state: 'DISCOVERED',
+        stateUpdatedAt: 20,
+      });
+      seedPredictionRun(store, persistence, {
+        requestId: 'verdict-a',
+        taskId: 'shared-task',
+        taskRole: 'evaluation',
+        state: 'COMPLETE',
+        stateUpdatedAt: 30,
+      });
+      seedPredictionRun(store, persistence, {
+        requestId: 'failed-a',
+        taskId: 'other-task',
+        state: 'FAILED',
+        stateUpdatedAt: 40,
+      });
+      seedPredictionRun(store, persistence, {
+        requestId: 'portfolio-a',
+        taskId: 'portfolio-task',
+        state: 'COMPLETE',
+        stateUpdatedAt: 50,
+        solverType: 'portfolio.v0',
+      });
+
+      const result = gatherPredictionV1Status(store, {
+        operator: {
+          kind: 'prediction.v1.operatorStatus',
+          ok: true,
+          configPath: '/tmp/config.json',
+          solverNet: {
+            name: 'prediction',
+            enabled: true,
+            solverType: 'prediction.v1',
+            harness: 'prediction-v1-baseline',
+            taskGeneratorEnabled: true,
+          },
+          extraPlugins: [],
+          diagnostics: [],
+          nextAction: { description: 'Run', cli: 'jinn run' },
+        },
+      });
+
+      expect(result.operator?.ok).toBe(true);
+      expect(result.totals).toEqual({
+        observedTasks: 2,
+        activeTaskRuns: 1,
+        solutions: 1,
+        verdicts: 1,
+        failed: 1,
+      });
+      expect(result.latest).toEqual({
+        taskAt: 40,
+        solutionAt: 10,
+        verdictAt: 30,
+      });
+      expect(result.recentTasks.map((task) => task.requestId)).toEqual([
+        'failed-a',
+        'verdict-a',
+        'solution-b',
+        'solution-a',
+      ]);
+      expect(result.recentSolutions[0]).toMatchObject({
+        requestId: 'solution-a',
+        taskRole: 'restoration',
+        manifestCid: 'bafy-manifest-solution-a',
+      });
+      expect(result.recentVerdicts[0]).toMatchObject({
+        requestId: 'verdict-a',
+        taskRole: 'evaluation',
+      });
+    });
+  });
+});

--- a/client/test/api/status-build.test.ts
+++ b/client/test/api/status-build.test.ts
@@ -151,4 +151,41 @@ describe('assembleStatusV1', () => {
     expect(j.rewards.claimedStakingRewardsWei).toBe('800');
     expect(j.rewards.totalStakingRewardsWei).toBe('1000');
   });
+
+  it('passes prediction.v1 status through when present', () => {
+    const raw: GatheredStatusRaw = {
+      shutdownState: 'running',
+      dbPath: '/tmp/x.db',
+      activityCounts: {},
+      recentActivity: [],
+      lastRewardClaimTickAt: null,
+      rewardClaimIntervalMs: 0,
+      fleet: minimalFleet(),
+      rpc: { ok: true, chainId: 8453, blockNumber: '1' },
+      master: { address: '0x1111111111111111111111111111111111111111' },
+      pollIntervalMs: 5000,
+      masterDailyEstimateWei: '1',
+      predictionV1: {
+        operator: null,
+        totals: {
+          observedTasks: 1,
+          activeTaskRuns: 0,
+          solutions: 1,
+          verdicts: 0,
+          failed: 0,
+        },
+        latest: {
+          taskAt: 100,
+          solutionAt: 100,
+          verdictAt: null,
+        },
+        recentTasks: [],
+        recentSolutions: [],
+        recentVerdicts: [],
+      },
+    };
+    const j = assembleStatusV1(raw);
+    expect(j.predictionV1?.totals.solutions).toBe(1);
+    expect(j.predictionV1?.latest.solutionAt).toBe(100);
+  });
 });

--- a/client/test/cli/commands/solver-nets.test.ts
+++ b/client/test/cli/commands/solver-nets.test.ts
@@ -3,6 +3,13 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import solverNetsCommand from '@/cli/commands/solver-nets.js';
+import { loadConfig, type JinnConfig } from '@/config.js';
+import type { Harness, RuntimePlugin } from '@/harnesses/types.js';
+import {
+  buildPredictionOperatorStatus,
+  runPredictionSample,
+  type PredictionOperatorDiagnostic,
+} from '@/solver-nets/prediction-operator-ux.js';
 import { makeCommandCtx } from '@test/cli.js';
 
 function tempConfig(values: Record<string, unknown> = {}): string {
@@ -35,6 +42,81 @@ async function runSolverNets(argv: string[]): Promise<{ envelope: Record<string,
     envelope: JSON.parse(made.writes.join('')) as Record<string, any>,
     exits: made.exits,
   };
+}
+
+const predictionPlugin: RuntimePlugin = {
+  role: 'canonical',
+  name: '@jinn-network/prediction-plugin',
+  version: '0.2.0',
+  supports: ['prediction.v1'],
+  root: '/test/prediction-plugin',
+  manifestPath: '/test/prediction-plugin/plugin.json',
+  sha256: '0'.repeat(64),
+};
+
+function stubHarness(
+  overrides: Partial<Harness> & Pick<Harness, 'name'>,
+): Harness {
+  return {
+    name: overrides.name,
+    version: overrides.version ?? '1.0.0',
+    supports: overrides.supports ?? (() => true),
+    isReady: overrides.isReady,
+    async run() {
+      throw new Error('stub Harness should not run in operator status tests');
+    },
+  };
+}
+
+function loadPredictionTestConfig(
+  overrides: Record<string, unknown> = {},
+  mutate?: (config: JinnConfig) => void,
+): { config: JinnConfig; configPath: string } {
+  const configPath = tempConfig(predictionConfig(overrides));
+  const config = loadConfig(configPath);
+  mutate?.(config);
+  return { config, configPath };
+}
+
+const operatorStatusDeps = {
+  loadSolverNets: async () => ({
+    get: (name: string) => name === 'prediction'
+      ? {
+          name: 'prediction',
+          enabled: true,
+          solverType: 'prediction.v1',
+          canonicalPlugin: predictionPlugin,
+          plugins: [],
+          taskGenerator: { enabled: true },
+        }
+      : undefined,
+  }),
+  loadExternalImpl: async () => ({ kind: 'error', reason: 'not configured' }),
+  buildHarnesses: () => [
+    stubHarness({ name: 'claude-code-learner' }),
+    stubHarness({ name: 'prediction-v1-baseline' }),
+  ],
+} satisfies Partial<Parameters<typeof buildPredictionOperatorStatus>[0]>;
+
+function expectDiagnosticContract(
+  diagnostic: PredictionOperatorDiagnostic,
+  expected: { code: string; severity: PredictionOperatorDiagnostic['severity']; configField?: string },
+): void {
+  expect(diagnostic).toEqual(expect.objectContaining({
+    code: expected.code,
+    severity: expected.severity,
+    message: expect.any(String),
+    nextAction: expect.objectContaining({
+      description: expect.any(String),
+    }),
+  }));
+  expect(diagnostic.message.length).toBeGreaterThan(0);
+  expect(diagnostic.nextAction?.description.length).toBeGreaterThan(0);
+  if (expected.configField) {
+    expect(diagnostic.configField).toBe(expected.configField);
+  } else {
+    expect(diagnostic).not.toHaveProperty('configField');
+  }
 }
 
 describe('solver-nets command', () => {
@@ -198,5 +280,202 @@ describe('solver-nets command', () => {
         }),
       ]),
     );
+  });
+
+  it.each([
+    {
+      label: 'disabled SolverNet',
+      fatalForSolvingNow: true,
+      warningForGeneratorOrDashboardCompleteness: false,
+      expectedOk: false,
+      expected: {
+        code: 'prediction_solvernet_disabled',
+        severity: 'error' as const,
+        configField: 'solverNets.prediction.enabled',
+      },
+      config: () => loadPredictionTestConfig({ enabled: false }),
+    },
+    {
+      label: 'invalid canonical plugin',
+      fatalForSolvingNow: true,
+      warningForGeneratorOrDashboardCompleteness: false,
+      expectedOk: false,
+      expected: {
+        code: 'prediction_plugin_unavailable',
+        severity: 'error' as const,
+        configField: 'solverNets.prediction.canonicalPlugin',
+      },
+      deps: {
+        loadSolverNets: async () => {
+          throw new Error('Cannot resolve SolverPlugin npm:@jinn-network/missing-prediction-plugin');
+        },
+      },
+      config: () => loadPredictionTestConfig({
+        canonicalPlugin: 'npm:@jinn-network/missing-prediction-plugin',
+      }),
+    },
+    {
+      label: 'missing canonical plugin',
+      fatalForSolvingNow: true,
+      warningForGeneratorOrDashboardCompleteness: false,
+      expectedOk: false,
+      expected: {
+        code: 'prediction_plugin_unavailable',
+        severity: 'error' as const,
+        configField: 'solverNets.prediction.canonicalPlugin',
+      },
+      deps: {
+        loadSolverNets: async () => {
+          throw new Error('Prediction SolverNet canonicalPlugin is missing');
+        },
+      },
+      config: () => loadPredictionTestConfig({}, (config) => {
+        config.solverNets.prediction.canonicalPlugin = undefined as unknown as string;
+      }),
+    },
+    {
+      label: 'unsupported canonical plugin solverType mismatch',
+      fatalForSolvingNow: true,
+      warningForGeneratorOrDashboardCompleteness: false,
+      expectedOk: false,
+      expected: {
+        code: 'prediction_plugin_unavailable',
+        severity: 'error' as const,
+        configField: 'solverNets.prediction.canonicalPlugin',
+      },
+      deps: {
+        loadSolverNets: async () => {
+          throw new Error('SolverNet prediction solverType mismatch: config=prediction.v1 plugin supports=portfolio.v0');
+        },
+      },
+      config: () => loadPredictionTestConfig({
+        canonicalPlugin: 'bundled:portfolio-v0-plugin',
+      }),
+    },
+    {
+      label: 'SolverNet solverType mismatch',
+      fatalForSolvingNow: true,
+      warningForGeneratorOrDashboardCompleteness: false,
+      expectedOk: false,
+      expected: {
+        code: 'prediction_solver_type_mismatch',
+        severity: 'error' as const,
+        configField: 'solverNets.prediction.solverType',
+      },
+      config: () => loadPredictionTestConfig({ solverType: 'portfolio.v0' }),
+    },
+    {
+      label: 'missing Harness selection',
+      fatalForSolvingNow: true,
+      warningForGeneratorOrDashboardCompleteness: false,
+      expectedOk: false,
+      expected: {
+        code: 'prediction_harness_missing',
+        severity: 'error' as const,
+        configField: 'solverNets.prediction.harness',
+      },
+      config: () => loadPredictionTestConfig({}, (config) => {
+        config.solverNets.prediction.harness = undefined as unknown as string;
+      }),
+    },
+    {
+      label: 'unknown Harness selection',
+      fatalForSolvingNow: true,
+      warningForGeneratorOrDashboardCompleteness: false,
+      expectedOk: false,
+      expected: {
+        code: 'prediction_harness_unknown',
+        severity: 'error' as const,
+        configField: 'solverNets.prediction.harness',
+      },
+      config: () => loadPredictionTestConfig({ harness: 'not-installed-prediction-harness' }),
+    },
+    {
+      label: 'unsupported Harness selection',
+      fatalForSolvingNow: true,
+      warningForGeneratorOrDashboardCompleteness: false,
+      expectedOk: false,
+      expected: {
+        code: 'prediction_harness_unsupported',
+        severity: 'error' as const,
+        configField: 'solverNets.prediction.harness',
+      },
+      deps: {
+        buildHarnesses: () => [
+          stubHarness({
+            name: 'prediction-v1-evaluator-only',
+            supports: () => false,
+          }),
+        ],
+      },
+      config: () => loadPredictionTestConfig({ harness: 'prediction-v1-evaluator-only' }),
+    },
+    {
+      label: 'non-ready Harness selection',
+      fatalForSolvingNow: false,
+      warningForGeneratorOrDashboardCompleteness: true,
+      expectedOk: true,
+      expected: {
+        code: 'prediction_harness_not_ready',
+        severity: 'warning' as const,
+        configField: 'solverNets.prediction.harness',
+      },
+      deps: {
+        buildHarnesses: () => [
+          stubHarness({
+            name: 'prediction-v1-needs-daemon',
+            isReady: async () => ({
+              ready: false,
+              reason: 'requires live daemon',
+              nextStep: { description: 'Start the daemon.', cli: 'jinn run' },
+            }),
+          }),
+        ],
+      },
+      config: () => loadPredictionTestConfig({ harness: 'prediction-v1-needs-daemon' }),
+    },
+    {
+      label: 'disabled task generator',
+      fatalForSolvingNow: false,
+      warningForGeneratorOrDashboardCompleteness: true,
+      expectedOk: true,
+      expected: {
+        code: 'prediction_task_generator_disabled',
+        severity: 'warning' as const,
+        configField: 'solverNets.prediction.taskGenerator.enabled',
+      },
+      config: () => loadPredictionTestConfig({ taskGenerator: { enabled: false } }),
+    },
+  ])(
+    'documents Prediction operator diagnostic matrix row: $label',
+    async ({ config: load, deps, expected, expectedOk, fatalForSolvingNow, warningForGeneratorOrDashboardCompleteness }) => {
+      expect(typeof fatalForSolvingNow).toBe('boolean');
+      expect(typeof warningForGeneratorOrDashboardCompleteness).toBe('boolean');
+
+      const { config, configPath } = load();
+      const status = await buildPredictionOperatorStatus({
+        config,
+        configPath,
+        ...operatorStatusDeps,
+        ...deps,
+      });
+      const diagnostic = status.diagnostics.find((candidate) => candidate.code === expected.code);
+
+      expect(status.ok).toBe(expectedOk);
+      expect(diagnostic).toBeDefined();
+      expectDiagnosticContract(diagnostic!, expected);
+    },
+  );
+
+  it('reports insufficient sample task windows with a complete non-config diagnostic', async () => {
+    const sample = await runPredictionSample({ closedWindow: true });
+    const diagnostic = sample.diagnostics.find((candidate) => candidate.code === 'prediction_sample_cannot_attempt');
+
+    expect(sample.ok).toBe(false);
+    expect(sample.solution).toBeUndefined();
+    expectDiagnosticContract(diagnostic!, {
+      code: 'prediction_sample_cannot_attempt',
+      severity: 'error',
+    });
   });
 });


### PR DESCRIPTION
## Summary

Adds the Prediction SolverNet operator UX/status slices for `jinn-mono-l2zl.6.3` and `jinn-mono-l2zl.6.4`.

- Adds a `predictionV1` section to `/v1/status` using the shared Prediction operator diagnostics builder.
- Derives recent prediction.v1 Task/Solution/Verdict counts and timestamps from `task_runs`.
- Renders a compact Prediction SolverNet panel in the operator SPA with SolverNet, Harness, plugin, generator, blockers, next action, and recent task rows.
- Adds API assembly and lifecycle aggregation tests.
- Adds a table-driven Prediction participation diagnostics matrix covering disabled SolverNet, missing/invalid canonical plugin, plugin/solverType mismatch, missing/unknown/unsupported/non-ready Harness, disabled task generator, and insufficient sample task window.

## Validation

- `yarn vitest run test/api/prediction-v1-build.test.ts test/api/status-build.test.ts`
- `yarn vitest run test/cli/commands/status.test.ts test/cli/commands/solver-nets.test.ts test/api/status-rollup-build.test.ts`
- `yarn vitest run test/cli/commands/solver-nets.test.ts`
- `yarn vitest run test/api/prediction-v1-build.test.ts test/api/status-build.test.ts test/api/status-rollup-build.test.ts test/cli/commands/status.test.ts test/cli/commands/solver-nets.test.ts`
- `yarn typecheck`
- `yarn tsc --noEmit`
- `yarn build:spa`

## Beads

- Closed `jinn-mono-l2zl.6.3`.
- Closed `jinn-mono-l2zl.6.4`.
- Closed parent `jinn-mono-l2zl.6`.
- Updated `jinn-mono-l2zl` notes to sequence the remaining corpus learner / builder onboarding lanes.