### PR TITLE
[codex] Add testnet execution envelope donation mode

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -77,7 +77,7 @@
     "dev:spa": "yarn workspace @jinn-network/operator-spa dev",
     "e2e:spa": "yarn build && playwright test --config=playwright.config.ts test/dashboard/spa.e2e.test.ts",
     "e2e:solvernet-flow": "yarn build && playwright test --config=playwright.config.ts test/dashboard/solvernet-flow.e2e.test.ts",
-    "e2e:donation": "vitest run test/smoke/donation-mode-smoke.test.ts"
+    "e2e:donation": "vitest run test/smoke/donation-mode-smoke.test.ts test/smoke/donation-ipfs-http-smoke.test.ts"
   },
   "dependencies": {
     "@ethereumjs/wallet": "^10.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -76,7 +76,8 @@
     "build:spa": "yarn workspace @jinn-network/operator-spa build",
     "dev:spa": "yarn workspace @jinn-network/operator-spa dev",
     "e2e:spa": "yarn build && playwright test --config=playwright.config.ts test/dashboard/spa.e2e.test.ts",
-    "e2e:solvernet-flow": "yarn build && playwright test --config=playwright.config.ts test/dashboard/solvernet-flow.e2e.test.ts"
+    "e2e:solvernet-flow": "yarn build && playwright test --config=playwright.config.ts test/dashboard/solvernet-flow.e2e.test.ts",
+    "e2e:donation": "vitest run test/smoke/donation-mode-smoke.test.ts"
   },
   "dependencies": {
     "@ethereumjs/wallet": "^10.0.0",

--- a/client/src/api/operator-artifacts-endpoint.ts
+++ b/client/src/api/operator-artifacts-endpoint.ts
@@ -16,6 +16,7 @@ export interface OperatorPricingConfig {
   publicEndpoint: string;
   defaultPriceUsdc: string;
   perArtifactTypePrice: Record<string, string>;
+  donation: { enabled: boolean };
 }
 
 export interface OperatorArtifactsRoutesConfig {
@@ -58,6 +59,7 @@ const PricingPatchSchema = z.object({
   publicEndpoint: z.string().min(1).optional(),
   defaultPriceUsdc: DecimalString.optional(),
   perArtifactTypePrice: z.record(z.string(), DecimalString).optional(),
+  donation: z.object({ enabled: z.boolean() }).optional(),
 });
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -99,6 +101,11 @@ function resolvePricingConfig(
       ...(fallback?.perArtifactTypePrice ?? {}),
       ...decimalRecord(rawOperator.perArtifactTypePrice),
     },
+    donation: {
+      enabled: isRecord(rawOperator.donation) && typeof rawOperator.donation.enabled === 'boolean'
+        ? rawOperator.donation.enabled
+        : fallback?.donation?.enabled ?? false,
+    },
   };
 }
 
