### PR TITLE
Fix SWE typed payload fallback validation

### DIFF
--- a/client/plugins/swe-rebench-v2-runtime/skills/plan/SKILL.md
+++ b/client/plugins/swe-rebench-v2-runtime/skills/plan/SKILL.md
@@ -27,7 +27,7 @@ Pass this plan forward to the Execute phase, which produces the actual patch.
 
 Once Execute has produced the unified diff, call the **`submit_typed_payload`** MCP tool exposed by the daemon to register the Solution. The daemon validates the payload against the SolverNet contract's solution schema before persisting it; if validation fails, the tool returns the Zod error tree under `error.issues` and you can retry.
 
-If `submit_typed_payload` is not available in the current harness, write the same payload object directly to `<workingDir>/.execute/solution-payload.json`. Create the `.execute` directory if needed. The daemon's harvester reads that file after the harness exits and applies the same SolverNet payload schema during envelope assembly.
+Only if `submit_typed_payload` is not available in the current harness, write the same payload object directly to `<workingDir>/.execute/solution-payload.json`. Do not choose the direct file path when the tool is available. Create the `.execute` directory if needed. The daemon's harvester reads that file after the harness exits and applies the same SolverNet payload schema during envelope assembly.
 
 Required payload shape for `swe-rebench-v2.v1`:
 

--- a/client/src/harnesses/impls/claude-code-learner/adapters/claude-code.ts
+++ b/client/src/harnesses/impls/claude-code-learner/adapters/claude-code.ts
@@ -110,7 +110,7 @@ function buildInitialPrompt(inputs: TaskSessionInputs): string {
     'Complete the task described by the task payload below.',
     'Use the available skills, plugins, tools, and runtime context exposed by this harness.',
     'Keep all task work inside `workingDir`.',
-    'When the task requires a typed SolverNet payload, submit it through an available submission tool or write the expected payload file for the harness harvester.',
+    'When the task requires a typed SolverNet payload, call submit_typed_payload. Do not write .execute/solution-payload.json directly unless submit_typed_payload is unavailable; if fallback is required, the file must match the exact SolverNet schema.',
     '',
     'Session inputs:',
     `- goal.id = ${inputs.taskId}`,

--- a/client/src/harnesses/impls/claude-code-learner/adapters/codex-code.ts
+++ b/client/src/harnesses/impls/claude-code-learner/adapters/codex-code.ts
@@ -119,7 +119,7 @@ function sweRebenchV2Guidance(inputs: TaskSessionInputs): string[] {
     `- Use ${inputs.workingDir}/repo as the only task repository checkout. Do not reuse a repo from another workingDir or from implStateDir.`,
     `- If ${inputs.workingDir}/repo/.git is missing, clone https://github.com/${repo}.git into ${inputs.workingDir}/repo and checkout ${baseCommit} before editing.`,
     '- Before planning, use Network Tools to search donated SWE execution data: call search_records, inspect_record, and acquire_artifact for useful donated IPFS records.',
-    `- Submit the final swe-rebench-v2-solution.v1 payload through submit_typed_payload, or write ${inputs.workingDir}/.execute/solution-payload.json.`,
+    `- Submit the final swe-rebench-v2-solution.v1 payload by calling submit_typed_payload. Do not write ${inputs.workingDir}/.execute/solution-payload.json directly unless submit_typed_payload is unavailable; if fallback is required, write {"schemaVersion":"swe-rebench-v2-solution.v1","patch":"<unified diff>"} to that path.`,
     `- If you rely on the harvester git-diff fallback, the patch must be present as git diff output under ${inputs.workingDir}/repo.`,
   ];
 }
