### PR TITLE
fix(client/faucet): size drip cap to clear bootstrap target

### DIFF
--- a/client/src/api/setup-endpoints.ts
+++ b/client/src/api/setup-endpoints.ts
@@ -26,7 +26,11 @@ import { dirname, join } from 'node:path';
 import { z } from 'zod';
 import { FleetStateStore } from '../earning/store.js';
 import { decryptMnemonic, encryptMnemonic } from '../earning/wallet.js';
-import { requestTestnetFunding } from '../earning/faucet.js';
+import {
+  DEFAULT_FAUCET_LOOP_TIMEOUT_MS,
+  computeFaucetDripCap,
+  requestTestnetFunding,
+} from '../earning/faucet.js';
 import { createJinnPublicClient, type JinnOnchainNetwork } from '../earning/viem-clients.js';
 import { detectAuthContext, probeClaudeAuth } from '../preflight/claude-auth.js';
 import { checkClaudeBinary, type ClaudeBinaryCheckResult } from '../preflight/claude-binary.js';
@@ -60,6 +64,14 @@ export interface SetupRoutesConfig {
   requestFunding?: typeof requestTestnetFunding;
   maxFaucetIters?: number;
   interDripPauseMs?: number;
+  /**
+   * Wall-clock cutoff for the drip loop. Mirrors the role of `maxFaucetIters`
+   * but in time rather than iterations — both are safety rails; the real exit
+   * conditions are reaching `minEoaGasWei` or the faucet rate-limiting.
+   */
+  faucetLoopTimeoutMs?: number;
+  /** Now-source override for tests. */
+  now?: () => number;
 }
 
 export function addSetupRoutes(app: Hono, config: SetupRoutesConfig = {}): void {
@@ -157,12 +169,13 @@ export function addSetupRoutes(app: Hono, config: SetupRoutesConfig = {}): void 
     }
 
     const requestFunding = config.requestFunding ?? requestTestnetFunding;
-    const maxFaucetIters = config.maxFaucetIters ?? 60;
     const interDripPauseMs = config.interDripPauseMs ?? 1_000;
     const targetWei = config.minEoaGasWei ? BigInt(config.minEoaGasWei) : null;
     const publicClient = config.rpcUrl
       ? createJinnPublicClient(config.rpcUrl, 'base-sepolia')
       : null;
+    const now = config.now ?? Date.now;
+    const loopTimeoutMs = config.faucetLoopTimeoutMs ?? DEFAULT_FAUCET_LOOP_TIMEOUT_MS;
 
     const getBalance = async (): Promise<bigint | null> => {
       if (!publicClient) return null;
@@ -183,7 +196,33 @@ export function addSetupRoutes(app: Hono, config: SetupRoutesConfig = {}): void 
         });
       }
 
