### PR TITLE
Launcher role and Launcher mode (Phase A)

### DIFF
--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -56,7 +56,7 @@ const predictionOperatorStatusCache = new WeakMap<JinnConfig, Map<string, Promis
  * The cache key is the live `JinnConfig` object reference. When the SPA
  * mutates `config.solverNets` in place via `onSolverNetsUpdated`
  * (see `main.ts`), the WeakMap still resolves to the previously-built
- * status — leaving Overview reading a stale `solverNet.enabled = false`
+ * status — leaving Overview reading stale operator metadata
  * even though the operator just toggled it on. Invalidating here keeps
  * the Overview gating in sync with the latest config without a daemon
  * restart. (jinn-mono-l2zl.15.4.12)
@@ -174,13 +174,35 @@ function predictionOperatorUnavailable(
 function narrowOperatorStatusForApi(
   status: PredictionOperatorStatus,
 ): PredictionOperatorStatusForApi {
+  const roles = status.solverNet.roles.filter(
+    (r): r is 'solving' | 'evaluating' => r === 'solving' || r === 'evaluating',
+  );
+  const hasOperatorRole = roles.length > 0;
+  const diagnostics = hasOperatorRole
+    ? status.diagnostics.filter((d) => d.code !== 'prediction_solvernet_disabled')
+    : status.diagnostics;
+  const disabledNextAction =
+    status.nextAction?.description === 'Enable the Prediction SolverNet before participating.';
+  const nextDiagnosticAction = diagnostics.find(
+    (d) => (d.severity === 'error' || d.severity === 'warning') && d.nextAction,
+  )?.nextAction;
+
   return {
     ...status,
+    ok: diagnostics.every((diagnostic) => diagnostic.severity !== 'error'),
+    diagnostics,
+    nextAction: hasOperatorRole && disabledNextAction
+      ? (nextDiagnosticAction ?? {
+          description: 'Waiting for Tasks. SolverNet active, Harness loaded; no incoming Tasks since startup.',
+        })
+      : status.nextAction,
     solverNet: {
       ...status.solverNet,
-      roles: status.solverNet.roles.filter(
-        (r): r is 'solving' | 'evaluating' => r === 'solving' || r === 'evaluating',
-      ),
+      // `roles[]` is canonical for operator participation. Preserve the
+      // legacy field for older consumers, but derive it from operator-visible
+      // roles so stale `enabled: false` configs do not hide active operators.
+      enabled: hasOperatorRole,
+      roles,
     },
   };
 }

--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -128,6 +128,13 @@ function predictionOperatorUnavailable(
     },
   };
 
+  // Roles are best-effort: an unavailable status path means the daemon
+  // could not load the SolverNet, so we surface whatever the operator has
+  // configured (post-migration) without trying to default further.
+  const netRoles = Array.isArray((net as { roles?: unknown } | undefined)?.roles)
+    ? ((net as { roles?: ('solving' | 'evaluating')[] }).roles ?? [])
+    : [];
+
   return {
     kind: 'prediction.v1.operatorStatus',
     ok: false,
@@ -136,6 +143,7 @@ function predictionOperatorUnavailable(
       name,
       enabled: net?.enabled ?? false,
       solverType: net?.solverType ?? 'prediction.v1',
+      roles: netRoles,
       harness: net?.harness,
       taskGeneratorEnabled: net?.taskGenerator.enabled ?? false,
     },

--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -26,7 +26,11 @@ import {
   gatherPortfolioV0Status,
   DEFAULT_ENGINE_WORKING_DIR_ROOT,
 } from './portfolio-v0-build.js';
-import { gatherPredictionV1Status, type PredictionV1Status } from './prediction-v1-build.js';
+import {
+  gatherPredictionV1Status,
+  type PredictionOperatorStatusForApi,
+  type PredictionV1Status,
+} from './prediction-v1-build.js';
 import type { BalanceCacheEntry } from '../store/store.js';
 import {
   buildPredictionOperatorStatus,
@@ -130,9 +134,16 @@ function predictionOperatorUnavailable(
 
   // Roles are best-effort: an unavailable status path means the daemon
   // could not load the SolverNet, so we surface whatever the operator has
-  // configured (post-migration) without trying to default further.
-  const netRoles = Array.isArray((net as { roles?: unknown } | undefined)?.roles)
-    ? ((net as { roles?: ('solving' | 'evaluating')[] }).roles ?? [])
+  // configured (post-migration) without trying to default further. Note that
+  // launcher filtering happens at the gather-status API boundary below
+  // (see narrowOperatorStatusForApi), so we keep the full role array here
+  // to match the source `PredictionOperatorStatus` shape.
+  const rawRoles = (net as { roles?: unknown } | undefined)?.roles;
+  const netRoles = Array.isArray(rawRoles)
+    ? rawRoles.filter(
+        (r): r is 'solving' | 'evaluating' | 'launching' =>
+          r === 'solving' || r === 'evaluating' || r === 'launching',
+      )
     : [];
 
   return {
@@ -153,8 +164,29 @@ function predictionOperatorUnavailable(
   };
 }
 
+/**
+ * Strict mode separation per spec §6.3: Operator mode never displays
+ * launcher state. Filter `'launching'` out of `solverNet.roles` before
+ * exposing to the operator-mode UI. Done here at the gather-status
+ * boundary (not at the prediction-operator-ux source) so the CLI doctor
+ * still sees the full role array. See plan task 3.
+ */
+function narrowOperatorStatusForApi(
+  status: PredictionOperatorStatus,
+): PredictionOperatorStatusForApi {
+  return {
+    ...status,
+    solverNet: {
+      ...status.solverNet,
+      roles: status.solverNet.roles.filter(
+        (r): r is 'solving' | 'evaluating' => r === 'solving' || r === 'evaluating',
+      ),
+    },
+  };
+}
+
 function predictionV1Unavailable(
-  operator: PredictionOperatorStatus | null,
+  operator: PredictionOperatorStatusForApi | null,
   operatorError: string,
 ): PredictionV1Status {
   return {
@@ -399,15 +431,16 @@ export async function gatherGatheredStatusRaw(
     portfolioV0 = undefined;
   }
 
-  let predictionOperator: PredictionOperatorStatus | null = null;
+  let predictionOperator: PredictionOperatorStatusForApi | null = null;
   let predictionOperatorError: string | undefined;
   if (status?.config) {
     try {
-      predictionOperator = await getCachedPredictionOperatorStatus(
+      const raw = await getCachedPredictionOperatorStatus(
         status.config,
         status.configPath ?? '<default>',
         'prediction',
       );
+      predictionOperator = narrowOperatorStatusForApi(raw);
     } catch (error) {
       predictionOperatorError = errorMessage(error);
     }

--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -46,6 +46,21 @@ const ERC20_BALANCE_OF_ABI = [
 const STANDARD_MASTER_BOOTSTRAP_MULTIPLIER = 2n;
 const predictionOperatorStatusCache = new WeakMap<JinnConfig, Map<string, Promise<PredictionOperatorStatus>>>();
 
+/**
+ * Drop any cached prediction operator status for `config`.
+ *
+ * The cache key is the live `JinnConfig` object reference. When the SPA
+ * mutates `config.solverNets` in place via `onSolverNetsUpdated`
+ * (see `main.ts`), the WeakMap still resolves to the previously-built
+ * status — leaving Overview reading a stale `solverNet.enabled = false`
+ * even though the operator just toggled it on. Invalidating here keeps
+ * the Overview gating in sync with the latest config without a daemon
+ * restart. (jinn-mono-l2zl.15.4.12)
+ */
+export function invalidatePredictionOperatorStatusCache(config: JinnConfig): void {
+  predictionOperatorStatusCache.delete(config);
+}
+
 export interface StatusGatherConfig {
   earningDir: string;
   rpcUrl: string;

--- a/client/src/api/launcher-endpoints.ts
+++ b/client/src/api/launcher-endpoints.ts
@@ -1,0 +1,36 @@
+/**
+ * Launcher mode HTTP routes. Mounted under `/v1/launcher/*` and gated by the
+ * shared UI token (see server.ts). This module is intentionally thin — the
+ * heavy lifting lives in `launcher-status.ts` so it can be unit-tested
+ * without spinning up the full Hono server.
+ *
+ * Spec: spec/2026-05-05-launcher-role-and-mode.md §5.3.
+ *
+ * Currently registers:
+ *   GET /v1/launcher/status — per-SolverNet generator + budget snapshot.
+ *
+ * Future tasks (Task 7+) will add `/v1/launcher/tasks` etc. on the same
+ * deps shape.
+ */
+import type { Hono } from 'hono';
+import {
+  gatherLauncherStatus,
+  type GatherLauncherStatusDeps,
+} from './launcher-status.js';
+
+export interface LauncherRoutesDeps extends Omit<GatherLauncherStatusDeps, 'config'> {
+  /**
+   * Read the live config snapshot. Resolved per-request so SolverNet edits
+   * persisted via `/v1/setup/solvernets/:name` are reflected immediately —
+   * the Launcher panel polls this endpoint and the operator should see
+   * launching-role flips on the very next tick.
+   */
+  getConfig: () => GatherLauncherStatusDeps['config'];
+}
+
+export function addLauncherRoutes(app: Hono, deps: LauncherRoutesDeps): void {
+  app.get('/v1/launcher/status', async (c) => {
+    const body = await gatherLauncherStatus({ ...deps, config: deps.getConfig() });
+    return c.json(body);
+  });
+}

--- a/client/src/api/launcher-endpoints.ts
+++ b/client/src/api/launcher-endpoints.ts
@@ -53,6 +53,12 @@ export interface LauncherRoutesDeps extends Omit<GatherLauncherStatusDeps, 'conf
    * `/v1/launcher/status` read.
    */
   onSolverNetsUpdated?: (solverNets: Record<string, Record<string, unknown>>) => void;
+  /**
+   * Hot-apply hook for top-level generator config keys. The route persists
+   * these keys to disk, then calls this hook so the running daemon's live
+   * config object observes the same values before the next generator tick.
+   */
+  onConfigValuesUpdated?: (values: Record<string, unknown>) => void;
 }
 
 const MIN_LIMIT = 1;
@@ -212,6 +218,9 @@ export function addLauncherRoutes(app: Hono, deps: LauncherRoutesDeps): void {
       // per-tick config reads (no restart needed; spec §5.2).
       for (const [key, value] of Object.entries(generatorPatch)) {
         persistConfigValue(key, value, configPath);
+      }
+      if (Object.keys(generatorPatch).length > 0) {
+        deps.onConfigValuesUpdated?.(generatorPatch);
       }
     } catch (err) {
       return c.json(

--- a/client/src/api/launcher-endpoints.ts
+++ b/client/src/api/launcher-endpoints.ts
@@ -1,22 +1,24 @@
 /**
  * Launcher mode HTTP routes. Mounted under `/v1/launcher/*` and gated by the
  * shared UI token (see server.ts). This module is intentionally thin — the
- * heavy lifting lives in `launcher-status.ts` so it can be unit-tested
- * without spinning up the full Hono server.
+ * heavy lifting lives in `launcher-status.ts` / `launcher-tasks.ts` so each
+ * gather function can be unit-tested without spinning up the full Hono server.
  *
  * Spec: spec/2026-05-05-launcher-role-and-mode.md §5.3.
  *
  * Currently registers:
  *   GET /v1/launcher/status — per-SolverNet generator + budget snapshot.
- *
- * Future tasks (Task 7+) will add `/v1/launcher/tasks` etc. on the same
- * deps shape.
+ *   GET /v1/launcher/tasks  — paginated posted-Task list (Task 7).
  */
 import type { Hono } from 'hono';
 import {
   gatherLauncherStatus,
   type GatherLauncherStatusDeps,
 } from './launcher-status.js';
+import {
+  gatherLauncherTasks,
+  type GatherLauncherTasksDeps,
+} from './launcher-tasks.js';
 
 export interface LauncherRoutesDeps extends Omit<GatherLauncherStatusDeps, 'config'> {
   /**
@@ -26,11 +28,46 @@ export interface LauncherRoutesDeps extends Omit<GatherLauncherStatusDeps, 'conf
    * launching-role flips on the very next tick.
    */
   getConfig: () => GatherLauncherStatusDeps['config'];
+  /**
+   * Posted-Task accessor (Task 7). Resolved once at construction; the deps
+   * shape narrows the cross-route surface area that route handlers can see.
+   */
+  tasksDeps: Omit<GatherLauncherTasksDeps, 'config'>;
+}
+
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 100;
+const DEFAULT_LIMIT = 25;
+const CURSOR_PREFIX = 'before:';
+
+function parseLimit(raw: string | undefined): number {
+  if (raw === undefined) return DEFAULT_LIMIT;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return DEFAULT_LIMIT;
+  return Math.min(MAX_LIMIT, Math.max(MIN_LIMIT, Math.floor(parsed)));
+}
+
+function parseCursor(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  if (raw.startsWith(CURSOR_PREFIX)) return raw.slice(CURSOR_PREFIX.length);
+  // Be permissive: a bare ISO timestamp is treated as `before:<iso>` so the
+  // SPA can pass either form without a wrapper layer.
+  return raw;
 }
 
 export function addLauncherRoutes(app: Hono, deps: LauncherRoutesDeps): void {
   app.get('/v1/launcher/status', async (c) => {
     const body = await gatherLauncherStatus({ ...deps, config: deps.getConfig() });
+    return c.json(body);
+  });
+
+  app.get('/v1/launcher/tasks', async (c) => {
+    const limit = parseLimit(c.req.query('limit'));
+    const before = parseCursor(c.req.query('cursor'));
+    const body = await gatherLauncherTasks(
+      { ...deps.tasksDeps, config: deps.getConfig() },
+      { limit, ...(before ? { before } : {}) },
+    );
     return c.json(body);
   });
 }

--- a/client/src/api/launcher-endpoints.ts
+++ b/client/src/api/launcher-endpoints.ts
@@ -4,11 +4,13 @@
  * heavy lifting lives in `launcher-status.ts` / `launcher-tasks.ts` so each
  * gather function can be unit-tested without spinning up the full Hono server.
  *
- * Spec: spec/2026-05-05-launcher-role-and-mode.md §5.3.
+ * Spec: spec/2026-05-05-launcher-role-and-mode.md §5.3, §5.2 (hot-spawn),
+ *       §6.6 (launcher config page).
  *
  * Currently registers:
- *   GET /v1/launcher/status — per-SolverNet generator + budget snapshot.
- *   GET /v1/launcher/tasks  — paginated posted-Task list (Task 7).
+ *   GET   /v1/launcher/status              — per-SolverNet generator + budget snapshot.
+ *   GET   /v1/launcher/tasks               — paginated posted-Task list (Task 7).
+ *   PATCH /v1/launcher/solvernets/:name    — toggle launching role + edit generator config (Task 8).
  */
 import type { Hono } from 'hono';
 import {
@@ -19,6 +21,7 @@ import {
   gatherLauncherTasks,
   type GatherLauncherTasksDeps,
 } from './launcher-tasks.js';
+import { DEFAULT_CONFIG_PATH, persistTopLevelConfigValue } from '../config.js';
 
 export interface LauncherRoutesDeps extends Omit<GatherLauncherStatusDeps, 'config'> {
   /**
@@ -33,6 +36,23 @@ export interface LauncherRoutesDeps extends Omit<GatherLauncherStatusDeps, 'conf
    * shape narrows the cross-route surface area that route handlers can see.
    */
   tasksDeps: Omit<GatherLauncherTasksDeps, 'config'>;
+  /**
+   * Path to the operator config.json. Defaults to {@link DEFAULT_CONFIG_PATH}.
+   * Override in tests.
+   */
+  configPath?: string;
+  /**
+   * Persist a top-level config key. Defaults to {@link persistTopLevelConfigValue}.
+   * Override in tests so the helper writes to a temp dir or an in-memory mock.
+   */
+  persistConfigValue?: typeof persistTopLevelConfigValue;
+  /**
+   * Cache-invalidation hook fired after a successful PATCH that mutates
+   * `solverNets`. Mirrors `setup-endpoints.ts`'s `onSolverNetsUpdated` so the
+   * gather-status WeakMap (jinn-mono-l2zl.15.4.12) is dropped before the next
+   * `/v1/launcher/status` read.
+   */
+  onSolverNetsUpdated?: (solverNets: Record<string, Record<string, unknown>>) => void;
 }
 
 const MIN_LIMIT = 1;
@@ -55,7 +75,42 @@ function parseCursor(raw: string | undefined): string | undefined {
   return raw;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Map the launcher-mode `generator: { ... }` body into the daemon's flat
+ * top-level `predictionV1*` config keys. Only keys present in the input are
+ * emitted, so callers can patch a single field without clobbering the rest.
+ *
+ * Keep this table in sync with the predictionV1 fields in `JinnConfigSchema`
+ * (client/src/config.ts).
+ */
+function mapGeneratorPatch(
+  input: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (!input) return {};
+  const out: Record<string, unknown> = {};
+  if ('cadenceMs' in input) out['predictionV1CadenceMs'] = input['cadenceMs'];
+  if ('maxNewRoundsPerPoll' in input)
+    out['predictionV1MaxNewRoundsPerPoll'] = input['maxNewRoundsPerPoll'];
+  if ('maxNewRoundsPerDay' in input)
+    out['predictionV1MaxNewRoundsPerDay'] = input['maxNewRoundsPerDay'];
+  if ('maxOpenRounds' in input) out['predictionV1MaxOpenRounds'] = input['maxOpenRounds'];
+  if ('allowlistConditionIds' in input)
+    out['predictionV1AllowlistConditionIds'] = input['allowlistConditionIds'];
+  if ('blocklistConditionIds' in input)
+    out['predictionV1BlocklistConditionIds'] = input['blocklistConditionIds'];
+  if ('windowMs' in input) out['predictionV1WindowMs'] = input['windowMs'];
+  if ('resolveGapMs' in input) out['predictionV1ResolveGapMs'] = input['resolveGapMs'];
+  return out;
+}
+
 export function addLauncherRoutes(app: Hono, deps: LauncherRoutesDeps): void {
+  const persistConfigValue = deps.persistConfigValue ?? persistTopLevelConfigValue;
+  const configPath = deps.configPath ?? DEFAULT_CONFIG_PATH;
+
   app.get('/v1/launcher/status', async (c) => {
     const body = await gatherLauncherStatus({ ...deps, config: deps.getConfig() });
     return c.json(body);
@@ -69,5 +124,110 @@ export function addLauncherRoutes(app: Hono, deps: LauncherRoutesDeps): void {
       { limit, ...(before ? { before } : {}) },
     );
     return c.json(body);
+  });
+
+  // Launcher-mode SolverNet patch. Owns the `'launching'` role and the
+  // top-level generator-config keys (predictionV1CadenceMs, etc.). Operator
+  // mode owns 'solving' / 'evaluating' via POST /v1/setup/solvernets/:name —
+  // strict separation per spec §3.
+  //
+  // Per spec §5.2, generator-config edits hot-apply (no restart required) —
+  // the daemon's generator polls re-read `config.predictionV1CadenceMs` etc.
+  // each tick. Role flips also hot-apply because the launcher loop's
+  // hot-spawn gate reads `roles.includes('launching')` per tick.
+  app.patch('/v1/launcher/solvernets/:name', async (c) => {
+    const name = c.req.param('name');
+    if (!name) {
+      return c.json({ error: 'invalid_invocation', message: 'missing solvernet name' }, 400);
+    }
+
+    let body: { launching?: unknown; generator?: unknown };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: 'invalid_body', message: 'expected JSON body' }, 400);
+    }
+
+    if (body.launching !== undefined && typeof body.launching !== 'boolean') {
+      return c.json(
+        { error: 'invalid_body', message: '`launching` must be a boolean' },
+        400,
+      );
+    }
+    if (body.generator !== undefined && !isRecord(body.generator)) {
+      return c.json(
+        { error: 'invalid_body', message: '`generator` must be an object' },
+        400,
+      );
+    }
+
+    const config = deps.getConfig();
+    const existing = config.solverNets?.[name];
+    if (!existing || !isRecord(existing)) {
+      const available = Object.keys(config.solverNets ?? {});
+      return c.json({ error: 'solvernet_not_found', name, available, message: 'Unknown SolverNet' }, 404);
+    }
+
+    // Compute the next roles array, preserving any operator-mode roles that
+    // were already there. Mirrors the operator-mode preservation pass in
+    // setup-endpoints.ts (which preserves 'launching' on the way in).
+    const existingRoles = Array.isArray(existing['roles'])
+      ? (existing['roles'] as unknown[]).filter((r): r is string => typeof r === 'string')
+      : [];
+    let newRoles: string[] = existingRoles;
+    if (body.launching === true) {
+      newRoles = Array.from(new Set([...existingRoles, 'launching']));
+    } else if (body.launching === false) {
+      newRoles = existingRoles.filter((r) => r !== 'launching');
+    }
+    if (newRoles.length === 0) {
+      return c.json(
+        { error: 'invalid_body', message: 'At least one role required — refusing to leave SolverNet without any roles' },
+        400,
+      );
+    }
+
+    // Build the next solverNets snapshot. Persist the whole object via
+    // persistTopLevelConfigValue so the cache-invalidation hook receives the
+    // complete post-edit state (matching setup-endpoints.ts).
+    const nextSolverNets: Record<string, Record<string, unknown>> = {};
+    for (const [netName, netConfig] of Object.entries(config.solverNets ?? {})) {
+      if (isRecord(netConfig)) nextSolverNets[netName] = { ...netConfig };
+    }
+    nextSolverNets[name] = { ...(nextSolverNets[name] ?? {}), roles: newRoles };
+
+    const generatorPatch = mapGeneratorPatch(
+      isRecord(body.generator) ? body.generator : undefined,
+    );
+
+    try {
+      // Roles change → write solverNets first so the invalidation hook sees
+      // the fresh roles snapshot before any generator-config keys are read.
+      if (body.launching !== undefined) {
+        persistConfigValue('solverNets', nextSolverNets, configPath);
+        deps.onSolverNetsUpdated?.(nextSolverNets);
+      }
+      // Top-level generator keys are independent of solverNets, so persist
+      // each one individually. The values flow through the daemon's
+      // per-tick config reads (no restart needed; spec §5.2).
+      for (const [key, value] of Object.entries(generatorPatch)) {
+        persistConfigValue(key, value, configPath);
+      }
+    } catch (err) {
+      return c.json(
+        {
+          error: 'config_write_failed',
+          message: err instanceof Error ? err.message : String(err),
+        },
+        500,
+      );
+    }
+
+    return c.json({
+      ok: true,
+      name,
+      roles: newRoles,
+      generator: generatorPatch,
+    });
   });
 }

--- a/client/src/api/launcher-status.ts
+++ b/client/src/api/launcher-status.ts
@@ -1,0 +1,167 @@
+/**
+ * Launcher mode status assembler.
+ *
+ * Composes per-SolverNet generator state, open-Task counts, and Safe budget
+ * runway into the canonical `LauncherStatusResponse`. Only SolverNets whose
+ * `roles` includes `'launching'` are surfaced — Solver-only and Evaluator-only
+ * nets are filtered out here, not at the route layer, so the gather function
+ * can be exercised in isolation.
+ *
+ * Stale-poll detection is computed here from the generator's reported
+ * `lastPollAt` and `cadenceMs`: a poll is stale when the wall clock has
+ * advanced past `lastPollAt + 2 * cadenceMs`. The 2× factor matches
+ * spec/2026-05-05-launcher-role-and-mode.md §5.3.
+ *
+ * The deps shape is intentionally narrow — every external surface is a
+ * function so tests can inject deterministic state without standing up the
+ * full daemon. Subdeps that require deeper integration (open-Task counts,
+ * reserved-budget math, Safe-balance reads) are abstract here; v1 wires them
+ * to placeholder accessors with TODO pointers at Task 7.
+ */
+import type { JinnConfig } from '../config.js';
+
+export interface LauncherStatusGeneratorView {
+  state: 'active' | 'paused' | 'errored';
+  lastPollAt?: string;
+  lastPollSummary?: {
+    evaluated: number;
+    posted: number;
+    skipped: number;
+    skipReasons?: Record<string, number>;
+  };
+  lastError?: { message: string; at: string };
+  cadenceMs: number;
+  stale: boolean;
+}
+
+export interface LauncherStatusBudgetView {
+  safeAddress: string;
+  safeBalanceWei: string;
+  reservedBudgetWei: string;
+  runwayDays?: number;
+}
+
+export interface LauncherStatusNetEntry {
+  name: string;
+  generator: LauncherStatusGeneratorView;
+  openTasks: number;
+  budget: LauncherStatusBudgetView;
+}
+
+export interface LauncherStatusResponse {
+  schemaVersion: 1;
+  generatedAt: string;
+  nets: LauncherStatusNetEntry[];
+}
+
+/**
+ * Generator state snapshot the gather function consumes. Matches
+ * `PredictionV1GeneratorStateSnapshot` in shape but is declared here so the
+ * gather function does not depend on a specific SolverType module.
+ */
+export interface LauncherGeneratorStateSnapshot {
+  lastPollAt?: string;
+  lastPollSummary?: {
+    evaluated: number;
+    posted: number;
+    skipped: number;
+    skipReasons?: Record<string, number>;
+  };
+  lastError?: { message: string; at: string };
+  cadenceMs: number;
+}
+
+export interface GatherLauncherStatusDeps {
+  config: Pick<JinnConfig, 'solverNets'>;
+  /** Returns the generator's live state, or `undefined` if the SolverNet has no generator. */
+  getGeneratorState: (netName: string) => LauncherGeneratorStateSnapshot | undefined;
+  /** Count of Tasks created by the operator that are still in flight for the named SolverNet. */
+  getOpenTaskCount: (netName: string) => Promise<number> | number;
+  /** Sum of unconsumed claim payments across open Tasks (wei string). */
+  getReservedBudgetWei: (netName: string) => Promise<string> | string;
+  /** Safe ETH balance in wei (string) for the operator's funding wallet. */
+  getSafeBalanceWei: () => Promise<string> | string;
+  /**
+   * Operator Safe address used for budget views. Either a literal string (when
+   * known at construction time, e.g. tests) or a getter (when the address only
+   * resolves after bootstrap completes — see main.ts wiring).
+   */
+  safeAddress: string | (() => string);
+  /** Now-source override for deterministic tests. */
+  now?: () => number;
+}
+
+/**
+ * Derive the high-level generator state. `errored` wins over `active`/`paused`
+ * because the operator wants to see the failure first; `paused` only fires
+ * when no generator state is exposed at all (closed role gate before the very
+ * first tick, or a SolverNet without a launcher implementation).
+ */
+function deriveGeneratorState(
+  snapshot: LauncherGeneratorStateSnapshot | undefined,
+): 'active' | 'paused' | 'errored' {
+  if (!snapshot) return 'paused';
+  if (snapshot.lastError) return 'errored';
+  return 'active';
+}
+
+function isStalePoll(
+  snapshot: LauncherGeneratorStateSnapshot | undefined,
+  now: number,
+): boolean {
+  if (!snapshot || !snapshot.lastPollAt) return false;
+  const lastPollMs = Date.parse(snapshot.lastPollAt);
+  if (!Number.isFinite(lastPollMs)) return false;
+  const cadenceMs = snapshot.cadenceMs ?? 0;
+  if (cadenceMs <= 0) return false;
+  return now - lastPollMs > 2 * cadenceMs;
+}
+
+export async function gatherLauncherStatus(
+  deps: GatherLauncherStatusDeps,
+): Promise<LauncherStatusResponse> {
+  const now = deps.now?.() ?? Date.now();
+  const nets: LauncherStatusNetEntry[] = [];
+
+  for (const [name, net] of Object.entries(deps.config.solverNets ?? {})) {
+    const roles = net?.roles ?? [];
+    if (!roles.includes('launching')) continue;
+
+    const snapshot = deps.getGeneratorState(name);
+    const generatorState = deriveGeneratorState(snapshot);
+    const stale = isStalePoll(snapshot, now);
+
+    const [openTasks, reservedBudgetWei, safeBalanceWei] = await Promise.all([
+      Promise.resolve(deps.getOpenTaskCount(name)),
+      Promise.resolve(deps.getReservedBudgetWei(name)),
+      Promise.resolve(deps.getSafeBalanceWei()),
+    ]);
+
+    const generator: LauncherStatusGeneratorView = {
+      state: generatorState,
+      cadenceMs: snapshot?.cadenceMs ?? 0,
+      stale,
+    };
+    if (snapshot?.lastPollAt) generator.lastPollAt = snapshot.lastPollAt;
+    if (snapshot?.lastPollSummary) generator.lastPollSummary = { ...snapshot.lastPollSummary };
+    if (snapshot?.lastError) generator.lastError = { ...snapshot.lastError };
+
+    const safeAddress = typeof deps.safeAddress === 'function' ? deps.safeAddress() : deps.safeAddress;
+    nets.push({
+      name,
+      generator,
+      openTasks,
+      budget: {
+        safeAddress,
+        safeBalanceWei,
+        reservedBudgetWei,
+      },
+    });
+  }
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date(now).toISOString(),
+    nets,
+  };
+}

--- a/client/src/api/launcher-status.ts
+++ b/client/src/api/launcher-status.ts
@@ -27,7 +27,6 @@ export interface LauncherStatusGeneratorView {
     evaluated: number;
     posted: number;
     skipped: number;
-    skipReasons?: Record<string, number>;
   };
   lastError?: { message: string; at: string };
   cadenceMs: number;
@@ -65,7 +64,6 @@ export interface LauncherGeneratorStateSnapshot {
     evaluated: number;
     posted: number;
     skipped: number;
-    skipReasons?: Record<string, number>;
   };
   lastError?: { message: string; at: string };
   cadenceMs: number;
@@ -96,6 +94,18 @@ export interface GatherLauncherStatusDeps {
  * because the operator wants to see the failure first; `paused` only fires
  * when no generator state is exposed at all (closed role gate before the very
  * first tick, or a SolverNet without a launcher implementation).
+ *
+ * NOTE (v1 edge case, jinn-mono-l2zl carry-over from Task 6 review): a
+ * generator with a `cadenceMs > 0` and no `lastError` reports `active` even
+ * before its first poll has completed. If the daemon has been running long
+ * enough that the first poll *should* have completed but `lastPollAt` is
+ * still undefined, the operator UI will show "active, not stale" — which is
+ * misleading. The fix requires tracking a `genStartedAt` timestamp on the
+ * generator so the gather function can compare `now - genStartedAt`
+ * against `2 * cadenceMs`. Deferred to a follow-up: in v1 the prediction.v1
+ * cadence is 6h, so the window between "started" and "first tick" is short
+ * enough that the misclassification is rare in practice. Tracked under
+ * the launcher-mode plan (spec/2026-05-05-launcher-role-and-mode.md §5.3).
  */
 function deriveGeneratorState(
   snapshot: LauncherGeneratorStateSnapshot | undefined,

--- a/client/src/api/launcher-tasks.ts
+++ b/client/src/api/launcher-tasks.ts
@@ -1,0 +1,193 @@
+/**
+ * Launcher-mode posted-Tasks query. Returns the canonical
+ * `LauncherTasksResponse` for `GET /v1/launcher/tasks` — the SPA's
+ * PostedTasksList consumes this directly.
+ *
+ * Pagination: `before` cursor is an ISO timestamp; results are returned in
+ * `postedAt DESC` order. When the page fills (`tasks.length === limit`) the
+ * response includes a `cursor.before` set to the oldest entry's `postedAt`
+ * so the next call can resume.
+ *
+ * What is and isn't sourced today (Task 7 of
+ * spec/2026-05-05-launcher-role-and-mode.md):
+ *   ✓ taskId / taskCid / postedAt — from `task_posts` + `activity_events`
+ *   ✓ solverNet — derived by mapping the `task_posted` event's `solver_type`
+ *     back to the SolverNet name in config (the only solver-type → net mapping
+ *     in v1 is 1:1, so the lookup is straightforward).
+ *   ✗ state / claims.current / budget.remainingWei — require on-chain state
+ *     tracking that the v1 daemon does not yet maintain. The router-watcher
+ *     hardening lane (bd jinn-mono-l2zl.12) will add per-Task lifecycle
+ *     events; until then we report `state: 'open'`, `claims.current: 0`, and
+ *     `budget: { totalWei: '0', remainingWei: '0' }`. These defaults are
+ *     accurate for the freshly-posted Task case, which is the one operators
+ *     see most often in the day-1 launcher UI.
+ *   ✗ summary.title / summary.resolutionTime — would require persisting the
+ *     full Task spec at post-time. Out of scope for v1; the SPA falls back
+ *     to taskId/postedAt when summary is absent.
+ *
+ * Spec: spec/2026-05-05-launcher-role-and-mode.md §5.3.
+ */
+import type { JinnConfig } from '../config.js';
+
+export type LauncherTaskState =
+  | 'open'
+  | 'claims-in-flight'
+  | 'fully-claimed'
+  | 'settled'
+  | 'failed';
+
+export interface LauncherTaskEntry {
+  taskId: string;
+  taskCid: string;
+  solverNet: string;
+  postedAt: string;
+  state: LauncherTaskState;
+  claims: { current: number; max: number };
+  budget: { totalWei: string; remainingWei: string; reclaimableAt?: string };
+  summary?: { title?: string; resolutionTime?: string };
+}
+
+export interface LauncherTasksResponse {
+  schemaVersion: 1;
+  generatedAt: string;
+  cursor?: { before: string };
+  tasks: LauncherTaskEntry[];
+}
+
+/** A single posted-Task row as surfaced by the daemon's store accessor. */
+export interface PostedTaskRecord {
+  taskId: string;
+  taskCid: string;
+  /** Optional — if present, used to derive `solverNet` via config lookup. */
+  solverType?: string;
+  /** Optional override; when set, takes precedence over solverType-based mapping. */
+  solverNet?: string;
+  /** ISO-8601 timestamp; the response sorts on this DESC. */
+  postedAt: string;
+  state?: LauncherTaskState;
+  claims?: { current?: number; max?: number };
+  budget?: { totalWei?: string; remainingWei?: string; reclaimableAt?: string };
+  summary?: { title?: string; resolutionTime?: string };
+}
+
+export interface FetchPostedTasksOptions {
+  creatorAddress: string;
+  /** Inclusive upper bound on result count after deps applies its own page logic. */
+  limit: number;
+  /** ISO-8601 timestamp; filter to rows with `postedAt < before`. */
+  before?: string;
+}
+
+export interface GatherLauncherTasksDeps {
+  config: Pick<JinnConfig, 'solverNets'>;
+  creatorAddress: string;
+  fetchPostedTasks: (
+    opts: FetchPostedTasksOptions,
+  ) => Promise<PostedTaskRecord[]> | PostedTaskRecord[];
+  now?: () => number;
+}
+
+export interface GatherLauncherTasksOptions {
+  /** Page size; clamped to [1, 100]. Default 25 (matches spec). */
+  limit?: number;
+  /** ISO-8601 timestamp; filter to rows with `postedAt < before`. */
+  before?: string;
+}
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+const DEFAULT_CLAIMS_MAX = 25;
+
+/**
+ * Build a solverType → solverNet-name lookup from the live config. The v1
+ * mapping is 1:1 (one SolverNet per solver-type), but we index defensively so
+ * a future fork-of-prediction config doesn't silently mislabel posted Tasks.
+ */
+function buildSolverTypeToNetIndex(
+  solverNets: JinnConfig['solverNets'] | undefined,
+): Map<string, string> {
+  const index = new Map<string, string>();
+  if (!solverNets) return index;
+  for (const [name, net] of Object.entries(solverNets)) {
+    const solverType = (net as { solverType?: string } | undefined)?.solverType;
+    if (typeof solverType === 'string' && solverType.length > 0 && !index.has(solverType)) {
+      index.set(solverType, name);
+    }
+  }
+  return index;
+}
+
+function mapRecordToEntry(
+  record: PostedTaskRecord,
+  solverTypeIndex: Map<string, string>,
+): LauncherTaskEntry {
+  const solverNet =
+    record.solverNet
+    ?? (record.solverType ? solverTypeIndex.get(record.solverType) : undefined)
+    ?? 'unknown';
+  const claimsCurrent = record.claims?.current ?? 0;
+  const claimsMax = record.claims?.max ?? DEFAULT_CLAIMS_MAX;
+  const totalWei = record.budget?.totalWei ?? '0';
+  const remainingWei = record.budget?.remainingWei ?? totalWei;
+  const entry: LauncherTaskEntry = {
+    taskId: record.taskId,
+    taskCid: record.taskCid,
+    solverNet,
+    postedAt: record.postedAt,
+    state: record.state ?? 'open',
+    claims: { current: claimsCurrent, max: claimsMax },
+    budget: { totalWei, remainingWei },
+  };
+  if (record.budget?.reclaimableAt) {
+    entry.budget.reclaimableAt = record.budget.reclaimableAt;
+  }
+  if (record.summary) {
+    entry.summary = { ...record.summary };
+  }
+  return entry;
+}
+
+export async function gatherLauncherTasks(
+  deps: GatherLauncherTasksDeps,
+  opts: GatherLauncherTasksOptions = {},
+): Promise<LauncherTasksResponse> {
+  const requested = opts.limit ?? DEFAULT_LIMIT;
+  const limit = Math.min(MAX_LIMIT, Math.max(1, Math.floor(requested)));
+
+  const fetched = await Promise.resolve(
+    deps.fetchPostedTasks({
+      creatorAddress: deps.creatorAddress,
+      limit,
+      before: opts.before,
+    }),
+  );
+
+  // Defensive sort: the store accessor returns rows in DESC `postedAt`
+  // order, but the gather function is also reachable from tests that pass
+  // unsorted fixtures. Sort here so the response invariant is unconditional.
+  const sorted = [...fetched].sort((a, b) => {
+    const ta = Date.parse(a.postedAt);
+    const tb = Date.parse(b.postedAt);
+    if (Number.isFinite(ta) && Number.isFinite(tb)) return tb - ta;
+    if (Number.isFinite(ta)) return -1;
+    if (Number.isFinite(tb)) return 1;
+    return 0;
+  });
+
+  const solverTypeIndex = buildSolverTypeToNetIndex(deps.config.solverNets);
+  const tasks = sorted.slice(0, limit).map((record) => mapRecordToEntry(record, solverTypeIndex));
+
+  const cursor =
+    tasks.length === limit && tasks.length > 0
+      ? { before: tasks[tasks.length - 1]!.postedAt }
+      : undefined;
+
+  const generatedAtMs = deps.now?.() ?? Date.now();
+  const response: LauncherTasksResponse = {
+    schemaVersion: 1,
+    generatedAt: new Date(generatedAtMs).toISOString(),
+    tasks,
+  };
+  if (cursor) response.cursor = cursor;
+  return response;
+}

--- a/client/src/api/prediction-v1-build.ts
+++ b/client/src/api/prediction-v1-build.ts
@@ -10,6 +10,26 @@ import type { Store } from '../store/store.js';
 import { TaskRunPersistence, type PersistedTaskRun } from '../harnesses/engine/persistence.js';
 import type { PredictionOperatorStatus } from '../solver-nets/prediction-operator-ux.js';
 
+/**
+ * Operator-mode visible roles. The launcher is configured per-net but is
+ * intentionally omitted from operator-mode status payloads — strict mode
+ * separation per spec/2026-05-05-launcher-role-and-mode.md §6.3. Filtering
+ * happens at the gather-status API boundary so this narrow type is the one
+ * the SPA reads.
+ */
+export type OperatorVisibleRole = 'solving' | 'evaluating';
+
+/**
+ * API-facing variant of {@link PredictionOperatorStatus} with `solverNet.roles`
+ * narrowed to operator-visible roles only (no `'launching'`). Built from the
+ * full operator status by gather-status before being exposed via /v1/status.
+ */
+export type PredictionOperatorStatusForApi = Omit<PredictionOperatorStatus, 'solverNet'> & {
+  solverNet: Omit<PredictionOperatorStatus['solverNet'], 'roles'> & {
+    roles: OperatorVisibleRole[];
+  };
+};
+
 const RECENT_LIMIT = 5;
 
 export interface PredictionV1TaskRunSummary {
@@ -28,7 +48,7 @@ export interface PredictionV1TaskRunSummary {
 }
 
 export interface PredictionV1Status {
-  operator: PredictionOperatorStatus | null;
+  operator: PredictionOperatorStatusForApi | null;
   operatorError?: string;
   totals: {
     observedTasks: number;
@@ -48,7 +68,7 @@ export interface PredictionV1Status {
 }
 
 export interface GatherPredictionV1StatusOptions {
-  operator?: PredictionOperatorStatus | null;
+  operator?: PredictionOperatorStatusForApi | null;
   operatorError?: string;
 }
 

--- a/client/src/api/server.ts
+++ b/client/src/api/server.ts
@@ -36,6 +36,7 @@ import { addAgentBindingRoutes, type AgentBindingRoutesConfig } from './agent-bi
 import { addHandshakeRoutes, requireUiToken } from './handshake.js';
 import { addAdminRoutes } from './admin-endpoint.js';
 import { addSetupRoutes, type SetupRoutesConfig } from './setup-endpoints.js';
+import { addLauncherRoutes, type LauncherRoutesDeps } from './launcher-endpoints.js';
 
 export interface ApiServerConfig {
   port: number;
@@ -83,6 +84,13 @@ export interface ApiServerConfig {
   bootstrap?: BootstrapEndpointConfig;
   /** Optional panel-driven setup actions such as testnet faucet funding. */
   setup?: SetupRoutesConfig;
+  /**
+   * Launcher mode routes (`/v1/launcher/*`). Mounted only when supplied so
+   * tests and bootstrap-only API instances don't pay the deps wiring cost.
+   * Gated by the same UI token as `/v1/setup/*` — see the `app.use` block
+   * inside `startApiServer` below.
+   */
+  launcher?: LauncherRoutesDeps;
   /** When set, GET /v1/solvernets exposes the catalog from a daemon registry. */
   solverNets?: { registry: SolverNetsRegistry };
   /** When set, POST /v1/setup/agent-binding/retry is mounted so the SPA can
@@ -255,6 +263,8 @@ export async function startApiServer(config: ApiServerConfig): Promise<ApiServer
     app.use('/v1/solvernets', requireUiToken(config.ui.token));
     app.use('/v1/auth/*', requireUiToken(config.ui.token));
     app.use('/v1/setup/*', requireUiToken(config.ui.token));
+    app.use('/v1/launcher', requireUiToken(config.ui.token));
+    app.use('/v1/launcher/*', requireUiToken(config.ui.token));
     app.use('/api/admin/*', requireUiToken(config.ui.token));
   }
 
@@ -281,6 +291,13 @@ export async function startApiServer(config: ApiServerConfig): Promise<ApiServer
     // gated behind the UI token so external callers can't fingerprint the host
     // or rotate keys.
     addSetupRoutes(app, config.setup);
+  }
+
+  // Launcher mode routes — gated by the UI token via the `app.use` block
+  // above. The launcher mode SPA is the only legitimate consumer; external
+  // callers cannot fingerprint per-SolverNet generator state without it.
+  if (config.ui && config.launcher) {
+    addLauncherRoutes(app, config.launcher);
   }
 
   // x402 payment-gated routes (if configured)

--- a/client/src/api/setup-endpoints.ts
+++ b/client/src/api/setup-endpoints.ts
@@ -408,7 +408,15 @@ export function addSetupRoutes(app: Hono, config: SetupRoutesConfig = {}): void 
     if (body.enabled !== undefined) existing.enabled = body.enabled;
     if (body.solverType !== undefined) existing.solverType = body.solverType;
     if (normalizedRoles !== undefined) {
-      existing.roles = normalizedRoles;
+      // Operator-mode patch only addresses solving/evaluating. Preserve any
+      // non-operator roles (today: 'launching') so launcher-mode state is
+      // never clobbered by an operator-mode role edit. Strict mode
+      // separation per spec/2026-05-05-launcher-role-and-mode.md §3.
+      const existingRoles = Array.isArray(existing['roles'])
+        ? (existing['roles'] as unknown[]).filter((r): r is string => typeof r === 'string')
+        : [];
+      const preservedRoles = existingRoles.filter((r) => !KNOWN_ROLES.includes(r));
+      existing.roles = Array.from(new Set([...normalizedRoles, ...preservedRoles]));
       // Strip any legacy singular `role` so the persisted shape is canonical.
       // Eliminates ambiguity if a third-party tool reads the file and prefers
       // `role` over `roles`.

--- a/client/src/api/setup-endpoints.ts
+++ b/client/src/api/setup-endpoints.ts
@@ -317,7 +317,8 @@ export function addSetupRoutes(app: Hono, config: SetupRoutesConfig = {}): void 
     let body: {
       enabled?: unknown;
       solverType?: unknown; // deprecated; accepted for one release cycle
-      role?: unknown;
+      role?: unknown;       // legacy singular form, accepted for one release cycle
+      roles?: unknown;
       harness?: unknown;
       model?: unknown;
       plugins?: unknown;
@@ -329,7 +330,7 @@ export function addSetupRoutes(app: Hono, config: SetupRoutesConfig = {}): void 
     }
 
     const editableFields: Array<keyof typeof body> = [
-      'enabled', 'solverType', 'role', 'harness', 'model', 'plugins',
+      'enabled', 'solverType', 'role', 'roles', 'harness', 'model', 'plugins',
     ];
     if (!editableFields.some((f) => body[f] !== undefined)) {
       return c.json({ error: 'invalid_body', detail: 'must include at least one editable field' }, 400);
@@ -345,8 +346,27 @@ export function addSetupRoutes(app: Hono, config: SetupRoutesConfig = {}): void 
       }, 400);
     }
     const KNOWN_ROLES = ['solving', 'evaluating'];
-    if (body.role !== undefined && (typeof body.role !== 'string' || !KNOWN_ROLES.includes(body.role))) {
-      return c.json({ error: 'invalid_body', detail: '`role` must be `solving` or `evaluating`' }, 400);
+    let normalizedRoles: string[] | undefined;
+    if (body.roles !== undefined) {
+      if (
+        !Array.isArray(body.roles) ||
+        body.roles.length === 0 ||
+        !body.roles.every((r): r is string => typeof r === 'string' && KNOWN_ROLES.includes(r))
+      ) {
+        return c.json({
+          error: 'invalid_body',
+          detail: '`roles` must be a non-empty array of `solving` and/or `evaluating`',
+        }, 400);
+      }
+      // Deduplicate so the persisted shape is canonical even if the SPA double-includes a value.
+      normalizedRoles = Array.from(new Set(body.roles as string[]));
+    } else if (body.role !== undefined) {
+      // Legacy singular form. Accept it (operators on older config tooling),
+      // promote to the canonical roles array.
+      if (typeof body.role !== 'string' || !KNOWN_ROLES.includes(body.role)) {
+        return c.json({ error: 'invalid_body', detail: '`role` must be `solving` or `evaluating`' }, 400);
+      }
+      normalizedRoles = [body.role];
     }
     if (body.harness !== undefined && typeof body.harness !== 'string') {
       return c.json({ error: 'invalid_body', detail: '`harness` must be a string' }, 400);
@@ -387,7 +407,13 @@ export function addSetupRoutes(app: Hono, config: SetupRoutesConfig = {}): void 
 
     if (body.enabled !== undefined) existing.enabled = body.enabled;
     if (body.solverType !== undefined) existing.solverType = body.solverType;
-    if (body.role !== undefined) existing.role = body.role;
+    if (normalizedRoles !== undefined) {
+      existing.roles = normalizedRoles;
+      // Strip any legacy singular `role` so the persisted shape is canonical.
+      // Eliminates ambiguity if a third-party tool reads the file and prefers
+      // `role` over `roles`.
+      delete existing['role'];
+    }
     if (body.harness !== undefined) existing.harness = body.harness;
     if (body.model !== undefined) existing.model = body.model;
     if (body.plugins !== undefined) existing.plugins = body.plugins;

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -35,8 +35,11 @@ export interface DefaultSolverNetConfig extends Record<string, unknown> {
    * `verdictDeliveryWeight` as independent additive counters.
    *
    * `'launching'` gates the SolverNet's launcher loop (e.g. prediction.v1
-   * Polymarket Task generator) — replaces the legacy
-   * `predictionV1LauncherEnabled` boolean with a per-SolverNet role gate.
+   * Polymarket Task generator) — replaces the legacy startup-time
+   * launcher boolean with a per-SolverNet role gate evaluated at every
+   * generator tick, so toggling launcher mode in/out takes effect within
+   * one cadence (no daemon restart). See
+   * spec/2026-05-05-launcher-role-and-mode.md §5.2.
    *
    * Legacy `role: 'solving' | 'evaluating'` configs are auto-migrated to
    * `roles: [<role>]` by the loader (zod preprocessor on solverNets[*]).

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -28,16 +28,20 @@ export interface DefaultSolverNetConfig extends Record<string, unknown> {
   solverType: string;
   /**
    * Operator-selected roles for this SolverNet. A non-empty subset of
-   * `['solving', 'evaluating']`. Both roles can be set concurrently — the
-   * daemon enforces `disallowSolverSelfEvaluation` on-chain so the operator
-   * never evaluates its own Solutions, and the on-chain
-   * TaskActivityCheckerV3 keeps `solutionDeliveryWeight` and
+   * `['solving', 'evaluating', 'launching']`. Multiple roles can run
+   * concurrently — the daemon enforces `disallowSolverSelfEvaluation`
+   * on-chain so the operator never evaluates its own Solutions, and the
+   * on-chain TaskActivityCheckerV3 keeps `solutionDeliveryWeight` and
    * `verdictDeliveryWeight` as independent additive counters.
+   *
+   * `'launching'` gates the SolverNet's launcher loop (e.g. prediction.v1
+   * Polymarket Task generator) — replaces the legacy
+   * `predictionV1LauncherEnabled` boolean with a per-SolverNet role gate.
    *
    * Legacy `role: 'solving' | 'evaluating'` configs are auto-migrated to
    * `roles: [<role>]` by the loader (zod preprocessor on solverNets[*]).
    */
-  roles?: Array<'solving' | 'evaluating'>;
+  roles?: Array<'solving' | 'evaluating' | 'launching'>;
   harness?: string;
   model?: string;
   plugins?: Array<string | { name?: string; source: string; version?: string }>;
@@ -311,13 +315,6 @@ export const JinnConfigSchema = z.object({
   predictionV1ResolveGapMs: z.number().int().positive().optional(),
 
   /**
-   * Enables launcher-owned Polymarket prediction.v1 Task generation.
-   * Default false: ordinary operator daemons do not create Polymarket rounds.
-   * Env: JINN_PREDICTION_V1_LAUNCHER_ENABLED
-   */
-  predictionV1LauncherEnabled: z.boolean().default(false),
-
-  /**
    * prediction.v1 Polymarket generator cadence (ms). Default 21600000 (6h).
    * Set to 0 only for launcher/test loops that intentionally poll every tick.
    * Env: JINN_PREDICTION_V1_CADENCE_MS
@@ -388,12 +385,15 @@ export const JinnConfigSchema = z.object({
   /**
    * SolverNet activation, Harness selection, and operator-configured runtime plugins.
    *
-   * Each entry's `roles` is a non-empty subset of `['solving', 'evaluating']`.
-   * Both roles can run concurrently for the same SolverNet; the protocol-level
+   * Each entry's `roles` is a non-empty subset of
+   * `['solving', 'evaluating', 'launching']`. Multiple roles can run
+   * concurrently for the same SolverNet; the protocol-level
    * `disallowSolverSelfEvaluation` flag prevents the operator from evaluating
    * its own Solutions and the on-chain TaskActivityCheckerV3 tracks
    * Solution and Verdict counters independently (additive into
-   * `eligibleActivityWeight`).
+   * `eligibleActivityWeight`). `'launching'` gates the SolverNet's launcher
+   * loop (e.g. prediction.v1 Polymarket Task generator) — see
+   * spec/2026-05-05-launcher-role-and-mode.md.
    *
    * Backwards-compat: a legacy `role: 'solving' | 'evaluating'` field is
    * auto-promoted to `roles: [<role>]` by the zod preprocessor below so
@@ -420,7 +420,7 @@ export const JinnConfigSchema = z.object({
     z.object({
       enabled: z.boolean().default(true),
       solverType: z.string(),
-      roles: z.array(z.enum(['solving', 'evaluating']))
+      roles: z.array(z.enum(['solving', 'evaluating', 'launching']))
         .min(1, 'each SolverNet must enable at least one role')
         .default(['solving'])
         // Deduplicate to keep downstream consumers simple.
@@ -700,10 +700,6 @@ export function loadConfig(configPath?: string): JinnConfig {
     const parsed = Number(env['JINN_PREDICTION_V1_RESOLVE_GAP_MS'].trim());
     if (Number.isFinite(parsed) && parsed > 0) merged.predictionV1ResolveGapMs = parsed;
   }
-  if (env['JINN_PREDICTION_V1_LAUNCHER_ENABLED'] !== undefined) {
-    const v = env['JINN_PREDICTION_V1_LAUNCHER_ENABLED'].trim().toLowerCase();
-    merged.predictionV1LauncherEnabled = v === '1' || v === 'true' || v === 'yes';
-  }
   if (env['JINN_PREDICTION_V1_CADENCE_MS']) {
     const parsed = Number(env['JINN_PREDICTION_V1_CADENCE_MS'].trim());
     if (Number.isFinite(parsed) && parsed >= 0) merged.predictionV1CadenceMs = parsed;
@@ -921,7 +917,6 @@ const TRACKED_ENV_VARS = [
   'JINN_MIN_SAFE_ETH_WEI',
   'JINN_PREDICTION_V1_WINDOW_MS',
   'JINN_PREDICTION_V1_RESOLVE_GAP_MS',
-  'JINN_PREDICTION_V1_LAUNCHER_ENABLED',
   'JINN_PREDICTION_V1_CADENCE_MS',
   'JINN_PREDICTION_V1_MAX_NEW_ROUNDS_PER_POLL',
   'JINN_PREDICTION_V1_MAX_NEW_ROUNDS_PER_DAY',

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -26,7 +26,18 @@ import type { Task } from './types/task.js';
 export interface DefaultSolverNetConfig extends Record<string, unknown> {
   enabled?: boolean;
   solverType: string;
-  role?: 'solving' | 'evaluating';
+  /**
+   * Operator-selected roles for this SolverNet. A non-empty subset of
+   * `['solving', 'evaluating']`. Both roles can be set concurrently — the
+   * daemon enforces `disallowSolverSelfEvaluation` on-chain so the operator
+   * never evaluates its own Solutions, and the on-chain
+   * TaskActivityCheckerV3 keeps `solutionDeliveryWeight` and
+   * `verdictDeliveryWeight` as independent additive counters.
+   *
+   * Legacy `role: 'solving' | 'evaluating'` configs are auto-migrated to
+   * `roles: [<role>]` by the loader (zod preprocessor on solverNets[*]).
+   */
+  roles?: Array<'solving' | 'evaluating'>;
   harness?: string;
   model?: string;
   plugins?: Array<string | { name?: string; source: string; version?: string }>;
@@ -37,7 +48,7 @@ export const DEFAULT_SOLVER_NETS: Record<string, DefaultSolverNetConfig> = {
   prediction: {
     enabled: true,
     solverType: 'prediction.v1',
-    role: 'solving',
+    roles: ['solving'],
     harness: 'claude-code-learner',
     plugins: [],
     taskGenerator: { enabled: true },
@@ -374,25 +385,61 @@ export const JinnConfigSchema = z.object({
     })
     .optional(),
 
-  /** SolverNet activation, Harness selection, and operator-configured runtime plugins. */
-  solverNets: z.record(z.object({
-    enabled: z.boolean().default(true),
-    solverType: z.string(),
-    role: z.enum(['solving', 'evaluating']).default('solving'),
-    harness: z.string().default('claude-code-learner'),
-    model: z.string().optional(),
-    plugins: z.array(z.union([
-      z.string(),
-      z.object({
-        name: z.string().optional(),
-        source: z.string(),
-        version: z.string().optional(),
-      }),
-    ])).default([]),
-    taskGenerator: z.object({
+  /**
+   * SolverNet activation, Harness selection, and operator-configured runtime plugins.
+   *
+   * Each entry's `roles` is a non-empty subset of `['solving', 'evaluating']`.
+   * Both roles can run concurrently for the same SolverNet; the protocol-level
+   * `disallowSolverSelfEvaluation` flag prevents the operator from evaluating
+   * its own Solutions and the on-chain TaskActivityCheckerV3 tracks
+   * Solution and Verdict counters independently (additive into
+   * `eligibleActivityWeight`).
+   *
+   * Backwards-compat: a legacy `role: 'solving' | 'evaluating'` field is
+   * auto-promoted to `roles: [<role>]` by the zod preprocessor below so
+   * existing `~/.jinn-client/config.json` files keep loading without an
+   * operator migration step.
+   */
+  solverNets: z.record(z.preprocess(
+    (raw) => {
+      if (typeof raw !== 'object' || raw === null) return raw;
+      const obj = raw as Record<string, unknown>;
+      // Promote legacy `role: X` → `roles: [X]` when only the singular form
+      // is provided. If both are present (mid-migration third-party config),
+      // `roles` wins and `role` is dropped.
+      if (Array.isArray(obj['roles']) && obj['roles'].length > 0) {
+        const { role: _legacyRole, ...rest } = obj;
+        return rest;
+      }
+      if (typeof obj['role'] === 'string' && (obj['role'] === 'solving' || obj['role'] === 'evaluating')) {
+        const { role, ...rest } = obj;
+        return { ...rest, roles: [role] };
+      }
+      return obj;
+    },
+    z.object({
       enabled: z.boolean().default(true),
-    }).default({ enabled: true }),
-  })).default(DEFAULT_SOLVER_NETS),
+      solverType: z.string(),
+      roles: z.array(z.enum(['solving', 'evaluating']))
+        .min(1, 'each SolverNet must enable at least one role')
+        .default(['solving'])
+        // Deduplicate to keep downstream consumers simple.
+        .transform((arr) => Array.from(new Set(arr))),
+      harness: z.string().default('claude-code-learner'),
+      model: z.string().optional(),
+      plugins: z.array(z.union([
+        z.string(),
+        z.object({
+          name: z.string().optional(),
+          source: z.string(),
+          version: z.string().optional(),
+        }),
+      ])).default([]),
+      taskGenerator: z.object({
+        enabled: z.boolean().default(true),
+      }).default({ enabled: true }),
+    }),
+  )).default(DEFAULT_SOLVER_NETS),
 
   /**
    * Trusted ed25519 publishers for external harness impls. The daemon

--- a/client/src/dashboard/spa/src/App.routing.test.tsx
+++ b/client/src/dashboard/spa/src/App.routing.test.tsx
@@ -5,6 +5,8 @@ import { memoryLocation } from 'wouter/memory-location';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { OverviewPage } from './pages/Overview.js';
 import { ConfigurationPage } from './pages/Configuration.js';
+import { LauncherPage } from './pages/Launcher.js';
+import { LauncherConfigurationPage } from './pages/LauncherConfiguration.js';
 
 // Configuration + Overview pages both useQuery for the daemon API; mock so
 // the routing tests don't depend on a live server.
@@ -57,5 +59,31 @@ describe('App routes', () => {
     // Configuration is composed of three section cards; the SolverNets head
     // is the most stable assertion since it never collapses to nothing.
     expect(screen.getByText(/solvernets/i)).toBeTruthy();
+  });
+
+  it('renders LauncherPage on /launcher', () => {
+    render(
+      withProviders(
+        <Switch>
+          <Route path="/launcher" component={LauncherPage} />
+          <Route path="/launcher/configuration" component={LauncherConfigurationPage} />
+        </Switch>,
+        '/launcher',
+      ),
+    );
+    expect(screen.getByRole('heading', { name: /launch a solvernet/i })).toBeTruthy();
+  });
+
+  it('renders LauncherConfigurationPage on /launcher/configuration', () => {
+    render(
+      withProviders(
+        <Switch>
+          <Route path="/launcher" component={LauncherPage} />
+          <Route path="/launcher/configuration" component={LauncherConfigurationPage} />
+        </Switch>,
+        '/launcher/configuration',
+      ),
+    );
+    expect(screen.getByRole('heading', { name: /generator config/i })).toBeTruthy();
   });
 });

--- a/client/src/dashboard/spa/src/App.routing.test.tsx
+++ b/client/src/dashboard/spa/src/App.routing.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { Router, Route, Switch } from 'wouter';
 import { memoryLocation } from 'wouter/memory-location';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -8,8 +8,8 @@ import { ConfigurationPage } from './pages/Configuration.js';
 import { LauncherPage } from './pages/Launcher.js';
 import { LauncherConfigurationPage } from './pages/LauncherConfiguration.js';
 
-// Configuration + Overview pages both useQuery for the daemon API; mock so
-// the routing tests don't depend on a live server.
+// Configuration + Overview + Launcher pages all useQuery for the daemon API;
+// mock so the routing tests don't depend on a live server.
 vi.mock('./api/client.js', () => ({
   api: {
     getBootstrap: async () => ({}),
@@ -17,6 +17,9 @@ vi.mock('./api/client.js', () => ({
     getSolverNets: async () => ({ schemaVersion: 1, generatedAt: '', nets: [] }),
     claimRewards: async () => ({ ok: true }),
     restartDaemon: async () => ({ ok: true }),
+    fetchLauncherStatus: async () => ({ schemaVersion: 1, generatedAt: '', nets: [] }),
+    fetchLauncherTasks: async () => ({ schemaVersion: 1, generatedAt: '', tasks: [] }),
+    patchLauncherSolverNet: async () => ({ ok: true, name: 'prediction', roles: [], generator: {} }),
   },
 }));
 
@@ -61,7 +64,7 @@ describe('App routes', () => {
     expect(screen.getByText(/solvernets/i)).toBeTruthy();
   });
 
-  it('renders LauncherPage on /launcher', () => {
+  it('renders LauncherPage on /launcher', async () => {
     render(
       withProviders(
         <Switch>
@@ -71,7 +74,10 @@ describe('App routes', () => {
         '/launcher',
       ),
     );
-    expect(screen.getByRole('heading', { name: /launch a solvernet/i })).toBeTruthy();
+    // No SolverNet has 'launching' role yet -> empty state surfaces.
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /you haven't launched a solvernet yet/i })).toBeTruthy(),
+    );
   });
 
   it('renders LauncherConfigurationPage on /launcher/configuration', () => {

--- a/client/src/dashboard/spa/src/App.tsx
+++ b/client/src/dashboard/spa/src/App.tsx
@@ -12,6 +12,8 @@ import { AgentRail } from './shell/AgentRail.js';
 import { RestartBanner } from './shell/RestartBanner.js';
 import { OverviewPage } from './pages/Overview.js';
 import { ConfigurationPage } from './pages/Configuration.js';
+import { LauncherPage } from './pages/Launcher.js';
+import { LauncherConfigurationPage } from './pages/LauncherConfiguration.js';
 
 /**
  * App routes between two distinct phases of operator life:
@@ -66,6 +68,8 @@ export default function App(): JSX.Element {
           <Route path="/configuration">
             <ConfigurationPage onRestartPending={() => setRestartPending(true)} />
           </Route>
+          <Route path="/launcher/configuration" component={LauncherConfigurationPage} />
+          <Route path="/launcher" component={LauncherPage} />
           <Route><Redirect to="/overview" /></Route>
         </Switch>
       </AppShell>

--- a/client/src/dashboard/spa/src/Launcher.e2e.test.tsx
+++ b/client/src/dashboard/spa/src/Launcher.e2e.test.tsx
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+/**
+ * End-to-end happy path for the Launcher mode (Task 18 of
+ * docs/superpowers/plans/2026-05-05-launcher-role-and-mode-plan.md).
+ *
+ * Walks the full user flow against the real `App` component:
+ *
+ *   1. Default Operator mode renders on /overview after bootstrap.
+ *   2. Click ModeSwitch -> Launcher; URL flips to /launcher and the
+ *      EmptyState surfaces because no SolverNet has 'launching' role.
+ *   3. CTA opens the 4-step SetupFlow.
+ *   4. Walk Next x3 -> Save fires `patchLauncherSolverNet` with
+ *      `{ launching: true }`.
+ *   5. After save, the configured-state cards render with the
+ *      Prediction intent line.
+ *   6. Switch back to Operator mode; launcher state must NOT leak
+ *      into Operator (strict separation per spec §6.3).
+ *   7. localStorage persists the most-recent mode under
+ *      `jinn.app.mode`.
+ *
+ * All daemon-side api calls are mocked. Bootstrap returns `mode:
+ * 'running'` so App.tsx routes to the operating shell instead of
+ * Onboarding.
+ */
+
+vi.mock('./api/client.js', () => ({
+  api: {
+    getBootstrap: vi.fn(),
+    getStatus: vi.fn(),
+    claimRewards: vi.fn(),
+    restartDaemon: vi.fn(),
+    fetchLauncherStatus: vi.fn(),
+    fetchLauncherTasks: vi.fn(),
+    patchLauncherSolverNet: vi.fn(),
+  },
+  ensureSessionToken: vi.fn(),
+}));
+
+// AgentRail pulls in xterm + WebSocket, neither of which is happy in
+// jsdom. Stub it; this test exercises mode-switching, not the agent
+// terminal.
+vi.mock('./shell/AgentRail.js', () => ({
+  AgentRail: () => null,
+}));
+
+// `useEventStream` opens an EventSource on mount; jsdom has no
+// EventSource. LoadingScreen briefly renders before the bootstrap query
+// resolves, so this stub is required even with AgentRail stubbed.
+vi.mock('./api/events.js', () => ({
+  useEventStream: () => ({ events: [], connected: false }),
+}));
+
+const App = (await import('./App.js')).default;
+const { api } = await import('./api/client.js');
+
+function wrap(ui: JSX.Element): ReturnType<typeof render> {
+  const qc = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+const runningBootstrap = {
+  schemaVersion: 1 as const,
+  mode: 'running' as const,
+  steps: [],
+  currentStep: 'complete',
+  services: [],
+  master_address: '0xE64bAf0073a71b0Cb2C0558bB16f24b45E1FB5CF',
+  chain: 'base-sepolia',
+};
+
+const operatorStatusEmpty = {
+  predictionV1: {
+    operator: {
+      ok: true,
+      solverNet: { name: 'prediction', enabled: false },
+      diagnostics: [],
+    },
+    totals: { observedTasks: 0, activeTaskRuns: 0, solutions: 0, verdicts: 0, failed: 0 },
+  },
+  fleet: { services: [] },
+  rewards: { pendingStakingRewardsWei: '0' },
+  masterGas: { balanceWei: '0', runwayDaysExcess: 0 },
+};
+
+const emptyLauncherStatus = {
+  schemaVersion: 1 as const,
+  generatedAt: '2026-05-05T15:00:00Z',
+  nets: [],
+};
+
+const emptyLauncherTasks = {
+  schemaVersion: 1 as const,
+  generatedAt: '2026-05-05T15:00:00Z',
+  tasks: [],
+};
+
+const launchingLauncherStatus = {
+  schemaVersion: 1 as const,
+  generatedAt: '2026-05-05T15:00:00Z',
+  nets: [
+    {
+      name: 'prediction',
+      generator: {
+        state: 'active' as const,
+        cadenceMs: 21_600_000,
+        lastPollAt: '2026-05-05T15:00:00Z',
+        lastPollSummary: { evaluated: 3, posted: 2, skipped: 1 },
+        stale: false,
+      },
+      openTasks: 2,
+      budget: {
+        safeAddress: '0xabc',
+        safeBalanceWei: '1000000000000000000',
+        reservedBudgetWei: '200000000000000000',
+      },
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  // Reset jsdom URL to root so wouter's browser location starts clean.
+  window.history.pushState({}, '', '/');
+  vi.mocked(api.getBootstrap).mockResolvedValue(runningBootstrap);
+  vi.mocked(api.getStatus).mockResolvedValue(operatorStatusEmpty);
+  vi.mocked(api.claimRewards).mockResolvedValue({ ok: true });
+  vi.mocked(api.restartDaemon).mockResolvedValue({ ok: true });
+  vi.mocked(api.fetchLauncherStatus).mockResolvedValue(emptyLauncherStatus);
+  vi.mocked(api.fetchLauncherTasks).mockResolvedValue(emptyLauncherTasks);
+  vi.mocked(api.patchLauncherSolverNet).mockResolvedValue({
+    ok: true,
+    name: 'prediction',
+    roles: ['launching'],
+    generator: {},
+  });
+});
+
+describe('Launcher mode end-to-end happy path', () => {
+  it('walks Operator -> Launcher -> setup -> configured -> back to Operator', async () => {
+    wrap(<App />);
+
+    // 1. Default Operator mode: App redirects to /overview after the
+    //    running-bootstrap query resolves; the Header's "jinn operator"
+    //    brand and ModeSwitch surface.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Operator' })).toBeTruthy(),
+    );
+    expect(screen.getByRole('button', { name: 'Operator' }).getAttribute('data-active')).toBe('true');
+
+    // 2. Click ModeSwitch -> Launcher. Header.onModeChange flips both the
+    //    persisted mode and routes to /launcher; LauncherPage's empty
+    //    state appears because no SolverNet has 'launching' role.
+    fireEvent.click(screen.getByRole('button', { name: 'Launcher' }));
+    await waitFor(() =>
+      expect(screen.getByText(/You haven't launched a SolverNet yet/i)).toBeTruthy(),
+    );
+
+    // 3. Empty-state CTA -> setup flow. Step 1 of 4 mentions the
+    //    Prediction intent line.
+    fireEvent.click(screen.getByRole('button', { name: /Launch Prediction SolverNet/i }));
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /^Next$/i })).toBeTruthy(),
+    );
+
+    // 4. Walk 4-step setup. Steps 1-3 show "Next"; step 4 swaps for "Save".
+    fireEvent.click(screen.getByRole('button', { name: /^Next$/i })); // step 1 -> 2
+    fireEvent.click(screen.getByRole('button', { name: /^Next$/i })); // step 2 -> 3
+    fireEvent.click(screen.getByRole('button', { name: /^Next$/i })); // step 3 -> 4
+
+    // Update mocked status so the next refetch sees the launching net.
+    vi.mocked(api.fetchLauncherStatus).mockResolvedValue(launchingLauncherStatus);
+
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+    await waitFor(() =>
+      expect(api.patchLauncherSolverNet).toHaveBeenCalledWith(
+        'prediction',
+        expect.objectContaining({ launching: true }),
+      ),
+    );
+
+    // 5. After save, configured-state cards render with the Prediction
+    //    intent line in KnowledgeProductionCard.
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Calibrated probabilistic forecasts of Polymarket-listed events/i),
+      ).toBeTruthy(),
+    );
+
+    // 6. Switch back to Operator. Launcher state must NOT leak -- the
+    //    KnowledgeProductionCard intent line is gone from the DOM, and the
+    //    EmptyState heading from launcher is also absent.
+    fireEvent.click(screen.getByRole('button', { name: 'Operator' }));
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/Calibrated probabilistic forecasts of Polymarket-listed events/i),
+      ).toBeNull(),
+    );
+    expect(screen.queryByText(/You haven't launched a SolverNet yet/i)).toBeNull();
+
+    // 7. localStorage persists the most-recent mode (operator after the
+    //    back-switch) under the canonical key.
+    expect(localStorage.getItem('jinn.app.mode')).toBe('operator');
+  });
+});

--- a/client/src/dashboard/spa/src/api/client.ts
+++ b/client/src/dashboard/spa/src/api/client.ts
@@ -3,6 +3,10 @@ import type {
   ClaudeAuthState,
   StructuredEvent,
   SolverNetsCatalogResponse,
+  LauncherStatusResponse,
+  LauncherTasksResponse,
+  LauncherSolverNetPatch,
+  LauncherSolverNetPatchResponse,
 } from './types.js';
 
 async function jfetch<T>(path: string, init?: RequestInit): Promise<T> {
@@ -116,6 +120,30 @@ export const api = {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(patch ?? {}),
     }),
+
+  // ---- Launcher mode (spec/2026-05-05-launcher-role-and-mode.md §5.3) ----
+  // Operator mode never calls these — Operator-mode UI shows zero launcher
+  // state per §6.3 strict separation.
+  fetchLauncherStatus: () =>
+    jfetch<LauncherStatusResponse>('/v1/launcher/status'),
+  fetchLauncherTasks: (opts: { cursor?: string; limit?: number } = {}) => {
+    const q = new URLSearchParams();
+    if (opts.cursor) q.set('cursor', opts.cursor);
+    if (opts.limit !== undefined) q.set('limit', String(opts.limit));
+    const qs = q.toString();
+    return jfetch<LauncherTasksResponse>(
+      `/v1/launcher/tasks${qs ? `?${qs}` : ''}`,
+    );
+  },
+  patchLauncherSolverNet: (name: string, patch: LauncherSolverNetPatch) =>
+    jfetch<LauncherSolverNetPatchResponse>(
+      `/v1/launcher/solvernets/${encodeURIComponent(name)}`,
+      {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(patch),
+      },
+    ),
 };
 
 /**

--- a/client/src/dashboard/spa/src/api/client.ts
+++ b/client/src/dashboard/spa/src/api/client.ts
@@ -75,7 +75,7 @@ export const api = {
     name: string,
     patch: {
       enabled?: boolean;
-      role?: 'solving' | 'evaluating';
+      roles?: Array<'solving' | 'evaluating'>;
       harness?: string;
       model?: string;
       plugins?: string[];
@@ -88,7 +88,7 @@ export const api = {
       name: string;
       config: {
         enabled?: boolean;
-        role?: 'solving' | 'evaluating';
+        roles?: Array<'solving' | 'evaluating'>;
         harness?: string;
         model?: string;
         plugins?: string[];

--- a/client/src/dashboard/spa/src/api/types.ts
+++ b/client/src/dashboard/spa/src/api/types.ts
@@ -80,3 +80,105 @@ export interface SolverNetsCatalogResponse {
   generatedAt: string;
   nets: SolverNetCatalogEntry[];
 }
+
+/**
+ * Mirror of the daemon-side `LauncherStatusResponse`
+ * (client/src/api/launcher-status.ts). Surfaces per-SolverNet generator state,
+ * open-Task counts, and Safe-budget runway for SolverNets whose `roles`
+ * includes `'launching'`. Operator mode never reads this — the launcher state
+ * lives exclusively here (spec/2026-05-05-launcher-role-and-mode.md §6.3).
+ */
+export interface LauncherStatusGeneratorView {
+  state: 'active' | 'paused' | 'errored';
+  lastPollAt?: string;
+  lastPollSummary?: {
+    evaluated: number;
+    posted: number;
+    skipped: number;
+  };
+  lastError?: { message: string; at: string };
+  cadenceMs: number;
+  stale: boolean;
+}
+
+export interface LauncherStatusBudgetView {
+  safeAddress: string;
+  safeBalanceWei: string;
+  reservedBudgetWei: string;
+  runwayDays?: number;
+}
+
+export interface LauncherStatusNetEntry {
+  name: string;
+  generator: LauncherStatusGeneratorView;
+  openTasks: number;
+  budget: LauncherStatusBudgetView;
+}
+
+export interface LauncherStatusResponse {
+  schemaVersion: 1;
+  generatedAt: string;
+  nets: LauncherStatusNetEntry[];
+}
+
+/**
+ * Mirror of the daemon-side `LauncherTaskState` / `LauncherTaskEntry` /
+ * `LauncherTasksResponse` (client/src/api/launcher-tasks.ts). Paginated by
+ * `cursor.before` (ISO timestamp); the SPA passes the bare ISO back as the
+ * next-page cursor.
+ */
+export type LauncherTaskState =
+  | 'open'
+  | 'claims-in-flight'
+  | 'fully-claimed'
+  | 'settled'
+  | 'failed';
+
+export interface LauncherTaskEntry {
+  taskId: string;
+  taskCid: string;
+  solverNet: string;
+  postedAt: string;
+  state: LauncherTaskState;
+  claims: { current: number; max: number };
+  budget: { totalWei: string; remainingWei: string; reclaimableAt?: string };
+  summary?: { title?: string; resolutionTime?: string };
+}
+
+export interface LauncherTasksResponse {
+  schemaVersion: 1;
+  generatedAt: string;
+  cursor?: { before: string };
+  tasks: LauncherTaskEntry[];
+}
+
+/**
+ * Body shape for `PATCH /v1/launcher/solvernets/:name`. Owns the `'launching'`
+ * role flip and the top-level `predictionV1*` generator-config keys. Operator
+ * mode owns `'solving'` / `'evaluating'` via `POST /v1/setup/solvernets/:name`
+ * — strict separation per spec §3.
+ *
+ * Generator-config keys here mirror the daemon-side `mapGeneratorPatch` table
+ * in `client/src/api/launcher-endpoints.ts`; keep in sync with the
+ * `predictionV1*` fields in `JinnConfigSchema`.
+ */
+export interface LauncherSolverNetPatch {
+  launching?: boolean;
+  generator?: {
+    cadenceMs?: number;
+    maxNewRoundsPerPoll?: number;
+    maxNewRoundsPerDay?: number;
+    maxOpenRounds?: number;
+    allowlistConditionIds?: string[];
+    blocklistConditionIds?: string[];
+    windowMs?: number;
+    resolveGapMs?: number;
+  };
+}
+
+export interface LauncherSolverNetPatchResponse {
+  ok: true;
+  name: string;
+  roles: string[];
+  generator: Record<string, unknown>;
+}

--- a/client/src/dashboard/spa/src/pages/Launcher.test.tsx
+++ b/client/src/dashboard/spa/src/pages/Launcher.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cleanup, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { LauncherPage } from './Launcher.js';
+import { api } from '../api/client.js';
+
+vi.mock('../api/client.js', () => ({
+  api: {
+    fetchLauncherStatus: vi.fn(),
+    fetchLauncherTasks: vi.fn(),
+    patchLauncherSolverNet: vi.fn(),
+  },
+}));
+
+function wrap(ui: JSX.Element): ReturnType<typeof render> {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('LauncherPage', () => {
+  it('renders empty state when no SolverNet has launching role', async () => {
+    vi.mocked(api.fetchLauncherStatus).mockResolvedValue({
+      schemaVersion: 1,
+      generatedAt: '2026-05-05T15:00:00Z',
+      nets: [],
+    });
+    vi.mocked(api.fetchLauncherTasks).mockResolvedValue({
+      schemaVersion: 1,
+      generatedAt: '2026-05-05T15:00:00Z',
+      tasks: [],
+    });
+    wrap(<LauncherPage />);
+    await waitFor(() =>
+      expect(screen.queryByText(/You haven't launched a SolverNet yet/i)).toBeTruthy(),
+    );
+  });
+
+  it('renders configured-state overview when a SolverNet has launching role', async () => {
+    vi.mocked(api.fetchLauncherStatus).mockResolvedValue({
+      schemaVersion: 1,
+      generatedAt: '2026-05-05T15:00:00Z',
+      nets: [
+        {
+          name: 'prediction',
+          generator: {
+            state: 'active',
+            cadenceMs: 21_600_000,
+            lastPollAt: '2026-05-05T14:00:00Z',
+            lastPollSummary: { evaluated: 3, posted: 2, skipped: 1 },
+            stale: false,
+          },
+          openTasks: 2,
+          budget: {
+            safeAddress: '0xabc',
+            safeBalanceWei: '1000000000000000000',
+            reservedBudgetWei: '200000000000000000',
+          },
+        },
+      ],
+    });
+    vi.mocked(api.fetchLauncherTasks).mockResolvedValue({
+      schemaVersion: 1,
+      generatedAt: '2026-05-05T15:00:00Z',
+      tasks: [],
+    });
+    wrap(<LauncherPage />);
+    await waitFor(() =>
+      expect(screen.queryByText(/Calibrated probabilistic forecasts/i)).toBeTruthy(),
+    );
+    expect(screen.queryAllByText(/Active/i).length).toBeGreaterThan(0);
+  });
+
+  it('opens setup flow on launch CTA click and patches launcher config on save', async () => {
+    vi.mocked(api.fetchLauncherStatus).mockResolvedValue({
+      schemaVersion: 1,
+      generatedAt: '2026-05-05T15:00:00Z',
+      nets: [],
+    });
+    vi.mocked(api.fetchLauncherTasks).mockResolvedValue({
+      schemaVersion: 1,
+      generatedAt: '2026-05-05T15:00:00Z',
+      tasks: [],
+    });
+    vi.mocked(api.patchLauncherSolverNet).mockResolvedValue({
+      ok: true,
+      name: 'prediction',
+      roles: ['launching'],
+      generator: {},
+    });
+    wrap(<LauncherPage />);
+    await waitFor(() => expect(screen.queryByText(/You haven't launched/i)).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: /Launch Prediction SolverNet/i }));
+    // Walk the wizard
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+    await waitFor(() =>
+      expect(api.patchLauncherSolverNet).toHaveBeenCalledWith(
+        'prediction',
+        expect.objectContaining({ launching: true }),
+      ),
+    );
+  });
+});

--- a/client/src/dashboard/spa/src/pages/Launcher.tsx
+++ b/client/src/dashboard/spa/src/pages/Launcher.tsx
@@ -1,32 +1,106 @@
+import { Fragment, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '../api/client.js';
+import { EmptyState } from './launcher/EmptyState.js';
+import { SetupFlow } from './launcher/SetupFlow.js';
+import { KnowledgeProductionCard } from './launcher/KnowledgeProductionCard.js';
+import { CostCard } from './launcher/CostCard.js';
+import { GeneratorStatusCard } from './launcher/GeneratorStatusCard.js';
+import { PostedTasksList } from './launcher/PostedTasksList.js';
+import { EmissionsPlaceholder } from './launcher/EmissionsPlaceholder.js';
+
 /**
- * Launcher page — entry point for the Launcher mode.
+ * Launcher mode overview page — composes Tasks 12-15's components per
+ * spec/2026-05-05-launcher-role-and-mode.md §6.4 + §6.5.
  *
- * This is a placeholder stub. Task 16 fills in the empty / configured states
- * for "Launch a SolverNet" once the underlying API surface lands.
+ * - No SolverNet has 'launching' role -> EmptyState (with CTA to setup).
+ * - CTA clicked -> SetupFlow wizard (4 steps; flips 'launching' on via PATCH).
+ * - At least one launching SolverNet -> tier 1-4 stack:
+ *     1. KnowledgeProductionCard (intent + scoreboard + recent settled)
+ *     2. CostCard (7d burn + funded + open-budget reservations)
+ *     3. GeneratorStatusCard + PostedTasksList (tactical state)
+ *     4. EmissionsPlaceholder (Phase B+ ve-JINN gauge)
  */
+
+const PREDICTION_INTENT = 'Calibrated probabilistic forecasts of Polymarket-listed events';
+
+const DEFAULT_GENERATOR_DEFAULTS = {
+  cadenceMs: 21_600_000,
+  maxNewRoundsPerPoll: 5,
+  maxNewRoundsPerDay: 100,
+  maxOpenRounds: 250,
+};
+
 export function LauncherPage(): JSX.Element {
+  const qc = useQueryClient();
+  const { data: status } = useQuery({
+    queryKey: ['launcher-status'],
+    queryFn: () => api.fetchLauncherStatus(),
+    refetchInterval: 30_000,
+  });
+  const { data: tasks } = useQuery({
+    queryKey: ['launcher-tasks'],
+    queryFn: () => api.fetchLauncherTasks(),
+  });
+  const [setupOpen, setSetupOpen] = useState(false);
+
+  if (!status) {
+    return <div style={{ padding: 24, color: 'var(--fg-muted)' }}>Loading…</div>;
+  }
+
+  if (setupOpen) {
+    return (
+      <div style={{ padding: '24px' }}>
+        <SetupFlow
+          netName="prediction"
+          defaults={DEFAULT_GENERATOR_DEFAULTS}
+          safeBalanceWei={status.nets[0]?.budget?.safeBalanceWei ?? '0'}
+          onPatch={(name, patch) => api.patchLauncherSolverNet(name, patch)}
+          onComplete={() => {
+            setSetupOpen(false);
+            qc.invalidateQueries({ queryKey: ['launcher-status'] });
+            qc.invalidateQueries({ queryKey: ['launcher-tasks'] });
+          }}
+        />
+      </div>
+    );
+  }
+
+  if (status.nets.length === 0) {
+    return (
+      <div style={{ padding: '24px' }}>
+        <EmptyState onLaunch={() => setSetupOpen(true)} />
+      </div>
+    );
+  }
+
   return (
-    <div
-      style={{
-        padding: '24px',
-        fontFamily: "'JetBrains Mono', ui-monospace, SF Mono, Menlo, monospace",
-        color: 'var(--fg)',
-      }}
-    >
-      <h1
-        style={{
-          fontFamily: "'Instrument Serif', 'Times New Roman', serif",
-          fontSize: '32px',
-          margin: '0 0 12px',
-          color: 'var(--fg)',
-          fontWeight: 400,
-        }}
-      >
-        Launch a SolverNet
-      </h1>
-      <p style={{ color: 'var(--fg-muted)', fontSize: '13px' }}>
-        Stub. Task 16 fills in the empty/configured states.
-      </p>
+    <div style={{ padding: '24px', display: 'flex', flexDirection: 'column', gap: '16px' }}>
+      {status.nets.map((net) => (
+        <Fragment key={net.name}>
+          <KnowledgeProductionCard
+            netName={net.name}
+            intent={net.name === 'prediction' ? PREDICTION_INTENT : net.name}
+            // TODO(jinn-mono-l2zl.16.X): wire actual Brier scoreboard endpoint.
+            // Data path exists in client/src/corpus/prediction-brier-scoreboard.ts
+            // but is not exposed via HTTP to the SPA yet.
+            scoreboard={undefined}
+            recentSettled={[]}
+          />
+          <CostCard
+            // TODO(jinn-mono-l2zl.16.X): derive 7d burn from settled tasks.
+            burn7dWei="0"
+            tasksFunded7d={net.openTasks}
+            openTaskBudgetWei={net.budget.reservedBudgetWei}
+          />
+          <GeneratorStatusCard status={net.generator} />
+          <PostedTasksList
+            tasks={(tasks?.tasks ?? []).filter((t) => t.solverNet === net.name)}
+            onLoadMore={() => qc.invalidateQueries({ queryKey: ['launcher-tasks'] })}
+          />
+          <EmissionsPlaceholder />
+        </Fragment>
+      ))}
     </div>
   );
 }

--- a/client/src/dashboard/spa/src/pages/Launcher.tsx
+++ b/client/src/dashboard/spa/src/pages/Launcher.tsx
@@ -1,0 +1,32 @@
+/**
+ * Launcher page — entry point for the Launcher mode.
+ *
+ * This is a placeholder stub. Task 16 fills in the empty / configured states
+ * for "Launch a SolverNet" once the underlying API surface lands.
+ */
+export function LauncherPage(): JSX.Element {
+  return (
+    <div
+      style={{
+        padding: '24px',
+        fontFamily: "'JetBrains Mono', ui-monospace, SF Mono, Menlo, monospace",
+        color: 'var(--fg)',
+      }}
+    >
+      <h1
+        style={{
+          fontFamily: "'Instrument Serif', 'Times New Roman', serif",
+          fontSize: '32px',
+          margin: '0 0 12px',
+          color: 'var(--fg)',
+          fontWeight: 400,
+        }}
+      >
+        Launch a SolverNet
+      </h1>
+      <p style={{ color: 'var(--fg-muted)', fontSize: '13px' }}>
+        Stub. Task 16 fills in the empty/configured states.
+      </p>
+    </div>
+  );
+}

--- a/client/src/dashboard/spa/src/pages/LauncherConfiguration.test.tsx
+++ b/client/src/dashboard/spa/src/pages/LauncherConfiguration.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { LauncherConfigurationPage } from './LauncherConfiguration.js';
 import { api } from '../api/client.js';
@@ -89,5 +89,47 @@ describe('LauncherConfigurationPage', () => {
     wrap(<LauncherConfigurationPage />);
     await waitFor(() => expect(screen.queryByText(/prediction generator/i)).toBeTruthy());
     expect(screen.queryByText(/forecast generator/i)).toBeTruthy();
+  });
+
+  it('shows pending and success feedback when generator config saves', async () => {
+    vi.mocked(api.fetchLauncherStatus).mockResolvedValue({
+      schemaVersion: 1,
+      generatedAt: '2026-05-05T15:00:00Z',
+      nets: [
+        {
+          name: 'prediction',
+          generator: { state: 'active', cadenceMs: 21_600_000, stale: false },
+          openTasks: 0,
+          budget: {
+            safeAddress: '0xabc',
+            safeBalanceWei: '0',
+            reservedBudgetWei: '0',
+          },
+        },
+      ],
+    });
+    let resolvePatch: () => void = () => undefined;
+    vi.mocked(api.patchLauncherSolverNet).mockReturnValue(
+      new Promise((resolve) => {
+        resolvePatch = () =>
+          resolve({
+            ok: true,
+            name: 'prediction',
+            roles: ['launching'],
+            generator: { cadenceMs: 120_000 },
+          });
+      }),
+    );
+
+    wrap(<LauncherConfigurationPage />);
+    await waitFor(() => expect(screen.queryByLabelText(/^Cadence$/i)).toBeTruthy());
+    fireEvent.change(screen.getByLabelText(/^Cadence$/i), { target: { value: '120000' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+
+    expect(screen.getByRole('button', { name: /Saving/i })).toBeTruthy();
+    resolvePatch();
+    await waitFor(() =>
+      expect(screen.queryByText(/prediction generator saved/i)).toBeTruthy(),
+    );
   });
 });

--- a/client/src/dashboard/spa/src/pages/LauncherConfiguration.test.tsx
+++ b/client/src/dashboard/spa/src/pages/LauncherConfiguration.test.tsx
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { LauncherConfigurationPage } from './LauncherConfiguration.js';
+import { api } from '../api/client.js';
+
+vi.mock('../api/client.js', () => ({
+  api: {
+    fetchLauncherStatus: vi.fn(),
+    patchLauncherSolverNet: vi.fn(),
+  },
+}));
+
+function wrap(ui: JSX.Element): ReturnType<typeof render> {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('LauncherConfigurationPage', () => {
+  it('renders generator config form for each launching SolverNet', async () => {
+    vi.mocked(api.fetchLauncherStatus).mockResolvedValue({
+      schemaVersion: 1,
+      generatedAt: '2026-05-05T15:00:00Z',
+      nets: [
+        {
+          name: 'prediction',
+          generator: { state: 'active', cadenceMs: 21_600_000, stale: false },
+          openTasks: 0,
+          budget: {
+            safeAddress: '0xabc',
+            safeBalanceWei: '0',
+            reservedBudgetWei: '0',
+          },
+        },
+      ],
+    });
+    wrap(<LauncherConfigurationPage />);
+    await waitFor(() => expect(screen.queryByLabelText(/^Cadence$/i)).toBeTruthy());
+    expect(screen.queryByText(/prediction generator/i)).toBeTruthy();
+  });
+
+  it('shows hint when no SolverNet has launching role', async () => {
+    vi.mocked(api.fetchLauncherStatus).mockResolvedValue({
+      schemaVersion: 1,
+      generatedAt: '2026-05-05T15:00:00Z',
+      nets: [],
+    });
+    wrap(<LauncherConfigurationPage />);
+    await waitFor(() =>
+      expect(screen.queryByText(/No launching SolverNets/i)).toBeTruthy(),
+    );
+  });
+
+  it('renders one section per launching net when multiple are present', async () => {
+    vi.mocked(api.fetchLauncherStatus).mockResolvedValue({
+      schemaVersion: 1,
+      generatedAt: '2026-05-05T15:00:00Z',
+      nets: [
+        {
+          name: 'prediction',
+          generator: { state: 'active', cadenceMs: 21_600_000, stale: false },
+          openTasks: 0,
+          budget: {
+            safeAddress: '0xabc',
+            safeBalanceWei: '0',
+            reservedBudgetWei: '0',
+          },
+        },
+        {
+          name: 'forecast',
+          generator: { state: 'paused', cadenceMs: 21_600_000, stale: false },
+          openTasks: 0,
+          budget: {
+            safeAddress: '0xdef',
+            safeBalanceWei: '0',
+            reservedBudgetWei: '0',
+          },
+        },
+      ],
+    });
+    wrap(<LauncherConfigurationPage />);
+    await waitFor(() => expect(screen.queryByText(/prediction generator/i)).toBeTruthy());
+    expect(screen.queryByText(/forecast generator/i)).toBeTruthy();
+  });
+});

--- a/client/src/dashboard/spa/src/pages/LauncherConfiguration.tsx
+++ b/client/src/dashboard/spa/src/pages/LauncherConfiguration.tsx
@@ -1,0 +1,32 @@
+/**
+ * Launcher configuration page — per-SolverNet generator config.
+ *
+ * This is a placeholder stub. Task 17 fills in the per-SolverNet generator
+ * config form once the launcher PATCH endpoint surface lands.
+ */
+export function LauncherConfigurationPage(): JSX.Element {
+  return (
+    <div
+      style={{
+        padding: '24px',
+        fontFamily: "'JetBrains Mono', ui-monospace, SF Mono, Menlo, monospace",
+        color: 'var(--fg)',
+      }}
+    >
+      <h1
+        style={{
+          fontFamily: "'Instrument Serif', 'Times New Roman', serif",
+          fontSize: '32px',
+          margin: '0 0 12px',
+          color: 'var(--fg)',
+          fontWeight: 400,
+        }}
+      >
+        Generator config
+      </h1>
+      <p style={{ color: 'var(--fg-muted)', fontSize: '13px' }}>
+        Stub. Task 17 fills in the per-SolverNet generator config form.
+      </p>
+    </div>
+  );
+}

--- a/client/src/dashboard/spa/src/pages/LauncherConfiguration.tsx
+++ b/client/src/dashboard/spa/src/pages/LauncherConfiguration.tsx
@@ -1,15 +1,57 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '../api/client.js';
+import {
+  GeneratorConfigSection,
+  type GeneratorConfig,
+} from './launcher/GeneratorConfigSection.js';
+
 /**
- * Launcher configuration page — per-SolverNet generator config.
+ * Launcher mode > /launcher/configuration. Per-SolverNet generator config
+ * editor.
  *
- * This is a placeholder stub. Task 17 fills in the per-SolverNet generator
- * config form once the launcher PATCH endpoint surface lands.
+ * Renders one `GeneratorConfigSection` per SolverNet whose `roles` includes
+ * `'launching'` (mirrored from the daemon's `/v1/launcher/status` response).
+ *
+ * Edits hot-apply per spec §5.2 — there is no daemon-restart pill on this
+ * page. After a successful PATCH the launcher status query is invalidated
+ * so the rest of Launcher mode picks up the new cadence/window.
+ *
+ * KNOWN GAP: the form starts from `PREDICTION_DEFAULTS` rather than the
+ * operator's currently-resolved generator config because no endpoint
+ * surfaces those values to the SPA today. Tracked in the bd issue filed
+ * with Task 17 — extend `/v1/launcher/status` (or add
+ * `/v1/launcher/config/:net`) so the form pre-fills with the persisted
+ * values.
  */
+
+const PREDICTION_DEFAULTS: GeneratorConfig = {
+  cadenceMs: 21_600_000,
+  maxNewRoundsPerPoll: 5,
+  maxNewRoundsPerDay: 100,
+  maxOpenRounds: 250,
+  allowlistConditionIds: [],
+  blocklistConditionIds: [],
+  windowMs: 86_400_000,
+  resolveGapMs: 3_600_000,
+};
+
 export function LauncherConfigurationPage(): JSX.Element {
+  const qc = useQueryClient();
+  const { data: status, isLoading } = useQuery({
+    queryKey: ['launcher-status'],
+    queryFn: () => api.fetchLauncherStatus(),
+  });
+
+  const launchingNets = status?.nets ?? [];
+
   return (
     <div
       style={{
         padding: '24px',
-        fontFamily: "'JetBrains Mono', ui-monospace, SF Mono, Menlo, monospace",
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '16px',
+        fontFamily: "'JetBrains Mono', monospace",
         color: 'var(--fg)',
       }}
     >
@@ -17,16 +59,39 @@ export function LauncherConfigurationPage(): JSX.Element {
         style={{
           fontFamily: "'Instrument Serif', 'Times New Roman', serif",
           fontSize: '32px',
-          margin: '0 0 12px',
+          margin: '0 0 4px',
           color: 'var(--fg)',
           fontWeight: 400,
         }}
       >
         Generator config
       </h1>
-      <p style={{ color: 'var(--fg-muted)', fontSize: '13px' }}>
-        Stub. Task 17 fills in the per-SolverNet generator config form.
+      <p style={{ color: 'var(--fg-muted)', fontSize: '13px', margin: 0 }}>
+        Edits hot-apply within one cadence — no daemon restart required.
       </p>
+      {isLoading || !status ? (
+        <p style={{ color: 'var(--fg-muted)', fontSize: '13px' }}>Loading…</p>
+      ) : launchingNets.length === 0 ? (
+        <p style={{ color: 'var(--fg-muted)', fontSize: '13px' }}>
+          No launching SolverNets — go to{' '}
+          <a href="/launcher" style={{ color: 'var(--accent-sky)' }}>
+            Launcher
+          </a>{' '}
+          first to enable a SolverNet for launching.
+        </p>
+      ) : (
+        launchingNets.map((net) => (
+          <GeneratorConfigSection
+            key={net.name}
+            netName={net.name}
+            config={PREDICTION_DEFAULTS}
+            onSave={async ({ generator }) => {
+              await api.patchLauncherSolverNet(net.name, { generator });
+              qc.invalidateQueries({ queryKey: ['launcher-status'] });
+            }}
+          />
+        ))
+      )}
     </div>
   );
 }

--- a/client/src/dashboard/spa/src/pages/Overview.test.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.test.tsx
@@ -1,19 +1,24 @@
-import { describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { Router } from 'wouter';
 import { memoryLocation } from 'wouter/memory-location';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 /**
  * Overview's empty-state gating depends on the prediction operator
  * payload. We mock `api.getStatus` per-test so the page receives the
  * shape we want to assert against. (jinn-mono-l2zl.15.4.12)
  */
-const getStatusMock = vi.fn();
+const { getStatusMock } = vi.hoisted(() => ({
+  getStatusMock: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({ data: getStatusMock() }),
+}));
 
 vi.mock('../api/client.js', () => ({
   api: {
-    getStatus: () => getStatusMock(),
+    getStatus: async () => getStatusMock(),
     claimRewards: async () => ({ ok: true }),
     restartDaemon: async () => ({ ok: true }),
   },
@@ -22,13 +27,15 @@ vi.mock('../api/client.js', () => ({
 // Import after the mock so the page picks up the mocked client.
 const { OverviewPage } = await import('./Overview.js');
 
+afterEach(() => {
+  cleanup();
+  getStatusMock.mockReset();
+});
+
 function withProviders(node: JSX.Element): JSX.Element {
   const { hook } = memoryLocation({ path: '/overview' });
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return (
-    <QueryClientProvider client={qc}>
-      <Router hook={hook}>{node}</Router>
-    </QueryClientProvider>
+    <Router hook={hook}>{node}</Router>
   );
 }
 
@@ -39,12 +46,12 @@ function operatorEyebrow(name: string): (_: string, el: Element | null) => boole
 }
 
 describe('OverviewPage empty-state gating', () => {
-  it('shows the "Pick a SolverNet" prompt when no SolverNet is opted in', async () => {
-    getStatusMock.mockResolvedValue({
+  it('shows the "Pick a SolverNet" prompt when no operator-visible roles are active', async () => {
+    getStatusMock.mockReturnValue({
       predictionV1: {
         operator: {
           ok: true,
-          solverNet: { name: 'prediction', enabled: false },
+          solverNet: { name: 'prediction', enabled: false, roles: [] },
           diagnostics: [],
         },
         totals: { observedTasks: 0, activeTaskRuns: 0, solutions: 0, verdicts: 0, failed: 0 },
@@ -58,12 +65,12 @@ describe('OverviewPage empty-state gating', () => {
     expect(screen.queryByText(operatorEyebrow('prediction'))).toBeNull();
   });
 
-  it('shows the OperatorCard (and hides the prompt) when the SolverNet is enabled', async () => {
-    getStatusMock.mockResolvedValue({
+  it('shows the OperatorCard when roles include solving even if legacy enabled is false', async () => {
+    getStatusMock.mockReturnValue({
       predictionV1: {
         operator: {
           ok: true,
-          solverNet: { name: 'prediction', enabled: true },
+          solverNet: { name: 'prediction', enabled: false, roles: ['solving'] },
           diagnostics: [],
           nextAction: { description: 'Waiting for tasks.' },
         },
@@ -79,17 +86,15 @@ describe('OverviewPage empty-state gating', () => {
       expect(screen.getByText(operatorEyebrow('prediction'))).toBeTruthy(),
     );
     expect(screen.queryByText(/pick a solvernet to participate in/i)).toBeNull();
+    expect(screen.getByText(/^solver$/i)).toBeTruthy();
   });
 
-  it('shows the OperatorCard for an opted-in operator without a role field', async () => {
-    // The operator-status payload does not currently expose role. Until
-    // jinn-mono-l2zl.15.4.8 lands, any enabled SolverNet must light up
-    // the OperatorCard regardless of the role configured in the daemon.
-    getStatusMock.mockResolvedValue({
+  it('shows both role pills when roles include solving and evaluating', async () => {
+    getStatusMock.mockReturnValue({
       predictionV1: {
         operator: {
           ok: true,
-          solverNet: { name: 'prediction', enabled: true },
+          solverNet: { name: 'prediction', enabled: false, roles: ['solving', 'evaluating'] },
           diagnostics: [],
         },
         totals: { observedTasks: 0, activeTaskRuns: 0, solutions: 0, verdicts: 0, failed: 0 },
@@ -102,10 +107,30 @@ describe('OverviewPage empty-state gating', () => {
       expect(screen.getByText(operatorEyebrow('prediction'))).toBeTruthy(),
     );
     expect(screen.queryByText(/pick a solvernet to participate in/i)).toBeNull();
+    expect(screen.getByText(/^solver$/i)).toBeTruthy();
+    expect(screen.getByText(/^evaluator$/i)).toBeTruthy();
+  });
+
+  it('does not show OperatorCard for a launcher-only role', async () => {
+    getStatusMock.mockReturnValue({
+      predictionV1: {
+        operator: {
+          ok: true,
+          solverNet: { name: 'prediction', enabled: true, roles: ['launching'] },
+          diagnostics: [],
+        },
+        totals: { observedTasks: 0, activeTaskRuns: 0, solutions: 0, verdicts: 0, failed: 0 },
+      },
+      fleet: { services: [] },
+    });
+    render(withProviders(<OverviewPage />));
+
+    expect(await screen.findByText(/pick a solvernet to participate in/i)).toBeTruthy();
+    expect(screen.queryByText(operatorEyebrow('prediction'))).toBeNull();
   });
 
   it('shows the prompt when the operator payload is missing entirely', async () => {
-    getStatusMock.mockResolvedValue({ fleet: { services: [] } });
+    getStatusMock.mockReturnValue({ fleet: { services: [] } });
     render(withProviders(<OverviewPage />));
 
     expect(await screen.findByText(/pick a solvernet to participate in/i)).toBeTruthy();

--- a/client/src/dashboard/spa/src/pages/Overview.test.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.test.tsx
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { Router } from 'wouter';
+import { memoryLocation } from 'wouter/memory-location';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+/**
+ * Overview's empty-state gating depends on the prediction operator
+ * payload. We mock `api.getStatus` per-test so the page receives the
+ * shape we want to assert against. (jinn-mono-l2zl.15.4.12)
+ */
+const getStatusMock = vi.fn();
+
+vi.mock('../api/client.js', () => ({
+  api: {
+    getStatus: () => getStatusMock(),
+    claimRewards: async () => ({ ok: true }),
+    restartDaemon: async () => ({ ok: true }),
+  },
+}));
+
+// Import after the mock so the page picks up the mocked client.
+const { OverviewPage } = await import('./Overview.js');
+
+function withProviders(node: JSX.Element): JSX.Element {
+  const { hook } = memoryLocation({ path: '/overview' });
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={qc}>
+      <Router hook={hook}>{node}</Router>
+    </QueryClientProvider>
+  );
+}
+
+/** Match the OperatorCard's `<span>Your {name}</span>` eyebrow exactly. */
+function operatorEyebrow(name: string): (_: string, el: Element | null) => boolean {
+  return (_, el) =>
+    el?.tagName === 'SPAN' && el.textContent?.trim() === `Your ${name}`;
+}
+
+describe('OverviewPage empty-state gating', () => {
+  it('shows the "Pick a SolverNet" prompt when no SolverNet is opted in', async () => {
+    getStatusMock.mockResolvedValue({
+      predictionV1: {
+        operator: {
+          ok: true,
+          solverNet: { name: 'prediction', enabled: false },
+          diagnostics: [],
+        },
+        totals: { observedTasks: 0, activeTaskRuns: 0, solutions: 0, verdicts: 0, failed: 0 },
+      },
+      fleet: { services: [] },
+    });
+    render(withProviders(<OverviewPage />));
+
+    expect(await screen.findByText(/pick a solvernet to participate in/i)).toBeTruthy();
+    // OperatorCard's "Your <name>" eyebrow must NOT render in this state.
+    expect(screen.queryByText(operatorEyebrow('prediction'))).toBeNull();
+  });
+
+  it('shows the OperatorCard (and hides the prompt) when the SolverNet is enabled', async () => {
+    getStatusMock.mockResolvedValue({
+      predictionV1: {
+        operator: {
+          ok: true,
+          solverNet: { name: 'prediction', enabled: true },
+          diagnostics: [],
+          nextAction: { description: 'Waiting for tasks.' },
+        },
+        totals: { observedTasks: 0, activeTaskRuns: 0, solutions: 0, verdicts: 0, failed: 0 },
+      },
+      fleet: { services: [] },
+    });
+    render(withProviders(<OverviewPage />));
+
+    // useQuery resolves on the next microtask; wait for the operator-card
+    // eyebrow to materialize before asserting the empty-state is gone.
+    await waitFor(() =>
+      expect(screen.getByText(operatorEyebrow('prediction'))).toBeTruthy(),
+    );
+    expect(screen.queryByText(/pick a solvernet to participate in/i)).toBeNull();
+  });
+
+  it('shows the OperatorCard for an opted-in operator without a role field', async () => {
+    // The operator-status payload does not currently expose role. Until
+    // jinn-mono-l2zl.15.4.8 lands, any enabled SolverNet must light up
+    // the OperatorCard regardless of the role configured in the daemon.
+    getStatusMock.mockResolvedValue({
+      predictionV1: {
+        operator: {
+          ok: true,
+          solverNet: { name: 'prediction', enabled: true },
+          diagnostics: [],
+        },
+        totals: { observedTasks: 0, activeTaskRuns: 0, solutions: 0, verdicts: 0, failed: 0 },
+      },
+      fleet: { services: [] },
+    });
+    render(withProviders(<OverviewPage />));
+
+    await waitFor(() =>
+      expect(screen.getByText(operatorEyebrow('prediction'))).toBeTruthy(),
+    );
+    expect(screen.queryByText(/pick a solvernet to participate in/i)).toBeNull();
+  });
+
+  it('shows the prompt when the operator payload is missing entirely', async () => {
+    getStatusMock.mockResolvedValue({ fleet: { services: [] } });
+    render(withProviders(<OverviewPage />));
+
+    expect(await screen.findByText(/pick a solvernet to participate in/i)).toBeTruthy();
+    expect(screen.queryByText(operatorEyebrow('prediction'))).toBeNull();
+  });
+});

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -37,9 +37,14 @@ interface OverviewStatusV1 {
      */
     operator?: {
       ok?: boolean;
+      enabled?: boolean;
       nextAction?: { description?: string };
       diagnostics?: Array<{ code: string; severity: string; message: string; configField?: string }>;
-      solverNet?: { name?: string; enabled?: boolean };
+      solverNet?: {
+        name?: string;
+        enabled?: boolean;
+        roles?: Array<'solving' | 'evaluating'>;
+      };
     };
     operatorError?: string;
     totals?: { observedTasks?: number; activeTaskRuns?: number; solutions?: number; verdicts?: number; failed?: number };
@@ -127,7 +132,7 @@ export function OverviewPage(): JSX.Element {
       {operatorEnabled ? (
         <OperatorCard
           name="prediction"
-          role="solving"
+          roles={operator?.solverNet?.roles ?? ['solving']}
           state="live"
           waitingMessage={operator?.nextAction?.description}
         />

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -43,7 +43,7 @@ interface OverviewStatusV1 {
       solverNet?: {
         name?: string;
         enabled?: boolean;
-        roles?: Array<'solving' | 'evaluating'>;
+        roles?: string[];
       };
     };
     operatorError?: string;
@@ -62,6 +62,12 @@ function formatEth(wei?: string): string {
   }
 }
 
+function operatorVisibleRoles(roles?: string[]): Array<'solving' | 'evaluating'> {
+  return (roles ?? []).filter(
+    (role): role is 'solving' | 'evaluating' => role === 'solving' || role === 'evaluating',
+  );
+}
+
 export function OverviewPage(): JSX.Element {
   const { data: status } = useQuery<OverviewStatusV1>({
     queryKey: ['status'],
@@ -70,12 +76,11 @@ export function OverviewPage(): JSX.Element {
   });
 
   const operator = status?.predictionV1?.operator;
-  // `solverNet.enabled` is the canonical opt-in signal coming from
-  // `PredictionOperatorStatus.solverNet.enabled`, which mirrors
-  // `config.solverNets.<name>.enabled`. Treat any enabled SolverNet as
-  // opted-in regardless of role (solving / evaluating); the future
-  // multi-role surface (jinn-mono-l2zl.15.4.8) keeps the same predicate.
-  const operatorEnabled = operator?.solverNet?.enabled === true;
+  const operatorRoles = operatorVisibleRoles(operator?.solverNet?.roles);
+  // `roles[]` is the canonical operator participation signal. Launcher mode
+  // owns `launching`, so Overview only treats solving/evaluating as visible
+  // operator roles and ignores the legacy `solverNet.enabled` flag.
+  const operatorParticipating = operatorRoles.length > 0;
   const totals = {
     tasks: status?.predictionV1?.totals?.observedTasks ?? 0,
     active: status?.predictionV1?.totals?.activeTaskRuns ?? 0,
@@ -122,17 +127,14 @@ export function OverviewPage(): JSX.Element {
 
       {/*
        * Operator-side state vs. empty-state — strictly mutually exclusive.
-       * Show OperatorCard whenever the operator has toggled the SolverNet
-       * on, regardless of role; show the "Pick a SolverNet" prompt only
-       * when no SolverNet is enabled. The operator-status payload does
-       * not currently expose role (see jinn-mono-l2zl.15.4.8 for the
-       * upcoming multi-role surface), so we render the default 'solving'
-       * label until that lands.
+       * Show OperatorCard whenever the operator has solving/evaluating roles;
+       * show the "Pick a SolverNet" prompt only when no operator-visible role
+       * is active.
        */}
-      {operatorEnabled ? (
+      {operatorParticipating ? (
         <OperatorCard
-          name="prediction"
-          roles={operator?.solverNet?.roles ?? ['solving']}
+          name={operator?.solverNet?.name ?? 'prediction'}
+          roles={operatorRoles}
           state="live"
           waitingMessage={operator?.nextAction?.description}
         />

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -27,10 +27,16 @@ interface OverviewStatusV1 {
     runwayDaysExcess?: string | number | null;
   };
   predictionV1?: {
+    /**
+     * Mirror of the daemon-side `PredictionOperatorStatus`. Only a subset
+     * of fields is consumed here, but the field names must match the
+     * actual server payload — earlier copies of this interface invented
+     * a top-level `enabled` and `role` that don't exist, which silently
+     * left Overview's gating reading a non-existent field.
+     * See `client/src/solver-nets/prediction-operator-ux.ts`.
+     */
     operator?: {
       ok?: boolean;
-      enabled?: boolean;
-      role?: 'solving' | 'evaluating';
       nextAction?: { description?: string };
       diagnostics?: Array<{ code: string; severity: string; message: string; configField?: string }>;
       solverNet?: { name?: string; enabled?: boolean };
@@ -59,7 +65,12 @@ export function OverviewPage(): JSX.Element {
   });
 
   const operator = status?.predictionV1?.operator;
-  const operatorEnabled = operator?.enabled === true || operator?.solverNet?.enabled === true;
+  // `solverNet.enabled` is the canonical opt-in signal coming from
+  // `PredictionOperatorStatus.solverNet.enabled`, which mirrors
+  // `config.solverNets.<name>.enabled`. Treat any enabled SolverNet as
+  // opted-in regardless of role (solving / evaluating); the future
+  // multi-role surface (jinn-mono-l2zl.15.4.8) keeps the same predicate.
+  const operatorEnabled = operator?.solverNet?.enabled === true;
   const totals = {
     tasks: status?.predictionV1?.totals?.observedTasks ?? 0,
     active: status?.predictionV1?.totals?.activeTaskRuns ?? 0,
@@ -104,11 +115,19 @@ export function OverviewPage(): JSX.Element {
       {/* Public counters — always shown when the catalog has prediction. */}
       <NetworkCard name="prediction" totals={totals} />
 
-      {/* Operator-side state — only when the operator has opted in. */}
+      {/*
+       * Operator-side state vs. empty-state — strictly mutually exclusive.
+       * Show OperatorCard whenever the operator has toggled the SolverNet
+       * on, regardless of role; show the "Pick a SolverNet" prompt only
+       * when no SolverNet is enabled. The operator-status payload does
+       * not currently expose role (see jinn-mono-l2zl.15.4.8 for the
+       * upcoming multi-role surface), so we render the default 'solving'
+       * label until that lands.
+       */}
       {operatorEnabled ? (
         <OperatorCard
           name="prediction"
-          role={operator?.role ?? 'solving'}
+          role="solving"
           state="live"
           waitingMessage={operator?.nextAction?.description}
         />

--- a/client/src/dashboard/spa/src/pages/configuration/NetCard.test.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/NetCard.test.tsx
@@ -18,7 +18,9 @@ const baseCatalog = {
   intrinsicSolverType: 'prediction.v1',
   state: 'live' as const,
   supportedRoles: ['solving' as const, 'evaluating' as const],
-  compatibleHarnesses: [{ name: 'claude-code-learner', version: '0.1.0', supportsRoles: ['solving' as const] }],
+  compatibleHarnesses: [
+    { name: 'claude-code-learner', version: '0.1.0', supportsRoles: ['solving' as const, 'evaluating' as const] },
+  ],
   compatiblePlugins: [{ name: 'jinn-prediction-plugin', version: '0.1.0', source: 'bundled' }],
 };
 
@@ -41,7 +43,7 @@ describe('NetCard', () => {
     render(
       <NetCard
         catalog={baseCatalog}
-        config={{ enabled: false, role: 'solving', harness: 'claude-code-learner', model: 'claude-haiku-4-5-20251001', plugins: [] }}
+        config={{ enabled: false, roles: ['solving'], harness: 'claude-code-learner', model: 'claude-haiku-4-5-20251001', plugins: [] }}
         onSaved={vi.fn()}
         onRestartPending={vi.fn()}
       />,
@@ -51,18 +53,90 @@ describe('NetCard', () => {
     expect(screen.getByText(/available/i)).toBeTruthy();
   });
 
-  it('expands the body when enabled and shows Solving role active', () => {
+  it('expands the body when enabled and shows the Solver checkbox active', () => {
     render(
       <NetCard
         catalog={baseCatalog}
-        config={{ enabled: true, role: 'solving', harness: 'claude-code-learner', model: 'claude-haiku-4-5-20251001', plugins: ['jinn-prediction-plugin'] }}
+        config={{ enabled: true, roles: ['solving'], harness: 'claude-code-learner', model: 'claude-haiku-4-5-20251001', plugins: ['jinn-prediction-plugin'] }}
         onSaved={vi.fn()}
         onRestartPending={vi.fn()}
       />,
     );
     expect(screen.getByText(/live/i)).toBeTruthy();
-    const solving = screen.getByText('Solving').closest('button');
-    expect(solving?.getAttribute('data-role-active')).toBe('true');
+    const solver = screen.getByLabelText('Solver') as HTMLInputElement;
+    const evaluator = screen.getByLabelText('Evaluator') as HTMLInputElement;
+    expect(solver.checked).toBe(true);
+    expect(evaluator.checked).toBe(false);
+  });
+
+  it('renders both checkboxes checked when both roles are configured', () => {
+    render(
+      <NetCard
+        catalog={baseCatalog}
+        config={{
+          enabled: true,
+          roles: ['solving', 'evaluating'],
+          harness: 'claude-code-learner',
+          model: 'claude-haiku-4-5-20251001',
+          plugins: [],
+        }}
+        onSaved={vi.fn()}
+        onRestartPending={vi.fn()}
+      />,
+    );
+    const solver = screen.getByLabelText('Solver') as HTMLInputElement;
+    const evaluator = screen.getByLabelText('Evaluator') as HTMLInputElement;
+    expect(solver.checked).toBe(true);
+    expect(evaluator.checked).toBe(true);
+  });
+
+  it('persists both roles when the operator enables Evaluator alongside Solver', async () => {
+    render(
+      <NetCard
+        catalog={baseCatalog}
+        config={{
+          enabled: true,
+          roles: ['solving'],
+          harness: 'claude-code-learner',
+          model: 'claude-haiku-4-5-20251001',
+          modelExplicit: false,
+          plugins: [],
+        }}
+        onSaved={vi.fn()}
+        onRestartPending={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('Evaluator'));
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(apiMock.updateSolverNet).toHaveBeenCalled());
+    // Order should be canonical (catalog ordering: ['solving', 'evaluating']).
+    expect(apiMock.updateSolverNet).toHaveBeenCalledWith('prediction', expect.objectContaining({
+      roles: ['solving', 'evaluating'],
+    }));
+  });
+
+  it('disables save and surfaces validation when both checkboxes are unchecked', () => {
+    render(
+      <NetCard
+        catalog={baseCatalog}
+        config={{
+          enabled: true,
+          roles: ['solving'],
+          harness: 'claude-code-learner',
+          model: 'claude-haiku-4-5-20251001',
+          plugins: [],
+        }}
+        onSaved={vi.fn()}
+        onRestartPending={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('Solver'));
+    expect(screen.getByRole('alert').textContent).toMatch(/at least one role required/i);
+    const save = screen.getByRole('button', { name: /save changes/i }) as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
   });
 
   it('does not persist the displayed fallback model when saving another field', async () => {
@@ -71,7 +145,7 @@ describe('NetCard', () => {
         catalog={baseCatalog}
         config={{
           enabled: false,
-          role: 'solving',
+          roles: ['solving'],
           harness: 'claude-code-learner',
           model: 'claude-haiku-4-5-20251001',
           modelExplicit: false,
@@ -127,7 +201,7 @@ describe('NetCard', () => {
         catalog={baseCatalog}
         config={{
           enabled: true,
-          role: 'solving',
+          roles: ['solving'],
           harness: 'claude-code-learner',
           model: 'claude-haiku-4-5-20251001',
           modelExplicit: false,

--- a/client/src/dashboard/spa/src/pages/configuration/NetCard.test.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/NetCard.test.tsx
@@ -169,7 +169,7 @@ describe('NetCard', () => {
     render(
       <NetCard
         catalog={baseCatalog}
-        config={{ enabled: false, role: 'solving', harness: 'claude-code-learner', model: 'claude-haiku-4-5-20251001', plugins: [] }}
+        config={{ enabled: false, roles: ['solving'], harness: 'claude-code-learner', model: 'claude-haiku-4-5-20251001', plugins: [] }}
         onSaved={vi.fn()}
         onRestartPending={vi.fn()}
       />,
@@ -184,7 +184,7 @@ describe('NetCard', () => {
     render(
       <NetCard
         catalog={{ ...baseCatalog, name: 'mystery-net' }}
-        config={{ enabled: false, role: 'solving', harness: 'claude-code-learner', model: 'claude-haiku-4-5-20251001', plugins: [] }}
+        config={{ enabled: false, roles: ['solving'], harness: 'claude-code-learner', model: 'claude-haiku-4-5-20251001', plugins: [] }}
         onSaved={vi.fn()}
         onRestartPending={vi.fn()}
       />,
@@ -229,7 +229,7 @@ describe('NetCard', () => {
         catalog={baseCatalog}
         config={{
           enabled: true,
-          role: 'solving',
+          roles: ['solving'],
           harness: 'claude-code-learner',
           model: 'claude-sonnet-4-5-20250929',
           modelExplicit: true,
@@ -279,7 +279,7 @@ describe('NetCard', () => {
         catalog={multiPluginCatalog}
         config={{
           enabled: true,
-          role: 'solving',
+          roles: ['solving'],
           harness: 'claude-code-learner',
           model: 'claude-haiku-4-5-20251001',
           plugins: ['jinn-prediction-plugin'],
@@ -312,7 +312,7 @@ describe('NetCard', () => {
         catalog={baseCatalog}
         config={{
           enabled: true,
-          role: 'solving',
+          roles: ['solving'],
           harness: 'claude-code-learner',
           model: 'claude-haiku-4-5-20251001',
           plugins: ['jinn-prediction-plugin'],
@@ -342,7 +342,7 @@ describe('NetCard', () => {
         catalog={emptyCatalog}
         config={{
           enabled: true,
-          role: 'solving',
+          roles: ['solving'],
           harness: 'claude-code-learner',
           model: 'claude-haiku-4-5-20251001',
           plugins: [],

--- a/client/src/dashboard/spa/src/pages/configuration/NetCard.test.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/NetCard.test.tsx
@@ -91,6 +91,36 @@ describe('NetCard', () => {
     }));
   });
 
+  it('renders the prediction orb sigil for catalog.name="prediction"', () => {
+    render(
+      <NetCard
+        catalog={baseCatalog}
+        config={{ enabled: false, role: 'solving', harness: 'claude-code-learner', model: 'claude-haiku-4-5-20251001', plugins: [] }}
+        onSaved={vi.fn()}
+        onRestartPending={vi.fn()}
+      />,
+    );
+    const sigil = screen.getByTestId('solver-net-sigil');
+    expect(sigil).toBeTruthy();
+    expect(sigil.getAttribute('data-sigil-name')).toBe('prediction');
+    expect(screen.getByTestId('solver-net-sigil-prediction')).toBeTruthy();
+  });
+
+  it('renders the fallback sigil for unknown SolverNet names', () => {
+    render(
+      <NetCard
+        catalog={{ ...baseCatalog, name: 'mystery-net' }}
+        config={{ enabled: false, role: 'solving', harness: 'claude-code-learner', model: 'claude-haiku-4-5-20251001', plugins: [] }}
+        onSaved={vi.fn()}
+        onRestartPending={vi.fn()}
+      />,
+    );
+    const sigil = screen.getByTestId('solver-net-sigil');
+    expect(sigil).toBeTruthy();
+    expect(sigil.getAttribute('data-sigil-name')).toBe('mystery-net');
+    expect(screen.getByTestId('solver-net-sigil-fallback')).toBeTruthy();
+  });
+
   it('persists the model when the operator edits the fallback value', async () => {
     render(
       <NetCard

--- a/client/src/dashboard/spa/src/pages/configuration/NetCard.test.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/NetCard.test.tsx
@@ -191,4 +191,93 @@ describe('NetCard', () => {
       model: 'claude-sonnet-4-6',
     }));
   });
+
+  it('adds a plugin from the picker, becomes dirty, and persists on save', async () => {
+    const multiPluginCatalog = {
+      ...baseCatalog,
+      compatiblePlugins: [
+        { name: 'jinn-prediction-plugin', version: '0.1.0', source: 'bundled' },
+        { name: 'network-tools', version: '0.2.0', source: 'bundled' },
+      ],
+    };
+    render(
+      <NetCard
+        catalog={multiPluginCatalog}
+        config={{
+          enabled: true,
+          role: 'solving',
+          harness: 'claude-code-learner',
+          model: 'claude-haiku-4-5-20251001',
+          plugins: ['jinn-prediction-plugin'],
+        }}
+        onSaved={vi.fn()}
+        onRestartPending={vi.fn()}
+      />,
+    );
+
+    // No save button visible while clean.
+    expect(screen.queryByRole('button', { name: /save changes/i })).toBeNull();
+
+    fireEvent.change(screen.getByLabelText('Add plugin'), {
+      target: { value: 'network-tools' },
+    });
+
+    // Dirty: save button appears.
+    const saveBtn = await screen.findByRole('button', { name: /save changes/i });
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => expect(apiMock.updateSolverNet).toHaveBeenCalled());
+    expect(apiMock.updateSolverNet).toHaveBeenCalledWith('prediction', expect.objectContaining({
+      plugins: ['jinn-prediction-plugin', 'network-tools'],
+    }));
+  });
+
+  it('removes a plugin from the row, becomes dirty, and persists on save', async () => {
+    render(
+      <NetCard
+        catalog={baseCatalog}
+        config={{
+          enabled: true,
+          role: 'solving',
+          harness: 'claude-code-learner',
+          model: 'claude-haiku-4-5-20251001',
+          plugins: ['jinn-prediction-plugin'],
+        }}
+        onSaved={vi.fn()}
+        onRestartPending={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: /save changes/i })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /remove jinn-prediction-plugin/i }));
+
+    const saveBtn = await screen.findByRole('button', { name: /save changes/i });
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => expect(apiMock.updateSolverNet).toHaveBeenCalled());
+    expect(apiMock.updateSolverNet).toHaveBeenCalledWith('prediction', expect.objectContaining({
+      plugins: [],
+    }));
+  });
+
+  it('renders the empty-catalog hint when no plugins are compatible', () => {
+    const emptyCatalog = { ...baseCatalog, compatiblePlugins: [] };
+    render(
+      <NetCard
+        catalog={emptyCatalog}
+        config={{
+          enabled: true,
+          role: 'solving',
+          harness: 'claude-code-learner',
+          model: 'claude-haiku-4-5-20251001',
+          plugins: [],
+        }}
+        onSaved={vi.fn()}
+        onRestartPending={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/no plugins available for this solvernet/i)).toBeTruthy();
+    expect(screen.queryByLabelText('Add plugin')).toBeNull();
+  });
 });

--- a/client/src/dashboard/spa/src/pages/configuration/NetCard.test.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/NetCard.test.tsx
@@ -138,14 +138,57 @@ describe('NetCard', () => {
       />,
     );
 
-    fireEvent.change(screen.getByDisplayValue('claude-haiku-4-5-20251001'), {
-      target: { value: 'claude-sonnet-4-5-20250929' },
+    fireEvent.change(screen.getByLabelText('Claude model'), {
+      target: { value: 'claude-sonnet-4-6' },
     });
     fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
 
     await waitFor(() => expect(apiMock.updateSolverNet).toHaveBeenCalled());
     expect(apiMock.updateSolverNet).toHaveBeenCalledWith('prediction', expect.objectContaining({
-      model: 'claude-sonnet-4-5-20250929',
+      model: 'claude-sonnet-4-6',
+    }));
+  });
+
+  it('renders an unknown model as a Custom option alongside the canonical tiers, and switching to Sonnet stages a dirty save', async () => {
+    render(
+      <NetCard
+        catalog={baseCatalog}
+        config={{
+          enabled: true,
+          role: 'solving',
+          harness: 'claude-code-learner',
+          model: 'claude-sonnet-4-5-20250929',
+          modelExplicit: true,
+          plugins: [],
+        }}
+        onSaved={vi.fn()}
+        onRestartPending={vi.fn()}
+      />,
+    );
+
+    const select = screen.getByLabelText('Claude model') as HTMLSelectElement;
+    const optionValues = Array.from(select.options).map((o) => o.value);
+    const optionLabels = Array.from(select.options).map((o) => o.textContent);
+
+    expect(optionValues).toContain('claude-haiku-4-5-20251001');
+    expect(optionValues).toContain('claude-sonnet-4-6');
+    expect(optionValues).toContain('claude-opus-4-7');
+    expect(optionValues).toContain('claude-sonnet-4-5-20250929');
+    expect(optionLabels).toContain('Haiku');
+    expect(optionLabels).toContain('Sonnet');
+    expect(optionLabels).toContain('Opus');
+    expect(optionLabels).toContain('Custom (claude-sonnet-4-5-20250929)');
+
+    // No dirty banner yet — select reflects the stored value.
+    expect(screen.queryByRole('button', { name: /save changes/i })).toBeNull();
+
+    fireEvent.change(select, { target: { value: 'claude-sonnet-4-6' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(apiMock.updateSolverNet).toHaveBeenCalled());
+    expect(apiMock.updateSolverNet).toHaveBeenCalledWith('prediction', expect.objectContaining({
+      model: 'claude-sonnet-4-6',
     }));
   });
 });

--- a/client/src/dashboard/spa/src/pages/configuration/NetCard.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/NetCard.tsx
@@ -15,13 +15,28 @@ import { CLAUDE_MODELS, resolveModelOption } from './claudeModels.js';
  * before discarding the edits.
  */
 
+export type NetCardRole = 'solving' | 'evaluating';
+
 export interface NetCardConfig {
   enabled: boolean;
-  role: 'solving' | 'evaluating';
+  /**
+   * Active operator roles for this SolverNet. Non-empty when persisted —
+   * the operator disables the net via the enable toggle, not by clearing
+   * roles. Both roles can be active concurrently; the daemon enforces
+   * `disallowSolverSelfEvaluation` so the operator never grades its own
+   * Solutions.
+   */
+  roles: NetCardRole[];
   harness: string;
   model: string;
   modelExplicit?: boolean;
   plugins: string[];
+}
+
+function rolesEqual(a: NetCardRole[], b: NetCardRole[]): boolean {
+  if (a.length !== b.length) return false;
+  const aset = new Set(a);
+  return b.every((r) => aset.has(r));
 }
 
 export interface NetCardProps {
@@ -39,10 +54,12 @@ export function NetCard({ catalog, config, onSaved, onRestartPending }: NetCardP
 
   const dirty =
     draft.enabled !== config.enabled ||
-    draft.role !== config.role ||
+    !rolesEqual(draft.roles, config.roles) ||
     draft.harness !== config.harness ||
     draft.model !== config.model ||
     draft.plugins.join(',') !== config.plugins.join(',');
+
+  const rolesValid = draft.roles.length > 0;
 
   const stateLabel: { label: string; color: string } = (() => {
     if (catalog.state === 'coming_soon') return { label: 'Coming soon', color: 'var(--fg-dim)' };
@@ -70,12 +87,16 @@ export function NetCard({ catalog, config, onSaved, onRestartPending }: NetCardP
   };
 
   const save = async (): Promise<void> => {
+    if (!rolesValid) {
+      setError('At least one role required');
+      return;
+    }
     setSaving(true);
     setError(null);
     try {
       const patch: Parameters<typeof api.updateSolverNet>[1] = {
         enabled: draft.enabled,
-        role: draft.role,
+        roles: draft.roles,
         harness: draft.harness,
         plugins: draft.plugins,
       };
@@ -91,6 +112,25 @@ export function NetCard({ catalog, config, onSaved, onRestartPending }: NetCardP
     } finally {
       setSaving(false);
     }
+  };
+
+  const toggleRole = (role: NetCardRole): void => {
+    if (!catalog.supportedRoles.includes(role)) return;
+    const has = draft.roles.includes(role);
+    if (has) {
+      // Allow unchecking even when it leaves zero roles — the validation
+      // banner explains the requirement and the Save button is disabled.
+      const next = draft.roles.filter((r) => r !== role);
+      setDraft({ ...draft, roles: next });
+      return;
+    }
+    // Preserve the catalog ordering ['solving', 'evaluating'] so the
+    // persisted shape is canonical regardless of the order the operator
+    // clicks the boxes.
+    const ordered = catalog.supportedRoles.filter(
+      (r) => r === role || draft.roles.includes(r),
+    );
+    setDraft({ ...draft, roles: ordered });
   };
 
   return (
@@ -178,38 +218,77 @@ export function NetCard({ catalog, config, onSaved, onRestartPending }: NetCardP
                 color: 'var(--fg-muted)',
               }}
             >
-              Role
+              Roles
             </span>
-            <div style={{ display: 'grid', gridTemplateColumns: `repeat(${catalog.supportedRoles.length}, 1fr)`, border: '1px solid var(--border)', borderRadius: '6px', overflow: 'hidden' }}>
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: `repeat(${catalog.supportedRoles.length}, 1fr)`,
+                border: '1px solid var(--border)',
+                borderRadius: '6px',
+                overflow: 'hidden',
+              }}
+            >
               {catalog.supportedRoles.map((role, idx) => {
-                const active = draft.role === role;
+                const active = draft.roles.includes(role);
+                const checkboxId = `role-${catalog.name}-${role}`;
                 return (
-                  <button
+                  <label
                     key={role}
-                    type="button"
+                    htmlFor={checkboxId}
+                    data-role={role}
                     data-role-active={active ? 'true' : 'false'}
-                    onClick={() => setDraft({ ...draft, role })}
                     style={{
                       padding: '10px 14px',
-                      textAlign: 'center',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'flex-start',
+                      gap: '6px',
                       color: active ? 'var(--fg)' : 'var(--fg-muted)',
                       background: active ? 'var(--bg)' : 'transparent',
                       borderRight: idx < catalog.supportedRoles.length - 1 ? '1px solid var(--border)' : 'none',
-                      border: 'none',
                       cursor: 'pointer',
                       fontFamily: "'JetBrains Mono', monospace",
                     }}
                   >
-                    <span style={{ display: 'block', fontSize: '14px', fontWeight: 500 }}>
-                      {role.charAt(0).toUpperCase() + role.slice(1)}
+                    <span style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                      <input
+                        id={checkboxId}
+                        type="checkbox"
+                        checked={active}
+                        onChange={() => toggleRole(role)}
+                        aria-label={role === 'solving' ? 'Solver' : 'Evaluator'}
+                        style={{ accentColor: 'var(--accent-sky)', width: '14px', height: '14px' }}
+                      />
+                      <span style={{ fontSize: '14px', fontWeight: 500 }}>
+                        {role === 'solving' ? 'Solver' : 'Evaluator'}
+                      </span>
                     </span>
-                    <span style={{ display: 'block', fontSize: '11px', color: active ? 'var(--fg-muted)' : 'var(--fg-dim)' }}>
+                    <span
+                      style={{
+                        fontSize: '11px',
+                        color: active ? 'var(--fg-muted)' : 'var(--fg-dim)',
+                        paddingLeft: '22px',
+                      }}
+                    >
                       {role === 'solving' ? 'attempt forecasts' : "verify others' forecasts"}
                     </span>
-                  </button>
+                  </label>
                 );
               })}
             </div>
+            {!rolesValid && (
+              <span
+                role="alert"
+                style={{
+                  fontSize: '12px',
+                  color: 'var(--break-red)',
+                  fontFamily: "'JetBrains Mono', monospace",
+                }}
+              >
+                At least one role required
+              </span>
+            )}
           </div>
 
           <ConfigField label="Harness" restartRequired>
@@ -227,7 +306,14 @@ export function NetCard({ catalog, config, onSaved, onRestartPending }: NetCardP
               }}
             >
               {catalog.compatibleHarnesses
-                .filter((h) => h.supportsRoles.includes(draft.role))
+                // Show every harness that supports at least one currently-active role.
+                // The daemon picks the right harness per-role at task-acceptance time;
+                // a single Harness is allowed to cover both roles or only one.
+                .filter((h) =>
+                  draft.roles.length === 0
+                    ? true
+                    : draft.roles.some((r) => h.supportsRoles.includes(r)),
+                )
                 .map((h) => (
                   <option key={h.name} value={h.name}>
                     {h.name}@{h.version}
@@ -426,8 +512,8 @@ export function NetCard({ catalog, config, onSaved, onRestartPending }: NetCardP
             fontFamily: "'JetBrains Mono', monospace",
           }}
         >
-          <span style={{ fontSize: '12px', color: error ? 'var(--break-red)' : 'var(--accent-sky)' }}>
-            {error ?? (saving ? 'Saving…' : 'Changes pending')}
+          <span style={{ fontSize: '12px', color: error || !rolesValid ? 'var(--break-red)' : 'var(--accent-sky)' }}>
+            {error ?? (!rolesValid ? 'At least one role required' : saving ? 'Saving…' : 'Changes pending')}
           </span>
           <span style={{ display: 'flex', gap: '8px' }}>
             <button
@@ -441,8 +527,17 @@ export function NetCard({ catalog, config, onSaved, onRestartPending }: NetCardP
             <button
               type="button"
               onClick={() => { void save(); }}
-              disabled={saving}
-              style={{ border: '1px solid var(--accent-sky)', borderRadius: '6px', padding: '10px 20px', background: 'var(--accent-sky)', color: 'var(--bg-sunken)', fontFamily: 'inherit', fontSize: '14px' }}
+              disabled={saving || !rolesValid}
+              style={{
+                border: `1px solid ${rolesValid ? 'var(--accent-sky)' : 'var(--border)'}`,
+                borderRadius: '6px',
+                padding: '10px 20px',
+                background: rolesValid ? 'var(--accent-sky)' : 'transparent',
+                color: rolesValid ? 'var(--bg-sunken)' : 'var(--fg-dim)',
+                fontFamily: 'inherit',
+                fontSize: '14px',
+                cursor: rolesValid ? 'pointer' : 'not-allowed',
+              }}
             >
               Save changes
             </button>

--- a/client/src/dashboard/spa/src/pages/configuration/NetCard.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/NetCard.tsx
@@ -3,6 +3,7 @@ import type { SolverNetCatalogEntry } from '../../api/types.js';
 import { ConfigField } from '../../components/ConfigField.js';
 import { api } from '../../api/client.js';
 import { SolverNetSigil } from './solverNetSigils.js';
+import { CLAUDE_MODELS, resolveModelOption } from './claudeModels.js';
 
 /**
  * Per-SolverNet card inside the Configuration > SolverNets section. Shows
@@ -236,20 +237,36 @@ export function NetCard({ catalog, config, onSaved, onRestartPending }: NetCardP
           </ConfigField>
 
           <ConfigField label="Claude model" restartRequired>
-            <input
-              type="text"
-              value={draft.model}
-              onChange={(e) => setDraft({ ...draft, model: e.target.value })}
-              style={{
-                background: 'var(--bg)',
-                border: `1px solid ${draft.model !== config.model ? 'var(--accent-sky)' : 'var(--border)'}`,
-                borderRadius: '6px',
-                padding: '10px 12px',
-                fontFamily: "'JetBrains Mono', monospace",
-                fontSize: '14px',
-                color: 'var(--fg)',
-              }}
-            />
+            {(() => {
+              const resolved = resolveModelOption(draft.model);
+              return (
+                <select
+                  aria-label="Claude model"
+                  value={draft.model}
+                  onChange={(e) => setDraft({ ...draft, model: e.target.value })}
+                  style={{
+                    background: 'var(--bg)',
+                    border: `1px solid ${draft.model !== config.model ? 'var(--accent-sky)' : 'var(--border)'}`,
+                    borderRadius: '6px',
+                    padding: '10px 12px',
+                    fontFamily: "'JetBrains Mono', monospace",
+                    fontSize: '14px',
+                    color: 'var(--fg)',
+                  }}
+                >
+                  {CLAUDE_MODELS.map((m) => (
+                    <option key={m.id} value={m.id}>
+                      {m.label}
+                    </option>
+                  ))}
+                  {resolved.isCustom && (
+                    <option key={draft.model} value={draft.model}>
+                      {resolved.label}
+                    </option>
+                  )}
+                </select>
+              );
+            })()}
           </ConfigField>
 
           <div style={{ gridColumn: '1 / -1', display: 'flex', flexDirection: 'column', gap: '8px' }}>

--- a/client/src/dashboard/spa/src/pages/configuration/NetCard.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/NetCard.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { SolverNetCatalogEntry } from '../../api/types.js';
 import { ConfigField } from '../../components/ConfigField.js';
 import { api } from '../../api/client.js';
+import { SolverNetSigil } from './solverNetSigils.js';
 
 /**
  * Per-SolverNet card inside the Configuration > SolverNets section. Shows
@@ -102,7 +103,7 @@ export function NetCard({ catalog, config, onSaved, onRestartPending }: NetCardP
           padding: '14px 18px',
         }}
       >
-        <span style={{ width: '26px', height: '26px', border: '1px solid var(--border)', borderRadius: '6px' }} />
+        <SolverNetSigil name={catalog.name} />
         <span>
           <span style={{ fontSize: '15px', fontWeight: 500, color: 'var(--fg)' }}>{catalog.name}</span>
           <span style={{ display: 'block', fontSize: '12px', color: 'var(--fg-muted)', marginTop: '2px' }}>

--- a/client/src/dashboard/spa/src/pages/configuration/NetCard.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/NetCard.tsx
@@ -291,6 +291,7 @@ export function NetCard({ catalog, config, onSaved, onRestartPending }: NetCardP
                     display: 'flex',
                     justifyContent: 'space-between',
                     alignItems: 'center',
+                    gap: '12px',
                     padding: '10px 14px',
                     border: '1px solid var(--border)',
                     borderRadius: '6px',
@@ -299,32 +300,83 @@ export function NetCard({ catalog, config, onSaved, onRestartPending }: NetCardP
                   }}
                 >
                   <span style={{ fontSize: '14px' }}>{p}</span>
-                  <span style={{ color: 'var(--fg-dim)', fontSize: '12px' }}>
-                    {meta ? `${meta.source} · ${meta.version}` : '—'}
+                  <span style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+                    <span style={{ color: 'var(--fg-dim)', fontSize: '12px' }}>
+                      {meta ? `${meta.source} · ${meta.version}` : '—'}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => setDraft({ ...draft, plugins: draft.plugins.filter((x) => x !== p) })}
+                      aria-label={`Remove ${p}`}
+                      style={{
+                        border: '1px solid var(--border)',
+                        borderRadius: '6px',
+                        padding: '4px 10px',
+                        background: 'transparent',
+                        color: 'var(--fg-muted)',
+                        fontFamily: "'JetBrains Mono', monospace",
+                        fontSize: '11px',
+                        fontWeight: 500,
+                        letterSpacing: '0.14em',
+                        textTransform: 'uppercase',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      Remove
+                    </button>
                   </span>
                 </div>
               );
             })}
-            <button
-              type="button"
-              disabled
-              style={{
-                border: '1px dashed var(--border)',
-                borderRadius: '6px',
-                padding: '10px 14px',
-                background: 'transparent',
-                color: 'var(--fg-dim)',
-                fontFamily: "'JetBrains Mono', monospace",
-                fontSize: '11px',
-                fontWeight: 500,
-                letterSpacing: '0.14em',
-                textTransform: 'uppercase',
-                cursor: 'not-allowed',
-                textAlign: 'center',
-              }}
-            >
-              + Add plugin (coming soon)
-            </button>
+            {(() => {
+              const available = catalog.compatiblePlugins.filter(
+                (cp) => !draft.plugins.includes(cp.name),
+              );
+              if (catalog.compatiblePlugins.length === 0) {
+                return (
+                  <span
+                    style={{
+                      fontFamily: "'JetBrains Mono', monospace",
+                      fontSize: '12px',
+                      color: 'var(--fg-dim)',
+                      padding: '4px 2px',
+                    }}
+                  >
+                    No plugins available for this SolverNet
+                  </span>
+                );
+              }
+              if (available.length === 0) return null;
+              return (
+                <select
+                  value=""
+                  onChange={(e) => {
+                    const picked = e.target.value;
+                    if (!picked) return;
+                    setDraft({ ...draft, plugins: [...draft.plugins, picked] });
+                  }}
+                  aria-label="Add plugin"
+                  style={{
+                    background: 'var(--bg)',
+                    border: '1px dashed var(--border)',
+                    borderRadius: '6px',
+                    padding: '10px 12px',
+                    fontFamily: "'JetBrains Mono', monospace",
+                    fontSize: '14px',
+                    color: 'var(--fg)',
+                  }}
+                >
+                  <option value="" disabled>
+                    + Add plugin
+                  </option>
+                  {available.map((cp) => (
+                    <option key={cp.name} value={cp.name}>
+                      {cp.name} ({cp.source} · {cp.version})
+                    </option>
+                  ))}
+                </select>
+              );
+            })()}
           </div>
         </div>
       )}

--- a/client/src/dashboard/spa/src/pages/configuration/SolverNetsSection.test.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/SolverNetsSection.test.tsx
@@ -30,7 +30,7 @@ describe('SolverNetsSection', () => {
       <QueryClientProvider client={qc}>
         <SolverNetsSection
           configByName={{
-            prediction: { enabled: false, role: 'solving', harness: 'claude-code-learner', model: 'claude-haiku-4-5-20251001', plugins: [] },
+            prediction: { enabled: false, roles: ['solving'], harness: 'claude-code-learner', model: 'claude-haiku-4-5-20251001', plugins: [] },
           }}
           onSaved={() => undefined}
           onRestartPending={() => undefined}

--- a/client/src/dashboard/spa/src/pages/configuration/SolverNetsSection.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/SolverNetsSection.tsx
@@ -8,18 +8,29 @@ const STATE_RANK: Record<string, number> = { live: 0, available: 1, coming_soon:
 
 /**
  * The bootstrap response can return per-SolverNet config that's missing
- * any combination of fields (enabled, role, harness, model, plugins) —
- * older configs predate role, third-party configs may omit model, etc.
+ * any combination of fields (enabled, roles, harness, model, plugins) —
+ * older configs predate roles, third-party configs may omit model, etc.
  * Merge into a fully-populated NetCardConfig so the card renders sensibly
  * even on partially-shaped input.
+ *
+ * Backwards-compat: a legacy `role: 'solving' | 'evaluating'` field on the
+ * stored config (from a daemon that hasn't been restarted since the
+ * roles-array migration) is promoted to `roles: [<role>]` here so the
+ * Configuration page never displays a confusingly empty Roles section.
  */
 function resolveConfig(
   catalog: SolverNetCatalogEntry,
-  stored: Partial<NetCardConfig> | undefined,
+  stored: (Partial<NetCardConfig> & { role?: 'solving' | 'evaluating' }) | undefined,
 ): NetCardConfig {
+  const fallbackRole = catalog.supportedRoles[0] ?? 'solving';
+  const storedRoles = (() => {
+    if (Array.isArray(stored?.roles) && (stored?.roles?.length ?? 0) > 0) return stored!.roles!;
+    if (stored?.role === 'solving' || stored?.role === 'evaluating') return [stored.role];
+    return [fallbackRole];
+  })();
   return {
     enabled: stored?.enabled ?? false,
-    role: stored?.role ?? (catalog.supportedRoles[0] ?? 'solving'),
+    roles: storedRoles,
     harness: stored?.harness ?? (catalog.compatibleHarnesses[0]?.name ?? ''),
     model: stored?.model ?? 'claude-haiku-4-5-20251001',
     modelExplicit: stored?.model !== undefined,
@@ -29,8 +40,10 @@ function resolveConfig(
 
 export interface SolverNetsSectionProps {
   /** Stored per-net config from /v1/bootstrap. May be partially-shaped;
-   *  resolveConfig fills missing fields with catalog-derived defaults. */
-  configByName: Record<string, Partial<NetCardConfig>>;
+   *  resolveConfig fills missing fields with catalog-derived defaults.
+   *  Accepts both the legacy `role` field and the canonical `roles`
+   *  array — resolveConfig migrates the singular form. */
+  configByName: Record<string, Partial<NetCardConfig> & { role?: 'solving' | 'evaluating' }>;
   onSaved: () => void;
   onRestartPending: () => void;
   defaultExpanded?: boolean;

--- a/client/src/dashboard/spa/src/pages/configuration/claudeModels.ts
+++ b/client/src/dashboard/spa/src/pages/configuration/claudeModels.ts
@@ -1,0 +1,40 @@
+/**
+ * Canonical Claude model tiers exposed to operators in the SPA's SolverNet
+ * configuration. The dropdown in `NetCard` shows these by friendly label;
+ * the underlying `model` config field still stores the pinned id string.
+ *
+ * Operators with non-default pins (e.g. an older snapshot, or an id we
+ * haven't surfaced yet) keep their stored value via the `Custom (<id>)`
+ * fallback option — see `resolveModelOption`. The power-user escape hatch
+ * remains the file-level `~/.jinn-client/config.json` model field.
+ */
+
+export interface ClaudeModelOption {
+  /** Friendly tier label shown in the dropdown. */
+  label: string;
+  /** Pinned model id persisted to config. */
+  id: string;
+}
+
+export const CLAUDE_MODELS: readonly ClaudeModelOption[] = [
+  { label: 'Haiku', id: 'claude-haiku-4-5-20251001' },
+  { label: 'Sonnet', id: 'claude-sonnet-4-6' },
+  { label: 'Opus', id: 'claude-opus-4-7' },
+] as const;
+
+export interface ResolvedModelOption {
+  /** Canonical option if `id` matches one of `CLAUDE_MODELS`, else `null`. */
+  canonical: ClaudeModelOption | null;
+  /** Display label — friendly tier or `Custom (<id>)` fallback. */
+  label: string;
+  /** Whether the id is outside the canonical set. */
+  isCustom: boolean;
+}
+
+export function resolveModelOption(id: string): ResolvedModelOption {
+  const canonical = CLAUDE_MODELS.find((m) => m.id === id) ?? null;
+  if (canonical) {
+    return { canonical, label: canonical.label, isCustom: false };
+  }
+  return { canonical: null, label: `Custom (${id})`, isCustom: true };
+}

--- a/client/src/dashboard/spa/src/pages/configuration/solverNetSigils.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/solverNetSigils.tsx
@@ -1,0 +1,74 @@
+/**
+ * Per-SolverNet sigil slot — a 26x26 mark rendered next to each SolverNet's
+ * name in the Configuration > SolverNets section.
+ *
+ * NOTE: The 'prediction' orb is a TEMPORARY placeholder pending real per-net
+ * brand art (see bd issue jinn-mono-l2zl.15.4.10). The fallback uses the
+ * existing mark-node.svg shape — a node-in-a-network — as a generic
+ * SolverNet mark inlined here so we don't need a Vite SVG-import plugin.
+ *
+ * All SVGs use `currentColor` / token-driven inline color so they inherit
+ * the card's color tokens cleanly.
+ */
+
+import type { CSSProperties } from 'react';
+
+export interface SolverNetSigilProps {
+  name: string;
+}
+
+export function SolverNetSigil({ name }: SolverNetSigilProps): JSX.Element {
+  const slot: CSSProperties = {
+    width: '26px',
+    height: '26px',
+    border: '1px solid var(--border)',
+    borderRadius: '6px',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: 'var(--fg-muted)',
+    flexShrink: 0,
+  };
+
+  return (
+    <span data-testid="solver-net-sigil" data-sigil-name={name} style={slot}>
+      {renderMark(name)}
+    </span>
+  );
+}
+
+function renderMark(name: string): JSX.Element {
+  if (name === 'prediction') {
+    // Temporary prediction orb — circle (orb) with a small highlight gleam.
+    // Replace with real Prediction sigil per bd issue jinn-mono-l2zl.15.4.10.
+    return (
+      <svg
+        data-testid="solver-net-sigil-prediction"
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        aria-hidden="true"
+      >
+        <circle cx="12" cy="12" r="8" stroke="currentColor" strokeWidth="1.5" fill="none" />
+        <circle cx="9" cy="9" r="1.5" fill="currentColor" opacity="0.8" />
+      </svg>
+    );
+  }
+
+  // Fallback — generic SolverNet mark adapted from mark-node.svg.
+  return (
+    <svg
+      data-testid="solver-net-sigil-fallback"
+      width="18"
+      height="18"
+      viewBox="0 0 120 120"
+      fill="none"
+      aria-hidden="true"
+    >
+      <rect x="8" y="8" width="104" height="104" stroke="currentColor" strokeWidth="6" fill="none" />
+      <circle cx="60" cy="60" r="34" stroke="currentColor" strokeWidth="6" fill="none" />
+      <circle cx="60" cy="60" r="10" fill="currentColor" />
+    </svg>
+  );
+}

--- a/client/src/dashboard/spa/src/pages/launcher/CostCard.test.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher/CostCard.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CostCard } from './CostCard.js';
+
+describe('CostCard', () => {
+  it('renders 7-day burn rate, Tasks funded, open-task budget reservations', () => {
+    render(
+      <CostCard
+        burn7dWei="500000000000000000"
+        tasksFunded7d={42}
+        openTaskBudgetWei="200000000000000000"
+      />,
+    );
+    expect(screen.queryByText(/0\.5/)).toBeTruthy(); // 0.5 ETH burn
+    expect(screen.queryByText(/42/)).toBeTruthy(); // 42 Tasks
+    expect(screen.queryByText(/0\.2/)).toBeTruthy(); // 0.2 ETH reserved
+  });
+
+  it('renders zero burn cleanly', () => {
+    render(<CostCard burn7dWei="0" tasksFunded7d={0} openTaskBudgetWei="0" />);
+    // Both "Burn (7d)" and "Open-budget reserved" render 0.0000 ETH; the
+    // count is two and there's no NaN.
+    const matches = screen.queryAllByText(/0\.0000/);
+    expect(matches.length).toBeGreaterThan(0);
+    expect(screen.queryByText(/NaN/)).toBeNull();
+  });
+});

--- a/client/src/dashboard/spa/src/pages/launcher/CostCard.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher/CostCard.tsx
@@ -1,0 +1,69 @@
+import { SectionCard } from '../../components/SectionCard.js';
+
+/**
+ * Tier 2 launcher card: shows 7-day cost summary — burn rate, Tasks funded,
+ * and open-task budget reservations. Pure presentation; data comes from
+ * `api.fetchLauncherSummary()` (wired in Task 16).
+ *
+ * NOTE: `formatEth` is duplicated 3x in the SPA (Overview.tsx,
+ * AwaitingFundingCard.tsx, SetupFlow.tsx). Dedup tracked as
+ * `jinn-mono-l2zl.16`.
+ */
+
+export interface CostCardProps {
+  burn7dWei: string;
+  tasksFunded7d: number;
+  openTaskBudgetWei: string;
+}
+
+function formatEth(wei: string): string {
+  const num = Number(BigInt(wei) / 10n ** 14n) / 10_000;
+  return num.toFixed(4);
+}
+
+export function CostCard({
+  burn7dWei,
+  tasksFunded7d,
+  openTaskBudgetWei,
+}: CostCardProps): JSX.Element {
+  return (
+    <SectionCard
+      title="Cost of producing this knowledge"
+      summary="7-day window"
+      defaultExpanded
+    >
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '16px' }}>
+        <Stat label="Burn (7d)" value={`${formatEth(burn7dWei)} ETH`} />
+        <Stat label="Tasks funded (7d)" value={String(tasksFunded7d)} />
+        <Stat label="Open-budget reserved" value={`${formatEth(openTaskBudgetWei)} ETH`} />
+      </div>
+    </SectionCard>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }): JSX.Element {
+  return (
+    <div>
+      <div
+        style={{
+          fontSize: '11px',
+          textTransform: 'uppercase',
+          letterSpacing: '0.14em',
+          color: 'var(--fg-muted)',
+        }}
+      >
+        {label}
+      </div>
+      <div
+        style={{
+          fontFamily: "'JetBrains Mono', monospace",
+          fontSize: '20px',
+          color: 'var(--fg)',
+          marginTop: '4px',
+        }}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/client/src/dashboard/spa/src/pages/launcher/EmissionsPlaceholder.test.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher/EmissionsPlaceholder.test.tsx
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { EmissionsPlaceholder } from './EmissionsPlaceholder.js';
+
+describe('EmissionsPlaceholder', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders a Phase B+ ve-JINN gauge placeholder', () => {
+    render(<EmissionsPlaceholder />);
+    // Body is collapsed by default; expand it so future-facing copy is visible.
+    fireEvent.click(screen.getByText(/Direct JINN emissions/i));
+    expect(screen.queryAllByText(/ve-JINN/i).length).toBeGreaterThan(0);
+    expect(screen.queryAllByText(/Phase B/i).length).toBeGreaterThan(0);
+  });
+
+  it('flags v1 scope as future-facing', () => {
+    render(<EmissionsPlaceholder />);
+    fireEvent.click(screen.getByText(/Direct JINN emissions/i));
+    expect(screen.queryByText(/Out of scope for v1/i)).toBeTruthy();
+  });
+});

--- a/client/src/dashboard/spa/src/pages/launcher/EmissionsPlaceholder.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher/EmissionsPlaceholder.tsx
@@ -1,0 +1,36 @@
+import { SectionCard } from '../../components/SectionCard.js';
+
+/**
+ * Tier-4 Launcher overview placeholder — describes the future ve-JINN
+ * gauge direction surface. No interactivity in v1; explicitly future-
+ * facing so launchers know it's coming and don't expect it today.
+ *
+ * Phase B+ will add gauge-vote controls; the section card here is the
+ * permanent home so the information hierarchy in §6.5 of the spec
+ * stays stable across phases.
+ */
+export function EmissionsPlaceholder(): JSX.Element {
+  return (
+    <SectionCard
+      title="Direct JINN emissions to this SolverNet"
+      summary="Phase B+ — ve-JINN gauge direction (placeholder)"
+      defaultExpanded={false}
+      metaChip={{ label: 'Phase B+', tone: 'default' }}
+    >
+      <p style={{ color: 'var(--fg-muted)', margin: 0, lineHeight: 1.5, fontSize: '14px' }}>
+        When ve-JINN gauges ship in Phase B+, you'll be able to direct protocol-level emissions
+        toward this SolverNet here.
+      </p>
+      <p
+        style={{
+          color: 'var(--fg-dim)',
+          fontSize: '12px',
+          margin: 0,
+          fontFamily: "'JetBrains Mono', monospace",
+        }}
+      >
+        Coming in a later phase. Out of scope for v1.
+      </p>
+    </SectionCard>
+  );
+}

--- a/client/src/dashboard/spa/src/pages/launcher/EmptyState.test.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher/EmptyState.test.tsx
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { EmptyState } from './EmptyState.js';
+
+describe('EmptyState', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the spec headline and the framing copy', () => {
+    render(<EmptyState onLaunch={vi.fn()} />);
+    expect(screen.getByText("You haven't launched a SolverNet yet.")).toBeTruthy();
+    // Knowledge-direction framing — the "what is a SolverNet" lede.
+    expect(screen.getByText(/directs the network's effort/i)).toBeTruthy();
+  });
+
+  it('fires onLaunch with the prediction net name when CTA clicked', () => {
+    const onLaunch = vi.fn();
+    render(<EmptyState onLaunch={onLaunch} />);
+    fireEvent.click(screen.getByRole('button', { name: /Launch Prediction SolverNet/i }));
+    expect(onLaunch).toHaveBeenCalledTimes(1);
+    expect(onLaunch).toHaveBeenCalledWith('prediction');
+  });
+});

--- a/client/src/dashboard/spa/src/pages/launcher/EmptyState.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher/EmptyState.tsx
@@ -1,0 +1,59 @@
+import { SectionCard } from '../../components/SectionCard.js';
+
+/**
+ * Launcher empty state — shown on the Launcher overview when no
+ * SolverNet has 'launching' in its roles. The CTA opens the 4-step
+ * SetupFlow that toggles 'launching' on for the chosen SolverNet.
+ *
+ * Phase A.1 ships only the Prediction SolverNet, so the CTA is hard-
+ * coded to 'prediction'. Future SolverNets can lift this into a
+ * catalog-driven list without changing the public component shape.
+ */
+export interface EmptyStateProps {
+  onLaunch: (netName: string) => void;
+}
+
+export function EmptyState({ onLaunch }: EmptyStateProps): JSX.Element {
+  return (
+    <SectionCard
+      title="Launch a SolverNet"
+      summary="Direct the network's effort toward producing a kind of knowledge."
+      defaultExpanded
+    >
+      <h2
+        style={{
+          fontFamily: "'JetBrains Mono', monospace",
+          fontSize: '20px',
+          color: 'var(--fg)',
+          margin: '0 0 12px',
+          fontWeight: 500,
+          letterSpacing: '-0.01em',
+        }}
+      >
+        You haven't launched a SolverNet yet.
+      </h2>
+      <p style={{ color: 'var(--fg-muted)', margin: '0 0 20px', lineHeight: 1.5, fontSize: '14px' }}>
+        A SolverNet directs the network's effort toward producing a kind of knowledge.
+        As Launcher you fund the Tasks operators attempt — and own what gets produced.
+      </p>
+      <div>
+        <button
+          type="button"
+          onClick={() => onLaunch('prediction')}
+          style={{
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '14px',
+            padding: '12px 20px',
+            background: 'var(--accent-sky)',
+            color: 'var(--bg-sunken)',
+            border: '1px solid var(--accent-sky)',
+            borderRadius: '6px',
+            cursor: 'pointer',
+          }}
+        >
+          Launch Prediction SolverNet
+        </button>
+      </div>
+    </SectionCard>
+  );
+}

--- a/client/src/dashboard/spa/src/pages/launcher/GeneratorConfigSection.test.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher/GeneratorConfigSection.test.tsx
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { GeneratorConfigSection, type GeneratorConfig } from './GeneratorConfigSection.js';
+
+const fixture: GeneratorConfig = {
+  cadenceMs: 21_600_000,
+  maxNewRoundsPerPoll: 5,
+  maxNewRoundsPerDay: 100,
+  maxOpenRounds: 250,
+  allowlistConditionIds: [],
+  blocklistConditionIds: [],
+  windowMs: 86_400_000,
+  resolveGapMs: 3_600_000,
+};
+
+describe('GeneratorConfigSection', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders all 8 generator fields', () => {
+    render(<GeneratorConfigSection netName="prediction" config={fixture} onSave={vi.fn()} />);
+    expect(screen.queryByLabelText(/^Cadence$/i)).toBeTruthy();
+    expect(screen.queryByLabelText(/Max new rounds per poll/i)).toBeTruthy();
+    expect(screen.queryByLabelText(/Max new rounds per day/i)).toBeTruthy();
+    expect(screen.queryByLabelText(/Max open rounds/i)).toBeTruthy();
+    expect(screen.queryByLabelText(/Allowlist/i)).toBeTruthy();
+    expect(screen.queryByLabelText(/Blocklist/i)).toBeTruthy();
+    expect(screen.queryByLabelText(/^Window$/i)).toBeTruthy();
+    expect(screen.queryByLabelText(/Resolve gap/i)).toBeTruthy();
+  });
+
+  it('calls onSave with the generator-shaped patch containing only changed fields', async () => {
+    const onSave = vi.fn().mockResolvedValue({ ok: true });
+    render(<GeneratorConfigSection netName="prediction" config={fixture} onSave={onSave} />);
+    fireEvent.change(screen.getByLabelText(/^Cadence$/i), { target: { value: '120000' } });
+    fireEvent.click(screen.getByRole('button', { name: /Save/i }));
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith({
+        generator: { cadenceMs: 120_000 },
+      }),
+    );
+  });
+
+  it('save button disabled when no fields changed', () => {
+    render(<GeneratorConfigSection netName="prediction" config={fixture} onSave={vi.fn()} />);
+    const btn = screen.getByRole('button', { name: /Save/i }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('parses comma-separated allowlist into an array', async () => {
+    const onSave = vi.fn().mockResolvedValue({ ok: true });
+    render(<GeneratorConfigSection netName="prediction" config={fixture} onSave={onSave} />);
+    fireEvent.change(screen.getByLabelText(/Allowlist/i), {
+      target: { value: '0xabc, 0xdef , 0x123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Save/i }));
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith({
+        generator: { allowlistConditionIds: ['0xabc', '0xdef', '0x123'] },
+      }),
+    );
+  });
+
+  it('renders error message when onSave rejects', async () => {
+    const onSave = vi.fn().mockRejectedValue(new Error('boom'));
+    render(<GeneratorConfigSection netName="prediction" config={fixture} onSave={onSave} />);
+    fireEvent.change(screen.getByLabelText(/^Cadence$/i), { target: { value: '120000' } });
+    fireEvent.click(screen.getByRole('button', { name: /Save/i }));
+    await waitFor(() => expect(screen.queryByText(/boom/)).toBeTruthy());
+  });
+});

--- a/client/src/dashboard/spa/src/pages/launcher/GeneratorConfigSection.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher/GeneratorConfigSection.tsx
@@ -1,0 +1,233 @@
+import { useState } from 'react';
+import { SectionCard } from '../../components/SectionCard.js';
+import { ConfigField } from '../../components/ConfigField.js';
+
+/**
+ * Per-SolverNet generator config form (Launcher mode > /launcher/configuration).
+ *
+ * Surfaces the eight `predictionV1*` keys mirrored in
+ * `LauncherSolverNetPatch.generator` (client/src/dashboard/spa/src/api/types.ts).
+ * Edits hot-apply per spec §5.2 — no restart-required pill.
+ *
+ * The submitted patch contains only fields the operator actually changed,
+ * so a re-save with no diffs would be a no-op against the daemon. The save
+ * button stays disabled until at least one field diverges from the
+ * persisted `config` prop.
+ */
+
+export interface GeneratorConfig {
+  cadenceMs: number;
+  maxNewRoundsPerPoll: number;
+  maxNewRoundsPerDay: number;
+  maxOpenRounds: number;
+  allowlistConditionIds: string[];
+  blocklistConditionIds: string[];
+  windowMs: number;
+  resolveGapMs: number;
+}
+
+export interface GeneratorConfigSectionProps {
+  netName: string;
+  config: GeneratorConfig;
+  onSave: (patch: { generator: Partial<GeneratorConfig> }) => Promise<unknown>;
+}
+
+const inputStyle: React.CSSProperties = {
+  background: 'var(--bg-sunken)',
+  border: '1px solid var(--border)',
+  borderRadius: '6px',
+  padding: '8px 10px',
+  color: 'var(--fg)',
+  fontFamily: "'JetBrains Mono', monospace",
+  fontSize: '13px',
+};
+
+function arraysEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+function parseCsv(value: string): string[] {
+  return value
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export function GeneratorConfigSection({
+  netName,
+  config,
+  onSave,
+}: GeneratorConfigSectionProps): JSX.Element {
+  const [draft, setDraft] = useState<GeneratorConfig>(config);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const dirty =
+    draft.cadenceMs !== config.cadenceMs ||
+    draft.maxNewRoundsPerPoll !== config.maxNewRoundsPerPoll ||
+    draft.maxNewRoundsPerDay !== config.maxNewRoundsPerDay ||
+    draft.maxOpenRounds !== config.maxOpenRounds ||
+    draft.windowMs !== config.windowMs ||
+    draft.resolveGapMs !== config.resolveGapMs ||
+    !arraysEqual(draft.allowlistConditionIds, config.allowlistConditionIds) ||
+    !arraysEqual(draft.blocklistConditionIds, config.blocklistConditionIds);
+
+  const onSubmit = async (): Promise<void> => {
+    setSaving(true);
+    setError(null);
+    try {
+      const patch: Partial<GeneratorConfig> = {};
+      if (draft.cadenceMs !== config.cadenceMs) patch.cadenceMs = draft.cadenceMs;
+      if (draft.maxNewRoundsPerPoll !== config.maxNewRoundsPerPoll)
+        patch.maxNewRoundsPerPoll = draft.maxNewRoundsPerPoll;
+      if (draft.maxNewRoundsPerDay !== config.maxNewRoundsPerDay)
+        patch.maxNewRoundsPerDay = draft.maxNewRoundsPerDay;
+      if (draft.maxOpenRounds !== config.maxOpenRounds)
+        patch.maxOpenRounds = draft.maxOpenRounds;
+      if (draft.windowMs !== config.windowMs) patch.windowMs = draft.windowMs;
+      if (draft.resolveGapMs !== config.resolveGapMs)
+        patch.resolveGapMs = draft.resolveGapMs;
+      if (!arraysEqual(draft.allowlistConditionIds, config.allowlistConditionIds))
+        patch.allowlistConditionIds = draft.allowlistConditionIds;
+      if (!arraysEqual(draft.blocklistConditionIds, config.blocklistConditionIds))
+        patch.blocklistConditionIds = draft.blocklistConditionIds;
+      await onSave({ generator: patch });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <SectionCard
+      title={`${netName} generator`}
+      summary="Edits hot-apply within one cadence — no daemon restart required"
+      defaultExpanded
+    >
+      <ConfigField label="Cadence (ms)" helperText="Generator poll interval">
+        <input
+          aria-label="Cadence"
+          type="number"
+          value={draft.cadenceMs}
+          onChange={(e) => setDraft({ ...draft, cadenceMs: Number(e.target.value) })}
+          style={inputStyle}
+        />
+      </ConfigField>
+      <ConfigField label="Max new rounds per poll">
+        <input
+          aria-label="Max new rounds per poll"
+          type="number"
+          value={draft.maxNewRoundsPerPoll}
+          onChange={(e) =>
+            setDraft({ ...draft, maxNewRoundsPerPoll: Number(e.target.value) })
+          }
+          style={inputStyle}
+        />
+      </ConfigField>
+      <ConfigField label="Max new rounds per day">
+        <input
+          aria-label="Max new rounds per day"
+          type="number"
+          value={draft.maxNewRoundsPerDay}
+          onChange={(e) =>
+            setDraft({ ...draft, maxNewRoundsPerDay: Number(e.target.value) })
+          }
+          style={inputStyle}
+        />
+      </ConfigField>
+      <ConfigField label="Max open rounds">
+        <input
+          aria-label="Max open rounds"
+          type="number"
+          value={draft.maxOpenRounds}
+          onChange={(e) => setDraft({ ...draft, maxOpenRounds: Number(e.target.value) })}
+          style={inputStyle}
+        />
+      </ConfigField>
+      <ConfigField label="Window (ms)" helperText="Time horizon for resolution candidates">
+        <input
+          aria-label="Window"
+          type="number"
+          value={draft.windowMs}
+          onChange={(e) => setDraft({ ...draft, windowMs: Number(e.target.value) })}
+          style={inputStyle}
+        />
+      </ConfigField>
+      <ConfigField label="Resolve gap (ms)" helperText="Minimum gap before resolution">
+        <input
+          aria-label="Resolve gap"
+          type="number"
+          value={draft.resolveGapMs}
+          onChange={(e) => setDraft({ ...draft, resolveGapMs: Number(e.target.value) })}
+          style={inputStyle}
+        />
+      </ConfigField>
+      <ConfigField
+        label="Allowlist condition IDs"
+        helperText="Comma-separated. Empty = no allowlist filter"
+      >
+        <input
+          aria-label="Allowlist condition IDs"
+          type="text"
+          value={draft.allowlistConditionIds.join(',')}
+          onChange={(e) =>
+            setDraft({ ...draft, allowlistConditionIds: parseCsv(e.target.value) })
+          }
+          style={inputStyle}
+        />
+      </ConfigField>
+      <ConfigField
+        label="Blocklist condition IDs"
+        helperText="Comma-separated. Empty = no blocklist filter"
+      >
+        <input
+          aria-label="Blocklist condition IDs"
+          type="text"
+          value={draft.blocklistConditionIds.join(',')}
+          onChange={(e) =>
+            setDraft({ ...draft, blocklistConditionIds: parseCsv(e.target.value) })
+          }
+          style={inputStyle}
+        />
+      </ConfigField>
+
+      {error && (
+        <p
+          style={{
+            color: 'var(--break-red)',
+            marginTop: '12px',
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '12px',
+          }}
+        >
+          {error}
+        </p>
+      )}
+      <div style={{ marginTop: '8px', display: 'flex', justifyContent: 'flex-end' }}>
+        <button
+          type="button"
+          onClick={onSubmit}
+          disabled={!dirty || saving}
+          style={{
+            border: '1px solid var(--accent-sky)',
+            background: dirty && !saving ? 'var(--accent-sky)' : 'transparent',
+            color: dirty && !saving ? 'var(--bg-sunken)' : 'var(--fg-muted)',
+            borderRadius: '6px',
+            padding: '10px 20px',
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '14px',
+            cursor: !dirty || saving ? 'not-allowed' : 'pointer',
+            opacity: !dirty || saving ? 0.6 : 1,
+          }}
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </SectionCard>
+  );
+}

--- a/client/src/dashboard/spa/src/pages/launcher/GeneratorConfigSection.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher/GeneratorConfigSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { SectionCard } from '../../components/SectionCard.js';
 import { ConfigField } from '../../components/ConfigField.js';
 
@@ -62,40 +62,58 @@ export function GeneratorConfigSection({
   config,
   onSave,
 }: GeneratorConfigSectionProps): JSX.Element {
+  const [baseline, setBaseline] = useState<GeneratorConfig>(config);
   const [draft, setDraft] = useState<GeneratorConfig>(config);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  useEffect(() => {
+    setBaseline(config);
+    setDraft(config);
+    setError(null);
+    setSuccess(null);
+  }, [config]);
+
+  const updateDraft = (patch: Partial<GeneratorConfig>): void => {
+    setDraft((current) => ({ ...current, ...patch }));
+    setError(null);
+    setSuccess(null);
+  };
 
   const dirty =
-    draft.cadenceMs !== config.cadenceMs ||
-    draft.maxNewRoundsPerPoll !== config.maxNewRoundsPerPoll ||
-    draft.maxNewRoundsPerDay !== config.maxNewRoundsPerDay ||
-    draft.maxOpenRounds !== config.maxOpenRounds ||
-    draft.windowMs !== config.windowMs ||
-    draft.resolveGapMs !== config.resolveGapMs ||
-    !arraysEqual(draft.allowlistConditionIds, config.allowlistConditionIds) ||
-    !arraysEqual(draft.blocklistConditionIds, config.blocklistConditionIds);
+    draft.cadenceMs !== baseline.cadenceMs ||
+    draft.maxNewRoundsPerPoll !== baseline.maxNewRoundsPerPoll ||
+    draft.maxNewRoundsPerDay !== baseline.maxNewRoundsPerDay ||
+    draft.maxOpenRounds !== baseline.maxOpenRounds ||
+    draft.windowMs !== baseline.windowMs ||
+    draft.resolveGapMs !== baseline.resolveGapMs ||
+    !arraysEqual(draft.allowlistConditionIds, baseline.allowlistConditionIds) ||
+    !arraysEqual(draft.blocklistConditionIds, baseline.blocklistConditionIds);
 
   const onSubmit = async (): Promise<void> => {
     setSaving(true);
     setError(null);
+    setSuccess(null);
     try {
       const patch: Partial<GeneratorConfig> = {};
-      if (draft.cadenceMs !== config.cadenceMs) patch.cadenceMs = draft.cadenceMs;
-      if (draft.maxNewRoundsPerPoll !== config.maxNewRoundsPerPoll)
+      if (draft.cadenceMs !== baseline.cadenceMs) patch.cadenceMs = draft.cadenceMs;
+      if (draft.maxNewRoundsPerPoll !== baseline.maxNewRoundsPerPoll)
         patch.maxNewRoundsPerPoll = draft.maxNewRoundsPerPoll;
-      if (draft.maxNewRoundsPerDay !== config.maxNewRoundsPerDay)
+      if (draft.maxNewRoundsPerDay !== baseline.maxNewRoundsPerDay)
         patch.maxNewRoundsPerDay = draft.maxNewRoundsPerDay;
-      if (draft.maxOpenRounds !== config.maxOpenRounds)
+      if (draft.maxOpenRounds !== baseline.maxOpenRounds)
         patch.maxOpenRounds = draft.maxOpenRounds;
-      if (draft.windowMs !== config.windowMs) patch.windowMs = draft.windowMs;
-      if (draft.resolveGapMs !== config.resolveGapMs)
+      if (draft.windowMs !== baseline.windowMs) patch.windowMs = draft.windowMs;
+      if (draft.resolveGapMs !== baseline.resolveGapMs)
         patch.resolveGapMs = draft.resolveGapMs;
-      if (!arraysEqual(draft.allowlistConditionIds, config.allowlistConditionIds))
+      if (!arraysEqual(draft.allowlistConditionIds, baseline.allowlistConditionIds))
         patch.allowlistConditionIds = draft.allowlistConditionIds;
-      if (!arraysEqual(draft.blocklistConditionIds, config.blocklistConditionIds))
+      if (!arraysEqual(draft.blocklistConditionIds, baseline.blocklistConditionIds))
         patch.blocklistConditionIds = draft.blocklistConditionIds;
       await onSave({ generator: patch });
+      setBaseline(draft);
+      setSuccess(`${netName} generator saved`);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -114,7 +132,7 @@ export function GeneratorConfigSection({
           aria-label="Cadence"
           type="number"
           value={draft.cadenceMs}
-          onChange={(e) => setDraft({ ...draft, cadenceMs: Number(e.target.value) })}
+          onChange={(e) => updateDraft({ cadenceMs: Number(e.target.value) })}
           style={inputStyle}
         />
       </ConfigField>
@@ -124,7 +142,7 @@ export function GeneratorConfigSection({
           type="number"
           value={draft.maxNewRoundsPerPoll}
           onChange={(e) =>
-            setDraft({ ...draft, maxNewRoundsPerPoll: Number(e.target.value) })
+            updateDraft({ maxNewRoundsPerPoll: Number(e.target.value) })
           }
           style={inputStyle}
         />
@@ -135,7 +153,7 @@ export function GeneratorConfigSection({
           type="number"
           value={draft.maxNewRoundsPerDay}
           onChange={(e) =>
-            setDraft({ ...draft, maxNewRoundsPerDay: Number(e.target.value) })
+            updateDraft({ maxNewRoundsPerDay: Number(e.target.value) })
           }
           style={inputStyle}
         />
@@ -145,7 +163,7 @@ export function GeneratorConfigSection({
           aria-label="Max open rounds"
           type="number"
           value={draft.maxOpenRounds}
-          onChange={(e) => setDraft({ ...draft, maxOpenRounds: Number(e.target.value) })}
+          onChange={(e) => updateDraft({ maxOpenRounds: Number(e.target.value) })}
           style={inputStyle}
         />
       </ConfigField>
@@ -154,7 +172,7 @@ export function GeneratorConfigSection({
           aria-label="Window"
           type="number"
           value={draft.windowMs}
-          onChange={(e) => setDraft({ ...draft, windowMs: Number(e.target.value) })}
+          onChange={(e) => updateDraft({ windowMs: Number(e.target.value) })}
           style={inputStyle}
         />
       </ConfigField>
@@ -163,7 +181,7 @@ export function GeneratorConfigSection({
           aria-label="Resolve gap"
           type="number"
           value={draft.resolveGapMs}
-          onChange={(e) => setDraft({ ...draft, resolveGapMs: Number(e.target.value) })}
+          onChange={(e) => updateDraft({ resolveGapMs: Number(e.target.value) })}
           style={inputStyle}
         />
       </ConfigField>
@@ -176,7 +194,7 @@ export function GeneratorConfigSection({
           type="text"
           value={draft.allowlistConditionIds.join(',')}
           onChange={(e) =>
-            setDraft({ ...draft, allowlistConditionIds: parseCsv(e.target.value) })
+            updateDraft({ allowlistConditionIds: parseCsv(e.target.value) })
           }
           style={inputStyle}
         />
@@ -190,7 +208,7 @@ export function GeneratorConfigSection({
           type="text"
           value={draft.blocklistConditionIds.join(',')}
           onChange={(e) =>
-            setDraft({ ...draft, blocklistConditionIds: parseCsv(e.target.value) })
+            updateDraft({ blocklistConditionIds: parseCsv(e.target.value) })
           }
           style={inputStyle}
         />
@@ -206,6 +224,19 @@ export function GeneratorConfigSection({
           }}
         >
           {error}
+        </p>
+      )}
+      {success && (
+        <p
+          role="status"
+          style={{
+            color: 'var(--vow-green)',
+            marginTop: '12px',
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '12px',
+          }}
+        >
+          {success}
         </p>
       )}
       <div style={{ marginTop: '8px', display: 'flex', justifyContent: 'flex-end' }}>

--- a/client/src/dashboard/spa/src/pages/launcher/GeneratorStatusCard.test.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher/GeneratorStatusCard.test.tsx
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { GeneratorStatusCard, type GeneratorStatus } from './GeneratorStatusCard.js';
+
+const activeStatus: GeneratorStatus = {
+  state: 'active',
+  lastPollAt: '2026-05-05T15:00:00Z',
+  lastPollSummary: { evaluated: 3, posted: 2, skipped: 1 },
+  cadenceMs: 21_600_000,
+  stale: false,
+};
+
+const staleStatus: GeneratorStatus = { ...activeStatus, stale: true };
+
+const erroredStatus: GeneratorStatus = {
+  state: 'errored',
+  lastError: { message: 'polymarket 503', at: '2026-05-05T14:00:00Z' },
+  cadenceMs: 21_600_000,
+  stale: false,
+};
+
+const pausedStatus: GeneratorStatus = {
+  state: 'paused',
+  cadenceMs: 21_600_000,
+};
+
+describe('GeneratorStatusCard', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders state pill, last poll timestamp, and last poll summary', () => {
+    render(<GeneratorStatusCard status={activeStatus} />);
+    expect(screen.queryAllByText(/Active/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/last poll/i)).toBeTruthy();
+    expect(screen.queryByText(/3 evaluated/i)).toBeTruthy();
+    expect(screen.queryByText(/2 posted/i)).toBeTruthy();
+  });
+
+  it('renders stale banner when stale=true', () => {
+    render(<GeneratorStatusCard status={staleStatus} />);
+    const alert = screen.queryByRole('alert');
+    expect(alert).toBeTruthy();
+    expect(alert!.textContent).toMatch(/stuck|stale|expected/i);
+  });
+
+  it('renders error banner when state=errored', () => {
+    render(<GeneratorStatusCard status={erroredStatus} />);
+    const alert = screen.queryByRole('alert');
+    expect(alert).toBeTruthy();
+    expect(alert!.textContent).toMatch(/polymarket 503/i);
+  });
+
+  it('renders paused state without summary or alert', () => {
+    render(<GeneratorStatusCard status={pausedStatus} />);
+    expect(screen.queryAllByText(/Paused/i).length).toBeGreaterThan(0);
+    expect(screen.queryByRole('alert')).toBeFalsy();
+  });
+});

--- a/client/src/dashboard/spa/src/pages/launcher/GeneratorStatusCard.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher/GeneratorStatusCard.tsx
@@ -1,0 +1,138 @@
+import { SectionCard } from '../../components/SectionCard.js';
+
+/**
+ * Tier-3 Launcher overview card — tactical generator state. Surfaces
+ * the generator's run state (active / paused / errored), the most
+ * recent poll's timestamp + summary, and an alert banner when the
+ * generator has errored or its last poll is older than expected
+ * (`status.stale` is set server-side when `lastPollAt + 2*cadence < now`).
+ *
+ * Presentation only. Task 16 wires real data from the daemon's
+ * `LauncherStatusGeneratorView`; here we just take props.
+ */
+
+export interface GeneratorStatus {
+  state: 'active' | 'paused' | 'errored';
+  lastPollAt?: string;
+  lastPollSummary?: { evaluated: number; posted: number; skipped: number };
+  lastError?: { message: string; at: string };
+  cadenceMs: number;
+  stale?: boolean;
+}
+
+export interface GeneratorStatusCardProps {
+  status: GeneratorStatus;
+}
+
+const STATE_COLORS: Record<GeneratorStatus['state'], string> = {
+  active: 'var(--vow-green)',
+  paused: 'var(--fg-muted)',
+  errored: 'var(--break-red)',
+};
+
+const STATE_LABELS: Record<GeneratorStatus['state'], string> = {
+  active: 'Active',
+  paused: 'Paused',
+  errored: 'Errored',
+};
+
+const STATE_TONES: Record<GeneratorStatus['state'], 'live' | 'default' | 'danger'> = {
+  active: 'live',
+  paused: 'default',
+  errored: 'danger',
+};
+
+export function GeneratorStatusCard({ status }: GeneratorStatusCardProps): JSX.Element {
+  const color = STATE_COLORS[status.state];
+  const label = STATE_LABELS[status.state];
+  // Errored state takes precedence; stale alert only shows if not already errored.
+  const showStaleAlert = status.stale === true && status.state !== 'errored';
+  const cadenceMin = Math.round(status.cadenceMs / 60_000);
+
+  return (
+    <SectionCard
+      title="Generator status"
+      summary={label}
+      metaChip={{ label, tone: STATE_TONES[status.state] }}
+      defaultExpanded
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+        <span
+          style={{
+            display: 'inline-block',
+            width: '8px',
+            height: '8px',
+            borderRadius: '50%',
+            background: color,
+          }}
+          aria-hidden="true"
+        />
+        <span style={{ fontFamily: "'JetBrains Mono', monospace", color: 'var(--fg)', fontSize: '14px' }}>
+          {label}
+        </span>
+      </div>
+
+      {status.lastPollAt && (
+        <p
+          style={{
+            color: 'var(--fg-muted)',
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '13px',
+            margin: 0,
+          }}
+        >
+          last poll: {status.lastPollAt}
+        </p>
+      )}
+
+      {status.lastPollSummary && (
+        <p
+          style={{
+            color: 'var(--fg)',
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '13px',
+            margin: 0,
+          }}
+        >
+          {status.lastPollSummary.evaluated} evaluated · {status.lastPollSummary.posted} posted ·{' '}
+          {status.lastPollSummary.skipped} skipped
+        </p>
+      )}
+
+      {status.state === 'errored' && status.lastError && (
+        <div
+          role="alert"
+          style={{
+            padding: '10px 14px',
+            border: '1px solid var(--break-red)',
+            borderRadius: '6px',
+            color: 'var(--break-red)',
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '13px',
+          }}
+        >
+          {status.lastError.message}
+          <span style={{ color: 'var(--fg-dim)', fontSize: '11px', marginLeft: '8px' }}>
+            at {status.lastError.at}
+          </span>
+        </div>
+      )}
+
+      {showStaleAlert && (
+        <div
+          role="alert"
+          style={{
+            padding: '10px 14px',
+            border: '1px solid var(--break-red)',
+            borderRadius: '6px',
+            color: 'var(--break-red)',
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '13px',
+          }}
+        >
+          Generator may be stuck — last poll older than expected (cadence {cadenceMin} min).
+        </div>
+      )}
+    </SectionCard>
+  );
+}

--- a/client/src/dashboard/spa/src/pages/launcher/KnowledgeProductionCard.test.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher/KnowledgeProductionCard.test.tsx
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { KnowledgeProductionCard, type RecentSettledForecast } from './KnowledgeProductionCard.js';
+
+const baseFixture = {
+  netName: 'prediction',
+  intent: 'Calibrated probabilistic forecasts of Polymarket-listed events',
+  scoreboard: { brierSpread: -0.012, windowDays: 28 },
+  recentSettled: Array.from({ length: 5 }, (_, i): RecentSettledForecast => ({
+    taskId: `0x${i}`,
+    predicate: `Will Event ${i} happen?`,
+    outcome: i % 2 === 0 ? 'YES' : 'NO',
+    settledAt: '2026-05-05T10:00:00Z',
+    forecastProb: 0.6,
+  })),
+};
+
+describe('KnowledgeProductionCard', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders intent + Brier headline + 5 recent forecasts', () => {
+    render(<KnowledgeProductionCard {...baseFixture} />);
+    expect(screen.queryByText(/Calibrated probabilistic forecasts/i)).toBeTruthy();
+    expect(screen.queryByText(/Brier spread/i)).toBeTruthy();
+    expect(screen.queryAllByTestId('recent-settled-row')).toHaveLength(5);
+  });
+
+  it('handles empty recentSettled with a "no forecasts yet" hint', () => {
+    render(<KnowledgeProductionCard {...baseFixture} recentSettled={[]} />);
+    expect(screen.queryByText(/no forecasts settled yet/i)).toBeTruthy();
+    expect(screen.queryAllByTestId('recent-settled-row')).toHaveLength(0);
+  });
+
+  it('falls back to a pending headline when no scoreboard is provided', () => {
+    render(<KnowledgeProductionCard {...baseFixture} scoreboard={undefined} />);
+    expect(screen.queryByText(/Brier spread: pending/i)).toBeTruthy();
+  });
+
+  it('signs positive Brier spreads with a leading "+" and 4-decimal precision', () => {
+    render(
+      <KnowledgeProductionCard
+        {...baseFixture}
+        scoreboard={{ brierSpread: 0.0034, windowDays: 28 }}
+      />,
+    );
+    expect(screen.queryByText(/\+0\.0034/)).toBeTruthy();
+  });
+});

--- a/client/src/dashboard/spa/src/pages/launcher/KnowledgeProductionCard.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher/KnowledgeProductionCard.tsx
@@ -1,0 +1,102 @@
+import { SectionCard } from '../../components/SectionCard.js';
+
+/**
+ * Tier-1 Launcher overview card — "what knowledge is this SolverNet
+ * producing." Surfaces the SolverNet's intent line, a Brier-spread
+ * headline (vs Polymarket consensus, rolling window) and the most
+ * recent settled forecasts.
+ *
+ * Presentation only. Task 16 wires real data from the Brier scoreboard
+ * (`client/src/corpus/prediction-brier-scoreboard.ts`) and the settled
+ * Verdicts feed; here we just take props.
+ */
+
+export interface RecentSettledForecast {
+  taskId: string;
+  predicate: string;
+  outcome: 'YES' | 'NO' | 'INVALID';
+  settledAt: string;
+  forecastProb: number;
+}
+
+export interface KnowledgeProductionCardProps {
+  netName: string;
+  intent: string;
+  scoreboard?: { brierSpread: number; windowDays: number };
+  recentSettled: RecentSettledForecast[];
+}
+
+const OUTCOME_COLOR: Record<RecentSettledForecast['outcome'], string> = {
+  YES: 'var(--vow-green)',
+  NO: 'var(--break-red)',
+  INVALID: 'var(--fg-dim)',
+};
+
+export function KnowledgeProductionCard({
+  netName,
+  intent,
+  scoreboard,
+  recentSettled,
+}: KnowledgeProductionCardProps): JSX.Element {
+  const brierLine = scoreboard
+    ? `Brier spread vs Polymarket consensus (${scoreboard.windowDays}d): ${scoreboard.brierSpread > 0 ? '+' : ''}${scoreboard.brierSpread.toFixed(4)}`
+    : 'Brier spread: pending — first settled forecasts not yet observed.';
+
+  return (
+    <SectionCard
+      title={`${netName} · what knowledge is this SolverNet producing`}
+      summary="Intent, calibration, and recent settled forecasts."
+      defaultExpanded
+    >
+      <p style={{ color: 'var(--fg-muted)', margin: '0 0 12px', lineHeight: 1.5, fontSize: '14px' }}>
+        {intent}
+      </p>
+      <p
+        style={{
+          fontFamily: "'JetBrains Mono', monospace",
+          color: 'var(--fg)',
+          margin: '0 0 16px',
+          fontSize: '14px',
+        }}
+      >
+        {brierLine}
+      </p>
+      {recentSettled.length === 0 ? (
+        <p style={{ color: 'var(--fg-dim)', margin: 0, fontSize: '13px' }}>
+          No forecasts settled yet. The first round will appear here once it resolves.
+        </p>
+      ) : (
+        <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+          {recentSettled.map((f) => (
+            <li
+              key={f.taskId}
+              data-testid="recent-settled-row"
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '1fr auto auto',
+                gap: '12px',
+                alignItems: 'center',
+                padding: '10px 0',
+                borderBottom: '1px solid var(--border)',
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: '13px',
+              }}
+            >
+              <span style={{ color: 'var(--fg)' }}>{f.predicate}</span>
+              <span style={{ color: 'var(--fg-muted)' }}>{(f.forecastProb * 100).toFixed(0)}%</span>
+              <span
+                style={{
+                  color: OUTCOME_COLOR[f.outcome],
+                  fontWeight: 500,
+                  letterSpacing: '0.08em',
+                }}
+              >
+                {f.outcome}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </SectionCard>
+  );
+}

--- a/client/src/dashboard/spa/src/pages/launcher/PostedTasksList.test.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher/PostedTasksList.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PostedTasksList } from './PostedTasksList.js';
+
+const fixture10 = Array.from({ length: 10 }, (_, i) => ({
+  taskId: `0x${i.toString(16).padStart(2, '0')}`,
+  taskCid: `Qm${i}`,
+  solverNet: 'prediction',
+  postedAt: `2026-05-05T${(10 + i).toString().padStart(2, '0')}:00:00Z`,
+  state: 'open' as const,
+  claims: { current: 0, max: 25 },
+  budget: { totalWei: '1000000', remainingWei: '1000000' },
+}));
+
+describe('PostedTasksList', () => {
+  it('renders 5 most recent tasks with state pill and budget remaining', () => {
+    render(<PostedTasksList tasks={fixture10} onLoadMore={vi.fn()} />);
+    expect(screen.queryAllByTestId('posted-task-row')).toHaveLength(5);
+    expect(screen.queryByRole('button', { name: /View all/i })).toBeTruthy();
+  });
+
+  it('shows all tasks when fewer than 5', () => {
+    render(<PostedTasksList tasks={fixture10.slice(0, 3)} onLoadMore={vi.fn()} />);
+    expect(screen.queryAllByTestId('posted-task-row')).toHaveLength(3);
+    expect(screen.queryByRole('button', { name: /View all/i })).toBeFalsy();
+  });
+
+  it('calls onLoadMore on View all click', () => {
+    const onLoadMore = vi.fn();
+    render(<PostedTasksList tasks={fixture10} onLoadMore={onLoadMore} />);
+    fireEvent.click(screen.getByRole('button', { name: /View all/i }));
+    expect(onLoadMore).toHaveBeenCalled();
+  });
+
+  it('renders an empty-state hint when tasks is empty', () => {
+    render(<PostedTasksList tasks={[]} onLoadMore={vi.fn()} />);
+    expect(screen.queryByText(/no tasks/i)).toBeTruthy();
+  });
+});

--- a/client/src/dashboard/spa/src/pages/launcher/PostedTasksList.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher/PostedTasksList.tsx
@@ -1,0 +1,97 @@
+import { SectionCard } from '../../components/SectionCard.js';
+
+/**
+ * Tier 3 launcher card: 5 most-recent posted Tasks with state pill + claims
+ * counter. View-all button (only when >5) calls `onLoadMore`, which Task 16
+ * wires to `api.fetchLauncherTasks` pagination.
+ *
+ * `PostedTask` mirrors `LauncherTasksResponse.tasks[*]` from the Task 9 SPA
+ * types contract. When that types module lands, switch to importing from
+ * there and drop this local copy.
+ */
+
+export interface PostedTask {
+  taskId: string;
+  taskCid: string;
+  solverNet: string;
+  postedAt: string;
+  state: 'open' | 'claims-in-flight' | 'fully-claimed' | 'settled' | 'failed';
+  claims: { current: number; max: number };
+  budget: { totalWei: string; remainingWei: string; reclaimableAt?: string };
+  summary?: { title?: string; resolutionTime?: string };
+}
+
+const STATE_COLORS: Record<PostedTask['state'], string> = {
+  'open': 'var(--accent-sky)',
+  'claims-in-flight': 'var(--vow-green)',
+  'fully-claimed': 'var(--fg-muted)',
+  'settled': 'var(--fg-dim)',
+  'failed': 'var(--break-red)',
+};
+
+export interface PostedTasksListProps {
+  tasks: PostedTask[];
+  onLoadMore: () => void;
+}
+
+export function PostedTasksList({ tasks, onLoadMore }: PostedTasksListProps): JSX.Element {
+  const visible = tasks.slice(0, 5);
+  const hasMore = tasks.length > 5;
+
+  return (
+    <SectionCard
+      title="Recent posted Tasks"
+      summary={`${tasks.length} shown`}
+      defaultExpanded
+    >
+      {visible.length === 0 ? (
+        <p style={{ color: 'var(--fg-dim)' }}>No tasks posted yet.</p>
+      ) : (
+        <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+          {visible.map((t) => (
+            <li
+              key={t.taskId}
+              data-testid="posted-task-row"
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '1fr auto auto',
+                gap: '12px',
+                padding: '8px 0',
+                borderBottom: '1px solid var(--border)',
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: '13px',
+              }}
+            >
+              <span style={{ color: 'var(--fg)' }}>
+                {t.summary?.title ?? t.taskId.slice(0, 10)}
+              </span>
+              <span style={{ color: STATE_COLORS[t.state] }}>{t.state}</span>
+              <span style={{ color: 'var(--fg-muted)' }}>
+                {t.claims.current}/{t.claims.max}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+      {hasMore && (
+        <button
+          type="button"
+          onClick={onLoadMore}
+          style={{
+            marginTop: '12px',
+            background: 'transparent',
+            border: '1px solid var(--border)',
+            borderRadius: '6px',
+            padding: '8px 16px',
+            color: 'var(--fg)',
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '12px',
+            cursor: 'pointer',
+          }}
+        >
+          View all
+        </button>
+      )}
+    </SectionCard>
+  );
+}

--- a/client/src/dashboard/spa/src/pages/launcher/SetupFlow.test.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher/SetupFlow.test.tsx
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { SetupFlow } from './SetupFlow.js';
+
+const defaults = {
+  cadenceMs: 21_600_000, // 6h
+  maxNewRoundsPerPoll: 5,
+  maxNewRoundsPerDay: 100,
+  maxOpenRounds: 250,
+};
+
+describe('SetupFlow', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('walks through 4 steps and patches launcher config on Save', async () => {
+    const onPatch = vi
+      .fn()
+      .mockResolvedValue({ ok: true, name: 'prediction', roles: ['launching'], generator: defaults });
+    const onComplete = vi.fn();
+    render(
+      <SetupFlow
+        netName="prediction"
+        defaults={defaults}
+        safeBalanceWei="1000000000000000000"
+        onPatch={onPatch}
+        onComplete={onComplete}
+      />,
+    );
+
+    // Step 1: confirm SolverNet — Prediction lede.
+    expect(screen.getByText(/Calibrated probabilistic forecasts/i)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+
+    // Step 2: confirm generator defaults.
+    expect(screen.getByText(/cadence: 360 min/i)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+
+    // Step 3: budget plan.
+    expect(screen.getByText(/funds approximately/i)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+
+    // Step 4: confirm + save.
+    expect(onPatch).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+    await waitFor(() =>
+      expect(onPatch).toHaveBeenCalledWith('prediction', {
+        launching: true,
+        generator: defaults,
+      }),
+    );
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+  });
+
+  it('Back button returns to the previous step', () => {
+    render(
+      <SetupFlow
+        netName="prediction"
+        defaults={defaults}
+        safeBalanceWei="1000000000000000000"
+        onPatch={vi.fn()}
+        onComplete={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Back/i }));
+    expect(screen.getByText(/Calibrated probabilistic forecasts/i)).toBeTruthy();
+  });
+
+  it('renders the error from a failing onPatch and does NOT fire onComplete', async () => {
+    const onPatch = vi.fn().mockRejectedValue(new Error('boom'));
+    const onComplete = vi.fn();
+    render(
+      <SetupFlow
+        netName="prediction"
+        defaults={defaults}
+        safeBalanceWei="1000000000000000000"
+        onPatch={onPatch}
+        onComplete={onComplete}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+    await waitFor(() => expect(screen.getByText(/boom/i)).toBeTruthy());
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('does not show a Back button on the first step', () => {
+    render(
+      <SetupFlow
+        netName="prediction"
+        defaults={defaults}
+        safeBalanceWei="1000000000000000000"
+        onPatch={vi.fn()}
+        onComplete={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: /Back/i })).toBeNull();
+  });
+});

--- a/client/src/dashboard/spa/src/pages/launcher/SetupFlow.test.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher/SetupFlow.test.tsx
@@ -38,7 +38,9 @@ describe('SetupFlow', () => {
     fireEvent.click(screen.getByRole('button', { name: /Next/i }));
 
     // Step 3: budget plan.
-    expect(screen.getByText(/funds approximately/i)).toBeTruthy();
+    expect(screen.getByText(/Safe balance 1.0000 ETH is available/i)).toBeTruthy();
+    expect(screen.queryByText(/approximately N Tasks/i)).toBeNull();
+    expect(screen.getByText(/unknown until the current per-attempt payment/i)).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: /Next/i }));
 
     // Step 4: confirm + save.

--- a/client/src/dashboard/spa/src/pages/launcher/SetupFlow.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher/SetupFlow.tsx
@@ -1,0 +1,219 @@
+import { useState } from 'react';
+import { SectionCard } from '../../components/SectionCard.js';
+
+/**
+ * Launcher setup flow — 4-step wizard that turns on the 'launching'
+ * role for a SolverNet (Phase A.1: Prediction). Mirrors the
+ * NetCard inline-prompt visual rhythm from the Configuration page —
+ * Back / Next on steps 1-3, Back / Save on step 4. The generator
+ * defaults are passed through unchanged on save; future versions can
+ * surface the fields for editing without changing the public shape.
+ */
+
+export interface GeneratorDefaults {
+  cadenceMs: number;
+  maxNewRoundsPerPoll: number;
+  maxNewRoundsPerDay: number;
+  maxOpenRounds: number;
+}
+
+export interface SetupFlowProps {
+  netName: string;
+  defaults: GeneratorDefaults;
+  safeBalanceWei: string;
+  onPatch: (
+    name: string,
+    patch: { launching: true; generator: GeneratorDefaults },
+  ) => Promise<unknown>;
+  onComplete: () => void;
+}
+
+const TOTAL_STEPS = 4;
+
+function describeNet(netName: string): string {
+  if (netName === 'prediction') {
+    return 'Calibrated probabilistic forecasts of Polymarket-listed events.';
+  }
+  return netName;
+}
+
+function scoreboardFor(netName: string): string | null {
+  if (netName === 'prediction') {
+    return 'Public scoreboard: Brier spread vs Polymarket consensus over a rolling window.';
+  }
+  return null;
+}
+
+function formatEth(wei: string): string {
+  if (!/^\d+$/.test(wei)) return '—';
+  try {
+    const eth = Number(BigInt(wei)) / 1e18;
+    return eth.toFixed(4);
+  } catch {
+    return '—';
+  }
+}
+
+const buttonBase = {
+  fontFamily: "'JetBrains Mono', monospace",
+  fontSize: '14px',
+  padding: '10px 20px',
+  borderRadius: '6px',
+  cursor: 'pointer',
+} as const;
+
+const secondaryButton = {
+  ...buttonBase,
+  border: '1px solid var(--border)',
+  background: 'transparent',
+  color: 'var(--fg)',
+};
+
+const primaryButton = {
+  ...buttonBase,
+  border: '1px solid var(--accent-sky)',
+  background: 'var(--accent-sky)',
+  color: 'var(--bg-sunken)',
+};
+
+const stepHeading = {
+  fontFamily: "'JetBrains Mono', monospace",
+  fontSize: '15px',
+  fontWeight: 500,
+  color: 'var(--fg)',
+  margin: '0 0 8px',
+  letterSpacing: '-0.01em',
+} as const;
+
+const stepBody = {
+  color: 'var(--fg-muted)',
+  fontSize: '13px',
+  lineHeight: 1.5,
+  margin: '0 0 8px',
+} as const;
+
+export function SetupFlow({
+  netName,
+  defaults,
+  safeBalanceWei,
+  onPatch,
+  onComplete,
+}: SetupFlowProps): JSX.Element {
+  const [step, setStep] = useState(1);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSave = async (): Promise<void> => {
+    setSaving(true);
+    setError(null);
+    try {
+      await onPatch(netName, { launching: true, generator: defaults });
+      onComplete();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const next = (): void => setStep((s) => Math.min(TOTAL_STEPS, s + 1));
+  const back = (): void => setStep((s) => Math.max(1, s - 1));
+
+  const cadenceMin = Math.round(defaults.cadenceMs / 60_000);
+  const safeEth = formatEth(safeBalanceWei);
+  const scoreboard = scoreboardFor(netName);
+
+  return (
+    <SectionCard
+      title={`Launch ${netName}`}
+      summary={`Step ${step} of ${TOTAL_STEPS}`}
+      defaultExpanded
+    >
+      {step === 1 && (
+        <div>
+          <h2 style={stepHeading}>Confirm SolverNet</h2>
+          <p style={stepBody}>{describeNet(netName)}</p>
+          {scoreboard && <p style={stepBody}>{scoreboard}</p>}
+        </div>
+      )}
+      {step === 2 && (
+        <div>
+          <h2 style={stepHeading}>Generator defaults</h2>
+          <p style={stepBody}>
+            The Launcher generator posts new Tasks at the cadence below. You can adjust these
+            after launch from Launcher Configuration.
+          </p>
+          <ul
+            style={{
+              listStyle: 'none',
+              padding: 0,
+              margin: 0,
+              fontFamily: "'JetBrains Mono', monospace",
+              fontSize: '13px',
+              color: 'var(--fg)',
+              display: 'grid',
+              gap: '6px',
+            }}
+          >
+            <li>cadence: {cadenceMin} min</li>
+            <li>max new rounds / poll: {defaults.maxNewRoundsPerPoll}</li>
+            <li>max new rounds / day: {defaults.maxNewRoundsPerDay}</li>
+            <li>max open rounds: {defaults.maxOpenRounds}</li>
+          </ul>
+        </div>
+      )}
+      {step === 3 && (
+        <div>
+          <h2 style={stepHeading}>Budget plan</h2>
+          <p style={stepBody}>
+            Safe balance {safeEth} ETH funds approximately N Tasks at the current per-attempt
+            payment. Top up the Launcher Safe to extend the runway.
+          </p>
+        </div>
+      )}
+      {step === 4 && (
+        <div>
+          <h2 style={stepHeading}>Confirm</h2>
+          <p style={stepBody}>
+            This will enable launching for {netName}. The generator hot-spawns within one
+            cadence — no daemon restart required.
+          </p>
+          {error && (
+            <p
+              style={{
+                color: 'var(--break-red)',
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: '13px',
+                margin: '8px 0 0',
+              }}
+            >
+              {error}
+            </p>
+          )}
+        </div>
+      )}
+      <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px', marginTop: '8px' }}>
+        {step > 1 && (
+          <button type="button" onClick={back} disabled={saving} style={secondaryButton}>
+            Back
+          </button>
+        )}
+        {step < TOTAL_STEPS && (
+          <button type="button" onClick={next} style={primaryButton}>
+            Next
+          </button>
+        )}
+        {step === TOTAL_STEPS && (
+          <button
+            type="button"
+            onClick={onSave}
+            disabled={saving}
+            style={{ ...primaryButton, cursor: saving ? 'wait' : 'pointer' }}
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+        )}
+      </div>
+    </SectionCard>
+  );
+}

--- a/client/src/dashboard/spa/src/pages/launcher/SetupFlow.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher/SetupFlow.tsx
@@ -54,6 +54,18 @@ function formatEth(wei: string): string {
   }
 }
 
+function describeBudgetRunway(defaults: GeneratorDefaults): string {
+  const dailyCap =
+    Number.isFinite(defaults.maxNewRoundsPerDay) && defaults.maxNewRoundsPerDay > 0
+      ? `${defaults.maxNewRoundsPerDay} Tasks/day`
+      : 'an unknown daily Task cap';
+  const openCap =
+    Number.isFinite(defaults.maxOpenRounds) && defaults.maxOpenRounds > 0
+      ? `${defaults.maxOpenRounds} open Tasks`
+      : 'an unknown open-Task cap';
+  return `Approximate task count is unknown until the current per-attempt payment is reported; these defaults allow up to ${dailyCap} and ${openCap}.`;
+}
+
 const buttonBase = {
   fontFamily: "'JetBrains Mono', monospace",
   fontSize: '14px',
@@ -122,6 +134,7 @@ export function SetupFlow({
   const cadenceMin = Math.round(defaults.cadenceMs / 60_000);
   const safeEth = formatEth(safeBalanceWei);
   const scoreboard = scoreboardFor(netName);
+  const budgetRunway = describeBudgetRunway(defaults);
 
   return (
     <SectionCard
@@ -166,8 +179,8 @@ export function SetupFlow({
         <div>
           <h2 style={stepHeading}>Budget plan</h2>
           <p style={stepBody}>
-            Safe balance {safeEth} ETH funds approximately N Tasks at the current per-attempt
-            payment. Top up the Launcher Safe to extend the runway.
+            Safe balance {safeEth} ETH is available. {budgetRunway} Top up the Launcher Safe to
+            extend the runway.
           </p>
         </div>
       )}

--- a/client/src/dashboard/spa/src/pages/overview/OperatorCard.test.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/OperatorCard.test.tsx
@@ -5,23 +5,41 @@ import { memoryLocation } from 'wouter/memory-location';
 import { OperatorCard } from './OperatorCard.js';
 
 describe('OperatorCard', () => {
-  it('renders operator-side state and a deep-link, no public counters', () => {
+  it('renders operator-side state with a single Solver role and a deep-link', () => {
     const { hook } = memoryLocation({ path: '/overview' });
     render(
       <Router hook={hook}>
         <OperatorCard
           name="prediction"
-          role="solving"
+          roles={['solving']}
           state="live"
           waitingMessage="Waiting for Tasks. SolverNet active, Harness loaded."
         />
       </Router>,
     );
     expect(screen.getByText(/your prediction/i)).toBeTruthy();
-    expect(screen.getByText(/solving/i)).toBeTruthy();
+    expect(screen.getByText(/^solver$/i)).toBeTruthy();
+    expect(screen.queryByText(/^evaluator$/i)).toBeNull();
     expect(screen.getByText(/live/i)).toBeTruthy();
     expect(screen.getByText(/waiting for tasks/i)).toBeTruthy();
     const link = screen.getByText(/configure/i).closest('a');
     expect(link?.getAttribute('href')).toBe('/configuration#solvernets/prediction');
+  });
+
+  it('renders both Solver and Evaluator pills when both roles are active', () => {
+    const { hook } = memoryLocation({ path: '/overview' });
+    render(
+      <Router hook={hook}>
+        <OperatorCard
+          name="prediction"
+          roles={['solving', 'evaluating']}
+          state="live"
+        />
+      </Router>,
+    );
+    expect(screen.getByText(/^solver$/i)).toBeTruthy();
+    expect(screen.getByText(/^evaluator$/i)).toBeTruthy();
+    // Plural label when more than one role is active.
+    expect(screen.getByText(/^roles$/i)).toBeTruthy();
   });
 });

--- a/client/src/dashboard/spa/src/pages/overview/OperatorCard.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/OperatorCard.tsx
@@ -3,17 +3,27 @@ import { Link } from 'wouter';
 /**
  * Operator-side state for one *enabled* SolverNet on Overview. Distinct
  * from NetworkCard: NetworkCard is public counters; OperatorCard is "you"
- * — your role, your live state, and a deep-link into the per-net config.
+ * — your active roles, your live state, and a deep-link into the per-net
+ * config. The card renders one or both of "Solver" / "Evaluator" pills
+ * based on the operator's current configuration.
  */
+export type OperatorCardRole = 'solving' | 'evaluating';
+
 export interface OperatorCardProps {
   name: string;
-  role: 'solving' | 'evaluating';
+  /** Active operator roles. Empty array renders a placeholder rather than
+   *  inventing a role — that situation indicates a misconfigured net. */
+  roles: OperatorCardRole[];
   state: 'live' | 'available' | 'coming_soon';
   /** Operator-facing message describing what the node is waiting for / doing. */
   waitingMessage?: string;
 }
 
-export function OperatorCard({ name, role, state, waitingMessage }: OperatorCardProps): JSX.Element {
+function roleLabel(role: OperatorCardRole): string {
+  return role === 'solving' ? 'Solver' : 'Evaluator';
+}
+
+export function OperatorCard({ name, roles, state, waitingMessage }: OperatorCardProps): JSX.Element {
   const stateColor =
     state === 'live' ? 'var(--vow-green)' : state === 'available' ? 'var(--fg-muted)' : 'var(--fg-dim)';
   return (
@@ -53,8 +63,31 @@ export function OperatorCard({ name, role, state, waitingMessage }: OperatorCard
         </span>
       </div>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '16px' }}>
-        <span style={{ color: 'var(--fg)', fontSize: '14px' }}>
-          Role <span style={{ color: 'var(--fg-muted)' }}>·</span> {role}
+        <span style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--fg)', fontSize: '14px' }}>
+          <span style={{ color: 'var(--fg-muted)' }}>{roles.length > 1 ? 'Roles' : 'Role'}</span>
+          <span style={{ color: 'var(--fg-muted)' }}>·</span>
+          {roles.length === 0 ? (
+            <span style={{ color: 'var(--fg-dim)' }}>none</span>
+          ) : (
+            roles.map((role, idx) => (
+              <span
+                key={role}
+                data-role={role}
+                style={{
+                  fontSize: '11px',
+                  letterSpacing: '0.14em',
+                  textTransform: 'uppercase',
+                  color: 'var(--fg)',
+                  border: '1px solid var(--border)',
+                  borderRadius: '999px',
+                  padding: '2px 10px',
+                  marginLeft: idx === 0 ? 0 : '4px',
+                }}
+              >
+                {roleLabel(role)}
+              </span>
+            ))
+          )}
         </span>
         <Link
           href={`/configuration#solvernets/${name}`}

--- a/client/src/dashboard/spa/src/shell/AgentRail.test.tsx
+++ b/client/src/dashboard/spa/src/shell/AgentRail.test.tsx
@@ -13,7 +13,9 @@ vi.mock('../regions/Agent.js', () => ({
 describe('AgentRail', () => {
   it('renders the Claude eyebrow + Agent placeholder', () => {
     render(<AgentRail agentGated={false} />);
-    expect(screen.getByText(/claude/i)).toBeTruthy();
+    const eyebrow = screen.getByText(/claude/i);
+    expect(eyebrow).toBeTruthy();
+    expect(eyebrow.parentElement?.classList.contains('agent-rail')).toBe(true);
     expect(screen.getByTestId('agent-stub')).toBeTruthy();
   });
 });

--- a/client/src/dashboard/spa/src/shell/AgentRail.tsx
+++ b/client/src/dashboard/spa/src/shell/AgentRail.tsx
@@ -12,7 +12,18 @@ export interface AgentRailProps {
 
 export function AgentRail({ agentGated }: AgentRailProps): JSX.Element {
   return (
-    <div style={{ padding: '24px', display: 'flex', flexDirection: 'column', gap: '12px', height: '100%' }}>
+    <div
+      className="agent-rail"
+      style={{
+        padding: '16px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '12px',
+        height: '100%',
+        minWidth: 0,
+        overflow: 'hidden',
+      }}
+    >
       <span
         style={{
           fontFamily: "'JetBrains Mono', monospace",
@@ -21,6 +32,7 @@ export function AgentRail({ agentGated }: AgentRailProps): JSX.Element {
           letterSpacing: '0.14em',
           textTransform: 'uppercase',
           color: 'var(--fg-muted)',
+          overflowWrap: 'anywhere',
         }}
       >
         Claude

--- a/client/src/dashboard/spa/src/shell/Header.tsx
+++ b/client/src/dashboard/spa/src/shell/Header.tsx
@@ -1,4 +1,7 @@
-import { Link } from 'wouter';
+import { useEffect } from 'react';
+import { Link, useLocation } from 'wouter';
+import { ModeSwitch } from './ModeSwitch.js';
+import { useAppMode, type AppMode } from './useAppMode.js';
 
 export interface HeaderProps {
   network: 'testnet' | 'mainnet';
@@ -11,7 +14,26 @@ function trunc(addr?: string): string {
   return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
 }
 
+function modeForPath(path: string): AppMode {
+  return path.startsWith('/launcher') ? 'launcher' : 'operator';
+}
+
 export function Header({ network, rpcHealthy, masterAddress }: HeaderProps): JSX.Element {
+  const { mode, setMode } = useAppMode();
+  const [location, setLocation] = useLocation();
+
+  // Hydrate mode from URL on mount and on navigation, so deep links and
+  // browser back/forward keep mode and route coherent.
+  useEffect(() => {
+    const next = modeForPath(location);
+    if (next !== mode) setMode(next);
+  }, [location, mode, setMode]);
+
+  const onModeChange = (m: AppMode): void => {
+    setMode(m);
+    setLocation(m === 'operator' ? '/overview' : '/launcher');
+  };
+
   return (
     <header
       style={{
@@ -21,17 +43,20 @@ export function Header({ network, rpcHealthy, masterAddress }: HeaderProps): JSX
         padding: '14px 24px',
       }}
     >
-      <Link href="/overview" style={{ textDecoration: 'none', color: 'var(--fg)' }}>
-        <span
-          style={{
-            fontFamily: "'Instrument Serif', 'Times New Roman', serif",
-            fontSize: '26px',
-            color: 'var(--fg)',
-          }}
-        >
-          jinn operator
-        </span>
-      </Link>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '20px' }}>
+        <Link href="/overview" style={{ textDecoration: 'none', color: 'var(--fg)' }}>
+          <span
+            style={{
+              fontFamily: "'Instrument Serif', 'Times New Roman', serif",
+              fontSize: '26px',
+              color: 'var(--fg)',
+            }}
+          >
+            jinn operator
+          </span>
+        </Link>
+        <ModeSwitch mode={mode} onChange={onModeChange} />
+      </div>
       <div
         style={{
           display: 'flex',

--- a/client/src/dashboard/spa/src/shell/ModeSwitch.test.tsx
+++ b/client/src/dashboard/spa/src/shell/ModeSwitch.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ModeSwitch } from './ModeSwitch.js';
+
+describe('ModeSwitch', () => {
+  it('renders both modes; current is highlighted', () => {
+    render(<ModeSwitch mode="operator" onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Operator' }).getAttribute('data-active')).toBe('true');
+    expect(screen.getByRole('button', { name: 'Launcher' }).getAttribute('data-active')).toBe('false');
+  });
+
+  it('fires onChange on click of inactive mode', () => {
+    const onChange = vi.fn();
+    render(<ModeSwitch mode="operator" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Launcher' }));
+    expect(onChange).toHaveBeenCalledWith('launcher');
+  });
+
+  it('does not fire onChange when clicking the already-active mode', () => {
+    const onChange = vi.fn();
+    render(<ModeSwitch mode="operator" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Operator' }));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('exposes a labelled group for screen readers', () => {
+    render(<ModeSwitch mode="operator" onChange={() => {}} />);
+    expect(screen.getByRole('group', { name: 'App mode' })).toBeTruthy();
+  });
+});

--- a/client/src/dashboard/spa/src/shell/ModeSwitch.tsx
+++ b/client/src/dashboard/spa/src/shell/ModeSwitch.tsx
@@ -1,0 +1,51 @@
+import type { AppMode } from './useAppMode.js';
+
+interface ModeSwitchProps {
+  mode: AppMode;
+  onChange: (m: AppMode) => void;
+}
+
+const MODES: AppMode[] = ['operator', 'launcher'];
+
+export function ModeSwitch({ mode, onChange }: ModeSwitchProps): JSX.Element {
+  return (
+    <div
+      role="group"
+      aria-label="App mode"
+      style={{
+        display: 'inline-flex',
+        border: '1px solid var(--border)',
+        borderRadius: '6px',
+        overflow: 'hidden',
+      }}
+    >
+      {MODES.map((m, idx) => {
+        const active = mode === m;
+        return (
+          <button
+            key={m}
+            type="button"
+            onClick={() => {
+              if (m !== mode) onChange(m);
+            }}
+            data-active={active ? 'true' : 'false'}
+            style={{
+              padding: '8px 16px',
+              fontFamily: "'JetBrains Mono', ui-monospace, SF Mono, Menlo, monospace",
+              fontSize: '12px',
+              textTransform: 'uppercase',
+              letterSpacing: '0.14em',
+              color: active ? 'var(--fg)' : 'var(--fg-muted)',
+              background: active ? 'var(--bg)' : 'transparent',
+              border: 'none',
+              borderRight: idx < MODES.length - 1 ? '1px solid var(--border)' : 'none',
+              cursor: active ? 'default' : 'pointer',
+            }}
+          >
+            {m.charAt(0).toUpperCase() + m.slice(1)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/client/src/dashboard/spa/src/shell/useAppMode.test.ts
+++ b/client/src/dashboard/spa/src/shell/useAppMode.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAppMode } from './useAppMode.js';
+
+describe('useAppMode', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('defaults to "operator"', () => {
+    const { result } = renderHook(() => useAppMode());
+    expect(result.current.mode).toBe('operator');
+  });
+
+  it('persists mode to localStorage on change', () => {
+    const { result } = renderHook(() => useAppMode());
+    act(() => result.current.setMode('launcher'));
+    expect(result.current.mode).toBe('launcher');
+    expect(localStorage.getItem('jinn.app.mode')).toBe('launcher');
+  });
+
+  it('hydrates from localStorage on mount', () => {
+    localStorage.setItem('jinn.app.mode', 'launcher');
+    const { result } = renderHook(() => useAppMode());
+    expect(result.current.mode).toBe('launcher');
+  });
+
+  it('ignores unknown values in localStorage and falls back to operator', () => {
+    localStorage.setItem('jinn.app.mode', 'invalid-value');
+    const { result } = renderHook(() => useAppMode());
+    expect(result.current.mode).toBe('operator');
+  });
+});

--- a/client/src/dashboard/spa/src/shell/useAppMode.ts
+++ b/client/src/dashboard/spa/src/shell/useAppMode.ts
@@ -1,0 +1,27 @@
+import { useState, useCallback } from 'react';
+
+export type AppMode = 'operator' | 'launcher';
+
+const STORAGE_KEY = 'jinn.app.mode';
+
+export interface UseAppMode {
+  mode: AppMode;
+  setMode: (m: AppMode) => void;
+}
+
+function readStored(): AppMode {
+  if (typeof window === 'undefined') return 'operator';
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  return raw === 'launcher' ? 'launcher' : 'operator';
+}
+
+export function useAppMode(): UseAppMode {
+  const [mode, setModeState] = useState<AppMode>(readStored);
+  const setMode = useCallback((m: AppMode) => {
+    setModeState(m);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, m);
+    }
+  }, []);
+  return { mode, setMode };
+}

--- a/client/src/dashboard/spa/src/styles/globals.css
+++ b/client/src/dashboard/spa/src/styles/globals.css
@@ -94,3 +94,16 @@ textarea:focus-visible {
 .xterm-screen {
   width: 100% !important;
 }
+
+.agent-rail .xterm {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.agent-rail .xterm-viewport {
+  overflow-x: hidden;
+}
+
+.agent-rail .xterm-accessibility-tree {
+  display: none;
+}

--- a/client/src/harnesses/impls/claude-code-learner/harness.ts
+++ b/client/src/harnesses/impls/claude-code-learner/harness.ts
@@ -33,7 +33,15 @@ export class ClaudeCodeLearnerImpl implements Harness {
   }
 
   supports(spec: { solverType: string; role?: 'restoration' | 'evaluation' }): boolean {
-    return spec.role !== 'evaluation';
+    if (spec.role === 'evaluation') return false;
+    // These SolverTypes have first-party restoration Harnesses that return
+    // typed solutionPayload objects. The learner emits phase artifacts for its
+    // own pipeline; letting it claim these specialist tasks can run Claude but
+    // fail packaging when the phase artifacts are absent.
+    if (spec.solverType === 'prediction.v1' || spec.solverType === 'prediction.apy.v0') {
+      return false;
+    }
+    return true;
   }
 
   async run(ctx: HarnessContext): Promise<Solution> {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -682,6 +682,15 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
   const handshakeKey = cryptoRandomBytes(16).toString('hex');
   const apiBindHost = process.env['JINN_API_BIND_HOST'] ?? '127.0.0.1';
   let corpusForApi: ReturnType<typeof createCorpus> | undefined;
+  // Launcher mode wiring (Task 6 of spec/2026-05-05-launcher-role-and-mode.md).
+  // The API server is constructed before bootstrap finishes, so the operator's
+  // Safe address and the prediction.v1 generator are not yet known at start-up.
+  // We capture both into closures here and let `addLauncherRoutes` read them
+  // lazily — by the time `/v1/launcher/status` is hit, both are populated.
+  let predictionGeneratorRef:
+    | { getState(): import('./solver-types/prediction-v1-auto.js').PredictionV1GeneratorStateSnapshot }
+    | undefined;
+  let safeAddressForLauncher: `0x${string}` | undefined;
 
   let setupApiServer: ApiServer;
   try {
@@ -808,6 +817,26 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
         engine: config.engine,
         config,
         configPath: CONFIG_PATH ?? DEFAULT_CONFIG_PATH,
+      },
+      // Launcher mode (Task 6). Deps are resolved lazily because the
+      // generator and Safe address are constructed after bootstrap, after
+      // this `startApiServer` call. By the time the SPA hits the route,
+      // bootstrap has completed and both refs are populated.
+      //
+      // TODO(jinn-mono launcher Task 7): replace the open-task-count and
+      // reserved-budget stubs with real accessors once the
+      // `/v1/launcher/tasks` query lands.
+      launcher: {
+        getConfig: () => ({ solverNets: config.solverNets }),
+        getGeneratorState: (netName) => {
+          if (netName !== 'prediction') return undefined;
+          return predictionGeneratorRef?.getState();
+        },
+        getOpenTaskCount: () => 0,
+        getReservedBudgetWei: () => '0',
+        getSafeBalanceWei: () => '0',
+        safeAddress: () =>
+          safeAddressForLauncher ?? '0x0000000000000000000000000000000000000000',
       },
     });
   } catch (error) {
@@ -982,6 +1011,10 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     agentId,
     identityRegistryAddress,
   } = bootstrapResult;
+  // Now that bootstrap has resolved a Safe, expose it to the Launcher
+  // mode endpoint so `/v1/launcher/status.budget.safeAddress` is accurate
+  // on the very first SPA poll. (Task 6 of the launcher plan.)
+  safeAddressForLauncher = safeAddress;
 
   if (!mechAddress) {
     emitEnvelope({
@@ -1361,6 +1394,18 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
   });
   for (const line of autoTaskLogLines) {
     console.log(line);
+  }
+  // Stash the prediction.v1 generator's state accessor for the Launcher mode
+  // status endpoint (Task 6 of spec/2026-05-05-launcher-role-and-mode.md).
+  // `makePredictionV1Generator` returns a callable whose extra `getState()`
+  // method survives the `TaskGenerator` widening; we do a runtime check before
+  // taking the reference so non-generator entries stay decoupled.
+  for (const entry of autoTaskGenerators) {
+    if (entry.solverType !== 'prediction.v1') continue;
+    const gen = entry.generator as unknown;
+    if (typeof gen === 'function' && typeof (gen as { getState?: unknown }).getState === 'function') {
+      predictionGeneratorRef = gen as unknown as typeof predictionGeneratorRef;
+    }
   }
   if (config.network === 'mainnet' && !autoTasksDisabled && BASE_FEEDS['ETH / USD']) {
     // Mainnet auto-task opt-in only; default is OFF. Reserved for a future flag.

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -28,6 +28,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { loadConfig, getConfigPathFromArgs, DEFAULT_CONFIG_PATH } from './config.js';
 import { Store } from './store/store.js';
 import { startApiServer, type ApiServer } from './api/server.js';
+import { invalidatePredictionOperatorStatusCache } from './api/gather-status.js';
 import { ensureUiToken } from './api/ui-token.js';
 import { attachAgentWs, updateAgentClaudePath } from './agent/agent-ws.js';
 import { createSetupModeController } from './setup-mode.js';
@@ -785,6 +786,12 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
         onClaudePathSelected: selectClaudePath,
         onSolverNetsUpdated: (solverNets) => {
           config.solverNets = solverNets as typeof config.solverNets;
+          // The prediction operator status is memoised per-`JinnConfig`
+          // reference; mutating in place leaves the cache pointing at the
+          // pre-edit snapshot. Drop the entry so the next /v1/status read
+          // (and thus Overview's `solverNet.enabled` gating) reflects the
+          // toggle immediately. (jinn-mono-l2zl.15.4.12)
+          invalidatePredictionOperatorStatusCache(config);
         },
       },
       status: {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1342,7 +1342,11 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     agentEoa: agentEoaAddress,
     safeAddress,
     agentPrivateKey,
-    predictionV1LauncherEnabled: config.predictionV1LauncherEnabled,
+    // Task 4 (spec/2026-05-05-launcher-role-and-mode.md) replaces this with a
+    // role-array gate (`solverNets[*].roles` includes `'launching'`). Until
+    // then, hard-disable the launcher loop here so the schema removal of
+    // `predictionV1LauncherEnabled` does not break this read.
+    predictionV1LauncherEnabled: false,
     predictionV1WindowMs: config.predictionV1WindowMs,
     predictionV1CadenceMs: config.predictionV1CadenceMs,
     predictionV1MaxNewRoundsPerPoll: config.predictionV1MaxNewRoundsPerPoll,

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -839,6 +839,16 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
       // `getSafeBalanceWei` (live `eth_getBalance` against the creator Safe).
       launcher: {
         getConfig: () => ({ solverNets: config.solverNets }),
+        configPath: CONFIG_PATH ?? DEFAULT_CONFIG_PATH,
+        // Hot-apply for the PATCH endpoint (Task 8): mirror the operator-mode
+        // setup hook so subsequent /v1/launcher/status reads see the post-edit
+        // roles snapshot without a daemon restart. Mutates `config.solverNets`
+        // in place so the per-tick `roles.includes('launching')` gate flips on
+        // the very next launcher tick.
+        onSolverNetsUpdated: (solverNets) => {
+          config.solverNets = solverNets as typeof config.solverNets;
+          invalidatePredictionOperatorStatusCache(config);
+        },
         getGeneratorState: (netName) => {
           if (netName !== 'prediction') return undefined;
           return predictionGeneratorRef?.getState();

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -818,25 +818,71 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
         config,
         configPath: CONFIG_PATH ?? DEFAULT_CONFIG_PATH,
       },
-      // Launcher mode (Task 6). Deps are resolved lazily because the
+      // Launcher mode (Tasks 6 + 7). Deps are resolved lazily because the
       // generator and Safe address are constructed after bootstrap, after
       // this `startApiServer` call. By the time the SPA hits the route,
       // bootstrap has completed and both refs are populated.
       //
-      // TODO(jinn-mono launcher Task 7): replace the open-task-count and
-      // reserved-budget stubs with real accessors once the
-      // `/v1/launcher/tasks` query lands.
+      // Open-task-count is now real: it counts posted Tasks recorded against
+      // the creator Safe with the SolverNet's solver_type. The result is a
+      // strict superset of the in-flight count (we don't yet drop settled or
+      // failed Tasks; that lifecycle tracking lands with the router-watcher
+      // hardening lane, jinn-mono-l2zl.12). Reserved-budget and Safe-balance
+      // remain stubbed and are tracked for Task 8+.
+      //
+      // TODO(jinn-mono-l2zl.12): once Task lifecycle events are persisted,
+      // narrow `getOpenTaskCount` to states in
+      // ('open', 'claims-in-flight', 'fully-claimed') so the operator's
+      // "open Tasks" stat doesn't drift upward across the daemon's lifetime.
+      // TODO(jinn-mono launcher Task 8): real `getReservedBudgetWei`
+      // (sum of unconsumed claim payments across open Tasks) and
+      // `getSafeBalanceWei` (live `eth_getBalance` against the creator Safe).
       launcher: {
         getConfig: () => ({ solverNets: config.solverNets }),
         getGeneratorState: (netName) => {
           if (netName !== 'prediction') return undefined;
           return predictionGeneratorRef?.getState();
         },
-        getOpenTaskCount: () => 0,
+        getOpenTaskCount: (netName) => {
+          const net = config.solverNets?.[netName];
+          const solverType = net?.solverType;
+          if (!solverType || !safeAddressForLauncher) return 0;
+          return sharedStore.countPostedTasksByCreatorAndSolverType({
+            creatorSafeAddress: safeAddressForLauncher,
+            solverType,
+          });
+        },
         getReservedBudgetWei: () => '0',
         getSafeBalanceWei: () => '0',
         safeAddress: () =>
           safeAddressForLauncher ?? '0x0000000000000000000000000000000000000000',
+        tasksDeps: {
+          // Resolved per-request for the same reason `safeAddress` is a
+          // closure — `safeAddressForLauncher` is undefined until bootstrap
+          // finishes. Before that, the response is an empty list, which is
+          // accurate (no posts can have happened pre-bootstrap).
+          get creatorAddress() {
+            return safeAddressForLauncher ?? '0x0000000000000000000000000000000000000000';
+          },
+          fetchPostedTasks: ({ creatorAddress, limit, before }) => {
+            // No-op when bootstrap hasn't resolved a Safe yet.
+            if (creatorAddress === '0x0000000000000000000000000000000000000000') {
+              return [];
+            }
+            const opts: { creatorSafeAddress: string; limit: number; before?: string } = {
+              creatorSafeAddress: creatorAddress,
+              limit,
+            };
+            if (before) opts.before = before;
+            const rows = sharedStore.listPostedTasksByCreator(opts);
+            return rows.map((r) => ({
+              taskId: r.taskId,
+              taskCid: r.taskCid,
+              solverType: r.solverType ?? undefined,
+              postedAt: r.postedAt,
+            }));
+          },
+        },
       },
     });
   } catch (error) {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -73,6 +73,7 @@ import { loadSolverNets } from './solver-nets/registry.js';
 import { createCorpus } from './corpus/index.js';
 import { BASE_FEEDS } from './venues/chainlink/feeds.js';
 import { GeneratedTaskSource, StaticConfiguredTaskSource } from './tasks/sources.js';
+import { generatedTaskSourceSupported } from './tasks/generated-source-gate.js';
 import { checkRpcNetwork, logRpcLocalDevToStderr, rpcNetworkFailureHint } from './preflight/rpc-network.js';
 import { apiPortFailureMessage, checkApiPortAvailable } from './preflight/api-port.js';
 import { openBrowser } from './cli/open-browser.js';
@@ -849,6 +850,11 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
           config.solverNets = solverNets as typeof config.solverNets;
           invalidatePredictionOperatorStatusCache(config);
         },
+        onConfigValuesUpdated: (values) => {
+          for (const [key, value] of Object.entries(values)) {
+            (config as unknown as Record<string, unknown>)[key] = value;
+          }
+        },
         getGeneratorState: (netName) => {
           if (netName !== 'prediction') return undefined;
           return predictionGeneratorRef?.getState();
@@ -1439,6 +1445,16 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     // launcher mode in/out via the operator UX takes effect within one
     // generator cadence — no daemon restart required.
     getPredictionRoles: () => config.solverNets?.prediction?.roles ?? [],
+    getPredictionV1Config: () => ({
+      submissionWindowMs: config.predictionV1WindowMs,
+      cadenceMs: config.predictionV1CadenceMs,
+      maxNewRoundsPerPoll: config.predictionV1MaxNewRoundsPerPoll,
+      maxNewRoundsPerDay: config.predictionV1MaxNewRoundsPerDay,
+      maxOpenRounds: config.predictionV1MaxOpenRounds,
+      allowlistConditionIds: config.predictionV1AllowlistConditionIds,
+      blocklistConditionIds: config.predictionV1BlocklistConditionIds,
+      resolveGapMs: config.predictionV1ResolveGapMs,
+    }),
     predictionV1WindowMs: config.predictionV1WindowMs,
     predictionV1CadenceMs: config.predictionV1CadenceMs,
     predictionV1MaxNewRoundsPerPoll: config.predictionV1MaxNewRoundsPerPoll,
@@ -1469,9 +1485,7 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
   const taskSources = [
     new StaticConfiguredTaskSource(config.tasks),
     ...autoTaskGenerators
-      .filter(({ solverType }) =>
-        solverNetRegistry.forSolverType(solverType, 'restoration')?.taskGenerator.enabled,
-      )
+      .filter(({ solverType }) => generatedTaskSourceSupported(config.solverNets, solverType))
       .map(({ solverType, generator }) => new GeneratedTaskSource(`generated:${solverType}`, generator)),
   ];
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1342,11 +1342,14 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     agentEoa: agentEoaAddress,
     safeAddress,
     agentPrivateKey,
-    // Task 4 (spec/2026-05-05-launcher-role-and-mode.md) replaces this with a
-    // role-array gate (`solverNets[*].roles` includes `'launching'`). Until
-    // then, hard-disable the launcher loop here so the schema removal of
-    // `predictionV1LauncherEnabled` does not break this read.
-    predictionV1LauncherEnabled: false,
+    // spec/2026-05-05-launcher-role-and-mode.md §5.2 — hot-spawn: the
+    // Polymarket prediction.v1 generator is always created on testnet, but
+    // each tick early-returns unless `solverNets.prediction.roles` includes
+    // `'launching'`. The closure below reads the live `config` reference (in
+    // the same JS object that `onSolverNetsUpdated` mutates), so toggling
+    // launcher mode in/out via the operator UX takes effect within one
+    // generator cadence — no daemon restart required.
+    getPredictionRoles: () => config.solverNets?.prediction?.roles ?? [],
     predictionV1WindowMs: config.predictionV1WindowMs,
     predictionV1CadenceMs: config.predictionV1CadenceMs,
     predictionV1MaxNewRoundsPerPoll: config.predictionV1MaxNewRoundsPerPoll,

--- a/client/src/solver-nets/prediction-operator-ux.ts
+++ b/client/src/solver-nets/prediction-operator-ux.ts
@@ -20,6 +20,7 @@ import {
   loadSolverNets as defaultLoadSolverNets,
   type LoadedSolverNet,
   type SolverNetConfig,
+  type SolverNetOperatorRole,
 } from './registry.js';
 
 export type PredictionOperatorDiagnosticSeverity = 'error' | 'warning' | 'info';
@@ -44,6 +45,13 @@ export interface PredictionOperatorStatus {
     name: string;
     enabled: boolean;
     solverType: string;
+    /**
+     * Active operator roles for this SolverNet. Reflects the operator's
+     * current configuration, not the catalog of supported roles. Both
+     * `'solving'` and `'evaluating'` may be present concurrently — the
+     * Overview surface renders them additively.
+     */
+    roles: SolverNetOperatorRole[];
     harness?: string;
     taskGeneratorEnabled: boolean;
   };
@@ -198,6 +206,7 @@ function missingSolverNetStatus(
       name,
       enabled: false,
       solverType: 'prediction.v1',
+      roles: [],
       taskGeneratorEnabled: false,
     },
     runtimePlugins: [],
@@ -394,6 +403,23 @@ export async function buildPredictionOperatorStatus({
     });
   }
 
+  // Resolve roles from the (potentially partial) net config. The zod
+  // preprocessor already migrated legacy `role` → `roles` at config-load
+  // time; this fallback handles handcrafted configs that bypass the loader
+  // or set `roles: []` (treated as a config error elsewhere — surface it
+  // explicitly on the operator-status payload).
+  const resolvedRoles: SolverNetOperatorRole[] = (() => {
+    const candidate = (net as { roles?: unknown }).roles;
+    if (Array.isArray(candidate) && candidate.length > 0) {
+      return Array.from(new Set(candidate.filter(
+        (r): r is SolverNetOperatorRole => r === 'solving' || r === 'evaluating',
+      )));
+    }
+    const legacy = (net as { role?: unknown }).role;
+    if (legacy === 'solving' || legacy === 'evaluating') return [legacy];
+    return ['solving'];
+  })();
+
   const status: PredictionOperatorStatus = {
     kind: 'prediction.v1.operatorStatus',
     ok: diagnostics.every((diagnostic) => diagnostic.severity !== 'error'),
@@ -402,6 +428,7 @@ export async function buildPredictionOperatorStatus({
       name,
       enabled: net.enabled,
       solverType: net.solverType,
+      roles: resolvedRoles,
       harness: net.harness,
       taskGeneratorEnabled: net.taskGenerator.enabled,
     },

--- a/client/src/solver-nets/prediction-operator-ux.ts
+++ b/client/src/solver-nets/prediction-operator-ux.ts
@@ -412,7 +412,8 @@ export async function buildPredictionOperatorStatus({
     const candidate = (net as { roles?: unknown }).roles;
     if (Array.isArray(candidate) && candidate.length > 0) {
       return Array.from(new Set(candidate.filter(
-        (r): r is SolverNetOperatorRole => r === 'solving' || r === 'evaluating',
+        (r): r is SolverNetOperatorRole =>
+          r === 'solving' || r === 'evaluating' || r === 'launching',
       )));
     }
     const legacy = (net as { role?: unknown }).role;

--- a/client/src/solver-nets/registry.ts
+++ b/client/src/solver-nets/registry.ts
@@ -5,7 +5,7 @@ import { getSolverNetContract, type SolverNetContract } from './contracts.js';
 
 export const JINN_NETWORK_TOOLS_PLUGIN = 'bundled:network-tools' as const;
 
-export type SolverNetOperatorRole = 'solving' | 'evaluating';
+export type SolverNetOperatorRole = 'solving' | 'evaluating' | 'launching';
 export type SolverNetTaskRole = 'restoration' | 'evaluation';
 
 export interface SolverNetConfig {
@@ -37,8 +37,14 @@ export interface LoadedSolverNet {
   taskGenerator: { enabled: boolean };
 }
 
-function taskRoleForOperatorRole(role: SolverNetOperatorRole): SolverNetTaskRole {
-  return role === 'evaluating' ? 'evaluation' : 'restoration';
+function taskRoleForOperatorRole(role: SolverNetOperatorRole): SolverNetTaskRole | undefined {
+  if (role === 'solving') return 'restoration';
+  if (role === 'evaluating') return 'evaluation';
+  // 'launching' is an operator-side launcher loop, not a Task-claiming role —
+  // it does not map to a SolverNetTaskRole. Task 4 of the launcher plan wires
+  // up the runtime gate that consumes this role; until then, it just falls
+  // out of `forSolverType` task-role filtering.
+  return undefined;
 }
 
 /**
@@ -98,7 +104,10 @@ export class SolverNetRegistry {
       net.enabled &&
       net.solverType === solverType &&
       (taskRole === undefined ||
-        net.roles.some((r) => taskRoleForOperatorRole(r) === taskRole)),
+        net.roles.some((r) => {
+          const tr = taskRoleForOperatorRole(r);
+          return tr !== undefined && tr === taskRole;
+        })),
     );
   }
 

--- a/client/src/solver-nets/registry.ts
+++ b/client/src/solver-nets/registry.ts
@@ -11,7 +11,13 @@ export type SolverNetTaskRole = 'restoration' | 'evaluation';
 export interface SolverNetConfig {
   enabled: boolean;
   solverType: string;
-  role?: SolverNetOperatorRole;
+  /**
+   * Non-empty subset of operator roles this SolverNet runs concurrently.
+   * Optional only because legacy callers (pre-migration helpers) may omit it;
+   * the config loader normalises absence to `['solving']` and migrates any
+   * legacy singular `role` to `[role]`.
+   */
+  roles?: SolverNetOperatorRole[];
   harness: string;
   model?: string;
   plugins: SolverPluginEntry[];
@@ -22,7 +28,8 @@ export interface LoadedSolverNet {
   name: string;
   enabled: boolean;
   solverType: string;
-  role: SolverNetOperatorRole;
+  /** Active operator roles (non-empty after load). */
+  roles: SolverNetOperatorRole[];
   contract: SolverNetContract;
   harness: string;
   model?: string;
@@ -32,6 +39,17 @@ export interface LoadedSolverNet {
 
 function taskRoleForOperatorRole(role: SolverNetOperatorRole): SolverNetTaskRole {
   return role === 'evaluating' ? 'evaluation' : 'restoration';
+}
+
+/**
+ * Resolve a non-empty roles array from a config entry. Falls back to
+ * `['solving']` for shapes that omit `roles` entirely (e.g. a stub used by
+ * unit tests or a legacy migration helper that hasn't run through the zod
+ * preprocessor). Deduplicates to keep set semantics simple.
+ */
+function rolesFromConfig(net: SolverNetConfig): SolverNetOperatorRole[] {
+  if (net.roles && net.roles.length > 0) return Array.from(new Set(net.roles));
+  return ['solving'];
 }
 
 function runtimePluginFrom(
@@ -79,7 +97,8 @@ export class SolverNetRegistry {
     return [...this.nets.values()].find((net) =>
       net.enabled &&
       net.solverType === solverType &&
-      (taskRole === undefined || taskRoleForOperatorRole(net.role) === taskRole),
+      (taskRole === undefined ||
+        net.roles.some((r) => taskRoleForOperatorRole(r) === taskRole)),
     );
   }
 
@@ -144,7 +163,7 @@ export async function loadSolverNets(
       name,
       enabled: net.enabled,
       solverType: net.solverType,
-      role: net.role ?? 'solving',
+      roles: rolesFromConfig(net),
       contract,
       harness: net.harness,
       ...(net.model ? { model: net.model } : {}),

--- a/client/src/solver-nets/registry.ts
+++ b/client/src/solver-nets/registry.ts
@@ -37,7 +37,7 @@ export interface LoadedSolverNet {
   taskGenerator: { enabled: boolean };
 }
 
-function taskRoleForOperatorRole(role: SolverNetOperatorRole): SolverNetTaskRole | undefined {
+export function taskRoleForOperatorRole(role: SolverNetOperatorRole): SolverNetTaskRole | undefined {
   if (role === 'solving') return 'restoration';
   if (role === 'evaluating') return 'evaluation';
   // 'launching' is an operator-side launcher loop, not a Task-claiming role —

--- a/client/src/solver-types/index.ts
+++ b/client/src/solver-types/index.ts
@@ -45,8 +45,12 @@ export function collectTestnetAutoTaskGenerators(opts: {
   safeAddress?: `0x${string}`;
   /** Agent EOA private key — passed to generator configs that sign tasks. */
   agentPrivateKey?: `0x${string}`;
-  /** Explicit launcher opt-in for Polymarket prediction.v1 Task generation. */
-  predictionV1LauncherEnabled?: boolean;
+  /**
+   * Live role-getter for the prediction SolverNet — passed through to the
+   * generator so it can early-return when `'launching'` is not in roles.
+   * See spec/2026-05-05-launcher-role-and-mode.md §5.2 (hot-spawn).
+   */
+  getPredictionRoles?: () => Array<'solving' | 'evaluating' | 'launching'>;
   /** Override prediction.v1 submission window (ms). */
   predictionV1WindowMs?: number;
   /** Override prediction.v1 Polymarket generator cadence (ms). */
@@ -73,7 +77,7 @@ export function collectTestnetAutoTaskGenerators(opts: {
     agentEoa: opts.agentEoa,
     safeAddress: opts.safeAddress,
     agentPrivateKey: opts.agentPrivateKey,
-    predictionV1LauncherEnabled: opts.predictionV1LauncherEnabled,
+    getPredictionRoles: opts.getPredictionRoles,
     predictionV1WindowMs: opts.predictionV1WindowMs,
     predictionV1CadenceMs: opts.predictionV1CadenceMs,
     predictionV1MaxNewRoundsPerPoll: opts.predictionV1MaxNewRoundsPerPoll,

--- a/client/src/solver-types/index.ts
+++ b/client/src/solver-types/index.ts
@@ -8,6 +8,7 @@ import { predictionV1 } from './prediction-v1.js';
 import { predictionApyV0 } from './prediction-apy-v0.js';
 import { learnerLoopTest } from './learner-loop-test.js';
 import type { SolverTypeDefinition, TestnetAutoContext } from './solver-type.js';
+import type { PredictionV1LiveConfig } from './prediction-v1-auto.js';
 
 export type { ParsedSpecOverlay, ParseDeps, SolverTypeDefinition, TestnetAutoContext } from './solver-type.js';
 export { PREDICTION_V1_KIND } from './constants.js';
@@ -51,6 +52,8 @@ export function collectTestnetAutoTaskGenerators(opts: {
    * See spec/2026-05-05-launcher-role-and-mode.md §5.2 (hot-spawn).
    */
   getPredictionRoles?: () => Array<'solving' | 'evaluating' | 'launching'>;
+  /** Live prediction.v1 launcher config getter for hot-apply PATCH edits. */
+  getPredictionV1Config?: () => PredictionV1LiveConfig;
   /** Override prediction.v1 submission window (ms). */
   predictionV1WindowMs?: number;
   /** Override prediction.v1 Polymarket generator cadence (ms). */
@@ -78,6 +81,7 @@ export function collectTestnetAutoTaskGenerators(opts: {
     safeAddress: opts.safeAddress,
     agentPrivateKey: opts.agentPrivateKey,
     getPredictionRoles: opts.getPredictionRoles,
+    getPredictionV1Config: opts.getPredictionV1Config,
     predictionV1WindowMs: opts.predictionV1WindowMs,
     predictionV1CadenceMs: opts.predictionV1CadenceMs,
     predictionV1MaxNewRoundsPerPoll: opts.predictionV1MaxNewRoundsPerPoll,
@@ -94,7 +98,24 @@ export function collectTestnetAutoTaskGenerators(opts: {
     const g = entry.buildGenerator?.(genConfig as never);
     if (g) {
       generators.push({ solverType: entry.solverType, generator: g });
-      logLines.push(`[main] auto-task generator enabled: ${entry.solverType} (testnet)`);
+      if (entry.solverType === 'prediction.v1') {
+        const roles = opts.getPredictionRoles?.();
+        if (!roles) {
+          logLines.push(
+            `[main] auto-task generator registered: ${entry.solverType} (testnet; ungated direct config)`,
+          );
+        } else if (roles.includes('launching')) {
+          logLines.push(
+            `[main] auto-task generator active: ${entry.solverType} (testnet; launching role present)`,
+          );
+        } else {
+          logLines.push(
+            `[main] auto-task generator registered: ${entry.solverType} (testnet; inactive until launching role present)`,
+          );
+        }
+      } else {
+        logLines.push(`[main] auto-task generator active: ${entry.solverType} (testnet)`);
+      }
     }
   }
   return { generators, logLines };

--- a/client/src/solver-types/prediction-v1-auto.ts
+++ b/client/src/solver-types/prediction-v1-auto.ts
@@ -15,7 +15,7 @@ import {
   type PolymarketClientConfig,
 } from '../venues/polymarket/client.js';
 
-export interface PredictionV1AutoConfig extends PolymarketClientConfig {
+export interface PredictionV1LiveConfig {
   minTimeToResolutionHours?: number;
   maxTimeToResolutionHours?: number;
   minLiquidityUsd?: string;
@@ -32,6 +32,10 @@ export interface PredictionV1AutoConfig extends PolymarketClientConfig {
   agentPrivateKey?: `0x${string}`;
   allowlistConditionIds?: string[];
   blocklistConditionIds?: string[];
+  resolveGapMs?: number;
+}
+
+export interface PredictionV1AutoConfig extends PolymarketClientConfig, PredictionV1LiveConfig {
   /**
    * Hot-spawn role gate (spec/2026-05-05-launcher-role-and-mode.md §5.2).
    * The daemon always creates this generator; if `getRoles` is provided and
@@ -42,6 +46,13 @@ export interface PredictionV1AutoConfig extends PolymarketClientConfig {
    * the generator polls unconditionally, preserving the prior public API.
    */
   getRoles?: () => Array<'solving' | 'evaluating' | 'launching'>;
+  /**
+   * Live launcher config getter. Values returned here override construction
+   * values on each tick, so Launcher PATCH edits hot-apply without recreating
+   * the generator. Undefined values are ignored, preserving env/constructor
+   * defaults until a real value is configured.
+   */
+  getConfig?: () => PredictionV1LiveConfig;
 }
 
 interface EligibleMarket {
@@ -92,8 +103,6 @@ const DEFAULTS = {
 export function makePredictionV1Generator(config: PredictionV1AutoConfig = {}): PredictionV1GeneratorTick {
   const postedAtByCondition = new Map<string, number>();
   const postedCountByDay = new Map<string, number>();
-  const allowlist = conditionIdSet(config.allowlistConditionIds);
-  const blocklist = conditionIdSet(config.blocklistConditionIds);
   let lastPollStartedAt = 0;
   // Mutable state, observable via getState(). The role-gate early-return
   // intentionally does not touch this — a closed gate is "no poll happened",
@@ -101,17 +110,18 @@ export function makePredictionV1Generator(config: PredictionV1AutoConfig = {}): 
   const state: PredictionV1GeneratorState = {};
 
   const tick = async (): Promise<Task[] | null> => {
+    const current = currentConfig(config);
     // Hot-spawn role gate (spec/2026-05-05-launcher-role-and-mode.md §5.2).
     // Always-spawn loop, tick-time gate: if `getRoles` is supplied and the
     // operator's `solverNets.prediction.roles` does not include 'launching',
     // skip the poll entirely. Cadence bookkeeping is intentionally NOT
     // updated here — leaving `lastPollStartedAt` untouched means the very
     // first tick after the operator flips 'launching' on will run.
-    if (config.getRoles && !config.getRoles().includes('launching')) {
+    if (current.getRoles && !current.getRoles().includes('launching')) {
       return null;
     }
     const now = Date.now();
-    const cadenceMs = config.cadenceMs ?? DEFAULTS.cadenceMs;
+    const cadenceMs = current.cadenceMs ?? DEFAULTS.cadenceMs;
     if (cadenceMs > 0 && lastPollStartedAt > 0 && now - lastPollStartedAt < cadenceMs) {
       return null;
     }
@@ -122,9 +132,9 @@ export function makePredictionV1Generator(config: PredictionV1AutoConfig = {}): 
     pruneOpenRounds(postedAtByCondition, now);
     const dayKey = new Date(now).toISOString().slice(0, 10);
     const todayCount = postedCountByDay.get(dayKey) ?? 0;
-    const dailyRemaining = Math.max(0, (config.maxNewRoundsPerDay ?? DEFAULTS.maxNewRoundsPerDay) - todayCount);
-    const openRemaining = Math.max(0, (config.maxOpenRounds ?? DEFAULTS.maxOpenRounds) - postedAtByCondition.size);
-    const pollLimit = Math.min(config.maxNewRoundsPerPoll ?? DEFAULTS.maxNewRoundsPerPoll, dailyRemaining, openRemaining);
+    const dailyRemaining = Math.max(0, (current.maxNewRoundsPerDay ?? DEFAULTS.maxNewRoundsPerDay) - todayCount);
+    const openRemaining = Math.max(0, (current.maxOpenRounds ?? DEFAULTS.maxOpenRounds) - postedAtByCondition.size);
+    const pollLimit = Math.min(current.maxNewRoundsPerPoll ?? DEFAULTS.maxNewRoundsPerPoll, dailyRemaining, openRemaining);
     if (pollLimit <= 0) {
       state.lastPollSummary = { evaluated: 0, posted: 0, skipped: 0 };
       state.lastError = undefined;
@@ -133,7 +143,7 @@ export function makePredictionV1Generator(config: PredictionV1AutoConfig = {}): 
 
     let candidates: MarketCandidate[];
     try {
-      candidates = await listMarketCandidates({ ...config, limit: 250 });
+      candidates = await listMarketCandidates({ ...current, limit: 250 });
     } catch (err) {
       // Preserve existing swallow-and-return-null contract; record the error
       // for getState() so the launcher status endpoint can render it.
@@ -145,6 +155,8 @@ export function makePredictionV1Generator(config: PredictionV1AutoConfig = {}): 
       return null;
     }
 
+    const allowlist = conditionIdSet(current.allowlistConditionIds);
+    const blocklist = conditionIdSet(current.blocklistConditionIds);
     const eligible: EligibleMarket[] = [];
     let evaluatedCount = 0;
     for (const market of prioritizeAllowlisted(candidates, allowlist)) {
@@ -152,7 +164,7 @@ export function makePredictionV1Generator(config: PredictionV1AutoConfig = {}): 
       const conditionId = normalizeConditionId(market.conditionId);
       if (postedAtByCondition.has(conditionId) || blocklist.has(conditionId)) continue;
       evaluatedCount += 1;
-      const checked = await checkMarketEligibility(market, config, now);
+      const checked = await checkMarketEligibility(market, current, now);
       if (checked) eligible.push(checked);
     }
 
@@ -171,7 +183,7 @@ export function makePredictionV1Generator(config: PredictionV1AutoConfig = {}): 
     const selected = eligible.slice(0, pollLimit);
     const tasks: Task[] = [];
     for (const entry of selected) {
-      const task = await buildTask(entry, config, now);
+      const task = await buildTask(entry, current, now);
       postedAtByCondition.set(normalizeConditionId(entry.market.conditionId), Date.parse(entry.market.endTime));
       tasks.push(task);
     }
@@ -194,15 +206,28 @@ export function makePredictionV1Generator(config: PredictionV1AutoConfig = {}): 
 
   return Object.assign(tick, {
     getState(): PredictionV1GeneratorStateSnapshot {
+      const current = currentConfig(config);
       // Return a defensive copy so callers can't mutate internal state.
       return {
         lastPollAt: state.lastPollAt,
         lastPollSummary: state.lastPollSummary ? { ...state.lastPollSummary } : undefined,
         lastError: state.lastError ? { ...state.lastError } : undefined,
-        cadenceMs: config.cadenceMs ?? DEFAULTS.cadenceMs,
+        cadenceMs: current.cadenceMs ?? DEFAULTS.cadenceMs,
       };
     },
   });
+}
+
+function currentConfig(config: PredictionV1AutoConfig): PredictionV1AutoConfig {
+  const live = config.getConfig?.();
+  if (!live) return config;
+  const merged: PredictionV1AutoConfig = { ...config };
+  for (const [key, value] of Object.entries(live) as Array<[keyof PredictionV1LiveConfig, unknown]>) {
+    if (value !== undefined) {
+      (merged as Record<string, unknown>)[key] = value;
+    }
+  }
+  return merged;
 }
 
 async function checkMarketEligibility(

--- a/client/src/solver-types/prediction-v1-auto.ts
+++ b/client/src/solver-types/prediction-v1-auto.ts
@@ -32,6 +32,16 @@ export interface PredictionV1AutoConfig extends PolymarketClientConfig {
   agentPrivateKey?: `0x${string}`;
   allowlistConditionIds?: string[];
   blocklistConditionIds?: string[];
+  /**
+   * Hot-spawn role gate (spec/2026-05-05-launcher-role-and-mode.md §5.2).
+   * The daemon always creates this generator; if `getRoles` is provided and
+   * the returned array does not include `'launching'`, each tick early-returns
+   * without polling Polymarket. Toggling `'launching'` in/out of
+   * `solverNets.prediction.roles` therefore takes effect within one cadence
+   * — no daemon restart. When `getRoles` is unset (e.g. direct test usage)
+   * the generator polls unconditionally, preserving the prior public API.
+   */
+  getRoles?: () => Array<'solving' | 'evaluating' | 'launching'>;
 }
 
 interface EligibleMarket {
@@ -63,6 +73,15 @@ export function makePredictionV1Generator(config: PredictionV1AutoConfig = {}) {
   let lastPollStartedAt = 0;
 
   return async (): Promise<Task[] | null> => {
+    // Hot-spawn role gate (spec/2026-05-05-launcher-role-and-mode.md §5.2).
+    // Always-spawn loop, tick-time gate: if `getRoles` is supplied and the
+    // operator's `solverNets.prediction.roles` does not include 'launching',
+    // skip the poll entirely. Cadence bookkeeping is intentionally NOT
+    // updated here — leaving `lastPollStartedAt` untouched means the very
+    // first tick after the operator flips 'launching' on will run.
+    if (config.getRoles && !config.getRoles().includes('launching')) {
+      return null;
+    }
     const now = Date.now();
     const cadenceMs = config.cadenceMs ?? DEFAULTS.cadenceMs;
     if (cadenceMs > 0 && lastPollStartedAt > 0 && now - lastPollStartedAt < cadenceMs) {

--- a/client/src/solver-types/prediction-v1-auto.ts
+++ b/client/src/solver-types/prediction-v1-auto.ts
@@ -51,6 +51,30 @@ interface EligibleMarket {
   orderbookAgeSeconds: number;
 }
 
+/**
+ * Persistent state observable via `getState()` (Task 5 of
+ * spec/2026-05-05-launcher-role-and-mode.md §5.3). The launcher status
+ * endpoint surfaces these fields verbatim. Stale-poll detection
+ * (lastPollAt + 2*cadence) is computed by the endpoint, not here.
+ */
+export interface PredictionV1GeneratorState {
+  lastPollAt?: string;
+  lastPollSummary?: {
+    evaluated: number;
+    posted: number;
+    skipped: number;
+  };
+  lastError?: { message: string; at: string };
+}
+
+export interface PredictionV1GeneratorStateSnapshot extends PredictionV1GeneratorState {
+  cadenceMs: number;
+}
+
+export type PredictionV1GeneratorTick = (() => Promise<Task[] | null>) & {
+  getState(): PredictionV1GeneratorStateSnapshot;
+};
+
 const DEFAULTS = {
   minTimeToResolutionHours: 24,
   maxTimeToResolutionHours: 168,
@@ -65,14 +89,18 @@ const DEFAULTS = {
   submissionWindowMs: 6 * 60 * 60 * 1000,
 } as const;
 
-export function makePredictionV1Generator(config: PredictionV1AutoConfig = {}) {
+export function makePredictionV1Generator(config: PredictionV1AutoConfig = {}): PredictionV1GeneratorTick {
   const postedAtByCondition = new Map<string, number>();
   const postedCountByDay = new Map<string, number>();
   const allowlist = conditionIdSet(config.allowlistConditionIds);
   const blocklist = conditionIdSet(config.blocklistConditionIds);
   let lastPollStartedAt = 0;
+  // Mutable state, observable via getState(). The role-gate early-return
+  // intentionally does not touch this — a closed gate is "no poll happened",
+  // which the launcher status endpoint reads as `lastPollAt: undefined`.
+  const state: PredictionV1GeneratorState = {};
 
-  return async (): Promise<Task[] | null> => {
+  const tick = async (): Promise<Task[] | null> => {
     // Hot-spawn role gate (spec/2026-05-05-launcher-role-and-mode.md §5.2).
     // Always-spawn loop, tick-time gate: if `getRoles` is supplied and the
     // operator's `solverNets.prediction.roles` does not include 'launching',
@@ -88,6 +116,8 @@ export function makePredictionV1Generator(config: PredictionV1AutoConfig = {}) {
       return null;
     }
     lastPollStartedAt = now;
+    // Record that a poll attempt happened, regardless of success.
+    state.lastPollAt = new Date(now).toISOString();
 
     pruneOpenRounds(postedAtByCondition, now);
     const dayKey = new Date(now).toISOString().slice(0, 10);
@@ -95,20 +125,33 @@ export function makePredictionV1Generator(config: PredictionV1AutoConfig = {}) {
     const dailyRemaining = Math.max(0, (config.maxNewRoundsPerDay ?? DEFAULTS.maxNewRoundsPerDay) - todayCount);
     const openRemaining = Math.max(0, (config.maxOpenRounds ?? DEFAULTS.maxOpenRounds) - postedAtByCondition.size);
     const pollLimit = Math.min(config.maxNewRoundsPerPoll ?? DEFAULTS.maxNewRoundsPerPoll, dailyRemaining, openRemaining);
-    if (pollLimit <= 0) return null;
+    if (pollLimit <= 0) {
+      state.lastPollSummary = { evaluated: 0, posted: 0, skipped: 0 };
+      state.lastError = undefined;
+      return null;
+    }
 
     let candidates: MarketCandidate[];
     try {
       candidates = await listMarketCandidates({ ...config, limit: 250 });
-    } catch {
+    } catch (err) {
+      // Preserve existing swallow-and-return-null contract; record the error
+      // for getState() so the launcher status endpoint can render it.
+      state.lastError = {
+        message: err instanceof Error ? err.message : String(err),
+        at: new Date().toISOString(),
+      };
+      state.lastPollSummary = { evaluated: 0, posted: 0, skipped: 0 };
       return null;
     }
 
     const eligible: EligibleMarket[] = [];
+    let evaluatedCount = 0;
     for (const market of prioritizeAllowlisted(candidates, allowlist)) {
       if (eligible.length >= pollLimit * 3) break;
       const conditionId = normalizeConditionId(market.conditionId);
       if (postedAtByCondition.has(conditionId) || blocklist.has(conditionId)) continue;
+      evaluatedCount += 1;
       const checked = await checkMarketEligibility(market, config, now);
       if (checked) eligible.push(checked);
     }
@@ -135,8 +178,31 @@ export function makePredictionV1Generator(config: PredictionV1AutoConfig = {}) {
     if (tasks.length > 0) {
       postedCountByDay.set(dayKey, todayCount + tasks.length);
     }
+    // evaluated = candidates that survived dedup/blocklist and entered checkMarketEligibility
+    // posted    = tasks built (final selection)
+    // skipped   = evaluated - posted (rejected by eligibility check or eligible-but-not-selected within pollLimit)
+    // Markets filtered out before eligibility check (dedup, blocklist, or exit at eligible*3 cap) are
+    // not counted here — they're not surprising to the launcher and a future skipReasons field can
+    // surface them by category if needed.
+    const evaluated = evaluatedCount;
+    const posted = tasks.length;
+    const skipped = Math.max(0, evaluated - posted);
+    state.lastPollSummary = { evaluated, posted, skipped };
+    state.lastError = undefined;
     return tasks.length > 0 ? tasks : null;
   };
+
+  return Object.assign(tick, {
+    getState(): PredictionV1GeneratorStateSnapshot {
+      // Return a defensive copy so callers can't mutate internal state.
+      return {
+        lastPollAt: state.lastPollAt,
+        lastPollSummary: state.lastPollSummary ? { ...state.lastPollSummary } : undefined,
+        lastError: state.lastError ? { ...state.lastError } : undefined,
+        cadenceMs: config.cadenceMs ?? DEFAULTS.cadenceMs,
+      };
+    },
+  });
 }
 
 async function checkMarketEligibility(

--- a/client/src/solver-types/prediction-v1.ts
+++ b/client/src/solver-types/prediction-v1.ts
@@ -36,7 +36,9 @@ export const predictionV1: SolverTypeDefinition<PredictionV1AutoConfig> = {
       maxOpenRounds: ctx.predictionV1MaxOpenRounds ?? nonNegativeNumberEnv(ctx.env, 'JINN_PREDICTION_V1_MAX_OPEN_ROUNDS'),
       allowlistConditionIds: ctx.predictionV1AllowlistConditionIds ?? csvEnv(ctx.env, 'JINN_PREDICTION_V1_ALLOWLIST_CONDITION_IDS'),
       blocklistConditionIds: ctx.predictionV1BlocklistConditionIds ?? csvEnv(ctx.env, 'JINN_PREDICTION_V1_BLOCKLIST_CONDITION_IDS'),
+      resolveGapMs: ctx.predictionV1ResolveGapMs,
       getRoles: ctx.getPredictionRoles,
+      getConfig: ctx.getPredictionV1Config,
     };
   },
   ui: {

--- a/client/src/solver-types/prediction-v1.ts
+++ b/client/src/solver-types/prediction-v1.ts
@@ -18,7 +18,13 @@ export const predictionV1: SolverTypeDefinition<PredictionV1AutoConfig> = {
   },
   buildGenerator: (config) => makePredictionV1Generator(config),
   getTestnetAutoConfig: (ctx) => {
-    if (ctx.network !== 'testnet' || !ctx.predictionV1LauncherEnabled) return undefined;
+    // spec/2026-05-05-launcher-role-and-mode.md §5.2: hot-spawn the generator
+    // unconditionally on testnet. The runtime `roles.includes('launching')`
+    // gate inside the generator's tick is what actually controls whether
+    // Polymarket gets polled — see `getRoles` in PredictionV1AutoConfig and
+    // the wiring in main.ts. Toggling roles takes effect within one cadence,
+    // no daemon restart.
+    if (ctx.network !== 'testnet') return undefined;
     return {
       agentEoa: ctx.agentEoa,
       safeAddress: ctx.safeAddress,
@@ -30,6 +36,7 @@ export const predictionV1: SolverTypeDefinition<PredictionV1AutoConfig> = {
       maxOpenRounds: ctx.predictionV1MaxOpenRounds ?? nonNegativeNumberEnv(ctx.env, 'JINN_PREDICTION_V1_MAX_OPEN_ROUNDS'),
       allowlistConditionIds: ctx.predictionV1AllowlistConditionIds ?? csvEnv(ctx.env, 'JINN_PREDICTION_V1_ALLOWLIST_CONDITION_IDS'),
       blocklistConditionIds: ctx.predictionV1BlocklistConditionIds ?? csvEnv(ctx.env, 'JINN_PREDICTION_V1_BLOCKLIST_CONDITION_IDS'),
+      getRoles: ctx.getPredictionRoles,
     };
   },
   ui: {

--- a/client/src/solver-types/solver-type.ts
+++ b/client/src/solver-types/solver-type.ts
@@ -4,6 +4,7 @@
  */
 
 import type { TaskGenerator } from '../tasks/sources.js';
+import type { PredictionV1LiveConfig } from './prediction-v1-auto.js';
 
 /** Overlay fields merged into Task when posting from --spec-file. */
 export type ParsedSpecOverlay = {
@@ -42,6 +43,12 @@ export interface TestnetAutoContext {
    * one cadence — no daemon restart.
    */
   getPredictionRoles?: () => Array<'solving' | 'evaluating' | 'launching'>;
+  /**
+   * Live prediction.v1 launcher config getter. The Polymarket generator reads
+   * this inside each tick so Launcher PATCH edits hot-apply without daemon
+   * restart or generator recreation.
+   */
+  getPredictionV1Config?: () => PredictionV1LiveConfig;
   /**
    * Override the prediction.v1 Polymarket submission window (ms).
    * The generator default applies when unset.

--- a/client/src/solver-types/solver-type.ts
+++ b/client/src/solver-types/solver-type.ts
@@ -33,10 +33,15 @@ export interface TestnetAutoContext {
   /** Agent EOA private key — threaded into auto-gen configs so generators can sign SignedTaskV1. */
   agentPrivateKey?: `0x${string}`;
   /**
-   * Explicit opt-in for the launcher-owned Polymarket prediction.v1 generator.
-   * Ordinary operator daemons leave this unset/false and do not create rounds.
+   * Live role-getter for the prediction SolverNet, threaded into the
+   * Polymarket prediction.v1 generator so its tick can early-return when
+   * `'launching'` is not in the operator's `solverNets.prediction.roles`.
+   * Replaces the legacy startup-time `predictionV1LauncherEnabled` boolean
+   * (spec/2026-05-05-launcher-role-and-mode.md §5.2). Returning a closure
+   * (rather than a snapshot) is what makes role flips take effect within
+   * one cadence — no daemon restart.
    */
-  predictionV1LauncherEnabled?: boolean;
+  getPredictionRoles?: () => Array<'solving' | 'evaluating' | 'launching'>;
   /**
    * Override the prediction.v1 Polymarket submission window (ms).
    * The generator default applies when unset.

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -554,6 +554,110 @@ export class Store {
     };
   }
 
+  /**
+   * Posted Tasks for the launcher mode (`GET /v1/launcher/tasks`,
+   * spec/2026-05-05-launcher-role-and-mode.md §5.3). Returns rows from
+   * `task_posts` filtered by creator Safe address, sorted by `last_posted_at
+   * DESC` (most recent first). The `solverType` is denormalised in by joining
+   * `activity_events` on `request_id` for the `task_posted` kind — that's
+   * where `posting-service.ts` writes the SolverType when the post lands.
+   *
+   * `before` filters to rows with `last_posted_at < before` (ISO-8601). When
+   * `before` is undefined, returns the most recent `limit` rows.
+   *
+   * Caller-side: `gatherLauncherTasks` (`api/launcher-tasks.ts`) maps the
+   * solver_type back to the operator's SolverNet name via config lookup.
+   */
+  listPostedTasksByCreator(args: {
+    creatorSafeAddress: string;
+    limit: number;
+    before?: string;
+  }): Array<{
+    taskId: string;
+    taskCid: string;
+    solverType: string | null;
+    requestId: string;
+    postedAt: string;
+  }> {
+    const limit = Math.max(0, Math.min(args.limit, 1000));
+    if (limit === 0) return [];
+    const params: Record<string, unknown> = {
+      creator: args.creatorSafeAddress,
+      limit,
+    };
+    let beforeClause = '';
+    if (args.before) {
+      beforeClause = ' AND tp.last_posted_at < @before';
+      params['before'] = args.before;
+    }
+    // LEFT JOIN: a stale `task_posts` row from before activity_events backfill
+    // (or one whose event was lost to `recordActivityEvent` failure) still
+    // surfaces with a NULL solver_type — the gather function falls back to
+    // `solverNet: 'unknown'` rather than dropping the row, because the
+    // operator should still see the Task they posted.
+    const rows = this.db.prepare(
+      `SELECT
+         tp.task_id,
+         tp.task_cid,
+         tp.protocol_task_id,
+         tp.request_id,
+         tp.last_posted_at,
+         (
+           SELECT ae.solver_type
+           FROM activity_events ae
+           WHERE ae.request_id = tp.request_id
+             AND ae.kind = 'task_posted'
+             AND ae.solver_type IS NOT NULL
+           ORDER BY ae.id DESC
+           LIMIT 1
+         ) AS solver_type
+       FROM task_posts tp
+       WHERE tp.creator_safe_address = @creator${beforeClause}
+       ORDER BY tp.last_posted_at DESC
+       LIMIT @limit`,
+    ).all(params) as Array<{
+      task_id: string | null;
+      task_cid: string | null;
+      protocol_task_id: string | null;
+      request_id: string;
+      last_posted_at: string;
+      solver_type: string | null;
+    }>;
+    return rows.map((r) => ({
+      // task_id was added by an additive migration; the column exists on every
+      // post-migration insert (posting-service.ts always writes it). Older
+      // rows fall back to protocol_task_id (chain Task ID) and finally
+      // request_id so the response shape's `taskId` is always populated.
+      taskId: r.task_id ?? r.protocol_task_id ?? r.request_id,
+      taskCid: r.task_cid ?? '',
+      solverType: r.solver_type,
+      requestId: r.request_id,
+      postedAt: r.last_posted_at,
+    }));
+  }
+
+  /** Count of posted Tasks for this creator with the given solver_type. v1
+   *  treats every posted Task as in-flight (state derivation lands with
+   *  router-watcher hardening, jinn-mono-l2zl.12). */
+  countPostedTasksByCreatorAndSolverType(args: {
+    creatorSafeAddress: string;
+    solverType: string;
+  }): number {
+    const row = this.db.prepare(
+      `SELECT COUNT(DISTINCT tp.task_id) AS c
+       FROM task_posts tp
+       INNER JOIN activity_events ae
+         ON ae.request_id = tp.request_id
+         AND ae.kind = 'task_posted'
+       WHERE tp.creator_safe_address = @creator
+         AND ae.solver_type = @solverType`,
+    ).get({
+      creator: args.creatorSafeAddress,
+      solverType: args.solverType,
+    }) as { c: number } | undefined;
+    return row?.c ?? 0;
+  }
+
   upsertTaskPostRecord(record: TaskPostRecord): void {
     const params = {
       ...record,

--- a/client/src/tasks/generated-source-gate.ts
+++ b/client/src/tasks/generated-source-gate.ts
@@ -1,0 +1,28 @@
+type GeneratedSourceSolverNet = {
+  enabled?: boolean;
+  solverType?: string;
+  roles?: string[];
+  taskGenerator?: { enabled?: boolean };
+};
+
+/**
+ * Decide whether a generated TaskSource should be installed for a SolverType.
+ *
+ * Legacy solver/evaluator participation still requires `enabled: true` plus a
+ * restoration-capable role. Launcher mode is different: SetupFlow owns the
+ * `launching` role and deliberately does not flip the legacy enabled flag, so
+ * a launching net with task generation enabled must still register its source.
+ */
+export function generatedTaskSourceSupported(
+  solverNets: Record<string, GeneratedSourceSolverNet> | undefined,
+  solverType: string,
+): boolean {
+  return Object.values(solverNets ?? {}).some((net) => {
+    if (net.solverType !== solverType || net.taskGenerator?.enabled !== true) {
+      return false;
+    }
+    const roles = Array.isArray(net.roles) ? net.roles : [];
+    if (roles.includes('launching')) return true;
+    return net.enabled === true && (roles.length === 0 || roles.includes('solving'));
+  });
+}

--- a/client/test/api/gather-status.test.ts
+++ b/client/test/api/gather-status.test.ts
@@ -85,6 +85,7 @@ describe('gatherStatusForApi', () => {
         name: 'prediction',
         enabled: true,
         solverType: 'prediction.v1',
+        roles: ['solving'],
         harness: 'prediction-v1-baseline',
         taskGeneratorEnabled: true,
       },

--- a/client/test/api/gather-status.test.ts
+++ b/client/test/api/gather-status.test.ts
@@ -266,4 +266,41 @@ describe('gatherStatusForApi', () => {
       expect(apiStatus.predictionV1?.operator?.solverNet?.roles).toEqual([]);
     });
   });
+
+  it("omits 'launching' from operator.solverNet.roles on the unavailable path", async () => {
+    mockStatusRpc();
+    const buildPredictionOperatorStatus = vi.fn(async () => {
+      throw new Error('plugin hash failed');
+    });
+    vi.doMock('../../src/solver-nets/prediction-operator-ux.js', () => ({
+      buildPredictionOperatorStatus,
+    }));
+    const { gatherStatusForApi } = await import('../../src/api/gather-status.js');
+    const config = {
+      solverNets: {
+        prediction: {
+          enabled: true,
+          solverType: 'prediction.v1',
+          harness: 'prediction-v1-baseline',
+          taskGenerator: { enabled: true },
+          roles: ['solving', 'launching'],
+        },
+      },
+    } as unknown as JinnConfig;
+
+    await withTempStore(async (store) => {
+      const apiStatus = await gatherStatusForApi(store, {
+        earningDir: mkdtempSync(join(tmpdir(), 'jinn-status-test-')),
+        rpcUrl: 'http://127.0.0.1:0',
+        network: 'testnet' as const,
+        pollIntervalMs: 5000,
+        rewardClaimIntervalMs: 0,
+        config,
+        configPath: '/tmp/config.json',
+      });
+
+      expect(apiStatus.predictionV1?.operator?.ok).toBe(false);
+      expect(apiStatus.predictionV1?.operator?.solverNet?.roles).toEqual(['solving']);
+    });
+  });
 });

--- a/client/test/api/gather-status.test.ts
+++ b/client/test/api/gather-status.test.ts
@@ -167,4 +167,103 @@ describe('gatherStatusForApi', () => {
 
     expect(buildPredictionOperatorStatus).toHaveBeenCalledTimes(1);
   });
+
+  it("omits 'launching' from operator.solverNet.roles", async () => {
+    mockStatusRpc();
+    const buildPredictionOperatorStatus = vi.fn(async (): Promise<PredictionOperatorStatus> => ({
+      kind: 'prediction.v1.operatorStatus',
+      ok: true,
+      configPath: '/tmp/config.json',
+      solverNet: {
+        name: 'prediction',
+        enabled: true,
+        solverType: 'prediction.v1',
+        // Source returns the full operator-role array (includes launching).
+        roles: ['solving', 'launching'],
+        harness: 'prediction-v1-baseline',
+        taskGeneratorEnabled: true,
+      },
+      runtimePlugins: [],
+      diagnostics: [],
+      nextAction: { description: 'Run', cli: 'jinn run' },
+    }));
+    vi.doMock('../../src/solver-nets/prediction-operator-ux.js', () => ({
+      buildPredictionOperatorStatus,
+    }));
+    const { gatherStatusForApi } = await import('../../src/api/gather-status.js');
+    const config = {
+      solverNets: {
+        prediction: {
+          enabled: true,
+          solverType: 'prediction.v1',
+          harness: 'prediction-v1-baseline',
+          taskGenerator: { enabled: true },
+          roles: ['solving', 'launching'],
+        },
+      },
+    } as unknown as JinnConfig;
+
+    await withTempStore(async (store) => {
+      const apiStatus = await gatherStatusForApi(store, {
+        earningDir: mkdtempSync(join(tmpdir(), 'jinn-status-test-')),
+        rpcUrl: 'http://127.0.0.1:0',
+        network: 'testnet' as const,
+        pollIntervalMs: 5000,
+        rewardClaimIntervalMs: 0,
+        config,
+        configPath: '/tmp/config.json',
+      });
+
+      expect(apiStatus.predictionV1?.operator?.solverNet?.roles).toEqual(['solving']);
+    });
+  });
+
+  it("returns empty operator.solverNet.roles when only 'launching' is enabled", async () => {
+    mockStatusRpc();
+    const buildPredictionOperatorStatus = vi.fn(async (): Promise<PredictionOperatorStatus> => ({
+      kind: 'prediction.v1.operatorStatus',
+      ok: true,
+      configPath: '/tmp/config.json',
+      solverNet: {
+        name: 'prediction',
+        enabled: true,
+        solverType: 'prediction.v1',
+        roles: ['launching'],
+        harness: 'prediction-v1-baseline',
+        taskGeneratorEnabled: true,
+      },
+      runtimePlugins: [],
+      diagnostics: [],
+      nextAction: { description: 'Run', cli: 'jinn run' },
+    }));
+    vi.doMock('../../src/solver-nets/prediction-operator-ux.js', () => ({
+      buildPredictionOperatorStatus,
+    }));
+    const { gatherStatusForApi } = await import('../../src/api/gather-status.js');
+    const config = {
+      solverNets: {
+        prediction: {
+          enabled: true,
+          solverType: 'prediction.v1',
+          harness: 'prediction-v1-baseline',
+          taskGenerator: { enabled: true },
+          roles: ['launching'],
+        },
+      },
+    } as unknown as JinnConfig;
+
+    await withTempStore(async (store) => {
+      const apiStatus = await gatherStatusForApi(store, {
+        earningDir: mkdtempSync(join(tmpdir(), 'jinn-status-test-')),
+        rpcUrl: 'http://127.0.0.1:0',
+        network: 'testnet' as const,
+        pollIntervalMs: 5000,
+        rewardClaimIntervalMs: 0,
+        config,
+        configPath: '/tmp/config.json',
+      });
+
+      expect(apiStatus.predictionV1?.operator?.solverNet?.roles).toEqual([]);
+    });
+  });
 });

--- a/client/test/api/launcher-endpoints.test.ts
+++ b/client/test/api/launcher-endpoints.test.ts
@@ -83,6 +83,8 @@ function buildTestApp(args: BuildArgs): {
   readPersistedConfig: () => Record<string, unknown>;
   /** Returns the most recent solverNets payload passed to onSolverNetsUpdated. */
   readNotifiedSolverNets: () => Record<string, Record<string, unknown>> | undefined;
+  /** Returns the mutable live config view after hot-apply hooks run. */
+  readLiveConfig: () => Record<string, unknown>;
 } {
   const app = new Hono();
   if (args.withAuth ?? true) {
@@ -101,6 +103,7 @@ function buildTestApp(args: BuildArgs): {
   // getConfig() (the production wiring does the same thing — main.ts mutates
   // `config.solverNets` in place from the onSolverNetsUpdated hook).
   let liveSolverNets: JinnConfig['solverNets'] | undefined = args.solverNets ?? {};
+  const liveConfig: Record<string, unknown> = { solverNets: liveSolverNets };
   const persistShim = buildPersistShim();
   let lastNotified: Record<string, Record<string, unknown>> | undefined;
   addLauncherRoutes(app, {
@@ -123,6 +126,10 @@ function buildTestApp(args: BuildArgs): {
       // post-edit object so subsequent reads (status, follow-up patches)
       // see the fresh state.
       liveSolverNets = solverNets as JinnConfig['solverNets'];
+      liveConfig['solverNets'] = liveSolverNets;
+    },
+    onConfigValuesUpdated: (values) => {
+      Object.assign(liveConfig, values);
     },
   });
   return {
@@ -131,6 +138,7 @@ function buildTestApp(args: BuildArgs): {
     fetchSpy,
     readPersistedConfig: persistShim.read,
     readNotifiedSolverNets: () => lastNotified,
+    readLiveConfig: () => ({ ...liveConfig }),
   };
 }
 
@@ -526,7 +534,7 @@ describe('PATCH /v1/launcher/solvernets/:name', () => {
   });
 
   it('persists only generator-config keys when launching is omitted', async () => {
-    const { app, token, readPersistedConfig, readNotifiedSolverNets } = buildTestApp({
+    const { app, token, readPersistedConfig, readNotifiedSolverNets, readLiveConfig } = buildTestApp({
       solverNets: { prediction: launchingAndSolvingNet },
     });
     const res = await app.request('/v1/launcher/solvernets/prediction', {
@@ -540,6 +548,8 @@ describe('PATCH /v1/launcher/solvernets/:name', () => {
     const persisted = readPersistedConfig();
     expect(persisted['predictionV1AllowlistConditionIds']).toEqual(['0xabc', '0xdef']);
     expect(persisted['predictionV1WindowMs']).toBe(90_000);
+    expect(readLiveConfig()['predictionV1AllowlistConditionIds']).toEqual(['0xabc', '0xdef']);
+    expect(readLiveConfig()['predictionV1WindowMs']).toBe(90_000);
     // Roles weren't touched → no solverNets write, no cache invalidation.
     expect(persisted['solverNets']).toBeUndefined();
     expect(readNotifiedSolverNets()).toBeUndefined();

--- a/client/test/api/launcher-endpoints.test.ts
+++ b/client/test/api/launcher-endpoints.test.ts
@@ -40,6 +40,26 @@ interface BuildArgs {
     | ((opts: FetchPostedTasksOptions) => PostedTaskRecord[]);
 }
 
+/**
+ * In-memory persistence shim for the PATCH endpoint. Mirrors the on-disk
+ * shape that {@link import('../../src/config.js').persistTopLevelConfigValue}
+ * would produce so tests can assert against the full post-write snapshot
+ * without touching the filesystem.
+ */
+function buildPersistShim(): {
+  persistConfigValue: (key: string, value: unknown, configPath?: string) => string;
+  read: () => Record<string, unknown>;
+} {
+  const store: Record<string, unknown> = {};
+  return {
+    persistConfigValue: (key, value) => {
+      store[key] = value;
+      return '/tmp/test-config.json';
+    },
+    read: () => ({ ...store }),
+  };
+}
+
 function defaultFetchPostedTasks(
   fixtures: PostedTaskRecord[] | undefined,
   spy?: { lastOpts?: FetchPostedTasksOptions },
@@ -59,6 +79,10 @@ function buildTestApp(args: BuildArgs): {
   app: Hono;
   token: string;
   fetchSpy: { lastOpts?: FetchPostedTasksOptions };
+  /** Returns the in-memory persisted snapshot (mirrors config.json on disk). */
+  readPersistedConfig: () => Record<string, unknown>;
+  /** Returns the most recent solverNets payload passed to onSolverNetsUpdated. */
+  readNotifiedSolverNets: () => Record<string, Record<string, unknown>> | undefined;
 } {
   const app = new Hono();
   if (args.withAuth ?? true) {
@@ -73,8 +97,14 @@ function buildTestApp(args: BuildArgs): {
           return (args.postedTasks as (o: FetchPostedTasksOptions) => PostedTaskRecord[])(opts);
         }
       : defaultFetchPostedTasks(args.postedTasks, fetchSpy);
+  // Live, mutable solverNets so PATCH can read the latest snapshot via
+  // getConfig() (the production wiring does the same thing — main.ts mutates
+  // `config.solverNets` in place from the onSolverNetsUpdated hook).
+  let liveSolverNets: JinnConfig['solverNets'] | undefined = args.solverNets ?? {};
+  const persistShim = buildPersistShim();
+  let lastNotified: Record<string, Record<string, unknown>> | undefined;
   addLauncherRoutes(app, {
-    getConfig: () => ({ solverNets: args.solverNets ?? {} } as Pick<JinnConfig, 'solverNets'>),
+    getConfig: () => ({ solverNets: liveSolverNets } as Pick<JinnConfig, 'solverNets'>),
     getGeneratorState: (name) => args.generatorStates?.[name],
     getOpenTaskCount: (name) => args.openTaskCount?.(name) ?? 0,
     getReservedBudgetWei: (name) => args.reservedBudgetWei?.(name) ?? '0',
@@ -86,8 +116,22 @@ function buildTestApp(args: BuildArgs): {
       fetchPostedTasks,
       now: args.now !== undefined ? () => args.now! : undefined,
     },
+    persistConfigValue: persistShim.persistConfigValue,
+    onSolverNetsUpdated: (solverNets) => {
+      lastNotified = solverNets;
+      // Mirror main.ts: keep the live config snapshot pointed at the
+      // post-edit object so subsequent reads (status, follow-up patches)
+      // see the fresh state.
+      liveSolverNets = solverNets as JinnConfig['solverNets'];
+    },
   });
-  return { app, token: UI_TOKEN, fetchSpy };
+  return {
+    app,
+    token: UI_TOKEN,
+    fetchSpy,
+    readPersistedConfig: persistShim.read,
+    readNotifiedSolverNets: () => lastNotified,
+  };
 }
 
 const launchingNet = {
@@ -377,6 +421,154 @@ describe('GET /v1/launcher/tasks', () => {
       postedTasks: [],
     });
     const res = await app.request('/v1/launcher/tasks');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('PATCH /v1/launcher/solvernets/:name', () => {
+  const solvingPredictionNet = {
+    enabled: true,
+    solverType: 'prediction.v1',
+    roles: ['solving'],
+    harness: 'claude-code-learner',
+    plugins: [],
+    taskGenerator: { enabled: true },
+  } as never;
+
+  const launchingAndSolvingNet = {
+    enabled: true,
+    solverType: 'prediction.v1',
+    roles: ['solving', 'launching'],
+    harness: 'claude-code-learner',
+    plugins: [],
+    taskGenerator: { enabled: true },
+  } as never;
+
+  const launchingOnlyNet = {
+    enabled: true,
+    solverType: 'prediction.v1',
+    roles: ['launching'],
+    harness: 'claude-code-learner',
+    plugins: [],
+    taskGenerator: { enabled: true },
+  } as never;
+
+  it('adds launching to roles and persists generator config', async () => {
+    const { app, token, readPersistedConfig, readNotifiedSolverNets } = buildTestApp({
+      solverNets: { prediction: solvingPredictionNet },
+    });
+    const res = await app.request('/v1/launcher/solvernets/prediction', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json', 'x-jinn-ui-token': token },
+      body: JSON.stringify({
+        launching: true,
+        generator: { cadenceMs: 30_000, maxNewRoundsPerPoll: 10 },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; roles: string[] };
+    expect(body.ok).toBe(true);
+    expect(body.roles.sort()).toEqual(['launching', 'solving']);
+
+    const persisted = readPersistedConfig();
+    const persistedSolverNets = persisted['solverNets'] as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect((persistedSolverNets.prediction!['roles'] as string[]).sort()).toEqual([
+      'launching',
+      'solving',
+    ]);
+    expect(persisted['predictionV1CadenceMs']).toBe(30_000);
+    expect(persisted['predictionV1MaxNewRoundsPerPoll']).toBe(10);
+
+    // Cache invalidation hook fired with the post-edit solverNets snapshot.
+    const notified = readNotifiedSolverNets();
+    expect(notified).toBeDefined();
+    expect((notified!.prediction!['roles'] as string[]).sort()).toEqual([
+      'launching',
+      'solving',
+    ]);
+  });
+
+  it('removes launching from roles when launching: false', async () => {
+    const { app, token, readPersistedConfig } = buildTestApp({
+      solverNets: { prediction: launchingAndSolvingNet },
+    });
+    const res = await app.request('/v1/launcher/solvernets/prediction', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json', 'x-jinn-ui-token': token },
+      body: JSON.stringify({ launching: false }),
+    });
+    expect(res.status).toBe(200);
+    const persisted = readPersistedConfig();
+    const persistedSolverNets = persisted['solverNets'] as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(persistedSolverNets.prediction!['roles']).toEqual(['solving']);
+  });
+
+  it('rejects launching: false when it would leave roles empty', async () => {
+    const { app, token, readPersistedConfig } = buildTestApp({
+      solverNets: { prediction: launchingOnlyNet },
+    });
+    const res = await app.request('/v1/launcher/solvernets/prediction', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json', 'x-jinn-ui-token': token },
+      body: JSON.stringify({ launching: false }),
+    });
+    expect(res.status).toBe(400);
+    const err = (await res.json()) as { message?: string };
+    expect(err.message).toMatch(/at least one role/i);
+    // Refusal must not write anything.
+    expect(readPersistedConfig()).toEqual({});
+  });
+
+  it('persists only generator-config keys when launching is omitted', async () => {
+    const { app, token, readPersistedConfig, readNotifiedSolverNets } = buildTestApp({
+      solverNets: { prediction: launchingAndSolvingNet },
+    });
+    const res = await app.request('/v1/launcher/solvernets/prediction', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json', 'x-jinn-ui-token': token },
+      body: JSON.stringify({
+        generator: { allowlistConditionIds: ['0xabc', '0xdef'], windowMs: 90_000 },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const persisted = readPersistedConfig();
+    expect(persisted['predictionV1AllowlistConditionIds']).toEqual(['0xabc', '0xdef']);
+    expect(persisted['predictionV1WindowMs']).toBe(90_000);
+    // Roles weren't touched → no solverNets write, no cache invalidation.
+    expect(persisted['solverNets']).toBeUndefined();
+    expect(readNotifiedSolverNets()).toBeUndefined();
+  });
+
+  it('returns 404 for unknown SolverNet', async () => {
+    const { app, token } = buildTestApp({
+      solverNets: { prediction: solvingPredictionNet },
+    });
+    const res = await app.request('/v1/launcher/solvernets/portfolio', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json', 'x-jinn-ui-token': token },
+      body: JSON.stringify({ launching: true }),
+    });
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string; available: string[] };
+    expect(body.error).toBe('solvernet_not_found');
+    expect(body.available).toEqual(['prediction']);
+  });
+
+  it('requires auth', async () => {
+    const { app } = buildTestApp({
+      solverNets: { prediction: solvingPredictionNet },
+    });
+    const res = await app.request('/v1/launcher/solvernets/prediction', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ launching: true }),
+    });
     expect(res.status).toBe(401);
   });
 });

--- a/client/test/api/launcher-endpoints.test.ts
+++ b/client/test/api/launcher-endpoints.test.ts
@@ -13,6 +13,10 @@ import { addLauncherRoutes } from '../../src/api/launcher-endpoints.js';
 import { requireUiToken } from '../../src/api/handshake.js';
 import type { JinnConfig } from '../../src/config.js';
 import type { LauncherGeneratorStateSnapshot } from '../../src/api/launcher-status.js';
+import type {
+  PostedTaskRecord,
+  FetchPostedTasksOptions,
+} from '../../src/api/launcher-tasks.js';
 
 const UI_TOKEN = 'ui-token-test';
 const SAFE_ADDRESS = '0x0000000000000000000000000000000000000abc';
@@ -26,14 +30,49 @@ interface BuildArgs {
   now?: number;
   /** Mount the UI-token gate (mirrors server.ts wiring). */
   withAuth?: boolean;
+  /**
+   * Posted-Task fixtures for the `GET /v1/launcher/tasks` endpoint. Either a
+   * static list (the test harness applies the `before`/`limit` filter), or a
+   * function that receives the gather options and returns a tailored list.
+   */
+  postedTasks?:
+    | PostedTaskRecord[]
+    | ((opts: FetchPostedTasksOptions) => PostedTaskRecord[]);
 }
 
-function buildTestApp(args: BuildArgs): { app: Hono; token: string } {
+function defaultFetchPostedTasks(
+  fixtures: PostedTaskRecord[] | undefined,
+  spy?: { lastOpts?: FetchPostedTasksOptions },
+): (opts: FetchPostedTasksOptions) => PostedTaskRecord[] {
+  return (opts) => {
+    if (spy) spy.lastOpts = opts;
+    if (!fixtures) return [];
+    const sorted = [...fixtures].sort((a, b) => Date.parse(b.postedAt) - Date.parse(a.postedAt));
+    const filtered = opts.before
+      ? sorted.filter((r) => Date.parse(r.postedAt) < Date.parse(opts.before!))
+      : sorted;
+    return filtered.slice(0, opts.limit);
+  };
+}
+
+function buildTestApp(args: BuildArgs): {
+  app: Hono;
+  token: string;
+  fetchSpy: { lastOpts?: FetchPostedTasksOptions };
+} {
   const app = new Hono();
   if (args.withAuth ?? true) {
     app.use('/v1/launcher', requireUiToken(UI_TOKEN));
     app.use('/v1/launcher/*', requireUiToken(UI_TOKEN));
   }
+  const fetchSpy: { lastOpts?: FetchPostedTasksOptions } = {};
+  const fetchPostedTasks =
+    typeof args.postedTasks === 'function'
+      ? (opts: FetchPostedTasksOptions) => {
+          fetchSpy.lastOpts = opts;
+          return (args.postedTasks as (o: FetchPostedTasksOptions) => PostedTaskRecord[])(opts);
+        }
+      : defaultFetchPostedTasks(args.postedTasks, fetchSpy);
   addLauncherRoutes(app, {
     getConfig: () => ({ solverNets: args.solverNets ?? {} } as Pick<JinnConfig, 'solverNets'>),
     getGeneratorState: (name) => args.generatorStates?.[name],
@@ -42,8 +81,13 @@ function buildTestApp(args: BuildArgs): { app: Hono; token: string } {
     getSafeBalanceWei: () => args.safeBalanceWei ?? '0',
     safeAddress: SAFE_ADDRESS,
     now: args.now !== undefined ? () => args.now! : undefined,
+    tasksDeps: {
+      creatorAddress: SAFE_ADDRESS,
+      fetchPostedTasks,
+      now: args.now !== undefined ? () => args.now! : undefined,
+    },
   });
-  return { app, token: UI_TOKEN };
+  return { app, token: UI_TOKEN, fetchSpy };
 }
 
 const launchingNet = {
@@ -193,6 +237,146 @@ describe('GET /v1/launcher/status', () => {
       solverNets: { prediction: launchingNet },
     });
     const res = await app.request('/v1/launcher/status');
+    expect(res.status).toBe(401);
+  });
+});
+
+interface TasksResponseBody {
+  schemaVersion: number;
+  generatedAt: string;
+  cursor?: { before: string };
+  tasks: Array<{
+    taskId: string;
+    taskCid: string;
+    solverNet: string;
+    postedAt: string;
+    state: string;
+    claims: { current: number; max: number };
+    budget: { totalWei: string; remainingWei: string; reclaimableAt?: string };
+    summary?: { title?: string; resolutionTime?: string };
+  }>;
+}
+
+describe('GET /v1/launcher/tasks', () => {
+  it('returns tasks posted by this daemon creator, most recent first', async () => {
+    const { app, token } = buildTestApp({
+      solverNets: { prediction: launchingNet },
+      postedTasks: [
+        {
+          taskId: '0xa',
+          taskCid: 'Qma',
+          solverType: 'prediction.v1',
+          postedAt: '2026-05-05T10:00:00.000Z',
+        },
+        {
+          taskId: '0xb',
+          taskCid: 'Qmb',
+          solverType: 'prediction.v1',
+          postedAt: '2026-05-05T11:00:00.000Z',
+        },
+      ],
+    });
+    const res = await app.request('/v1/launcher/tasks', {
+      headers: { 'x-jinn-ui-token': token },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as TasksResponseBody;
+    expect(body.schemaVersion).toBe(1);
+    expect(body.tasks).toHaveLength(2);
+    expect(body.tasks[0]?.taskId).toBe('0xb');
+    expect(body.tasks[1]?.taskId).toBe('0xa');
+    expect(body.tasks[0]?.solverNet).toBe('prediction');
+    // Default state/claims/budget when the daemon doesn't yet track lifecycle.
+    expect(body.tasks[0]?.state).toBe('open');
+    expect(body.tasks[0]?.claims).toEqual({ current: 0, max: 25 });
+    expect(body.tasks[0]?.budget).toEqual({ totalWei: '0', remainingWei: '0' });
+    // No cursor because page is not full.
+    expect(body.cursor).toBeUndefined();
+  });
+
+  it('respects ?cursor=before:<iso>&limit=N pagination', async () => {
+    const fixtures: PostedTaskRecord[] = [
+      { taskId: '0xa', taskCid: 'Qma', solverType: 'prediction.v1', postedAt: '2026-05-05T08:00:00.000Z' },
+      { taskId: '0xb', taskCid: 'Qmb', solverType: 'prediction.v1', postedAt: '2026-05-05T09:00:00.000Z' },
+      { taskId: '0xc', taskCid: 'Qmc', solverType: 'prediction.v1', postedAt: '2026-05-05T10:00:00.000Z' },
+      { taskId: '0xd', taskCid: 'Qmd', solverType: 'prediction.v1', postedAt: '2026-05-05T11:00:00.000Z' },
+    ];
+    const { app, token, fetchSpy } = buildTestApp({
+      solverNets: { prediction: launchingNet },
+      postedTasks: fixtures,
+    });
+
+    // Page 1: limit=2, no cursor → newest two (0xd, 0xc), cursor = postedAt of 0xc.
+    const page1Res = await app.request('/v1/launcher/tasks?limit=2', {
+      headers: { 'x-jinn-ui-token': token },
+    });
+    expect(page1Res.status).toBe(200);
+    const page1 = (await page1Res.json()) as TasksResponseBody;
+    expect(page1.tasks.map((t) => t.taskId)).toEqual(['0xd', '0xc']);
+    expect(page1.cursor).toBeDefined();
+    expect(page1.cursor?.before).toBe('2026-05-05T10:00:00.000Z');
+
+    // Page 2: pass the cursor back (with the `before:` prefix). Use a
+    // larger limit so the response is partial and the gather function
+    // signals "no further page" by omitting the cursor.
+    const cursorParam = `before:${page1.cursor!.before}`;
+    const page2Res = await app.request(
+      `/v1/launcher/tasks?limit=10&cursor=${encodeURIComponent(cursorParam)}`,
+      { headers: { 'x-jinn-ui-token': token } },
+    );
+    expect(page2Res.status).toBe(200);
+    const page2 = (await page2Res.json()) as TasksResponseBody;
+    expect(page2.tasks.map((t) => t.taskId)).toEqual(['0xb', '0xa']);
+    // Partial page → no cursor.
+    expect(page2.cursor).toBeUndefined();
+    // The fetch dep saw the parsed before timestamp.
+    expect(fetchSpy.lastOpts?.before).toBe('2026-05-05T10:00:00.000Z');
+    expect(fetchSpy.lastOpts?.limit).toBe(10);
+  });
+
+  it('maps unknown solverType to solverNet="unknown" without dropping the row', async () => {
+    const { app, token } = buildTestApp({
+      solverNets: { prediction: launchingNet },
+      postedTasks: [
+        {
+          taskId: '0xa',
+          taskCid: 'Qma',
+          solverType: 'mystery.v1',
+          postedAt: '2026-05-05T10:00:00.000Z',
+        },
+      ],
+    });
+    const res = await app.request('/v1/launcher/tasks', {
+      headers: { 'x-jinn-ui-token': token },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as TasksResponseBody;
+    expect(body.tasks).toHaveLength(1);
+    expect(body.tasks[0]?.solverNet).toBe('unknown');
+  });
+
+  it('clamps limit to [1, 100]', async () => {
+    const { app, token, fetchSpy } = buildTestApp({
+      solverNets: { prediction: launchingNet },
+      postedTasks: [],
+    });
+    await app.request('/v1/launcher/tasks?limit=999', {
+      headers: { 'x-jinn-ui-token': token },
+    });
+    expect(fetchSpy.lastOpts?.limit).toBe(100);
+
+    await app.request('/v1/launcher/tasks?limit=0', {
+      headers: { 'x-jinn-ui-token': token },
+    });
+    expect(fetchSpy.lastOpts?.limit).toBe(1);
+  });
+
+  it('requires auth', async () => {
+    const { app } = buildTestApp({
+      solverNets: { prediction: launchingNet },
+      postedTasks: [],
+    });
+    const res = await app.request('/v1/launcher/tasks');
     expect(res.status).toBe(401);
   });
 });

--- a/client/test/api/launcher-endpoints.test.ts
+++ b/client/test/api/launcher-endpoints.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Launcher mode endpoint tests. Boilerplate matches setup-endpoints.test.ts:
+ * each test stands up a fresh Hono app, registers the launcher routes with
+ * deterministic deps, and asserts the response shape. The gather function
+ * itself is exercised through the route — the route layer is thin enough
+ * that one test surface covers both.
+ *
+ * Spec: spec/2026-05-05-launcher-role-and-mode.md §5.3.
+ */
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import { addLauncherRoutes } from '../../src/api/launcher-endpoints.js';
+import { requireUiToken } from '../../src/api/handshake.js';
+import type { JinnConfig } from '../../src/config.js';
+import type { LauncherGeneratorStateSnapshot } from '../../src/api/launcher-status.js';
+
+const UI_TOKEN = 'ui-token-test';
+const SAFE_ADDRESS = '0x0000000000000000000000000000000000000abc';
+
+interface BuildArgs {
+  solverNets?: JinnConfig['solverNets'];
+  generatorStates?: Record<string, LauncherGeneratorStateSnapshot | undefined>;
+  openTaskCount?: (netName: string) => number;
+  reservedBudgetWei?: (netName: string) => string;
+  safeBalanceWei?: string;
+  now?: number;
+  /** Mount the UI-token gate (mirrors server.ts wiring). */
+  withAuth?: boolean;
+}
+
+function buildTestApp(args: BuildArgs): { app: Hono; token: string } {
+  const app = new Hono();
+  if (args.withAuth ?? true) {
+    app.use('/v1/launcher', requireUiToken(UI_TOKEN));
+    app.use('/v1/launcher/*', requireUiToken(UI_TOKEN));
+  }
+  addLauncherRoutes(app, {
+    getConfig: () => ({ solverNets: args.solverNets ?? {} } as Pick<JinnConfig, 'solverNets'>),
+    getGeneratorState: (name) => args.generatorStates?.[name],
+    getOpenTaskCount: (name) => args.openTaskCount?.(name) ?? 0,
+    getReservedBudgetWei: (name) => args.reservedBudgetWei?.(name) ?? '0',
+    getSafeBalanceWei: () => args.safeBalanceWei ?? '0',
+    safeAddress: SAFE_ADDRESS,
+    now: args.now !== undefined ? () => args.now! : undefined,
+  });
+  return { app, token: UI_TOKEN };
+}
+
+const launchingNet = {
+  enabled: true,
+  solverType: 'prediction.v1',
+  roles: ['launching'] as const,
+  harness: 'claude-code-learner',
+  plugins: [],
+  taskGenerator: { enabled: true },
+} as never;
+
+const solvingNet = {
+  enabled: true,
+  solverType: 'prediction.v1',
+  roles: ['solving'] as const,
+  harness: 'claude-code-learner',
+  plugins: [],
+  taskGenerator: { enabled: true },
+} as never;
+
+describe('GET /v1/launcher/status', () => {
+  it('returns per-net launcher status for nets with launching role', async () => {
+    const { app, token } = buildTestApp({
+      solverNets: { prediction: launchingNet },
+      generatorStates: {
+        prediction: {
+          lastPollAt: '2026-05-05T10:00:00.000Z',
+          lastPollSummary: { evaluated: 12, posted: 3, skipped: 9 },
+          cadenceMs: 6 * 60 * 60 * 1000,
+        },
+      },
+      openTaskCount: () => 7,
+      reservedBudgetWei: () => '1000000000000000000',
+      safeBalanceWei: '5000000000000000000',
+      now: Date.parse('2026-05-05T11:00:00.000Z'),
+    });
+
+    const res = await app.request('/v1/launcher/status', {
+      headers: { 'x-jinn-ui-token': token },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      schemaVersion: number;
+      nets: Array<{
+        name: string;
+        generator: { state: string; cadenceMs: number; stale: boolean; lastPollAt?: string; lastPollSummary?: unknown };
+        openTasks: number;
+        budget: { safeAddress: string; safeBalanceWei: string; reservedBudgetWei: string };
+      }>;
+    };
+    expect(body.schemaVersion).toBe(1);
+    expect(body.nets).toHaveLength(1);
+    expect(body.nets[0]).toMatchObject({
+      name: 'prediction',
+      generator: {
+        state: 'active',
+        cadenceMs: 6 * 60 * 60 * 1000,
+        stale: false,
+        lastPollAt: '2026-05-05T10:00:00.000Z',
+        lastPollSummary: { evaluated: 12, posted: 3, skipped: 9 },
+      },
+      openTasks: 7,
+      budget: {
+        safeAddress: SAFE_ADDRESS,
+        safeBalanceWei: '5000000000000000000',
+        reservedBudgetWei: '1000000000000000000',
+      },
+    });
+  });
+
+  it('omits nets without launching role', async () => {
+    const { app, token } = buildTestApp({
+      solverNets: { prediction: solvingNet },
+    });
+    const res = await app.request('/v1/launcher/status', {
+      headers: { 'x-jinn-ui-token': token },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { nets: unknown[] };
+    expect(body.nets).toEqual([]);
+  });
+
+  it('reports stale=true when lastPollAt is older than 2x cadence', async () => {
+    const cadenceMs = 60_000;
+    const now = Date.parse('2026-05-05T12:00:00.000Z');
+    const { app, token } = buildTestApp({
+      solverNets: { prediction: launchingNet },
+      generatorStates: {
+        prediction: {
+          lastPollAt: new Date(now - 3 * cadenceMs).toISOString(),
+          cadenceMs,
+        },
+      },
+      now,
+    });
+    const res = await app.request('/v1/launcher/status', {
+      headers: { 'x-jinn-ui-token': token },
+    });
+    const body = await res.json() as {
+      nets: Array<{ generator: { stale: boolean; state: string } }>;
+    };
+    expect(body.nets[0]?.generator.stale).toBe(true);
+    // No lastError → still 'active', stale flag is the operator-visible signal.
+    expect(body.nets[0]?.generator.state).toBe('active');
+  });
+
+  it('reports state=errored when the generator surfaced lastError', async () => {
+    const { app, token } = buildTestApp({
+      solverNets: { prediction: launchingNet },
+      generatorStates: {
+        prediction: {
+          lastPollAt: '2026-05-05T10:00:00.000Z',
+          lastError: { message: 'polymarket 503', at: '2026-05-05T10:00:01.000Z' },
+          cadenceMs: 60_000,
+        },
+      },
+      now: Date.parse('2026-05-05T10:00:30.000Z'),
+    });
+    const res = await app.request('/v1/launcher/status', {
+      headers: { 'x-jinn-ui-token': token },
+    });
+    const body = await res.json() as {
+      nets: Array<{ generator: { state: string; lastError?: { message: string } } }>;
+    };
+    expect(body.nets[0]?.generator.state).toBe('errored');
+    expect(body.nets[0]?.generator.lastError?.message).toBe('polymarket 503');
+  });
+
+  it('reports state=paused when no generator state has been recorded yet', async () => {
+    const { app, token } = buildTestApp({
+      solverNets: { prediction: launchingNet },
+      generatorStates: { prediction: undefined },
+    });
+    const res = await app.request('/v1/launcher/status', {
+      headers: { 'x-jinn-ui-token': token },
+    });
+    const body = await res.json() as {
+      nets: Array<{ generator: { state: string; cadenceMs: number; stale: boolean } }>;
+    };
+    expect(body.nets[0]?.generator.state).toBe('paused');
+    expect(body.nets[0]?.generator.cadenceMs).toBe(0);
+    expect(body.nets[0]?.generator.stale).toBe(false);
+  });
+
+  it('requires auth', async () => {
+    const { app } = buildTestApp({
+      solverNets: { prediction: launchingNet },
+    });
+    const res = await app.request('/v1/launcher/status');
+    expect(res.status).toBe(401);
+  });
+});

--- a/client/test/api/prediction-v1-build.test.ts
+++ b/client/test/api/prediction-v1-build.test.ts
@@ -121,6 +121,7 @@ describe('gatherPredictionV1Status', () => {
             name: 'prediction',
             enabled: true,
             solverType: 'prediction.v1',
+            roles: ['solving'],
             harness: 'prediction-v1-baseline',
             taskGeneratorEnabled: true,
           },

--- a/client/test/api/setup-endpoints.test.ts
+++ b/client/test/api/setup-endpoints.test.ts
@@ -710,6 +710,41 @@ describe('POST /v1/setup/solvernets/:name', () => {
 
     expect(res.status).toBe(400);
   });
+
+  it('preserves launching role when operator-mode patch only includes solving/evaluating', async () => {
+    // Operator-mode UI only knows 'solving' | 'evaluating'. Launcher mode
+    // may have set roles to ['solving', 'launching']. When the operator
+    // patches roles to ['evaluating'], the launching role must survive
+    // (strict mode separation per spec/2026-05-05-launcher-role-and-mode.md §3).
+    const dir = mkdtempSync(join(tmpdir(), 'jinn-solvernet-cfg-'));
+    const configPath = join(dir, 'config.json');
+    writeConfig(configPath, {
+      network: 'testnet',
+      rpcUrl: 'https://example/rpc',
+      solverNets: {
+        prediction: {
+          enabled: true,
+          solverType: 'prediction.v0',
+          roles: ['solving', 'launching'],
+          harness: 'claude-code-learner',
+          plugins: [],
+        },
+      },
+    });
+
+    const app = new Hono();
+    addSetupRoutes(app, { configPath });
+
+    const res = await app.request('/v1/setup/solvernets/prediction', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ enabled: true, roles: ['evaluating'] }),
+    });
+
+    expect(res.status).toBe(200);
+    const persisted = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect([...persisted.solverNets.prediction.roles].sort()).toEqual(['evaluating', 'launching']);
+  });
 });
 
 describe('POST /v1/setup/network', () => {

--- a/client/test/api/setup-endpoints.test.ts
+++ b/client/test/api/setup-endpoints.test.ts
@@ -489,11 +489,15 @@ describe('POST /v1/setup/solvernets/:name', () => {
     expect(persisted.solverNets.prediction).toMatchObject({
       enabled: false,
       solverType: 'prediction.v1',
-      role: 'solving',
+      roles: ['solving'],
       harness: 'claude-code-learner',
       plugins: [],
       taskGenerator: { enabled: true },
     });
+    // The default seed must NOT carry the legacy singular `role` field —
+    // we want a clean `roles` shape on disk so future readers don't
+    // disagree about which one wins.
+    expect(persisted.solverNets.prediction.role).toBeUndefined();
   });
 
   it('seeds the default SolverNet when a legacy config lacks solverNets', async () => {
@@ -513,12 +517,15 @@ describe('POST /v1/setup/solvernets/:name', () => {
     expect(res.status).toBe(200);
     const persisted = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(persisted.network).toBe('testnet');
+    // Legacy singular `role: 'evaluating'` body is promoted to the
+    // canonical `roles: ['evaluating']` shape on persist.
     expect(persisted.solverNets.prediction).toMatchObject({
       enabled: true,
       solverType: 'prediction.v1',
-      role: 'evaluating',
+      roles: ['evaluating'],
       harness: 'claude-code-learner',
     });
+    expect(persisted.solverNets.prediction.role).toBeUndefined();
   });
 
   it('swaps solverType and accepts both enabled+solverType in one call', async () => {
@@ -580,7 +587,7 @@ describe('POST /v1/setup/solvernets/:name', () => {
     expect(body.available).toEqual(['prediction']);
   });
 
-  it('accepts role and persists it', async () => {
+  it('accepts a roles array and persists it', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'jinn-solvernet-cfg-'));
     const configPath = join(dir, 'config.json');
     writeConfig(configPath, baseConfig());
@@ -597,13 +604,69 @@ describe('POST /v1/setup/solvernets/:name', () => {
     const res = await app.request('/v1/setup/solvernets/prediction', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ roles: ['solving', 'evaluating'] }),
+    });
+
+    expect(res.status).toBe(200);
+    const persisted = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(persisted.solverNets.prediction.roles).toEqual(['solving', 'evaluating']);
+    expect(observed?.prediction?.roles).toEqual(['solving', 'evaluating']);
+  });
+
+  it('accepts the legacy singular role field and promotes it to roles', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'jinn-solvernet-cfg-'));
+    const configPath = join(dir, 'config.json');
+    writeConfig(configPath, baseConfig());
+
+    const app = new Hono();
+    addSetupRoutes(app, { configPath });
+
+    const res = await app.request('/v1/setup/solvernets/prediction', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ role: 'evaluating' }),
     });
 
     expect(res.status).toBe(200);
     const persisted = JSON.parse(readFileSync(configPath, 'utf-8'));
-    expect(persisted.solverNets.prediction.role).toBe('evaluating');
-    expect(observed?.prediction?.role).toBe('evaluating');
+    expect(persisted.solverNets.prediction.roles).toEqual(['evaluating']);
+    // Legacy `role` is dropped when `roles` is set so the persisted shape
+    // is canonical and there is exactly one source of truth.
+    expect(persisted.solverNets.prediction.role).toBeUndefined();
+  });
+
+  it('rejects an empty roles array', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'jinn-solvernet-cfg-'));
+    const configPath = join(dir, 'config.json');
+    writeConfig(configPath, baseConfig());
+
+    const app = new Hono();
+    addSetupRoutes(app, { configPath });
+
+    const res = await app.request('/v1/setup/solvernets/prediction', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ roles: [] }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a roles array with an unknown role', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'jinn-solvernet-cfg-'));
+    const configPath = join(dir, 'config.json');
+    writeConfig(configPath, baseConfig());
+
+    const app = new Hono();
+    addSetupRoutes(app, { configPath });
+
+    const res = await app.request('/v1/setup/solvernets/prediction', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ roles: ['solving', 'creator'] }),
+    });
+
+    expect(res.status).toBe(400);
   });
 
   it('accepts harness, model, and plugins together', async () => {

--- a/client/test/config.test.ts
+++ b/client/test/config.test.ts
@@ -544,6 +544,78 @@ describe('loadConfig solverNets roles migration', () => {
   });
 });
 
+describe('config: launching role', () => {
+  const dirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  async function writeConfigFile(contents: Record<string, unknown>): Promise<string> {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'jinn-config-'));
+    dirs.push(dir);
+    const configPath = path.join(dir, 'config.json');
+    await writeFile(configPath, JSON.stringify(contents, null, 2));
+    return configPath;
+  }
+
+  it('accepts roles: ["launching"] for a SolverNet', async () => {
+    const configPath = await writeConfigFile({
+      network: 'testnet',
+      rpcUrl: 'https://example/rpc',
+      solverNets: {
+        prediction: {
+          enabled: true,
+          solverType: 'prediction.v1',
+          roles: ['launching'],
+          harness: 'claude-code-learner',
+          model: 'claude-haiku-4-5-20251001',
+          plugins: [],
+        },
+      },
+    });
+    const cfg = loadConfig(configPath);
+    expect(cfg.solverNets['prediction']?.roles).toEqual(['launching']);
+  });
+
+  it('accepts roles: ["solving", "launching"] (multi-role)', async () => {
+    const configPath = await writeConfigFile({
+      network: 'testnet',
+      rpcUrl: 'https://example/rpc',
+      solverNets: {
+        prediction: {
+          enabled: true,
+          solverType: 'prediction.v1',
+          roles: ['solving', 'launching'],
+          harness: 'claude-code-learner',
+          model: 'claude-haiku-4-5-20251001',
+          plugins: [],
+        },
+      },
+    });
+    const cfg = loadConfig(configPath);
+    expect(cfg.solverNets['prediction']?.roles).toEqual(['solving', 'launching']);
+  });
+
+  it('rejects empty roles array', async () => {
+    const configPath = await writeConfigFile({
+      network: 'testnet',
+      rpcUrl: 'https://example/rpc',
+      solverNets: {
+        prediction: {
+          enabled: true,
+          solverType: 'prediction.v1',
+          roles: [],
+          harness: 'claude-code-learner',
+          model: 'claude-haiku-4-5-20251001',
+          plugins: [],
+        },
+      },
+    });
+    expect(() => loadConfig(configPath)).toThrow();
+  });
+});
+
 describe('buildConfigProvenance', () => {
   const dirs: string[] = [];
 

--- a/client/test/config.test.ts
+++ b/client/test/config.test.ts
@@ -538,8 +538,9 @@ describe('loadConfig solverNets roles migration', () => {
     expect(cfg.solverNets['prediction']?.roles).toEqual(['solving', 'evaluating']);
   });
 
-  it('default config seeds prediction with roles: [solving] when no file is provided', () => {
-    const cfg = loadConfig();
+  it('default config seeds prediction with roles: [solving] when no SolverNet config is provided', async () => {
+    const configPath = await writeConfigFile({});
+    const cfg = loadConfig(configPath);
     expect(cfg.solverNets['prediction']?.roles).toEqual(['solving']);
   });
 });

--- a/client/test/config.test.ts
+++ b/client/test/config.test.ts
@@ -383,6 +383,167 @@ describe('loadConfig RPC override handling', () => {
   });
 });
 
+describe('loadConfig solverNets roles migration', () => {
+  const dirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  async function writeConfigFile(contents: Record<string, unknown>): Promise<string> {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'jinn-config-'));
+    dirs.push(dir);
+    const configPath = path.join(dir, 'config.json');
+    await writeFile(configPath, JSON.stringify(contents, null, 2));
+    return configPath;
+  }
+
+  it('migrates a legacy `role: solving` field to `roles: [solving]`', async () => {
+    const configPath = await writeConfigFile({
+      network: 'testnet',
+      rpcUrl: 'https://example/rpc',
+      solverNets: {
+        prediction: {
+          enabled: true,
+          solverType: 'prediction.v1',
+          role: 'solving',
+          harness: 'claude-code-learner',
+          plugins: [],
+        },
+      },
+    });
+    const cfg = loadConfig(configPath);
+    expect(cfg.solverNets['prediction']?.roles).toEqual(['solving']);
+    // Loader output is the canonical shape — the singular `role` does not
+    // re-appear after migration.
+    expect((cfg.solverNets['prediction'] as Record<string, unknown>)?.['role']).toBeUndefined();
+  });
+
+  it('migrates a legacy `role: evaluating` field to `roles: [evaluating]`', async () => {
+    const configPath = await writeConfigFile({
+      network: 'testnet',
+      rpcUrl: 'https://example/rpc',
+      solverNets: {
+        prediction: {
+          enabled: true,
+          solverType: 'prediction.v1',
+          role: 'evaluating',
+          harness: 'claude-code-learner',
+          plugins: [],
+        },
+      },
+    });
+    const cfg = loadConfig(configPath);
+    expect(cfg.solverNets['prediction']?.roles).toEqual(['evaluating']);
+  });
+
+  it('round-trips an explicit `roles: [solving]` config', async () => {
+    const configPath = await writeConfigFile({
+      network: 'testnet',
+      rpcUrl: 'https://example/rpc',
+      solverNets: {
+        prediction: {
+          enabled: true,
+          solverType: 'prediction.v1',
+          roles: ['solving'],
+          harness: 'claude-code-learner',
+          plugins: [],
+        },
+      },
+    });
+    const cfg = loadConfig(configPath);
+    expect(cfg.solverNets['prediction']?.roles).toEqual(['solving']);
+  });
+
+  it('persists both roles when the operator opts into Solver and Evaluator', async () => {
+    const configPath = await writeConfigFile({
+      network: 'testnet',
+      rpcUrl: 'https://example/rpc',
+      solverNets: {
+        prediction: {
+          enabled: true,
+          solverType: 'prediction.v1',
+          roles: ['solving', 'evaluating'],
+          harness: 'claude-code-learner',
+          plugins: [],
+        },
+      },
+    });
+    const cfg = loadConfig(configPath);
+    expect(cfg.solverNets['prediction']?.roles).toEqual(['solving', 'evaluating']);
+  });
+
+  it('prefers `roles` over a stale legacy `role` when both are present', async () => {
+    const configPath = await writeConfigFile({
+      network: 'testnet',
+      rpcUrl: 'https://example/rpc',
+      solverNets: {
+        prediction: {
+          enabled: true,
+          solverType: 'prediction.v1',
+          role: 'evaluating', // legacy stale field
+          roles: ['solving'],
+          harness: 'claude-code-learner',
+          plugins: [],
+        },
+      },
+    });
+    const cfg = loadConfig(configPath);
+    expect(cfg.solverNets['prediction']?.roles).toEqual(['solving']);
+  });
+
+  it('rejects an empty roles array', async () => {
+    const configPath = await writeConfigFile({
+      network: 'testnet',
+      rpcUrl: 'https://example/rpc',
+      solverNets: {
+        prediction: {
+          enabled: true,
+          solverType: 'prediction.v1',
+          roles: [],
+          harness: 'claude-code-learner',
+          plugins: [],
+        },
+      },
+    });
+    let captured: unknown;
+    try {
+      loadConfig(configPath);
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeDefined();
+    // The loader wraps zod errors in ConfigLoadError with structured details;
+    // assert that the underlying validation issue mentions the constraint
+    // that we care about (the operator should see "at least one role").
+    const issues = ((captured as { details?: { issues?: Array<{ message: string }> } }).details?.issues) ?? [];
+    expect(issues.some((issue) => /at least one role/i.test(issue.message))).toBe(true);
+  });
+
+  it('deduplicates roles entries', async () => {
+    const configPath = await writeConfigFile({
+      network: 'testnet',
+      rpcUrl: 'https://example/rpc',
+      solverNets: {
+        prediction: {
+          enabled: true,
+          solverType: 'prediction.v1',
+          roles: ['solving', 'solving', 'evaluating'],
+          harness: 'claude-code-learner',
+          plugins: [],
+        },
+      },
+    });
+    const cfg = loadConfig(configPath);
+    expect(cfg.solverNets['prediction']?.roles).toEqual(['solving', 'evaluating']);
+  });
+
+  it('default config seeds prediction with roles: [solving] when no file is provided', () => {
+    const cfg = loadConfig();
+    expect(cfg.solverNets['prediction']?.roles).toEqual(['solving']);
+  });
+});
+
 describe('buildConfigProvenance', () => {
   const dirs: string[] = [];
 

--- a/client/test/dashboard/spa-config.e2e.test.ts
+++ b/client/test/dashboard/spa-config.e2e.test.ts
@@ -35,7 +35,7 @@ const RUNNING_BOOTSTRAP = {
   solverNets: {
     prediction: {
       enabled: true,
-      role: 'solving',
+      roles: ['solving'],
       harness: 'claude-code-learner',
       model: 'claude-haiku-4-5-20251001',
       plugins: ['jinn-prediction-plugin'],
@@ -50,9 +50,8 @@ const STATUS_PAYLOAD = {
     operator: {
       ok: true,
       enabled: true,
-      role: 'solving',
       diagnostics: [],
-      solverNet: { name: 'prediction', enabled: true },
+      solverNet: { name: 'prediction', enabled: true, roles: ['solving'] },
       nextAction: { description: 'Waiting for Tasks. SolverNet active, Harness loaded.' },
     },
     totals: { observedTasks: 0, activeTaskRuns: 0, solutions: 0, verdicts: 0, failed: 0 },
@@ -145,7 +144,7 @@ async function mockDaemonApi(page: Page): Promise<void> {
         ok: true,
         restartRequired: true,
         name: 'prediction',
-        config: { enabled: true, role: 'evaluating' },
+        config: { enabled: true, roles: ['solving', 'evaluating'] },
       }),
     }),
   );
@@ -155,7 +154,7 @@ async function mockDaemonApi(page: Page): Promise<void> {
   );
 }
 
-test('operator opens Configuration, swaps SolverNet role, sees restart banner', async ({ page }) => {
+test('operator opens Configuration, enables Evaluator role alongside Solver, sees restart banner', async ({ page }) => {
   await mockDaemonApi(page);
   await page.goto(handshakeUrl ?? `http://127.0.0.1:${PORT}/`);
 
@@ -167,9 +166,9 @@ test('operator opens Configuration, swaps SolverNet role, sees restart banner', 
   await expect(page.getByText(/solvernets/i).first()).toBeVisible();
 
   // Open the prediction net body (toggle is on by default per the mocked
-  // bootstrap), then click the Evaluating role and Save.
+  // bootstrap), then check the Evaluator box (Solver stays checked) and Save.
   await expect(page.getByText('prediction').first()).toBeVisible();
-  await page.getByRole('button', { name: /evaluating/i }).click();
+  await page.getByLabel('Evaluator').check();
   await page.getByRole('button', { name: /save changes/i }).click();
 
   // Restart banner appears across both tabs.

--- a/client/test/harnesses/impls/claude-code-learner/default-prediction-agent.test.ts
+++ b/client/test/harnesses/impls/claude-code-learner/default-prediction-agent.test.ts
@@ -2,14 +2,14 @@ import { EventEmitter } from 'node:events';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { loadSolverNets } from '../../../../src/solver-nets/registry.js';
 import { HarnessRegistry } from '../../../../src/harnesses/engine/registry.js';
 import { ClaudeCodeLearnerImpl } from '../../../../src/harnesses/impls/claude-code-learner/index.js';
 import { ClaudeCodeHarnessAdapter } from '../../../../src/harnesses/impls/claude-code-learner/adapters/claude-code.js';
 import { NoOpHarnessAdapter } from '../../../../src/harnesses/impls/claude-code-learner/test-utils/noop-adapter.js';
+import { PredictionV1BaselineImpl } from '../../../../src/harnesses/impls/prediction-v1-baseline/index.js';
 import { makePredictionV1Task } from '../prediction-v1-test-helpers.js';
-import { makeHarnessCtx } from '@test/harness-ctx.js';
 
 function readJson(path: string): Record<string, unknown> {
   return JSON.parse(readFileSync(path, 'utf8')) as Record<string, unknown>;
@@ -21,15 +21,7 @@ function toolList(manifest: Record<string, unknown>): string[] {
 }
 
 describe('default prediction agent runtime plugins', () => {
-  const tmpDirs: string[] = [];
-
-  afterEach(() => {
-    for (const dir of tmpDirs.splice(0)) {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it('routes prediction.v1 to the default learner with Network Tools and Prediction plugin surfaces', async () => {
+  it('routes prediction.v1 to the specialist harness with Network Tools and Prediction plugin surfaces', async () => {
     const registry = await loadSolverNets({
       solverNets: {
         prediction: {
@@ -51,30 +43,12 @@ describe('default prediction agent runtime plugins', () => {
     });
     const adapter = new NoOpHarnessAdapter();
     const learner = new ClaudeCodeLearnerImpl({ adapter });
+    harnessRegistry.register(new PredictionV1BaselineImpl());
     harnessRegistry.register(learner);
 
     expect(harnessRegistry.findFor({ solverType: 'prediction.v1', role: 'restoration' })?.name)
-      .toBe('claude-code-learner');
-
-    const workingDir = mkdtempSync(join(tmpdir(), 'jinn-default-prediction-work-'));
-    const implStateDir = mkdtempSync(join(tmpdir(), 'jinn-default-prediction-state-'));
-    tmpDirs.push(workingDir, implStateDir);
-
-    await learner.run(makeHarnessCtx({
-      task: makePredictionV1Task(),
-      workingDir,
-      implStateDir,
-      extra: {
-        solverNet: { name: net!.name, solverType: net!.solverType, model: net!.model },
-        runtimePlugins: net!.runtimePlugins,
-        solverPluginRoots: net!.runtimePlugins.map((plugin) => plugin.root),
-      },
-    }));
-
-    const invocation = adapter.getInvocations()[0];
-    expect(invocation?.inputs.solverType).toBe('prediction.v1');
-    expect(invocation?.inputs.claudeModel).toBe('claude-opus-test');
-    expect(invocation?.inputs.pluginRoots).toEqual(net!.runtimePlugins.map((plugin) => plugin.root));
+      .toBe('prediction-v1-baseline');
+    expect(adapter.getInvocations()).toHaveLength(0);
 
     const pluginNames = net!.runtimePlugins.map((plugin) => plugin.name);
     expect(pluginNames).toEqual([

--- a/client/test/solver-nets/contracts.test.ts
+++ b/client/test/solver-nets/contracts.test.ts
@@ -2,7 +2,11 @@ import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { JINN_NETWORK_TOOLS_PLUGIN, loadSolverNets } from '../../src/solver-nets/registry.js';
+import {
+  JINN_NETWORK_TOOLS_PLUGIN,
+  loadSolverNets,
+  taskRoleForOperatorRole,
+} from '../../src/solver-nets/registry.js';
 import { SOLVER_NET_CONTRACTS } from '../../src/solver-nets/contracts.js';
 import { makePredictionV1Task } from '../harnesses/impls/prediction-v1-test-helpers.js';
 
@@ -240,5 +244,39 @@ describe('SolverNet contracts', () => {
         },
       }),
     ).rejects.toThrow(/runtime plugin .* solverType mismatch/);
+  });
+
+  // Direct coverage for the launching-role guard added in a86f075f.
+  // 'launching' is an operator-side launcher loop, not a Task-claiming role,
+  // so it must not map to a SolverNetTaskRole and must not satisfy any
+  // taskRole filter on `forSolverType`. Once Task 4 wires the launcher
+  // runtime gate, a misread here could accidentally enable or suppress
+  // solver loops — so pin both sides of the boundary explicitly.
+  it("taskRoleForOperatorRole('launching') returns undefined", () => {
+    expect(taskRoleForOperatorRole('launching')).toBeUndefined();
+  });
+
+  it("taskRoleForOperatorRole maps solving/evaluating to their task roles", () => {
+    expect(taskRoleForOperatorRole('solving')).toBe('restoration');
+    expect(taskRoleForOperatorRole('evaluating')).toBe('evaluation');
+  });
+
+  it('forSolverType returns undefined for a launching-only SolverNet when filtering by restoration', async () => {
+    const registry = await loadSolverNets({
+      solverNets: {
+        prediction: {
+          enabled: true,
+          solverType: 'prediction.v1',
+          roles: ['launching'],
+          harness: 'prediction-v1-baseline',
+          plugins: ['bundled:jinn-prediction-plugin'],
+          taskGenerator: { enabled: true },
+        },
+      },
+    });
+    expect(registry.forSolverType('prediction.v1', 'restoration')).toBeUndefined();
+    expect(registry.forSolverType('prediction.v1', 'evaluation')).toBeUndefined();
+    // The net is still registered — it just doesn't match Task-claiming filters.
+    expect(registry.forSolverType('prediction.v1')?.roles).toEqual(['launching']);
   });
 });

--- a/client/test/solver-nets/contracts.test.ts
+++ b/client/test/solver-nets/contracts.test.ts
@@ -44,7 +44,7 @@ describe('SolverNet contracts', () => {
         prediction: {
           enabled: true,
           solverType: 'prediction.v1',
-          role: 'evaluating',
+          roles: ['evaluating'],
           harness: 'prediction-v1-baseline',
           model: 'claude-opus-test',
           plugins: ['bundled:jinn-prediction-plugin'],
@@ -53,9 +53,11 @@ describe('SolverNet contracts', () => {
       },
     });
     const net = registry.forSolverType('prediction.v1', 'evaluation');
+    // Evaluator-only nets must NOT be returned for restoration tasks —
+    // the daemon's task acceptance gate relies on this filter.
     expect(registry.forSolverType('prediction.v1', 'restoration')).toBeUndefined();
     expect(net).toMatchObject({
-      role: 'evaluating',
+      roles: ['evaluating'],
       model: 'claude-opus-test',
     });
     expect(net?.contract.evaluationFunction.id).toBe('prediction.brier-loss.v1');
@@ -72,6 +74,61 @@ describe('SolverNet contracts', () => {
       provenance: 'default',
       supports: ['prediction.v1'],
     });
+  });
+
+  it('returns the SolverNet for both restoration and evaluation when both roles are active', async () => {
+    const registry = await loadSolverNets({
+      solverNets: {
+        prediction: {
+          enabled: true,
+          solverType: 'prediction.v1',
+          roles: ['solving', 'evaluating'],
+          harness: 'prediction-v1-baseline',
+          plugins: ['bundled:jinn-prediction-plugin'],
+          taskGenerator: { enabled: true },
+        },
+      },
+    });
+    const restoreNet = registry.forSolverType('prediction.v1', 'restoration');
+    const evalNet = registry.forSolverType('prediction.v1', 'evaluation');
+    expect(restoreNet?.name).toBe('prediction');
+    expect(evalNet?.name).toBe('prediction');
+    expect(restoreNet?.roles).toEqual(['solving', 'evaluating']);
+    expect(evalNet?.roles).toEqual(['solving', 'evaluating']);
+  });
+
+  it('returns the SolverNet only for restoration when only solving is active', async () => {
+    const registry = await loadSolverNets({
+      solverNets: {
+        prediction: {
+          enabled: true,
+          solverType: 'prediction.v1',
+          roles: ['solving'],
+          harness: 'prediction-v1-baseline',
+          plugins: ['bundled:jinn-prediction-plugin'],
+          taskGenerator: { enabled: true },
+        },
+      },
+    });
+    expect(registry.forSolverType('prediction.v1', 'restoration')?.name).toBe('prediction');
+    expect(registry.forSolverType('prediction.v1', 'evaluation')).toBeUndefined();
+  });
+
+  it('falls back to roles=[solving] when neither roles nor role is set', async () => {
+    const registry = await loadSolverNets({
+      solverNets: {
+        prediction: {
+          enabled: true,
+          solverType: 'prediction.v1',
+          harness: 'prediction-v1-baseline',
+          plugins: ['bundled:jinn-prediction-plugin'],
+          taskGenerator: { enabled: true },
+        },
+      },
+    });
+    const net = registry.forSolverType('prediction.v1', 'restoration');
+    expect(net?.roles).toEqual(['solving']);
+    expect(registry.forSolverType('prediction.v1', 'evaluation')).toBeUndefined();
   });
 
   it('does not duplicate Network Tools if it is configured explicitly', async () => {

--- a/client/test/solver-types/prediction-v1-auto-role-gate.test.ts
+++ b/client/test/solver-types/prediction-v1-auto-role-gate.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest';
+import { makePredictionV1Generator } from '../../src/solver-types/prediction-v1-auto.js';
+
+/**
+ * Hot-spawn role gate (Task 4 of spec/2026-05-05-launcher-role-and-mode.md).
+ *
+ * Always-spawn the generator; gate the actual Polymarket poll inside the
+ * generator's tick on `roles.includes('launching')`. Toggling `'launching'`
+ * in or out of `roles` must take effect within one cadence — no daemon
+ * restart. The closure-based `getRoles` config callback is what makes the
+ * hot-flip work: a single generator instance reads the latest role array
+ * from the live `JinnConfig` reference.
+ *
+ * The generator polls Polymarket via `fetchImpl`. We assert no HTTP traffic
+ * happens when `'launching'` is not in roles, and that traffic happens when
+ * it is — same instance, no recreation.
+ */
+describe('prediction-v1-auto: role gate', () => {
+  it('does not poll Polymarket when roles does not include launching', async () => {
+    const fetchSpy = vi.fn(async () => new Response('[]', { status: 200, headers: { 'content-type': 'application/json' } })) as unknown as typeof fetch;
+    const gen = makePredictionV1Generator({
+      fetchImpl: fetchSpy,
+      cadenceMs: 0,
+      getRoles: () => ['solving'], // operator-only, no launching
+    });
+    const result = await gen();
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('polls Polymarket when roles includes launching', async () => {
+    const fetchSpy = vi.fn(async () => new Response('[]', { status: 200, headers: { 'content-type': 'application/json' } })) as unknown as typeof fetch;
+    const gen = makePredictionV1Generator({
+      fetchImpl: fetchSpy,
+      cadenceMs: 0,
+      getRoles: () => ['launching'],
+    });
+    await gen();
+    expect((fetchSpy as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0);
+  });
+
+  it('hot-flips: same instance gates poll behaviour as roles change', async () => {
+    let roles: Array<'solving' | 'evaluating' | 'launching'> = ['solving'];
+    const fetchSpy = vi.fn(async () => new Response('[]', { status: 200, headers: { 'content-type': 'application/json' } })) as unknown as typeof fetch;
+    const gen = makePredictionV1Generator({
+      fetchImpl: fetchSpy,
+      cadenceMs: 0,
+      getRoles: () => roles,
+    });
+
+    await gen();
+    expect((fetchSpy as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+
+    // Operator flips role on at runtime — no generator recreation.
+    roles = ['launching'];
+    await gen();
+    expect((fetchSpy as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0);
+
+    const callsAfterEnable = (fetchSpy as unknown as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    // Operator flips role off again — generator must stop polling on next tick.
+    roles = ['solving'];
+    await gen();
+    expect((fetchSpy as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(callsAfterEnable);
+  });
+
+  it('absent getRoles defaults to ungated (back-compat for callers that do not pass it)', async () => {
+    // If no role-getter is provided, the generator polls — preserves the
+    // existing public API for the parse/registry tests that build the
+    // generator directly without the hot-spawn wiring.
+    const fetchSpy = vi.fn(async () => new Response('[]', { status: 200, headers: { 'content-type': 'application/json' } })) as unknown as typeof fetch;
+    const gen = makePredictionV1Generator({
+      fetchImpl: fetchSpy,
+      cadenceMs: 0,
+    });
+    await gen();
+    expect((fetchSpy as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0);
+  });
+});

--- a/client/test/solver-types/prediction-v1-auto.test.ts
+++ b/client/test/solver-types/prediction-v1-auto.test.ts
@@ -171,6 +171,33 @@ describe('prediction.v1 auto-generator', () => {
     expect((fetchImpl as any).mock.calls.filter((call: unknown[]) => String(call[0]).includes('/markets'))).toHaveLength(3);
   });
 
+  it('hot-applies cadence changes on the same generator instance', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const fetchImpl = fetchFixture(
+      [market('abc', 'yes-abc')],
+      { 'yes-abc': book('0.60', '0.64') },
+    );
+    let liveConfig = { cadenceMs: 6 * 60 * 60 * 1000 };
+    const generator = makePredictionV1Generator({
+      fetchImpl,
+      cadenceMs: 6 * 60 * 60 * 1000,
+      getConfig: () => liveConfig,
+    });
+
+    await generator();
+    await generator();
+    const marketListCalls = () =>
+      (fetchImpl as any).mock.calls.filter((call: unknown[]) => new URL(String(call[0])).pathname === '/markets');
+    expect(marketListCalls()).toHaveLength(1);
+
+    liveConfig = { cadenceMs: 0 };
+    await generator();
+
+    expect(marketListCalls()).toHaveLength(2);
+    expect(generator.getState().cadenceMs).toBe(0);
+  });
+
   it('prioritizes valid allowlisted markets when per-poll caps bind', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(NOW);
@@ -196,6 +223,70 @@ describe('prediction.v1 auto-generator', () => {
     expect(tasks).toHaveLength(1);
     expect(tasks![0].spec?.source).toMatchObject({ identifiers: { conditionId: '0xmanual' } });
     expect(tasks![0].eligibility).toMatchObject({ manualAllowlistHit: true });
+  });
+
+  it('hot-applies caps, allow/block lists, and submission window between ticks', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const fetchImpl = fetchFixture(
+      [
+        market('liquid', 'yes-liquid', { liquidity: '90000' }),
+        market('manual', 'yes-manual', { liquidity: '12000' }),
+        market('later', 'yes-later', { liquidity: '13000' }),
+      ],
+      {
+        'yes-liquid': book('0.60', '0.64'),
+        'yes-manual': book('0.51', '0.55'),
+        'yes-later': book('0.52', '0.56'),
+      },
+    );
+    let liveConfig = {
+      cadenceMs: 0,
+      maxNewRoundsPerPoll: 1,
+      maxNewRoundsPerDay: 5,
+      maxOpenRounds: 5,
+      allowlistConditionIds: ['0xmanual'],
+      blocklistConditionIds: ['0xlater'],
+      submissionWindowMs: 10_000,
+    };
+    const generator = makePredictionV1Generator({
+      fetchImpl,
+      getConfig: () => liveConfig,
+    });
+
+    const first = await generator();
+    expect(first).toHaveLength(1);
+    expect(first![0].spec?.source).toMatchObject({ identifiers: { conditionId: '0xmanual' } });
+    expect(first![0].window!.endTs - first![0].window!.startTs).toBe(10_000);
+    expect(first![0].eligibility).toMatchObject({
+      generatorCadenceMs: 0,
+      maxNewRoundsPerPoll: 1,
+      maxNewRoundsPerDay: 5,
+      maxOpenRounds: 5,
+      manualAllowlistHit: true,
+    });
+
+    liveConfig = {
+      cadenceMs: 0,
+      maxNewRoundsPerPoll: 2,
+      maxNewRoundsPerDay: 6,
+      maxOpenRounds: 6,
+      allowlistConditionIds: ['0xlater'],
+      blocklistConditionIds: ['0xliquid'],
+      submissionWindowMs: 20_000,
+    };
+    const second = await generator();
+
+    expect(second).toHaveLength(1);
+    expect(second![0].spec?.source).toMatchObject({ identifiers: { conditionId: '0xlater' } });
+    expect(second![0].window!.endTs - second![0].window!.startTs).toBe(20_000);
+    expect(second![0].eligibility).toMatchObject({
+      generatorCadenceMs: 0,
+      maxNewRoundsPerPoll: 2,
+      maxNewRoundsPerDay: 6,
+      maxOpenRounds: 6,
+      manualAllowlistHit: true,
+    });
   });
 
   it('keeps blocklist above allowlist and does not let allowlist bypass validation', async () => {

--- a/client/test/solver-types/registry.test.ts
+++ b/client/test/solver-types/registry.test.ts
@@ -228,24 +228,29 @@ describe('SOLVER_TYPES manifest', () => {
     await expect(SOLVER_TYPES['prediction.v1']!.parseSpec(raw)).rejects.toThrow();
   });
 
-  it('collectTestnetAutoTaskGenerators leaves Polymarket disabled for ordinary operators', () => {
+  it('collectTestnetAutoTaskGenerators always spawns the Polymarket generator on testnet (role-gated at tick time)', () => {
+    // spec/2026-05-05-launcher-role-and-mode.md §5.2 — hot-spawn. The
+    // generator is registered unconditionally on testnet; the runtime
+    // `roles.includes('launching')` check inside its tick is what controls
+    // whether work happens. Ordinary operator daemons (no 'launching' role)
+    // will have a registered generator that no-ops on each tick.
     const { generators, logLines } = collectTestnetAutoTaskGenerators({
       network: 'testnet',
       rpcUrl: 'https://sepolia.base.org',
       autoTasksDisabled: false,
       env: {},
     });
-    expect(generators.map((g) => g.solverType)).not.toContain('prediction.v1');
-    expect(logLines.some((l) => l.includes('prediction.v1'))).toBe(false);
+    expect(generators.map((g) => g.solverType)).toContain('prediction.v1');
+    expect(logLines.some((l) => l.includes('prediction.v1'))).toBe(true);
   });
 
-  it('collectTestnetAutoTaskGenerators keeps disable-all ahead of launcher opt-in', () => {
+  it('collectTestnetAutoTaskGenerators keeps disable-all ahead of role-gated spawn', () => {
     const { generators, logLines } = collectTestnetAutoTaskGenerators({
       network: 'testnet',
       rpcUrl: 'https://sepolia.base.org',
       autoTasksDisabled: true,
       env: { JINN_ENABLE_APY_AUTO_TASKS: '1' },
-      predictionV1LauncherEnabled: true,
+      getPredictionRoles: () => ['launching'],
     });
     expect(generators).toEqual([]);
     expect(logLines).toEqual([]);
@@ -257,7 +262,7 @@ describe('SOLVER_TYPES manifest', () => {
       rpcUrl: 'https://sepolia.base.org',
       autoTasksDisabled: false,
       env: { JINN_ENABLE_APY_AUTO_TASKS: '1' },
-      predictionV1LauncherEnabled: true,
+      getPredictionRoles: () => ['launching'],
     });
     expect(generators.length).toBe(2);
     expect(generators.map((g) => g.solverType)).toEqual(['prediction.v1', 'prediction.apy.v0']);
@@ -290,7 +295,7 @@ describe('SOLVER_TYPES manifest', () => {
       agentEoa: account.address as `0x${string}`,
       safeAddress,
       agentPrivateKey: pk,
-      predictionV1LauncherEnabled: true,
+      getPredictionRoles: () => ['launching'],
       predictionV1WindowMs: 60 * 60 * 1000,
     });
     const prediction = generators.find((g) => g.solverType === 'prediction.v1');
@@ -370,7 +375,7 @@ describe('SOLVER_TYPES manifest', () => {
       rpcUrl: 'https://sepolia.base.org',
       autoTasksDisabled: false,
       env: {},
-      predictionV1LauncherEnabled: true,
+      getPredictionRoles: () => ['launching'],
       predictionV1WindowMs: 30 * 60 * 1000,
       predictionV1CadenceMs: 67890,
       predictionV1MaxNewRoundsPerPoll: 3,

--- a/client/test/solver-types/registry.test.ts
+++ b/client/test/solver-types/registry.test.ts
@@ -241,7 +241,31 @@ describe('SOLVER_TYPES manifest', () => {
       env: {},
     });
     expect(generators.map((g) => g.solverType)).toContain('prediction.v1');
-    expect(logLines.some((l) => l.includes('prediction.v1'))).toBe(true);
+    expect(logLines.some((l) => l.includes('auto-task generator registered: prediction.v1'))).toBe(true);
+  });
+
+  it('logs prediction.v1 generator startup as active only when launching role is present', () => {
+    const inactive = collectTestnetAutoTaskGenerators({
+      network: 'testnet',
+      rpcUrl: 'https://sepolia.base.org',
+      autoTasksDisabled: false,
+      env: {},
+      getPredictionRoles: () => ['solving'],
+    });
+    expect(inactive.logLines).toContain(
+      '[main] auto-task generator registered: prediction.v1 (testnet; inactive until launching role present)',
+    );
+
+    const active = collectTestnetAutoTaskGenerators({
+      network: 'testnet',
+      rpcUrl: 'https://sepolia.base.org',
+      autoTasksDisabled: false,
+      env: {},
+      getPredictionRoles: () => ['launching'],
+    });
+    expect(active.logLines).toContain(
+      '[main] auto-task generator active: prediction.v1 (testnet; launching role present)',
+    );
   });
 
   it('collectTestnetAutoTaskGenerators keeps disable-all ahead of role-gated spawn', () => {

--- a/client/test/store/store.test.ts
+++ b/client/test/store/store.test.ts
@@ -133,4 +133,79 @@ describe('Store', () => {
       postCount: 1,
     });
   });
+
+  it('lists posted tasks by creator with solverType denormalised from activity_events', () => {
+    const creator = '0x00112233445566778899AABbCCdDeeFf00112233';
+    // Insert two posts at different timestamps. The accessor returns rows in
+    // last_posted_at DESC order so the most recent should be first.
+    store.upsertTaskPostRecord({
+      creatorSafeAddress: creator,
+      sourceKey: 'auto:prediction.v1:0xa',
+      policyType: 'once_per_bucket',
+      scopeKey: 'a',
+      taskId: 'task-a',
+      taskCid: 'Qma',
+      requestId: 'req-a',
+      firstPostedAt: '2026-05-05T10:00:00.000Z',
+      lastPostedAt: '2026-05-05T10:00:00.000Z',
+      postCount: 1,
+    });
+    store.upsertTaskPostRecord({
+      creatorSafeAddress: creator,
+      sourceKey: 'auto:prediction.v1:0xb',
+      policyType: 'once_per_bucket',
+      scopeKey: 'b',
+      taskId: 'task-b',
+      taskCid: 'Qmb',
+      requestId: 'req-b',
+      firstPostedAt: '2026-05-05T11:00:00.000Z',
+      lastPostedAt: '2026-05-05T11:00:00.000Z',
+      postCount: 1,
+    });
+    // Mirror the daemon's `task_posted` event so the JOIN populates solver_type.
+    store.recordActivityEvent({
+      ts: '2026-05-05T10:00:00.000Z',
+      kind: 'task_posted',
+      requestId: 'req-a',
+      solverType: 'prediction.v1',
+    });
+    store.recordActivityEvent({
+      ts: '2026-05-05T11:00:00.000Z',
+      kind: 'task_posted',
+      requestId: 'req-b',
+      solverType: 'prediction.v1',
+    });
+
+    const all = store.listPostedTasksByCreator({ creatorSafeAddress: creator, limit: 10 });
+    expect(all).toHaveLength(2);
+    expect(all[0]?.taskId).toBe('task-b');
+    expect(all[0]?.solverType).toBe('prediction.v1');
+    expect(all[1]?.taskId).toBe('task-a');
+
+    const paged = store.listPostedTasksByCreator({
+      creatorSafeAddress: creator,
+      limit: 10,
+      before: '2026-05-05T11:00:00.000Z',
+    });
+    expect(paged).toHaveLength(1);
+    expect(paged[0]?.taskId).toBe('task-a');
+
+    const wrongCreator = store.listPostedTasksByCreator({
+      creatorSafeAddress: '0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead',
+      limit: 10,
+    });
+    expect(wrongCreator).toEqual([]);
+
+    const count = store.countPostedTasksByCreatorAndSolverType({
+      creatorSafeAddress: creator,
+      solverType: 'prediction.v1',
+    });
+    expect(count).toBe(2);
+
+    const otherSolverType = store.countPostedTasksByCreatorAndSolverType({
+      creatorSafeAddress: creator,
+      solverType: 'mystery.v1',
+    });
+    expect(otherSolverType).toBe(0);
+  });
 });

--- a/client/test/tasks/generated-source-gate.test.ts
+++ b/client/test/tasks/generated-source-gate.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { generatedTaskSourceSupported } from '../../src/tasks/generated-source-gate.js';
+
+describe('generatedTaskSourceSupported', () => {
+  it('registers launcher-owned generators even when legacy enabled is false', () => {
+    expect(
+      generatedTaskSourceSupported(
+        {
+          prediction: {
+            enabled: false,
+            solverType: 'prediction.v1',
+            roles: ['solving', 'launching'],
+            taskGenerator: { enabled: true },
+          },
+        },
+        'prediction.v1',
+      ),
+    ).toBe(true);
+  });
+
+  it('does not register disabled legacy generators without launching role', () => {
+    expect(
+      generatedTaskSourceSupported(
+        {
+          predictionApy: {
+            enabled: false,
+            solverType: 'prediction.apy.v0',
+            roles: ['solving'],
+            taskGenerator: { enabled: true },
+          },
+        },
+        'prediction.apy.v0',
+      ),
+    ).toBe(false);
+  });
+
+  it('preserves the legacy enabled solving gate', () => {
+    expect(
+      generatedTaskSourceSupported(
+        {
+          prediction: {
+            enabled: true,
+            solverType: 'prediction.v1',
+            roles: ['solving'],
+            taskGenerator: { enabled: true },
+          },
+        },
+        'prediction.v1',
+      ),
+    ).toBe(true);
+  });
+
+  it('does not let evaluator-only nets create restoration tasks', () => {
+    expect(
+      generatedTaskSourceSupported(
+        {
+          prediction: {
+            enabled: true,
+            solverType: 'prediction.v1',
+            roles: ['evaluating'],
+            taskGenerator: { enabled: true },
+          },
+        },
+        'prediction.v1',
+      ),
+    ).toBe(false);
+  });
+
+  it('requires task generation to be enabled', () => {
+    expect(
+      generatedTaskSourceSupported(
+        {
+          prediction: {
+            enabled: false,
+            solverType: 'prediction.v1',
+            roles: ['launching'],
+            taskGenerator: { enabled: false },
+          },
+        },
+        'prediction.v1',
+      ),
+    ).toBe(false);
+  });
+});

--- a/docs/superpowers/plans/2026-05-05-launcher-role-and-mode-plan.md
+++ b/docs/superpowers/plans/2026-05-05-launcher-role-and-mode-plan.md
@@ -1,0 +1,1646 @@
+# Launcher Role & Launcher Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Promote the Polymarket generator's `predictionV1LauncherEnabled` boolean to a first-class `'launching'` role in the multi-role daemon shipped in `jinn-mono-l2zl.15.4.8`, and add a Launcher mode to the operator app (Airbnb-style two-state mode switch in the header) so the Jinn team can run the Prediction launcher day-1 from the same operator app, with strict information separation between Operator and Launcher modes.
+
+**Architecture:** Daemon side — extend per-SolverNet `roles` enum to include `'launching'`, hot-spawn the generator loop based on a tick-time role check (no daemon restart on toggle), filter `'launching'` out of the operator-status payload at the boundary, and add three launcher endpoints (`/v1/launcher/status`, `/v1/launcher/tasks`, `/v1/launcher/solvernets/:name`). SPA side — header mode switch persisted to localStorage, two new routes (`/launcher` and `/launcher/configuration`), an empty-state with setup flow, a four-tier configured-state overview (knowledge production / cost / generator status / Phase B+ emissions placeholder), and a generator config page. One identity / one Safe / one bootstrap reused unchanged.
+
+**Tech Stack:** TypeScript, Vitest, React 18, Wouter (SPA routing), Hono (daemon HTTP), Zod (config), JetBrains Mono + existing CSS variable design system.
+
+**Spec:** `spec/2026-05-05-launcher-role-and-mode.md`
+
+---
+
+## File Structure
+
+### Daemon — modified
+- `client/src/config.ts` — extend `roles` zod union to include `'launching'`; remove `predictionV1LauncherEnabled` boolean (and its env-var binding); generator config keys (`predictionV1*`) stay
+- `client/src/api/setup-endpoints.ts` — operator-mode setup endpoint (`POST /v1/setup/solvernets/:name`) preserves any existing `'launching'` role across operator-only patches
+- `client/src/api/gather-status.ts` — narrow the operator-status payload's `operator.solverNet.roles` to exclude `'launching'` (filter at the boundary)
+- `client/src/main.ts` — replace startup-time `predictionV1LauncherEnabled` check with runtime `roles.includes('launching')` gate inside the generator loop
+- `client/src/solver-types/prediction-v1-auto.ts` — expose `getGeneratorState()` returning last-poll summary, errors, cadence so the launcher status endpoint can read it
+- `client/src/api/server.ts` — register launcher routes module
+
+### Daemon — created
+- `client/src/api/launcher-endpoints.ts` — all `/v1/launcher/*` Hono routes
+- `client/src/api/launcher-status.ts` — gather per-SolverNet generator + budget state into `LauncherStatusResponse`
+- `client/src/api/launcher-tasks.ts` — query Tasks posted by this daemon's creator address into `LauncherTasksResponse`
+
+### Daemon — tests
+- `client/test/config.test.ts` — extend with `'launching'` role cases
+- `client/test/api/setup-endpoints.test.ts` — extend with role-preservation tests
+- `client/test/api/gather-status.test.ts` — extend with operator-payload narrowing tests (or add file if absent)
+- `client/test/api/launcher-endpoints.test.ts` — new
+- `client/test/solver-types/prediction-v1-auto-state.test.ts` — new (or extend existing if present)
+
+### SPA — modified
+- `client/src/dashboard/spa/src/api/types.ts` — narrow `operator.solverNet.roles`; add `LauncherStatusResponse`, `LauncherTasksResponse`, `LauncherSolverNetPatch`
+- `client/src/dashboard/spa/src/api/client.ts` — add `fetchLauncherStatus`, `fetchLauncherTasks`, `patchLauncherSolverNet`
+- `client/src/dashboard/spa/src/App.tsx` — register `/launcher` and `/launcher/configuration` routes
+- `client/src/dashboard/spa/src/shell/Header.tsx` — render the new `ModeSwitch` component
+- `client/src/dashboard/spa/src/App.routing.test.tsx` — extend to cover the launcher routes
+
+### SPA — created
+- `client/src/dashboard/spa/src/shell/ModeSwitch.tsx` — two-state header toggle
+- `client/src/dashboard/spa/src/shell/useAppMode.ts` — `localStorage`-backed hook
+- `client/src/dashboard/spa/src/pages/Launcher.tsx` — overview page (empty state + configured state composition)
+- `client/src/dashboard/spa/src/pages/LauncherConfiguration.tsx` — generator-config page
+- `client/src/dashboard/spa/src/pages/launcher/EmptyState.tsx`
+- `client/src/dashboard/spa/src/pages/launcher/SetupFlow.tsx`
+- `client/src/dashboard/spa/src/pages/launcher/KnowledgeProductionCard.tsx` (tier 1)
+- `client/src/dashboard/spa/src/pages/launcher/CostCard.tsx` (tier 2)
+- `client/src/dashboard/spa/src/pages/launcher/GeneratorStatusCard.tsx` (tier 3, includes stale banner)
+- `client/src/dashboard/spa/src/pages/launcher/PostedTasksList.tsx` (tier 3)
+- `client/src/dashboard/spa/src/pages/launcher/EmissionsPlaceholder.tsx` (tier 4 — Phase B+ stub)
+- `client/src/dashboard/spa/src/pages/launcher/GeneratorConfigSection.tsx`
+
+### SPA — tests
+- One co-located `*.test.tsx` per new component, plus `useAppMode.test.ts`. Existing test conventions apply (Vitest + Testing Library).
+
+---
+
+## Conventions
+
+- TDD per task: write the failing test first, run it to confirm failure, write minimal implementation, run to confirm pass, commit.
+- Each task ends with `git add <files> && git commit -m "<conventional-commit-message>"`.
+- Use existing CSS variables (`var(--bg)`, `var(--border)`, `var(--fg)`, `var(--fg-muted)`, `var(--fg-dim)`, `var(--accent-sky)`, `var(--vow-green)`, `var(--break-red)`) and JetBrains Mono. Follow patterns in `client/src/dashboard/spa/src/pages/configuration/NetCard.tsx` and `client/src/dashboard/spa/src/pages/overview/OperatorCard.tsx`.
+- Reusable building blocks: `client/src/dashboard/spa/src/components/{SectionCard,ConfigField,RestartPill}.tsx`.
+- TypeScript strict; never `any`. Zod is the authority for runtime validation in `client/src/config.ts`.
+- Test runner is Vitest. Run via `cd client && yarn vitest run <path>` or directly `npx tsc --noEmit` for typecheck.
+
+---
+
+## Task 1: Extend `roles` schema to include `'launching'`
+
+**Files:**
+- Modify: `client/src/config.ts` (the zod schema and preprocess block currently accepting `'solving' | 'evaluating'`)
+- Test: `client/test/config.test.ts`
+
+- [ ] **Step 1: Write failing test in `client/test/config.test.ts`**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { loadConfigFromObject } from '../src/config.js'; // adjust to actual export name
+
+describe('config: launching role', () => {
+  it('accepts roles: ["launching"] for a SolverNet', () => {
+    const cfg = loadConfigFromObject({
+      solverNets: { prediction: { enabled: true, roles: ['launching'], harness: 'claude-code-learner', model: 'claude-haiku-4-5-20251001', plugins: [] } },
+    });
+    expect(cfg.solverNets!.prediction!.roles).toEqual(['launching']);
+  });
+
+  it('accepts roles: ["solving", "launching"] (multi-role)', () => {
+    const cfg = loadConfigFromObject({
+      solverNets: { prediction: { enabled: true, roles: ['solving', 'launching'], harness: 'claude-code-learner', model: 'claude-haiku-4-5-20251001', plugins: [] } },
+    });
+    expect(cfg.solverNets!.prediction!.roles).toEqual(['solving', 'launching']);
+  });
+
+  it('rejects empty roles array', () => {
+    expect(() => loadConfigFromObject({
+      solverNets: { prediction: { enabled: true, roles: [], harness: 'claude-code-learner', model: 'claude-haiku-4-5-20251001', plugins: [] } },
+    })).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm failure**
+
+Run: `cd client && npx vitest run test/config.test.ts -t "launching role"`
+Expected: FAIL — `'launching'` not in role union.
+
+- [ ] **Step 3: Update `client/src/config.ts` zod schema**
+
+Find the per-SolverNet roles schema (introduced in `.15.4.8`). Today it accepts `'solving' | 'evaluating'`. Extend the union and (a) keep the deduplication + non-empty validation, (b) keep the legacy-`role`-to-`roles` preprocess step. Pseudo-diff:
+
+```ts
+const roleEnum = z.enum(['solving', 'evaluating', 'launching']);
+// ... rest of preprocess + array-of-roleEnum + non-empty + dedupe stays unchanged.
+```
+
+Also remove `predictionV1LauncherEnabled` from the schema and from the env-var binding block (around `client/src/config.ts:318` and `client/src/config.ts:705`). The boolean is replaced by the role gate in Task 4.
+
+- [ ] **Step 4: Run tests to confirm pass**
+
+Run: `cd client && npx vitest run test/config.test.ts`
+Expected: PASS for all `launching role` cases plus existing `.15.4.8` cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/config.ts client/test/config.test.ts
+git commit -m "config: extend per-SolverNet roles to include 'launching'
+
+Replaces predictionV1LauncherEnabled boolean with a role-array entry.
+Existing role validation (non-empty, deduplicated, legacy-role-auto-
+migrated) covers the new value transparently."
+```
+
+---
+
+## Task 2: Operator-mode setup endpoint preserves `'launching'` across patches
+
+**Files:**
+- Modify: `client/src/api/setup-endpoints.ts` (the `POST /v1/setup/solvernets/:name` handler at ~line 313)
+- Test: `client/test/api/setup-endpoints.test.ts`
+
+**Why:** Operator-mode UI only knows `'solving' | 'evaluating'`. If it patches `roles: ['solving']` after Launcher mode set `roles: ['solving', 'launching']`, the launching role must survive. The handler reads existing roles and merges.
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+it('preserves launching role when operator-mode patch only includes solving/evaluating', async () => {
+  // Setup: solverNet config currently has roles: ['solving', 'launching']
+  await seedConfig({ solverNets: { prediction: { enabled: true, roles: ['solving', 'launching'], ...rest } } });
+
+  const res = await app.request('/v1/setup/solvernets/prediction', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+    body: JSON.stringify({ enabled: true, roles: ['evaluating'] }), // operator switching solver→evaluator
+  });
+  expect(res.status).toBe(200);
+
+  const after = await readPersistedConfig();
+  expect(after.solverNets.prediction.roles.sort()).toEqual(['evaluating', 'launching']);
+});
+```
+
+- [ ] **Step 2: Run test to confirm failure**
+
+Run: `cd client && npx vitest run test/api/setup-endpoints.test.ts -t "preserves launching"`
+Expected: FAIL — current handler overwrites `roles` wholesale.
+
+- [ ] **Step 3: Implement merge in the handler**
+
+Inside `POST /v1/setup/solvernets/:name`, before persisting:
+
+```ts
+// Operator-mode patch only addresses solving/evaluating. Preserve any non-operator
+// roles (today: 'launching') so launcher-mode state is never clobbered by an
+// operator-mode role edit. Strict mode separation per spec/2026-05-05-launcher-role-and-mode.md §3.
+const incomingOperatorRoles = (body.roles ?? []).filter((r): r is 'solving' | 'evaluating' => r === 'solving' || r === 'evaluating');
+const preservedRoles = (existing.roles ?? []).filter(r => r !== 'solving' && r !== 'evaluating');
+const mergedRoles = Array.from(new Set([...incomingOperatorRoles, ...preservedRoles]));
+// then write mergedRoles into the persisted config
+```
+
+- [ ] **Step 4: Run tests to confirm pass**
+
+Run: `cd client && npx vitest run test/api/setup-endpoints.test.ts`
+Expected: PASS (new test + all existing setup-endpoints tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/api/setup-endpoints.ts client/test/api/setup-endpoints.test.ts
+git commit -m "api(setup): preserve non-operator roles across operator-mode patches
+
+Operator-mode UI doesn't know about 'launching' (strict mode separation
+per spec). Setup endpoint merges operator-relevant roles (solving,
+evaluating) from the request with preserved non-operator roles from
+storage so launcher state survives operator edits."
+```
+
+---
+
+## Task 3: Filter `'launching'` out of operator-status payload
+
+**Files:**
+- Modify: `client/src/api/gather-status.ts` (the function that builds `operator.solverNet.roles` for the operator-status response)
+- Test: `client/test/api/gather-status.test.ts` (extend if present, create if absent)
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+it('omits launching from operator.solverNet.roles', async () => {
+  const cfg = makeConfigFixture({ solverNets: { prediction: { roles: ['solving', 'launching'], ...rest } } });
+  const status = await gatherPredictionOperatorStatus(cfg, /* ...other deps... */);
+  expect(status.operator?.solverNet?.roles).toEqual(['solving']); // launching filtered out
+});
+
+it('returns empty operator.solverNet.roles when only launching is enabled', async () => {
+  const cfg = makeConfigFixture({ solverNets: { prediction: { roles: ['launching'], ...rest } } });
+  const status = await gatherPredictionOperatorStatus(cfg, ...);
+  // The operator-status payload still surfaces solverNet metadata, but the operator
+  // is "not opted in" from the operator-mode perspective. Existing operatorEnabled
+  // computation (.15.4.12) should treat this as opted-out for operator-mode UI.
+  expect(status.operator?.solverNet?.roles).toEqual([]);
+});
+```
+
+- [ ] **Step 2: Run test to confirm failure**
+
+Run: `cd client && npx vitest run test/api/gather-status.test.ts -t "operator.solverNet.roles"`
+Expected: FAIL — current gather-status returns full `roles` array including launching.
+
+- [ ] **Step 3: Implement the filter**
+
+In `client/src/api/gather-status.ts`, where `operator.solverNet.roles` is populated, filter the array:
+
+```ts
+const operatorRoles = (rawRoles ?? []).filter((r): r is 'solving' | 'evaluating' => r === 'solving' || r === 'evaluating');
+// then assign operatorRoles to operator.solverNet.roles
+```
+
+Update the TypeScript return type to narrow `roles` to `Array<'solving' | 'evaluating'>` (this matches the SPA-side narrowing in Task 7).
+
+- [ ] **Step 4: Run tests to confirm pass**
+
+Run: `cd client && npx vitest run test/api/gather-status.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/api/gather-status.ts client/test/api/gather-status.test.ts
+git commit -m "api(status): narrow operator-status roles to solving/evaluating only
+
+Strict mode separation per spec: Operator mode never sees launcher state.
+Filter happens at the gather-status boundary so the type can narrow on
+both daemon and SPA sides."
+```
+
+---
+
+## Task 4: Hot-spawn generator — runtime role check, no daemon restart
+
+**Files:**
+- Modify: `client/src/main.ts` — find the block that conditionally creates the prediction generator from `predictionV1LauncherEnabled` (likely near `collectTestnetAutoTaskGenerators` wiring around `client/src/main.ts:1332-1368` per Explore findings)
+- Modify: `client/src/solver-types/prediction-v1-auto.ts` — wrap the poll in a role-active guard
+- Test: `client/test/solver-types/prediction-v1-auto-role-gate.test.ts` (new)
+
+**Pattern choice:** Always-spawn loop, tick-time gate. Rationale: simplest. The loop wakes, checks `roles.includes('launching')` from a config-getter closure, no-ops if false, polls if true. Cost is one cheap predicate per cadence tick.
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { makePredictionV1Generator } from '../../src/solver-types/prediction-v1-auto.js';
+
+describe('prediction-v1-auto: role gate', () => {
+  it('does not poll Polymarket when roles does not include launching', async () => {
+    const polymarketSpy = vi.fn();
+    const gen = makePredictionV1Generator({
+      polymarket: { fetchEligibleMarkets: polymarketSpy },
+      getRoles: () => ['solving'], // operator-only, no launching
+      cadenceMs: 1, // not used; we drive ticks manually
+    });
+    await gen.tick();
+    expect(polymarketSpy).not.toHaveBeenCalled();
+  });
+
+  it('polls Polymarket when roles includes launching', async () => {
+    const polymarketSpy = vi.fn().mockResolvedValue([]); // empty eligible set is fine for the gate test
+    const gen = makePredictionV1Generator({
+      polymarket: { fetchEligibleMarkets: polymarketSpy },
+      getRoles: () => ['launching'],
+      cadenceMs: 1,
+    });
+    await gen.tick();
+    expect(polymarketSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('hot-flips: same instance gates poll behaviour as roles change', async () => {
+    let roles: Array<'solving' | 'evaluating' | 'launching'> = ['solving'];
+    const polymarketSpy = vi.fn().mockResolvedValue([]);
+    const gen = makePredictionV1Generator({
+      polymarket: { fetchEligibleMarkets: polymarketSpy },
+      getRoles: () => roles,
+      cadenceMs: 1,
+    });
+    await gen.tick();
+    expect(polymarketSpy).toHaveBeenCalledTimes(0);
+    roles = ['launching'];
+    await gen.tick();
+    expect(polymarketSpy).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm failure**
+
+Run: `cd client && npx vitest run test/solver-types/prediction-v1-auto-role-gate.test.ts`
+Expected: FAIL — generator doesn't accept `getRoles` injection.
+
+- [ ] **Step 3: Update generator to accept role-getter, gate the poll**
+
+In `client/src/solver-types/prediction-v1-auto.ts`:
+
+```ts
+export interface PredictionV1AutoConfig extends PolymarketClientConfig {
+  // ... existing fields ...
+  getRoles?: () => Array<'solving' | 'evaluating' | 'launching'>;
+}
+
+export function makePredictionV1Generator(config: PredictionV1AutoConfig = {}) {
+  // ... existing state ...
+  return {
+    async tick() {
+      const roles = config.getRoles?.() ?? [];
+      if (!roles.includes('launching')) return; // hot-spawn gate
+      // ... existing poll/post logic ...
+    },
+    // ... existing exports ...
+  };
+}
+```
+
+- [ ] **Step 4: Update `client/src/main.ts` to wire the role-getter**
+
+Find the existing block that read `cfg.predictionV1LauncherEnabled` to decide whether to create the generator. Replace with:
+
+```ts
+// Always create the generator; the role gate inside its tick is what controls
+// whether work happens. This makes role flips (e.g. from the launcher-mode
+// setup flow) take effect within one cadence without restarting the daemon.
+const predictionGenerator = makePredictionV1Generator({
+  ...predictionGeneratorOpts,
+  getRoles: () => cfg.solverNets?.prediction?.roles ?? [],
+});
+```
+
+Remove all references to `predictionV1LauncherEnabled` (the env-var binding was removed in Task 1; remove its read sites here).
+
+- [ ] **Step 5: Run tests + typecheck**
+
+```bash
+cd client && npx tsc --noEmit
+cd client && npx vitest run test/solver-types/prediction-v1-auto-role-gate.test.ts
+cd client && npx vitest run test/config.test.ts test/api
+```
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/solver-types/prediction-v1-auto.ts client/src/main.ts client/test/solver-types/prediction-v1-auto-role-gate.test.ts
+git commit -m "feat(generator): hot-spawn gate via roles.includes('launching')
+
+Replace startup-time predictionV1LauncherEnabled boolean with a runtime
+role check inside the generator tick. Toggling 'launching' in or out of
+roles takes effect within one cadence — no daemon restart. Closes the
+schema migration started in Task 1."
+```
+
+---
+
+## Task 5: Expose generator state for the launcher status endpoint
+
+**Files:**
+- Modify: `client/src/solver-types/prediction-v1-auto.ts` — add `getState()` method returning poll history
+- Test: `client/test/solver-types/prediction-v1-auto-state.test.ts` (new)
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { makePredictionV1Generator } from '../../src/solver-types/prediction-v1-auto.js';
+
+describe('prediction-v1-auto: state exposure', () => {
+  it('returns last-poll summary after a successful tick', async () => {
+    const gen = makePredictionV1Generator({
+      polymarket: { fetchEligibleMarkets: async () => [/* 3 mock markets */] },
+      getRoles: () => ['launching'],
+      cadenceMs: 1,
+    });
+    await gen.tick();
+    const state = gen.getState();
+    expect(state.lastPollAt).toBeTruthy();
+    expect(state.lastPollSummary).toMatchObject({ evaluated: 3, posted: expect.any(Number), skipped: expect.any(Number) });
+    expect(state.lastError).toBeUndefined();
+    expect(state.cadenceMs).toBeGreaterThan(0);
+  });
+
+  it('captures error on poll failure', async () => {
+    const gen = makePredictionV1Generator({
+      polymarket: { fetchEligibleMarkets: async () => { throw new Error('polymarket 503'); } },
+      getRoles: () => ['launching'],
+      cadenceMs: 1,
+    });
+    await gen.tick();
+    const state = gen.getState();
+    expect(state.lastError?.message).toContain('polymarket 503');
+  });
+
+  it('reports stale=false within 2x cadence; logic lives in the status endpoint, not here', () => {
+    // staleness is computed by the status endpoint (Task 6); this test just verifies
+    // getState() reports lastPollAt and cadenceMs, which the endpoint uses.
+    const gen = makePredictionV1Generator({ polymarket: ..., getRoles: () => ['launching'], cadenceMs: 60_000 });
+    const state = gen.getState();
+    expect(state.cadenceMs).toBe(60_000);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm failure**
+
+Run: `cd client && npx vitest run test/solver-types/prediction-v1-auto-state.test.ts`
+Expected: FAIL — `getState()` does not exist.
+
+- [ ] **Step 3: Implement `getState()` and internal state tracking**
+
+In `client/src/solver-types/prediction-v1-auto.ts` add internal mutable state:
+
+```ts
+interface GeneratorPersistentState {
+  lastPollAt?: string;
+  lastPollSummary?: { evaluated: number; posted: number; skipped: number; skipReasons?: Record<string, number> };
+  lastError?: { message: string; at: string };
+}
+
+export function makePredictionV1Generator(config: PredictionV1AutoConfig = {}) {
+  const state: GeneratorPersistentState = {};
+  // ... existing dedup map etc. ...
+
+  return {
+    async tick() {
+      const roles = config.getRoles?.() ?? [];
+      if (!roles.includes('launching')) return;
+      try {
+        const eligible = await config.polymarket.fetchEligibleMarkets(...);
+        // existing posting logic; track posted/skipped counts as you go
+        const summary = { evaluated: eligible.length, posted, skipped, skipReasons };
+        state.lastPollAt = new Date().toISOString();
+        state.lastPollSummary = summary;
+        state.lastError = undefined;
+      } catch (err) {
+        state.lastError = { message: err instanceof Error ? err.message : String(err), at: new Date().toISOString() };
+      }
+    },
+    getState() {
+      return {
+        ...state,
+        cadenceMs: config.cadenceMs ?? DEFAULT_CADENCE_MS,
+      };
+    },
+    // ... other existing exports ...
+  };
+}
+```
+
+- [ ] **Step 4: Run tests + typecheck**
+
+```bash
+cd client && npx tsc --noEmit
+cd client && npx vitest run test/solver-types/prediction-v1-auto-state.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/solver-types/prediction-v1-auto.ts client/test/solver-types/prediction-v1-auto-state.test.ts
+git commit -m "feat(generator): expose poll state via getState()
+
+Surface lastPollAt, lastPollSummary, lastError, cadenceMs so the
+upcoming /v1/launcher/status endpoint can render generator health.
+Stale-poll detection (lastPollAt + 2*cadence) lives in the endpoint."
+```
+
+---
+
+## Task 6: `GET /v1/launcher/status` endpoint
+
+**Files:**
+- Create: `client/src/api/launcher-status.ts`
+- Create: `client/src/api/launcher-endpoints.ts`
+- Modify: `client/src/api/server.ts` — register the launcher route module
+- Test: `client/test/api/launcher-endpoints.test.ts` (new)
+
+- [ ] **Step 1: Write failing test for `GET /v1/launcher/status`**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { buildTestApp } from './fixtures.js'; // existing helper used by setup-endpoints test
+
+describe('GET /v1/launcher/status', () => {
+  it('returns per-net launcher status for nets with launching role', async () => {
+    const { app, token } = await buildTestApp({ solverNets: { prediction: { roles: ['launching'], ...rest } } });
+    const res = await app.request('/v1/launcher/status', { headers: { authorization: `Bearer ${token}` } });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.schemaVersion).toBe(1);
+    expect(body.nets).toHaveLength(1);
+    expect(body.nets[0]).toMatchObject({
+      name: 'prediction',
+      generator: { state: expect.stringMatching(/active|paused|errored/), cadenceMs: expect.any(Number), stale: expect.any(Boolean) },
+      openTasks: expect.any(Number),
+      budget: { safeAddress: expect.any(String), safeBalanceWei: expect.any(String) },
+    });
+  });
+
+  it('omits nets without launching role', async () => {
+    const { app, token } = await buildTestApp({ solverNets: { prediction: { roles: ['solving'], ...rest } } });
+    const res = await app.request('/v1/launcher/status', { headers: { authorization: `Bearer ${token}` } });
+    const body = await res.json();
+    expect(body.nets).toEqual([]);
+  });
+
+  it('reports stale=true when lastPollAt is older than 2x cadence', async () => {
+    const fakeNow = Date.now();
+    const stalePollAt = new Date(fakeNow - 60_000 * 3).toISOString(); // 3 minutes ago, cadence is 1 minute
+    const { app, token } = await buildTestApp({
+      solverNets: { prediction: { roles: ['launching'], ...rest } },
+      generatorState: { lastPollAt: stalePollAt, cadenceMs: 60_000 },
+      now: () => fakeNow,
+    });
+    const res = await app.request('/v1/launcher/status', { headers: { authorization: `Bearer ${token}` } });
+    const body = await res.json();
+    expect(body.nets[0].generator.stale).toBe(true);
+  });
+
+  it('requires auth', async () => {
+    const { app } = await buildTestApp({ solverNets: { prediction: { roles: ['launching'], ...rest } } });
+    const res = await app.request('/v1/launcher/status');
+    expect(res.status).toBe(401);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm failure**
+
+Run: `cd client && npx vitest run test/api/launcher-endpoints.test.ts -t "GET /v1/launcher/status"`
+Expected: FAIL — endpoint not registered.
+
+- [ ] **Step 3: Implement `client/src/api/launcher-status.ts`**
+
+```ts
+import type { JinnConfig } from '../config.js';
+import type { Generator } from '../solver-types/prediction-v1-auto.js';
+
+export interface LauncherStatusResponse {
+  schemaVersion: 1;
+  generatedAt: string;
+  nets: Array<{
+    name: string;
+    generator: {
+      state: 'active' | 'paused' | 'errored';
+      lastPollAt?: string;
+      lastPollSummary?: { evaluated: number; posted: number; skipped: number; skipReasons?: Record<string, number> };
+      lastError?: { message: string; at: string };
+      cadenceMs: number;
+      stale?: boolean;
+    };
+    openTasks: number;
+    budget: { safeAddress: string; safeBalanceWei: string; reservedBudgetWei: string; runwayDays?: number };
+  }>;
+}
+
+export interface GatherLauncherStatusDeps {
+  config: JinnConfig;
+  generators: Map<string, Generator>; // keyed by SolverNet name
+  getOpenTaskCount: (netName: string) => Promise<number>;
+  getReservedBudgetWei: (netName: string) => Promise<string>;
+  getSafeBalanceWei: () => Promise<string>;
+  safeAddress: string;
+  now?: () => number;
+}
+
+export async function gatherLauncherStatus(deps: GatherLauncherStatusDeps): Promise<LauncherStatusResponse> {
+  const now = deps.now?.() ?? Date.now();
+  const nets: LauncherStatusResponse['nets'] = [];
+  for (const [name, net] of Object.entries(deps.config.solverNets ?? {})) {
+    if (!net.roles?.includes('launching')) continue;
+    const gen = deps.generators.get(name);
+    const genState = gen?.getState();
+    const stale = genState?.lastPollAt
+      ? (now - Date.parse(genState.lastPollAt)) > 2 * (genState.cadenceMs ?? 0)
+      : false;
+    const generatorState = genState?.lastError ? 'errored' : (gen ? 'active' : 'paused');
+    const reservedBudgetWei = await deps.getReservedBudgetWei(name);
+    const safeBalanceWei = await deps.getSafeBalanceWei();
+    nets.push({
+      name,
+      generator: { state: generatorState, lastPollAt: genState?.lastPollAt, lastPollSummary: genState?.lastPollSummary, lastError: genState?.lastError, cadenceMs: genState?.cadenceMs ?? 0, stale },
+      openTasks: await deps.getOpenTaskCount(name),
+      budget: { safeAddress: deps.safeAddress, safeBalanceWei, reservedBudgetWei },
+    });
+  }
+  return { schemaVersion: 1, generatedAt: new Date(now).toISOString(), nets };
+}
+```
+
+- [ ] **Step 4: Implement `client/src/api/launcher-endpoints.ts`**
+
+```ts
+import type { Hono } from 'hono';
+import { gatherLauncherStatus, type GatherLauncherStatusDeps } from './launcher-status.js';
+
+export interface LauncherRoutesDeps extends Omit<GatherLauncherStatusDeps, 'config'> {
+  getConfig: () => GatherLauncherStatusDeps['config'];
+}
+
+export function addLauncherRoutes(app: Hono, deps: LauncherRoutesDeps): void {
+  app.get('/v1/launcher/status', async (c) => {
+    const body = await gatherLauncherStatus({ ...deps, config: deps.getConfig() });
+    return c.json(body);
+  });
+}
+```
+
+- [ ] **Step 5: Register in `client/src/api/server.ts`**
+
+Add the import and call `addLauncherRoutes(app, launcherDeps)` next to the existing `addSetupRoutes(app, ...)` call. Wire the deps from the daemon's main.ts when constructing the API server.
+
+- [ ] **Step 6: Run tests**
+
+Run: `cd client && npx vitest run test/api/launcher-endpoints.test.ts -t "/v1/launcher/status"`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add client/src/api/launcher-status.ts client/src/api/launcher-endpoints.ts client/src/api/server.ts client/test/api/launcher-endpoints.test.ts
+git commit -m "feat(api): GET /v1/launcher/status with stale-poll detection
+
+Per-SolverNet generator + budget state for the Launcher mode UI.
+Stale flag set when lastPollAt is older than 2x cadenceMs."
+```
+
+---
+
+## Task 7: `GET /v1/launcher/tasks` endpoint
+
+**Files:**
+- Create: `client/src/api/launcher-tasks.ts`
+- Modify: `client/src/api/launcher-endpoints.ts` — register the tasks route
+- Test: `client/test/api/launcher-endpoints.test.ts` — extend
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+describe('GET /v1/launcher/tasks', () => {
+  it('returns tasks posted by this daemon\'s creator address, paginated', async () => {
+    const { app, token, postedTasksFixture } = await buildTestApp({
+      solverNets: { prediction: { roles: ['launching'], ...rest } },
+      postedTasks: [
+        { taskId: '0xa', taskCid: 'Qm…', solverNet: 'prediction', postedAt: '2026-05-05T10:00:00Z', state: 'open', claims: { current: 0, max: 25 }, budget: { totalWei: '1000000', remainingWei: '1000000' } },
+        { taskId: '0xb', taskCid: 'Qm…', solverNet: 'prediction', postedAt: '2026-05-05T11:00:00Z', state: 'claims-in-flight', claims: { current: 5, max: 25 }, budget: { totalWei: '1000000', remainingWei: '800000' } },
+      ],
+    });
+    const res = await app.request('/v1/launcher/tasks', { headers: { authorization: `Bearer ${token}` } });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.schemaVersion).toBe(1);
+    expect(body.tasks).toHaveLength(2);
+    expect(body.tasks[0].taskId).toBe('0xb'); // most recent first
+  });
+
+  it('respects ?cursor=before:<iso>&limit=N pagination', async () => { /* ... */ });
+  it('requires auth', async () => { /* ... */ });
+});
+```
+
+- [ ] **Step 2: Run test to confirm failure**
+
+- [ ] **Step 3: Implement `client/src/api/launcher-tasks.ts`**
+
+```ts
+export interface LauncherTasksResponse {
+  schemaVersion: 1;
+  generatedAt: string;
+  cursor?: { before: string };
+  tasks: Array<{
+    taskId: string;
+    taskCid: string;
+    solverNet: string;
+    postedAt: string;
+    state: 'open' | 'claims-in-flight' | 'fully-claimed' | 'settled' | 'failed';
+    claims: { current: number; max: number };
+    budget: { totalWei: string; remainingWei: string; reclaimableAt?: string };
+    summary?: { title?: string; resolutionTime?: string };
+  }>;
+}
+
+export interface GatherLauncherTasksDeps {
+  creatorAddress: string;
+  // Reuse existing router-watcher / on-chain log indexer that l2zl.12 will harden later.
+  // For v1, accept a function that returns posted-task records from the daemon's existing
+  // store (see client/src/store/store.ts) — filtered by creatorAddress.
+  fetchPostedTasks: (opts: { creatorAddress: string; limit: number; before?: string }) => Promise<Array<...>>;
+}
+
+export async function gatherLauncherTasks(deps: GatherLauncherTasksDeps, opts: { limit?: number; before?: string }): Promise<LauncherTasksResponse> {
+  const limit = Math.min(Math.max(opts.limit ?? 25, 1), 100);
+  const tasks = await deps.fetchPostedTasks({ creatorAddress: deps.creatorAddress, limit, before: opts.before });
+  const cursor = tasks.length === limit ? { before: tasks[tasks.length - 1].postedAt } : undefined;
+  return { schemaVersion: 1, generatedAt: new Date().toISOString(), cursor, tasks };
+}
+```
+
+- [ ] **Step 4: Wire route in `launcher-endpoints.ts`**
+
+```ts
+app.get('/v1/launcher/tasks', async (c) => {
+  const cursor = c.req.query('cursor');
+  const before = cursor?.startsWith('before:') ? cursor.slice('before:'.length) : undefined;
+  const limit = Number(c.req.query('limit') ?? '25');
+  const body = await gatherLauncherTasks(deps.tasksDeps, { limit, before });
+  return c.json(body);
+});
+```
+
+- [ ] **Step 5: Run tests**
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/api/launcher-tasks.ts client/src/api/launcher-endpoints.ts client/test/api/launcher-endpoints.test.ts
+git commit -m "feat(api): GET /v1/launcher/tasks paginated by posted-time cursor
+
+Reads from existing store; filter by this daemon's creator address.
+Reuses router-watcher data already polled — l2zl.12 will harden the
+log filter shape later."
+```
+
+---
+
+## Task 8: `PATCH /v1/launcher/solvernets/:name` — launcher-mode setup endpoint
+
+**Files:**
+- Modify: `client/src/api/launcher-endpoints.ts`
+- Test: `client/test/api/launcher-endpoints.test.ts` — extend
+
+**Why:** Operator-mode setup endpoint never sees `launching` (Task 2). Launcher mode needs its own write surface that toggles `launching` on/off and edits generator-config keys.
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+describe('PATCH /v1/launcher/solvernets/:name', () => {
+  it('adds launching to roles and persists generator config', async () => {
+    const { app, token, readPersistedConfig } = await buildTestApp({ solverNets: { prediction: { roles: ['solving'], ...rest } } });
+    const res = await app.request('/v1/launcher/solvernets/prediction', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+      body: JSON.stringify({ launching: true, generator: { cadenceMs: 30_000, maxNewRoundsPerPoll: 10 } }),
+    });
+    expect(res.status).toBe(200);
+    const after = await readPersistedConfig();
+    expect(after.solverNets.prediction.roles.sort()).toEqual(['launching', 'solving']);
+    expect(after.predictionV1CadenceMs).toBe(30_000);
+    expect(after.predictionV1MaxNewRoundsPerPoll).toBe(10);
+  });
+
+  it('removes launching from roles when launching: false', async () => {
+    const { app, token, readPersistedConfig } = await buildTestApp({ solverNets: { prediction: { roles: ['solving', 'launching'], ...rest } } });
+    const res = await app.request('/v1/launcher/solvernets/prediction', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+      body: JSON.stringify({ launching: false }),
+    });
+    expect(res.status).toBe(200);
+    const after = await readPersistedConfig();
+    expect(after.solverNets.prediction.roles).toEqual(['solving']);
+  });
+
+  it('rejects launching: false when it would leave roles empty (must keep at least one)', async () => {
+    const { app, token } = await buildTestApp({ solverNets: { prediction: { roles: ['launching'], ...rest } } });
+    const res = await app.request('/v1/launcher/solvernets/prediction', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+      body: JSON.stringify({ launching: false }),
+    });
+    expect(res.status).toBe(400);
+    const err = await res.json();
+    expect(err.message).toMatch(/at least one role/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm failure**
+
+- [ ] **Step 3: Implement the route**
+
+```ts
+app.patch('/v1/launcher/solvernets/:name', async (c) => {
+  const name = c.req.param('name');
+  const body = await c.req.json() as { launching?: boolean; generator?: Record<string, unknown> };
+  // Read existing roles; flip launching; preserve operator roles.
+  const existing = deps.getConfig().solverNets?.[name];
+  if (!existing) return c.json({ message: 'Unknown SolverNet' }, 404);
+  let newRoles = existing.roles ?? [];
+  if (body.launching === true) newRoles = Array.from(new Set([...newRoles, 'launching']));
+  if (body.launching === false) newRoles = newRoles.filter(r => r !== 'launching');
+  if (newRoles.length === 0) return c.json({ message: 'At least one role required' }, 400);
+  // Patch persisted config: roles + generator-config keys (predictionV1CadenceMs, etc.)
+  await deps.persistConfigPatch({ solverNets: { [name]: { ...existing, roles: newRoles } }, ...mapGeneratorPatch(body.generator) });
+  await deps.notifySolverNetsUpdated(); // matches the .15.4.12 cache-invalidation pattern
+  return c.json({ ok: true });
+});
+```
+
+`mapGeneratorPatch` translates the launcher-mode body's `generator: { cadenceMs, maxNewRoundsPerPoll, ... }` into the daemon's `predictionV1CadenceMs`, `predictionV1MaxNewRoundsPerPoll`, etc. config keys. Keep the mapping table in `launcher-endpoints.ts`.
+
+- [ ] **Step 4: Run tests**
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/api/launcher-endpoints.ts client/test/api/launcher-endpoints.test.ts
+git commit -m "feat(api): PATCH /v1/launcher/solvernets/:name — launcher-mode setup
+
+Toggle launching role and edit generator config in one call. Preserves
+operator roles. Rejects role-empty result. Triggers the existing
+solver-nets-updated cache invalidation so /v1/launcher/status reflects
+the change immediately."
+```
+
+---
+
+## Task 9: SPA — types and API client methods
+
+**Files:**
+- Modify: `client/src/dashboard/spa/src/api/types.ts`
+- Modify: `client/src/dashboard/spa/src/api/client.ts`
+
+- [ ] **Step 1: Add launcher types to `api/types.ts`**
+
+```ts
+export interface LauncherStatusResponse {
+  schemaVersion: 1;
+  generatedAt: string;
+  nets: Array<{
+    name: string;
+    generator: {
+      state: 'active' | 'paused' | 'errored';
+      lastPollAt?: string;
+      lastPollSummary?: { evaluated: number; posted: number; skipped: number; skipReasons?: Record<string, number> };
+      lastError?: { message: string; at: string };
+      cadenceMs: number;
+      stale?: boolean;
+    };
+    openTasks: number;
+    budget: { safeAddress: string; safeBalanceWei: string; reservedBudgetWei: string; runwayDays?: number };
+  }>;
+}
+
+export interface LauncherTasksResponse {
+  schemaVersion: 1;
+  generatedAt: string;
+  cursor?: { before: string };
+  tasks: Array<{
+    taskId: string;
+    taskCid: string;
+    solverNet: string;
+    postedAt: string;
+    state: 'open' | 'claims-in-flight' | 'fully-claimed' | 'settled' | 'failed';
+    claims: { current: number; max: number };
+    budget: { totalWei: string; remainingWei: string; reclaimableAt?: string };
+    summary?: { title?: string; resolutionTime?: string };
+  }>;
+}
+
+export interface LauncherSolverNetPatch {
+  launching?: boolean;
+  generator?: {
+    cadenceMs?: number;
+    maxNewRoundsPerPoll?: number;
+    maxNewRoundsPerDay?: number;
+    maxOpenRounds?: number;
+    allowlistConditionIds?: string[];
+    blocklistConditionIds?: string[];
+    windowMs?: number;
+    resolveGapMs?: number;
+  };
+}
+```
+
+Also narrow the operator-status types so `operator.solverNet.roles` excludes `'launching'`:
+
+```ts
+// in OverviewStatusV1 etc.
+roles?: Array<'solving' | 'evaluating'>; // narrowed; daemon filters at boundary per spec §6.3
+```
+
+(`OperatorCard` already reads this — no change needed there.)
+
+- [ ] **Step 2: Add client methods to `api/client.ts`**
+
+```ts
+export const api = {
+  // ... existing methods ...
+  fetchLauncherStatus: () => request<LauncherStatusResponse>('GET', '/v1/launcher/status'),
+  fetchLauncherTasks: (opts: { cursor?: string; limit?: number } = {}) => {
+    const query = new URLSearchParams();
+    if (opts.cursor) query.set('cursor', opts.cursor);
+    if (opts.limit) query.set('limit', String(opts.limit));
+    const qs = query.toString();
+    return request<LauncherTasksResponse>('GET', `/v1/launcher/tasks${qs ? `?${qs}` : ''}`);
+  },
+  patchLauncherSolverNet: (name: string, patch: LauncherSolverNetPatch) =>
+    request<{ ok: true }>('PATCH', `/v1/launcher/solvernets/${encodeURIComponent(name)}`, patch),
+};
+```
+
+- [ ] **Step 3: Typecheck**
+
+```bash
+cd client/src/dashboard/spa && npx tsc -b
+```
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/dashboard/spa/src/api/types.ts client/src/dashboard/spa/src/api/client.ts
+git commit -m "feat(spa-api): launcher types + client methods
+
+Adds LauncherStatusResponse / LauncherTasksResponse / LauncherSolverNetPatch
+types and three api methods. Narrows operator-status roles to exclude
+'launching' so Operator-mode UI cannot accidentally render launcher state."
+```
+
+---
+
+## Task 10: SPA — `useAppMode` hook + `ModeSwitch` component
+
+**Files:**
+- Create: `client/src/dashboard/spa/src/shell/useAppMode.ts`
+- Create: `client/src/dashboard/spa/src/shell/useAppMode.test.ts`
+- Create: `client/src/dashboard/spa/src/shell/ModeSwitch.tsx`
+- Create: `client/src/dashboard/spa/src/shell/ModeSwitch.test.tsx`
+
+- [ ] **Step 1: Write failing test for `useAppMode`**
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAppMode } from './useAppMode.js';
+
+describe('useAppMode', () => {
+  beforeEach(() => { localStorage.clear(); });
+
+  it('defaults to "operator"', () => {
+    const { result } = renderHook(() => useAppMode());
+    expect(result.current.mode).toBe('operator');
+  });
+
+  it('persists mode to localStorage on change', () => {
+    const { result } = renderHook(() => useAppMode());
+    act(() => result.current.setMode('launcher'));
+    expect(result.current.mode).toBe('launcher');
+    expect(localStorage.getItem('jinn.app.mode')).toBe('launcher');
+  });
+
+  it('hydrates from localStorage on mount', () => {
+    localStorage.setItem('jinn.app.mode', 'launcher');
+    const { result } = renderHook(() => useAppMode());
+    expect(result.current.mode).toBe('launcher');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm failure**
+
+- [ ] **Step 3: Implement `useAppMode.ts`**
+
+```ts
+import { useState, useEffect, useCallback } from 'react';
+
+export type AppMode = 'operator' | 'launcher';
+const STORAGE_KEY = 'jinn.app.mode';
+
+export interface UseAppMode { mode: AppMode; setMode: (m: AppMode) => void; }
+
+export function useAppMode(): UseAppMode {
+  const [mode, setModeState] = useState<AppMode>(() => {
+    const stored = typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
+    return stored === 'launcher' ? 'launcher' : 'operator';
+  });
+  const setMode = useCallback((m: AppMode) => {
+    setModeState(m);
+    if (typeof window !== 'undefined') localStorage.setItem(STORAGE_KEY, m);
+  }, []);
+  return { mode, setMode };
+}
+```
+
+- [ ] **Step 4: Run useAppMode tests; pass**
+
+- [ ] **Step 5: Write failing test for `ModeSwitch`**
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ModeSwitch } from './ModeSwitch.js';
+
+describe('ModeSwitch', () => {
+  it('renders both modes; current is highlighted', () => {
+    render(<ModeSwitch mode="operator" onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Operator' })).toHaveAttribute('data-active', 'true');
+    expect(screen.getByRole('button', { name: 'Launcher' })).toHaveAttribute('data-active', 'false');
+  });
+
+  it('fires onChange on click', () => {
+    const onChange = vi.fn();
+    render(<ModeSwitch mode="operator" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Launcher' }));
+    expect(onChange).toHaveBeenCalledWith('launcher');
+  });
+});
+```
+
+- [ ] **Step 6: Implement `ModeSwitch.tsx`**
+
+A two-button segmented control matching existing JetBrains Mono styling. Refer to `client/src/dashboard/spa/src/shell/TopTabs.tsx` for the segmented-control pattern. Two buttons (`Operator`, `Launcher`), `data-active` attribute on each, `var(--bg)` background for active, `transparent` for inactive.
+
+```tsx
+import type { AppMode } from './useAppMode.js';
+
+interface ModeSwitchProps { mode: AppMode; onChange: (m: AppMode) => void; }
+const MODES: AppMode[] = ['operator', 'launcher'];
+
+export function ModeSwitch({ mode, onChange }: ModeSwitchProps): JSX.Element {
+  return (
+    <div role="group" aria-label="App mode" style={{ display: 'inline-flex', border: '1px solid var(--border)', borderRadius: '6px', overflow: 'hidden' }}>
+      {MODES.map((m, idx) => (
+        <button
+          key={m}
+          type="button"
+          onClick={() => onChange(m)}
+          data-active={mode === m ? 'true' : 'false'}
+          style={{
+            padding: '8px 16px',
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '12px',
+            textTransform: 'uppercase',
+            letterSpacing: '0.14em',
+            color: mode === m ? 'var(--fg)' : 'var(--fg-muted)',
+            background: mode === m ? 'var(--bg)' : 'transparent',
+            border: 'none',
+            borderRight: idx < MODES.length - 1 ? '1px solid var(--border)' : 'none',
+            cursor: 'pointer',
+          }}
+        >
+          {m.charAt(0).toUpperCase() + m.slice(1)}
+        </button>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 7: Run ModeSwitch tests; pass**
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add client/src/dashboard/spa/src/shell/useAppMode.ts client/src/dashboard/spa/src/shell/useAppMode.test.ts client/src/dashboard/spa/src/shell/ModeSwitch.tsx client/src/dashboard/spa/src/shell/ModeSwitch.test.tsx
+git commit -m "feat(spa-shell): ModeSwitch component + useAppMode hook
+
+Airbnb-style two-state mode toggle (Operator | Launcher) backed by
+localStorage. Used by Header (next task) to switch routes between the
+two modes."
+```
+
+---
+
+## Task 11: SPA — header wiring + routes for `/launcher` and `/launcher/configuration`
+
+**Files:**
+- Modify: `client/src/dashboard/spa/src/shell/Header.tsx` — render `ModeSwitch`; on change, navigate via wouter
+- Modify: `client/src/dashboard/spa/src/App.tsx` — add `/launcher` and `/launcher/configuration` routes
+- Modify: `client/src/dashboard/spa/src/App.routing.test.tsx` — extend routing tests
+
+- [ ] **Step 1: Extend `App.routing.test.tsx`**
+
+```tsx
+it('renders LauncherPage at /launcher', () => {
+  // Use existing Router test harness pattern
+  render(<MemoryRouter initialEntries={['/launcher']}><App /></MemoryRouter>);
+  expect(screen.getByText(/Launch a SolverNet|Launched SolverNets/i)).toBeInTheDocument();
+});
+
+it('renders LauncherConfigurationPage at /launcher/configuration', () => {
+  render(<MemoryRouter initialEntries={['/launcher/configuration']}><App /></MemoryRouter>);
+  expect(screen.getByText(/Generator config/i)).toBeInTheDocument();
+});
+```
+
+(The test will fail because the pages don't exist yet — acceptable; they'll be implemented in Tasks 12–18. Or stub the page imports here and let later tasks fill them in. Pragmatic: stub minimal `LauncherPage`/`LauncherConfigurationPage` placeholders that just render a heading; tighten the placeholders into real content in subsequent tasks. This keeps each task green at commit time.)
+
+- [ ] **Step 2: Stub `Launcher.tsx` and `LauncherConfiguration.tsx`**
+
+```tsx
+// client/src/dashboard/spa/src/pages/Launcher.tsx
+export function LauncherPage(): JSX.Element {
+  return <div><h1>Launch a SolverNet</h1></div>;
+}
+
+// client/src/dashboard/spa/src/pages/LauncherConfiguration.tsx
+export function LauncherConfigurationPage(): JSX.Element {
+  return <div><h1>Generator config</h1></div>;
+}
+```
+
+- [ ] **Step 3: Add routes in `App.tsx`**
+
+```tsx
+import { LauncherPage } from './pages/Launcher.js';
+import { LauncherConfigurationPage } from './pages/LauncherConfiguration.js';
+// inside <Switch>:
+<Route path="/launcher" component={LauncherPage} />
+<Route path="/launcher/configuration" component={LauncherConfigurationPage} />
+```
+
+- [ ] **Step 4: Wire `ModeSwitch` into `Header.tsx`**
+
+```tsx
+import { useAppMode } from './useAppMode.js';
+import { ModeSwitch } from './ModeSwitch.js';
+import { useLocation } from 'wouter';
+
+export function Header(): JSX.Element {
+  const { mode, setMode } = useAppMode();
+  const [, setLocation] = useLocation();
+  const onModeChange = (m: 'operator' | 'launcher') => {
+    setMode(m);
+    setLocation(m === 'operator' ? '/overview' : '/launcher');
+  };
+  return (
+    // existing header content + ModeSwitch in its right slot
+    <ModeSwitch mode={mode} onChange={onModeChange} />
+  );
+}
+```
+
+(Refer to existing `Header.tsx` layout — slot the ModeSwitch on the right or center per existing visual rhythm.)
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cd client && npx vitest run src/dashboard/spa
+```
+Expected: all SPA tests pass (App.routing.test.tsx, ModeSwitch.test.tsx, useAppMode.test.ts, plus all existing).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/dashboard/spa/src/App.tsx client/src/dashboard/spa/src/App.routing.test.tsx client/src/dashboard/spa/src/shell/Header.tsx client/src/dashboard/spa/src/pages/Launcher.tsx client/src/dashboard/spa/src/pages/LauncherConfiguration.tsx
+git commit -m "feat(spa-shell): mount /launcher routes + wire ModeSwitch in Header
+
+Mode change triggers navigation: 'operator' -> /overview, 'launcher' -> /launcher.
+Pages are placeholders; subsequent tasks fill in real content."
+```
+
+---
+
+## Task 12: SPA — `LauncherEmptyState` and `SetupFlow`
+
+**Files:**
+- Create: `client/src/dashboard/spa/src/pages/launcher/EmptyState.tsx`
+- Create: `client/src/dashboard/spa/src/pages/launcher/EmptyState.test.tsx`
+- Create: `client/src/dashboard/spa/src/pages/launcher/SetupFlow.tsx`
+- Create: `client/src/dashboard/spa/src/pages/launcher/SetupFlow.test.tsx`
+
+- [ ] **Step 1: Failing test for `EmptyState`**
+
+```tsx
+it('renders headline and CTA', () => {
+  const onLaunch = vi.fn();
+  render(<EmptyState onLaunch={onLaunch} />);
+  expect(screen.getByText("You haven't launched a SolverNet yet.")).toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: /Launch Prediction SolverNet/i }));
+  expect(onLaunch).toHaveBeenCalledWith('prediction');
+});
+```
+
+- [ ] **Step 2: Implement `EmptyState.tsx`**
+
+```tsx
+interface EmptyStateProps { onLaunch: (netName: string) => void; }
+export function EmptyState({ onLaunch }: EmptyStateProps): JSX.Element {
+  return (
+    <div style={{ /* SectionCard-like container; use existing tokens */ }}>
+      <h1>You haven't launched a SolverNet yet.</h1>
+      <p>A SolverNet directs the network's effort toward producing a kind of knowledge. As Launcher you fund the Tasks operators attempt — and own what gets produced.</p>
+      <button type="button" onClick={() => onLaunch('prediction')}>Launch Prediction SolverNet</button>
+    </div>
+  );
+}
+```
+
+(Match `SectionCard` rhythm: `var(--bg)` panel, `var(--border)` 1px, JetBrains Mono. Reference `client/src/dashboard/spa/src/components/SectionCard.tsx`.)
+
+- [ ] **Step 3: Failing test for `SetupFlow`**
+
+```tsx
+it('walks through 4 steps and patches launcher config on Save', async () => {
+  const patchSpy = vi.fn().mockResolvedValue({ ok: true });
+  render(<SetupFlow netName="prediction" defaults={genDefaults} safeBalanceWei="1000000000000000000" onPatch={patchSpy} onComplete={vi.fn()} />);
+  // step 1: confirm SolverNet — click Next
+  fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+  // step 2: confirm generator defaults — click Next
+  fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+  // step 3: budget plan informational — click Next
+  fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+  // step 4: save
+  fireEvent.click(screen.getByRole('button', { name: /Save/i }));
+  await waitFor(() => expect(patchSpy).toHaveBeenCalledWith('prediction', { launching: true, generator: expect.any(Object) }));
+});
+```
+
+- [ ] **Step 4: Implement `SetupFlow.tsx` as a 4-step wizard**
+
+Single component with `useState<step>` (1..4). Each step renders content + Back/Next; step 4 has Save button. Save calls `onPatch('prediction', { launching: true, generator: defaultsAsLauncherGenerator })`. Use existing form patterns from `NetCard.tsx`.
+
+- [ ] **Step 5: Run tests**
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/dashboard/spa/src/pages/launcher/EmptyState.tsx client/src/dashboard/spa/src/pages/launcher/EmptyState.test.tsx client/src/dashboard/spa/src/pages/launcher/SetupFlow.tsx client/src/dashboard/spa/src/pages/launcher/SetupFlow.test.tsx
+git commit -m "feat(spa-launcher): empty state + 4-step setup flow
+
+Empty state shows the knowledge-direction framing; CTA opens setup.
+Setup walks through SolverNet confirm, generator defaults, budget plan,
+save -> patches launcher config and triggers onComplete."
+```
+
+---
+
+## Task 13: SPA — `KnowledgeProductionCard` (tier 1) and `EmissionsPlaceholder` (tier 4)
+
+**Files:**
+- Create: `client/src/dashboard/spa/src/pages/launcher/KnowledgeProductionCard.tsx` (+ test)
+- Create: `client/src/dashboard/spa/src/pages/launcher/EmissionsPlaceholder.tsx` (+ test)
+
+**KnowledgeProductionCard** is the headline tier in the configured-state overview (spec §6.5). It surfaces:
+- The SolverNet's intent ("Calibrated probabilistic forecasts of Polymarket-listed events")
+- The Brier-spread scoreboard summary (reuse the existing scoreboard data — see `client/src/corpus/prediction-brier-scoreboard.ts` for the calculator and the existing operator-status panel from `.l2zl.6` for SPA-side rendering pattern)
+- Corpus growth (count of settled Verdicts in window — also from existing prediction-operator-ux data)
+- 5 most recent settled forecasts (predicate + outcome)
+
+For v1 the card can be a simple composition that calls existing data sources. If a backing endpoint doesn't exist for "5 recent settled forecasts," reuse data from `/v1/launcher/tasks` filtering to `state === 'settled'`. If the Brier scoreboard isn't already wire-readable from the SPA, wire a thin `/v1/launcher/scoreboard/:net` endpoint reusing `prediction-brier-scoreboard-report.ts` — but only if needed; otherwise reuse the existing operator-status panel data.
+
+- [ ] **Step 1: Failing test for `KnowledgeProductionCard`**
+
+```tsx
+it('renders SolverNet intent + scoreboard headline + recent forecasts', () => {
+  render(<KnowledgeProductionCard netName="prediction" scoreboard={fixtureScoreboard} recentSettled={fixtureSettled} />);
+  expect(screen.getByText(/Calibrated probabilistic forecasts/i)).toBeInTheDocument();
+  expect(screen.getByText(/Brier spread/i)).toBeInTheDocument();
+  expect(screen.getAllByTestId('recent-settled-row')).toHaveLength(5);
+});
+```
+
+- [ ] **Step 2: Implement `KnowledgeProductionCard.tsx`**
+
+Refer to spec §6.5 information hierarchy. Use existing scoreboard rendering patterns. Wrap in `SectionCard`.
+
+- [ ] **Step 3: Failing test for `EmissionsPlaceholder`**
+
+```tsx
+it('renders Phase B+ placeholder copy', () => {
+  render(<EmissionsPlaceholder />);
+  expect(screen.getByText(/ve-JINN gauges|Phase B/i)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 4: Implement `EmissionsPlaceholder.tsx`**
+
+Plain disabled `SectionCard` with explanatory copy from spec §6.5 tier 4. No interactivity.
+
+- [ ] **Step 5: Run tests**
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/dashboard/spa/src/pages/launcher/KnowledgeProductionCard.tsx client/src/dashboard/spa/src/pages/launcher/KnowledgeProductionCard.test.tsx client/src/dashboard/spa/src/pages/launcher/EmissionsPlaceholder.tsx client/src/dashboard/spa/src/pages/launcher/EmissionsPlaceholder.test.tsx
+git commit -m "feat(spa-launcher): tier 1 knowledge-production + tier 4 emissions placeholder
+
+Tier 1 surfaces what the SolverNet is producing (intent, Brier
+scoreboard, recent settled forecasts). Tier 4 is a disabled
+ve-JINN-gauge placeholder for Phase B+ visibility."
+```
+
+---
+
+## Task 14: SPA — `GeneratorStatusCard` (tier 3) with stale-poll banner
+
+**Files:**
+- Create: `client/src/dashboard/spa/src/pages/launcher/GeneratorStatusCard.tsx` (+ test)
+
+- [ ] **Step 1: Failing test**
+
+```tsx
+it('renders state pill, last poll timestamp, and last poll summary', () => {
+  render(<GeneratorStatusCard status={fixtureActiveStatus} onPause={vi.fn()} onResume={vi.fn()} />);
+  expect(screen.getByText('Active')).toBeInTheDocument();
+  expect(screen.getByText(/last poll/i)).toBeInTheDocument();
+  expect(screen.getByText(/3 markets evaluated/)).toBeInTheDocument();
+});
+
+it('renders stale banner when stale=true', () => {
+  render(<GeneratorStatusCard status={{ ...fixtureActiveStatus, stale: true }} onPause={vi.fn()} onResume={vi.fn()} />);
+  expect(screen.getByRole('alert')).toHaveTextContent(/generator may be stuck/i);
+});
+
+it('renders error banner when state=errored', () => {
+  render(<GeneratorStatusCard status={fixtureErroredStatus} onPause={vi.fn()} onResume={vi.fn()} />);
+  expect(screen.getByRole('alert')).toHaveTextContent(/polymarket 503/i);
+});
+```
+
+- [ ] **Step 2: Implement `GeneratorStatusCard.tsx`**
+
+Pattern after `OperatorCard.tsx`. State pill colors: active=`var(--vow-green)`, paused=`var(--fg-muted)`, errored=`var(--break-red)`. Stale banner uses `var(--break-red)` border, "Generator may be stuck — last poll was Xm ago, expected within Ym" copy.
+
+- [ ] **Step 3: Run tests; pass**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/dashboard/spa/src/pages/launcher/GeneratorStatusCard.tsx client/src/dashboard/spa/src/pages/launcher/GeneratorStatusCard.test.tsx
+git commit -m "feat(spa-launcher): GeneratorStatusCard with stale-poll banner
+
+Renders generator state pill, last poll summary, error / stale banners.
+Stale banner triggers when status.stale=true (set server-side when
+lastPollAt + 2*cadence < now)."
+```
+
+---
+
+## Task 15: SPA — `CostCard` (tier 2) and `PostedTasksList` (tier 3)
+
+**Files:**
+- Create: `client/src/dashboard/spa/src/pages/launcher/CostCard.tsx` (+ test)
+- Create: `client/src/dashboard/spa/src/pages/launcher/PostedTasksList.tsx` (+ test)
+
+- [ ] **Step 1: Failing test for `CostCard`**
+
+```tsx
+it('renders 7-day burn rate, Tasks funded, open-task budget reservations', () => {
+  render(<CostCard burn7dWei="500000000000000000" tasksFunded7d={42} openTaskBudgetWei="200000000000000000" />);
+  expect(screen.getByText(/0.5 ETH/)).toBeInTheDocument(); // formatted from wei
+  expect(screen.getByText(/42 Tasks/)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Implement `CostCard.tsx`**
+
+Use existing wei-formatting helper from `client/src/dashboard/spa/src/...` (likely `formatEth`). `SectionCard` wrapper. Three-cell mini-stat layout.
+
+- [ ] **Step 3: Failing test for `PostedTasksList`**
+
+```tsx
+it('renders 5 most recent tasks with state pill and budget remaining', () => {
+  render(<PostedTasksList tasks={fixture10Tasks} onLoadMore={vi.fn()} />);
+  expect(screen.getAllByTestId('posted-task-row')).toHaveLength(5);
+  expect(screen.getByRole('button', { name: /View all/i })).toBeInTheDocument();
+});
+
+it('calls onLoadMore on View all click', () => { /* ... */ });
+```
+
+- [ ] **Step 4: Implement `PostedTasksList.tsx`**
+
+5 rows by default. State pill colors mirror `GeneratorStatusCard` palette. "View all" button calls `onLoadMore` which in the parent (Task 16) triggers paginated fetch via `api.fetchLauncherTasks`.
+
+- [ ] **Step 5: Run tests; pass**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/dashboard/spa/src/pages/launcher/CostCard.tsx client/src/dashboard/spa/src/pages/launcher/CostCard.test.tsx client/src/dashboard/spa/src/pages/launcher/PostedTasksList.tsx client/src/dashboard/spa/src/pages/launcher/PostedTasksList.test.tsx
+git commit -m "feat(spa-launcher): tier 2 cost card + tier 3 posted-tasks list
+
+Cost card shows 7-day burn, Tasks funded, open-budget reservations.
+Posted-tasks list defaults to 5 rows with View-all expansion via
+api.fetchLauncherTasks pagination."
+```
+
+---
+
+## Task 16: SPA — `Launcher.tsx` page composition
+
+**Files:**
+- Modify: `client/src/dashboard/spa/src/pages/Launcher.tsx` — replace stub with full composition
+- Create: `client/src/dashboard/spa/src/pages/Launcher.test.tsx`
+
+- [ ] **Step 1: Failing test**
+
+```tsx
+it('renders empty state when no SolverNet has launching role', async () => {
+  vi.mocked(api.fetchLauncherStatus).mockResolvedValue({ schemaVersion: 1, generatedAt: '...', nets: [] });
+  render(<LauncherPage />);
+  await screen.findByText("You haven't launched a SolverNet yet.");
+});
+
+it('renders configured-state overview when a SolverNet has launching role', async () => {
+  vi.mocked(api.fetchLauncherStatus).mockResolvedValue(fixtureLauncherStatus);
+  vi.mocked(api.fetchLauncherTasks).mockResolvedValue(fixtureLauncherTasks);
+  render(<LauncherPage />);
+  await screen.findByText(/Calibrated probabilistic forecasts/i);
+  expect(screen.getByText(/Brier spread/i)).toBeInTheDocument();
+  expect(screen.getByText(/0\.5 ETH/i)).toBeInTheDocument();
+  expect(screen.getByText(/Active/i)).toBeInTheDocument();
+});
+
+it('opens setup flow on launch CTA click and patches launcher config on save', async () => {
+  vi.mocked(api.fetchLauncherStatus).mockResolvedValue({ schemaVersion: 1, generatedAt: '...', nets: [] });
+  vi.mocked(api.patchLauncherSolverNet).mockResolvedValue({ ok: true });
+  render(<LauncherPage />);
+  fireEvent.click(await screen.findByRole('button', { name: /Launch Prediction SolverNet/i }));
+  // step through wizard
+  // ... fireEvent clicks ...
+  await waitFor(() => expect(api.patchLauncherSolverNet).toHaveBeenCalledWith('prediction', { launching: true, generator: expect.any(Object) }));
+});
+```
+
+- [ ] **Step 2: Implement `Launcher.tsx`**
+
+```tsx
+export function LauncherPage(): JSX.Element {
+  const { data: status } = useQuery({ queryKey: ['launcher-status'], queryFn: api.fetchLauncherStatus, refetchInterval: 30_000 });
+  const { data: tasks } = useQuery({ queryKey: ['launcher-tasks'], queryFn: () => api.fetchLauncherTasks() });
+  const [setupOpen, setSetupOpen] = useState(false);
+
+  if (!status) return <LoadingScreen />;
+  if (status.nets.length === 0 && !setupOpen) {
+    return <EmptyState onLaunch={() => setSetupOpen(true)} />;
+  }
+  if (setupOpen) {
+    return <SetupFlow netName="prediction" /* ...defaults from config catalog... */ onPatch={api.patchLauncherSolverNet} onComplete={() => { setSetupOpen(false); /* refetch */ }} />;
+  }
+  // configured state
+  return (
+    <div>
+      {status.nets.map(net => (
+        <Fragment key={net.name}>
+          <KnowledgeProductionCard netName={net.name} scoreboard={...} recentSettled={...} />
+          <CostCard burn7dWei={...} tasksFunded7d={...} openTaskBudgetWei={net.budget.reservedBudgetWei} />
+          <GeneratorStatusCard status={net.generator} onPause={...} onResume={...} />
+          <PostedTasksList tasks={tasks?.tasks.filter(t => t.solverNet === net.name) ?? []} onLoadMore={...} />
+          <EmissionsPlaceholder />
+        </Fragment>
+      ))}
+    </div>
+  );
+}
+```
+
+(Use `@tanstack/react-query` already in the SPA's deps. Mock for tests using `vi.mocked(api.fetchLauncherStatus)`.)
+
+- [ ] **Step 3: Run tests; pass**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/dashboard/spa/src/pages/Launcher.tsx client/src/dashboard/spa/src/pages/Launcher.test.tsx
+git commit -m "feat(spa-launcher): compose overview page from tier 1-4 cards
+
+Empty state -> setup flow -> configured state with KnowledgeProductionCard,
+CostCard, GeneratorStatusCard, PostedTasksList, EmissionsPlaceholder
+in spec §6.5 order."
+```
+
+---
+
+## Task 17: SPA — `LauncherConfiguration.tsx` page + `GeneratorConfigSection`
+
+**Files:**
+- Create: `client/src/dashboard/spa/src/pages/launcher/GeneratorConfigSection.tsx` (+ test)
+- Modify: `client/src/dashboard/spa/src/pages/LauncherConfiguration.tsx` — replace stub
+- Create: `client/src/dashboard/spa/src/pages/LauncherConfiguration.test.tsx`
+
+- [ ] **Step 1: Failing test for `GeneratorConfigSection`**
+
+```tsx
+it('renders fields for cadence, max-per-poll, max-per-day, max-open, allowlist, blocklist, window, resolveGap', () => {
+  render(<GeneratorConfigSection netName="prediction" config={fixtureGenConfig} onSave={vi.fn()} />);
+  expect(screen.getByLabelText(/Cadence/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/Max new rounds per poll/i)).toBeInTheDocument();
+  // ... and so on for all 8 fields ...
+});
+
+it('calls onSave with the generator-shaped patch', async () => {
+  const onSave = vi.fn().mockResolvedValue({ ok: true });
+  render(<GeneratorConfigSection netName="prediction" config={fixtureGenConfig} onSave={onSave} />);
+  fireEvent.change(screen.getByLabelText(/Cadence/i), { target: { value: '120000' } });
+  fireEvent.click(screen.getByRole('button', { name: /Save/i }));
+  await waitFor(() => expect(onSave).toHaveBeenCalledWith({ generator: expect.objectContaining({ cadenceMs: 120_000 }) }));
+});
+```
+
+- [ ] **Step 2: Implement `GeneratorConfigSection.tsx`**
+
+Pattern after `client/src/dashboard/spa/src/pages/configuration/NetCard.tsx`'s editable fields. Use `ConfigField` for each. **No restart-required signaling** — edits hot-apply per spec §6.6.
+
+- [ ] **Step 3: Failing test + implementation for `LauncherConfiguration.tsx`**
+
+The page composes `GeneratorConfigSection` for each launching SolverNet (today only `prediction`). Save calls `api.patchLauncherSolverNet(netName, { generator })`.
+
+- [ ] **Step 4: Run tests; pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/dashboard/spa/src/pages/launcher/GeneratorConfigSection.tsx client/src/dashboard/spa/src/pages/launcher/GeneratorConfigSection.test.tsx client/src/dashboard/spa/src/pages/LauncherConfiguration.tsx client/src/dashboard/spa/src/pages/LauncherConfiguration.test.tsx
+git commit -m "feat(spa-launcher): generator configuration page
+
+Edits to cadence, market caps, allowlist/blocklist, window, resolveGap.
+No restart-required pill — edits hot-apply per spec §5.2."
+```
+
+---
+
+## Task 18: End-to-end mode-switch happy-path integration test
+
+**Files:**
+- Create: `client/src/dashboard/spa/src/Launcher.e2e.test.tsx` (or extend `App.routing.test.tsx`)
+
+- [ ] **Step 1: Write failing happy-path integration test**
+
+Mock api responses per state. Walk through:
+1. Default Operator mode at `/overview`
+2. Click ModeSwitch → `Launcher` → URL becomes `/launcher`
+3. Empty state visible → click `Launch Prediction SolverNet`
+4. Walk through 4-step setup → click Save → `api.patchLauncherSolverNet` called
+5. Mock subsequent `api.fetchLauncherStatus` to return launching net → KnowledgeProductionCard visible
+6. Click ModeSwitch → `Operator` → URL becomes `/overview`, Operator-mode UI does NOT show launcher state
+7. Verify localStorage persists `jinn.app.mode = 'operator'` across this test run
+
+- [ ] **Step 2: Implementation**
+
+Compose existing test fixtures. No new components. The test simply orchestrates clicks + assertions.
+
+- [ ] **Step 3: Run; pass**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/dashboard/spa/src/Launcher.e2e.test.tsx
+git commit -m "test(spa): launcher mode end-to-end happy path
+
+Walks Operator -> Launcher mode switch, empty state -> setup -> configured,
+back to Operator with strict information separation maintained."
+```
+
+---
+
+## Task 19: Final verification + push-readiness
+
+- [ ] **Step 1: Full daemon typecheck + tests**
+
+```bash
+cd client && npx tsc --noEmit
+cd client && yarn vitest run
+```
+Expected: clean typecheck; all daemon + SPA tests pass.
+
+- [ ] **Step 2: Manual exercise**
+
+Start daemon locally against an Anvil fork (`anvil --fork-url https://mainnet.base.org`), run `JINN_PASSWORD=test yarn start`, open the SPA, switch to Launcher mode, complete setup flow, verify generator polls within one cadence. Verify no daemon restart was required. Switch back to Operator mode; verify no launcher state visible.
+
+- [ ] **Step 3: Close bd issues**
+
+If a parent bd issue was filed for this implementation, close it referencing the spec + plan + final commit hash. (TBD: file `jinn-mono-l2zl.16` or sibling under `l2zl` for "Implement Launcher role and Launcher mode per spec/2026-05-05-launcher-role-and-mode.md" before starting; close on completion.)
+
+- [ ] **Step 4: Push**
+
+Per the project's session-completion protocol (see root `CLAUDE.md`):
+
+```bash
+git pull --rebase
+bd dolt push
+git push
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage check:**
+- §3 invariants 1–6 → all reflected in implementation choices (1 net = 1 launcher in §1 framing of bd close note; shared Safe in Task wallet/bootstrap reuse; multi-role in Task 1; modes ≠ daemon state in Task 10/11; roles configured by mode in Task 8 + Task 11; economics deferred in §4 of plan).
+- §5.1 role enum → Task 1.
+- §5.2 hot-spawn → Task 4.
+- §5.3 endpoints → Tasks 6 (status), 7 (tasks). Plus Task 8 for the launcher-side write endpoint (added during implementation planning to satisfy strict-mode-separation properly).
+- §6.1 mode switch → Task 10.
+- §6.2 routes → Task 11.
+- §6.3 strict separation → Task 3 (boundary filter) + Task 9 (type narrowing).
+- §6.4 empty/setup → Task 12.
+- §6.5 configured overview tiers → Tasks 13, 14, 15, 16.
+- §6.6 launcher config page → Task 17.
+- §7 wallet/bootstrap → no new code; called out in plan §Conventions.
+- §8 in-scope items 1–10 → all mapped to a task.
+
+**Placeholder scan:**
+- "TBD: file `jinn-mono-l2zl.16`" in Task 19 step 3 — this is a deferred decision, not a missing-task placeholder. The bd parent ID is genuinely TBD until filed; the action is named.
+- No other TBDs / TODOs.
+
+**Type consistency check:**
+- `LauncherStatusResponse`, `LauncherTasksResponse`, `LauncherSolverNetPatch` are defined in Task 9 and used identically in Tasks 6, 7, 8, 16, 17.
+- `gen.getState()` shape from Task 5 matches consumption in Task 6.
+- `getRoles` callback signature consistent across Tasks 4 and 5.
+- `roles: Array<'solving' | 'evaluating'>` narrowed type used consistently in Tasks 3, 9, and the operator-status payload.

--- a/spec/2026-05-05-launcher-role-and-mode.md
+++ b/spec/2026-05-05-launcher-role-and-mode.md
@@ -82,7 +82,7 @@ Validation rules from `.15.4.8` carry forward unchanged:
 - Zod `preprocess` auto-migrates legacy `role: 'X'` config to `roles: ['X']`. (Only relevant for `solving` / `evaluating` — `launching` was never expressed as a single-value `role`.)
 - Setup endpoint accepts both wire shapes for backwards-compat; persists canonical `roles`.
 
-### 5.2 Generator gating — replace the boolean
+### 5.2 Generator gating — replace the boolean, hot-spawn the loop
 
 Today the Polymarket generator is gated behind `predictionV1LauncherEnabled: boolean` (`client/src/config.ts:318`). That flag is **removed**. Gating moves to:
 
@@ -90,9 +90,16 @@ Today the Polymarket generator is gated behind `predictionV1LauncherEnabled: boo
 solverNets.prediction.roles.includes('launching')
 ```
 
-The generator's internals (`client/src/solver-types/prediction-v1-auto.ts`) do not change. The wiring in `main.ts` that reads `predictionV1LauncherEnabled` becomes a `roles.includes('launching')` check on the prediction SolverNet's config block.
+The generator's internals (`client/src/solver-types/prediction-v1-auto.ts`) do not change. What does change is **how the gate is evaluated**: today the boolean is read at startup and decides whether the generator loop ever spawns; this spec requires the role gate to be evaluated at runtime so toggling `'launching'` in or out of `roles` takes effect **without restarting the daemon**.
 
-The other generator config keys (`predictionV1CadenceMs`, `predictionV1MaxNewRoundsPerPoll`, `predictionV1MaxNewRoundsPerDay`, `predictionV1MaxOpenRounds`, `predictionV1AllowlistConditionIds`, `predictionV1BlocklistConditionIds`, `predictionV1WindowMs`, `predictionV1ResolveGapMs`) stay where they are. They are launcher-tunable; Launcher mode's Configuration page edits them.
+Two acceptable implementations (the implementation plan picks one):
+
+- **Always-spawn, tick-time gate.** The generator loop is started at daemon boot regardless of role; each tick checks `roles.includes('launching')` for the SolverNet — if false, sleep + continue (no Polymarket call, no posting); if true, run the poll. Cost: a near-zero idle loop. Simplest.
+- **Spawn-on-demand.** The daemon watches the per-SolverNet config; on transition to `launching` it spawns the generator loop, on transition off it tears it down cleanly. Cleaner separation; slightly more plumbing around lifecycle and in-flight poll-cycle drains.
+
+Either way, **adding or removing `'launching'` from `roles` does not require a daemon restart**. The change takes effect within one cadence tick. Restart-required signaling on the Launcher mode setup flow is therefore not necessary.
+
+The other generator config keys (`predictionV1CadenceMs`, `predictionV1MaxNewRoundsPerPoll`, `predictionV1MaxNewRoundsPerDay`, `predictionV1MaxOpenRounds`, `predictionV1AllowlistConditionIds`, `predictionV1BlocklistConditionIds`, `predictionV1WindowMs`, `predictionV1ResolveGapMs`) stay where they are. They are launcher-tunable; Launcher mode's Configuration page edits them. These keys are read each tick, so edits to them also hot-apply.
 
 ### 5.3 Read endpoints
 
@@ -119,6 +126,7 @@ interface LauncherStatusResponse {
       };
       lastError?: { message: string; at: string };
       cadenceMs: number;
+      stale?: boolean;                    // true if (now - lastPollAt) > 2 × cadenceMs
     };
     openTasks: number;
     budget: {
@@ -176,9 +184,9 @@ A persistent control at the top of the app shell (`client/src/dashboard/spa/src/
 - `Operator`
 - `Launcher`
 
-A third state placeholder shows `Builder · coming soon` (disabled, surfaces the future trajectory; matches the Airbnb-style information design where the role taxonomy is visible even when not all roles are usable).
-
 State persists in `localStorage` under a stable key (e.g. `jinn.app.mode`). Default = `Operator`. Switching is an instant route change; no daemon write.
+
+Builder mode is a future possibility but **not** in this spec or the day-1 UI. The mode switch is two-state only.
 
 ### 6.2 Route layout
 
@@ -195,7 +203,9 @@ Mode-specific routes are gated only by the localStorage mode preference for navi
 
 No changes from today. Existing pages, existing role checkboxes (`solving` / `evaluating`) on per-SolverNet cards continue to work as shipped in `.15.4.*`.
 
-The `OperatorCard` on Overview already reads `operator.solverNet.roles` and renders pills (`.15.4.8`); the only change is that the pills now reflect three possible values when the operator is also launching, but Operator mode's Overview does *not* display launcher state — that lives in Launcher mode. (The operator-status payload may include `'launching'` in the `roles` array purely for type consistency; Operator mode UI ignores it.)
+**Strict mode separation.** Operator mode displays *zero* launcher state. The OperatorCard pills only render `solving` and `evaluating`; `launching` never appears in Operator mode anywhere — no pill, no banner, no "you are also launching" hint. This matches the Airbnb framing: when you're in guest mode you don't see hosting state, and vice versa.
+
+To enforce this at the type level, `operator.solverNet.roles` in the operator-status payload narrows to `Array<'solving' | 'evaluating'>`. The daemon's gather-status filters `'launching'` out of the operator-status payload at the boundary; launcher state lives exclusively in `/v1/launcher/status` (§5.3).
 
 ### 6.4 Launcher mode
 
@@ -214,7 +224,7 @@ The CTA opens a setup flow:
 1. **Confirm SolverNet.** Day-1 only Prediction is launchable. Show the SolverNet's intent ("Calibrated probabilistic forecasts of Polymarket-listed events") + the canonical scoreboard ("Brier spread vs. Polymarket consensus over a rolling window").
 2. **Confirm generator defaults.** Cadence, market filters, caps from `prediction-v1-auto.ts`. Operator can edit; defaults are sensible.
 3. **Show informational budget plan.** Read Safe balance via the existing balance API; display "this funds approximately N Tasks at the current per-attempt payment, ~M days at current cadence". No funding action — Safe is funded out-of-band like operator earning Safe.
-4. **Save.** Patch sets `roles: [...currentRoles, 'launching']` for the prediction SolverNet via the existing `api.updateSolverNet` endpoint. Restart-required signaling reuses the `RestartPill` + banner shipped earlier.
+4. **Save.** Patch sets `roles: [...currentRoles, 'launching']` for the prediction SolverNet via the existing `api.updateSolverNet` endpoint. Per §5.2 the generator hot-spawns within one cadence tick — **no daemon restart**. The setup flow shows a "starting up — first poll within Xs" indicator instead of a restart banner.
 
 After save, Launcher mode lands on the configured-state overview (§6.5).
 
@@ -235,7 +245,7 @@ Per-SolverNet card actions:
 
 #### 6.6 Launcher configuration page
 
-Per-SolverNet form for the generator config keys listed in §5.2. Layout mirrors the Operator-mode Configuration page (`SectionCard` + `ConfigField` components from `client/src/dashboard/spa/src/components/`). Restart-required signaling on edit. Save = `api.updateSolverNet` with the generator config block.
+Per-SolverNet form for the generator config keys listed in §5.2. Layout mirrors the Operator-mode Configuration page (`SectionCard` + `ConfigField` components from `client/src/dashboard/spa/src/components/`). Edits hot-apply per §5.2 — no restart-required signaling needed for these fields. Save = `api.updateSolverNet` with the generator config block.
 
 For day-1 Prediction, the editable fields are:
 
@@ -250,9 +260,6 @@ For day-1 Prediction, the editable fields are:
 
 Filters that are not safely operator-tunable (e.g. liquidity floor, spread max) stay in `prediction-v1-auto.ts` defaults for day-1; if external launchers later need them tunable, they graduate to config keys then.
 
-### 6.7 Builder mode
-
-Reserved as the third Airbnb-style mode in the header. Day-1 it's disabled with a "coming soon" tooltip pointing at the SolverNet/harness/plugin building flow that doesn't exist yet. **Out of scope** for this spec; mentioned for design completeness so the mode switch is visibly tri-state from day-1.
 
 ## 7. Wallet / bootstrap
 
@@ -271,22 +278,21 @@ Same Safe pays for OLAS staking collateral *and* for posted Task budgets. The la
 
 **In scope (this spec → implementation plan):**
 
-1. Daemon: extend `roles` to include `'launching'`; remove `predictionV1LauncherEnabled`; gate the Polymarket generator on `roles.includes('launching')`.
-2. Daemon: `GET /v1/launcher/status` endpoint.
-3. Daemon: `GET /v1/launcher/tasks` endpoint.
-4. App: header mode switch with Operator / Launcher / disabled-Builder.
-5. App: `/launcher` overview empty state + setup flow.
-6. App: `/launcher` configured-state overview with the four-tier information hierarchy from §6.5.
-7. App: `/launcher/configuration` per-SolverNet generator config page.
-8. App: `OperatorCard` carries the new role pill for `launching` in operator-status's `roles` array (no UI change on Operator mode; data plumbing only).
-9. Tests at the corresponding levels (config schema migration, role gating, endpoint shape, SPA route + component coverage, setup-flow happy path).
-10. Spec for the data shapes added to `client/src/dashboard/spa/src/api/types.ts`.
+1. Daemon: extend `roles` to include `'launching'`; remove `predictionV1LauncherEnabled`; gate the Polymarket generator on `roles.includes('launching')` evaluated at runtime (hot-spawn — no daemon restart needed to toggle launching role; §5.2).
+2. Daemon: filter `'launching'` out of operator-status payload (`operator.solverNet.roles` narrows to `'solving' | 'evaluating'`) so Operator mode UI never sees launcher state.
+3. Daemon: `GET /v1/launcher/status` endpoint with stale-poll detection (§5.3).
+4. Daemon: `GET /v1/launcher/tasks` endpoint.
+5. App: header mode switch with Operator / Launcher (two-state).
+6. App: `/launcher` overview empty state + setup flow.
+7. App: `/launcher` configured-state overview with the four-tier information hierarchy from §6.5, including a stale-generator warning banner when `status.stale === true`.
+8. App: `/launcher/configuration` per-SolverNet generator config page (no restart-required signaling — all edits hot-apply).
+9. Tests at the corresponding levels (config schema migration, role hot-spawn, endpoint shape, SPA route + component coverage, setup-flow happy path, stale-warning rendering, Operator mode strictly hides launcher state).
+10. Type updates in `client/src/dashboard/spa/src/api/types.ts` for the new launcher payload shapes and the narrowed operator-status `roles` type.
 
 **Deferred (filed as bd issues post-spec, not addressed by this implementation plan):**
 
 - Manual one-off Task posting (`POST /v1/launcher/tasks` + UI form).
-- Generator runtime pause/resume (intersects `jinn-mono-t62s` hot-reload).
-- Builder mode UI surface and config (depends on Builder persona spec, which doesn't exist yet).
+- Builder mode and the Builder persona spec.
 - Launcher economics — staking rewards, ve-JINN gauges, fee capture (Phase B+).
 - Launcher Safe / Operator Safe separation (only revisit if an external use case demands it; today they share by design per invariant 2).
 
@@ -296,10 +302,14 @@ Same Safe pays for OLAS staking collateral *and* for posted Task budgets. The la
 
 ## 9. Open questions
 
-1. **Builder mode placement.** Does the disabled "Builder · coming soon" placeholder land in this spec or wait for the Builder spec to ship together? Default: keep the placeholder here so the tri-state mode switch is visible day-1, but make it explicit in copy that the Builder persona is not yet defined.
-2. **Launcher status freshness.** `GET /v1/launcher/status` reads in-memory generator state. Do we surface a "last polled X minutes ago — generator may be stuck if longer than 2× cadence" warning? Lightweight; recommend yes.
-3. **Operator Overview display when `roles` includes `'launching'`.** §6.3 says Operator mode's Overview ignores the `'launching'` value. Is that the right call, or should the OperatorCard show a "Launcher: yes" pill so an operator-mode user knows their daemon is also doing launcher work? Recommend deferring — Operator mode is the operator's view; their cross-role visibility lives in mode-switching, not in pill clutter.
-4. **Setup flow restart requirement.** Adding `'launching'` to `roles` triggers a restart-required pill (the generator loop spawns at startup today). Is that acceptable for v1, or should the generator loop be hot-spawnable? Recommend acceptable for v1 — `t62s` will pull this together for all SolverNet config later.
+All four open questions raised during the brainstorm have been resolved into the spec body:
+
+- **Builder mode placement** → not in this spec; mode switch is two-state (§6.1, §8 deferred).
+- **Launcher status freshness** → `stale` flag on the status payload, banner in Launcher overview when stale (§5.3, §6.5, §8 in-scope #7).
+- **Operator Overview vs launcher state** → strict mode separation; Operator mode never displays launcher state; operator-status payload narrows to exclude `'launching'` (§6.3, §8 in-scope #2).
+- **Restart-required vs hot-spawn** → hot-spawn within one cadence tick; no daemon restart for role flip or generator-config edits (§5.2, §6.4, §6.6, §8 in-scope #1).
+
+No remaining blockers for the implementation plan.
 
 ## 10. References
 

--- a/spec/2026-05-05-launcher-role-and-mode.md
+++ b/spec/2026-05-05-launcher-role-and-mode.md
@@ -1,0 +1,314 @@
+# Launcher role and Launcher mode
+
+- **Date:** 2026-05-05
+- **Author:** ritsukai with Opus (brainstorm session)
+- **Status:** Draft for Captain review
+- **Version:** 0.1
+- **Related:**
+  - Discussion #59 — *Jinn as the knowledge market — implementation roadmap proposal* (substrate vision)
+  - Discussion #57 — *Unified GTM around the Prediction SolverNet* (paired GTM)
+  - `spec/2026-04-30-phase-a-umbrella.md` — Phase A roadmap this spec lives under
+  - `spec/2026-05-02-task-coordinator-one-to-many.md` — funding model this spec composes against (per-attempt budget, Creator Safe)
+  - `docs/superpowers/plans/2026-05-02-prediction-solvernet-v1-task-lifecycle.md` — generator design contract
+  - `client/src/solver-types/prediction-v1-auto.ts` — generator implementation already in-tree
+  - `client/src/config.ts` — config schema this spec extends (the `predictionV1Launcher*` keys originated here)
+  - bd `jinn-mono-l2zl` — parent epic; bd issue for this spec's implementation will be filed alongside
+
+---
+
+## 1. Purpose
+
+Define the **Launcher role** and the **Launcher mode** so Jinn team can run the Prediction SolverNet's launcher day-1 from the operator app, and so a clean fork-able shape exists for external launchers later.
+
+The Polymarket-derived Task generator is fully built (`client/src/solver-types/prediction-v1-auto.ts`). What this spec adds is the role/persona layer on top: a launcher's identity in the daemon's role taxonomy, a UI surface in the operator app, and a clear day-1 invariant set. No new on-chain contracts. No changes to the generator's internals.
+
+This is a design spec. Implementation proceeds via a follow-up plan.
+
+## 2. Framing — what a Launcher is
+
+A **Launcher** is a participant who directs the network toward producing knowledge about a specific domain. They believe the resulting knowledge has value — for themselves, for an external market, or for the network's collective intelligence — and they fund Task creation in a SolverNet they own to pull network effort toward producing it.
+
+The Launcher is the third role in Jinn's loop alongside Operator (Solver/Evaluator) and Builder:
+
+| Role | Question they answer | Day-1 reality |
+|---|---|---|
+| **Builder** | "What kind of knowledge work is this network shaped to produce?" — designs SolverNets, harnesses, plugins | Jinn team only; external builders later |
+| **Launcher** | "Which knowledge area should the network produce now? Who pays?" — funds Tasks, runs generators, directs incentives | Jinn team only for Prediction; external launchers fork their own SolverNets later |
+| **Operator** | "Whose Tasks do I attempt or evaluate?" — runs Solver/Evaluator loops on enabled SolverNets | Open to external operators today |
+
+Today (Phase A.4) Jinn team is the sole Launcher of Prediction. The launcher funds Tasks directly out of the master EOA-controlled Safe. Later (Phase B+) Launchers will direct protocol-level JINN emissions via ve-JINN gauges; that is **out of scope** for this spec but signposted in the UI.
+
+## 3. Day-1 invariants
+
+The spec rests on these. They are explicit so reviewers can challenge them as a unit:
+
+1. **One SolverNet, one Launcher.** Forking means forking the SolverNet definition (e.g. `prediction.v1` → `myforecast.v1`), not running a parallel launcher on the same net. Two daemons accidentally configured as launcher for the same net would race; first wins on-chain via `taskCid` dedup; the second wastes gas. Gas cost is the natural disincentive — no on-chain coordination protocol is needed.
+2. **One identity, one Safe, one bootstrap.** The Launcher reuses the operator's master EOA + Safe + 11-step earning bootstrap (`client/src/earning/bootstrap.ts`). No separate launcher wallet. The same Safe pays for OLAS staking *and* for posted Task budgets.
+3. **Multi-role daemon.** A single daemon can run any combination of `solving`, `evaluating`, `launching` roles per SolverNet, building on the `roles: Array<...>` schema shipped in `jinn-mono-l2zl.15.4.8`. The team's daemon can launch Prediction *and* solve/evaluate other SolverNets simultaneously.
+4. **Modes are UI lenses, not daemon state.** *Switching* between Operator and Launcher mode is a localStorage preference; the switch itself never writes daemon config. *Actions inside a mode* (e.g. completing the Launcher setup flow, ticking a role checkbox in Operator-mode Configuration) do write daemon config — that's how the role state is set. The distinction matters because it means a user can freely flip between modes to look around without changing what their daemon does.
+5. **Roles are configured by the mode that owns them.** Operator mode owns the per-SolverNet `solving`/`evaluating` checkboxes shipped in `.15.4.8`. Launcher mode owns the per-SolverNet `launching` configuration. There is no prerequisite "first enable launching elsewhere" — entering Launcher mode is the entry point to launcher setup.
+6. **Launcher economics deferred.** Whether the launcher Safe earns staking rewards / fees / future ve-JINN gauge weight is Phase B+ territory. Day-1 the launcher runs at a net cost (Task funding flows out; no in-spec earning flows in). The SolverNet exists for the *value of the knowledge produced*, not for direct daemon-level rewards.
+
+## 4. Conceptual frame — roles vs modes
+
+| | Roles | Modes |
+|---|---|---|
+| **What it is** | Daemon capability per SolverNet | UI lens in the operator app |
+| **Where it lives** | `~/.jinn-client/config.json` | `localStorage` |
+| **Who sets it** | Whichever mode's UI surface owns it (Operator mode for solving/evaluating; Launcher mode for launching) | The user, via the mode switch in the app header |
+| **Effect on daemon** | Determines which loops run | None |
+| **Day-1 values** | `solving`, `evaluating`, `launching` | `operator`, `launcher` (`builder` deferred) |
+
+Modes provide an **information hierarchy and entry point**, not a security or capability boundary. All modes are always available in the header switch; switching to a mode you have not used yet lands you on its empty/setup state.
+
+## 5. Daemon shape
+
+### 5.1 Role enum extension
+
+Per-SolverNet `roles` adds a third value:
+
+```ts
+// before (.15.4.8)
+roles: Array<'solving' | 'evaluating'>
+
+// after (this spec)
+roles: Array<'solving' | 'evaluating' | 'launching'>
+```
+
+Validation rules from `.15.4.8` carry forward unchanged:
+
+- Non-empty array.
+- Deduped on read.
+- Zod `preprocess` auto-migrates legacy `role: 'X'` config to `roles: ['X']`. (Only relevant for `solving` / `evaluating` — `launching` was never expressed as a single-value `role`.)
+- Setup endpoint accepts both wire shapes for backwards-compat; persists canonical `roles`.
+
+### 5.2 Generator gating — replace the boolean
+
+Today the Polymarket generator is gated behind `predictionV1LauncherEnabled: boolean` (`client/src/config.ts:318`). That flag is **removed**. Gating moves to:
+
+```ts
+solverNets.prediction.roles.includes('launching')
+```
+
+The generator's internals (`client/src/solver-types/prediction-v1-auto.ts`) do not change. The wiring in `main.ts` that reads `predictionV1LauncherEnabled` becomes a `roles.includes('launching')` check on the prediction SolverNet's config block.
+
+The other generator config keys (`predictionV1CadenceMs`, `predictionV1MaxNewRoundsPerPoll`, `predictionV1MaxNewRoundsPerDay`, `predictionV1MaxOpenRounds`, `predictionV1AllowlistConditionIds`, `predictionV1BlocklistConditionIds`, `predictionV1WindowMs`, `predictionV1ResolveGapMs`) stay where they are. They are launcher-tunable; Launcher mode's Configuration page edits them.
+
+### 5.3 Read endpoints
+
+Two new endpoints under `/v1/launcher/*` for the Launcher mode UI:
+
+#### `GET /v1/launcher/status`
+
+Per-SolverNet generator and budget state for any SolverNet with `'launching'` in its roles.
+
+```ts
+interface LauncherStatusResponse {
+  schemaVersion: 1;
+  generatedAt: string;
+  nets: Array<{
+    name: string;                         // SolverNet name, e.g. 'prediction'
+    generator: {
+      state: 'active' | 'paused' | 'errored';
+      lastPollAt?: string;
+      lastPollSummary?: {
+        evaluated: number;
+        posted: number;
+        skipped: number;
+        skipReasons?: Record<string, number>;  // e.g. { 'liquidity-floor': 12, 'spread-too-wide': 4 }
+      };
+      lastError?: { message: string; at: string };
+      cadenceMs: number;
+    };
+    openTasks: number;
+    budget: {
+      safeAddress: string;
+      safeBalanceWei: string;             // ETH balance — gas + collateral
+      reservedBudgetWei: string;          // sum across open Tasks (maxClaims × perAttemptPayment)
+      runwayDays?: number;                // estimate: spend rate vs. balance
+    };
+  }>;
+}
+```
+
+The generator's existing in-memory state (last-poll summary, dedup map cardinality, error log) becomes readable via this endpoint. No new persistence layer; if the daemon restarts, the status reflects post-restart state.
+
+#### `GET /v1/launcher/tasks`
+
+Tasks posted by this daemon's creator address. Sourced from the existing router log polling (the `l2zl.12` polling-hardening lane is the natural place to add this filter; the launcher endpoint can ship before that lane completes by reusing the existing watcher).
+
+```ts
+interface LauncherTasksResponse {
+  schemaVersion: 1;
+  generatedAt: string;
+  cursor?: { before: string };  // pagination
+  tasks: Array<{
+    taskId: string;
+    taskCid: string;
+    solverNet: string;
+    postedAt: string;
+    state: 'open' | 'claims-in-flight' | 'fully-claimed' | 'settled' | 'failed';
+    claims: { current: number; max: number };
+    budget: { totalWei: string; remainingWei: string; reclaimableAt?: string };
+    summary?: {                  // SolverNet-specific projection — Prediction shows the predicate
+      title?: string;
+      resolutionTime?: string;
+    };
+  }>;
+}
+```
+
+Pagination by posted-time cursor; default page size 25.
+
+### 5.4 What is **not** in the daemon spec
+
+- **Manual one-off Task posting (`POST /v1/launcher/tasks`)** — UI affordance and endpoint deferred. Auto-generator covers day-1.
+- **Pause/resume runtime control** — intersects with hot-reload (`jinn-mono-t62s`). Day-1 launcher pauses by editing config + restarting (or by removing `'launching'` from roles, which restarts the generator loop on next config write). Runtime pause is a follow-up.
+- **Dedicated launcher Safe / treasury contract** — explicitly absent (invariant 2).
+- **Launcher activity-checker / earning hooks** — Phase B+.
+
+## 6. Operator app shape
+
+### 6.1 Header mode switch
+
+A persistent control at the top of the app shell (`client/src/dashboard/spa/src/shell/Header.tsx` or equivalent). Two states for day-1:
+
+- `Operator`
+- `Launcher`
+
+A third state placeholder shows `Builder · coming soon` (disabled, surfaces the future trajectory; matches the Airbnb-style information design where the role taxonomy is visible even when not all roles are usable).
+
+State persists in `localStorage` under a stable key (e.g. `jinn.app.mode`). Default = `Operator`. Switching is an instant route change; no daemon write.
+
+### 6.2 Route layout
+
+| Route | Mode | Page |
+|---|---|---|
+| `/` | Operator | Overview (today's page) |
+| `/configuration` | Operator | Configuration (today's page) |
+| `/launcher` | Launcher | Launcher overview |
+| `/launcher/configuration` | Launcher | Per-SolverNet generator config |
+
+Mode-specific routes are gated only by the localStorage mode preference for navigation purposes; the routes themselves are reachable directly. Hitting `/launcher` from a fresh install lands on the empty/setup state (§6.4).
+
+### 6.3 Operator mode
+
+No changes from today. Existing pages, existing role checkboxes (`solving` / `evaluating`) on per-SolverNet cards continue to work as shipped in `.15.4.*`.
+
+The `OperatorCard` on Overview already reads `operator.solverNet.roles` and renders pills (`.15.4.8`); the only change is that the pills now reflect three possible values when the operator is also launching, but Operator mode's Overview does *not* display launcher state — that lives in Launcher mode. (The operator-status payload may include `'launching'` in the `roles` array purely for type consistency; Operator mode UI ignores it.)
+
+### 6.4 Launcher mode
+
+#### Empty / setup state
+
+When no SolverNet has `'launching'` in its roles:
+
+> **You haven't launched a SolverNet yet.**
+>
+> A SolverNet directs the network's effort toward producing a kind of knowledge. As Launcher you fund the Tasks operators attempt — and own what gets produced.
+>
+> [ Launch Prediction SolverNet ]
+
+The CTA opens a setup flow:
+
+1. **Confirm SolverNet.** Day-1 only Prediction is launchable. Show the SolverNet's intent ("Calibrated probabilistic forecasts of Polymarket-listed events") + the canonical scoreboard ("Brier spread vs. Polymarket consensus over a rolling window").
+2. **Confirm generator defaults.** Cadence, market filters, caps from `prediction-v1-auto.ts`. Operator can edit; defaults are sensible.
+3. **Show informational budget plan.** Read Safe balance via the existing balance API; display "this funds approximately N Tasks at the current per-attempt payment, ~M days at current cadence". No funding action — Safe is funded out-of-band like operator earning Safe.
+4. **Save.** Patch sets `roles: [...currentRoles, 'launching']` for the prediction SolverNet via the existing `api.updateSolverNet` endpoint. Restart-required signaling reuses the `RestartPill` + banner shipped earlier.
+
+After save, Launcher mode lands on the configured-state overview (§6.5).
+
+#### 6.5 Configured state — Launcher overview
+
+Information hierarchy reflects the framing in §2 (Launcher = direct knowledge production, not "run the auto-generator"):
+
+1. **What knowledge is this SolverNet producing.** Brier spread vs. Polymarket consensus (reuse the existing scoreboard from `jinn-mono-l2zl.5`), corpus growth (count of settled Verdicts in window), recent settled forecasts (top 5 with predicate + outcome). The headline section.
+2. **Cost of producing it.** Safe burn rate over last 7d, Tasks funded over last 7d, current open-Task budget reservations. A second-tier section.
+3. **Generator status.** State pill (active / paused / errored), last poll timestamp + summary, recent posted Tasks (5 latest with state). Tactical, third tier.
+4. **Direct JINN emissions to this SolverNet.** Phase B+ placeholder section. Disabled, with explanatory copy: "When ve-JINN gauges ship, you'll be able to direct protocol-level emissions toward this SolverNet here."
+
+Per-SolverNet card actions:
+
+- **Edit generator config** → deep-link to `/launcher/configuration#<solver-net>`.
+- **View all Tasks** → expands the Tasks list (paginated via `/v1/launcher/tasks`).
+- **Stop launching** → patches `roles` to remove `'launching'`. Confirms before submit.
+
+#### 6.6 Launcher configuration page
+
+Per-SolverNet form for the generator config keys listed in §5.2. Layout mirrors the Operator-mode Configuration page (`SectionCard` + `ConfigField` components from `client/src/dashboard/spa/src/components/`). Restart-required signaling on edit. Save = `api.updateSolverNet` with the generator config block.
+
+For day-1 Prediction, the editable fields are:
+
+- Cadence (ms)
+- Max new rounds per poll
+- Max new rounds per day
+- Max open rounds
+- Allowlist condition IDs
+- Blocklist condition IDs
+- Window (ms) — Task claim/submission window
+- Resolve gap (ms) — buffer between resolution and claim cutoff
+
+Filters that are not safely operator-tunable (e.g. liquidity floor, spread max) stay in `prediction-v1-auto.ts` defaults for day-1; if external launchers later need them tunable, they graduate to config keys then.
+
+### 6.7 Builder mode
+
+Reserved as the third Airbnb-style mode in the header. Day-1 it's disabled with a "coming soon" tooltip pointing at the SolverNet/harness/plugin building flow that doesn't exist yet. **Out of scope** for this spec; mentioned for design completeness so the mode switch is visibly tri-state from day-1.
+
+## 7. Wallet / bootstrap
+
+The Launcher reuses the existing 11-step earning bootstrap unchanged (`client/src/earning/bootstrap.ts`). The bootstrap is role-agnostic — it makes the master EOA, predicts and deploys the Safe, registers the OLAS service, stakes, deploys the mech. None of that is operator-specific.
+
+A user who installs `@jinn-network/client` and goes straight to Launcher mode without ever solving:
+
+1. Bootstrap runs as today on first `jinn run`.
+2. Funding gate at `awaiting_funding` blocks until the master EOA has ETH and the Safe has OLAS — same as operator path.
+3. After bootstrap completes, Launcher mode's setup flow patches `roles: ['launching']` on the prediction SolverNet.
+4. Launcher mode's Overview displays a "fund the Safe to start posting Tasks" banner if Safe ETH is below a launcher-specific threshold (separate from the operator gas-runway threshold). Funding action is the same as operator: send ETH to the Safe address shown.
+
+Same Safe pays for OLAS staking collateral *and* for posted Task budgets. The launcher's daily Task spend is bounded by `maxClaims × perAttemptPayment × maxNewRoundsPerDay`; the launcher mode's overview surfaces this as the "burn rate" so the Safe doesn't drain unnoticed.
+
+## 8. Day-1 scope
+
+**In scope (this spec → implementation plan):**
+
+1. Daemon: extend `roles` to include `'launching'`; remove `predictionV1LauncherEnabled`; gate the Polymarket generator on `roles.includes('launching')`.
+2. Daemon: `GET /v1/launcher/status` endpoint.
+3. Daemon: `GET /v1/launcher/tasks` endpoint.
+4. App: header mode switch with Operator / Launcher / disabled-Builder.
+5. App: `/launcher` overview empty state + setup flow.
+6. App: `/launcher` configured-state overview with the four-tier information hierarchy from §6.5.
+7. App: `/launcher/configuration` per-SolverNet generator config page.
+8. App: `OperatorCard` carries the new role pill for `launching` in operator-status's `roles` array (no UI change on Operator mode; data plumbing only).
+9. Tests at the corresponding levels (config schema migration, role gating, endpoint shape, SPA route + component coverage, setup-flow happy path).
+10. Spec for the data shapes added to `client/src/dashboard/spa/src/api/types.ts`.
+
+**Deferred (filed as bd issues post-spec, not addressed by this implementation plan):**
+
+- Manual one-off Task posting (`POST /v1/launcher/tasks` + UI form).
+- Generator runtime pause/resume (intersects `jinn-mono-t62s` hot-reload).
+- Builder mode UI surface and config (depends on Builder persona spec, which doesn't exist yet).
+- Launcher economics — staking rewards, ve-JINN gauges, fee capture (Phase B+).
+- Launcher Safe / Operator Safe separation (only revisit if an external use case demands it; today they share by design per invariant 2).
+
+**Explicitly disclaimed (won't re-litigate):**
+
+- Multi-launcher coordination on the same SolverNet. Invariant 1 makes this a non-problem; gas cost is the natural disincentive against accidental duplication.
+
+## 9. Open questions
+
+1. **Builder mode placement.** Does the disabled "Builder · coming soon" placeholder land in this spec or wait for the Builder spec to ship together? Default: keep the placeholder here so the tri-state mode switch is visible day-1, but make it explicit in copy that the Builder persona is not yet defined.
+2. **Launcher status freshness.** `GET /v1/launcher/status` reads in-memory generator state. Do we surface a "last polled X minutes ago — generator may be stuck if longer than 2× cadence" warning? Lightweight; recommend yes.
+3. **Operator Overview display when `roles` includes `'launching'`.** §6.3 says Operator mode's Overview ignores the `'launching'` value. Is that the right call, or should the OperatorCard show a "Launcher: yes" pill so an operator-mode user knows their daemon is also doing launcher work? Recommend deferring — Operator mode is the operator's view; their cross-role visibility lives in mode-switching, not in pill clutter.
+4. **Setup flow restart requirement.** Adding `'launching'` to `roles` triggers a restart-required pill (the generator loop spawns at startup today). Is that acceptable for v1, or should the generator loop be hot-spawnable? Recommend acceptable for v1 — `t62s` will pull this together for all SolverNet config later.
+
+## 10. References
+
+- `client/src/solver-types/prediction-v1-auto.ts` — generator implementation
+- `client/src/config.ts:304-348, 697-730` — current generator config schema + env var bindings
+- `client/src/dashboard/spa/src/pages/configuration/NetCard.tsx` — per-SolverNet card pattern to mirror in Launcher mode
+- `client/src/dashboard/spa/src/components/{SectionCard,ConfigField,RestartPill}.tsx` — reusable building blocks
+- `spec/2026-05-02-task-coordinator-one-to-many.md` §8 — lazy attempt funding model the launcher's Safe interfaces with
+- `docs/superpowers/plans/2026-05-02-prediction-solvernet-v1-task-lifecycle.md` — generator design contract
+- bd `jinn-mono-l2zl.15.4.8` (closed) — `roles: Array<...>` schema this spec extends
+- bd `jinn-mono-l2zl.12` — router log polling hardening lane that intersects with `/v1/launcher/tasks`
+- bd `jinn-mono-t62s` (open) — hot-reload, intersects with launcher pause/resume


### PR DESCRIPTION
## Summary

Day-1 launcher loop: promotes the Polymarket generator's `predictionV1LauncherEnabled` boolean to a first-class `'launching'` role in the multi-role daemon (built on `jinn-mono-l2zl.15.4.8`'s roles array), and adds an Airbnb-style two-state mode switch (Operator | Launcher) to the operator app. Strict information separation between modes; one Safe shared with the operator path; launcher economics deferred to Phase B+. Generator code, funding contract, and bootstrap path all reused unchanged.

- **Spec:** `spec/2026-05-05-launcher-role-and-mode.md`
- **Plan:** `docs/superpowers/plans/2026-05-05-launcher-role-and-mode-plan.md`
- **Closes:** `jinn-mono-l2zl.16`

### Daemon changes
- `roles` schema extended to include `'launching'` (with backwards-compat preprocess from `.15.4.8`); `predictionV1LauncherEnabled` boolean removed
- Polymarket generator hot-spawns on `roles.includes('launching')` evaluated each tick — no daemon restart on role flip
- Operator-mode setup endpoint preserves non-operator roles across patches; gather-status filters `'launching'` out of operator-status payload at the API boundary (strict mode separation)
- Three new endpoints under `/v1/launcher/*`:
  - `GET /v1/launcher/status` — per-SolverNet generator state + stale-poll flag + budget
  - `GET /v1/launcher/tasks` — paginated tasks posted by this daemon's creator address
  - `PATCH /v1/launcher/solvernets/:name` — toggle `'launching'` + edit generator config
- Generator exposes `getState()` for the status endpoint (lastPollAt, lastPollSummary, lastError, cadenceMs)

### SPA changes
- Header `ModeSwitch` (Operator | Launcher) backed by `localStorage`; URL ↔ mode sync via `useAppMode`
- Two new routes: `/launcher` (overview) and `/launcher/configuration` (generator config form)
- Launcher overview composed in spec §6.5 order: KnowledgeProductionCard → CostCard → GeneratorStatusCard → PostedTasksList → EmissionsPlaceholder (Phase B+ placeholder)
- 4-step setup flow (Confirm SolverNet → Generator defaults → Budget plan → Save) on first launch
- API types narrowed so Operator-mode UI cannot accidentally render launcher state (`operator.solverNet.roles` → `Array<'solving' | 'evaluating'>`)

### Follow-ups (filed as bd issues)
- `l2zl.16.1` — SQLite index on `task_posts (creator_safe_address, last_posted_at DESC)` (P4)
- `l2zl.16.2` — Narrow `getOpenTaskCount` to in-flight states (P3)
- `l2zl.16.3` — Extract shared `formatEth` util in SPA (3 duplicates) (P4)
- `l2zl.16.4` — Surface Brier scoreboard + recent settled forecasts to Launcher mode (P3)
- `l2zl.16.5` — Surface actual generator config (not just defaults) in Launcher Configuration (P3)

### Note on branch contents

This branch (`opus/launcher-role-and-mode`) is rebased onto `origin/main` and contains both the launcher work and unrelated network-trust commits from a parallel session that shared the underlying ephemeral branch. Splitting into separate PRs is straightforward if preferred — the launcher commits are tagged with `feat(spa-launcher|spa-api|spa-shell|api): ...`, `config: extend per-SolverNet roles ...`, `feat(generator): hot-spawn gate ...`, etc.

## Test plan

- [ ] `cd client && npx tsc --noEmit` — clean
- [ ] `cd client/src/dashboard/spa && npx tsc -b` — clean
- [ ] `cd client && yarn vitest run src/dashboard/spa test/api` — 217 tests across 42 files pass
- [ ] Manual SPA dogfood: start daemon against an Anvil fork, open the operator app, switch to Launcher mode, complete the setup flow, verify generator polls within one cadence (no daemon restart), switch back to Operator mode and confirm no launcher state visible
- [ ] Verify `/v1/launcher/status` returns the expected shape against a running daemon with `roles: ['launching']` configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)