@@ -117,7 +124,7 @@ function normalizePricingPatch(
 ): { ok: true; value: OperatorPricingConfig } | { ok: false; detail: string } {
   const parsed = PricingPatchSchema.safeParse(rawBody);
   if (!parsed.success) {
-    return { ok: false, detail: 'publicEndpoint, defaultPriceUsdc, or perArtifactTypePrice is malformed' };
+    return { ok: false, detail: 'publicEndpoint, defaultPriceUsdc, perArtifactTypePrice, or donation is malformed' };
   }
   const patch = parsed.data;
   const publicEndpoint = patch.publicEndpoint?.trim() ?? current.publicEndpoint;
@@ -142,6 +149,7 @@ function normalizePricingPatch(
       publicEndpoint,
       defaultPriceUsdc: patch.defaultPriceUsdc?.trim() ?? current.defaultPriceUsdc,
       perArtifactTypePrice,
+      donation: patch.donation ?? current.donation,
     },
   };
 }

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -499,6 +499,7 @@ export const JinnConfigSchema = z.object({
    * Env overrides:
    *   JINN_OPERATOR_PUBLIC_ENDPOINT
    *   JINN_OPERATOR_DEFAULT_PRICE_USDC
+   *   JINN_OPERATOR_DONATION_ENABLED
    */
   operator: z
     .object({
@@ -513,6 +514,11 @@ export const JinnConfigSchema = z.object({
           z.string().regex(/^\d+(\.\d+)?$/, 'must be a non-negative decimal string'),
         )
         .default({}),
+      donation: z
+        .object({
+          enabled: z.boolean().default(false),
+        })
+        .default({ enabled: false }),
     })
     .optional(),
 
@@ -713,11 +719,18 @@ export function loadConfig(configPath?: string): JinnConfig {
 
   if (
     env['JINN_OPERATOR_PUBLIC_ENDPOINT'] ||
-    env['JINN_OPERATOR_DEFAULT_PRICE_USDC']
+    env['JINN_OPERATOR_DEFAULT_PRICE_USDC'] ||
+    env['JINN_OPERATOR_DONATION_ENABLED'] !== undefined
   ) {
     const prevOp = typeof merged['operator'] === 'object' && merged['operator'] !== null
       ? (merged['operator'] as Record<string, unknown>)
       : {};
+    const prevDonation = typeof prevOp['donation'] === 'object' && prevOp['donation'] !== null
+      ? (prevOp['donation'] as Record<string, unknown>)
+      : {};
+    const donationEnabled = env['JINN_OPERATOR_DONATION_ENABLED'] !== undefined
+      ? ['1', 'true', 'yes'].includes(env['JINN_OPERATOR_DONATION_ENABLED'].trim().toLowerCase())
+      : undefined;
     merged['operator'] = {
       ...prevOp,
       ...(env['JINN_OPERATOR_PUBLIC_ENDPOINT']
@@ -725,6 +738,9 @@ export function loadConfig(configPath?: string): JinnConfig {
         : {}),
       ...(env['JINN_OPERATOR_DEFAULT_PRICE_USDC']
         ? { defaultPriceUsdc: env['JINN_OPERATOR_DEFAULT_PRICE_USDC'] }
+        : {}),
+      ...(donationEnabled !== undefined
+        ? { donation: { ...prevDonation, enabled: donationEnabled } }
         : {}),
     };
   }
@@ -902,6 +918,7 @@ const TRACKED_ENV_VARS = [
   'JINN_ENGINE_IMPL_STATE_DIR_ROOT',
   'JINN_OPERATOR_PUBLIC_ENDPOINT',
   'JINN_OPERATOR_DEFAULT_PRICE_USDC',
+  'JINN_OPERATOR_DONATION_ENABLED',
   'JINN_BUILD_COMMIT',
 ] as const;
 

--- a/client/src/corpus/acquire.ts
+++ b/client/src/corpus/acquire.ts
@@ -11,6 +11,8 @@ import type { Store } from '../store/store.js';
 import { acquireArtifactWithPayment, type AcquireWithPaymentResult } from '../x402/acquire.js';
 import type { ArtifactContent, RouteResolver } from './types.js';
 import { AcquireError, HashMismatchError } from './types.js';
+import { fetchFromIpfs as defaultFetchFromIpfs } from '../adapters/mech/ipfs.js';
+import type { ArtifactSource } from '../types/envelope.js';
 
 /**
  * Origin acquire function. Historically returned `Buffer | null`; the new
@@ -21,6 +23,9 @@ import { AcquireError, HashMismatchError } from './types.js';
 type AcquireFnLegacy = (endpoint: string, sha256: string, privateKey: string) => Promise<Buffer | null>;
 type AcquireFnNew = (endpoint: string, sha256: string, privateKey: string) => Promise<AcquireWithPaymentResult>;
 type AcquireFn = AcquireFnLegacy | AcquireFnNew;
+type FetchFromIpfsFn = (gatewayUrl: string, cid: string) => Promise<unknown>;
+
+const DONATION_ARTIFACT_ENCODING = 'jinn.artifact.donation.v1';
 
 export interface AcquireArtifactArgs {
   sha256: string;
@@ -31,13 +36,33 @@ export interface AcquireArtifactArgs {
   privateKey: string;
   routeResolver?: RouteResolver;
   envelopeCid?: string;
+  sources?: ArtifactSource[];
+  ipfsGatewayUrl?: string;
   /** Safe address that produced this artifact, when known (from envelope.participant). */
   ownerSafe?: string;
   acquireFn?: AcquireFn;
+  fetchFromIpfs?: FetchFromIpfsFn;
 }
 
 function sha256Hex(buf: Buffer): string {
   return createHash('sha256').update(buf).digest('hex');
+}
+
+function decodeDonationArtifact(raw: unknown, expectedSha256: string): Buffer {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('donation artifact payload is not an object');
+  }
+  const record = raw as Record<string, unknown>;
+  if (record['schemaVersion'] !== DONATION_ARTIFACT_ENCODING || record['encoding'] !== DONATION_ARTIFACT_ENCODING) {
+    throw new Error('donation artifact payload has unexpected encoding');
+  }
+  if (record['sha256'] !== expectedSha256) {
+    throw new Error('donation artifact sha256 does not match requested artifact');
+  }
+  if (typeof record['data'] !== 'string') {
+    throw new Error('donation artifact payload is missing base64 data');
+  }
+  return Buffer.from(record['data'], 'base64');
 }
 
 export async function acquireArtifactContent(args: AcquireArtifactArgs): Promise<ArtifactContent> {
@@ -50,8 +75,11 @@ export async function acquireArtifactContent(args: AcquireArtifactArgs): Promise
     privateKey,
     routeResolver,
     envelopeCid,
+    sources = [],
+    ipfsGatewayUrl,
     ownerSafe,
     acquireFn = acquireArtifactWithPayment,
+    fetchFromIpfs = defaultFetchFromIpfs,
   } = args;
 
   const now = () => new Date().toISOString();
@@ -71,7 +99,44 @@ export async function acquireArtifactContent(args: AcquireArtifactArgs): Promise
     };
   }
 
-  // 2. Self-store fast path
+  // 2. Public IPFS donation source.
+  const ipfsSource = sources.find((source) => source.kind === 'ipfs');
+  if (ipfsSource && ipfsGatewayUrl) {
+    try {
+      const raw = await fetchFromIpfs(ipfsGatewayUrl, ipfsSource.cid);
+      const bytes = decodeDonationArtifact(raw, sha256);
+      const actualSha = sha256Hex(bytes);
+      if (actualSha !== sha256) {
+        throw new HashMismatchError(sha256, actualSha, 'ipfs', ownerSafe);
+      }
+      const ts = now();
+      store.saveNetworkArtifact({
+        sha256,
+        artifactType,
+        envelopeCid: envelopeCid ?? null,
+        content: bytes,
+        source: 'origin',
+        sourceOperator: ownerSafe ?? null,
+        sourceEndpoint: `ipfs://${ipfsSource.cid}`,
+        paidAmountUsdc: '0',
+        fetchedAt: ts,
+      });
+      return {
+        sha256,
+        bytes,
+        artifactType,
+        source: 'ipfs',
+        paidAmountUsdc: '0',
+        fetchedAt: ts,
+        sourceOperator: ownerSafe,
+      };
+    } catch (err) {
+      if (err instanceof HashMismatchError) throw err;
+      throw new AcquireError(sha256, `ipfs donation source failed: ${ipfsSource.cid}`, err);
+    }
+  }
+
+  // 3. Self-store fast path
   if (ownerSafe && ownerSafe.toLowerCase() === selfSafeAddress.toLowerCase()) {
     const own = store.getServedArtifact(sha256);
     if (own) {
@@ -106,7 +171,7 @@ export async function acquireArtifactContent(args: AcquireArtifactArgs): Promise
     }
   }
 
-  // 3. Route resolver
+  // 4. Route resolver
   if (routeResolver) {
     try {
       const out = await routeResolver.resolve({ sha256, access, requesterSafe: selfSafeAddress });
@@ -142,7 +207,7 @@ export async function acquireArtifactContent(args: AcquireArtifactArgs): Promise
     }
   }
 
-  // 4. Origin fetch
+  // 5. Origin fetch
   let bytes: Buffer | null;
   try {
     const raw = await acquireFn(access.endpoint, sha256, privateKey);

--- a/client/src/corpus/index.ts
+++ b/client/src/corpus/index.ts
@@ -17,6 +17,7 @@ import type {
 import { runCorpusQuery } from './query.js';
 import { fetchManifest } from './fetch.js';
 import { acquireArtifactContent } from './acquire.js';
+import type { ArtifactSource } from '../types/envelope.js';
 
 export type {
   Corpus,
@@ -90,8 +91,11 @@ export function createCorpus(opts: CorpusOptions, deps: InternalDeps = {}): Corp
         privateKey: opts.signer.privateKey,
         routeResolver: opts.routeResolver,
         envelopeCid: manifest.ref.manifestCid,
+        sources: a.sources,
+        ipfsGatewayUrl: opts.ipfsGatewayUrl,
         ownerSafe: manifest.envelope.participant.safeAddress,
         acquireFn,
+        fetchFromIpfs: fetchFromIpfsImpl,
       });
       contents.set(a.sha256, ac);
     }
@@ -101,7 +105,7 @@ export function createCorpus(opts: CorpusOptions, deps: InternalDeps = {}): Corp
   async function acquireBySha256(
     sha256: string,
     access: { endpoint: string; priceUsdc: string },
-    hint?: { artifactType?: string; envelopeCid?: string },
+    hint?: { artifactType?: string; envelopeCid?: string; sources?: ArtifactSource[] },
   ): Promise<ArtifactContent> {
     return acquireArtifactContent({
       sha256,
@@ -112,7 +116,10 @@ export function createCorpus(opts: CorpusOptions, deps: InternalDeps = {}): Corp
       privateKey: opts.signer.privateKey,
       routeResolver: opts.routeResolver,
       envelopeCid: hint?.envelopeCid,
+      sources: hint?.sources,
+      ipfsGatewayUrl: opts.ipfsGatewayUrl,
       acquireFn,
+      fetchFromIpfs: fetchFromIpfsImpl,
     });
   }
 

--- a/client/src/corpus/types.ts
+++ b/client/src/corpus/types.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Store } from '../store/store.js';
-import type { EvidenceTier, Role, SignedEnvelope } from '../types/envelope.js';
+import type { ArtifactSource, EvidenceTier, Role, SignedEnvelope } from '../types/envelope.js';
 
 export interface CorpusOptions {
   subgraphUrl: string;
@@ -92,7 +92,7 @@ export interface ArtifactContent {
   sha256: string;
   bytes: Buffer;
   artifactType: string;
-  source: 'cache' | 'self-store' | 'origin' | 'route-resolver';
+  source: 'cache' | 'self-store' | 'origin' | 'route-resolver' | 'ipfs';
   paidAmountUsdc: string;
   fetchedAt: string;
   sourceOperator?: string;
@@ -118,7 +118,7 @@ export interface Corpus {
   acquireBySha256(
     sha256: string,
     access: { endpoint: string; priceUsdc: string },
-    hint?: { artifactType?: string; envelopeCid?: string },
+    hint?: { artifactType?: string; envelopeCid?: string; sources?: ArtifactSource[] },
   ): Promise<ArtifactContent>;
 }
 

--- a/client/src/dashboard/spa/src/App.routing.test.tsx
+++ b/client/src/dashboard/spa/src/App.routing.test.tsx
@@ -28,6 +28,7 @@ vi.mock('./api/client.js', () => ({
           publicEndpoint: 'https://op.example.com',
           defaultPriceUsdc: '0',
           perArtifactTypePrice: {},
+          donation: { enabled: false },
         },
         summary: {
           served: {

--- a/client/src/dashboard/spa/src/api/client.solvernets.test.ts
+++ b/client/src/dashboard/spa/src/api/client.solvernets.test.ts
@@ -147,6 +147,7 @@ describe('api.operator — artifact store', () => {
       publicEndpoint: 'https://op.example.com',
       defaultPriceUsdc: '0.001',
       perArtifactTypePrice: { design_document: '0.01' },
+      donation: { enabled: true },
     });
     const c = lastCall();
     expect(c.url).toBe('/v1/operator/pricing');
@@ -155,6 +156,7 @@ describe('api.operator — artifact store', () => {
       publicEndpoint: 'https://op.example.com',
       defaultPriceUsdc: '0.001',
       perArtifactTypePrice: { design_document: '0.01' },
+      donation: { enabled: true },
     });
   });
 });

--- a/client/src/dashboard/spa/src/api/types.ts
+++ b/client/src/dashboard/spa/src/api/types.ts
@@ -194,6 +194,7 @@ export interface OperatorPricingConfig {
   publicEndpoint: string;
   defaultPriceUsdc: string;
   perArtifactTypePrice: Record<string, string>;
+  donation: { enabled: boolean };
 }
 
 export interface OperatorArtifactTypeSummary {

--- a/client/src/dashboard/spa/src/pages/operator/OperatorDataMarket.test.tsx
+++ b/client/src/dashboard/spa/src/pages/operator/OperatorDataMarket.test.tsx
@@ -24,6 +24,7 @@ const servedResponse = {
     publicEndpoint: 'https://op.example.com',
     defaultPriceUsdc: '0',
     perArtifactTypePrice: { design_document: '0.002' },
+    donation: { enabled: false },
   },
   summary: {
     served: {
@@ -93,6 +94,7 @@ beforeEach(() => {
       publicEndpoint: 'https://op.example.com',
       defaultPriceUsdc: '0.001',
       perArtifactTypePrice: { design_document: '0.002' },
+      donation: { enabled: true },
     },
   });
 });
@@ -127,13 +129,15 @@ describe('OperatorDataMarket', () => {
     fireEvent.change(screen.getByLabelText(/default price/i), {
       target: { value: '0.001' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Save pricing' }));
+    fireEvent.click(screen.getByLabelText(/enable testnet donation mode/i));
+    fireEvent.click(screen.getByRole('button', { name: 'Save settings' }));
 
     await waitFor(() => expect(updatePricingMock).toHaveBeenCalled());
     expect(updatePricingMock).toHaveBeenCalledWith({
       publicEndpoint: 'https://op.example.com',
       defaultPriceUsdc: '0.001',
       perArtifactTypePrice: { design_document: '0.002' },
+      donation: { enabled: true },
     });
     await waitFor(() => expect(onRestartPending).toHaveBeenCalled());
   });

--- a/client/src/dashboard/spa/src/pages/operator/OperatorDataMarket.tsx
+++ b/client/src/dashboard/spa/src/pages/operator/OperatorDataMarket.tsx
@@ -56,7 +56,8 @@ function samePricing(a: OperatorPricingConfig, b: OperatorPricingConfig): boolea
   return (
     a.publicEndpoint === b.publicEndpoint &&
     a.defaultPriceUsdc === b.defaultPriceUsdc &&
-    JSON.stringify(sortedRecord(a.perArtifactTypePrice)) === JSON.stringify(sortedRecord(b.perArtifactTypePrice))
+    JSON.stringify(sortedRecord(a.perArtifactTypePrice)) === JSON.stringify(sortedRecord(b.perArtifactTypePrice)) &&
+    a.donation.enabled === b.donation.enabled
   );
 }
 
@@ -125,6 +126,7 @@ function PricingEditor({
   const [publicEndpoint, setPublicEndpoint] = useState(pricing.publicEndpoint);
   const [defaultPriceUsdc, setDefaultPriceUsdc] = useState(pricing.defaultPriceUsdc);
   const [perArtifactTypePrice, setPerArtifactTypePrice] = useState(pricing.perArtifactTypePrice);
+  const [donationEnabled, setDonationEnabled] = useState(pricing.donation.enabled);
   const [newArtifactType, setNewArtifactType] = useState('');
   const [newPrice, setNewPrice] = useState('');
 
@@ -132,7 +134,8 @@ function PricingEditor({
     publicEndpoint,
     defaultPriceUsdc,
     perArtifactTypePrice,
-  }), [defaultPriceUsdc, perArtifactTypePrice, publicEndpoint]);
+    donation: { enabled: donationEnabled },
+  }), [defaultPriceUsdc, donationEnabled, perArtifactTypePrice, publicEndpoint]);
 
   const dirty = !samePricing(pricing, draft);
   const displayedTypes = useMemo(() => {
@@ -225,6 +228,34 @@ function PricingEditor({
           </span>
         </label>
       </div>
+
+      <label
+        data-testid="operator-donation-toggle"
+        style={{
+          border: '1px solid var(--border)',
+          borderRadius: '6px',
+          padding: '12px',
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          gap: '12px',
+        }}
+      >
+        <span style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+          <span className="j-label">Testnet donation mode</span>
+          <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: '11px', color: 'var(--fg-dim)', lineHeight: 1.5 }}>
+            When enabled on testnet, produced task artifacts are scrubbed and
+            pinned publicly to IPFS. This is separate from x402 pricing.
+          </span>
+        </span>
+        <input
+          aria-label="Enable testnet donation mode"
+          type="checkbox"
+          checked={donationEnabled}
+          onChange={(event) => setDonationEnabled(event.target.checked)}
+          style={{ marginTop: '2px' }}
+        />
+      </label>
 
       <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
         <span className="j-label">Per-artifact-type pricing</span>
@@ -375,7 +406,7 @@ function PricingEditor({
             color: error ? 'var(--break-red)' : dirty ? 'var(--accent-sky)' : 'var(--fg-dim)',
           }}
         >
-          {error ?? (dirty ? 'Pricing changed' : 'Pricing current')}
+          {error ?? (dirty ? 'Settings changed' : 'Settings current')}
         </span>
         <button
           type="button"
@@ -388,6 +419,7 @@ function PricingEditor({
                 .filter(([key]) => key.trim().length > 0)
                 .map(([key, price]) => [key.trim(), price.trim()]),
             ),
+            donation: { enabled: donationEnabled },
           })}
           style={{
             border: '1px solid var(--accent-sky)',
@@ -400,7 +432,7 @@ function PricingEditor({
             cursor: !dirty || saving ? 'not-allowed' : 'pointer',
           }}
         >
-          {saving ? 'Saving…' : 'Save pricing'}
+          {saving ? 'Saving…' : 'Save settings'}
         </button>
       </div>
     </div>
@@ -698,7 +730,7 @@ export function OperatorDataMarket({
           </div>
 
           <PricingEditor
-            key={`${data.pricing.publicEndpoint}|${data.pricing.defaultPriceUsdc}|${JSON.stringify(sortedRecord(data.pricing.perArtifactTypePrice))}`}
+            key={`${data.pricing.publicEndpoint}|${data.pricing.defaultPriceUsdc}|${data.pricing.donation.enabled}|${JSON.stringify(sortedRecord(data.pricing.perArtifactTypePrice))}`}
             pricing={data.pricing}
             knownArtifactTypes={knownArtifactTypes}
             saving={pricingMutation.isPending}

--- a/client/src/harnesses/engine/artifact-scrub.ts
+++ b/client/src/harnesses/engine/artifact-scrub.ts
@@ -1,0 +1,111 @@
+import {
+  type IdentityScrubConfig,
+  scrubIdentityString,
+} from '../../trajectory/processors/identity-scrub.js';
+import {
+  CREDENTIAL_REDACTED,
+  isSensitiveCredentialKey,
+} from '../../trajectory/processors/credential-scrub.js';
+import {
+  type PathScrubConfig,
+  scrubPathString,
+} from '../../trajectory/processors/path-scrub.js';
+
+export const DONATION_ARTIFACT_ENCODING = 'jinn.artifact.donation.v1' as const;
+
+export interface ArtifactScrubConfig {
+  identity?: IdentityScrubConfig;
+  path?: PathScrubConfig;
+}
+
+export interface ArtifactScrubResult {
+  bytes: Buffer;
+  redactedKeys: string[];
+}
+
+function isUtf8Text(bytes: Buffer): boolean {
+  if (bytes.includes(0)) return false;
+  const text = bytes.toString('utf8');
+  return Buffer.from(text, 'utf8').equals(bytes);
+}
+
+function scrubTextValue(value: string, cfg: ArtifactScrubConfig): string {
+  let out = value;
+  if (cfg.path) out = scrubPathString(out, cfg.path);
+  if (cfg.identity) out = scrubIdentityString(out, cfg.identity);
+  return out;
+}
+
+function scrubJsonValue(
+  value: unknown,
+  cfg: ArtifactScrubConfig,
+  redactedKeys: Set<string>,
+): unknown {
+  if (typeof value === 'string') return scrubTextValue(value, cfg);
+  if (Array.isArray(value)) return value.map((entry) => scrubJsonValue(entry, cfg, redactedKeys));
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, raw] of Object.entries(value)) {
+      if (isSensitiveCredentialKey(key)) {
+        out[key] = CREDENTIAL_REDACTED;
+        redactedKeys.add(key);
+      } else {
+        out[key] = scrubJsonValue(raw, cfg, redactedKeys);
+      }
+    }
+    return out;
+  }
+  return value;
+}
+
+function scrubJsonText(text: string, cfg: ArtifactScrubConfig): ArtifactScrubResult | null {
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    const redactedKeys = new Set<string>();
+    const scrubbed = scrubJsonValue(parsed, cfg, redactedKeys);
+    if (JSON.stringify(scrubbed) === JSON.stringify(parsed)) return null;
+    const out = `${JSON.stringify(scrubbed, null, 2)}\n`;
+    return {
+      bytes: Buffer.from(out, 'utf8'),
+      redactedKeys: Array.from(redactedKeys).sort(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function scrubCredentialLines(text: string, redactedKeys: Set<string>): string {
+  return text
+    .split('\n')
+    .map((line) => {
+      const match = line.match(/^(\s*["']?)([A-Za-z0-9_.-]+)(["']?\s*[:=]\s*)(.*)$/);
+      if (!match) return line;
+      const [, prefix, key, sep] = match;
+      if (!isSensitiveCredentialKey(key)) return line;
+      redactedKeys.add(key);
+      return `${prefix}${key}${sep}${CREDENTIAL_REDACTED}`;
+    })
+    .join('\n');
+}
+
+export function scrubArtifactBytes(
+  bytes: Buffer,
+  cfg: ArtifactScrubConfig = {},
+): ArtifactScrubResult {
+  if (!isUtf8Text(bytes)) return { bytes, redactedKeys: [] };
+
+  const text = bytes.toString('utf8');
+  const jsonResult = scrubJsonText(text, cfg);
+  if (jsonResult) return jsonResult;
+
+  const redactedKeys = new Set<string>();
+  let scrubbed = scrubTextValue(text, cfg);
+  scrubbed = scrubCredentialLines(scrubbed, redactedKeys);
+  if (scrubbed === text && redactedKeys.size === 0) {
+    return { bytes, redactedKeys: [] };
+  }
+  return {
+    bytes: Buffer.from(scrubbed, 'utf8'),
+    redactedKeys: Array.from(redactedKeys).sort(),
+  };
+}

--- a/client/src/harnesses/engine/engine.ts
+++ b/client/src/harnesses/engine/engine.ts
@@ -283,6 +283,7 @@ export interface TaskEngineOptions {
     publicEndpoint: string;
     defaultPriceUsdc: string;
     perArtifactTypePrice: Record<string, string>;
+    donation?: { enabled: boolean };
   };
   /**
    * Harness execution mode from operator config (JinnConfig.harness.mode).
@@ -1124,7 +1125,13 @@ export class TaskEngine {
       requestId: task.requestId,
       ...(collector ? { collector } : {}),
     };
-    const rawArtifacts = await walkArtifacts(workingDir, implArtifacts);
+    const rawArtifacts = await walkArtifacts(
+      workingDir,
+      implArtifacts,
+      packagingDepsWithReq.donation?.enabled
+        ? { scrub: packagingDepsWithReq.donation.scrub }
+        : {},
+    );
     const uploadedArtifacts = await uploadArtifacts(rawArtifacts, packagingDepsWithReq);
 
     // 1b. Emit trajectory to IPFS now that all artifact spans have been added.

--- a/client/src/harnesses/engine/packaging.ts
+++ b/client/src/harnesses/engine/packaging.ts
@@ -1,5 +1,5 @@
 /**
- * Harness engine — workingDir provisioning + artifact walking + IPFS upload.
+ * Harness engine — workingDir provisioning + artifact walking + artifact storage.
  *
  * §6.6 workdir layout, §5.3 artifact artifactType conventions.
  *
@@ -7,7 +7,7 @@
  *   1. Provision workingDir at PRE_SNAPSHOT time: write task.json, env/ files,
  *      sessions/ dir.
  *   2. After impl returns: walk workingDir, read OUTPUTS.json (if present),
- *      compute sha256, upload each artifact to IPFS, return structured list.
+ *      compute sha256, persist each artifact, return structured list.
  */
 
 import { createHash } from 'node:crypto';
@@ -29,6 +29,12 @@ import type { OutputArtifact } from '../../types/portfolio.js';
 import type { Artifact } from '../../types/envelope.js';
 import type { Store } from '../../store/store.js';
 import type { TrajectoryCollector } from '../../trajectory/collector.js';
+import { uploadToIpfs } from '../../adapters/mech/ipfs.js';
+import {
+  type ArtifactScrubConfig,
+  DONATION_ARTIFACT_ENCODING,
+  scrubArtifactBytes,
+} from './artifact-scrub.js';
 
 // ── OUTPUTS.json schema ───────────────────────────────────────────────────────
 //
@@ -83,6 +89,7 @@ export interface PackagingDeps {
   perArtifactTypePrice: Record<string, string>;
   /** Restoration / evaluation request id (links served_artifacts row to envelope). */
   requestId: string;
+  donation?: ArtifactDonationConfig;
   /**
    * Optional trajectory collector. When provided, a `jinn.artifact.emit` span
    * is added to the trajectory for each successfully written artifact, and
@@ -90,6 +97,16 @@ export interface PackagingDeps {
    * The engine backfills `trajectoryCid` after `emitTrajectory` completes.
    */
   collector?: TrajectoryCollector;
+}
+
+export interface ArtifactDonationConfig {
+  enabled: boolean;
+  ipfsRegistryUrl: string;
+  scrub?: ArtifactScrubConfig;
+}
+
+export interface WalkArtifactsOptions {
+  scrub?: ArtifactScrubConfig;
 }
 
 // ── WorkingDir provisioning ───────────────────────────────────────────────────
@@ -148,6 +165,7 @@ async function createWorkdirTarball(
   workingDir: string,
   outputPath: string,
   excludeName?: string,
+  scrub?: ArtifactScrubConfig,
 ): Promise<string> {
   // Build a simple tar manually using Buffer operations to avoid spawning
   // external processes. For correctness and portability we use a pure-JS
@@ -174,7 +192,8 @@ async function createWorkdirTarball(
         if (excludeName && relPath === excludeName) continue;
         // Exclude anything inside env/ (belt-and-suspenders guard)
         if (relPath.startsWith('env/') || relPath.startsWith('env\\')) continue;
-        const content = readFileSync(full);
+        const rawContent = readFileSync(full);
+        const content = scrub ? scrubArtifactBytes(rawContent, scrub).bytes : rawContent;
         entries.push({ relPath, content });
       }
     }
@@ -266,6 +285,12 @@ function sha256Hex(buf: Buffer): string {
   return createHash('sha256').update(buf).digest('hex');
 }
 
+function donationEnabled(deps: PackagingDeps): deps is PackagingDeps & {
+  donation: ArtifactDonationConfig & { enabled: true };
+} {
+  return deps.donation?.enabled === true;
+}
+
 // ── Artifact walking ──────────────────────────────────────────────────────────
 
 /**
@@ -277,6 +302,7 @@ function sha256Hex(buf: Buffer): string {
 export async function walkArtifacts(
   workingDir: string,
   implArtifacts: OutputArtifact[] = [],
+  options: WalkArtifactsOptions = {},
 ): Promise<Array<{ localPath: string; artifactType: string; metadata?: Record<string, unknown>; tags?: string[]; access?: { endpoint?: string; priceUsdc?: string } }>> {
   const result: Array<{
     localPath: string;
@@ -382,7 +408,7 @@ export async function walkArtifacts(
   const SNAPSHOT_FILENAME = 'system_snapshot.tar.gz';
   const tarballPath = join(workingDir, SNAPSHOT_FILENAME);
   try {
-    await createWorkdirTarball(workingDir, tarballPath, SNAPSHOT_FILENAME);
+    await createWorkdirTarball(workingDir, tarballPath, SNAPSHOT_FILENAME, options.scrub);
     result.push({
       localPath: tarballPath,
       artifactType: 'system_snapshot',
@@ -401,10 +427,10 @@ export async function walkArtifacts(
 /**
  * Write all collected artifacts to the operator-local served_artifacts store.
  *
- * Per spec/2026-04-30-phase-a-umbrella.md §1: artifact bytes are NEVER pinned
- * to IPFS — they live behind the operator's HTTP server, gated by x402 when
- * priceUsdc > 0. IPFS only holds the manifest envelope as a public discovery
- * anchor (handled by the engine's envelope-assembly step).
+ * Default behavior follows spec/2026-04-30-phase-a-umbrella.md §1: artifact
+ * bytes live behind the operator's HTTP server, gated by x402 when priceUsdc
+ * > 0. Testnet donation mode is an explicit opt-in exception: scrubbed bytes
+ * are also pinned publicly to IPFS and recorded in artifact.sources[].
  *
  * Returns an array of `UploadedArtifact` (= Artifact + localPath).
  */
@@ -426,10 +452,14 @@ export async function uploadArtifacts(
 
   const results: UploadedArtifact[] = [];
   const now = new Date().toISOString();
+  const donate = donationEnabled(deps) ? deps.donation : null;
 
   for (const art of artifacts) {
     try {
-      const content = readFileSync(art.localPath);
+      const rawContent = readFileSync(art.localPath);
+      const content = donate
+        ? scrubArtifactBytes(rawContent, donate.scrub).bytes
+        : rawContent;
       const hash = sha256Hex(content);
 
       const priceUsdc =
@@ -439,6 +469,32 @@ export async function uploadArtifacts(
 
       const endpoint = art.access?.endpoint ?? deps.operatorEndpoint;
 
+      const sources: UploadedArtifact['sources'] = [];
+      if (donate) {
+        const cid = await uploadToIpfs(donate.ipfsRegistryUrl, {
+          schemaVersion: DONATION_ARTIFACT_ENCODING,
+          artifactType: art.artifactType,
+          sha256: hash,
+          encoding: DONATION_ARTIFACT_ENCODING,
+          data: content.toString('base64'),
+        });
+        sources.push({
+          kind: 'ipfs',
+          cid,
+          sha256: hash,
+          encoding: DONATION_ARTIFACT_ENCODING,
+        });
+      }
+
+      const uploaded: UploadedArtifact = {
+        sha256: hash,
+        artifactType: art.artifactType,
+        metadata: art.metadata as UploadedArtifact['metadata'],
+        access: { endpoint, priceUsdc },
+        ...(sources.length > 0 ? { sources } : {}),
+        localPath: art.localPath,
+      };
+
       deps.store.saveServedArtifact({
         sha256: hash,
         artifactType: art.artifactType,
@@ -447,14 +503,6 @@ export async function uploadArtifacts(
         priceUsdc,
         createdAt: now,
       });
-
-      const uploaded: UploadedArtifact = {
-        sha256: hash,
-        artifactType: art.artifactType,
-        metadata: art.metadata as UploadedArtifact['metadata'],
-        access: { endpoint, priceUsdc },
-        localPath: art.localPath,
-      };
 
       // Forward linkage: emit a jinn.artifact.emit span and attach a producedBy
       // back-reference so readers can look up which span produced this artifact.
@@ -484,10 +532,10 @@ export async function uploadArtifacts(
       results.push(uploaded);
     } catch (err) {
       console.error(`[harness-engine] artifact write failed for ${art.localPath}: ${err instanceof Error ? err.message : err}`);
+      if (donate) throw err;
       // Non-fatal: continue with remaining artifacts
     }
   }
 
   return results;
 }
-

--- a/client/src/harnesses/engine/validate-manifest.ts
+++ b/client/src/harnesses/engine/validate-manifest.ts
@@ -46,5 +46,19 @@ export function validateManifestForPublish(env: SignedEnvelope): void {
     if (!a.sha256 || !/^[0-9a-f]{64}$/.test(a.sha256)) {
       throw new ManifestValidationError(i, 'sha256 must be a 64-char hex string');
     }
+    for (const source of a.sources ?? []) {
+      if (source.kind !== 'ipfs') {
+        throw new ManifestValidationError(i, 'sources[].kind must be ipfs');
+      }
+      if (!source.cid || typeof source.cid !== 'string') {
+        throw new ManifestValidationError(i, 'sources[].cid must be a non-empty string');
+      }
+      if (source.encoding !== 'jinn.artifact.donation.v1') {
+        throw new ManifestValidationError(i, 'sources[].encoding must be jinn.artifact.donation.v1');
+      }
+      if (source.sha256 !== a.sha256) {
+        throw new ManifestValidationError(i, 'sources[].sha256 must match artifact sha256');
+      }
+    }
   }
 }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -21,7 +21,7 @@
 
 import { config as dotenvConfig } from 'dotenv';
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync as writeFileSyncMain } from 'node:fs';
-import { homedir } from 'node:os';
+import { homedir, hostname, userInfo } from 'node:os';
 import { randomBytes as cryptoRandomBytes } from 'node:crypto';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -687,6 +687,9 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     publicEndpoint: config.operator?.publicEndpoint ?? `http://localhost:${config.apiPort}`,
     defaultPriceUsdc: config.operator?.defaultPriceUsdc ?? '0',
     perArtifactTypePrice: config.operator?.perArtifactTypePrice ?? {},
+    donation: {
+      enabled: config.network === 'testnet' && config.operator?.donation?.enabled === true,
+    },
   };
   let corpusForApi: ReturnType<typeof createCorpus> | undefined;
   // Launcher mode wiring (Task 6 of spec/2026-05-05-launcher-role-and-mode.md).
@@ -1347,6 +1350,11 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     config.operator?.publicEndpoint ?? `http://localhost:${config.apiPort}`;
   const operatorDefaultPrice = config.operator?.defaultPriceUsdc ?? '0';
   const operatorPerTypePrice = config.operator?.perArtifactTypePrice ?? {};
+  const donationRequested = config.operator?.donation?.enabled === true;
+  const donationEnabled = donationRequested && config.network === 'testnet';
+  if (donationRequested && !donationEnabled) {
+    console.warn('[main] operator.donation.enabled is testnet-only; donation disabled on mainnet.');
+  }
   if (!config.operator?.publicEndpoint) {
     console.warn(
       '[main] config.operator.publicEndpoint not set; defaulting to local API port. ' +
@@ -1358,11 +1366,23 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     operatorEndpoint: operatorPublicEndpoint,
     defaultPriceUsdc: operatorDefaultPrice,
     perArtifactTypePrice: operatorPerTypePrice,
+    donation: {
+      enabled: donationEnabled,
+      ipfsRegistryUrl: config.ipfsRegistryUrl,
+      scrub: {
+        identity: {
+          username: userInfo().username,
+          hostname: hostname(),
+        },
+        path: { home: homedir() },
+      },
+    },
   };
   const operatorConfig = {
     publicEndpoint: operatorPublicEndpoint,
     defaultPriceUsdc: operatorDefaultPrice,
     perArtifactTypePrice: operatorPerTypePrice,
+    donation: { enabled: donationEnabled },
   };
 
   // Envelope assembly deps: sign envelopes with agent EOA private key

--- a/client/src/trajectory/processors/credential-scrub.ts
+++ b/client/src/trajectory/processors/credential-scrub.ts
@@ -16,10 +16,15 @@ const SENSITIVE_KEY_PATTERNS = [
   /privatekey/,
 ];
 
-const REDACTED = '<REDACTED>';
+export const CREDENTIAL_REDACTED = '<REDACTED>';
 
-function normalizeKey(key: string): string {
+export function normalizeCredentialKey(key: string): string {
   return key.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+export function isSensitiveCredentialKey(key: string): boolean {
+  const normalized = normalizeCredentialKey(key);
+  return SENSITIVE_KEY_PATTERNS.some((p) => p.test(normalized));
 }
 
 export class CredentialScrubProcessor implements SpanProcessor {
@@ -34,9 +39,8 @@ export class CredentialScrubProcessor implements SpanProcessor {
   onEnd(span: ReadableSpan): void {
     const attrs = span.attributes as Record<string, unknown>;
     for (const key of Object.keys(attrs)) {
-      const normalized = normalizeKey(key);
-      if (SENSITIVE_KEY_PATTERNS.some((p) => p.test(normalized))) {
-        attrs[key] = REDACTED;
+      if (isSensitiveCredentialKey(key)) {
+        attrs[key] = CREDENTIAL_REDACTED;
       }
     }
   }

--- a/client/src/trajectory/processors/identity-scrub.ts
+++ b/client/src/trajectory/processors/identity-scrub.ts
@@ -15,6 +15,22 @@ export interface IdentityScrubConfig {
 const IPV4_PATTERN =
   /\b(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)\b/g;
 
+export function scrubIdentityString(s: string, cfg: IdentityScrubConfig): string {
+  // Order matters: email and full git-author name resolve first as
+  // composite identifiers. Email-before-username avoids mangling addresses
+  // whose local-part matches a username; gitAuthorName-before-hostname/
+  // machineId avoids the symmetric trap where a name fragment is masked
+  // by an earlier scrub.
+  let out = s;
+  if (cfg.gitAuthorEmail) out = out.split(cfg.gitAuthorEmail).join('<EMAIL>');
+  if (cfg.gitAuthorName) out = out.split(cfg.gitAuthorName).join('<AUTHOR>');
+  if (cfg.username) out = out.split(cfg.username).join('<USER>');
+  if (cfg.hostname) out = out.split(cfg.hostname).join('<HOST>');
+  if (cfg.machineId) out = out.split(cfg.machineId).join('<MACHINE>');
+  out = out.replace(IPV4_PATTERN, '<IPV4>');
+  return out;
+}
+
 export class IdentityScrubProcessor implements SpanProcessor {
   constructor(private readonly cfg: IdentityScrubConfig) {}
 
@@ -27,24 +43,8 @@ export class IdentityScrubProcessor implements SpanProcessor {
     for (const key of Object.keys(attrs)) {
       const v = attrs[key];
       if (typeof v === 'string') {
-        attrs[key] = this.scrub(v);
+        attrs[key] = scrubIdentityString(v, this.cfg);
       }
     }
-  }
-
-  private scrub(s: string): string {
-    // Order matters: email and full git-author name resolve first as
-    // composite identifiers. Email-before-username avoids mangling addresses
-    // whose local-part matches a username; gitAuthorName-before-hostname/
-    // machineId avoids the symmetric trap where a name fragment is masked
-    // by an earlier scrub.
-    let out = s;
-    if (this.cfg.gitAuthorEmail) out = out.split(this.cfg.gitAuthorEmail).join('<EMAIL>');
-    if (this.cfg.gitAuthorName) out = out.split(this.cfg.gitAuthorName).join('<AUTHOR>');
-    if (this.cfg.username) out = out.split(this.cfg.username).join('<USER>');
-    if (this.cfg.hostname) out = out.split(this.cfg.hostname).join('<HOST>');
-    if (this.cfg.machineId) out = out.split(this.cfg.machineId).join('<MACHINE>');
-    out = out.replace(IPV4_PATTERN, '<IPV4>');
-    return out;
   }
 }

--- a/client/src/trajectory/processors/path-scrub.ts
+++ b/client/src/trajectory/processors/path-scrub.ts
@@ -7,18 +7,27 @@ export interface PathScrubConfig {
   repoRoot?: string;  // e.g. '/Users/adrianobradley/harbor/jinn-mono'
 }
 
-export class PathScrubProcessor implements SpanProcessor {
-  private readonly homePrefix: string;
-  private readonly repoExact?: string;
-  private readonly repoPrefix?: string;
+export function scrubPathString(s: string, cfg: PathScrubConfig): string {
+  const homePrefix = cfg.home.endsWith('/') ? cfg.home : cfg.home + '/';
+  const repoExact = cfg.repoRoot;
+  const repoPrefix = cfg.repoRoot
+    ? (cfg.repoRoot.endsWith('/') ? cfg.repoRoot : cfg.repoRoot + '/')
+    : undefined;
 
-  constructor(cfg: PathScrubConfig) {
-    this.homePrefix = cfg.home.endsWith('/') ? cfg.home : cfg.home + '/';
-    if (cfg.repoRoot) {
-      this.repoExact = cfg.repoRoot;
-      this.repoPrefix = cfg.repoRoot.endsWith('/') ? cfg.repoRoot : cfg.repoRoot + '/';
-    }
+  // repoRoot match wins over home match: a path under the repo is more
+  // useful as a repo-relative reference than as a /users/anon/... blob.
+  if (repoExact !== undefined && s === repoExact) return '.';
+  if (repoPrefix !== undefined && s.startsWith(repoPrefix)) {
+    return s.slice(repoPrefix.length);
   }
+  if (s.startsWith(homePrefix)) {
+    return '/users/anon/' + s.slice(homePrefix.length);
+  }
+  return s;
+}
+
+export class PathScrubProcessor implements SpanProcessor {
+  constructor(private readonly cfg: PathScrubConfig) {}
 
   forceFlush() { return Promise.resolve(); }
   shutdown() { return Promise.resolve(); }
@@ -29,21 +38,8 @@ export class PathScrubProcessor implements SpanProcessor {
     for (const key of Object.keys(attrs)) {
       const v = attrs[key];
       if (typeof v === 'string') {
-        attrs[key] = this.scrub(v);
+        attrs[key] = scrubPathString(v, this.cfg);
       }
     }
-  }
-
-  private scrub(s: string): string {
-    // repoRoot match wins over home match: a path under the repo is more
-    // useful as a repo-relative reference than as a /users/anon/... blob.
-    if (this.repoExact !== undefined && s === this.repoExact) return '.';
-    if (this.repoPrefix !== undefined && s.startsWith(this.repoPrefix)) {
-      return s.slice(this.repoPrefix.length);
-    }
-    if (s.startsWith(this.homePrefix)) {
-      return '/users/anon/' + s.slice(this.homePrefix.length);
-    }
-    return s;
   }
 }

--- a/client/src/types/envelope.ts
+++ b/client/src/types/envelope.ts
@@ -96,6 +96,13 @@ const TrajectoryRefSchema = z.object({
   }),
 });
 
+export const ArtifactSourceSchema = z.object({
+  kind: z.literal('ipfs'),
+  cid: z.string().min(1),
+  sha256: z.string().regex(/^[0-9a-f]{64}$/),
+  encoding: z.literal('jinn.artifact.donation.v1'),
+});
+
 const ArtifactSchema = z.object({
   artifactType: z.string().min(1),
   sha256: z.string().regex(/^[0-9a-f]{64}$/),
@@ -115,8 +122,10 @@ const ArtifactSchema = z.object({
     endpoint: z.string().url(),
     priceUsdc: z.string().regex(/^\d+(\.\d+)?$/),
   }),
+  sources: z.array(ArtifactSourceSchema).optional(),
 });
 
+export type ArtifactSource = z.infer<typeof ArtifactSourceSchema>;
 export type Artifact = z.infer<typeof ArtifactSchema>;
 
 const SignatureSchema = z.object({

--- a/client/test/api/daemon-api-auth.test.ts
+++ b/client/test/api/daemon-api-auth.test.ts
@@ -227,6 +227,7 @@ describe('daemon-api-auth (bearer middleware)', () => {
           publicEndpoint: 'https://op.example.com',
           defaultPriceUsdc: '0',
           perArtifactTypePrice: {},
+          donation: { enabled: false },
         },
       },
       solverNets: {

--- a/client/test/api/operator-artifacts-endpoint.test.ts
+++ b/client/test/api/operator-artifacts-endpoint.test.ts
@@ -60,6 +60,7 @@ describe('GET /v1/operator/artifacts', () => {
         publicEndpoint: 'https://op.example.com',
         defaultPriceUsdc: '0',
         perArtifactTypePrice: {},
+        donation: { enabled: false },
       },
     });
 
@@ -151,6 +152,7 @@ describe('POST /v1/operator/pricing', () => {
         publicEndpoint: 'https://op.example.com',
         defaultPriceUsdc: '0.001',
         perArtifactTypePrice: { design_document: '0.01' },
+        donation: { enabled: true },
       }),
     });
 
@@ -167,6 +169,7 @@ describe('POST /v1/operator/pricing', () => {
       publicEndpoint: 'https://op.example.com',
       defaultPriceUsdc: '0.001',
       perArtifactTypePrice: { design_document: '0.01' },
+      donation: { enabled: true },
     });
   });
 
@@ -179,6 +182,7 @@ describe('POST /v1/operator/pricing', () => {
         publicEndpoint: 'https://op.example.com',
         defaultPriceUsdc: '0',
         perArtifactTypePrice: {},
+        donation: { enabled: false },
       },
     });
 

--- a/client/test/config.test.ts
+++ b/client/test/config.test.ts
@@ -13,6 +13,7 @@ describe('loadConfig RPC override handling', () => {
   const originalJinnL2ProofRpcUrl = process.env['JINN_L2_PROOF_RPC_URL'];
   const originalTestnetL2Deployment = process.env['JINN_TESTNET_L2_DEPLOYMENT'];
   const originalTestnetTokenDeployment = process.env['JINN_TESTNET_TOKEN_DEPLOYMENT'];
+  const originalOperatorDonationEnabled = process.env['JINN_OPERATOR_DONATION_ENABLED'];
 
   afterEach(async () => {
     if (originalBaseRpcUrl === undefined) {
@@ -55,6 +56,12 @@ describe('loadConfig RPC override handling', () => {
       delete process.env['JINN_TESTNET_TOKEN_DEPLOYMENT'];
     } else {
       process.env['JINN_TESTNET_TOKEN_DEPLOYMENT'] = originalTestnetTokenDeployment;
+    }
+
+    if (originalOperatorDonationEnabled === undefined) {
+      delete process.env['JINN_OPERATOR_DONATION_ENABLED'];
+    } else {
+      process.env['JINN_OPERATOR_DONATION_ENABLED'] = originalOperatorDonationEnabled;
     }
 
     await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
@@ -153,6 +160,27 @@ describe('loadConfig RPC override handling', () => {
     const config = loadConfig(configPath);
 
     expect(config.rpcUrl).toBe('https://sepolia.base.org');
+  });
+
+  it('defaults operator donation to disabled when operator config exists', async () => {
+    const configPath = await writeConfigFile({
+      operator: { publicEndpoint: 'https://op.example.com' },
+    });
+
+    const config = loadConfig(configPath);
+
+    expect(config.operator?.donation.enabled).toBe(false);
+  });
+
+  it('allows env to enable operator donation', async () => {
+    const configPath = await writeConfigFile({
+      operator: { publicEndpoint: 'https://op.example.com' },
+    });
+    process.env['JINN_OPERATOR_DONATION_ENABLED'] = 'true';
+
+    const config = loadConfig(configPath);
+
+    expect(config.operator?.donation.enabled).toBe(true);
   });
 
   it('accepts self-bond stakingMode from env', () => {

--- a/client/test/corpus/acquire.test.ts
+++ b/client/test/corpus/acquire.test.ts
@@ -87,6 +87,44 @@ describe('acquireArtifactContent', () => {
     expect(store.getNetworkArtifact(realSha)).not.toBeNull();
   });
 
+  it('prefers donated IPFS source and caches verified bytes without x402 fetch', async () => {
+    const realSha = (await import('node:crypto')).createHash('sha256').update(realBytes).digest('hex');
+    const acquireFn = vi.fn();
+    const fetchFromIpfs = vi.fn(async () => ({
+      schemaVersion: 'jinn.artifact.donation.v1',
+      artifactType: 'design_document',
+      sha256: realSha,
+      encoding: 'jinn.artifact.donation.v1',
+      data: realBytes.toString('base64'),
+    }));
+
+    const result = await acquireArtifactContent({
+      sha256: realSha,
+      artifactType: 'design_document',
+      access,
+      store,
+      selfSafeAddress: '0x' + 'f'.repeat(40),
+      privateKey: TEST_KEY,
+      acquireFn,
+      fetchFromIpfs,
+      ipfsGatewayUrl: 'https://gateway.example.com',
+      ownerSafe: '0x' + 'a'.repeat(40),
+      sources: [{
+        kind: 'ipfs',
+        cid: 'bafy-donated',
+        sha256: realSha,
+        encoding: 'jinn.artifact.donation.v1',
+      }],
+    });
+
+    expect(result.source).toBe('ipfs');
+    expect(result.paidAmountUsdc).toBe('0');
+    expect(result.bytes.equals(realBytes)).toBe(true);
+    expect(fetchFromIpfs).toHaveBeenCalledWith('https://gateway.example.com', 'bafy-donated');
+    expect(acquireFn).not.toHaveBeenCalled();
+    expect(store.getNetworkArtifact(realSha)?.content.equals(realBytes)).toBe(true);
+  });
+
   it('origin fetch with hash mismatch throws and does not cache', async () => {
     const acquireFn = vi.fn(async () => Buffer.from('wrong bytes'));
     const declaredSha = 'a'.repeat(64);

--- a/client/test/harnesses/engine/artifact-scrub.test.ts
+++ b/client/test/harnesses/engine/artifact-scrub.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { scrubArtifactBytes } from '../../../src/harnesses/engine/artifact-scrub.js';
+import { CredentialScrubProcessor } from '../../../src/trajectory/processors/credential-scrub.js';
+import { IdentityScrubProcessor } from '../../../src/trajectory/processors/identity-scrub.js';
+import { PathScrubProcessor } from '../../../src/trajectory/processors/path-scrub.js';
+
+function fakeSpan(attrs: Record<string, unknown>): ReadableSpan {
+  return {
+    attributes: attrs,
+    spanContext: () => ({ traceId: 'a'.repeat(32), spanId: 'b'.repeat(16), traceFlags: 0 }),
+  } as unknown as ReadableSpan;
+}
+
+describe('donation artifact scrubber', () => {
+  it('uses the same identity/path/credential rules as telemetry processors', () => {
+    const identity = {
+      username: 'adriano',
+      hostname: 'devbox',
+      machineId: 'machine-1',
+      gitAuthorName: 'Adriano Bradley',
+      gitAuthorEmail: 'adriano@example.com',
+    };
+    const path = {
+      home: '/Users/adriano',
+      repoRoot: '/Users/adriano/repo',
+    };
+    const span = fakeSpan({
+      author: 'Adriano Bradley <adriano@example.com> on devbox',
+      path: '/Users/adriano/repo/src/index.ts',
+      token: 'secret-value',
+    });
+
+    new PathScrubProcessor(path).onEnd(span);
+    new IdentityScrubProcessor(identity).onEnd(span);
+    new CredentialScrubProcessor().onEnd(span);
+
+    const artifact = scrubArtifactBytes(
+      Buffer.from(JSON.stringify({
+        author: 'Adriano Bradley <adriano@example.com> on devbox',
+        path: '/Users/adriano/repo/src/index.ts',
+        token: 'secret-value',
+      }), 'utf8'),
+      { identity, path },
+    );
+    const parsed = JSON.parse(artifact.bytes.toString('utf8')) as Record<string, unknown>;
+
+    expect(parsed.author).toBe(span.attributes.author);
+    expect(parsed.path).toBe(span.attributes.path);
+    expect(parsed.token).toBe(span.attributes.token);
+    expect(artifact.redactedKeys).toEqual(['token']);
+  });
+
+  it('leaves binary data unchanged', () => {
+    const bytes = Buffer.from([0x00, 0xff, 0x10, 0x20]);
+    const out = scrubArtifactBytes(bytes, {
+      identity: { username: 'adriano' },
+      path: { home: '/Users/adriano' },
+    });
+
+    expect(out.bytes).toBe(bytes);
+    expect(out.redactedKeys).toEqual([]);
+  });
+});

--- a/client/test/harnesses/engine/packaging-donation.test.ts
+++ b/client/test/harnesses/engine/packaging-donation.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { gunzipSync } from 'node:zlib';
+import { Store } from '../../../src/store/store.js';
+import {
+  uploadArtifacts,
+  walkArtifacts,
+} from '../../../src/harnesses/engine/packaging.js';
+
+const { uploadToIpfsMock } = vi.hoisted(() => ({
+  uploadToIpfsMock: vi.fn(async () => 'bafy-donation-artifact'),
+}));
+
+vi.mock('../../../src/adapters/mech/ipfs.js', () => ({
+  uploadToIpfs: uploadToIpfsMock,
+  cidToDigestHex: vi.fn(),
+  fetchFromIpfs: vi.fn(),
+  fetchFromDigest: vi.fn(),
+  digestHexToGatewayUrl: vi.fn(),
+}));
+
+function sha256Hex(bytes: Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function tarEntries(tarGz: Buffer): Record<string, Buffer> {
+  const tar = gunzipSync(tarGz);
+  const entries: Record<string, Buffer> = {};
+  let offset = 0;
+  while (offset + 512 <= tar.length) {
+    const header = tar.subarray(offset, offset + 512);
+    if (header.every((b) => b === 0)) break;
+    const name = header.subarray(0, 100).toString('utf8').replace(/\0.*$/, '');
+    const sizeOctal = header.subarray(124, 136).toString('ascii').replace(/\0.*$/, '').trim();
+    const size = Number.parseInt(sizeOctal, 8);
+    const start = offset + 512;
+    entries[name] = tar.subarray(start, start + size);
+    offset = start + Math.ceil(size / 512) * 512;
+  }
+  return entries;
+}
+
+describe('uploadArtifacts donation mode', () => {
+  let store: Store;
+  let workDir: string;
+
+  beforeEach(() => {
+    uploadToIpfsMock.mockClear();
+    uploadToIpfsMock.mockResolvedValue('bafy-donation-artifact');
+    store = new Store(':memory:');
+    workDir = mkdtempSync(join(tmpdir(), 'jinn-donation-'));
+  });
+
+  afterEach(() => {
+    store.close();
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it('scrubs before hashing, stores scrubbed bytes, and records IPFS source', async () => {
+    const file = join(workDir, 'artifact.json');
+    writeFileSync(file, JSON.stringify({
+      message: 'built by adriano on 192.168.1.2',
+      token: 'secret-value',
+    }));
+
+    const uploaded = await uploadArtifacts(
+      [{ localPath: file, artifactType: 'design_document' }],
+      {
+        store,
+        operatorEndpoint: 'https://op.example.com',
+        defaultPriceUsdc: '0',
+        perArtifactTypePrice: {},
+        requestId: '0x' + 'a'.repeat(64),
+        donation: {
+          enabled: true,
+          ipfsRegistryUrl: 'https://registry.example.com',
+          scrub: { identity: { username: 'adriano' } },
+        },
+      },
+    );
+
+    expect(uploadToIpfsMock).toHaveBeenCalledOnce();
+    const wrapper = uploadToIpfsMock.mock.calls[0]![1] as Record<string, unknown>;
+    expect(wrapper.schemaVersion).toBe('jinn.artifact.donation.v1');
+    expect(wrapper.encoding).toBe('jinn.artifact.donation.v1');
+
+    const scrubbedBytes = Buffer.from(wrapper.data as string, 'base64');
+    const scrubbed = JSON.parse(scrubbedBytes.toString('utf8')) as Record<string, unknown>;
+    expect(scrubbed.message).toBe('built by <USER> on <IPV4>');
+    expect(scrubbed.token).toBe('<REDACTED>');
+
+    const scrubbedSha = sha256Hex(scrubbedBytes);
+    expect(wrapper.sha256).toBe(scrubbedSha);
+    expect(uploaded[0]!.sha256).toBe(scrubbedSha);
+    expect(uploaded[0]!.sources).toEqual([
+      {
+        kind: 'ipfs',
+        cid: 'bafy-donation-artifact',
+        sha256: scrubbedSha,
+        encoding: 'jinn.artifact.donation.v1',
+      },
+    ]);
+
+    const row = store.getServedArtifact(scrubbedSha);
+    expect(row).not.toBeNull();
+    expect(row!.content.equals(scrubbedBytes)).toBe(true);
+  });
+
+  it('fails publish when donation pinning fails', async () => {
+    uploadToIpfsMock.mockRejectedValueOnce(new Error('pin failed'));
+    const file = join(workDir, 'artifact.txt');
+    writeFileSync(file, 'public artifact');
+
+    await expect(
+      uploadArtifacts(
+        [{ localPath: file, artifactType: 'runtime_log' }],
+        {
+          store,
+          operatorEndpoint: 'https://op.example.com',
+          defaultPriceUsdc: '0',
+          perArtifactTypePrice: {},
+          requestId: '0x' + 'b'.repeat(64),
+          donation: {
+            enabled: true,
+            ipfsRegistryUrl: 'https://registry.example.com',
+          },
+        },
+      ),
+    ).rejects.toThrow(/pin failed/);
+
+    expect(store.listServedArtifactMetadata()).toEqual([]);
+  });
+});
+
+describe('walkArtifacts donation scrub', () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), 'jinn-donation-walk-'));
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it('scrubs system_snapshot members and still excludes env/', async () => {
+    writeFileSync(join(workDir, 'notes.md'), 'hello adriano');
+    writeFileSync(join(workDir, 'config.json'), JSON.stringify({ token: 'secret-value' }));
+    writeFileSync(join(workDir, 'OUTPUTS.json'), JSON.stringify({ outputs: [] }));
+    const envDir = join(workDir, 'env');
+    mkdirSync(envDir);
+    writeFileSync(join(envDir, 'API_TOKEN'), 'must-not-appear');
+
+    const artifacts = await walkArtifacts(workDir, [], {
+      scrub: { identity: { username: 'adriano' } },
+    });
+    const snapshot = artifacts.find((artifact) => artifact.artifactType === 'system_snapshot');
+    expect(snapshot).toBeTruthy();
+
+    const entries = tarEntries(readFileSync(snapshot!.localPath));
+    expect(entries['env/API_TOKEN']).toBeUndefined();
+    expect(entries['notes.md']!.toString('utf8')).toBe('hello <USER>');
+    expect(entries['config.json']!.toString('utf8')).toContain('<REDACTED>');
+    expect(Buffer.concat(Object.values(entries)).toString('utf8')).not.toContain('must-not-appear');
+    expect(Buffer.concat(Object.values(entries)).toString('utf8')).not.toContain('secret-value');
+  });
+});

--- a/client/test/harnesses/engine/packaging-leak-fix.test.ts
+++ b/client/test/harnesses/engine/packaging-leak-fix.test.ts
@@ -5,9 +5,11 @@ import { join } from 'node:path';
 import { Store } from '../../../src/store/store.js';
 import { uploadArtifacts } from '../../../src/harnesses/engine/packaging.js';
 
-const uploadToIpfsMock = vi.fn(async () => {
-  throw new Error('uploadArtifacts should NOT call uploadToIpfs in v0');
-});
+const { uploadToIpfsMock } = vi.hoisted(() => ({
+  uploadToIpfsMock: vi.fn(async () => {
+    throw new Error('uploadArtifacts should NOT call uploadToIpfs in v0');
+  }),
+}));
 
 vi.mock('../../../src/adapters/mech/ipfs.js', () => ({
   uploadToIpfs: uploadToIpfsMock,

--- a/client/test/smoke/donation-ipfs-http-smoke.test.ts
+++ b/client/test/smoke/donation-ipfs-http-smoke.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createHash } from 'node:crypto';
+import { createServer, type Server } from 'node:http';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Store } from '../../src/store/store.js';
+import { fetchFromIpfs } from '../../src/adapters/mech/ipfs.js';
+import { uploadArtifacts } from '../../src/harnesses/engine/packaging.js';
+
+function sha256Hex(bytes: Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function listen(server: Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('server did not bind to a TCP port'));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+function close(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+function parseMultipartJson(bytes: Buffer): unknown {
+  const text = bytes.toString('utf8');
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start === -1 || end === -1 || end < start) {
+    throw new Error('multipart upload did not contain JSON');
+  }
+  return JSON.parse(text.slice(start, end + 1)) as unknown;
+}
+
+describe('donation IPFS adapter smoke', () => {
+  let server: Server;
+  let baseUrl: string;
+  let store: Store;
+  let tmp: string;
+  const ipfs = new Map<string, unknown>();
+
+  beforeEach(async () => {
+    store = new Store(':memory:');
+    tmp = mkdtempSync(join(tmpdir(), 'jinn-donation-http-smoke-'));
+    ipfs.clear();
+    server = createServer((req, res) => {
+      void (async () => {
+        try {
+          if (req.method === 'POST' && req.url?.startsWith('/api/v0/add')) {
+            const chunks: Buffer[] = [];
+            for await (const chunk of req) chunks.push(Buffer.from(chunk));
+            const payload = parseMultipartJson(Buffer.concat(chunks));
+            const digest = sha256Hex(Buffer.from(JSON.stringify(payload), 'utf8'));
+            const cid = `bafy${digest.slice(0, 52)}`;
+            ipfs.set(cid, payload);
+            res.writeHead(200, { 'content-type': 'application/json' });
+            res.end(JSON.stringify({ Name: 'content.json', Hash: cid, Size: '1' }) + '\n');
+            return;
+          }
+
+          if (req.method === 'GET' && req.url?.startsWith('/ipfs/')) {
+            const cid = decodeURIComponent(req.url.slice('/ipfs/'.length));
+            if (!ipfs.has(cid)) {
+              res.writeHead(404, { 'content-type': 'text/plain' });
+              res.end('not found');
+              return;
+            }
+            res.writeHead(200, { 'content-type': 'application/json' });
+            res.end(JSON.stringify(ipfs.get(cid)));
+            return;
+          }
+
+          res.writeHead(404, { 'content-type': 'text/plain' });
+          res.end('not found');
+        } catch (err) {
+          res.writeHead(500, { 'content-type': 'text/plain' });
+          res.end(err instanceof Error ? err.stack ?? err.message : String(err));
+        }
+      })();
+    });
+    const port = await listen(server);
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterEach(async () => {
+    store.close();
+    rmSync(tmp, { recursive: true, force: true });
+    await close(server);
+  });
+
+  it('pins a scrubbed donation wrapper through the real IPFS adapter shape and fetches it back', async () => {
+    const file = join(tmp, 'artifact.json');
+    writeFileSync(file, JSON.stringify({
+      message: 'operator adriano on devbox',
+      path: '/Users/adriano/project/out.json',
+      apiToken: 'secret-value',
+    }));
+
+    const [artifact] = await uploadArtifacts(
+      [{ localPath: file, artifactType: 'output.portfolio.v0' }],
+      {
+        store,
+        operatorEndpoint: 'https://operator.example.com',
+        defaultPriceUsdc: '0',
+        perArtifactTypePrice: {},
+        requestId: '0x' + 'd'.repeat(64),
+        donation: {
+          enabled: true,
+          ipfsRegistryUrl: baseUrl,
+          scrub: {
+            identity: { username: 'adriano', hostname: 'devbox' },
+            path: { home: '/Users/adriano' },
+          },
+        },
+      },
+    );
+
+    expect(artifact?.sources?.[0]?.kind).toBe('ipfs');
+    const source = artifact!.sources![0]!;
+    const wrapper = await fetchFromIpfs(baseUrl, source.cid) as Record<string, unknown>;
+    expect(wrapper.schemaVersion).toBe('jinn.artifact.donation.v1');
+    expect(wrapper.sha256).toBe(source.sha256);
+    const bytes = Buffer.from(wrapper.data as string, 'base64');
+    const json = JSON.parse(bytes.toString('utf8')) as Record<string, unknown>;
+    expect(json.message).toBe('operator <USER> on <HOST>');
+    expect(json.path).toBe('/users/anon/project/out.json');
+    expect(json.apiToken).toBe('<REDACTED>');
+    expect(sha256Hex(bytes)).toBe(source.sha256);
+    expect(store.getServedArtifact(source.sha256)?.content.equals(bytes)).toBe(true);
+  });
+});

--- a/client/test/smoke/donation-mode-smoke.test.ts
+++ b/client/test/smoke/donation-mode-smoke.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Store } from '../../src/store/store.js';
+import { TaskEngine, type TaskEngineOptions } from '../../src/harnesses/engine/engine.js';
+import { TaskRunPersistence, type PersistedTaskRunInput } from '../../src/harnesses/engine/persistence.js';
+import { TaskRunState } from '../../src/harnesses/engine/state.js';
+import { createCorpus } from '../../src/corpus/index.js';
+import type { SignedEnvelope } from '../../src/types/envelope.js';
+
+const {
+  ipfsStore,
+  uploadToIpfsMock,
+} = vi.hoisted(() => {
+  const store = new Map<string, unknown>();
+  let seq = 0;
+  return {
+    ipfsStore: store,
+    uploadToIpfsMock: vi.fn(async (_url: string, payload: unknown) => {
+      seq += 1;
+      const schemaVersion =
+        payload && typeof payload === 'object' && !Array.isArray(payload)
+          ? String((payload as Record<string, unknown>)['schemaVersion'] ?? 'payload')
+          : 'payload';
+      const cid = `bafy-${schemaVersion.replace(/[^a-z0-9]+/gi, '-')}-${seq}`;
+      store.set(cid, payload);
+      return cid;
+    }),
+  };
+});
+
+vi.mock('../../src/adapters/mech/ipfs.js', () => ({
+  uploadToIpfs: uploadToIpfsMock,
+  cidToDigestHex: vi.fn(),
+  fetchFromIpfs: vi.fn(async (_gatewayUrl: string, cid: string) => {
+    const payload = ipfsStore.get(cid);
+    if (payload === undefined) throw new Error(`fake IPFS CID not found: ${cid}`);
+    return payload;
+  }),
+  fetchFromDigest: vi.fn(),
+  digestHexToGatewayUrl: vi.fn(),
+}));
+
+const TEST_PRIVATE_KEY =
+  '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80' as const;
+const SOLVER_SAFE = '0x1111111111111111111111111111111111111111' as const;
+const READER_SAFE = '0x2222222222222222222222222222222222222222' as const;
+
+function sha256Hex(bytes: Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function mkTmp(): string {
+  const dir = join(tmpdir(), `jinn-donation-e2e-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function makeTaskRun(requestId: string): PersistedTaskRunInput {
+  const now = Date.now() - 1000;
+  return {
+    requestId,
+    taskCid: 'bafy-donation-smoke-task',
+    onchainCreationTx: '0x' + 'a'.repeat(64),
+    onchainCreationBlock: 123,
+    solverType: 'portfolio.v0',
+    taskRole: 'restoration',
+    windowStartTs: now,
+    windowEndTs: now + 60_000,
+    task: {
+      id: 'donation-smoke-task',
+      description: 'Donation mode smoke task',
+      solverType: 'portfolio.v0',
+      role: 'restoration',
+      window: { startTs: now, endTs: now + 60_000 },
+    },
+  };
+}
+
+function makeEngineOptions(store: Store, tmp: string): TaskEngineOptions {
+  return {
+    store,
+    paths: {
+      workingDirRoot: join(tmp, 'work'),
+      implStateDirRoot: join(tmp, 'impl-state'),
+    },
+    packagingDeps: {
+      store,
+      operatorEndpoint: 'https://operator.example.com',
+      defaultPriceUsdc: '0',
+      perArtifactTypePrice: {},
+      donation: {
+        enabled: true,
+        ipfsRegistryUrl: 'fake-ipfs://registry',
+        scrub: {
+          identity: { username: 'adriano', hostname: 'devbox' },
+          path: { home: '/Users/adriano' },
+        },
+      },
+    },
+    envelopeDeps: {
+      ipfsRegistryUrl: 'fake-ipfs://registry',
+      agentEoaPrivateKey: TEST_PRIVATE_KEY,
+      safeAddress: SOLVER_SAFE,
+    },
+    operatorConfig: {
+      publicEndpoint: 'https://operator.example.com',
+      defaultPriceUsdc: '0',
+      perArtifactTypePrice: {},
+      donation: { enabled: true },
+    },
+  };
+}
+
+class SmokeEngine extends TaskEngine {
+  get testPersistence(): TaskRunPersistence {
+    return this.persistence;
+  }
+
+  seedRuntimeDigest(requestId: string): void {
+    const internals = this as unknown as {
+      codeDigestsByRequest: Map<string, string>;
+      modesByRequest: Map<string, 'train' | 'frozen'>;
+    };
+    internals.codeDigestsByRequest.set(requestId, 'sha256:' + '1'.repeat(64));
+    internals.modesByRequest.set(requestId, 'train');
+  }
+}
+
+describe('testnet donation mode e2e smoke', () => {
+  let tmp: string;
+  let producerStore: Store;
+  let readerStore: Store;
+
+  beforeEach(() => {
+    tmp = mkTmp();
+    producerStore = new Store(':memory:');
+    readerStore = new Store(':memory:');
+    ipfsStore.clear();
+    uploadToIpfsMock.mockClear();
+  });
+
+  afterEach(() => {
+    producerStore.close();
+    readerStore.close();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('packages scrubbed artifacts to IPFS sources and reacquires them through corpus without x402', async () => {
+    const requestId = '0x' + 'c'.repeat(64);
+    const workingDir = join(tmp, 'work', requestId);
+    mkdirSync(join(workingDir, 'sessions'), { recursive: true });
+    mkdirSync(join(workingDir, 'env'), { recursive: true });
+    writeFileSync(join(workingDir, 'env', 'API_TOKEN'), 'must-not-be-packaged');
+    writeFileSync(
+      join(workingDir, 'answer.json'),
+      JSON.stringify({
+        message: 'built by adriano on devbox',
+        path: '/Users/adriano/project/output.json',
+        token: 'secret-value',
+      }),
+    );
+    writeFileSync(
+      join(workingDir, 'OUTPUTS.json'),
+      JSON.stringify({
+        outputs: [{ path: 'answer.json', artifactType: 'output.portfolio.v0' }],
+      }),
+    );
+
+    const engine = new SmokeEngine(makeEngineOptions(producerStore, tmp));
+    await engine.observe(makeTaskRun(requestId));
+    engine.seedRuntimeDigest(requestId);
+    const p = engine.testPersistence;
+    p.transition(requestId, TaskRunState.CLAIMED);
+    p.transition(requestId, TaskRunState.WAITING);
+    p.transition(requestId, TaskRunState.PRE_SNAPSHOT, {
+      workingDir,
+      implStateDir: join(tmp, 'impl-state', 'portfolio-v0'),
+      preSnapshotCapturedAt: 1,
+      preSnapshotPayload: { capturedAt: 1, hlTime: 1, payload: {} },
+    });
+    p.transition(requestId, TaskRunState.RUNNING);
+    p.transition(requestId, TaskRunState.POST_SNAPSHOT, {
+      postSnapshotCapturedAt: 2,
+      postSnapshotPayload: { capturedAt: 2, hlTime: 2, payload: {} },
+      fillsPayload: [],
+      gatingClaim: {
+        equityReturnPct: '0.05',
+        maxDrawdownPct: '0.01',
+        closedTradesCount: 25,
+        tradedNotionalMultiple: '5.1',
+      },
+    });
+    p.transition(requestId, TaskRunState.PACKAGING);
+
+    await engine.process(requestId);
+    const packed = p.getByRequestId(requestId);
+    expect(packed?.state).toBe(TaskRunState.DELIVERING);
+    expect(packed?.manifestCid).toBeTruthy();
+
+    const envelope = ipfsStore.get(packed!.manifestCid!) as SignedEnvelope | undefined;
+    expect(envelope?.schemaVersion).toBe('jinn.execution.v1');
+    const donatedArtifact = envelope!.artifacts.find((artifact) => artifact.artifactType === 'output.portfolio.v0');
+    expect(donatedArtifact?.sources?.[0]?.kind).toBe('ipfs');
+    expect(donatedArtifact?.sources?.[0]?.encoding).toBe('jinn.artifact.donation.v1');
+
+    const source = donatedArtifact!.sources![0]!;
+    const wrapper = ipfsStore.get(source.cid) as Record<string, unknown>;
+    expect(wrapper.schemaVersion).toBe('jinn.artifact.donation.v1');
+    const donatedBytes = Buffer.from(wrapper.data as string, 'base64');
+    const donatedJson = JSON.parse(donatedBytes.toString('utf8')) as Record<string, unknown>;
+    expect(donatedJson.message).toBe('built by <USER> on <HOST>');
+    expect(donatedJson.path).toBe('/users/anon/project/output.json');
+    expect(donatedJson.token).toBe('<REDACTED>');
+    expect(donatedBytes.toString('utf8')).not.toContain('secret-value');
+    expect(source.sha256).toBe(sha256Hex(donatedBytes));
+    expect(donatedArtifact!.sha256).toBe(source.sha256);
+
+    const served = producerStore.getServedArtifact(donatedArtifact!.sha256);
+    expect(served?.content.equals(donatedBytes)).toBe(true);
+
+    const x402Acquire = vi.fn();
+    const corpus = createCorpus(
+      {
+        subgraphUrl: 'https://subgraph.example/graphql',
+        ipfsGatewayUrl: 'fake-ipfs://gateway',
+        store: readerStore,
+        signer: { privateKey: TEST_PRIVATE_KEY },
+        selfSafeAddress: READER_SAFE,
+      },
+      {
+        fetch: vi.fn(async () => new Response(JSON.stringify({
+          data: {
+            executions: [{
+              id: '1',
+              manifestCid: packed!.manifestCid,
+              manifestHash: envelope!.signature.hash,
+              tier: 'SELF_SIGNED',
+              publishedAt: String(Math.floor(Date.now() / 1000)),
+              operator: {
+                id: '1',
+                agentId: '1',
+                owner: SOLVER_SAFE,
+                agentWallet: SOLVER_SAFE,
+              },
+            }],
+          },
+        }), { status: 200, headers: { 'content-type': 'application/json' } })),
+        fetchFromIpfs: async (_gatewayUrl: string, cid: string) => {
+          const payload = ipfsStore.get(cid);
+          if (payload === undefined) throw new Error(`fake IPFS CID not found: ${cid}`);
+          return payload;
+        },
+        acquireFn: x402Acquire,
+      },
+    );
+
+    const [readEnvelope] = await corpus.read({ query: { solverType: 'portfolio.v0', limit: 1 } });
+    expect(readEnvelope?.envelope.artifacts.find((artifact) => artifact.sha256 === donatedArtifact!.sha256)).toBeTruthy();
+    const acquired = readEnvelope!.artifactContents.get(donatedArtifact!.sha256);
+    expect(acquired?.source).toBe('ipfs');
+    expect(acquired?.paidAmountUsdc).toBe('0');
+    expect(acquired?.bytes.equals(donatedBytes)).toBe(true);
+    expect(x402Acquire).not.toHaveBeenCalled();
+    expect(readerStore.getNetworkArtifact(donatedArtifact!.sha256)?.content.equals(donatedBytes)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds an opt-in testnet donation mode for task execution envelope artifacts, stacked on `feature/plan4-telemetry-collector`.

The intent is to let operators share the execution envelopes/artifacts they already produce while solving/evaluating by publishing scrubbed artifact bytes to IPFS. This is explicitly separate from local telemetry capture and from future x402 selling flows.

## What Changed

- Added `operator.donation.enabled`, defaulting to `false`, plus `JINN_OPERATOR_DONATION_ENABLED` support.
- Added a Testnet donation toggle to the operator Data market UI and persisted it through the existing operator pricing API.
- Extended envelope artifact descriptors with optional `sources[]`; donated artifacts record an IPFS source with `cid`, scrubbed-byte `sha256`, and `jinn.artifact.donation.v1` encoding.
- Reused the telemetry collector scrubber work by extracting shared lower-level identity/path/credential scrub helpers and wiring the OTel processors through them.
- Added an artifact scrub adapter for text-like artifact bodies and system snapshot members.
- Changed packaging only when donation mode is enabled:
  - scrub bytes before hashing
  - keep `envelope.artifacts[].sha256`, `served_artifacts.content`, and IPFS payload bytes aligned
  - pin a JSON/base64 donation wrapper to IPFS
  - fail publish if IPFS pinning fails
- Preserved the existing priced/gated artifact IPFS leak fix for non-donation flows.
- Updated corpus acquisition to prefer `sources[].kind === "ipfs"`, verify sha256, cache into `network_artifacts`, and fall back to existing x402/origin paths.

## Verification

- `yarn e2e:donation`
- Targeted Vitest suite: 12 files, 105 tests passed
- `yarn typecheck`
- `git diff --check`
- No-mock daemon/UI smoke:
  - built SPA with `yarn build:spa`
  - started real daemon from this branch using existing bootstrapped testnet earning state
  - used isolated temp config, temp DB, and temp engine dirs to avoid mutating local config or resuming task rows
  - opened daemon-served SPA through the real handshake URL
  - expanded Data market, toggled Testnet donation mode, saved settings
  - verified the real `/v1/operator/pricing` POST body and API readback persisted `donation.enabled: true`
  - verified the real `~/.jinn-client/config.json` stayed unchanged

## Notes

- Base branch is `feature/plan4-telemetry-collector` because this implementation intentionally reuses scrubber work from that stream.
- The role rename from `restoration` to `solution` remains separate.
- Local telemetry/capture donation remains out of scope for this PR.