+      // Size the iteration cap to actually reach the target (≈0.0001 ETH per
+      // drip). The hard exits are still: target reached, faucet rate-limited,
+      // wall-clock deadline. The cap just prevents an unbounded loop if the
+      // estimate is wildly off in either direction.
+      const maxFaucetIters = computeFaucetDripCap({
+        override: config.maxFaucetIters,
+        targetWei,
+        balanceWei,
+      });
+      const deadline = now() + loopTimeoutMs;
+
       for (let i = 0; i < maxFaucetIters; i++) {
+        if (now() >= deadline) {
+          return c.json(
+            {
+              ok: txHashes.length > 0,
+              address,
+              txHash: txHashes.at(-1),
+              txHashes,
+              attempts: i,
+              balanceWei: balanceWei?.toString(),
+              targetWei: targetWei?.toString(),
+              reason: 'faucet_loop_timeout',
+            },
+            txHashes.length > 0 ? 202 : 200,
+          );
+        }
         const result = await requestFunding(address, 'base-sepolia');
         if (!result.ok) {
           return c.json(

--- a/client/src/earning/bootstrap.ts
+++ b/client/src/earning/bootstrap.ts
@@ -73,7 +73,11 @@ import {
   previousSafeBeingAbandoned,
   sweepOrphanedServiceFunds,
 } from './orphan-sweep.js';
-import { requestTestnetFunding } from './faucet.js';
+import {
+  DEFAULT_FAUCET_LOOP_TIMEOUT_MS,
+  computeFaucetDripCap,
+  requestTestnetFunding,
+} from './faucet.js';
 import {
   flattenErrorMessage,
   viemSendTransactionWithRetry,
@@ -282,19 +286,36 @@ export class FleetBootstrapper {
       };
 
       // On testnet, drain the CDP faucet in a loop until master has enough ETH.
-      // CDP's drip is tiny (~0.0001 ETH) vs the 0.005 ETH bootstrap floor — a
+      // CDP's drip is tiny (~0.0001 ETH) vs the bootstrap floor (e.g. 0.010 ETH
+      // for a fresh fleet, after STANDARD_MASTER_BOOTSTRAP_MULTIPLIER) — a
       // single drip is never enough, and the older two-drip pattern forced
       // operators to re-run `jinn bootstrap` 25+ times. We loop until funded,
-      // rate-limited, or an error. Cap at 60 iterations as a safety bound.
+      // rate-limited, an error, or the wall-clock timeout. The iteration cap is
+      // sized from the remaining shortfall so it can actually clear the target;
+      // a fixed 60-drip cap (≈0.006 ETH) used to leave fresh fleets stuck
+      // forever at "0.006 / 0.010 ETH".
       if (systemEth < requiredMasterEth && this.chain === 'base-sepolia' && autoFaucetEnabled) {
-        const MAX_FAUCET_ITERS = 60;
+        const maxFaucetIters = computeFaucetDripCap({
+          targetWei: requiredMasterEth,
+          balanceWei: systemEth,
+        });
         const INTER_DRIP_PAUSE_MS = 1_000;
+        const loopTimeoutMs = DEFAULT_FAUCET_LOOP_TIMEOUT_MS;
+        const deadline = Date.now() + loopTimeoutMs;
         console.error(
           `[fleet-bootstrap] Master has ${formatEther(systemEth)} ETH; need ${formatEther(requiredMasterEth)} ETH. ` +
           `Draining CDP faucet on ${this.chain} via ${rpcHostForDisplay(this.config.rpcUrl)} ` +
-          `(each drip ≈ 0.0001 ETH, up to ${MAX_FAUCET_ITERS} drips; expect ~30-60 s on first run).`,
+          `(each drip ≈ 0.0001 ETH, up to ${maxFaucetIters} drips or ${Math.round(loopTimeoutMs / 1000)} s — whichever comes first).`,
         );
-        for (let i = 0; i < MAX_FAUCET_ITERS; i++) {
+        for (let i = 0; i < maxFaucetIters; i++) {
+          if (Date.now() >= deadline) {
+            console.error(
+              `[fleet-bootstrap] Faucet drip loop hit ${Math.round(loopTimeoutMs / 1000)} s timeout after ${i} drips ` +
+              `(master=${formatEther(masterBalance)} ETH; target=${formatEther(requiredMasterEth)} ETH). ` +
+              `CDP rate limits 1 claim per address per 24 h — retry later or fund manually.`,
+            );
+            break;
+          }
           const faucetResult = await this.requestFunding(masterAddress, 'base-sepolia');
           if (!faucetResult.ok) {
             if (faucetResult.rateLimited) {
@@ -310,7 +331,7 @@ export class FleetBootstrapper {
           masterBalance = refreshed.master;
           if ((i + 1) % 5 === 0) {
             console.error(
-              `[fleet-bootstrap] drip ${i + 1}/${MAX_FAUCET_ITERS} · chain=${this.chain} · rpc=${rpcHostForDisplay(this.config.rpcUrl)} · ` +
+              `[fleet-bootstrap] drip ${i + 1}/${maxFaucetIters} · chain=${this.chain} · rpc=${rpcHostForDisplay(this.config.rpcUrl)} · ` +
               `master=${formatEther(masterBalance)} ETH · target=${formatEther(requiredMasterEth)} ETH`,
             );
           }

--- a/client/src/earning/faucet.ts
+++ b/client/src/earning/faucet.ts
@@ -20,6 +20,64 @@ export interface FaucetResult {
   rateLimited?: boolean;
 }
 
+/**
+ * Conservative estimate for one CDP drip (~0.0001 ETH). Used to size the drip
+ * loop cap so it can actually reach the bootstrap target.
+ */
+export const ESTIMATED_DRIP_WEI = 100_000_000_000_000n;
+
+/**
+ * Default wall-clock safety cutoff for a faucet drip loop. Real loops should
+ * exit on success, rate-limit, or this deadline — whichever comes first.
+ */
+export const DEFAULT_FAUCET_LOOP_TIMEOUT_MS = 5 * 60 * 1000;
+
+export interface ComputeFaucetDripCapInput {
+  /** Bootstrap target (wei) the drip loop is trying to reach. */
+  targetWei?: bigint | null;
+  /** Current balance (wei) at the start of the loop. */
+  balanceWei?: bigint | null;
+  /** Explicit override; bypasses the calculation entirely when provided. */
+  override?: number;
+  /** Lower bound — preserves the historical 60-drip cap for callers without a target. */
+  floor?: number;
+  /** Upper bound — prevents runaway loops if estimates are wrong. */
+  ceiling?: number;
+}
+
+/**
+ * Compute the maximum number of faucet drip iterations needed to clear
+ * `targetWei` from `balanceWei`, given a conservative per-drip estimate.
+ *
+ * The cap is a *safety bound*, not a target — the real exit conditions are
+ * (a) the balance reaches the target, (b) the faucet rate-limits, or
+ * (c) the wall-clock deadline elapses. Sizing it dynamically just prevents
+ * the loop from terminating early on small fixed budgets (the previous
+ * 60-drip cap × ~0.0001 ETH = 0.006 ETH could not reach the 0.010 ETH
+ * fresh-fleet bootstrap target).
+ */
+export function computeFaucetDripCap(input: ComputeFaucetDripCapInput): number {
+  const floor = input.floor ?? 60;
+  const ceiling = input.ceiling ?? 500;
+  if (typeof input.override === 'number') {
+    return Math.max(0, Math.floor(input.override));
+  }
+  const target = input.targetWei ?? null;
+  if (target === null || target <= 0n) {
+    return floor;
+  }
+  const balance = input.balanceWei ?? 0n;
+  const remaining = target - balance;
+  if (remaining <= 0n) {
+    return floor;
+  }
+  const estimatedDrips = Number(remaining / ESTIMATED_DRIP_WEI);
+  // 2x safety multiplier (drips can come in slightly under the estimate) plus
+  // a 20-iteration floor of headroom for rounding on small targets.
+  const computed = estimatedDrips * 2 + 20;
+  return Math.max(floor, Math.min(ceiling, computed));
+}
+
 export async function requestTestnetFunding(
   address: string,
   network: 'base-sepolia',

--- a/client/test/api/setup-endpoints.test.ts
+++ b/client/test/api/setup-endpoints.test.ts
@@ -249,6 +249,44 @@ describe('POST /v1/setup/change-password', () => {
 });
 
 describe('POST /v1/setup/drip', () => {
+  it('sizes the iteration cap to clear the fresh-fleet bootstrap target (0.010 ETH)', async () => {
+    const earningDir = mkdtempSync(join(tmpdir(), 'jinn-drip-cap-'));
+    const store = new FleetStateStore(earningDir);
+    const state = await store.load('base-sepolia');
+    await store.save({
+      ...state,
+      master_address: '0x2222222222222222222222222222222222222222',
+    });
+
+    // Each drip credits ~0.0001 ETH, so reaching the 0.010 ETH fresh-fleet
+    // target requires at least 100 successful drips. The previous fixed
+    // 60-drip cap (≈0.006 ETH max) could not clear this and stranded
+    // onboarding at "0.006 / 0.010 ETH" forever.
+    const requestFunding = vi.fn(async () => ({
+      ok: true,
+      txHash: '0x' + 'cd'.repeat(32),
+    }));
+    const app = new Hono();
+    addSetupRoutes(app, {
+      earningDir,
+      chain: 'base-sepolia',
+      requestFunding,
+      // Fresh-fleet master target: minEoaGasEth (0.005) ×
+      // STANDARD_MASTER_BOOTSTRAP_MULTIPLIER (2) = 0.010 ETH.
+      minEoaGasWei: '10000000000000000',
+      interDripPauseMs: 0,
+    });
+
+    const res = await app.request('/v1/setup/drip', { method: 'POST' });
+    expect(res.status).toBe(202);
+
+    const attempts = requestFunding.mock.calls.length;
+    const DRIP_WEI = 100_000_000_000_000n; // ≈0.0001 ETH per drip
+    const TARGET_WEI = 10_000_000_000_000_000n; // 0.010 ETH
+    expect(BigInt(attempts) * DRIP_WEI >= TARGET_WEI).toBe(true);
+    expect(attempts).toBeGreaterThan(60);
+  });
+
   it('runs the user-triggered faucet loop for the persisted Base Sepolia master wallet', async () => {
     const earningDir = mkdtempSync(join(tmpdir(), 'jinn-drip-'));
     const store = new FleetStateStore(earningDir);

--- a/client/test/earning/bootstrap-faucet.test.ts
+++ b/client/test/earning/bootstrap-faucet.test.ts
@@ -17,11 +17,52 @@ describe('Fleet bootstrap faucet cap', () => {
     await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
   });
 
+  it('keeps dripping until the master EOA reaches the fresh-fleet bootstrap target (0.010 ETH)', async () => {
+    const earningDir = await mkdtemp(join(tmpdir(), 'jinn-faucet-success-'));
+    dirs.push(earningDir);
+
+    const { FleetBootstrapper } = await import('../../src/earning/bootstrap.js');
+    const bootstrapper = new FleetBootstrapper({
+      earningDir,
+      chain: 'base-sepolia',
+      rpcUrl: 'https://sepolia.base.org',
+      env: {},
+      stakingMode: 'standard',
+      requestFunding: requestTestnetFundingMock,
+    });
+
+    // Each successful drip credits ~0.0001 ETH. The fresh-fleet target is
+    // minEoaGasEth (0.005) × STANDARD_MASTER_BOOTSTRAP_MULTIPLIER (2) = 0.010
+    // ETH, so ~100 drips should clear it. The previous fixed 60-drip cap
+    // (≈0.006 ETH max) could not.
+    const DRIP_WEI = 100_000_000_000_000n;
+    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockImplementation(async () => {
+      const drips = BigInt(requestTestnetFundingMock.mock.calls.length);
+      return drips * DRIP_WEI;
+    });
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation((cb: (...args: unknown[]) => void) => {
+      queueMicrotask(cb);
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    });
+    // We only care about the funding loop here — short-circuit Phase 2 so the
+    // test doesn't fall through into the live on-chain reconcile/create paths.
+    vi.spyOn(bootstrapper as any, 'reconcileFleetWithChain').mockImplementation(async () => {
+      throw new Error('reconcile_short_circuit');
+    });
+
+    await bootstrapper.bootstrap('test-password');
+
+    // 0.010 ETH ÷ 0.0001 ETH/drip = 100 drips; loop must break exactly when
+    // the balance first meets the target, and never exceed the new cap.
+    expect(requestTestnetFundingMock).toHaveBeenCalledTimes(100);
+  });
+
   it('does not send an extra faucet request after the drip cap', async () => {
     const earningDir = await mkdtemp(join(tmpdir(), 'jinn-faucet-cap-'));
     dirs.push(earningDir);
 
     const { FleetBootstrapper } = await import('../../src/earning/bootstrap.js');
+    const { computeFaucetDripCap } = await import('../../src/earning/faucet.js');
     const bootstrapper = new FleetBootstrapper({
       earningDir,
       chain: 'base-sepolia',
@@ -39,8 +80,18 @@ describe('Fleet bootstrap faucet cap', () => {
 
     const result = await bootstrapper.bootstrap('test-password');
 
+    // Fresh standard-mode fleet on base-sepolia → required master ETH is
+    // minEoaGasEth (0.005) × STANDARD_MASTER_BOOTSTRAP_MULTIPLIER (2) = 0.010
+    // ETH. With a balance of 0 and ~0.0001 ETH per drip, computeFaucetDripCap
+    // sizes the safety bound to clear the target (the previous fixed 60-drip
+    // cap topped out at ~0.006 ETH and stranded fresh fleets).
+    const expectedCap = computeFaucetDripCap({
+      targetWei: 10_000_000_000_000_000n,
+      balanceWei: 0n,
+    });
+    expect(expectedCap).toBeGreaterThan(60);
     expect(result.ok).toBe(false);
     expect(result.funding).toBeDefined();
-    expect(requestTestnetFundingMock).toHaveBeenCalledTimes(60);
+    expect(requestTestnetFundingMock).toHaveBeenCalledTimes(expectedCap);
   });
 });


### PR DESCRIPTION
## Summary

Fresh-fleet testnet onboarding never auto-completes from the SPA's "Fund From Faucet" button because the faucet drip cap (60 × 0.0001 ETH = 0.006 ETH) is below the bootstrap target (0.005 ETH × `STANDARD_MASTER_BOOTSTRAP_MULTIPLIER` = 0.010 ETH).

The drip loop always exits "0.006 / 0.010 ETH" — the SPA renders that exact string ("Faucet funding complete (60 drips). Balance 0.006 ETH / target 0.010 ETH") and bootstrap stays pinned on `awaiting_funding`, retrying every 15 s with no progress.

## Fix

- Add a shared `computeFaucetDripCap(targetWei, balanceWei)` helper in `client/src/earning/faucet.ts` that sizes the iteration cap from `(target − balance) / ESTIMATED_DRIP_WEI` with a 60-drip floor (preserves the historical lower bound for callers without a target) and 500-drip ceiling (prevents runaways).
- Replace the two hardcoded 60s — `client/src/earning/bootstrap.ts` (auto-loop) and `client/src/api/setup-endpoints.ts` (`POST /v1/setup/drip`) — with calls to the helper.
- Add a 5-minute wall-clock deadline inside both loops as the real safety rail. The iteration cap is now just a bound; the actual exit conditions remain (a) target reached, (b) faucet rate-limited, (c) deadline elapsed.
- Update the bootstrap log message so the announced budget matches the dynamic cap instead of a stale "60 drips".

The protocol-level values (`minEoaGasEth`, `STANDARD_MASTER_BOOTSTRAP_MULTIPLIER`) are intentionally unchanged — they are correct; the cap was wrong.

## Tests

- `test/earning/bootstrap-faucet.test.ts`: existing "does not send extra request after cap" updated to assert against `computeFaucetDripCap` rather than the literal 60. Adds a new success test that simulates ~0.0001 ETH per drip and asserts the loop exits at 100 drips when the balance reaches 0.010 ETH.
- `test/api/setup-endpoints.test.ts`: adds a fresh-fleet drip-flow test that passes the 0.010 ETH target and asserts the loop runs enough drips to clear it (>60). Both would have failed under the old fixed cap.

## Test plan

- [ ] Verify on a fresh testnet earning dir: SPA "Fund From Faucet" reaches the 0.010 ETH target without manual top-up.
- [ ] Verify bootstrap auto-loop reaches the target with `autoTestnetFaucet=true`.
- [ ] Verify rate-limit early-exit still works (stub a 429 from CDP — should not exhaust the cap).
- [ ] Verify the 5-minute wall-clock fallback fires if drips silently no-op (stub `requestFunding` to return `ok: true` with no balance increase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)