@@ -130,7 +130,7 @@ function buildInitialPrompt(inputs: TaskSessionInputs): string {
     'Complete the task described by the task payload below.',
     'Use the available skills, plugins, tools, and runtime context exposed by this harness.',
     'Keep all task work inside `workingDir`.',
-    'When the task requires a typed SolverNet payload, submit it through an available submission tool or write the expected payload file for the harness harvester.',
+    'When the task requires a typed SolverNet payload, call submit_typed_payload. Do not write .execute/solution-payload.json directly unless submit_typed_payload is unavailable; if fallback is required, the file must match the exact SolverNet schema.',
     ...sweRebenchV2Guidance(inputs),
     '',
     'Session inputs:',

--- a/client/src/harnesses/impls/claude-code-learner/harvest.ts
+++ b/client/src/harnesses/impls/claude-code-learner/harvest.ts
@@ -2,6 +2,8 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { buildSolutionOutput } from '@jinn-network/sdk/solvernets/prediction-v1';
+import type { Role } from '../../../types/envelope.js';
+import { SOLVER_TYPE_PAYLOADS, validatePayload } from '../../../types/payloads/index.js';
 import type { OutputArtifact } from '../../../types/portfolio.js';
 import type { Task } from '../../../types/task.js';
 import type { Solution } from '../../types.js';
@@ -81,6 +83,24 @@ function safeReadJson(path: string): Record<string, unknown> | null {
   } catch {
     return null;
   }
+}
+
+function readTypedPayloadJson(path: string): Record<string, unknown> | null {
+  if (!existsSync(path)) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown;
+  } catch (err) {
+    throw new Error(
+      `[claude-code-learner] harvestOutput: invalid JSON in typed payload ${path}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!isRecord(parsed)) {
+    throw new Error(
+      `[claude-code-learner] harvestOutput: typed payload ${path} must contain a JSON object`,
+    );
+  }
+  return parsed;
 }
 
 function decimalProbability(value: unknown): string | undefined {
@@ -184,6 +204,47 @@ function maybeMaterializeSweRebenchPatchPayload(
     join(executeDir, 'solution-payload.json'),
     JSON.stringify(payload, null, 2),
   );
+  return payload;
+}
+
+function payloadRole(task?: Task): Role {
+  return task?.role === 'evaluation' ? 'verdict' : 'restoration';
+}
+
+function normalizeTypedPayload(
+  raw: Record<string, unknown>,
+  task: Task | undefined,
+  typedPayloadPath: string,
+): Record<string, unknown> {
+  const solverType = typeof task?.solverType === 'string' ? task.solverType : undefined;
+  const role = payloadRole(task);
+  let payload = raw;
+
+  if (
+    solverType === 'swe-rebench-v2.v1' &&
+    role === 'restoration' &&
+    raw['schemaVersion'] === undefined &&
+    typeof raw['patch'] === 'string' &&
+    raw['patch'].trim()
+  ) {
+    payload = {
+      ...raw,
+      schemaVersion: 'swe-rebench-v2-solution.v1',
+    };
+    writeFileSync(typedPayloadPath, JSON.stringify(payload, null, 2));
+  }
+
+  if (solverType && SOLVER_TYPE_PAYLOADS[solverType]?.[role]) {
+    try {
+      validatePayload(solverType, role, payload);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `[claude-code-learner] harvestOutput: typed payload ${typedPayloadPath} failed ${solverType}/${role} validation. Use submit_typed_payload or write the exact schema shape. ${detail}`,
+      );
+    }
+  }
+
   return payload;
 }
 
@@ -388,9 +449,12 @@ export function harvestOutput(workingDir: string, phaseRange?: string, task?: Ta
   const range = resolvePhaseRange(phaseRange);
   const requiredPhases = new Set<Phase>(REQUIRED_PHASES[range]);
   const typedPayloadPath = join(workingDir, '.execute', 'solution-payload.json');
-  const typedPayload =
-    safeReadJson(typedPayloadPath) ??
+  const rawTypedPayload =
+    readTypedPayloadJson(typedPayloadPath) ??
     maybeMaterializeSweRebenchPatchPayload(workingDir, task);
+  const typedPayload = rawTypedPayload
+    ? normalizeTypedPayload(rawTypedPayload, task, typedPayloadPath)
+    : null;
 
   // Hard-fail on missing or corrupt primary artifacts for all required phases
   // unless a typed SolverNet payload is already present. In the typed-payload

--- a/client/test/harnesses/impls/claude-code-learner/codex-code-adapter.test.ts
+++ b/client/test/harnesses/impls/claude-code-learner/codex-code-adapter.test.ts
@@ -226,7 +226,12 @@ describe('CodexCodeHarnessAdapter', () => {
       expect(promptArg).toContain(`Use ${workingDir}/repo as the only task repository checkout`);
       expect(promptArg).toContain(`clone https://github.com/Unidata/netcdf-c.git into ${workingDir}/repo`);
       expect(promptArg).toContain('search_records, inspect_record, and acquire_artifact');
+      expect(promptArg).toContain('call submit_typed_payload');
+      expect(promptArg).toContain('Do not write');
+      expect(promptArg).toContain('"schemaVersion":"swe-rebench-v2-solution.v1"');
       expect(promptArg).toContain(`${workingDir}/.execute/solution-payload.json`);
+      expect(promptArg).not.toContain('submit_typed_payload, or write');
+      expect(promptArg).not.toContain('submission tool or write the expected payload file');
       expect(promptArg).not.toContain('claude-code-learner:learn');
       expect(promptArg).not.toContain('Subagent dispatch is available as `spawn_agent`');
       expect(promptArg).not.toContain('Do not pass both `message` and `items`');

--- a/client/test/harnesses/impls/claude-code-learner/harvest.test.ts
+++ b/client/test/harnesses/impls/claude-code-learner/harvest.test.ts
@@ -527,6 +527,56 @@ describe('harvestOutput — generic typed-payload path', () => {
     });
   });
 
