### PR TITLE
Prepare SWE donation flow for public testnet release

### DIFF
--- a/client/CONTRIBUTING.md
+++ b/client/CONTRIBUTING.md
@@ -98,7 +98,7 @@ This copies the 4 deployment JSON files from `contracts/` into `client/deploymen
 | `yarn staking` | Earning bootstrap validation on Anvil fork |
 | `yarn pack:smoke` | Pack tarball and run smoke tests |
 | `yarn release:operator-gate` | Run the stable-release operator gate (`staking` then `e2e`) |
-| `yarn release:donation-consumption` | Prove two isolated operators can consume donated SWE execution data through real testnet IPFS/subgraph/MCP paths |
+| `yarn release:donation-consumption` | Prove two isolated operators can consume donated SWE execution data through real testnet on-chain/IPFS/MCP paths |
 | `cd ../contracts && yarn test && forge install foundry-rs/forge-std --no-git && forge test --match-contract Invariant` | Run the contracts release gate |
 | `yarn release:testnet-acceptance` | Run the manual Docker-first real testnet acceptance harness |
 | `yarn setup:testnet-acceptance-operator` | First-time Docker acceptance setup + bootstrap/funding helper (`TESTNET_ACCEPTANCE.md`) |

--- a/client/TESTNET_ACCEPTANCE.md
+++ b/client/TESTNET_ACCEPTANCE.md
@@ -52,8 +52,9 @@ release.
 `yarn corpus:e2e` and `yarn e2e:donation` remain fast mocked/smoke checks.
 They do not replace `yarn release:donation-consumption`, which is the
 release-blocking proof that another isolated operator can discover and consume
-donated SWE execution data through the real MCP acquisition path, cache it as a
-network artifact, reuse that cache from the learner-facing MCP path, and
+donated SWE execution data through the canonical on-chain/IPFS discovery path
+and real MCP acquisition path, cache it as a network artifact, reuse that cache
+from the learner-facing MCP path, and
 continue through the real SWE solve/evaluate loop.
 
 ## Required Browser Gates
@@ -105,6 +106,8 @@ The release is not ready until the live or canary-dry-run proof shows:
    expected hashes, discovered by another operator, verified, acquired through
    Network Tools/MCP, cached as `network_artifacts`, and followed by a real
    SWE solve/evaluate loop.
+   The subgraph may accelerate discovery, but on-chain ERC-8004 metadata plus
+   IPFS must be sufficient for release proof.
 
 Run the live donation proof with:
 
@@ -148,6 +151,8 @@ failure messaging.
 
 Missing `operator.publicEndpoint` is not a blocker for the public testnet
 donation path. Donation mode must use IPFS as the public artifact transport.
+The Graph/Subgraph endpoints are optional accelerators, not the correctness
+root for the release gate.
 IPFS pinning, hash verification, or scrubbing failures are blockers.
 
 ## Docker Acceptance

--- a/client/src/adapters/mech/adapter.ts
+++ b/client/src/adapters/mech/adapter.ts
@@ -1,4 +1,4 @@
-import { getAddress, zeroAddress, type Address, type Hex, type PublicClient, type WalletClient } from 'viem';
+import { getAddress, zeroAddress, type Address, type Hex, type Log, type PublicClient, type WalletClient } from 'viem';
 import { keccak256, toBytes } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import { base, baseSepolia } from 'viem/chains';
@@ -45,6 +45,7 @@ import {
 } from './contracts.js';
 import { type MechAdapterConfig } from './types.js';
 import {
+  manifestDigestForCid,
   queryClaimableTaskCandidates,
   type SubgraphTaskCandidate,
 } from './task-subgraph.js';
@@ -70,6 +71,11 @@ interface PendingEvaluationSolution {
 const ROUTER_REQUEST_CURSOR_CONFIG_KEY = 'mech_router_request_block_cursor_v1';
 const PENDING_EVALUATION_SOLUTIONS_CONFIG_KEY = 'mech_pending_evaluation_solutions_v1';
 const DEFAULT_MECH_DELIVER_BACKFILL_LOOKBACK_BLOCKS = 100_000n;
+const DEFAULT_ROUTER_LOG_CHUNK_BLOCKS = 9_999n;
+const DEFAULT_TASK_DISCOVERY_FROM_BLOCK: Record<number, bigint> = {
+  84532: 41_153_291n,
+  8453: 25_000_000n,
+};
 const DEFAULT_MECH_CLAIM_POLICY: TaskClaimPolicy = {
   mode: 'exclusive',
   maxClaims: 1,
@@ -169,6 +175,11 @@ export class MechAdapter implements ExecutionAdapter {
     if (this.store) {
       this.loadPendingEvaluationSolutions();
       await this.recoverPendingState(blockNumber);
+    } else {
+      const fromBlock = this.onchainTaskDiscoveryFromBlock();
+      if (fromBlock && fromBlock <= blockNumber) {
+        this.requestBlockCursor = fromBlock - 1n;
+      }
     }
   }
 
@@ -189,6 +200,65 @@ export class MechAdapter implements ExecutionAdapter {
     if (routerFromBlock < currentBlock) {
       this.requestBlockCursor = routerFromBlock;
     }
+
+    const scanFromBlock = this.onchainTaskDiscoveryFromBlock();
+    if (scanFromBlock && scanFromBlock <= currentBlock) {
+      const canonicalCursor = scanFromBlock - 1n;
+      if (canonicalCursor < this.requestBlockCursor) {
+        this.requestBlockCursor = canonicalCursor;
+      }
+      console.error(
+        `[mech] TaskCreated canonical backlog scan enabled from block ${scanFromBlock}; ` +
+        'subgraph discovery is optional acceleration only',
+      );
+    }
+  }
+
+  private onchainTaskDiscoveryFromBlock(): bigint | undefined {
+    const discovery = this.config.taskDiscovery;
+    const hasJoinedSolverNet = (discovery?.solverNetManifestCids?.length ?? 0) > 0;
+    if (!hasJoinedSolverNet) return undefined;
+    if (discovery?.onchainFromBlock !== undefined) {
+      const raw = discovery.onchainFromBlock;
+      const value = typeof raw === 'bigint' ? raw : BigInt(Math.max(0, Math.floor(raw)));
+      return value > 0n ? value : undefined;
+    }
+    return DEFAULT_TASK_DISCOVERY_FROM_BLOCK[this.config.chainId];
+  }
+
+  private joinedManifestDigestSet(): Set<string> {
+    const cids = this.config.taskDiscovery?.solverNetManifestCids ?? [];
+    return new Set(
+      cids
+        .filter(Boolean)
+        .map((cid) => manifestDigestForCid(cid).toLowerCase()),
+    );
+  }
+
+  private allowedDiscoveryTaskIds(): Set<string> | null {
+    const raw = this.config.taskDiscovery?.allowedTaskIds ?? [];
+    const ids = raw.map((id) => id.trim()).filter(Boolean);
+    return ids.length > 0 ? new Set(ids) : null;
+  }
+
+  private isDiscoveryTaskAllowed(taskId: string): boolean {
+    const allowed = this.allowedDiscoveryTaskIds();
+    return allowed === null || allowed.has(taskId);
+  }
+
+  private async getRouterLogsInChunks(fromBlock: bigint, toBlock: bigint): Promise<Log[]> {
+    const logs: Log[] = [];
+    for (let start = fromBlock; start <= toBlock; start += DEFAULT_ROUTER_LOG_CHUNK_BLOCKS + 1n) {
+      const end = start + DEFAULT_ROUTER_LOG_CHUNK_BLOCKS > toBlock
+        ? toBlock
+        : start + DEFAULT_ROUTER_LOG_CHUNK_BLOCKS;
+      logs.push(...await this.publicClient.getLogs({
+        address: this.config.routerAddress,
+        fromBlock: start,
+        toBlock: end,
+      }));
+    }
+    return logs;
   }
 
   private loadPendingEvaluationSolutions(): void {
@@ -497,6 +567,7 @@ export class MechAdapter implements ExecutionAdapter {
     }
 
     for (const candidate of candidates) {
+      if (!this.isDiscoveryTaskAllowed(candidate.taskId)) continue;
       if (this.claimedRestorationTaskIds.has(candidate.taskId)) continue;
 
       const claimable = await canClaimTask(
@@ -525,11 +596,6 @@ export class MechAdapter implements ExecutionAdapter {
         );
       }
     }
-  }
-
-  private hasSubgraphTaskDiscovery(): boolean {
-    const discovery = this.config.taskDiscovery;
-    return Boolean(discovery?.subgraphUrl && (discovery.solverNetManifestCids?.length ?? 0) > 0);
   }
 
   private async deliveryEnvelopeCidForSolution(solution: {
@@ -568,6 +634,14 @@ export class MechAdapter implements ExecutionAdapter {
   private async evaluationAnnouncementForSolution(
     solution: PendingEvaluationSolution,
   ): Promise<TaskAnnouncement | undefined> {
+    if (!this.isDiscoveryTaskAllowed(solution.taskId)) {
+      console.log(
+        `[mech] skipping evaluation opportunity ${solution.requestId} for task ${solution.taskId}/${solution.attemptIndex}: outside configured task discovery scope`,
+      );
+      this.forgetPendingEvaluationSolution(solution.requestId);
+      return undefined;
+    }
+
     const restoration = await this.restorationAnnouncementForTaskId(solution.taskId);
     const claimable = await canClaimEvaluation(
       this.publicClient,
@@ -648,11 +722,7 @@ export class MechAdapter implements ExecutionAdapter {
         const currentBlock = await this.publicClient.getBlockNumber();
         if (currentBlock > this.requestBlockCursor) {
           const fromBlock = this.requestBlockCursor + 1n;
-          const logs = await this.publicClient.getLogs({
-            address: this.config.routerAddress,
-            fromBlock,
-            toBlock: currentBlock,
-          });
+          const logs = await this.getRouterLogsInChunks(fromBlock, currentBlock);
 
           const submittedSolutions = decodeSolutionDeliveryClaimedLogs(logs);
           for (const solution of submittedSolutions) {
@@ -663,23 +733,32 @@ export class MechAdapter implements ExecutionAdapter {
             this.store.setConfigValue(ROUTER_REQUEST_CURSOR_CONFIG_KEY, currentBlock.toString());
           }
 
-          if (!this.hasSubgraphTaskDiscovery()) {
-            const createdTasks = decodeTaskCreatedLogs(logs);
-            for (const { taskId, taskCidDigest, transactionHash, blockNumber } of createdTasks) {
-              try {
-                const announcement = await this.restorationAnnouncementFromDigest({
-                  taskId,
-                  taskCidDigest,
-                  transactionHash,
-                  blockNumber,
-                });
-                yield announcement;
-              } catch (err) {
-                console.error(`[mech] Failed to parse task ${taskId}:`, err);
-              }
+          const joinedManifestDigests = this.joinedManifestDigestSet();
+          const createdTasks = decodeTaskCreatedLogs(logs);
+          for (const { taskId, taskCidDigest, manifestDigest, transactionHash, blockNumber } of createdTasks) {
+            if (!this.isDiscoveryTaskAllowed(taskId)) continue;
+            if (this.claimedRestorationTaskIds.has(taskId) || this.observedTasks.has(taskId)) continue;
+            if (joinedManifestDigests.size > 0 && !joinedManifestDigests.has(manifestDigest.toLowerCase())) continue;
+            try {
+              const claimable = await canClaimTask(
+                this.publicClient,
+                this.config.safeAddress,
+                this.config.routerAddress,
+                taskId,
+                this.config.mechContractAddress,
+              );
+              if (!claimable.ok) continue;
+              const announcement = await this.restorationAnnouncementFromDigest({
+                taskId,
+                taskCidDigest,
+                transactionHash,
+                blockNumber,
+              });
+              yield announcement;
+            } catch (err) {
+              console.error(`[mech] Failed to parse task ${taskId}:`, err);
             }
           }
-
           for await (const announcement of this.retryPendingEvaluationSolutions()) {
             yield announcement;
           }

--- a/client/src/adapters/mech/contracts.ts
+++ b/client/src/adapters/mech/contracts.ts
@@ -695,6 +695,7 @@ export async function pollDeliverEvents(
 export interface TaskRecord {
   taskId: string;
   taskCidDigest: string;
+  manifestDigest?: string;
   creator: string;
   transactionHash?: `0x${string}`;
   blockNumber?: number;
@@ -726,11 +727,17 @@ export async function scanTasks(
           topics: log.topics,
         });
         if (decoded.eventName === 'TaskCreated') {
-          const args = decoded.args as { creator: Address; taskId: bigint; taskCidDigest: Hex };
+          const args = decoded.args as {
+            creator: Address;
+            taskId: bigint;
+            manifestDigest: Hex;
+            taskCidDigest: Hex;
+          };
           if (args.creator.toLowerCase() === creator.toLowerCase()) {
             results.push({
               taskId: String(args.taskId),
               taskCidDigest: String(args.taskCidDigest),
+              manifestDigest: String(args.manifestDigest),
               creator: String(args.creator),
               transactionHash: log.transactionHash ?? undefined,
               blockNumber: log.blockNumber != null ? Number(log.blockNumber) : undefined,
@@ -757,6 +764,7 @@ export interface DecodedMarketplaceRequest {
 export interface DecodedTaskCreated {
   taskId: string;
   taskCidDigest: string;
+  manifestDigest: string;
   creator: string;
   transactionHash?: `0x${string}`;
   blockNumber?: number;
@@ -781,10 +789,16 @@ export function decodeTaskCreatedLogs(logs: Log[]): DecodedTaskCreated[] {
         topics: log.topics,
       });
       if (decoded.eventName === 'TaskCreated') {
-        const args = decoded.args as { creator: Address; taskId: bigint; taskCidDigest: Hex };
+        const args = decoded.args as {
+          creator: Address;
+          taskId: bigint;
+          manifestDigest: Hex;
+          taskCidDigest: Hex;
+        };
         results.push({
           taskId: String(args.taskId),
           taskCidDigest: String(args.taskCidDigest),
+          manifestDigest: String(args.manifestDigest),
           creator: String(args.creator),
           transactionHash: log.transactionHash ?? undefined,
           blockNumber: log.blockNumber != null ? Number(log.blockNumber) : undefined,

--- a/client/src/adapters/mech/types.ts
+++ b/client/src/adapters/mech/types.ts
@@ -26,6 +26,13 @@ export interface MechAdapterConfig {
   taskDiscovery?: {
     subgraphUrl?: string;
     solverNetManifestCids?: string[];
+    /**
+     * Lower bound for the canonical on-chain TaskCreated scan. The subgraph is
+     * only an acceleration path; this scan is the correctness path.
+     */
+    onchainFromBlock?: number | bigint;
+    /** Optional release/acceptance guard: only discover these on-chain task ids. */
+    allowedTaskIds?: string[];
     pageSize?: number;
     maxPages?: number;
     fetchImpl?: typeof fetch;

--- a/client/src/api/server.ts
+++ b/client/src/api/server.ts
@@ -86,10 +86,10 @@ export interface ApiServerConfig {
    * payment dance.
    *
    * Asymmetry with `search_records` / `inspect_record`: record discovery is
-   * keyless (subgraph + IPFS gateway only) and stays client-side in the MCP
-   * server. Artifact acquisition is the only path that needs the signing key
-   * for x402 payments, so it's the only one that moves to the daemon. See
-   * spec/2026-04-30-phase-a-umbrella.md §4.
+   * keyless (subgraph/on-chain reads + IPFS gateway) and stays client-side in
+   * the MCP server. Artifact acquisition is the only path that needs the
+   * signing key for x402 payments, so it's the only one that moves to the
+   * daemon. See spec/2026-04-30-phase-a-umbrella.md §4.
    */
   corpus?: Corpus | (() => Corpus | undefined);
   /** When set, GET /v1/bootstrap reads <earningDir>/earning_state.json. */
@@ -519,7 +519,8 @@ export async function startApiServer(config: ApiServerConfig): Promise<ApiServer
   // daemon will sign x402 payments on the caller's behalf.
   //
   // Asymmetry with `search_records` / `inspect_record`: record lookup stays
-  // client-side because subgraph queries and IPFS manifest fetches are keyless.
+  // client-side because subgraph/on-chain queries and IPFS manifest fetches are
+  // keyless.
   // Only the buyer side of x402 needs the signing key, so only the buyer path
   // moves here.
   // See spec/2026-04-30-phase-a-umbrella.md §4.
@@ -550,6 +551,7 @@ export async function startApiServer(config: ApiServerConfig): Promise<ApiServer
       const access = body['access'] as { endpoint?: unknown; priceUsdc?: unknown } | undefined;
       const envelopeCid = body['envelopeCid'];
       const artifactType = body['artifactType'];
+      const ownerSafe = body['ownerSafe'];
       const sources = parseArtifactSources(body['sources']);
 
       if (typeof sha256 !== 'string' || !/^[0-9a-f]{64}$/.test(sha256)) {
@@ -582,10 +584,16 @@ export async function startApiServer(config: ApiServerConfig): Promise<ApiServer
       }
 
       const accessNormalized = { endpoint: access.endpoint, priceUsdc: access.priceUsdc };
-      const hint: { artifactType?: string; envelopeCid?: string; sources?: ArtifactSource[] } = {};
+      const hint: {
+        artifactType?: string;
+        envelopeCid?: string;
+        sources?: ArtifactSource[];
+        ownerSafe?: string;
+      } = {};
       if (typeof artifactType === 'string') hint.artifactType = artifactType;
       if (typeof envelopeCid === 'string') hint.envelopeCid = envelopeCid;
       if (sources && sources.length > 0) hint.sources = sources;
+      if (typeof ownerSafe === 'string') hint.ownerSafe = ownerSafe;
 
       const existing = inFlight.get(sha256);
       const acquirePromise = existing ?? corpus.acquireBySha256(sha256, accessNormalized, hint);
@@ -673,12 +681,28 @@ export async function startApiServer(config: ApiServerConfig): Promise<ApiServer
         port: actualPort,
         close: () =>
           new Promise<void>((res) => {
-            httpServer.close(() => res());
-            // Shutdown should not wait for dashboard keep-alive/SSE clients.
-            // Once the daemon is stopping, close existing sockets after the
-            // listener has stopped accepting new connections.
-            httpServer.closeIdleConnections();
-            httpServer.closeAllConnections();
+            let settled = false;
+            const done = () => {
+              if (settled) return;
+              settled = true;
+              res();
+            };
+            const timer = setTimeout(done, 2_000);
+            timer.unref?.();
+            try {
+              httpServer.close(() => {
+                clearTimeout(timer);
+                done();
+              });
+              // Shutdown should not wait for dashboard keep-alive/SSE clients.
+              // Once the daemon is stopping, close existing sockets after the
+              // listener has stopped accepting new connections.
+              httpServer.closeIdleConnections();
+              httpServer.closeAllConnections();
+            } catch {
+              clearTimeout(timer);
+              done();
+            }
           }),
         // serve() returns Server | Http2Server | Http2SecureServer; we never
         // pass http2/https opts so it's always a node http.Server at runtime.

--- a/client/src/api/task-runs-build.ts
+++ b/client/src/api/task-runs-build.ts
@@ -24,6 +24,8 @@ export interface TaskRunsStatus {
     observedTasks: number;
     activeTaskRuns: number;
     completed: number;
+    solutions: number;
+    verdicts: number;
     failed: number;
   };
   inFlight: TaskRunSummary[];
@@ -37,12 +39,16 @@ export function gatherTaskRunsStatus(store: Store): TaskRunsStatus {
   const failed = persistence.getByState('FAILED');
   const allRuns = [...inFlight, ...complete, ...failed];
   const allRecent = [...allRuns].sort((a, b) => b.stateUpdatedAt - a.stateUpdatedAt);
+  const solutions = complete.filter((run) => run.taskRole !== 'evaluation');
+  const verdicts = complete.filter((run) => run.taskRole === 'evaluation');
 
   return {
     totals: {
       observedTasks: distinctTaskCount(allRuns),
       activeTaskRuns: inFlight.length,
       completed: complete.length,
+      solutions: solutions.length,
+      verdicts: verdicts.length,
       failed: failed.length,
     },
     inFlight: [...inFlight]

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -149,6 +149,13 @@ export const JinnConfigSchema = z.object({
   /** The Graph subgraph URL for artifact discovery */
   subgraphUrl: z.string().optional(),
 
+  /**
+   * Narrow task discovery to specific on-chain task ids. This is primarily
+   * for live acceptance gates that must avoid claiming unrelated public
+   * backlog while proving one fresh task path.
+   */
+  taskDiscoveryAllowedTaskIds: z.array(z.string()).optional(),
+
   /** This node's public HTTP endpoint (for 8004 registration) */
   nodeEndpoint: z.string().optional(),
 

--- a/client/src/corpus/index.ts
+++ b/client/src/corpus/index.ts
@@ -15,6 +15,7 @@ import type {
   ReadArgs,
 } from './types.js';
 import { runCorpusQuery } from './query.js';
+import { runOnchainCorpusQuery } from './onchain-query.js';
 import { fetchManifest } from './fetch.js';
 import { acquireArtifactContent } from './acquire.js';
 import type { ArtifactSource } from '../types/envelope.js';
@@ -72,7 +73,33 @@ export function createCorpus(opts: CorpusOptions, deps: InternalDeps = {}): Corp
   const acquireFn = deps.acquireFn;
 
   async function query(q: CorpusQuery): Promise<EnvelopeRef[]> {
-    return runCorpusQuery(opts.subgraphUrl, q, fetchImpl);
+    const refs: EnvelopeRef[] = [];
+    const warnings: string[] = [];
+    let successfulSources = 0;
+    if (opts.subgraphUrl) {
+      try {
+        refs.push(...await runCorpusQuery(opts.subgraphUrl, q, fetchImpl));
+        successfulSources += 1;
+      } catch (err) {
+        warnings.push(`subgraph: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+    if (opts.onchain) {
+      try {
+        refs.push(...await runOnchainCorpusQuery(q, opts.onchain));
+        successfulSources += 1;
+      } catch (err) {
+        warnings.push(`onchain: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+    const deduped = new Map<string, EnvelopeRef>();
+    for (const ref of refs) {
+      if (!deduped.has(ref.manifestCid)) deduped.set(ref.manifestCid, ref);
+    }
+    if (deduped.size === 0 && warnings.length > 0 && successfulSources === 0) {
+      throw new Error(`corpus query failed: ${warnings.join('; ')}`);
+    }
+    return [...deduped.values()];
   }
 
   async function fetchOne(ref: EnvelopeRef): Promise<ManifestPreview> {
@@ -105,7 +132,7 @@ export function createCorpus(opts: CorpusOptions, deps: InternalDeps = {}): Corp
   async function acquireBySha256(
     sha256: string,
     access: { endpoint: string; priceUsdc: string },
-    hint?: { artifactType?: string; envelopeCid?: string; sources?: ArtifactSource[] },
+    hint?: { artifactType?: string; envelopeCid?: string; sources?: ArtifactSource[]; ownerSafe?: string },
   ): Promise<ArtifactContent> {
     return acquireArtifactContent({
       sha256,
@@ -118,6 +145,7 @@ export function createCorpus(opts: CorpusOptions, deps: InternalDeps = {}): Corp
       envelopeCid: hint?.envelopeCid,
       sources: hint?.sources,
       ipfsGatewayUrl: opts.ipfsGatewayUrl,
+      ownerSafe: hint?.ownerSafe,
       acquireFn,
       fetchFromIpfs: fetchFromIpfsImpl,
     });

--- a/client/src/corpus/onchain-query.ts
+++ b/client/src/corpus/onchain-query.ts
@@ -1,0 +1,197 @@
+import {
+  createPublicClient,
+  decodeAbiParameters,
+  decodeEventLog,
+  http,
+  type Address,
+  type Hex,
+  type Log,
+  type PublicClient,
+} from 'viem';
+import { base, baseSepolia } from 'viem/chains';
+import type { CorpusQuery, EnvelopeRef } from './types.js';
+import { PAYLOAD_TUPLE, PAYLOAD_TUPLE_V2 } from '../erc8004/abis.js';
+
+const DEFAULT_LIMIT = 50;
+const HARD_LIMIT = 500;
+const DEFAULT_CHUNK_BLOCKS = 9_999n;
+
+export const DEFAULT_EXECUTION_DISCOVERY_FROM_BLOCK: Record<number, bigint> = {
+  84532: 41_100_000n,
+  8453: 25_000_000n,
+};
+
+export const DEFAULT_IDENTITY_REGISTRY_BY_CHAIN_ID: Record<number, Address> = {
+  84532: '0x8004A818BFB912233c491871b3d84c89A494BD9e',
+  8453: '0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
+};
+
+const IDENTITY_METADATA_ABI = [
+  {
+    type: 'event',
+    name: 'MetadataSet',
+    inputs: [
+      { name: 'agentId', type: 'uint256', indexed: true },
+      { name: 'indexedMetadataKey', type: 'string', indexed: true },
+      { name: 'metadataKey', type: 'string', indexed: false },
+      { name: 'metadataValue', type: 'bytes', indexed: false },
+    ],
+  },
+] as const;
+
+export interface OnchainCorpusQueryOptions {
+  rpcUrl?: string;
+  chainId: number;
+  identityRegistryAddress?: Address;
+  fromBlock?: bigint | number;
+  chunkBlocks?: bigint | number;
+  publicClient?: Pick<PublicClient, 'getBlockNumber' | 'getLogs'>;
+}
+
+interface ExecutionMetadataEvent {
+  ref: EnvelopeRef;
+  blockNumber: bigint;
+  logIndex: number;
+}
+
+function chainForId(chainId: number) {
+  return chainId === 84532 ? baseSepolia : base;
+}
+
+function toBigIntBlock(value: bigint | number | undefined, fallback: bigint): bigint {
+  if (value === undefined) return fallback;
+  if (typeof value === 'bigint') return value;
+  return BigInt(Math.max(0, Math.floor(value)));
+}
+
+function parseExecutionMetadataKey(key: string): { kind: string; cid: string } | null {
+  const colon = key.indexOf(':');
+  if (colon <= 0 || colon === key.length - 1) return null;
+  const kind = key.slice(0, colon);
+  if (kind !== 'envelope' && kind !== 'evaluation' && kind !== 'capture') return null;
+  return { kind, cid: key.slice(colon + 1) };
+}
+
+function tierFromRaw(value: number): EnvelopeRef['evidenceTier'] {
+  if (value === 0) return 'self-signed';
+  if (value === 1) return 'committed';
+  if (value === 3) return 'attested';
+  return 'unknown';
+}
+
+function decodePayload(value: Hex): { manifestHash: string; evidenceTier: EnvelopeRef['evidenceTier'] } {
+  try {
+    const decoded = decodeAbiParameters(PAYLOAD_TUPLE_V2, value);
+    return {
+      manifestHash: decoded[2],
+      evidenceTier: tierFromRaw(Number(decoded[1])),
+    };
+  } catch {
+    // v1 payloads do not have the trailing harness identity fields.
+  }
+  try {
+    const decoded = decodeAbiParameters(PAYLOAD_TUPLE, value);
+    return {
+      manifestHash: decoded[2],
+      evidenceTier: tierFromRaw(Number(decoded[1])),
+    };
+  } catch {
+    return { manifestHash: '', evidenceTier: 'unknown' };
+  }
+}
+
+function decodeMetadataLog(log: Log): ExecutionMetadataEvent | null {
+  let decoded: {
+    eventName: 'MetadataSet';
+    args: {
+      agentId: bigint;
+      metadataKey: string;
+      metadataValue: Hex;
+    };
+  };
+  try {
+    decoded = decodeEventLog({
+      abi: IDENTITY_METADATA_ABI,
+      data: log.data,
+      topics: log.topics,
+    }) as typeof decoded;
+  } catch {
+    return null;
+  }
+  if (decoded.eventName !== 'MetadataSet') return null;
+  const parsedKey = parseExecutionMetadataKey(decoded.args.metadataKey);
+  if (!parsedKey) return null;
+  const payload = decodePayload(decoded.args.metadataValue);
+  return {
+    ref: {
+      manifestCid: parsedKey.cid,
+      manifestHash: payload.manifestHash,
+      operator: {
+        agentId: decoded.args.agentId.toString(),
+        safeAddress: '',
+      },
+      evidenceTier: payload.evidenceTier,
+      publishedAt: 0,
+    },
+    blockNumber: log.blockNumber ?? 0n,
+    logIndex: log.logIndex ?? 0,
+  };
+}
+
+function matchesQuery(ref: EnvelopeRef, q: CorpusQuery): boolean {
+  if (q.evidenceTier && ref.evidenceTier !== q.evidenceTier) return false;
+  return true;
+}
+
+export async function runOnchainCorpusQuery(
+  q: CorpusQuery,
+  opts: OnchainCorpusQueryOptions,
+): Promise<EnvelopeRef[]> {
+  const address = opts.identityRegistryAddress ?? DEFAULT_IDENTITY_REGISTRY_BY_CHAIN_ID[opts.chainId];
+  if (!address) return [];
+  const client = opts.publicClient ?? createPublicClient({
+    chain: chainForId(opts.chainId),
+    transport: http(opts.rpcUrl),
+  });
+  const currentBlock = await client.getBlockNumber();
+  const fromBlock = toBigIntBlock(
+    opts.fromBlock,
+    DEFAULT_EXECUTION_DISCOVERY_FROM_BLOCK[opts.chainId] ?? currentBlock,
+  );
+  if (fromBlock > currentBlock) return [];
+
+  const limit = Math.min(Math.max(1, q.limit ?? DEFAULT_LIMIT), HARD_LIMIT);
+  const chunk = toBigIntBlock(opts.chunkBlocks, DEFAULT_CHUNK_BLOCKS);
+  const out: ExecutionMetadataEvent[] = [];
+  const seen = new Set<string>();
+
+  for (let end = currentBlock; end >= fromBlock && out.length < limit; ) {
+    const start = end > chunk && end - chunk + 1n > fromBlock
+      ? end - chunk + 1n
+      : fromBlock;
+    const logs = await client.getLogs({
+      address,
+      fromBlock: start,
+      toBlock: end,
+    });
+    const decoded = logs
+      .map(decodeMetadataLog)
+      .filter((item): item is ExecutionMetadataEvent => item !== null)
+      .sort((a, b) => {
+        if (a.blockNumber === b.blockNumber) return b.logIndex - a.logIndex;
+        return a.blockNumber > b.blockNumber ? -1 : 1;
+      });
+    for (const item of decoded) {
+      if (!matchesQuery(item.ref, q)) continue;
+      const key = item.ref.manifestCid;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(item);
+      if (out.length >= limit) break;
+    }
+    if (start === fromBlock) break;
+    end = start - 1n;
+  }
+
+  return out.map((item) => item.ref);
+}

--- a/client/src/corpus/types.ts
+++ b/client/src/corpus/types.ts
@@ -9,12 +9,13 @@ import type { Store } from '../store/store.js';
 import type { ArtifactSource, EvidenceTier, Role, SignedEnvelope } from '../types/envelope.js';
 
 export interface CorpusOptions {
-  subgraphUrl: string;
+  subgraphUrl?: string;
   ipfsGatewayUrl: string;
   store: Store;
   signer: { privateKey: string };
   selfSafeAddress: string;
   routeResolver?: RouteResolver;
+  onchain?: import('./onchain-query.js').OnchainCorpusQueryOptions;
 }
 
 export interface CorpusQuery {
@@ -118,7 +119,7 @@ export interface Corpus {
   acquireBySha256(
     sha256: string,
     access: { endpoint: string; priceUsdc: string },
-    hint?: { artifactType?: string; envelopeCid?: string; sources?: ArtifactSource[] },
+    hint?: { artifactType?: string; envelopeCid?: string; sources?: ArtifactSource[]; ownerSafe?: string },
   ): Promise<ArtifactContent>;
 }
 

--- a/client/src/dashboard/spa/src/App.routing.test.tsx
+++ b/client/src/dashboard/spa/src/App.routing.test.tsx
@@ -110,7 +110,7 @@ describe('App routes', () => {
       ),
     );
     // Overview renders HeroStats with these canonical eyebrows.
-    expect(screen.getByText(/tasks delivered/i)).toBeTruthy();
+    expect(screen.getByText(/solutions delivered/i)).toBeTruthy();
     expect(screen.getByText(/jinn earned/i)).toBeTruthy();
   });
 

--- a/client/src/dashboard/spa/src/pages/LauncherLaunched.test.tsx
+++ b/client/src/dashboard/spa/src/pages/LauncherLaunched.test.tsx
@@ -197,7 +197,7 @@ describe('LauncherLaunchedPage', () => {
     );
     // Status header still renders (with fallback name).
     expect(screen.getByTestId('launcher-launched-status-header')).toBeTruthy();
-    expect(screen.getByTestId('launcher-launched-name').textContent).toContain('unnamed');
+    expect(screen.getByTestId('launcher-launched-name').textContent).toBe('sn-1');
   });
 
   it('Pause button → dialog → confirm calls transitionLifecycle("paused") and refetches', async () => {

--- a/client/src/dashboard/spa/src/pages/LauncherLaunched.tsx
+++ b/client/src/dashboard/spa/src/pages/LauncherLaunched.tsx
@@ -147,6 +147,7 @@ export function LauncherLaunchedPage({
 
   const record = recordQuery.data;
   const manifest = manifestQuery.data?.manifest;
+  const solverNetName = manifest?.name ?? record.summary?.name ?? record.solverNetId;
 
   return (
     <main
@@ -196,7 +197,7 @@ export function LauncherLaunchedPage({
       <PauseRetireDialog
         open={dialogTarget !== null}
         target={dialogTarget ?? 'paused'}
-        solverNetName={manifest?.name ?? ''}
+        solverNetName={solverNetName}
         pending={lifecycleMutation.isPending}
         errorMessage={dialogError ?? undefined}
         onCancel={() => {

--- a/client/src/dashboard/spa/src/pages/Overview.test.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { Router } from 'wouter';
 import { memoryLocation } from 'wouter/memory-location';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -81,6 +81,7 @@ describe('OverviewPage empty-state gating', () => {
           ok: true,
           solverNet: { name: 'prediction', enabled: false },
           diagnostics: [],
+          nextAction: { description: 'Waiting for Tasks. SolverNet active, Harness loaded; no incoming Tasks since startup.' },
         },
         totals: { observedTasks: 0, activeTaskRuns: 0, solutions: 0, verdicts: 0, failed: 0 },
       },
@@ -211,6 +212,55 @@ describe('OverviewPage empty-state gating', () => {
     expect(screen.queryByText(operatorEyebrow('prediction'))).toBeNull();
     const configure = screen.getByText(/configure/i).closest('a');
     expect(configure?.getAttribute('href')).toBe('/operator#solvernets/bafkreiswe');
+  });
+
+  it('uses generic task-run totals before stale prediction counters', async () => {
+    getStatusMock.mockResolvedValue({
+      taskRuns: {
+        totals: {
+          observedTasks: 102,
+          activeTaskRuns: 3,
+          completed: 87,
+          solutions: 45,
+          verdicts: 42,
+          failed: 63,
+        },
+        inFlight: [],
+        recentTasks: [],
+      },
+      predictionV1: {
+        operator: {
+          ok: true,
+          solverNet: { name: 'prediction', enabled: false },
+          diagnostics: [],
+        },
+        totals: { observedTasks: 10, activeTaskRuns: 0, solutions: 5, verdicts: 0, failed: 5 },
+      },
+      fleet: { services: [] },
+    });
+    getBootstrapMock.mockResolvedValue({
+      joinedSolverNets: {
+        bafkreiswe: {
+          manifestCid: 'bafkreiswe',
+          name: 'SWE-rebench v2',
+          roles: ['solver', 'evaluator'],
+        },
+      },
+    });
+    render(withProviders(<OverviewPage />));
+
+    const networkTitle = await screen.findByText(/network · swe-rebench v2/i);
+    const network = networkTitle.closest('section');
+    expect(network).not.toBeNull();
+    expect(within(network as HTMLElement).getByText('102')).toBeTruthy();
+    expect(within(network as HTMLElement).getByText('3')).toBeTruthy();
+    expect(within(network as HTMLElement).getByText('45')).toBeTruthy();
+    expect(within(network as HTMLElement).getByText('42')).toBeTruthy();
+    expect(within(network as HTMLElement).getByText('63')).toBeTruthy();
+    expect(within(network as HTMLElement).queryByText('10')).toBeNull();
+    expect(screen.getByText(/solutions delivered/i)).toBeTruthy();
+    expect(screen.getByText(/working on current run/i)).toBeTruthy();
+    expect(screen.queryByText(/no incoming tasks since startup/i)).toBeNull();
   });
 
   it('shows the OperatorCard from the predictionV1 status as a back-compat signal', async () => {

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -38,7 +38,14 @@ interface OverviewStatusV1 {
     }>;
   };
   taskRuns?: {
-    totals?: { activeTaskRuns?: number };
+    totals?: {
+      observedTasks?: number;
+      activeTaskRuns?: number;
+      completed?: number;
+      solutions?: number;
+      verdicts?: number;
+      failed?: number;
+    };
     inFlight?: Array<{ state: string; taskRole: 'restoration' | 'evaluation' | null; stateUpdatedAt: number }>;
     recentTasks?: Array<{ state: string; taskRole: 'restoration' | 'evaluation' | null; stateUpdatedAt: number }>;
   };
@@ -67,6 +74,8 @@ interface OverviewStatusV1 {
     recentTasks?: Array<{ state: string; taskRole: 'restoration' | 'evaluation' | null; stateUpdatedAt: number }>;
   };
 }
+
+type OverviewTaskRunTotals = NonNullable<OverviewStatusV1['taskRuns']>['totals'];
 
 /**
  * The operator's joined SolverNets per spec §12. Tasks 21/22 finish the
@@ -203,6 +212,28 @@ function formatEth(wei?: string): string {
   }
 }
 
+function operatorWaitingMessage(
+  joined: JoinedSolverNet | null,
+  taskRunTotals: OverviewTaskRunTotals,
+  predictionDescription: string | undefined,
+): string | undefined {
+  const hasGenericRuns =
+    (taskRunTotals?.observedTasks ?? 0) > 0 ||
+    (taskRunTotals?.activeTaskRuns ?? 0) > 0 ||
+    (taskRunTotals?.completed ?? 0) > 0 ||
+    (taskRunTotals?.failed ?? 0) > 0;
+  if (hasGenericRuns) {
+    if ((taskRunTotals?.activeTaskRuns ?? 0) > 0) {
+      return 'Working on current run.';
+    }
+    return 'Waiting for the next available run.';
+  }
+  if (joined?.configId === 'prediction') {
+    return predictionDescription;
+  }
+  return undefined;
+}
+
 export function OverviewPage(): JSX.Element {
   const [, navigate] = useLocation();
   const { data: status } = useQuery<OverviewStatusV1>({
@@ -229,12 +260,14 @@ export function OverviewPage(): JSX.Element {
     operator?.solverNet?.enabled === true,
     operator?.solverNet?.roles,
   );
+  const taskRunTotals = status?.taskRuns?.totals;
+  const predictionTotals = status?.predictionV1?.totals;
   const totals = {
-    tasks: status?.predictionV1?.totals?.observedTasks ?? 0,
-    active: status?.predictionV1?.totals?.activeTaskRuns ?? 0,
-    solutions: status?.predictionV1?.totals?.solutions ?? 0,
-    verdicts: status?.predictionV1?.totals?.verdicts ?? 0,
-    failed: status?.predictionV1?.totals?.failed ?? 0,
+    tasks: taskRunTotals?.observedTasks ?? predictionTotals?.observedTasks ?? 0,
+    active: taskRunTotals?.activeTaskRuns ?? predictionTotals?.activeTaskRuns ?? 0,
+    solutions: taskRunTotals?.solutions ?? predictionTotals?.solutions ?? 0,
+    verdicts: taskRunTotals?.verdicts ?? predictionTotals?.verdicts ?? 0,
+    failed: taskRunTotals?.failed ?? predictionTotals?.failed ?? 0,
   };
   const services: ServiceIdentity[] = (status?.fleet?.services ?? []).map((s) => ({
     index: s.index,
@@ -247,6 +280,7 @@ export function OverviewPage(): JSX.Element {
   const jinnEarned = formatEth(status?.rewards?.pendingStakingRewardsWei);
   const gasRunwayDays = status?.masterGas?.runwayDaysExcess ?? '—';
   const liveNow = deriveLiveNow(status);
+  const waitingMessage = operatorWaitingMessage(joined, taskRunTotals, operator?.nextAction?.description);
 
   return (
     <div style={{ padding: '24px', display: 'flex', flexDirection: 'column', gap: '24px' }}>
@@ -279,7 +313,7 @@ export function OverviewPage(): JSX.Element {
           configId={joined.configId}
           roles={joined.roles}
           state="live"
-          waitingMessage={operator?.nextAction?.description}
+          waitingMessage={waitingMessage}
         />
       ) : (
         <AlertBand

--- a/client/src/dashboard/spa/src/pages/launcher-launched/SpendPanel.test.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher-launched/SpendPanel.test.tsx
@@ -71,6 +71,28 @@ function buildManifest(
   };
 }
 
+function buildRecordSummary(
+  overrides: Partial<NonNullable<LaunchedSolverNetRecord['summary']>> = {},
+): NonNullable<LaunchedSolverNetRecord['summary']> {
+  return {
+    manifestCid: 'bafybeig',
+    solverNetId: 'sn-1',
+    name: 'SWE-rebench v2',
+    network: 'base-sepolia',
+    launcherAgentId: '5474',
+    launcherSafeAddress: '0xE64bAf0073a71b0Cb2C0558bB16f24b45E1FB5CF',
+    status: 'launched',
+    statusUpdatedAt: '2026-05-05T15:00:00Z',
+    contractId: 'swe-rebench-v2',
+    contractVersion: 'v1',
+    solutionPriceWei: '10000000000',
+    verdictPriceWei: '5000000000',
+    openRoles: ['solver', 'evaluator'],
+    anchorBlock: 1,
+    ...overrides,
+  };
+}
+
 function buildStatusResponse(
   netName: string,
   safeBalanceWei: string,
@@ -214,6 +236,26 @@ describe('SpendPanel', () => {
     expect(screen.getByTestId('launcher-launched-spend-solution-price').textContent).toBe('10 gwei');
     expect(screen.getByTestId('launcher-launched-spend-verdict-price').textContent).toBe('5 gwei');
     expect(screen.getByTestId('launcher-launched-spend-per-task').textContent).not.toContain('e-');
+  });
+
+  it('uses the launched record summary for prices while the manifest is loading', async () => {
+    const fetchLauncherStatus = vi.fn().mockResolvedValue(
+      buildStatusResponse('SWE-rebench v2', '2000000000000000', 'swe-rebench-v2.v1'),
+    );
+    wrap(
+      <SpendPanel
+        record={buildRecord({ summary: buildRecordSummary() })}
+        fetchLauncherStatus={fetchLauncherStatus}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId('launcher-launched-spend-per-task').textContent,
+      ).toBe('15 gwei'),
+    );
+    expect(screen.getByTestId('launcher-launched-spend-solution-price').textContent).toBe('10 gwei');
+    expect(screen.getByTestId('launcher-launched-spend-verdict-price').textContent).toBe('5 gwei');
   });
 
   it('falls back to "balance unavailable" when no matching launcher-status entry', async () => {

--- a/client/src/dashboard/spa/src/pages/launcher-launched/SpendPanel.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher-launched/SpendPanel.tsx
@@ -45,10 +45,13 @@ export function SpendPanel({
 
   const manifestSolverType = manifest
     ? `${manifest.contract.id}.${manifest.contract.version}`
-    : undefined;
-  const matchedEntry = manifest
+    : record.summary
+      ? `${record.summary.contractId}.${record.summary.contractVersion}`
+      : undefined;
+  const matchedEntry = manifestSolverType
     ? status?.nets.find((n) =>
-        n.solverType === manifestSolverType || n.name === manifest.name,
+        n.solverType === manifestSolverType ||
+        n.name === (manifest?.name ?? record.summary?.name),
       )
     : undefined;
 
@@ -56,8 +59,8 @@ export function SpendPanel({
   const safeAddress =
     matchedEntry?.budget.safeAddress ?? record.launcherSafeAddress;
 
-  const solutionPriceWei = manifest?.solutionPriceWei;
-  const verdictPriceWei = manifest?.verdictPriceWei;
+  const solutionPriceWei = manifest?.solutionPriceWei ?? record.summary?.solutionPriceWei;
+  const verdictPriceWei = manifest?.verdictPriceWei ?? record.summary?.verdictPriceWei;
 
   const projection = projectRunwayTasks(
     safeBalanceWei,

--- a/client/src/dashboard/spa/src/pages/launcher-launched/StatusHeader.test.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher-launched/StatusHeader.test.tsx
@@ -25,6 +25,28 @@ function buildRecord(
   };
 }
 
+function buildRecordSummary(
+  overrides: Partial<NonNullable<LaunchedSolverNetRecord['summary']>> = {},
+): NonNullable<LaunchedSolverNetRecord['summary']> {
+  return {
+    manifestCid: 'bafybeigdyrztabcdef0123456789abcdef0123456789abcdef0123456789abc',
+    solverNetId: 'agent-1_prediction.v1-1_abcdef01',
+    name: 'SWE-rebench v2',
+    network: 'base-sepolia',
+    launcherAgentId: '5474',
+    launcherSafeAddress: '0xE64bAf0073a71b0Cb2C0558bB16f24b45E1FB5CF',
+    status: 'launched',
+    statusUpdatedAt: '2026-05-05T15:00:00Z',
+    contractId: 'swe-rebench-v2',
+    contractVersion: 'v1',
+    solutionPriceWei: '100',
+    verdictPriceWei: '50',
+    openRoles: ['solver', 'evaluator'],
+    anchorBlock: 1,
+    ...overrides,
+  };
+}
+
 function buildManifest(
   overrides: Partial<SolverNetManifestV1> = {},
 ): SolverNetManifestV1 {
@@ -95,14 +117,24 @@ describe('StatusHeader', () => {
     expect(screen.getByText(/Forecast resolved markets/)).toBeTruthy();
   });
 
-  it('falls back to "— unnamed" when no manifest is supplied', () => {
+  it('falls back to the launched record summary while the manifest is loading', () => {
+    render(
+      <StatusHeader
+        record={buildRecord({ summary: buildRecordSummary() })}
+        onAction={() => undefined}
+      />,
+    );
+    expect(screen.getByTestId('launcher-launched-name').textContent).toBe('SWE-rebench v2');
+  });
+
+  it('falls back to the SolverNet id when no manifest or summary is supplied', () => {
     render(
       <StatusHeader
         record={buildRecord()}
         onAction={() => undefined}
       />,
     );
-    expect(screen.getByTestId('launcher-launched-name').textContent).toContain('unnamed');
+    expect(screen.getByTestId('launcher-launched-name').textContent).toBe('agent-1_prediction.v1-1_abcdef01');
   });
 
   it('renders Pause + Retire when status=launched', () => {

--- a/client/src/dashboard/spa/src/pages/launcher-launched/StatusHeader.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher-launched/StatusHeader.tsx
@@ -51,7 +51,7 @@ export function StatusHeader({
 }: StatusHeaderProps): JSX.Element {
   const tone = STATUS_TONE[record.status] ?? STATUS_TONE.launching;
   const allowed = ALLOWED_TRANSITIONS[record.status] ?? [];
-  const name = manifest?.name ?? '— unnamed';
+  const name = manifest?.name ?? record.summary?.name ?? record.solverNetId;
 
   return (
     <header

--- a/client/src/dashboard/spa/src/pages/overview/HeroStats.test.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/HeroStats.test.tsx
@@ -14,6 +14,7 @@ describe('HeroStats', () => {
         statusDot="var(--vow-green)"
       />,
     );
+    expect(screen.getByText(/solutions delivered/i)).toBeTruthy();
     expect(screen.getByText('42')).toBeTruthy();
     expect(screen.getByText('123')).toBeTruthy();
     expect(screen.getByText('4')).toBeTruthy();

--- a/client/src/dashboard/spa/src/pages/overview/HeroStats.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/HeroStats.tsx
@@ -133,7 +133,7 @@ export function HeroStats({
         gap: '16px',
       }}
     >
-      <Stat label="Tasks delivered" value={tasksDelivered} />
+      <Stat label="Solutions delivered" value={tasksDelivered} />
       <Stat label="JINN earned" value={jinnEarned} unit="JINN" />
       <Stat label="Gas runway" value={gasRunwayDays} unit="days" />
       <StatusStat label={statusLabel} state={statusState} dot={statusDot} />

--- a/client/src/harnesses/engine/engine.ts
+++ b/client/src/harnesses/engine/engine.ts
@@ -312,6 +312,22 @@ export interface RecoveryReport {
   error?: string;
 }
 
+interface TickOptions {
+  /**
+   * When true, wait for newly scheduled task processing to settle before
+   * returning. Direct callers keep the historical behavior. The daemon's
+   * periodic loop uses wait=false so one long harness run cannot starve
+   * other in-flight tasks discovered later.
+   */
+  wait?: boolean;
+}
+
+interface ProcessReport {
+  requestId: string;
+  outcome: 'ok' | 'failed';
+  error?: string;
+}
+
 // ── TaskEngine ─────────────────────────────────────────────────────────
 
 export class TaskEngine {
@@ -361,9 +377,14 @@ export class TaskEngine {
   // Keyed by requestId; cleared after successful pack.
   private readonly trajectoryRefs = new Map<string, { cid: string; sha256: string; sources?: ArtifactSource[] } | null>();
   private readonly runtimePluginsByRequest = new Map<string, RuntimePlugin[]>();
+  private readonly processingRequestIds = new Set<string>();
 
   /** Set by stop(); causes runTickLoop to exit at the next iteration. */
   private stopped = false;
+  private stopResolve?: () => void;
+  private readonly stopPromise = new Promise<void>((resolve) => {
+    this.stopResolve = resolve;
+  });
 
   constructor(opts: TaskEngineOptions) {
     this.persistence = new TaskRunPersistence(opts.store.db);
@@ -442,18 +463,24 @@ export class TaskEngine {
    *
    * Errors from individual tasks are logged but do not stop the loop.
    */
-  async tick(): Promise<void> {
+  async tick(options: TickOptions = {}): Promise<void> {
+    const wait = options.wait ?? true;
     const inflight = this.persistence.getInFlight();
-    const results = await Promise.allSettled(
-      inflight.map((task) => this.process(task.requestId)),
-    );
-    for (let i = 0; i < results.length; i++) {
-      const r = results[i]!;
-      if (r.status === 'rejected') {
-        const requestId = inflight[i]!.requestId;
-        const reason = r.reason instanceof Error ? r.reason.message : String(r.reason);
-        console.warn(`[harness-engine] tick: process(${requestId}) failed: ${reason}`);
+    const scheduled: Array<Promise<ProcessReport>> = [];
+    for (const task of inflight) {
+      const processPromise = this.scheduleProcess(task.requestId);
+      if (!processPromise) continue;
+      scheduled.push(processPromise);
+      if (!wait) {
+        void processPromise.then((report) => this.logProcessReport('tick', report));
       }
+    }
+
+    if (!wait) return;
+
+    const reports = await Promise.all(scheduled);
+    for (const report of reports) {
+      this.logProcessReport('tick', report);
     }
   }
 
@@ -464,18 +491,44 @@ export class TaskEngine {
   async runTickLoop(intervalMs: number): Promise<void> {
     while (!this.stopped) {
       try {
-        await this.tick();
+        await this.tick({ wait: false });
       } catch (err) {
         console.error('[harness-engine] tick loop error (continuing):', err instanceof Error ? err.message : err);
       }
       if (this.stopped) break;
-      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+      await Promise.race([
+        new Promise((resolve) => setTimeout(resolve, intervalMs)),
+        this.stopPromise,
+      ]);
     }
   }
 
   /** Signal `runTickLoop` to exit at the next iteration. */
   stop(): void {
     this.stopped = true;
+    this.stopResolve?.();
+  }
+
+  private scheduleProcess(requestId: string): Promise<ProcessReport> | null {
+    if (this.processingRequestIds.has(requestId)) {
+      return null;
+    }
+    this.processingRequestIds.add(requestId);
+    return this.process(requestId)
+      .then((): ProcessReport => ({ requestId, outcome: 'ok' }))
+      .catch((err: unknown): ProcessReport => ({
+        requestId,
+        outcome: 'failed',
+        error: err instanceof Error ? err.message : String(err),
+      }))
+      .finally(() => {
+        this.processingRequestIds.delete(requestId);
+      });
+  }
+
+  private logProcessReport(source: string, report: ProcessReport): void {
+    if (report.outcome !== 'failed') return;
+    console.warn(`[harness-engine] ${source}: process(${report.requestId}) failed: ${report.error ?? 'unknown error'}`);
   }
 
   /**

--- a/client/src/harnesses/impls/claude-code-learner/adapters/claude-code.ts
+++ b/client/src/harnesses/impls/claude-code-learner/adapters/claude-code.ts
@@ -24,6 +24,10 @@ export interface ClaudeCodeHarnessAdapterConfig {
   corpusEnv?: {
     subgraphUrl?: string;
     ipfsGatewayUrl?: string;
+    rpcUrl?: string;
+    chainId?: number;
+    identityRegistryAddress?: string;
+    fromBlock?: number;
   };
   /**
    * Plugin install directory for Claude Code. Defaults to
@@ -201,6 +205,10 @@ export class ClaudeCodeHarnessAdapter implements HarnessAdapter {
       DAEMON_API_TOKEN: this.daemonApiToken ?? '',
       JINN_CORPUS_SUBGRAPH_URL: this.corpusEnv?.subgraphUrl ?? '',
       JINN_CORPUS_IPFS_GATEWAY_URL: this.corpusEnv?.ipfsGatewayUrl ?? '',
+      JINN_CORPUS_RPC_URL: this.corpusEnv?.rpcUrl ?? '',
+      JINN_CORPUS_CHAIN_ID: this.corpusEnv?.chainId != null ? String(this.corpusEnv.chainId) : '',
+      JINN_CORPUS_IDENTITY_REGISTRY_ADDRESS: this.corpusEnv?.identityRegistryAddress ?? '',
+      JINN_CORPUS_FROM_BLOCK: this.corpusEnv?.fromBlock != null ? String(this.corpusEnv.fromBlock) : '',
       ...(inputs.adapterEnv ?? {}),
     });
 

--- a/client/src/harnesses/impls/claude-code-learner/adapters/codex-code.ts
+++ b/client/src/harnesses/impls/claude-code-learner/adapters/codex-code.ts
@@ -1,5 +1,5 @@
 import { spawn, spawnSync, type ChildProcess, type SpawnOptions } from 'node:child_process';
-import { createWriteStream, mkdirSync } from 'node:fs';
+import { accessSync, constants, createWriteStream, mkdirSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { finished } from 'node:stream/promises';
 import { fileURLToPath } from 'node:url';
@@ -15,6 +15,10 @@ export interface CodexCodeHarnessAdapterConfig {
   corpusEnv?: {
     subgraphUrl?: string;
     ipfsGatewayUrl?: string;
+    rpcUrl?: string;
+    chainId?: number;
+    identityRegistryAddress?: string;
+    fromBlock?: number;
   };
   clientRoot?: string;
   _spawnFn?: typeof spawn;
@@ -22,6 +26,7 @@ export interface CodexCodeHarnessAdapterConfig {
 }
 
 const DEFAULT_CODEX_MODEL = 'gpt-5.4-mini';
+const MACOS_CODEX_APP_BINARY = '/Applications/Codex.app/Contents/Resources/codex';
 
 const ENV_ALLOWLIST = [
   'PATH',
@@ -39,11 +44,28 @@ const ENV_ALLOWLIST = [
   'NPM_CONFIG_PREFIX',
   'OPENAI_API_KEY',
   'CODEX_HOME',
+  'JINN_CODEX_PATH',
 ];
 
 function defaultClientRoot(): string {
   const here = dirname(fileURLToPath(import.meta.url));
   return resolve(here, '..', '..', '..', '..', '..');
+}
+
+function isExecutable(path: string): boolean {
+  try {
+    accessSync(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function defaultCodexPath(): string {
+  const explicit = process.env['JINN_CODEX_PATH']?.trim();
+  if (explicit) return explicit;
+  if (isExecutable(MACOS_CODEX_APP_BINARY)) return MACOS_CODEX_APP_BINARY;
+  return 'codex';
 }
 
 function buildAgentEnv(extra: Record<string, string>): NodeJS.ProcessEnv {
@@ -146,7 +168,7 @@ export class CodexCodeHarnessAdapter implements HarnessAdapter {
   private readonly runSessionStartHook: boolean;
 
   constructor(config: CodexCodeHarnessAdapterConfig = {}) {
-    this.codexPath = config.codexPath ?? 'codex';
+    this.codexPath = config.codexPath ?? defaultCodexPath();
     this.codexModel = config.codexModel ?? DEFAULT_CODEX_MODEL;
     this.storePath = config.storePath;
     this.daemonApiUrl = config.daemonApiUrl;
@@ -177,6 +199,10 @@ export class CodexCodeHarnessAdapter implements HarnessAdapter {
       DAEMON_API_TOKEN: this.daemonApiToken ?? '',
       JINN_CORPUS_SUBGRAPH_URL: this.corpusEnv?.subgraphUrl ?? '',
       JINN_CORPUS_IPFS_GATEWAY_URL: this.corpusEnv?.ipfsGatewayUrl ?? '',
+      JINN_CORPUS_RPC_URL: this.corpusEnv?.rpcUrl ?? '',
+      JINN_CORPUS_CHAIN_ID: this.corpusEnv?.chainId != null ? String(this.corpusEnv.chainId) : '',
+      JINN_CORPUS_IDENTITY_REGISTRY_ADDRESS: this.corpusEnv?.identityRegistryAddress ?? '',
+      JINN_CORPUS_FROM_BLOCK: this.corpusEnv?.fromBlock != null ? String(this.corpusEnv.fromBlock) : '',
       ...(inputs.adapterEnv ?? {}),
     };
     const env = buildAgentEnv(baseEnv);

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -77,6 +77,7 @@ import type { Harness } from './harnesses/types.js';
 import { createClients } from './adapters/mech/safe.js';
 import { loadSolverNets } from './solver-nets/registry.js';
 import { createCorpus } from './corpus/index.js';
+import { DEFAULT_EXECUTION_DISCOVERY_FROM_BLOCK } from './corpus/onchain-query.js';
 import { CapturesStore } from './store/captures.js';
 import { createLiveCapturePublisher } from './captures/live-publisher.js';
 import { startReceiver, type Receiver } from './trajectory/receiver.js';
@@ -1469,10 +1470,14 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     chainId: config.network === 'testnet' ? 84532 : 8453,
     routerClaimDeliveryVariant: CHAIN_CONFIG.routerClaimDeliveryVersion,
     evictionRecovery,
-    taskDiscovery: config.subgraphUrl && taskDiscoveryManifestCids.length > 0
+    taskDiscovery: taskDiscoveryManifestCids.length > 0
       ? {
-          subgraphUrl: config.subgraphUrl,
+          ...(config.subgraphUrl ? { subgraphUrl: config.subgraphUrl } : {}),
           solverNetManifestCids: taskDiscoveryManifestCids,
+          onchainFromBlock: config.network === 'testnet' ? 41_153_291 : 25_000_000,
+          ...(config.taskDiscoveryAllowedTaskIds?.length
+            ? { allowedTaskIds: config.taskDiscoveryAllowedTaskIds }
+            : {}),
         }
       : undefined,
   }, sharedStore);
@@ -1583,11 +1588,17 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
   }
 
   // legacy-claude: wraps ClaudeRunner; handles spec=undefined (health-check) tasks
+  const corpusChainId = config.network === 'testnet' ? 84532 : 8453;
+  const corpusFromBlock = Number(DEFAULT_EXECUTION_DISCOVERY_FROM_BLOCK[corpusChainId] ?? 0n);
   const corpusEnv: RunnerContext['corpusEnv'] | undefined =
-    config.subgraphUrl?.trim()
+    (config.subgraphUrl?.trim() || identityRegistryAddress)
       ? {
-          subgraphUrl: config.subgraphUrl,
+          ...(config.subgraphUrl?.trim() ? { subgraphUrl: config.subgraphUrl } : {}),
           ipfsGatewayUrl: config.ipfsGatewayUrl,
+          rpcUrl: config.rpcUrl,
+          chainId: corpusChainId,
+          ...(identityRegistryAddress ? { identityRegistryAddress } : {}),
+          ...(corpusFromBlock > 0 ? { fromBlock: corpusFromBlock } : {}),
         }
       : undefined;
 
@@ -1990,21 +2001,32 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
   // Built once per daemon lifetime; the agent EOA private key stays in this
   // process's memory and never crosses into the MCP subprocess. The MCP
   // tool `acquire_artifact` proxies to `POST /v1/artifacts/acquire` instead.
-  // Disabled when subgraphUrl is unset — the API route is then absent and
-  // MCP falls back to local-only behaviour with a warning.
-  const corpusFactory = config.subgraphUrl?.trim()
+  // Enabled when either the optional subgraph accelerator or canonical
+  // on-chain ERC-8004/IPFS discovery is configured. Otherwise the API route is
+  // absent and MCP falls back to local-only behaviour with a warning.
+  const corpusFactory = (config.subgraphUrl?.trim() || identityRegistryAddress)
     ? (store: Store) =>
         (corpusForApi = createCorpus({
-          subgraphUrl: config.subgraphUrl!,
+          ...(config.subgraphUrl?.trim() ? { subgraphUrl: config.subgraphUrl } : {}),
           ipfsGatewayUrl: config.ipfsGatewayUrl,
           store,
           signer: { privateKey: agentPrivateKey },
           selfSafeAddress: safeAddress,
+          ...(identityRegistryAddress
+            ? {
+                onchain: {
+                  rpcUrl: config.rpcUrl,
+                  chainId: corpusChainId,
+                  identityRegistryAddress,
+                  ...(corpusFromBlock > 0 ? { fromBlock: corpusFromBlock } : {}),
+                },
+              }
+            : {}),
         }))
     : undefined;
   if (!corpusFactory) {
     console.warn(
-      '[main] Corpus disabled (config.subgraphUrl not set); ' +
+      '[main] Corpus disabled (no subgraphUrl or on-chain identity registry); ' +
         'MCP record lookup and artifact acquisition network branches will be unavailable.',
     );
   }

--- a/client/src/mcp/acquire-artifact.ts
+++ b/client/src/mcp/acquire-artifact.ts
@@ -24,6 +24,7 @@ export interface AcquireArtifactArgs {
   envelopeCid?: string;
   artifactType?: string;
   sources?: ArtifactSource[];
+  ownerSafe?: string;
 }
 
 export type AcquireArtifactResult =
@@ -103,6 +104,7 @@ export async function handleAcquireArtifact(
         envelopeCid: args.envelopeCid,
         artifactType: args.artifactType,
         sources: args.sources,
+        ownerSafe: args.ownerSafe,
       }),
     });
   } catch (err) {

--- a/client/src/mcp/search-records.ts
+++ b/client/src/mcp/search-records.ts
@@ -35,11 +35,12 @@ export interface ArtifactDescriptor {
     arguments: {
       sha256: string;
       access: { endpoint: string; priceUsdc: string };
-      envelopeCid?: string;
-      artifactType?: string;
-      sources?: ArtifactSource[];
+        envelopeCid?: string;
+        artifactType?: string;
+        sources?: ArtifactSource[];
+        ownerSafe?: string;
+      };
     };
-  };
   paidAmountUsdc?: string;
   sourceOperator?: string | null;
   createdAt?: string;
@@ -174,13 +175,17 @@ function localArtifactDescriptor(row: ReturnType<Store['searchOwnAndCached']>[nu
   return descriptor;
 }
 
-function manifestArtifactDescriptor(ref: EnvelopeRef, artifact: Artifact): ArtifactDescriptor {
+function manifestArtifactDescriptor(ref: EnvelopeRef, artifact: Artifact, ownerSafe?: string): ArtifactDescriptor {
   const acquisitionArguments: NonNullable<ArtifactDescriptor['acquisition']>['arguments'] = {
     sha256: artifact.sha256,
     access: artifact.access,
     envelopeCid: ref.manifestCid,
     artifactType: artifact.artifactType,
   };
+  const sourceOperator = ownerSafe || ref.operator.safeAddress;
+  if (sourceOperator) {
+    acquisitionArguments.ownerSafe = sourceOperator;
+  }
   if (artifact.sources && artifact.sources.length > 0) {
     acquisitionArguments.sources = artifact.sources;
   }
@@ -235,20 +240,27 @@ function manifestMatchesArgs(preview: ManifestPreview, args: SearchRecordsArgs):
 function manifestRecord(preview: ManifestPreview, args: SearchRecordsArgs): RecordSummary | null {
   const envelope = preview.envelope;
   if (!manifestMatchesArgs(preview, args)) return null;
+  const ref: EnvelopeRef = {
+    ...preview.ref,
+    operator: {
+      agentId: preview.ref.operator.agentId,
+      safeAddress: preview.ref.operator.safeAddress || envelope.participant.safeAddress,
+    },
+  };
   const artifacts = envelope.artifacts
     .filter((artifact) => !args.artifactType || artifact.artifactType === args.artifactType)
-    .map((artifact) => manifestArtifactDescriptor(preview.ref, artifact));
+    .map((artifact) => manifestArtifactDescriptor(ref, artifact, envelope.participant.safeAddress));
   if (args.artifactType && artifacts.length === 0) return null;
   return {
-    recordRef: `network:envelope:${preview.ref.manifestCid}`,
+    recordRef: `network:envelope:${ref.manifestCid}`,
     source: 'network',
     envelopeRef: {
-      cid: preview.ref.manifestCid,
+      cid: ref.manifestCid,
       sha256: null,
-      manifestHash: preview.ref.manifestHash,
-      evidenceTier: preview.ref.evidenceTier,
-      publishedAt: preview.ref.publishedAt,
-      operator: preview.ref.operator,
+      manifestHash: ref.manifestHash,
+      evidenceTier: ref.evidenceTier,
+      publishedAt: ref.publishedAt,
+      operator: ref.operator,
     },
     taskRef: envelope.task
       ? { cid: envelope.task.cid, requestId: envelope.task.requestId }
@@ -296,7 +308,7 @@ export async function handleSearchRecords(
 
   if (!corpus) {
     console.warn(
-      '[mcp:search_records] corpus not configured (missing JINN_CORPUS_SUBGRAPH_URL or JINN_CORPUS_IPFS_GATEWAY_URL) - local-only results',
+      '[mcp:search_records] corpus not configured (missing IPFS gateway plus subgraph or on-chain corpus config) - local-only results',
     );
     const records: RecordSummary[] = [];
     for (const projection of projections) appendUnique(records, projection);
@@ -304,7 +316,7 @@ export async function handleSearchRecords(
     return {
       records,
       warning:
-        'corpus not configured (missing JINN_CORPUS_SUBGRAPH_URL or JINN_CORPUS_IPFS_GATEWAY_URL); network results unavailable',
+        'corpus not configured (missing IPFS gateway plus subgraph or on-chain corpus config); network results unavailable',
     };
   }
 

--- a/client/src/mcp/server.ts
+++ b/client/src/mcp/server.ts
@@ -75,15 +75,32 @@ function buildReadOnlyCorpus(): Pick<Corpus, 'query' | 'fetchManifest'> | null {
   if (!store) return null;
   const subgraphUrl = process.env['JINN_CORPUS_SUBGRAPH_URL'] ?? '';
   const ipfsGatewayUrl = process.env['JINN_CORPUS_IPFS_GATEWAY_URL'] ?? '';
-  if (!subgraphUrl || !ipfsGatewayUrl) {
+  const rpcUrl = process.env['JINN_CORPUS_RPC_URL'] ?? '';
+  const chainIdRaw = process.env['JINN_CORPUS_CHAIN_ID'] ?? '';
+  const chainId = chainIdRaw ? Number.parseInt(chainIdRaw, 10) : undefined;
+  const identityRegistryAddress = process.env['JINN_CORPUS_IDENTITY_REGISTRY_ADDRESS'] ?? '';
+  const fromBlockRaw = process.env['JINN_CORPUS_FROM_BLOCK'] ?? '';
+  const fromBlock = fromBlockRaw ? Number.parseInt(fromBlockRaw, 10) : undefined;
+  const hasOnchainCorpus = Boolean(rpcUrl && chainId && identityRegistryAddress);
+  if (!ipfsGatewayUrl || (!subgraphUrl && !hasOnchainCorpus)) {
     return null;
   }
   const full = createCorpus({
-    subgraphUrl,
+    ...(subgraphUrl ? { subgraphUrl } : {}),
     ipfsGatewayUrl,
     store,
     signer: { privateKey: '0x0' },
     selfSafeAddress: '0x0000000000000000000000000000000000000000',
+    ...(hasOnchainCorpus
+      ? {
+          onchain: {
+            rpcUrl,
+            chainId: chainId!,
+            identityRegistryAddress: identityRegistryAddress as `0x${string}`,
+            ...(fromBlock !== undefined ? { fromBlock } : {}),
+          },
+        }
+      : {}),
   });
   return {
     query: full.query.bind(full),
@@ -415,6 +432,7 @@ server.tool(
     }),
     envelopeCid: z.string().optional(),
     artifactType: z.string().optional(),
+    ownerSafe: z.string().optional(),
     sources: z.array(artifactSourceSchema).optional(),
   },
   async (args) => {

--- a/client/src/runner/claude.ts
+++ b/client/src/runner/claude.ts
@@ -78,6 +78,10 @@ export class ClaudeRunner implements Runner {
             // proxies through DAEMON_API_URL instead.
             JINN_CORPUS_SUBGRAPH_URL: context.corpusEnv?.subgraphUrl ?? '',
             JINN_CORPUS_IPFS_GATEWAY_URL: context.corpusEnv?.ipfsGatewayUrl ?? '',
+            JINN_CORPUS_RPC_URL: context.corpusEnv?.rpcUrl ?? '',
+            JINN_CORPUS_CHAIN_ID: context.corpusEnv?.chainId != null ? String(context.corpusEnv.chainId) : '',
+            JINN_CORPUS_IDENTITY_REGISTRY_ADDRESS: context.corpusEnv?.identityRegistryAddress ?? '',
+            JINN_CORPUS_FROM_BLOCK: context.corpusEnv?.fromBlock != null ? String(context.corpusEnv.fromBlock) : '',
           },
         },
       },

--- a/client/src/runner/runner.ts
+++ b/client/src/runner/runner.ts
@@ -26,6 +26,10 @@ export interface RunnerContext {
   corpusEnv?: {
     subgraphUrl?: string;
     ipfsGatewayUrl?: string;
+    rpcUrl?: string;
+    chainId?: number;
+    identityRegistryAddress?: string;
+    fromBlock?: number;
   };
   /**
    * In-run trajectory collector. When provided, the runner emits a

--- a/client/src/scripts/donation-consumption-acceptance.ts
+++ b/client/src/scripts/donation-consumption-acceptance.ts
@@ -3,22 +3,27 @@
  * Release-blocking two-operator donation consumption gate.
  *
  * This is intentionally not a mocked corpus test. It expects real testnet
- * subgraph/IPFS discovery, a producer daemon with fresh donated SWE execution
+ * canonical on-chain/IPFS discovery, a producer daemon with fresh donated SWE execution
  * data, and a separate consumer operator home/db that can consume that data
  * through the same MCP tools exposed to the learner runtime.
  */
 
 import { createHash, randomBytes } from 'node:crypto';
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 import { fileURLToPath } from 'node:url';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { Store } from '../store/store.js';
 import { DEFAULT_CONFIG_PATH, DEFAULT_TESTNET_SUBGRAPH_URL } from '../config.js';
+import {
+  DEFAULT_EXECUTION_DISCOVERY_FROM_BLOCK,
+  DEFAULT_IDENTITY_REGISTRY_BY_CHAIN_ID,
+  runOnchainCorpusQuery,
+} from '../corpus/onchain-query.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 function findPackageRoot(startDir: string): string {
@@ -69,6 +74,7 @@ interface LocalConfig {
   dbPath?: string;
   earningDir?: string;
   subgraphUrl?: string;
+  taskDiscoveryAllowedTaskIds?: string[];
   ipfsGatewayUrl?: string;
   ipfsRegistryUrl?: string;
   pollIntervalMs?: number;
@@ -92,7 +98,7 @@ interface VerifiedDonation {
   trajectorySourceCid: string;
   envelope: JsonRecord;
   redactedEnvelope: JsonRecord;
-  subgraphExecution: JsonRecord;
+  indexExecution: JsonRecord;
 }
 
 interface HeaderAuth {
@@ -130,6 +136,10 @@ function asString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
 
+function defaultRpcUrlForChain(chainId: number): string {
+  return chainId === 8453 ? 'https://mainnet.base.org' : 'https://sepolia.base.org';
+}
+
 function asInt(value: unknown, fallback: number): number {
   const n = Number.parseInt(String(value ?? ''), 10);
   return Number.isFinite(n) ? n : fallback;
@@ -143,6 +153,17 @@ function readJsonFile(path: string): JsonRecord {
 function writeJson(path: string, value: unknown): void {
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function archiveManagedConsumerDb(dbPath: string, evidenceDir: string): string[] {
+  const archived: string[] = [];
+  for (const path of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) {
+    if (!existsSync(path)) continue;
+    const target = join(evidenceDir, `previous-${basename(path)}`);
+    renameSync(path, target);
+    archived.push(target);
+  }
+  return archived;
 }
 
 function defaultClientHome(home: string): string {
@@ -233,25 +254,99 @@ async function querySubgraphExecution(subgraphUrl: string, manifestCid: string):
   });
   const errors = body.errors;
   if (Array.isArray(errors) && errors.length > 0) {
-    fail('subgraph_query_failed', 'Subgraph returned errors while checking donated envelope indexing.', { errors });
+    throw new Error(`Subgraph returned errors while checking donated envelope indexing: ${JSON.stringify(errors)}`);
   }
   const executions = ((body.data as JsonRecord | undefined)?.executions ?? []) as JsonRecord[];
   const execution = executions[0];
   return execution ?? null;
 }
 
-async function waitForSubgraphExecution(opts: {
-  subgraphUrl: string;
+async function querySubgraphTaskIdByTaskCidDigest(subgraphUrl: string, taskCidDigest: string): Promise<string | null> {
+  const body = await fetchJson(subgraphUrl, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      query: `
+        query TaskByTaskCidDigest($taskCidDigest: Bytes!) {
+          tasks(first: 1, where: { taskCidDigest: $taskCidDigest }) {
+            id
+            taskId
+            taskCidDigest
+            createdAtTx
+          }
+        }
+      `,
+      variables: { taskCidDigest: taskCidDigest.toLowerCase() },
+    }),
+  });
+  const errors = body.errors;
+  if (Array.isArray(errors) && errors.length > 0) {
+    throw new Error(`Subgraph returned errors while resolving producer task id: ${JSON.stringify(errors)}`);
+  }
+  const tasks = ((body.data as JsonRecord | undefined)?.tasks ?? []) as JsonRecord[];
+  const task = tasks[0];
+  return asString(task?.taskId) ?? asString(task?.id) ?? null;
+}
+
+async function queryCanonicalExecutionIndex(opts: {
+  subgraphUrl?: string;
+  rpcUrl?: string;
+  chainId: number;
+  manifestCid: string;
+}): Promise<JsonRecord | null> {
+  const warnings: string[] = [];
+  if (opts.subgraphUrl) {
+    try {
+      const subgraphExecution = await querySubgraphExecution(opts.subgraphUrl, opts.manifestCid);
+      if (subgraphExecution) return { source: 'subgraph', ...subgraphExecution };
+    } catch (err) {
+      warnings.push(err instanceof Error ? err.message : String(err));
+    }
+  }
+  const identityRegistryAddress = DEFAULT_IDENTITY_REGISTRY_BY_CHAIN_ID[opts.chainId];
+  if (opts.rpcUrl && identityRegistryAddress) {
+    try {
+      const refs = await runOnchainCorpusQuery(
+        { limit: 100 },
+        {
+          rpcUrl: opts.rpcUrl,
+          chainId: opts.chainId,
+          identityRegistryAddress,
+          fromBlock: DEFAULT_EXECUTION_DISCOVERY_FROM_BLOCK[opts.chainId],
+        },
+      );
+      const ref = refs.find((candidate) => candidate.manifestCid === opts.manifestCid);
+      if (ref) {
+        return {
+          source: 'onchain',
+          manifestCid: ref.manifestCid,
+          manifestHash: ref.manifestHash,
+          tier: ref.evidenceTier,
+          publishedAt: ref.publishedAt,
+          operator: ref.operator,
+        };
+      }
+    } catch (err) {
+      warnings.push(err instanceof Error ? err.message : String(err));
+    }
+  }
+  return warnings.length > 0 ? { source: 'unavailable', warnings } : null;
+}
+
+async function waitForCanonicalExecutionIndex(opts: {
+  subgraphUrl?: string;
+  rpcUrl?: string;
+  chainId: number;
   manifestCid: string;
   deadline: number;
   pollMs: number;
 }): Promise<JsonRecord> {
   while (Date.now() < opts.deadline) {
-    const execution = await querySubgraphExecution(opts.subgraphUrl, opts.manifestCid);
-    if (execution) return execution;
+    const execution = await queryCanonicalExecutionIndex(opts);
+    if (execution && execution.source !== 'unavailable') return execution;
     await boundedPollSleep(opts.deadline, opts.pollMs);
   }
-  fail('envelope_not_indexed', 'Donated envelope is not visible in the configured subgraph.', {
+  fail('envelope_not_indexed', 'Donated envelope is not visible through the canonical on-chain/IPFS index path.', {
     manifestCid: opts.manifestCid,
   });
 }
@@ -344,7 +439,7 @@ async function verifyTrajectorySource(envelope: JsonRecord, ipfsGatewayUrl: stri
 async function verifyDonatedEnvelope(
   artifact: ProducerArtifact,
   ipfsGatewayUrl: string,
-  subgraphUrl: string,
+  indexOpts: { subgraphUrl?: string; rpcUrl?: string; chainId: number },
   deadline: number,
   pollMs: number,
 ): Promise<VerifiedDonation> {
@@ -400,8 +495,8 @@ async function verifyDonatedEnvelope(
     }
   }
   const trajectorySourceCid = await verifyTrajectorySource(envelope, ipfsGatewayUrl);
-  const subgraphExecution = await waitForSubgraphExecution({
-    subgraphUrl,
+  const indexExecution = await waitForCanonicalExecutionIndex({
+    ...indexOpts,
     manifestCid: artifact.envelopeCid,
     deadline,
     pollMs,
@@ -412,7 +507,7 @@ async function verifyDonatedEnvelope(
     trajectorySourceCid,
     envelope,
     redactedEnvelope: redactEnvelope(envelope),
-    subgraphExecution,
+    indexExecution,
   };
 }
 
@@ -806,6 +901,69 @@ function startConsumerDaemon(opts: {
   return child;
 }
 
+function childHasExited(child: ChildProcess): boolean {
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
+function waitForChildExit(child: ChildProcess, timeoutMs: number): Promise<boolean> {
+  if (childHasExited(child)) return Promise.resolve(true);
+  return new Promise((resolvePromise) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      resolvePromise(childHasExited(child));
+    }, timeoutMs);
+    const done = () => {
+      cleanup();
+      resolvePromise(true);
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      child.off('exit', done);
+      child.off('error', done);
+    };
+    child.once('exit', done);
+    child.once('error', done);
+  });
+}
+
+async function stopManagedConsumerDaemon(opts: {
+  child: ChildProcess;
+  configPath: string;
+  home: string;
+  apiToken: string;
+  evidenceDir: string;
+  codexHome?: string;
+}): Promise<void> {
+  const stopResult = spawnSync(process.execPath, [jinnBinPath, 'stop', '--json', '--config', opts.configPath], {
+    cwd: clientRoot,
+    env: buildConsumerChildEnv(opts.home, opts.apiToken, opts.codexHome),
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+  writeFileSync(join(opts.evidenceDir, 'consumer-daemon-stop.stdout'), stopResult.stdout ?? '', { flag: 'a' });
+  writeFileSync(join(opts.evidenceDir, 'consumer-daemon-stop.stderr'), stopResult.stderr ?? '', { flag: 'a' });
+
+  if (!childHasExited(opts.child)) {
+    opts.child.kill('SIGTERM');
+    await waitForChildExit(opts.child, 5_000);
+  }
+  if (!childHasExited(opts.child)) {
+    opts.child.kill('SIGKILL');
+    await waitForChildExit(opts.child, 5_000);
+  }
+
+  opts.child.stdout?.destroy();
+  opts.child.stderr?.destroy();
+  if (!childHasExited(opts.child)) {
+    fail('consumer_daemon_cleanup_failed', 'Managed consumer daemon did not exit after the live gate completed.', {
+      pid: opts.child.pid,
+      stopStatus: stopResult.status,
+      stdoutPath: join(opts.evidenceDir, 'consumer-daemon-stop.stdout'),
+      stderrPath: join(opts.evidenceDir, 'consumer-daemon-stop.stderr'),
+    });
+  }
+}
+
 async function waitForStatus(opts: {
   baseUrl: string;
   deadline: number;
@@ -840,8 +998,12 @@ async function callMcpTool(opts: {
   storePath: string;
   daemonApiUrl: string;
   daemonApiToken: string;
-  subgraphUrl: string;
+  subgraphUrl?: string;
   ipfsGatewayUrl: string;
+  rpcUrl?: string;
+  chainId: number;
+  identityRegistryAddress?: string;
+  fromBlock?: number;
 }): Promise<JsonRecord> {
   const client = new Client({ name: 'donation-consumption-acceptance', version: '1.0.0' });
   const transport = new StdioClientTransport({
@@ -853,8 +1015,12 @@ async function callMcpTool(opts: {
       STORE_PATH: opts.storePath,
       DAEMON_API_URL: opts.daemonApiUrl,
       DAEMON_API_TOKEN: opts.daemonApiToken,
-      JINN_CORPUS_SUBGRAPH_URL: opts.subgraphUrl,
+      JINN_CORPUS_SUBGRAPH_URL: opts.subgraphUrl ?? '',
       JINN_CORPUS_IPFS_GATEWAY_URL: opts.ipfsGatewayUrl,
+      JINN_CORPUS_RPC_URL: opts.rpcUrl ?? '',
+      JINN_CORPUS_CHAIN_ID: String(opts.chainId),
+      JINN_CORPUS_IDENTITY_REGISTRY_ADDRESS: opts.identityRegistryAddress ?? '',
+      JINN_CORPUS_FROM_BLOCK: opts.fromBlock != null ? String(opts.fromBlock) : '',
       DESIRED_STATE_ID: 'donation-consumption-acceptance',
       DESIRED_STATE_DESCRIPTION: 'Verify cross-operator donated SWE execution data consumption.',
       DESIRED_STATE_ROLE: 'restoration',
@@ -884,15 +1050,26 @@ async function callMcpTool(opts: {
   }
 }
 
-function findDonatedArtifactRecord(searchResult: JsonRecord, proof: VerifiedDonation): JsonRecord {
+function hasDonatedIpfsSourceArgs(artifact: JsonRecord): boolean {
+  const acquisition = artifact.acquisition as JsonRecord | undefined;
+  const args = acquisition?.arguments as JsonRecord | undefined;
+  const sources = Array.isArray(args?.sources) ? args.sources as JsonRecord[] : [];
+  return sources.some((source) => source.kind === 'ipfs' && source.encoding === 'jinn.artifact.donation.v1');
+}
+
+export function findDonatedArtifactRecord(searchResult: JsonRecord, proof: VerifiedDonation): JsonRecord {
   const records = Array.isArray(searchResult.records) ? searchResult.records as JsonRecord[] : [];
+  const matches: JsonRecord[] = [];
   for (const record of records) {
     const envelopeRef = record.envelopeRef as JsonRecord | null | undefined;
     if (envelopeRef?.cid !== proof.artifact.envelopeCid) continue;
     const artifactRefs = Array.isArray(record.artifactRefs) ? record.artifactRefs as JsonRecord[] : [];
     const artifact = artifactRefs.find((candidate) => candidate.sha256 === proof.artifact.sha256);
-    if (artifact) return artifact;
+    if (artifact) matches.push(artifact);
   }
+  const networkAcquisition = matches.find(hasDonatedIpfsSourceArgs);
+  if (networkAcquisition) return networkAcquisition;
+  if (matches[0]) return matches[0];
   fail('consumer_discovery_missing', 'Consumer MCP search_records did not discover the producer donated artifact.', {
     envelopeCid: proof.artifact.envelopeCid,
     sha256: proof.artifact.sha256,
@@ -908,13 +1085,78 @@ function acquisitionArgsFromArtifact(artifact: JsonRecord): JsonRecord {
       artifact,
     });
   }
-  const sources = Array.isArray(args.sources) ? args.sources as JsonRecord[] : [];
-  if (!sources.some((source) => source.kind === 'ipfs' && source.encoding === 'jinn.artifact.donation.v1')) {
+  if (!hasDonatedIpfsSourceArgs(artifact)) {
     fail('consumer_acquisition_sources_missing', 'Discovered artifact acquisition args do not include donated IPFS sources.', {
       args,
     });
   }
   return args;
+}
+
+function proofParticipantSafe(proof: VerifiedDonation): string {
+  const participant = proof.envelope.participant;
+  if (participant && typeof participant === 'object' && !Array.isArray(participant)) {
+    const safe = (participant as JsonRecord).safeAddress;
+    if (typeof safe === 'string' && safe) return safe;
+  }
+  return '';
+}
+
+function producerTaskCreationTx(proof: VerifiedDonation): string | undefined {
+  const task = proof.envelope.task;
+  if (!task || typeof task !== 'object' || Array.isArray(task)) return undefined;
+  return asString((task as JsonRecord).onchainCreationTx);
+}
+
+function producerTaskCidDigest(proof: VerifiedDonation): string | undefined {
+  const task = proof.envelope.task;
+  if (!task || typeof task !== 'object' || Array.isArray(task)) return undefined;
+  const cid = asString((task as JsonRecord).cid);
+  if (!cid) return undefined;
+  if (/^0x[0-9a-fA-F]{64}$/.test(cid)) return cid;
+  const rawMultihashPrefix = 'f01551220';
+  if (cid.startsWith(rawMultihashPrefix) && cid.length === rawMultihashPrefix.length + 64) {
+    return `0x${cid.slice(rawMultihashPrefix.length)}`;
+  }
+  return undefined;
+}
+
+export async function scopeConsumerConfigToProducerTask(opts: {
+  consumerConfig: LocalConfig;
+  consumerConfigPath: string;
+  proof: VerifiedDonation;
+  subgraphUrl: string;
+  evidenceDir?: string;
+}): Promise<string> {
+  const taskCidDigest = producerTaskCidDigest(opts.proof);
+  if (!taskCidDigest) {
+    fail('producer_task_scope_missing_cid_digest', 'Producer envelope is missing a task CID digest, so the gate cannot scope consumer task discovery.', {
+      envelopeCid: opts.proof.artifact.envelopeCid,
+    });
+  }
+  const createdAtTx = producerTaskCreationTx(opts.proof);
+  const taskId = await querySubgraphTaskIdByTaskCidDigest(opts.subgraphUrl, taskCidDigest);
+  if (!taskId) {
+    fail('producer_task_scope_unresolved', 'Could not resolve the producer on-chain task id from the configured subgraph.', {
+      envelopeCid: opts.proof.artifact.envelopeCid,
+      taskCidDigest,
+      createdAtTx,
+      subgraphUrl: opts.subgraphUrl,
+    });
+  }
+
+  opts.consumerConfig.taskDiscoveryAllowedTaskIds = [taskId];
+  writeJson(opts.consumerConfigPath, opts.consumerConfig);
+  if (opts.evidenceDir) {
+    writeJson(join(opts.evidenceDir, 'consumer-task-scope.json'), {
+      allowedTaskIds: [taskId],
+      producerEnvelopeCid: opts.proof.artifact.envelopeCid,
+      producerTaskCidDigest: taskCidDigest,
+      producerTaskCreatedAtTx: createdAtTx ?? null,
+      consumerConfigPath: opts.consumerConfigPath,
+    });
+  }
+  return taskId;
 }
 
 function parseMaybeJson(bytes: Buffer): JsonRecord | null {
@@ -929,6 +1171,7 @@ function parseMaybeJson(bytes: Buffer): JsonRecord | null {
 export async function waitForConsumerSolveAndEvaluatorProof(opts: {
   storePath: string;
   proof: VerifiedDonation;
+  allowedTaskId?: string;
   startedAt: Date;
   acquisitionStartedAt: Date;
   acquisitionFinishedAt: Date;
@@ -940,21 +1183,57 @@ export async function waitForConsumerSolveAndEvaluatorProof(opts: {
     const store = new Store(opts.storePath);
     try {
       const networkRow = store.getNetworkArtifact(opts.proof.artifact.sha256);
+      const runMatches = (
+        requestId: string | null | undefined,
+        expectedRole: 'restoration' | 'evaluation',
+      ): boolean => {
+        if (!requestId) return false;
+        const row = store.db.prepare(`
+          SELECT
+            task_id AS taskId,
+            task_role AS taskRole,
+            state,
+            manifest_cid AS manifestCid,
+            delivery_tx_hash AS deliveryTxHash
+          FROM task_runs
+          WHERE request_id = ?
+        `).get(requestId) as {
+          taskId?: string | null;
+          taskRole?: string | null;
+          state?: string | null;
+          manifestCid?: string | null;
+          deliveryTxHash?: string | null;
+        } | undefined;
+        if (!row) return false;
+        if (!opts.reuseExisting && opts.allowedTaskId && row.taskId !== opts.allowedTaskId) return false;
+        return (
+          row.taskRole === expectedRole &&
+          row.state === 'COMPLETE' &&
+          typeof row.manifestCid === 'string' &&
+          row.manifestCid.length > 0 &&
+          typeof row.deliveryTxHash === 'string' &&
+          row.deliveryTxHash.length > 0
+        );
+      };
       const solutionRow = store.listServedArtifactMetadata({
         artifactType: SWE_SOLUTION_ARTIFACT_TYPE,
         limit: 50,
       }).find((row) => (
-        opts.reuseExisting ||
-        Date.parse(row.createdAt) >= opts.acquisitionFinishedAt.getTime()
+        (opts.reuseExisting || Date.parse(row.createdAt) >= opts.acquisitionFinishedAt.getTime()) &&
+        runMatches(row.requestId, 'restoration')
       ));
       const verdictRow = store.listServedArtifactMetadata({ limit: 100 }).find((row) => {
         if (!VERDICT_ARTIFACT_TYPES.has(row.artifactType)) return false;
-        return opts.reuseExisting || Date.parse(row.createdAt) >= opts.acquisitionFinishedAt.getTime();
+        return (
+          (opts.reuseExisting || Date.parse(row.createdAt) >= opts.acquisitionFinishedAt.getTime()) &&
+          runMatches(row.requestId, 'evaluation')
+        );
       });
       if (
         networkRow &&
         networkRow.envelopeCid === opts.proof.artifact.envelopeCid &&
         networkRow.sourceEndpoint === `ipfs://${opts.proof.sourceCid}` &&
+        networkRow.sourceOperator === proofParticipantSafe(opts.proof) &&
         networkRow.paidAmountUsdc === '0' &&
         (opts.reuseExisting || Date.parse(networkRow.fetchedAt) >= opts.startedAt.getTime()) &&
         (opts.reuseExisting || Date.parse(networkRow.lastUsedAt) >= opts.acquisitionStartedAt.getTime()) &&
@@ -996,6 +1275,7 @@ export async function waitForConsumerSolveAndEvaluatorProof(opts: {
     sha256: opts.proof.artifact.sha256,
     envelopeCid: opts.proof.artifact.envelopeCid,
     sourceCid: opts.proof.sourceCid,
+    allowedTaskId: opts.allowedTaskId,
     acquisitionStartedAt: opts.acquisitionStartedAt.toISOString(),
     acquisitionFinishedAt: opts.acquisitionFinishedAt.toISOString(),
     requiredArtifacts: [SWE_SOLUTION_ARTIFACT_TYPE, ...VERDICT_ARTIFACT_TYPES],
@@ -1097,6 +1377,10 @@ async function main(): Promise<void> {
   });
   const subgraphUrl = asString(producerConfig.subgraphUrl) ?? DEFAULT_TESTNET_SUBGRAPH_URL;
   const ipfsGatewayUrl = asString(producerConfig.ipfsGatewayUrl) ?? DEFAULT_IPFS_GATEWAY_URL;
+  const chainId = producerConfig.network === 'mainnet' ? 8453 : 84532;
+  const producerRpcUrl = asString(producerConfig.rpcUrl) ?? defaultRpcUrlForChain(chainId);
+  const corpusFromBlock = Number(DEFAULT_EXECUTION_DISCOVERY_FROM_BLOCK[chainId] ?? 0n);
+  const identityRegistryAddress = DEFAULT_IDENTITY_REGISTRY_BY_CHAIN_ID[chainId];
 
   const consumerHome = resolve(parsed.values['consumer-home'] ?? join(clientRoot, '.acceptance', 'donation-consumer'));
   const consumerCodexHome = resolveConsumerCodexHome(parsed.values['consumer-codex-home']);
@@ -1125,9 +1409,12 @@ async function main(): Promise<void> {
     });
     writeJson(consumerConfigPath, consumerConfig);
   }
-  const consumerConfig = loadLocalConfig(consumerConfigPath);
+  let consumerConfig = loadLocalConfig(consumerConfigPath);
   const consumerDbPath = configDbPath(consumerConfig, consumerHome);
   const consumerEarningDir = configEarningDir(consumerConfig, consumerHome);
+  const archivedConsumerDb = (!attachConsumerUrl && !parsed.values['consumer-config'] && !reuseExisting)
+    ? archiveManagedConsumerDb(consumerDbPath, evidenceDir)
+    : [];
   assertConsumerConfiguredForSwe(consumerConfig, consumerConfigPath);
   const consumerEvaluatorStatePath = ensureConsumerSweEvaluatorState({
     producerConfig,
@@ -1152,6 +1439,7 @@ async function main(): Promise<void> {
     consumerHome,
     consumerCodexHome: consumerCodexHome ?? '<OPENAI_API_KEY>',
     consumerDbPath,
+    archivedConsumerDb,
     consumerEarningDir,
     consumerEvaluatorStatePath,
     subgraphUrl,
@@ -1168,15 +1456,31 @@ async function main(): Promise<void> {
     pollMs,
     producerAuth,
   });
-  console.log('[donation-consumption] verifying producer IPFS envelope and subgraph indexing');
-  const donationProof = await verifyDonatedEnvelope(producerArtifact, ipfsGatewayUrl, subgraphUrl, deadline, pollMs);
+  console.log('[donation-consumption] verifying producer IPFS envelope and canonical index visibility');
+  const donationProof = await verifyDonatedEnvelope(
+    producerArtifact,
+    ipfsGatewayUrl,
+    { subgraphUrl, rpcUrl: producerRpcUrl, chainId },
+    deadline,
+    pollMs,
+  );
   writeJson(join(evidenceDir, 'producer-proof.json'), {
     artifact: donationProof.artifact,
     sourceCid: donationProof.sourceCid,
     trajectorySourceCid: donationProof.trajectorySourceCid,
-    subgraphExecution: donationProof.subgraphExecution,
+    indexExecution: donationProof.indexExecution,
   });
   writeJson(join(evidenceDir, 'producer-envelope-redacted.json'), donationProof.redactedEnvelope);
+
+  const allowedConsumerTaskId = await scopeConsumerConfigToProducerTask({
+    consumerConfig,
+    consumerConfigPath,
+    proof: donationProof,
+    subgraphUrl,
+    evidenceDir,
+  });
+  consumerConfig = loadLocalConfig(consumerConfigPath);
+  console.log(`[donation-consumption] scoped consumer task discovery to producer task ${allowedConsumerTaskId}`);
 
   let consumerProcess: ChildProcess | null = null;
   if (!attachConsumerUrl) {
@@ -1214,6 +1518,10 @@ async function main(): Promise<void> {
       daemonApiToken: consumerApiToken,
       subgraphUrl,
       ipfsGatewayUrl,
+      rpcUrl: asString(consumerConfig.rpcUrl) ?? producerRpcUrl,
+      chainId,
+      identityRegistryAddress,
+      fromBlock: corpusFromBlock,
     });
     writeJson(join(evidenceDir, 'consumer-search-records.json'), searchResult);
     const discoveredArtifact = findDonatedArtifactRecord(searchResult, donationProof);
@@ -1230,6 +1538,10 @@ async function main(): Promise<void> {
       daemonApiToken: consumerApiToken,
       subgraphUrl,
       ipfsGatewayUrl,
+      rpcUrl: asString(consumerConfig.rpcUrl) ?? producerRpcUrl,
+      chainId,
+      identityRegistryAddress,
+      fromBlock: corpusFromBlock,
     });
     const acquisitionFinishedAt = new Date();
     writeJson(join(evidenceDir, 'consumer-acquire-artifact.json'), {
@@ -1263,6 +1575,7 @@ async function main(): Promise<void> {
     const liveProof = await waitForConsumerSolveAndEvaluatorProof({
       storePath: consumerDbPath,
       proof: donationProof,
+      allowedTaskId: allowedConsumerTaskId,
       startedAt,
       acquisitionStartedAt,
       acquisitionFinishedAt,
@@ -1281,6 +1594,7 @@ async function main(): Promise<void> {
       producerArtifact: donationProof.artifact,
       sourceCid: donationProof.sourceCid,
       trajectorySourceCid: donationProof.trajectorySourceCid,
+      allowedConsumerTaskId,
       acquisitionStartedAt: acquisitionStartedAt.toISOString(),
       acquisitionFinishedAt: acquisitionFinishedAt.toISOString(),
       consumerNetworkArtifact: liveProof.networkRow,
@@ -1290,8 +1604,15 @@ async function main(): Promise<void> {
     writeJson(join(evidenceDir, 'summary.json'), summary);
     console.log(JSON.stringify(summary, null, 2));
   } finally {
-    if (consumerProcess && !consumerProcess.killed) {
-      consumerProcess.kill('SIGTERM');
+    if (consumerProcess) {
+      await stopManagedConsumerDaemon({
+        child: consumerProcess,
+        configPath: consumerConfigPath,
+        home: consumerHome,
+        apiToken: consumerApiToken,
+        evidenceDir,
+        codexHome: consumerCodexHome,
+      });
     }
   }
 }

--- a/client/src/solvernets/registry-client-erc8004.ts
+++ b/client/src/solvernets/registry-client-erc8004.ts
@@ -422,9 +422,17 @@ export class IdentityRegistryBackedSolverNetRegistryClient
       // current cache-population paths, which always mark verified, but
       // we keep this branch defensive). Verify hash against on-chain
       // advertised hash if any setMetadata events exist for this cid.
-      const events = await this.subgraph.fetchSetMetadataEventsForCid({
-        manifestCid: args.manifestCid,
-      });
+      let events: SetMetadataEvent[] = [];
+      try {
+        events = await this.subgraph.fetchSetMetadataEventsForCid({
+          manifestCid: args.manifestCid,
+        });
+      } catch (err) {
+        console.error(
+          `[solvernet] manifest ${args.manifestCid}: subgraph hash check unavailable; ` +
+          `using IPFS CID-bound manifest (${err instanceof Error ? err.message : String(err)})`,
+        );
+      }
       if (events.length > 0) {
         const advertised = this.latestAdvertisedHash(events);
         const actual = manifestHash(cached);
@@ -528,9 +536,17 @@ export class IdentityRegistryBackedSolverNetRegistryClient
 
     let hash = expectedHash ?? null;
     if (hash === null) {
-      const events = await this.subgraph.fetchSetMetadataEventsForCid({
-        manifestCid,
-      });
+      let events: SetMetadataEvent[] = [];
+      try {
+        events = await this.subgraph.fetchSetMetadataEventsForCid({
+          manifestCid,
+        });
+      } catch (err) {
+        console.error(
+          `[solvernet] manifest ${manifestCid}: subgraph hash check unavailable; ` +
+          `using IPFS CID-bound manifest (${err instanceof Error ? err.message : String(err)})`,
+        );
+      }
       if (events.length > 0) {
         hash = this.latestAdvertisedHash(events);
       }

--- a/client/src/trajectory/receiver.ts
+++ b/client/src/trajectory/receiver.ts
@@ -325,11 +325,28 @@ async function startHttpServer(
     port: addr.port,
     close: () =>
       new Promise<void>((resolve) => {
+        let settled = false;
+        const done = () => {
+          if (settled) return;
+          settled = true;
+          resolve();
+        };
+        const timer = setTimeout(done, 2_000);
+        timer.unref?.();
         // `server.close()` stops accepting new connections but lets keep-alive
         // sockets idle on. Without `closeIdleConnections()` shutdown can hang
         // for the full keep-alive timeout. Available since Node 18.2.
-        server.closeIdleConnections();
-        server.close(() => resolve());
+        try {
+          server.closeIdleConnections();
+          server.closeAllConnections();
+          server.close(() => {
+            clearTimeout(timer);
+            done();
+          });
+        } catch {
+          clearTimeout(timer);
+          done();
+        }
       }),
   };
 }
@@ -402,12 +419,24 @@ async function startGrpcServer(
     port: boundPort,
     close: () =>
       new Promise<void>((resolve) => {
+        let settled = false;
+        const done = () => {
+          if (settled) return;
+          settled = true;
+          resolve();
+        };
+        const timer = setTimeout(() => {
+          server.forceShutdown();
+          done();
+        }, 2_000);
+        timer.unref?.();
         server.tryShutdown((err) => {
+          clearTimeout(timer);
           if (err) {
             // forceShutdown returns void
             server.forceShutdown();
           }
-          resolve();
+          done();
         });
       }),
   };

--- a/client/test/adapters/mech/adapter.test.ts
+++ b/client/test/adapters/mech/adapter.test.ts
@@ -6,6 +6,7 @@ const HOISTED = vi.hoisted(() => {
   const REQUEST_ID = ('0x' + 'aa'.repeat(32)) as `0x${string}`;
   const TASK_CID_DIGEST = ('0x' + 'cc'.repeat(32)) as `0x${string}`;
   const TASK_CID = `f01551220${'cc'.repeat(32)}`;
+  const MANIFEST_DIGEST = ('0x' + '99'.repeat(32)) as `0x${string}`;
   const TX_HASH = ('0x' + '12'.repeat(32)) as `0x${string}`;
   const signedTask = (overrides: Partial<SignedTaskV1> = {}): SignedTaskV1 => ({
     schemaVersion: 'task.v1',
@@ -44,10 +45,10 @@ const HOISTED = vi.hoisted(() => {
     },
     ...overrides,
   });
-  return { REQUEST_ID, TASK_CID_DIGEST, TASK_CID, TX_HASH, signedTask };
+  return { REQUEST_ID, TASK_CID_DIGEST, TASK_CID, MANIFEST_DIGEST, TX_HASH, signedTask };
 });
 
-const { REQUEST_ID, TASK_CID_DIGEST, TASK_CID, TX_HASH, signedTask } = HOISTED;
+const { REQUEST_ID, TASK_CID_DIGEST, TASK_CID, MANIFEST_DIGEST, TX_HASH, signedTask } = HOISTED;
 
 // MOCK_JUSTIFICATION: src/adapters/mech/contracts.js is the I/O leaf for chain RPC calls; mocking it is mocking the boundary.
 vi.mock('../../../src/adapters/mech/contracts.js', () => ({
@@ -99,6 +100,7 @@ vi.mock('../../../src/adapters/mech/ipfs.js', () => ({
 
 // MOCK_JUSTIFICATION: task-subgraph.js is the GraphQL candidate-index boundary; adapter tests decide when candidates exist.
 vi.mock('../../../src/adapters/mech/task-subgraph.js', () => ({
+  manifestDigestForCid: vi.fn().mockReturnValue(MANIFEST_DIGEST),
   queryClaimableTaskCandidates: vi.fn().mockResolvedValue([]),
 }));
 
@@ -257,6 +259,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
     vi.mocked(decodeTaskCreatedLogs).mockReturnValueOnce([{
       taskId: '7',
       taskCidDigest: TASK_CID_DIGEST,
+      manifestDigest: MANIFEST_DIGEST,
       creator: TEST_CONFIG.safeAddress,
       transactionHash: TX_HASH,
       blockNumber: 321,
@@ -294,7 +297,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
     vi.mocked(queryClaimableTaskCandidates).mockResolvedValueOnce([{
       taskId: '42',
       taskCidDigest: TASK_CID_DIGEST,
-      manifestDigest: ('0x' + '99'.repeat(32)) as `0x${string}`,
+      manifestDigest: MANIFEST_DIGEST,
       createdAtBlock: 80,
       createdAtTx: TX_HASH,
       attemptCount: 0,
@@ -359,7 +362,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
       {
         taskId: '42',
         taskCidDigest: TASK_CID_DIGEST,
-        manifestDigest: ('0x' + '99'.repeat(32)) as `0x${string}`,
+        manifestDigest: MANIFEST_DIGEST,
         createdAtBlock: 80,
         createdAtTx: TX_HASH,
         attemptCount: 0,
@@ -368,7 +371,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
       {
         taskId: '43',
         taskCidDigest: TASK_CID_DIGEST,
-        manifestDigest: ('0x' + '99'.repeat(32)) as `0x${string}`,
+        manifestDigest: MANIFEST_DIGEST,
         createdAtBlock: 81,
         createdAtTx: TX_HASH,
         attemptCount: 0,
@@ -397,6 +400,152 @@ describe('MechAdapter TaskCoordinator flow', () => {
     expect(second.done).toBe(true);
     expect(canClaimTask).toHaveBeenCalledTimes(1);
     expect(fetchSignedTaskFromIpfs).toHaveBeenCalledTimes(1);
+
+    await adapter.stop();
+  });
+
+  it('subgraph discovery honors an explicit task id scope', async () => {
+    const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+    const { queryClaimableTaskCandidates } = await import('../../../src/adapters/mech/task-subgraph.js');
+    const { canClaimTask } = await import('../../../src/adapters/mech/contracts.js');
+    const { fetchSignedTaskFromIpfs } = await import('../../../src/adapters/mech/ipfs.js');
+
+    vi.mocked(queryClaimableTaskCandidates).mockResolvedValueOnce([
+      {
+        taskId: '42',
+        taskCidDigest: TASK_CID_DIGEST,
+        manifestDigest: MANIFEST_DIGEST,
+        createdAtBlock: 80,
+        createdAtTx: TX_HASH,
+        attemptCount: 0,
+        operatorAttemptCount: 0,
+      },
+      {
+        taskId: '43',
+        taskCidDigest: TASK_CID_DIGEST,
+        manifestDigest: MANIFEST_DIGEST,
+        createdAtBlock: 81,
+        createdAtTx: TX_HASH,
+        attemptCount: 0,
+        operatorAttemptCount: 0,
+      },
+    ]);
+    vi.mocked(fetchSignedTaskFromIpfs).mockResolvedValueOnce(signedTask({ id: 'scoped-subgraph-task' }));
+
+    const adapter = new MechAdapter({
+      ...TEST_CONFIG,
+      taskDiscovery: {
+        subgraphUrl: 'https://subgraph.example/graphql',
+        solverNetManifestCids: ['bafyfixturecid'],
+        allowedTaskIds: ['43'],
+      },
+    });
+    await adapter.initialize();
+
+    const iter = (adapter as any).discoverSubgraphRestorationTasks()[Symbol.asyncIterator]();
+    const first = await iter.next();
+
+    expect(first.value).toMatchObject({
+      taskId: '43',
+      task: { id: 'scoped-subgraph-task' },
+    });
+    expect(canClaimTask).toHaveBeenCalledTimes(1);
+    expect(canClaimTask).toHaveBeenCalledWith(
+      expect.anything(),
+      TEST_CONFIG.safeAddress,
+      TEST_CONFIG.routerAddress,
+      '43',
+      TEST_CONFIG.mechContractAddress,
+    );
+
+    await adapter.stop();
+  });
+
+  it('falls back to canonical TaskCreated logs when configured subgraph discovery fails', async () => {
+    const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+    const { decodeTaskCreatedLogs } = await import('../../../src/adapters/mech/contracts.js');
+    const { fetchSignedTaskFromIpfs } = await import('../../../src/adapters/mech/ipfs.js');
+    const { queryClaimableTaskCandidates } = await import('../../../src/adapters/mech/task-subgraph.js');
+    const manifestCid = 'bafyfixturecid';
+
+    vi.mocked(queryClaimableTaskCandidates).mockRejectedValueOnce(new Error('subgraph HTTP 429'));
+    vi.mocked(decodeTaskCreatedLogs).mockReturnValueOnce([{
+      taskId: '44',
+      taskCidDigest: TASK_CID_DIGEST,
+      manifestDigest: MANIFEST_DIGEST,
+      creator: TEST_CONFIG.safeAddress,
+      transactionHash: TX_HASH,
+      blockNumber: 101,
+    }]);
+    vi.mocked(fetchSignedTaskFromIpfs).mockResolvedValueOnce(signedTask({ id: 'fallback-task' }));
+
+    const adapter = new MechAdapter({
+      ...TEST_CONFIG,
+      taskDiscovery: {
+        subgraphUrl: 'https://subgraph.example/graphql',
+        solverNetManifestCids: [manifestCid],
+        onchainFromBlock: 100,
+      },
+    });
+    await adapter.initialize();
+    (adapter as any).publicClient.getBlockNumber = vi.fn().mockResolvedValue(101n);
+    (adapter as any).publicClient.getLogs = vi.fn().mockResolvedValue([{ data: '0x', topics: [] }]);
+
+    const gen = adapter.watchForTasks()[Symbol.asyncIterator]();
+    const { value } = await gen.next();
+
+    expect(value).toMatchObject({
+      taskId: '44',
+      task: { id: 'fallback-task' },
+      taskCid: TASK_CID,
+    });
+
+    await adapter.stop();
+  });
+
+  it('canonical TaskCreated scan honors an explicit task id scope', async () => {
+    const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+    const { decodeTaskCreatedLogs } = await import('../../../src/adapters/mech/contracts.js');
+    const { fetchSignedTaskFromIpfs } = await import('../../../src/adapters/mech/ipfs.js');
+    const manifestCid = 'bafyfixturecid';
+
+    vi.mocked(decodeTaskCreatedLogs).mockReturnValueOnce([
+      {
+        taskId: '44',
+        taskCidDigest: TASK_CID_DIGEST,
+        manifestDigest: MANIFEST_DIGEST,
+        transactionHash: TX_HASH,
+        blockNumber: 101,
+      },
+      {
+        taskId: '45',
+        taskCidDigest: TASK_CID_DIGEST,
+        manifestDigest: MANIFEST_DIGEST,
+        transactionHash: TX_HASH,
+        blockNumber: 102,
+      },
+    ]);
+    vi.mocked(fetchSignedTaskFromIpfs).mockResolvedValueOnce(signedTask({ id: 'scoped-onchain-task' }));
+
+    const adapter = new MechAdapter({
+      ...TEST_CONFIG,
+      taskDiscovery: {
+        solverNetManifestCids: [manifestCid],
+        onchainFromBlock: 100,
+        allowedTaskIds: ['45'],
+      },
+    });
+    await adapter.initialize();
+    (adapter as any).publicClient.getBlockNumber = vi.fn().mockResolvedValue(102n);
+    (adapter as any).publicClient.getLogs = vi.fn().mockResolvedValue([{ data: '0x', topics: [] }]);
+
+    const gen = adapter.watchForTasks()[Symbol.asyncIterator]();
+    const { value } = await gen.next();
+
+    expect(value).toMatchObject({
+      taskId: '45',
+      task: { id: 'scoped-onchain-task' },
+    });
 
     await adapter.stop();
   });
@@ -651,6 +800,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
     vi.mocked(decodeTaskCreatedLogs).mockReturnValueOnce([{
       taskId: '7',
       taskCidDigest: TASK_CID_DIGEST,
+      manifestDigest: MANIFEST_DIGEST,
       transactionHash: TX_HASH,
       blockNumber: 105,
     }]);
@@ -678,6 +828,57 @@ describe('MechAdapter TaskCoordinator flow', () => {
       toBlock: 110n,
     });
     expect(store.values.get('mech_router_request_block_cursor_v1')).toBe('110');
+
+    await adapter.stop();
+  });
+
+  it('rescans the canonical on-chain backlog on restart even after a previous scan marker', async () => {
+    const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+    const { decodeTaskCreatedLogs } = await import('../../../src/adapters/mech/contracts.js');
+    const { fetchSignedTaskFromIpfs } = await import('../../../src/adapters/mech/ipfs.js');
+    const store = makeConfigStore({
+      mech_router_request_block_cursor_v1: '119',
+      mech_router_task_created_canonical_scan_v1: '1',
+    }, 119n);
+
+    vi.mocked(decodeTaskCreatedLogs).mockReturnValueOnce([{
+      taskId: '88',
+      taskCidDigest: TASK_CID_DIGEST,
+      manifestDigest: MANIFEST_DIGEST,
+      transactionHash: TX_HASH,
+      blockNumber: 105,
+    }]);
+    vi.mocked(fetchSignedTaskFromIpfs).mockResolvedValueOnce(signedTask({ id: 'rescanned-task' }));
+
+    const adapter = new MechAdapter(
+      {
+        ...TEST_CONFIG,
+        pollIntervalMs: 0,
+        taskDiscovery: {
+          solverNetManifestCids: ['bafyfixturecid'],
+          onchainFromBlock: 100,
+        },
+      },
+      store as any,
+    );
+    await adapter.initialize();
+    (adapter as any).publicClient.getBlockNumber = vi.fn().mockResolvedValue(120n);
+    const getLogs = vi.fn().mockResolvedValue([{ data: '0x', topics: [] }]);
+    (adapter as any).publicClient.getLogs = getLogs;
+
+    const gen = adapter.watchForTasks()[Symbol.asyncIterator]();
+    const { value } = await gen.next();
+
+    expect(value).toMatchObject({
+      taskId: '88',
+      task: { id: 'rescanned-task' },
+    });
+    expect(getLogs).toHaveBeenCalledWith({
+      address: TEST_CONFIG.routerAddress,
+      fromBlock: 100n,
+      toBlock: 120n,
+    });
+    expect(store.values.get('mech_router_request_block_cursor_v1')).toBe('120');
 
     await adapter.stop();
   });

--- a/client/test/api/status-build.test.ts
+++ b/client/test/api/status-build.test.ts
@@ -203,7 +203,7 @@ describe('assembleStatusV1', () => {
       pollIntervalMs: 5000,
       masterDailyEstimateWei: '1',
       taskRuns: {
-        totals: { observedTasks: 1, activeTaskRuns: 1, completed: 0, failed: 0 },
+        totals: { observedTasks: 1, activeTaskRuns: 1, completed: 0, solutions: 0, verdicts: 0, failed: 0 },
         inFlight: [{
           requestId: 'req-1',
           taskId: '15',
@@ -224,6 +224,8 @@ describe('assembleStatusV1', () => {
     };
     const j = assembleStatusV1(raw);
     expect(j.taskRuns?.totals.activeTaskRuns).toBe(1);
+    expect(j.taskRuns?.totals.solutions).toBe(0);
+    expect(j.taskRuns?.totals.verdicts).toBe(0);
     expect(j.taskRuns?.inFlight[0]?.solverType).toBe('swe-rebench-v2.v1');
   });
 });

--- a/client/test/api/task-runs-build.test.ts
+++ b/client/test/api/task-runs-build.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { gatherTaskRunsStatus } from '../../src/api/task-runs-build.js';
+import { TaskRunPersistence } from '../../src/harnesses/engine/persistence.js';
+import { withTempStore } from '@test/store.js';
+
+describe('gatherTaskRunsStatus', () => {
+  it('splits completed generic task runs into solution and verdict totals', async () => {
+    await withTempStore(async (store) => {
+      const persistence = new TaskRunPersistence(store.db);
+      insertTask(persistence, {
+        requestId: 'restoration-complete',
+        taskId: 'task-1',
+        taskRole: 'restoration',
+      });
+      insertTask(persistence, {
+        requestId: 'evaluation-complete',
+        taskId: 'task-2',
+        taskRole: 'evaluation',
+      });
+      insertTask(persistence, {
+        requestId: 'restoration-running',
+        taskId: 'task-3',
+        taskRole: 'restoration',
+      });
+      insertTask(persistence, {
+        requestId: 'evaluation-failed',
+        taskId: 'task-4',
+        taskRole: 'evaluation',
+      });
+
+      store.db.prepare(`UPDATE task_runs SET state = 'COMPLETE', state_updated_at = ? WHERE request_id = ?`)
+        .run(2_000, 'restoration-complete');
+      store.db.prepare(`UPDATE task_runs SET state = 'COMPLETE', state_updated_at = ? WHERE request_id = ?`)
+        .run(3_000, 'evaluation-complete');
+      store.db.prepare(`UPDATE task_runs SET state = 'RUNNING', state_updated_at = ? WHERE request_id = ?`)
+        .run(4_000, 'restoration-running');
+      store.db.prepare(`UPDATE task_runs SET state = 'FAILED', state_updated_at = ?, failure_reason = ? WHERE request_id = ?`)
+        .run(5_000, 'boom', 'evaluation-failed');
+
+      const status = gatherTaskRunsStatus(store);
+
+      expect(status.totals).toEqual({
+        observedTasks: 4,
+        activeTaskRuns: 1,
+        completed: 2,
+        solutions: 1,
+        verdicts: 1,
+        failed: 1,
+      });
+    });
+  });
+});
+
+function insertTask(
+  persistence: TaskRunPersistence,
+  input: {
+    requestId: string;
+    taskId: string;
+    taskRole: 'restoration' | 'evaluation';
+  },
+): void {
+  persistence.insertDiscovered({
+    requestId: input.requestId,
+    taskId: input.taskId,
+    taskCid: `bafy-${input.requestId}`,
+    onchainCreationTx: '0xabc',
+    onchainCreationBlock: 1,
+    solverType: 'swe-rebench-v2.v1',
+    taskRole: input.taskRole,
+    windowStartTs: 1_000,
+    windowEndTs: 2_000,
+    task: {
+      id: input.taskId,
+      description: input.taskId,
+      solverType: 'swe-rebench-v2.v1',
+      role: input.taskRole,
+    },
+  });
+}

--- a/client/test/corpus/integration.test.ts
+++ b/client/test/corpus/integration.test.ts
@@ -107,4 +107,54 @@ describe('createCorpus.read (integration)', () => {
 
     expect(acquireFn).toHaveBeenCalledTimes(1); // second read served from cache
   });
+
+  it('falls back to an empty successful on-chain result when the subgraph is unavailable', async () => {
+    const fakeFetch = vi.fn(async () => new Response('rate limited', { status: 429 }));
+    const publicClient = {
+      getBlockNumber: vi.fn(async () => 20n),
+      getLogs: vi.fn(async () => []),
+    };
+    const corpus = createCorpus({
+      subgraphUrl: 'https://subgraph.test/graphql',
+      ipfsGatewayUrl: 'https://gateway.test',
+      store,
+      signer: { privateKey: TEST_KEY },
+      selfSafeAddress: '0x' + 'b'.repeat(40),
+      onchain: {
+        chainId: 84532,
+        identityRegistryAddress: '0x' + '8'.repeat(40),
+        fromBlock: 1,
+        publicClient,
+      },
+    }, { fetch: fakeFetch });
+
+    await expect(corpus.query({ limit: 5 })).resolves.toEqual([]);
+    expect(fakeFetch).toHaveBeenCalled();
+    expect(publicClient.getLogs).toHaveBeenCalled();
+  });
+
+  it('surfaces an actionable error when all configured corpus indexes fail', async () => {
+    const fakeFetch = vi.fn(async () => new Response('rate limited', { status: 429 }));
+    const publicClient = {
+      getBlockNumber: vi.fn(async () => { throw new Error('rpc unavailable'); }),
+      getLogs: vi.fn(async () => []),
+    };
+    const corpus = createCorpus({
+      subgraphUrl: 'https://subgraph.test/graphql',
+      ipfsGatewayUrl: 'https://gateway.test',
+      store,
+      signer: { privateKey: TEST_KEY },
+      selfSafeAddress: '0x' + 'b'.repeat(40),
+      onchain: {
+        chainId: 84532,
+        identityRegistryAddress: '0x' + '8'.repeat(40),
+        fromBlock: 1,
+        publicClient,
+      },
+    }, { fetch: fakeFetch });
+
+    await expect(corpus.query({ limit: 5 })).rejects.toThrow(
+      /corpus query failed: subgraph: .*429.*onchain: .*rpc unavailable/,
+    );
+  });
 });

--- a/client/test/corpus/query.test.ts
+++ b/client/test/corpus/query.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
+import { encodeAbiParameters, encodeEventTopics, type Hex } from 'viem';
 import { runCorpusQuery, buildSubgraphQuery } from '../../src/corpus/query.js';
+import { runOnchainCorpusQuery } from '../../src/corpus/onchain-query.js';
+import { PAYLOAD_TUPLE } from '../../src/erc8004/abis.js';
 
 describe('buildSubgraphQuery', () => {
   it('builds a query with solverType filter', () => {
@@ -49,6 +52,68 @@ describe('buildSubgraphQuery', () => {
   it('defaults limit to 50 when unset', () => {
     const { variables } = buildSubgraphQuery({});
     expect(variables.first).toBe(50);
+  });
+});
+
+describe('runOnchainCorpusQuery', () => {
+  it('discovers execution envelope metadata from IdentityRegistry logs', async () => {
+    const metadataKey = 'envelope:bafyManifestOnchain';
+    const metadataValue = encodeAbiParameters(PAYLOAD_TUPLE, [
+      1,
+      1,
+      `0x${'a'.repeat(64)}` as Hex,
+      '0x',
+      `0x${'0'.repeat(64)}` as Hex,
+    ]);
+    const topics = encodeEventTopics({
+      abi: [{
+        type: 'event',
+        name: 'MetadataSet',
+        inputs: [
+          { name: 'agentId', type: 'uint256', indexed: true },
+          { name: 'indexedMetadataKey', type: 'string', indexed: true },
+          { name: 'metadataKey', type: 'string', indexed: false },
+          { name: 'metadataValue', type: 'bytes', indexed: false },
+        ],
+      }],
+      eventName: 'MetadataSet',
+      args: {
+        agentId: 42n,
+        indexedMetadataKey: metadataKey,
+      },
+    });
+    const data = encodeAbiParameters([
+      { name: 'metadataKey', type: 'string' },
+      { name: 'metadataValue', type: 'bytes' },
+    ], [metadataKey, metadataValue]);
+    const publicClient = {
+      getBlockNumber: vi.fn(async () => 20n),
+      getLogs: vi.fn(async () => [{
+        address: `0x${'8'.repeat(40)}` as Hex,
+        data,
+        topics,
+        blockNumber: 18n,
+        logIndex: 3,
+      }]),
+    };
+
+    const refs = await runOnchainCorpusQuery(
+      { limit: 5 },
+      {
+        chainId: 84532,
+        identityRegistryAddress: `0x${'8'.repeat(40)}`,
+        fromBlock: 1,
+        publicClient,
+      },
+    );
+
+    expect(refs).toEqual([{
+      manifestCid: 'bafyManifestOnchain',
+      manifestHash: `0x${'a'.repeat(64)}`,
+      operator: { agentId: '42', safeAddress: '' },
+      evidenceTier: 'committed',
+      publishedAt: 0,
+    }]);
   });
 });
 

--- a/client/test/harnesses/engine/bug-fixes.test.ts
+++ b/client/test/harnesses/engine/bug-fixes.test.ts
@@ -6,7 +6,7 @@
  *   - jinn-mono-u59: takePreSnapshot resolves impl.name via registry for implStateDir
  *   - jinn-mono-cmb: session-orchestrator ignores undefined config overrides
  */
-import { mkdtempSync } from 'node:fs';
+import { mkdirSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -75,6 +75,35 @@ function fullTask(id: string, windowStartTs: number, windowEndTs: number): Task 
     },
     eligibility: { minEquityUsd: 100 },
     window: { startTs: windowStartTs, endTs: windowEndTs },
+  };
+}
+
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function timeout<T>(ms: number, value: T): Promise<T> {
+  return new Promise((resolve) => setTimeout(() => resolve(value), ms));
+}
+
+function testSolution(): Solution {
+  const baseSnapshot = { capturedAt: Date.now(), hlTime: 0, payload: {} };
+  return {
+    venueRef: { name: 'test' },
+    gating: { ok: true },
+    preSnapshot: baseSnapshot,
+    postSnapshot: baseSnapshot,
+    fills: [],
   };
 }
 
@@ -395,5 +424,88 @@ describe('jinn-mono-eci: tick advances WAITING intents past windowStartTs', () =
     // to runImpl which throws NotImplementedError → FAILED — but in any case
     // the intent has advanced past WAITING).
     expect(after.state).not.toBe(TaskRunState.WAITING);
+  });
+});
+
+// ── Canary blocker: one long run must not starve later in-flight tasks ───────
+
+describe('runTickLoop schedules other in-flight tasks while a harness is still running', () => {
+  let store: Store;
+  beforeEach(() => { store = new Store(':memory:'); });
+  afterEach(() => { store.close(); });
+
+  it('does not wait for a long RUNNING task before processing a later WAITING task', async () => {
+    const now = Date.now();
+    const longRelease = deferred<Solution>();
+    const longStarted = deferred<'long-started'>();
+    const laterStarted = deferred<'later-started'>();
+    const impl: Harness = {
+      name: 'nonblocking-test-impl',
+      version: '0.0.1',
+      supports: () => true,
+      async run(ctx) {
+        if (ctx.requestId === 'long-running') {
+          longStarted.resolve('long-started');
+          return longRelease.promise;
+        }
+        laterStarted.resolve('later-started');
+        return testSolution();
+      },
+    };
+
+    const opts: TaskEngineOptions = {
+      ...makeOpts(store, { findFor: () => impl }),
+    };
+    const engine = new TaskEngine(opts);
+    const persistence = new TaskRunPersistence(store.db);
+
+    const longWorkingDir = join(engTestRoot, 'work', 'long-running');
+    const longImplStateDir = join(engTestRoot, 'impl', 'nonblocking-test-impl', 'portfolio_v0');
+    mkdirSync(longWorkingDir, { recursive: true });
+    mkdirSync(longImplStateDir, { recursive: true });
+
+    persistence.insertDiscovered({
+      requestId: 'long-running',
+      taskCid: 'cid-long-running',
+      onchainCreationTx: '0xlong',
+      onchainCreationBlock: 10,
+      solverType: 'portfolio.v0',
+      windowStartTs: now - 1_000,
+      windowEndTs: now + 86_400_000,
+      task: fullTask('long-running', now - 1_000, now + 86_400_000),
+    });
+    persistence.transition('long-running', TaskRunState.CLAIMED);
+    persistence.transition('long-running', TaskRunState.WAITING);
+    persistence.transition('long-running', TaskRunState.PRE_SNAPSHOT);
+    persistence.transition('long-running', TaskRunState.RUNNING, {
+      workingDir: longWorkingDir,
+      implStateDir: longImplStateDir,
+      preSnapshotCapturedAt: now,
+      preSnapshotPayload: { provisioned: true },
+    });
+
+    const loop = engine.runTickLoop(5);
+    await expect(Promise.race([longStarted.promise, timeout(300, 'timeout' as const)]))
+      .resolves.toBe('long-started');
+
+    persistence.insertDiscovered({
+      requestId: 'later-waiting',
+      taskCid: 'cid-later-waiting',
+      onchainCreationTx: '0xlater',
+      onchainCreationBlock: 11,
+      solverType: 'portfolio.v0',
+      windowStartTs: now - 1_000,
+      windowEndTs: now + 86_400_000,
+      task: fullTask('later-waiting', now - 1_000, now + 86_400_000),
+    });
+    persistence.transition('later-waiting', TaskRunState.CLAIMED);
+    persistence.transition('later-waiting', TaskRunState.WAITING);
+
+    await expect(Promise.race([laterStarted.promise, timeout(500, 'timeout' as const)]))
+      .resolves.toBe('later-started');
+
+    engine.stop();
+    longRelease.resolve(testSolution());
+    await Promise.race([loop, timeout(500, undefined)]);
   });
 });

--- a/client/test/harnesses/impls/claude-code-learner/codex-code-adapter.test.ts
+++ b/client/test/harnesses/impls/claude-code-learner/codex-code-adapter.test.ts
@@ -114,6 +114,48 @@ describe('CodexCodeHarnessAdapter', () => {
     expect(skill).not.toContain('do not call spawn_agent');
   });
 
+  it('uses JINN_CODEX_PATH when no codexPath is configured', async () => {
+    const previous = process.env['JINN_CODEX_PATH'];
+    process.env['JINN_CODEX_PATH'] = 'codex-env-test';
+    const calls: SpawnCall[] = [];
+    const spawnFn = vi.fn((command: string, args: string[], options: { env?: NodeJS.ProcessEnv; cwd?: string }) => {
+      calls.push({ command, args, options });
+      return fakeCodexChild();
+    });
+    const workingDir = mkdtempSync(join(tmpdir(), 'jinn-codex-env-work-'));
+    const implStateDir = mkdtempSync(join(tmpdir(), 'jinn-codex-env-state-'));
+    try {
+      const adapter = new CodexCodeHarnessAdapter({
+        clientRoot: '/client/root',
+        _spawnFn: spawnFn as never,
+        _runSessionStartHook: false,
+      });
+
+      await adapter.runTask({
+        taskId: 'swe-rebench-task-restoration',
+        requestId: '0x' + '7'.repeat(64),
+        solverType: 'swe-rebench-v2.v1',
+        taskBody: sweTask() as never,
+        implStateDir,
+        workingDir,
+        pluginRoots: [sweRuntimePluginRoot, networkToolsPluginRoot],
+        windowStartTs: 1,
+        windowEndTs: 2,
+        msUntilEndTs: 1,
+        mode: 'train',
+        abort: new AbortController().signal,
+      }, learnerPluginRoot);
+
+      expect(calls[0]!.command).toBe('codex-env-test');
+      expect(calls[0]!.options.env?.JINN_CODEX_PATH).toBe('codex-env-test');
+    } finally {
+      if (previous === undefined) delete process.env['JINN_CODEX_PATH'];
+      else process.env['JINN_CODEX_PATH'] = previous;
+      rmSync(workingDir, { recursive: true, force: true });
+      rmSync(implStateDir, { recursive: true, force: true });
+    }
+  });
+
   it('spawns codex exec with per-run plugin projection, MCP config, and cheap model', async () => {
     const calls: SpawnCall[] = [];
     const spawnFn = vi.fn((command: string, args: string[], options: { env?: NodeJS.ProcessEnv; cwd?: string }) => {

--- a/client/test/mcp/acquire-artifact-fast-path.test.ts
+++ b/client/test/mcp/acquire-artifact-fast-path.test.ts
@@ -129,6 +129,7 @@ describe('acquire_artifact (daemon proxy + fast paths)', () => {
 
   it('forwards envelopeCid + artifactType hints to the daemon route', async () => {
     const sha256 = 'e'.repeat(64);
+    const ownerSafe = '0x' + '2'.repeat(40);
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
       new Response(
         JSON.stringify({
@@ -148,6 +149,7 @@ describe('acquire_artifact (daemon proxy + fast paths)', () => {
       access: { endpoint: 'https://op.example.com', priceUsdc: '0.01' },
       envelopeCid: 'bafyEnv',
       artifactType: 'design_document',
+      ownerSafe,
     });
     const body = JSON.parse((fetchSpy.mock.calls[0]![1] as RequestInit).body as string);
     expect(body).toEqual({
@@ -155,6 +157,7 @@ describe('acquire_artifact (daemon proxy + fast paths)', () => {
       access: { endpoint: 'https://op.example.com', priceUsdc: '0.01' },
       envelopeCid: 'bafyEnv',
       artifactType: 'design_document',
+      ownerSafe,
     });
     fetchSpy.mockRestore();
   });

--- a/client/test/mcp/search-records-corpus.test.ts
+++ b/client/test/mcp/search-records-corpus.test.ts
@@ -194,6 +194,7 @@ describe('search_records (corpus-backed)', () => {
         access: { endpoint: 'https://operator.example.com/artifacts/b', priceUsdc: '0.25' },
         envelopeCid: 'bafyManifest',
         artifactType: 'output.prediction.v1',
+        ownerSafe: '0x' + '4'.repeat(40),
       },
     });
     store.close();
@@ -262,6 +263,7 @@ describe('search_records (corpus-backed)', () => {
         access: { endpoint: 'http://localhost:7332/v1/artifacts/content', priceUsdc: '0' },
         envelopeCid: envelopeRef.manifestCid,
         artifactType: 'swe-rebench-v2_v1_solution',
+        ownerSafe: '0x' + '4'.repeat(40),
         sources: [{
           kind: 'ipfs',
           cid: 'bafy-swe-donated',
@@ -462,6 +464,7 @@ describe('MCP record tool registration source', () => {
       'evidenceTier',
       'generatedAfter',
       'generatedBefore',
+      'ownerSafe',
       'limit',
     ]) {
       expect(source).toContain(field);

--- a/client/test/scripts/donation-consumption-acceptance.test.ts
+++ b/client/test/scripts/donation-consumption-acceptance.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -7,7 +7,9 @@ import {
   buildConsumerChildEnv,
   buildConsumerConfig,
   ensureConsumerSweEvaluatorState,
+  findDonatedArtifactRecord,
   resolveConsumerCodexHome,
+  scopeConsumerConfigToProducerTask,
   waitForConsumerSolveAndEvaluatorProof,
 } from '../../src/scripts/donation-consumption-acceptance.js';
 import { Store } from '../../src/store/store.js';
@@ -113,6 +115,125 @@ describe('donation consumption acceptance config', () => {
     });
   });
 
+  it('scopes the managed consumer to the producer task id resolved from the subgraph', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'jinn-donation-consumer-scope-'));
+    const configPath = join(root, 'config.json');
+    const consumerConfig = {
+      network: 'testnet',
+      rpcUrl: 'https://rpc.example',
+      apiPort: 7333,
+    };
+    writeFileSync(configPath, JSON.stringify(consumerConfig));
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          tasks: [{ taskId: '109', createdAtTx: '0xabc' }],
+        },
+      }),
+    } as unknown as Response);
+    try {
+      const taskId = await scopeConsumerConfigToProducerTask({
+        consumerConfig,
+        consumerConfigPath: configPath,
+        subgraphUrl: 'https://subgraph.example/graphql',
+        proof: {
+          artifact: {
+            sha256: 'producer-sha',
+            artifactType: 'swe-rebench-v2_v1_solution',
+            requestId: 'producer-request',
+            envelopeCid: 'bafk-envelope',
+            createdAt: '2026-05-10T17:15:00.000Z',
+          },
+          sourceCid: 'bafk-source',
+          trajectorySourceCid: 'bafk-trajectory',
+          envelope: {
+            task: {
+              cid: 'f01551220aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              onchainCreationTx: '0xAbC',
+            },
+          },
+          redactedEnvelope: {},
+          indexExecution: {},
+        },
+      });
+
+      expect(taskId).toBe('109');
+      expect(fetchSpy).toHaveBeenCalledWith('https://subgraph.example/graphql', expect.objectContaining({
+        method: 'POST',
+      }));
+      expect(JSON.parse(readFileSync(configPath, 'utf8'))).toMatchObject({
+        taskDiscoveryAllowedTaskIds: ['109'],
+      });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('prefers network discovery records with donated IPFS source args over cached local records', () => {
+    const proof = {
+      artifact: {
+        sha256: 'producer-sha',
+        artifactType: 'swe-rebench-v2_v1_solution',
+        requestId: 'producer-request',
+        envelopeCid: 'bafk-envelope',
+        createdAt: '2026-05-10T17:15:00.000Z',
+      },
+      sourceCid: 'bafk-source',
+      trajectorySourceCid: 'bafk-trajectory',
+      envelope: {},
+      redactedEnvelope: {},
+      indexExecution: {},
+    } as any;
+
+    const localCachedArtifact = {
+      sha256: 'producer-sha',
+      envelopeCid: 'bafk-envelope',
+      acquisition: {
+        arguments: {
+          sha256: 'producer-sha',
+          access: { endpoint: 'ipfs://bafk-source', priceUsdc: '0' },
+          envelopeCid: 'bafk-envelope',
+          artifactType: 'swe-rebench-v2_v1_solution',
+        },
+      },
+    };
+    const networkArtifact = {
+      sha256: 'producer-sha',
+      envelopeCid: 'bafk-envelope',
+      acquisition: {
+        arguments: {
+          sha256: 'producer-sha',
+          envelopeCid: 'bafk-envelope',
+          artifactType: 'swe-rebench-v2_v1_solution',
+          sources: [{
+            kind: 'ipfs',
+            cid: 'bafk-source',
+            sha256: 'producer-sha',
+            encoding: 'jinn.artifact.donation.v1',
+          }],
+        },
+      },
+    };
+
+    const artifact = findDonatedArtifactRecord({
+      records: [
+        {
+          source: 'local',
+          envelopeRef: { cid: 'bafk-envelope' },
+          artifactRefs: [localCachedArtifact],
+        },
+        {
+          source: 'network',
+          envelopeRef: { cid: 'bafk-envelope' },
+          artifactRefs: [networkArtifact],
+        },
+      ],
+    }, proof);
+
+    expect(artifact).toBe(networkArtifact);
+  });
+
   it('accepts cache usage written during acquire_artifact before the call returns', async () => {
     const root = mkdtempSync(join(tmpdir(), 'jinn-donation-consumption-timestamps-'));
     const dbPath = join(root, 'jinn.db');
@@ -151,6 +272,45 @@ describe('donation consumption acceptance config', () => {
         priceUsdc: '0',
         createdAt: '2026-05-10T17:15:39.000Z',
       });
+      const insertRun = store.db.prepare(`
+        INSERT INTO task_runs (
+          request_id, task_id, task_cid, onchain_creation_tx, onchain_creation_block,
+          solver_type, task_role, state, state_updated_at, window_start_ts, window_end_ts,
+          manifest_cid, delivery_tx_hash, task_payload
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+      insertRun.run(
+        'consumer-request',
+        '15',
+        'cid-consumer-task',
+        '0xsolution',
+        1,
+        'swe-rebench-v2.v1',
+        'restoration',
+        'COMPLETE',
+        acquisitionFinishedAt.getTime(),
+        acquisitionStartedAt.getTime(),
+        acquisitionFinishedAt.getTime() + 1000,
+        'bafk-consumer-solution',
+        '0xsolutiondelivery',
+        JSON.stringify({ id: 'task-15', role: 'restoration' }),
+      );
+      insertRun.run(
+        'consumer-verdict',
+        '15',
+        'cid-consumer-task',
+        '0xverdict',
+        2,
+        'swe-rebench-v2.v1',
+        'evaluation',
+        'COMPLETE',
+        acquisitionFinishedAt.getTime(),
+        acquisitionStartedAt.getTime(),
+        acquisitionFinishedAt.getTime() + 1000,
+        'bafk-consumer-verdict',
+        '0xverdictdelivery',
+        JSON.stringify({ id: 'task-15-evaluation', role: 'evaluation' }),
+      );
     } finally {
       store.close();
     }
@@ -165,14 +325,19 @@ describe('donation consumption acceptance config', () => {
       },
       sourceCid: 'bafk-source',
       trajectorySourceCid: 'bafk-trajectory',
-      envelope: {},
+      envelope: {
+        participant: {
+          safeAddress: 'operator-a',
+        },
+      },
       redactedEnvelope: {},
-      subgraphExecution: {},
+      indexExecution: {},
     };
 
     const result = await waitForConsumerSolveAndEvaluatorProof({
       storePath: dbPath,
       proof,
+      allowedTaskId: '15',
       startedAt,
       acquisitionStartedAt,
       acquisitionFinishedAt,

--- a/client/test/solvernets/registry-client-erc8004.test.ts
+++ b/client/test/solvernets/registry-client-erc8004.test.ts
@@ -10,7 +10,7 @@
  * chain calls; no real network requests.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import type { SolverNetManifestV1 } from '@jinn-network/sdk/solvernets';
 
@@ -662,6 +662,40 @@ describe('IdentityRegistryBackedSolverNetRegistryClient.getManifest', () => {
     const fetched = await client.getManifest({ manifestCid });
     expect(fetched.solverNetId).toBe(manifest.solverNetId);
     expect(fetched.signature.value).toBe(manifest.signature.value);
+  });
+
+  it('uses the CID-bound IPFS manifest when the subgraph hash check is unavailable', async () => {
+    const sharedIpfs = makeMockIpfs();
+    const publisherClient = new IdentityRegistryBackedSolverNetRegistryClient({
+      ipfs: sharedIpfs,
+      publisher: makeMockPublisher(),
+      subgraph: makeMockSubgraph(),
+      network: 'base-sepolia',
+    });
+    const { manifest, signer } = await buildSignedManifest();
+    const { manifestCid } = await publisherClient.publishManifest({ manifest, signer });
+
+    const subgraph = makeMockSubgraph();
+    subgraph.fetchSetMetadataEventsForCid = async () => {
+      throw new Error('subgraph HTTP 429');
+    };
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const reader = new IdentityRegistryBackedSolverNetRegistryClient({
+      ipfs: sharedIpfs,
+      publisher: makeMockPublisher(),
+      subgraph,
+      network: 'base-sepolia',
+    });
+
+    try {
+      const fetched = await reader.getManifest({ manifestCid });
+      expect(fetched.solverNetId).toBe(manifest.solverNetId);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('subgraph hash check unavailable'),
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it('rejects when the canonical hash of fetched IPFS content differs from the on-chain advertised hash', async () => {

--- a/docs/runbooks/swe-rebench-v2-public-testnet.md
+++ b/docs/runbooks/swe-rebench-v2-public-testnet.md
@@ -97,7 +97,9 @@ another operator without a CLI-only workaround:
 1. Operator A runs with donation mode enabled and produces artifacts.
 2. Operator B runs a solver or evaluator on SWE-rebench v2.
 3. Operator B discovers envelopes through Network Tools
-   (`search_records` or `inspect_record`).
+   (`search_records` or `inspect_record`) using canonical on-chain ERC-8004
+   metadata plus IPFS. A subgraph may accelerate this query, but it is not the
+   required correctness path.
 4. `acquire_artifact` receives the donated IPFS `sources` from the envelope and
    retrieves the artifact by CID.
 5. The artifact is mirrored into Operator B's network artifact cache with IPFS
@@ -154,7 +156,7 @@ yarn release:donation-consumption --producer-handshake-key <daemon-handshake-key
 `yarn corpus:e2e` and the donation smoke suites are mocked/fast-path coverage.
 They are useful diagnostics, but they are not the release proof for public
 donation mode. The release-blocking proof is `yarn release:donation-consumption`
-with fresh two-operator evidence.
+with fresh two-operator evidence from the canonical on-chain/IPFS path.
 The producer daemon prints the handshake key on startup; the gate uses it only
 to read the UI-protected producer artifact inventory.
 For the broader `yarn release:client --prepare` gate on `main`, export


### PR DESCRIPTION
## Summary
- makes task discovery canonical via subgraph/on-chain fallback and scopes the live donation-consumption gate to the fresh producer task
- hardens cross-operator donated execution data acquisition through MCP/IPFS and records fresh solver + evaluator proof before passing
- fixes release-blocking app issues in the operator/launcher flow, including stale overview totals, launched-page summary fallback, package gate parity, node-pty/daemon cleanup, and clearer docs/runbooks

## Public testnet release note
This PR prepares the SWE-rebench v2 public testnet flow around IPFS donation mode. Public operator endpoints and pricing remain deferred; donated, scrubbed execution data is shared through IPFS and consumed by other operators through Network Tools/MCP.

## Release evidence
- Fresh live gate: `yarn release:donation-consumption`
- Evidence dir: `client/acceptance-runs/2026-05-11T09-52-38-917Z-donation-consumption`
- Producer task: `113`
- Producer request: `0x1f31333cba53837d34603352f338d948999f16292b8357ec26bb87317bfc4c06`
- Producer envelope: `bafkreidlt3zw4gum3c7zd3nuisb3kh2cilyhlncnfqez2djuyq24lem7wi`
- Consumer acquired IPFS source: `bafkreiftux6j3whkbagokcqubzfk3ykqn25cs3sl5uox67quccymtowqfy`
- Consumer solution envelope: `bafkreiamf6via5lviyjc3pvedixaiebou2zj7zj6d5xvm5d4rjgxjsfkhu`
- Consumer verdict envelope: `bafkreia4edrjm2gzuq7f5nj4gm3drql4hmzr6xw6nagwuopfogtfvowxvi`

## Acceptance gates
- `cd client && yarn typecheck`
- `cd client && yarn build`
- targeted release vitest suite: 19 files / 164 tests
- `cd client && yarn pack:smoke`
- `cd client && yarn release:donation-consumption`
- browser verified `/operator`, `/operator/execution-data`, and `/launcher/launched/5474_swe-rebench-v2-v1_edb172d3`

## Notes
- `--reuse-existing` remains diagnostics-only and is not counted as release evidence.
- The launcher cooldown was temporarily lowered to create fresh task 113 for the gate and restored to `86400000` ms afterward.