### PR TITLE
fix(client): make onboarding faucet loop reach the bootstrap target

### DIFF
--- a/client/src/api/setup-endpoints.ts
+++ b/client/src/api/setup-endpoints.ts
@@ -157,7 +157,6 @@ export function addSetupRoutes(app: Hono, config: SetupRoutesConfig = {}): void 
     }
 
     const requestFunding = config.requestFunding ?? requestTestnetFunding;
-    const maxFaucetIters = config.maxFaucetIters ?? 60;
     const interDripPauseMs = config.interDripPauseMs ?? 1_000;
     const targetWei = config.minEoaGasWei ? BigInt(config.minEoaGasWei) : null;
     const publicClient = config.rpcUrl
@@ -167,6 +166,23 @@ export function addSetupRoutes(app: Hono, config: SetupRoutesConfig = {}): void 
     const getBalance = async (): Promise<bigint | null> => {
       if (!publicClient) return null;
       return publicClient.getBalance({ address: address as `0x${string}` });
+    };
+
+    // Cap is dynamic: derived from how far the balance is from the target so
+    // the loop is mathematically able to reach it. Each CDP drip is ~0.0001
+    // ETH; we use a 2x safety multiplier and a 60-drip floor so this is at
+    // least as permissive as the prior fixed cap. Hard ceiling at 500 to
+    // bound rogue scenarios. Rate-limit / error responses still exit early.
+    const computeCap = (balance: bigint | null): number => {
+      const ESTIMATED_DRIP_WEI = 100_000_000_000_000n; // 0.0001 ETH (conservative)
+      const SAFETY_MULT = 2n;
+      const FLOOR = 60;
+      const CEIL = 500;
+      if (config.maxFaucetIters !== undefined) return config.maxFaucetIters;
+      if (targetWei === null || balance === null || balance >= targetWei) return FLOOR;
+      const remaining = targetWei - balance;
+      const computed = Number((remaining / ESTIMATED_DRIP_WEI) * SAFETY_MULT) + 20;
+      return Math.max(FLOOR, Math.min(computed, CEIL));
     };
 
     try {
@@ -183,6 +199,7 @@ export function addSetupRoutes(app: Hono, config: SetupRoutesConfig = {}): void 
         });
       }
 