+  it('normalizes a direct SWE patch-only payload before validation', () => {
+    const patch = 'diff --git a/foo b/foo\n@@ -1 +1 @@\n-old\n+new\n';
+    writeTypedPayload({ patch });
+
+    const out = harvestOutput(workingDir, undefined, {
+      id: 'task-1',
+      description: 'd',
+      solverType: 'swe-rebench-v2.v1',
+      role: 'restoration',
+    } as never);
+
+    expect(out.solutionPayload).toEqual({
+      schemaVersion: 'swe-rebench-v2-solution.v1',
+      patch,
+    });
+    const payloadPath = join(workingDir, '.execute', 'solution-payload.json');
+    expect(JSON.parse(readFileSync(payloadPath, 'utf8'))).toEqual(out.solutionPayload);
+  });
+
+  it('rejects malformed direct SWE typed payloads at harvest time', () => {
+    writeTypedPayload({
+      schemaVersion: 'swe-rebench-v2-solution.v1',
+      patch: '',
+    });
+
+    expect(() =>
+      harvestOutput(workingDir, undefined, {
+        id: 'task-1',
+        description: 'd',
+        solverType: 'swe-rebench-v2.v1',
+        role: 'restoration',
+      } as never),
+    ).toThrow(/failed swe-rebench-v2\.v1\/restoration validation/);
+  });
+
+  it('rejects corrupt direct typed payload files at harvest time', () => {
+    const dir = join(workingDir, '.execute');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'solution-payload.json'), '{');
+
+    expect(() =>
+      harvestOutput(workingDir, undefined, {
+        id: 'task-1',
+        description: 'd',
+        solverType: 'swe-rebench-v2.v1',
+        role: 'restoration',
+      } as never),
+    ).toThrow(/invalid JSON in typed payload/);
+  });
+
   it('reads typed payload as verdictPayload for evaluation role', () => {
     const verdict = {
       schemaVersion: 'swe-rebench-v2-verdict.v1',

--- a/client/test/harnesses/impls/claude-code-learner/swe-rebench-v2-roundtrip.test.ts
+++ b/client/test/harnesses/impls/claude-code-learner/swe-rebench-v2-roundtrip.test.ts
@@ -154,6 +154,8 @@ describe('swe-rebench-v2 solver round-trip via ClaudeCodeLearnerImpl', () => {
       'utf8',
     );
     expect(skill).toContain('submit_typed_payload');
+    expect(skill).toContain('Only if `submit_typed_payload` is not available');
+    expect(skill).toContain('Do not choose the direct file path when the tool is available');
     expect(skill).toContain('.execute/solution-payload.json');
 
     const workingDir = mkdtempSync(join(tmpdir(), 'jinn-swe-rebench-fallback-'));


### PR DESCRIPTION
## Summary
- require typed SolverNet runs to prefer `submit_typed_payload` in the learner prompts
- keep direct `.execute/solution-payload.json` as an explicit fallback only
- normalize SWE patch-only fallback payloads by adding `schemaVersion: "swe-rebench-v2-solution.v1"`
- validate direct typed payload files during harvest so malformed files fail before packaging

## Test plan
- `cd client && yarn vitest run test/harnesses/impls/claude-code-learner/harvest.test.ts test/harnesses/impls/claude-code-learner/codex-code-adapter.test.ts test/harnesses/impls/claude-code-learner/swe-rebench-v2-roundtrip.test.ts`
- `cd client && yarn typecheck`
- `cd client && yarn build`

## Release note
This fixes the canary blocker where an isolated consumer learner wrote a patch-only `.execute/solution-payload.json`, bypassing `submit_typed_payload` validation and failing later during package assembly.