+      const maxFaucetIters = computeCap(balanceWei);
       for (let i = 0; i < maxFaucetIters; i++) {
         const result = await requestFunding(address, 'base-sepolia');
         if (!result.ok) {

--- a/client/src/dashboard/spa/src/regions/AwaitingFundingCard.tsx
+++ b/client/src/dashboard/spa/src/regions/AwaitingFundingCard.tsx
@@ -98,6 +98,23 @@ export function AwaitingFundingCard({
       ? dripStatus.txHashes?.length ?? dripStatus.attempts ?? (dripStatus.txHash ? 1 : 0)
       : 0;
 
+  // The /v1/setup/drip endpoint returns ok:true whenever any drips landed,
+  // even if the balance is still under target. Treat 'sent' as terminal only
+  // when the balance has actually cleared the target — otherwise let the user
+  // click again to top up the gap.
+  const targetReached =
+    dripStatus.state === 'sent' &&
+    dripStatus.balanceWei !== undefined &&
+    dripStatus.targetWei !== undefined &&
+    (() => {
+      try {
+        return BigInt(dripStatus.balanceWei!) >= BigInt(dripStatus.targetWei!);
+      } catch {
+        return false;
+      }
+    })();
+  const partialDrip = dripStatus.state === 'sent' && !targetReached;
+
   return (
     <div
       className="px-6 py-5 flex flex-col gap-4"
@@ -127,7 +144,7 @@ export function AwaitingFundingCard({
         <button
           onClick={requestDrip}
           type="button"
-          disabled={dripStatus.state === 'requesting' || dripStatus.state === 'sent'}
+          disabled={dripStatus.state === 'requesting' || targetReached}
           className="px-3 py-1.5 j-label hover:opacity-90 disabled:opacity-50"
           style={{
             background: 'var(--accent-gold)',
@@ -137,9 +154,11 @@ export function AwaitingFundingCard({
         >
           {dripStatus.state === 'requesting'
             ? 'Funding...'
-            : dripStatus.state === 'sent'
+            : targetReached
               ? 'Faucet funded'
-              : 'Fund from faucet'}
+              : partialDrip
+                ? 'Fund more'
+                : 'Fund from faucet'}
         </button>
         <button
           onClick={copy}
@@ -169,12 +188,16 @@ export function AwaitingFundingCard({
         </a>
       </div>
       {dripStatus.state === 'sent' && (
-        <p className="j-mono text-[11px]" style={{ color: 'var(--vow-green)' }}>
-          Faucet funding complete
+        <p
+          className="j-mono text-[11px]"
+          style={{ color: targetReached ? 'var(--vow-green)' : 'var(--accent-gold)' }}
+        >
+          {targetReached ? 'Faucet funding complete' : 'Faucet funding partial'}
           {sentTxCount > 0 ? ` (${sentTxCount} drip${sentTxCount === 1 ? '' : 's'})` : ''}.
           {dripStatus.balanceWei && dripStatus.targetWei
             ? ` Balance ${formatEth(dripStatus.balanceWei)} / target ${formatEth(dripStatus.targetWei)}.`
             : ''}
+          {partialDrip ? ' Click "Fund more" to top up.' : ''}
           {dripStatus.txHash && (
             <>
               {' '}

--- a/client/src/earning/bootstrap.ts
+++ b/client/src/earning/bootstrap.ts
@@ -282,17 +282,25 @@ export class FleetBootstrapper {
       };
 
       // On testnet, drain the CDP faucet in a loop until master has enough ETH.
-      // CDP's drip is tiny (~0.0001 ETH) vs the 0.005 ETH bootstrap floor — a
-      // single drip is never enough, and the older two-drip pattern forced
-      // operators to re-run `jinn bootstrap` 25+ times. We loop until funded,
-      // rate-limited, or an error. Cap at 60 iterations as a safety bound.
+      // CDP's drip is tiny (~0.0001 ETH) vs a 0.005-0.010 ETH bootstrap floor —
+      // a single drip is never enough, and a fixed cap of 60 was below the
+      // fresh-fleet target (0.010 ETH on first bootstrap), so onboarding could
+      // never auto-complete. The cap is now derived from the actual gap so the
+      // loop is guaranteed to be able to reach the target; rate-limit / error
+      // responses still terminate early.
       if (systemEth < requiredMasterEth && this.chain === 'base-sepolia' && autoFaucetEnabled) {
-        const MAX_FAUCET_ITERS = 60;
+        const ESTIMATED_DRIP_WEI = 100_000_000_000_000n; // 0.0001 ETH (conservative)
+        const SAFETY_MULT = 2n;
+        const FLOOR = 60;
+        const CEIL = 500;
+        const remaining = requiredMasterEth - systemEth;
+        const computed = Number((remaining / ESTIMATED_DRIP_WEI) * SAFETY_MULT) + 20;
+        const MAX_FAUCET_ITERS = Math.max(FLOOR, Math.min(computed, CEIL));
         const INTER_DRIP_PAUSE_MS = 1_000;
         console.error(
           `[fleet-bootstrap] Master has ${formatEther(systemEth)} ETH; need ${formatEther(requiredMasterEth)} ETH. ` +
           `Draining CDP faucet on ${this.chain} via ${rpcHostForDisplay(this.config.rpcUrl)} ` +
-          `(each drip ≈ 0.0001 ETH, up to ${MAX_FAUCET_ITERS} drips; expect ~30-60 s on first run).`,
+          `(each drip ≈ 0.0001 ETH, up to ${MAX_FAUCET_ITERS} drips; expect ~30-90 s on first run).`,
         );
         for (let i = 0; i < MAX_FAUCET_ITERS; i++) {
           const faucetResult = await this.requestFunding(masterAddress, 'base-sepolia');


### PR DESCRIPTION
## Summary

Fresh-fleet onboarding could never auto-complete because the CDP faucet drip cap (60 × ~0.0001 ETH = 0.006 ETH) is below the effective bootstrap target (0.010 ETH on first fleet, from \`minEoaGasEth: 0.005 ETH\` × \`STANDARD_MASTER_BOOTSTRAP_MULTIPLIER\` of 2). The SPA's "Fund from faucet" button also became permanently disabled after a partial drip round, so the user couldn't even retry without restarting the daemon.

This PR fixes both:

- **`bootstrap.ts`**: `MAX_FAUCET_ITERS` is now derived from \`(target − balance) × 2\` with a 60-drip floor and 500-drip ceiling. The loop is mathematically able to reach the actual target; rate-limit / error responses still exit early.
- **`setup-endpoints.ts`**: same dynamic cap inside \`POST /v1/setup/drip\`. Existing \`config.maxFaucetIters\` override still wins, so existing tests pass unchanged.
- **`AwaitingFundingCard.tsx`**: the endpoint already returned \`balanceWei\` and \`targetWei\` — the SPA now uses them. The button stays clickable as **"Fund more"** when \`balance < target\` and only shows **"Faucet funded"** + disabled state when the target is actually reached. Status copy flips between "Faucet funding partial" and "Faucet funding complete" to match.

## Repro before this PR

1. Fresh \`JINN_EARNING_DIR\`, run \`jinn run\` on Base Sepolia.
2. Open the SPA, click "Fund from faucet".
3. Loop runs 60 drips, balance lands at ~0.006 ETH, button becomes disabled with label "Faucet funded".
4. \`/v1/bootstrap\` reports \`currentStep: awaiting_funding\` forever; daemon log shows \`[main] Awaiting funding... (Ns elapsed; will retry in 15s)\` indefinitely.

## After

1. Same fresh setup → click "Fund from faucet" → loop sizes itself to clear the gap (about ~120 drips on a fresh wallet) → balance reaches 0.010 ETH → bootstrap auto-advances to \`safe_deployed\` → SPA flips to "Joining Jinn".
2. If the loop is interrupted (rate limit, transient faucet error), the button reads "Fund more" with the current balance/target gap surfaced; clicking again re-issues the drip from where the balance is.

## Test plan

- [x] \`yarn typecheck\` (clean)
- [x] \`yarn build\` (TS + SPA)
- [x] \`yarn vitest run test/api/setup-endpoints.test.ts test/earning/bootstrap.test.ts\` — 27/27 pass
- [ ] Manual: fresh Base Sepolia operator on this branch reaches \`complete\` without operator intervention beyond the single faucet click.

## Notes

- The existing `setup-endpoints` test passes \`maxFaucetIters: 3\` explicitly via config; my dynamic-cap path early-returns when that override is set, so the test is unchanged.
- The dynamic cap uses \`100_000_000_000_000n\` (0.0001 ETH) as the conservative drip estimate; if CDP changes its drip size we can rebalance the multiplier without touching call sites.
- Out of scope: the hardcoded \`minEoaGasEth\` / \`STANDARD_MASTER_BOOTSTRAP_MULTIPLIER\` themselves — those are protocol-level values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)