### PR TITLE
docs: engineering handbook v1 design + engineering-substrate DR

### DIFF
--- a/.claude/skills/eng-day/SKILL.md
+++ b/.claude/skills/eng-day/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: eng-day
+description: Daily aggregator + guidance surface for Jinn engineering work — reads bd ready queue, open PRs, and (once GitHub Project (v2) "Jinn engineering" board exists, per jinn-mono-2cl.9) the current sprint state. Surfaces sprint progress against the upcoming Monday cut, yesterday's shipped, today's top-3 *guidance* actions tagged by work shape (fix / feat / refactor / spike / chore / docs / test), drift flags (canary status, sprint age > 7 days, PRs > 3 days stale, latest vs canary mismatch). Not a dispatcher — does not invoke action skills (brainstorming / writing-plans / executing-plans / systematic-debugging / etc.); Captain invokes those from the brief. Triggers on "eng day", "morning engineering standup", "what should I do today", "daily eng check", "what's pending", "start of day engineering", "let's plan today's work", "engineering check-in", "what's next". Reads bd state via `bd ready` and `bd list`, open PRs via `gh pr list`, and the GitHub Project board state via `gh project item-list` (when 2cl.9 lands). Refuses to produce a top-3 if no active sprint exists in the Project board (fail-loud, references docs/engineering/handbook.md §The shipping machine for the daily-loop shape).
+---
+
+# Engineering day
+
+The daily aggregator + guidance surface for Jinn engineering work. Run by Captain at the start of an engineering block. Reads operational state (bd ready, open PRs, Project board); surfaces sprint progress, today's top-3 actions tagged by work shape, drift flags. Not a dispatcher — Captain picks and invokes from the brief.
+
+Modeled on the `growth-day` skill — same Tier-A discipline, same drift-flag pattern, same fail-loud sprint precondition.
+
+## Read first
+
+- [`docs/engineering/handbook.md`](../../../docs/engineering/handbook.md) §The shipping machine (daily loop + weekly retrace), §The shapes of work (which shapes exist + their flows), §Sprint surface (GH Project shape).
+- [`CLAUDE.md`](../../../CLAUDE.md) — agent-canonical project guide.
+- bd state: `bd ready`, `bd list --status=in_progress`, `bd list --status=open --priority=P0,P1`.
+- Open PRs: `gh pr list --search 'is:open draft:false' --json number,title,author,createdAt,reviewDecision,mergeable`.
+- GitHub Project board (once `jinn-mono-2cl.9` lands): `gh project item-list <project-number> --owner Jinn-Network --format json` filtered to the current Sprint field value.
+
+## Sprint precondition (fail-loud)
+
+This skill refuses to produce a top-3 unless an active sprint exists. Active sprint = at least one item on the "Jinn engineering" GitHub Project (v2) board with `Sprint = <upcoming-monday-date>`. Until `jinn-mono-2cl.9` creates the Project board, the precondition relaxes to: at least one P0 or P1 bd issue in `bd ready` is recent (created or updated within the last 7 days).
+
+No active sprint = no daily plan. Either declare a sprint (mirror at least one bd issue to the Project board with Sprint = upcoming-Monday) or explicitly take a rest day. The fail-loud message quotes `docs/engineering/handbook.md` §Sprint surface for the sprint shape.
+
+## Output shape
+
+A four-section brief:
+
+1. **Sprint context** — current sprint window (Monday cut date), days elapsed, % closed vs queued, any work in-progress.
+2. **Yesterday shipped** — PRs merged in the last 24h (with shape prefix and author), bd issues closed.
+3. **Today's top-3 guidance** — tagged by work shape, with bd id + one-line context. Order by: blockers first, then by sprint-fit (sprint-target items rank above unrelated ready items), then by priority. Always include the next stale PR (> 3 days idle) if there is one.
+4. **Drift flags** — surface only the flags that are active:
+   - Canary publish broken on most recent merge.
+   - npm `latest` mismatched against expected weekly cut (no Monday Release in the last 8+ days).
+   - PR open > 3 days without review activity.
+   - Sprint age > 7 days (Monday cut should reset weekly).
+   - bd state has issues marked in-progress with no commits in 5+ days.
+
+## How to assemble
+
+1. Read state in parallel:
+   - `bd ready`
+   - `bd list --status=in_progress --json id,title,priority,assignee,updated_at`
+   - `gh pr list --search 'is:open draft:false' --json number,title,author,createdAt,updatedAt,reviewDecision,mergeable`
+   - When 2cl.9 lands: `gh project item-list <project-number> --owner Jinn-Network --format json`
+2. Compute drift flags from the joined state.
+3. Build the top-3 by:
+   - Filter `bd ready` to items with `Sprint = <upcoming-monday>` on the Project board (when available); else recent P0/P1 in bd-only.
+   - Rank by: stale-PR-review-needed > sprint-blocker > sprint-target ready > non-sprint P0 > non-sprint P1.
+   - Tag each with shape from the bd `Run-mode` field.
+4. Format the brief; output to terminal; do not dispatch.
+
+## Failure modes
+
+- **No active sprint.** Print the fail-loud message:
+  > No active sprint declared. Per docs/engineering/handbook.md §Sprint surface, the canonical sprint board is the "Jinn engineering" GitHub Project (v2) on Jinn-Network/mono. Mirror at least one bd issue to the Project board with `Sprint = <upcoming-monday-date>` to declare a sprint, or take an explicit rest day. (Until `jinn-mono-2cl.9` creates the board, the precondition relaxes to: at least one recent P0/P1 in bd ready.)
+- **Project board absent (2cl.9 not landed).** Print a one-line note and fall back to bd-only state. Continue.
+- **gh CLI unauthenticated.** Print the auth instruction (`gh auth login`); do not block on the brief.
+
+## v0 vs v1
+
+This is the v0 skill. v1 will:
+- Auto-detect Project board number from `gh project list` (currently hardcoded after 2cl.9 lands).
+- Compute the suggested-semver-bump heuristic surface (always-minor; Captain-overrides) and flag if an epic-major bd issue closed in the window.
+- Surface shape-flow refinement candidates (per handbook §Iterative refinement) if friction signals emerge in repeated brief runs.
+
+These v1 improvements come from iterative refinement (handbook §Iterative refinement) — file a bd under `jinn-mono-2cl` if friction observed.
+
+## Composition
+
+- Composes with `growth-day` only at the Captain's invocation level (Captain reads both each morning). The two skills do not share state; engineering and growth loops have different rhythms (engineering weekly cut vs growth daily loop).
+- Composes downstream with the action skills it lists but does not invoke (`brainstorming`, `writing-plans`, `executing-plans`, `systematic-debugging`, `dispatching-parallel-agents`, `subagent-driven-development`, `verification-before-completion`, `receiving-code-review`).
+- Composes with the Friday triage cron (`jinn-mono-2cl.11`) which mirrors bd → GitHub Issues + Project board — `eng-day` reads what triage produced.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,40 @@
 ## Summary
 
-<!-- What does this PR do and why? -->
+<!--
+Problem (not solution): what's wrong / what gap does this close / what need triggers this?
+Use the seven work shapes from docs/engineering/handbook.md:
+fix / feat / refactor / spike / chore / docs / test (plus fix(incident) for hotfixes).
+The shape goes in the PR title as a Conventional Commits prefix:
+  fix: SWE typed payload fallback validation
+  feat(uy6v): live verdict-success on Base Sepolia
+  refactor: extract Harness selection from buildHarnesses
+-->
+
+## Linked bd
+
+<!-- e.g. Closes jinn-mono-XXX -->
 
 ## Test plan
 
-<!-- How was this verified? -->
+<!--
+How was this verified? Reference the test discipline for the shape:
+- fix: regression test first
+- feat: TDD per acceptance criteria
+- refactor: TDD + integration tests on migration/contract surfaces
+- chore (deps): integration test
+- spike: not applicable (output is a finding)
+- docs / test: skipped or meta
+- fix(incident): defer test; file a follow-up bead for the regression test BEFORE closing the incident
+-->
+
+## Agent identity (if AI-authored)
+
+<!--
+Add a Co-Authored-By trailer to your commits for AI contributions, e.g.:
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  Co-Authored-By: OpenAI Codex <noreply@openai.com>
+Reviewer parity (handbook rule 4): agent PRs go through the same review gate as human PRs.
+-->
 
 ### Canonical-doc changes (delete if not applicable)
 
@@ -12,3 +42,9 @@
 - [ ] CODEOWNERS approval obtained
 - [ ] Ran `git grep -l "Canonical references.*<changed-file>"` and re-reviewed downstream docs
 - [ ] Updated downstream docs that needed it (or noted why none did)
+
+### Prediction-freeze guardrail (delete if not applicable)
+
+<!-- Prediction SolverNet is frozen per DR-2026-05-11-a. Prediction-only PRs require explicit Captain approval citing shared-infrastructure rationale. -->
+
+- [ ] This PR touches Prediction-only surfaces (Polymarket task generator, prediction.v0/v1 contracts, prediction-flavored plugins/harness pieces) — Captain approval obtained, rationale: ...

--- a/.github/workflows/changelog-mirror.yml
+++ b/.github/workflows/changelog-mirror.yml
@@ -52,7 +52,7 @@ jobs:
             echo ""
             echo "## $HEADING"
             echo ""
-            echo "_Released $DATE_"
+            echo "_Released ${DATE}_"
             echo ""
             echo "$RELEASE_BODY"
           } > /tmp/new-section.md

--- a/.github/workflows/changelog-mirror.yml
+++ b/.github/workflows/changelog-mirror.yml
@@ -1,0 +1,102 @@
+# CHANGELOG auto-mirror on Release publish — implements jinn-mono-2cl.10.
+#
+# On a GitHub Release publish, append the Release body as a new section under the Unreleased
+# heading in cargo/client/CHANGELOG.md, commit, and push. Captain stops hand-editing CHANGELOG.md;
+# the GitHub Release body is the single source of truth. npm consumers still get CHANGELOG.md in
+# the package tarball.
+#
+# Reference:
+# - cargo/docs/engineering/handbook.md §Building in public — substrate
+# - cargo/docs/superpowers/specs/2026-05-11-engineering-handbook-codesign.md Thread 7
+# - cargo/client/CHANGELOG.md (current hand-maintained state)
+
+name: CHANGELOG mirror
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  mirror:
+    name: Append Release body to client/CHANGELOG.md
+    runs-on: ubuntu-latest
+    # Only mirror Releases that look like a Monday named-minor (skip drafts and -canary tags).
+    if: github.event.release.draft == false && !contains(github.event.release.tag_name, 'canary') && !contains(github.event.release.tag_name, '-draft')
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 1
+
+      - name: Build new CHANGELOG section
+        env:
+          RELEASE_NAME: ${{ github.event.release.name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+          RELEASE_DATE: ${{ github.event.release.published_at }}
+        shell: bash
+        run: |
+          # Derive a semver-shaped section heading. Tag format is one of:
+          #   v0.4.0          (preferred; semver dual-tag)
+          #   v2026.05.18     (date dual-tag — fallback)
+          #   client-v0.4.0   (legacy)
+          # Prefer RELEASE_NAME if it starts with the semver; fall back to tag.
+          HEADING="${RELEASE_NAME:-$RELEASE_TAG}"
+
+          DATE="$(echo "$RELEASE_DATE" | cut -dT -f1)"
+          {
+            echo ""
+            echo "## $HEADING"
+            echo ""
+            echo "_Released $DATE_"
+            echo ""
+            echo "$RELEASE_BODY"
+          } > /tmp/new-section.md
+
+      - name: Append under Unreleased and commit
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        shell: bash
+        run: |
+          set -e
+          CHANGELOG="client/CHANGELOG.md"
+          if [ ! -f "$CHANGELOG" ]; then
+            echo "::error::CHANGELOG not found at $CHANGELOG"
+            exit 1
+          fi
+
+          # Insert the new section AFTER the Unreleased heading and any current Unreleased bullets,
+          # but BEFORE the next ## section. Strategy: find the line number of the first "## " heading
+          # below the "## Unreleased" line; insert above that.
+          UNRELEASED_LINE="$(grep -n '^## Unreleased' "$CHANGELOG" | head -1 | cut -d: -f1 || true)"
+          if [ -z "$UNRELEASED_LINE" ]; then
+            # No Unreleased heading — insert at the top, after the first "# " heading.
+            HEADER_LINE="$(grep -n '^# ' "$CHANGELOG" | head -1 | cut -d: -f1 || echo 1)"
+            INSERT_AFTER=$((HEADER_LINE + 1))
+          else
+            # Find the next "## " heading after the Unreleased line.
+            NEXT_HEADING="$(awk -v start="$UNRELEASED_LINE" 'NR > start && /^## / { print NR; exit }' "$CHANGELOG")"
+            if [ -z "$NEXT_HEADING" ]; then
+              # No next heading; append to end of file.
+              INSERT_AFTER="$(wc -l < "$CHANGELOG" | tr -d ' ')"
+            else
+              INSERT_AFTER=$((NEXT_HEADING - 1))
+            fi
+          fi
+
+          # Build the new file: lines 1..INSERT_AFTER, then new-section, then remainder.
+          head -n "$INSERT_AFTER" "$CHANGELOG" > /tmp/new-changelog.md
+          cat /tmp/new-section.md >> /tmp/new-changelog.md
+          tail -n "+$((INSERT_AFTER + 1))" "$CHANGELOG" >> /tmp/new-changelog.md
+          mv /tmp/new-changelog.md "$CHANGELOG"
+
+          # Commit as github-actions[bot] with [skip ci] so this doesn't re-trigger npm-publish.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$CHANGELOG"
+          git commit -m "docs(changelog): mirror release $RELEASE_TAG [skip ci]" -m "Co-Authored-By: GitHub Actions <41898282+github-actions[bot]@users.noreply.github.com>"
+          git push origin main

--- a/.github/workflows/friday-triage.yml
+++ b/.github/workflows/friday-triage.yml
@@ -1,0 +1,136 @@
+# Friday triage cron — implements jinn-mono-2cl.11.
+#
+# Auto-mirrors the top-N priority bd issues for the upcoming Monday's sprint into public GitHub
+# Issues + the "Jinn engineering" Project (v2) board. Captain reviews on Friday afternoon and
+# **rejects** anything that doesn't belong by closing the GitHub Issue. Captain only adds Issues
+# by exception. The default flow is reject, not select.
+#
+# Uses cargo/scripts/bd-mirror (jinn-mono-2cl.12) for the actual mirror operation.
+#
+# v0 status: shipped with `workflow_dispatch` only — cron schedule below is commented out.
+# Enable after:
+#   - jinn-mono-2cl.9 (GitHub Project board) exists; until then, bd-mirror falls back to
+#     "Issue created, Project add skipped" mode and the sprint surface won't update.
+#   - A manual run validates the workflow output and shape.
+#
+# Reference:
+# - cargo/docs/engineering/handbook.md §The shipping machine §Weekly retrace
+# - cargo/docs/superpowers/specs/2026-05-11-engineering-handbook-codesign.md §Weekly retrace
+# - DR-2026-05-11-b (Engineering substrate)
+
+name: Friday triage
+
+on:
+  workflow_dispatch:
+    inputs:
+      sprint_date:
+        description: "Upcoming Monday date (yyyy-mm-dd). Defaults to next Monday from today."
+        required: false
+        type: string
+      sprint_cap:
+        description: "Max number of P1 issues to mirror (P0 always mirror, no cap)."
+        required: false
+        default: "8"
+        type: string
+  # schedule:
+  #   - cron: '0 15 * * 5'  # Friday 15:00 UTC — enable once 2cl.9 board exists and manual run validates.
+
+permissions:
+  contents: read
+  issues: write
+  repository-projects: write
+
+jobs:
+  triage:
+    name: Mirror top-N bd → GitHub Issue + Project
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      # bd CLI install — adjust to your installation method. This is best-effort; if bd is not
+      # available in CI yet, the workflow exits gracefully with a clear note.
+      - name: Probe bd CLI
+        id: bd_probe
+        shell: bash
+        run: |
+          if command -v bd >/dev/null 2>&1; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::bd CLI not available in CI runner. Skipping triage. Install bd or move triage to a self-hosted runner with bd."
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve sprint date
+        if: steps.bd_probe.outputs.available == 'true'
+        id: sprint
+        shell: bash
+        run: |
+          INPUT="${{ inputs.sprint_date }}"
+          if [ -n "$INPUT" ]; then
+            DATE="$INPUT"
+          else
+            # Default: next Monday from today.
+            DATE="$(date -u -d 'next Monday' +%Y-%m-%d 2>/dev/null || python3 -c "
+import datetime
+today = datetime.datetime.utcnow().date()
+days_ahead = (0 - today.weekday()) % 7
+days_ahead = days_ahead if days_ahead != 0 else 7
+print((today + datetime.timedelta(days=days_ahead)).isoformat())
+")"
+          fi
+          echo "date=$DATE" >> "$GITHUB_OUTPUT"
+
+      - name: Pick top-N priority bd issues
+        if: steps.bd_probe.outputs.available == 'true'
+        id: pick
+        env:
+          SPRINT_DATE: ${{ steps.sprint.outputs.date }}
+          SPRINT_CAP: ${{ inputs.sprint_cap }}
+        shell: bash
+        run: |
+          # Top-N policy: all P0 in ready state + capped P1 by configured cap.
+          CAP="${SPRINT_CAP:-8}"
+
+          P0_IDS="$(bd list --status=open --priority=P0 --json 2>/dev/null | jq -r '.[].id' || true)"
+          P1_IDS="$(bd list --status=open --priority=P1 --json 2>/dev/null | jq -r '.[].id' | head -n "$CAP" || true)"
+
+          : > /tmp/to-mirror.txt
+          for id in $P0_IDS $P1_IDS; do
+            # Skip if already mirrored (external-ref points at this org).
+            EXT="$(bd show "$id" --json 2>/dev/null | jq -r '.external_ref // ""')"
+            if [ -n "$EXT" ] && echo "$EXT" | grep -q 'Jinn-Network/mono'; then
+              continue
+            fi
+            echo "$id" >> /tmp/to-mirror.txt
+          done
+
+          COUNT="$(wc -l < /tmp/to-mirror.txt | tr -d ' ')"
+          echo "::notice::Triage candidates for sprint $SPRINT_DATE: $COUNT bd issues"
+
+      - name: Mirror each candidate via bd-mirror helper
+        if: steps.bd_probe.outputs.available == 'true'
+        env:
+          SPRINT_DATE: ${{ steps.sprint.outputs.date }}
+        shell: bash
+        run: |
+          if [ ! -s /tmp/to-mirror.txt ]; then
+            echo "::notice::No new candidates to mirror this triage run."
+            exit 0
+          fi
+          FAILED=0
+          while IFS= read -r id; do
+            if [ -z "$id" ]; then continue; fi
+            echo "→ Mirroring $id"
+            if ! cargo/scripts/bd-mirror "$id" "$SPRINT_DATE"; then
+              echo "::warning::Mirror failed for $id"
+              FAILED=$((FAILED + 1))
+            fi
+          done < /tmp/to-mirror.txt
+          if [ "$FAILED" -gt 0 ]; then
+            echo "::warning::$FAILED candidate(s) failed to mirror — Captain may need to mirror manually."
+          fi
+          echo "::notice::Friday triage complete for sprint $SPRINT_DATE. Captain: review the Project board and reject anything that doesn't belong."

--- a/.github/workflows/friday-triage.yml
+++ b/.github/workflows/friday-triage.yml
@@ -125,7 +125,7 @@ print((today + datetime.timedelta(days=days_ahead)).isoformat())
           while IFS= read -r id; do
             if [ -z "$id" ]; then continue; fi
             echo "→ Mirroring $id"
-            if ! cargo/scripts/bd-mirror "$id" "$SPRINT_DATE"; then
+            if ! scripts/bd-mirror "$id" "$SPRINT_DATE"; then
               echo "::warning::Mirror failed for $id"
               FAILED=$((FAILED + 1))
             fi

--- a/.github/workflows/release-notes-scaffold.yml
+++ b/.github/workflows/release-notes-scaffold.yml
@@ -179,21 +179,24 @@ jobs:
           BODY_FILE: ${{ steps.body.outputs.body_file }}
         shell: bash
         run: |
-          # Use a draft-only tag name that won't conflict with the eventual published v-tag.
-          DRAFT_TAG="v${SUGGESTED}-draft"
-          # If a draft for this version already exists, update it instead of creating a new one.
-          EXISTING="$(gh release view "$DRAFT_TAG" --json id,isDraft --jq '.id' 2>/dev/null || true)"
+          # The draft uses the eventual published tag directly. GitHub does not materialize the
+          # git tag until the draft is published, so multiple unpublished drafts with different
+          # tags (one per scheduled cut) coexist safely. When Captain clicks Publish, the tag
+          # `v<SUGGESTED>` is created in git, which is what npm-publish.yml (release: published)
+          # and the dual-tag policy (jinn-mono-2cl.6) expect.
+          TAG="v${SUGGESTED}"
+          EXISTING="$(gh release view "$TAG" --json id,isDraft --jq '.id' 2>/dev/null || true)"
           if [ -n "$EXISTING" ]; then
-            gh release edit "$DRAFT_TAG" \
+            gh release edit "$TAG" \
               --title "v$SUGGESTED — Build Notes (draft)" \
               --notes-file "$BODY_FILE"
-            echo "Updated existing draft: $DRAFT_TAG"
+            echo "Updated existing draft: $TAG"
           else
-            gh release create "$DRAFT_TAG" \
+            gh release create "$TAG" \
               --draft \
               --title "v$SUGGESTED — Build Notes (draft)" \
               --notes-file "$BODY_FILE" \
               --target main
-            echo "Created new draft: $DRAFT_TAG"
+            echo "Created new draft: $TAG"
           fi
           echo "::notice::Release draft v$SUGGESTED ready for Captain review at https://github.com/${{ github.repository }}/releases"

--- a/.github/workflows/release-notes-scaffold.yml
+++ b/.github/workflows/release-notes-scaffold.yml
@@ -1,0 +1,199 @@
+# Monday release-notes scaffold cron — implements jinn-mono-2cl.2.
+#
+# Creates a GitHub Release **draft** every Monday at 09:00 UTC with the mechanical inputs for the
+# named-minor release (merged PRs since the previous `v0.N.0` tag with authors, closed bd issues,
+# contributor list, line-change stats, suggested semver bump = minor). Captain edits the draft in
+# the GitHub Release UI to fill in <build name>, ## Highlights, and ## Known issues, then clicks
+# Publish. Publish triggers npm `latest` (already wired in `npm-publish.yml` on release: published)
+# and the CHANGELOG auto-mirror (`changelog-mirror.yml`, jinn-mono-2cl.10).
+#
+# v0 status: shipped with `workflow_dispatch` only — cron schedule below is commented out.
+# Promote to scheduled cron after first manual run validates output.
+#
+# Reference:
+# - cargo/docs/engineering/handbook.md §The shipping machine
+# - cargo/docs/superpowers/specs/2026-05-11-engineering-handbook-codesign.md Threads 5 + 6
+# - Hermes v0.13.0 release notes for the shape reference
+
+name: Monday release-notes scaffold
+
+on:
+  workflow_dispatch:
+  # schedule:
+  #   - cron: '0 9 * * 1'  # Monday 09:00 UTC — enable once a manual run validates the workflow.
+
+permissions:
+  contents: write
+  pull-requests: read
+  issues: read
+
+jobs:
+  scaffold:
+    name: Build release-notes draft
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # need full history to walk tags + commits since last v0.N.0
+
+      - name: Resolve window
+        id: window
+        shell: bash
+        run: |
+          # Find the most recent v0.N.0 tag (handle pre-v1 minors; ignore canary tags / unrelated tags)
+          PREV_TAG="$(git tag --list 'v0.*.0' 'client-v0.*.0' --sort=-creatordate | head -1 || true)"
+          if [ -z "$PREV_TAG" ]; then
+            # Fall back to last tag of any shape if no v0.N.0 yet
+            PREV_TAG="$(git tag --list 'client-v*' --sort=-creatordate | head -1 || echo '')"
+          fi
+          if [ -z "$PREV_TAG" ]; then
+            # First release ever — use repo root commit.
+            PREV_SHA="$(git rev-list --max-parents=0 HEAD | head -1)"
+            PREV_TAG="(repo root)"
+          else
+            PREV_SHA="$(git rev-parse "$PREV_TAG")"
+          fi
+          echo "prev_tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
+          echo "prev_sha=$PREV_SHA" >> "$GITHUB_OUTPUT"
+          echo "today=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Compute current version + suggested bump
+        id: version
+        shell: bash
+        run: |
+          CURRENT_VERSION="$(node -e "console.log(JSON.parse(require('fs').readFileSync('client/package.json','utf8')).version)")"
+          # Suggested bump: minor by default (handbook §Cadence + pgjj Thread 5).
+          MAJOR="$(echo "$CURRENT_VERSION" | cut -d. -f1)"
+          MINOR="$(echo "$CURRENT_VERSION" | cut -d. -f2)"
+          NEXT_MINOR=$((MINOR + 1))
+          SUGGESTED="$MAJOR.$NEXT_MINOR.0"
+          echo "current=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "suggested=$SUGGESTED" >> "$GITHUB_OUTPUT"
+
+      - name: Gather merged PRs since last tag
+        id: prs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PREV_SHA: ${{ steps.window.outputs.prev_sha }}
+        shell: bash
+        run: |
+          # List PRs merged on main since PREV_SHA. Group by Conventional Commits shape from PR title.
+          # `gh pr list --search 'is:merged base:main merged:>YYYY-MM-DD'` is the simplest path; using
+          # commit walk for robustness against rebased PRs.
+          PR_NUMBERS="$(git log "$PREV_SHA..HEAD" --merges --pretty=format:'%s' \
+            | grep -oE '#[0-9]+' | sort -u | tr -d '#' || true)"
+          : > /tmp/prs.txt
+          : > /tmp/contributors.txt
+          for n in $PR_NUMBERS; do
+            line="$(gh pr view "$n" --json number,title,author --jq '"\(.number)\t\(.title)\t\(.author.login)"' 2>/dev/null || true)"
+            if [ -n "$line" ]; then
+              echo "$line" >> /tmp/prs.txt
+              echo "$line" | cut -f3 >> /tmp/contributors.txt
+            fi
+          done
+          sort -u /tmp/contributors.txt -o /tmp/contributors.txt
+
+      - name: Gather closed bd issues since last tag
+        id: bd
+        shell: bash
+        run: |
+          # bd is the internal SoR; query if the CLI is available in CI. If not, fall back to "see internal tracker".
+          if command -v bd >/dev/null 2>&1; then
+            bd list --status=closed --json id,title 2>/dev/null \
+              | jq -r '.[] | "- \(.id) — \(.title)"' > /tmp/bd-closed.txt || echo "- (bd query failed)" > /tmp/bd-closed.txt
+          else
+            echo "- (bd CLI not installed in CI — see internal bd tracker for closed issues this week)" > /tmp/bd-closed.txt
+          fi
+
+      - name: Compute stats
+        id: stats
+        env:
+          PREV_SHA: ${{ steps.window.outputs.prev_sha }}
+        shell: bash
+        run: |
+          COMMITS="$(git rev-list --count "$PREV_SHA..HEAD")"
+          FILES="$(git diff --name-only "$PREV_SHA..HEAD" | wc -l | tr -d ' ')"
+          STATS="$(git diff --shortstat "$PREV_SHA..HEAD" || echo '0 insertions(+), 0 deletions(-)')"
+          PRS_COUNT="$(wc -l < /tmp/prs.txt | tr -d ' ')"
+          CONTRIBUTORS_COUNT="$(wc -l < /tmp/contributors.txt | tr -d ' ')"
+          echo "commits=$COMMITS" >> "$GITHUB_OUTPUT"
+          echo "files=$FILES" >> "$GITHUB_OUTPUT"
+          echo "prs_count=$PRS_COUNT" >> "$GITHUB_OUTPUT"
+          echo "contributors_count=$CONTRIBUTORS_COUNT" >> "$GITHUB_OUTPUT"
+          echo "stats=$STATS" >> "$GITHUB_OUTPUT"
+
+      - name: Build draft body
+        id: body
+        env:
+          TODAY: ${{ steps.window.outputs.today }}
+          PREV_TAG: ${{ steps.window.outputs.prev_tag }}
+          SUGGESTED: ${{ steps.version.outputs.suggested }}
+          COMMITS: ${{ steps.stats.outputs.commits }}
+          FILES: ${{ steps.stats.outputs.files }}
+          PRS_COUNT: ${{ steps.stats.outputs.prs_count }}
+          CONTRIBUTORS_COUNT: ${{ steps.stats.outputs.contributors_count }}
+          STATS: ${{ steps.stats.outputs.stats }}
+        shell: bash
+        run: |
+          BODY_FILE="/tmp/release-body.md"
+          {
+            echo "# v$SUGGESTED — \"<build name placeholder>\""
+            echo "$TODAY · Suggested bump: minor (Captain: override to vX.0.0 if an epic-major bd issue closed)"
+            echo ""
+            echo "## Highlights"
+            echo "- <placeholder — Captain edits>"
+            echo ""
+            echo "## Changes"
+            # Group by Conventional Commits shape prefix on the PR title.
+            for shape in feat fix refactor spike chore docs test; do
+              MATCHES="$(grep -E "	(${shape}[\(:])" /tmp/prs.txt || true)"
+              if [ -n "$MATCHES" ]; then
+                echo ""
+                echo "### ${shape}"
+                echo "$MATCHES" | awk -F'\t' '{printf "- (#%s) %s — @%s\n", $1, $2, $3}'
+              fi
+            done
+            UNGROUPED="$(grep -vE "	(feat[\(:]|fix[\(:]|refactor[\(:]|spike[\(:]|chore[\(:]|docs[\(:]|test[\(:])" /tmp/prs.txt || true)"
+            if [ -n "$UNGROUPED" ]; then
+              echo ""
+              echo "### other"
+              echo "$UNGROUPED" | awk -F'\t' '{printf "- (#%s) %s — @%s\n", $1, $2, $3}'
+            fi
+            echo ""
+            echo "## Closed this week"
+            cat /tmp/bd-closed.txt
+            echo ""
+            echo "## Stats"
+            echo "- Window: $PREV_TAG → HEAD ($TODAY)"
+            echo "- $COMMITS commits · $PRS_COUNT PRs · $FILES files · $STATS · $CONTRIBUTORS_COUNT contributors"
+            echo ""
+            echo "## Known issues"
+            echo "- <placeholder — Captain edits>"
+          } > "$BODY_FILE"
+          echo "body_file=$BODY_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update the Release draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SUGGESTED: ${{ steps.version.outputs.suggested }}
+          BODY_FILE: ${{ steps.body.outputs.body_file }}
+        shell: bash
+        run: |
+          # Use a draft-only tag name that won't conflict with the eventual published v-tag.
+          DRAFT_TAG="v${SUGGESTED}-draft"
+          # If a draft for this version already exists, update it instead of creating a new one.
+          EXISTING="$(gh release view "$DRAFT_TAG" --json id,isDraft --jq '.id' 2>/dev/null || true)"
+          if [ -n "$EXISTING" ]; then
+            gh release edit "$DRAFT_TAG" \
+              --title "v$SUGGESTED — Build Notes (draft)" \
+              --notes-file "$BODY_FILE"
+            echo "Updated existing draft: $DRAFT_TAG"
+          else
+            gh release create "$DRAFT_TAG" \
+              --draft \
+              --title "v$SUGGESTED — Build Notes (draft)" \
+              --notes-file "$BODY_FILE" \
+              --target main
+            echo "Created new draft: $DRAFT_TAG"
+          fi
+          echo "::notice::Release draft v$SUGGESTED ready for Captain review at https://github.com/${{ github.repository }}/releases"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,47 @@ Canonical docs are the repo's stable sources of truth. They change only via appr
 - `GROWTH.md` — read before planning distribution, campaigns, channel strategy, or growth experiments
 - `GLOSSARY.md` — read whenever a Jinn-specific term appears; never redefine terms locally
 
+## Engineering handbook
+
+How this team ships — cadence, dist-tags, work-shape taxonomy, AI workflow rules. Full text at [`docs/engineering/handbook.md`](docs/engineering/handbook.md). Always read the handbook before doing non-trivial work; it ratifies the SOPs that apply to every shape.
+
+### Work shape (declare it before executing)
+
+Seven shapes plus one emergency sub-flow, keyed to Conventional Commits prefixes. Declare the shape in the bd issue's `Run-mode` field; replicate it as the PR title prefix.
+
+- **`fix`** — bug fix. Regression test first. Skill chain: `systematic-debugging` → `executing-plans` → `verification-before-completion` → `receiving-code-review`.
+- **`feat`** — feature. TDD. Skill chain: (`brainstorming` if ambiguous) → `writing-plans` → `test-driven-development` → `executing-plans` / `dispatching-parallel-agents` → `verification-before-completion` → `receiving-code-review`.
+- **`refactor`** — architecture / migration. TDD + integration tests; required design upfront; stacked PRs required (strangler-fig).
+- **`spike`** — research / exploration. Output is a finding, not code. Spike code does not merge.
+- **`chore`** — deps, CI, dev tooling. Integration tests if touches a dep.
+- **`docs`** — documentation. Canonical-doc changes need Discussion + CODEOWNERS approval.
+- **`test`** — test-only. Meta test discipline.
+- **`fix(incident)`** — hotfix sub-flow. Relaxed review; post-hoc regression test required as a follow-up bead before closing the incident.
+
+If a bd issue does not fit one of these shapes, it is mis-scoped — split or reshape it. Per-shape SOPs (v0 flows) live in the handbook §The shapes of work; they evolve via iterative refinement (file a bd under `jinn-mono-2cl` when friction surfaces).
+
+### Eight ratified AI workflow rules
+
+1. **Worktree-for-multi-agent.** Multi-agent or speculative subagent work uses `git worktree add cargo/.tasks/<id>`.
+2. **Beads frame problems, not solutions.** bd body = context + impact + acceptance criteria. Solutions go in design sessions.
+3. **bd-as-SoR, not `MEMORY.md`.** Use `bd remember` / `bd memories`.
+4. **Agent PR review parity.** Codex / Opus / Sonnet / Claude PRs reviewed like human PRs. No agent self-merge. Exception: `fix(incident)` with reviewer justification.
+5. _(Deferred — supervised-diff for the self-modifying learner. Mechanism open; see `jinn-mono-8qbc`.)_
+6. **Integration tests > mocks for migration / contract surfaces.**
+7. **TDD for new features, regression test for fixes.**
+8. **Auto-canary on main merge; Monday-only named minor.** Cadence policy.
+9. **`canary` for rolling patches, `latest` for Monday named.** Dist-tag policy.
+
+### Cadence
+
+- Every merge to main → npm `canary` (`<v>-canary.<sha>`).
+- Every Monday 09:00 UTC → GitHub Release draft (Hermes-style); Captain publishes; publish triggers npm `latest` + CHANGELOG auto-mirror.
+- Pre-v1: weekly minor (`v0.N.0 → v0.N+1.0`). `v1.0.0` = the Monday cut that ships `jinn-mono-uy6v`. Post-v1 epic close = major bump.
+
+### Daily entry point
+
+`eng-day` skill (in `cargo/.claude/skills/eng-day/`) is the canonical daily brief. Fallback when the GitHub Project board doesn't exist yet: `bd ready` + `gh pr list --search 'is:open draft:false'`.
+
 ## Repository Structure
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+# Contributing to Jinn
+
+Jinn is built in the open. This file is the entry point for contributors — humans and AI agents — opening PRs against `Jinn-Network/mono`.
+
+The long form lives at [`docs/engineering/handbook.md`](docs/engineering/handbook.md). Read it before opening anything non-trivial.
+
+## Quick start
+
+```
+git clone https://github.com/Jinn-Network/mono.git
+cd mono/client
+yarn install
+yarn typecheck
+yarn test
+```
+
+Per-package developer guides:
+- [`client/CONTRIBUTING.md`](client/CONTRIBUTING.md) — Jinn client (TypeScript daemon).
+- [`contracts/`](contracts/) — Solidity smart contracts (Hardhat).
+
+## What to read before you open a PR
+
+In rough order:
+
+1. **[`docs/engineering/handbook.md`](docs/engineering/handbook.md)** — cadence, dist-tags, work-shape taxonomy, AI workflow rules, doc ladder.
+2. **[`CLAUDE.md`](CLAUDE.md)** — agent-canonical project guide (architecture, conventions, design system pointers).
+3. **[`BRAND.md`](BRAND.md)** — voice, headless-brand posture, content non-negotiables. Read before any user-facing copy.
+4. Canonical docs as needed: [`SPEC.md`](SPEC.md), [`THESIS.md`](THESIS.md), [`GROWTH.md`](GROWTH.md), [`GLOSSARY.md`](GLOSSARY.md).
+
+## How work is shaped
+
+Jinn engineering recognises seven shapes of work plus one emergency sub-flow, keyed to Conventional Commits prefixes:
+
+| Shape | When | PR title prefix |
+|---|---|---|
+| `fix` | Bug fix | `fix:` or `fix(scope):` |
+| `feat` | Feature | `feat:` or `feat(scope):` |
+| `refactor` | Architecture / migration | `refactor:` |
+| `spike` | Research / exploration | `spike:` (does not merge to main) |
+| `chore` | Deps, CI, dev tooling | `chore:` or `chore(deps):` |
+| `docs` | Documentation | `docs:` |
+| `test` | Test-only | `test:` |
+| `fix(incident)` | Hotfix under pressure | `fix(incident):` (relaxed review, postmortem follow-up required) |
+
+Each shape has a distinct SOP — different skill chain, test discipline, design ceremony, stacking policy. The full table with v0 flows lives in [`docs/engineering/handbook.md`](docs/engineering/handbook.md#the-shapes-of-work).
+
+If a PR doesn't fit one of these shapes, it's mis-scoped. Split it.
+
+## PR expectations
+
+- **Title**: `<shape>: <one-line summary>` per Conventional Commits (e.g. `fix: SWE typed payload fallback validation`, `feat(uy6v): live verdict-success on Base Sepolia`).
+- **Body**: problem-not-solution framing (what's wrong / what gap / what need triggered this), test plan, agent identity if AI-authored.
+- **Linked bd issue**: `Closes jinn-mono-<id>` in the body so merge auto-closes the mirror.
+- **Co-Authored-By trailer** for AI commits, e.g.:
+  ```
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  Co-Authored-By: OpenAI Codex <noreply@openai.com>
+  ```
+- **Test discipline matches the shape** — see handbook §The shapes of work.
+- **Stacked PRs** encouraged for features > 300 LOC; aim for < 200 LOC per layer, "one logical thing per layer." `gh-stack` is the canonical tool; Graphite (`gt`) is allowed.
+
+## Review policy
+
+**Agent PR review parity** (handbook rule 4): Codex / Opus / Sonnet / Claude PRs go through the same review gate as human PRs. No agent self-merge. The one allowed relaxation is `fix(incident)` with documented reviewer justification.
+
+Canonical-doc changes (`SPEC.md`, `BRAND.md`, `THESIS.md`, `GROWTH.md`, `GLOSSARY.md`, `CLAUDE.md`, `README.md`) require:
+- A linked GitHub Discussion proposing the change.
+- CODEOWNERS approval (see [`.github/CODEOWNERS`](.github/CODEOWNERS)).
+- Downstream-doc review per [`spec/2026-04-28-canonical-docs.md`](spec/2026-04-28-canonical-docs.md).
+
+## Prediction-freeze guardrail
+
+**Prediction SolverNet is frozen** as of 2026-05-11 per [DR-2026-05-11-a](log/decisions/2026-05-11-freeze-prediction-solvernet.md). Reviewers reject Prediction-only PRs by default. Bug fixes against existing Prediction surfaces require explicit Captain approval citing why the fix is load-bearing for SWE-rebench v2 or shared infrastructure.
+
+If your PR touches Prediction-only surfaces (Polymarket task generator, `prediction.v0` / `prediction.v1` contracts, prediction-flavored plugins/harness pieces), check the corresponding box in the PR template and cite Captain approval.
+
+## AI workflow rules (summary)
+
+Full text in [`docs/engineering/handbook.md`](docs/engineering/handbook.md#ai-workflow-rules). The eight ratified rules (rule 5 deferred):
+
+1. Worktree-for-multi-agent — multi-agent or speculative subagent work uses `git worktree add cargo/.tasks/<id>`.
+2. Beads frame problems, not solutions — bd bodies = context + impact + acceptance criteria; solutions go in design sessions.
+3. bd-as-SoR, not `MEMORY.md` — use `bd remember` for persistent knowledge.
+4. Agent PR review parity — agent PRs reviewed like human PRs.
+5. _(Deferred — see [`jinn-mono-8qbc`](https://github.com/Jinn-Network/mono/issues?q=jinn-mono-8qbc))_
+6. Integration tests > mocks for migration / contract surfaces.
+7. TDD for new features, regression test for fixes.
+8. Auto-canary on main merge; Monday-only named minor.
+9. `canary` for rolling patches, `latest` for Monday named.
+
+## Issue tracker
+
+The internal SoR is **bd (beads)** — see [`CLAUDE.md`](CLAUDE.md) §Beads Issue Tracker for the workflow. External contributors interact via:
+
+- **Public GitHub Issues** — the sprint-scoped subset of bd, mirrored by the Friday triage automation. The Issue body ends with `Internal tracking: jinn-mono-<bd-id>`.
+- **GitHub Project (v2) "Jinn engineering"** — the public sprint board.
+- **GitHub Discussions** — RFCs / Q&A / governance prep.
+
+If you can't find a public Issue for what you want to work on, open a Discussion (RFC / question) or comment on the closest-matching Issue.
+
+## Building in public
+
+See [`docs/engineering/handbook.md`](docs/engineering/handbook.md#building-in-public--substrate). The substrate is intentional — GitHub Projects, Issues, Releases, repo-as-docs, Discussions. Every shipped artifact emits a knowledge artifact (Release notes / CHANGELOG / DR / spec / runbook).

--- a/docs/engineering/handbook.md
+++ b/docs/engineering/handbook.md
@@ -1,0 +1,162 @@
+# Engineering handbook (v1)
+
+This handbook describes how the Jinn engineering team ships. It is the canonical reference for the SOPs, AI workflow rules, and cadence that every contributor (human or AI agent) is expected to follow.
+
+The handbook is **Jinn-flavored**, not generic. Per [`BRAND.md`](../../BRAND.md) the engineering substrate is itself a brand surface — the public sprint board, GitHub Releases, CHANGELOG, DRs, and specs are the visible artifacts that make the headless-brand posture legible. The shipping machine is not separate from the work; it is the work made public.
+
+Canonical references:
+- Design that ratified this handbook: [`docs/superpowers/specs/2026-05-11-engineering-handbook-codesign.md`](../superpowers/specs/2026-05-11-engineering-handbook-codesign.md)
+- DR-2026-05-11-b — Engineering substrate decision: [`log/decisions/2026-05-11-engineering-substrate.md`](../../log/decisions/2026-05-11-engineering-substrate.md)
+- DR-2026-05-11-a — Prediction freeze: [`log/decisions/2026-05-11-freeze-prediction-solvernet.md`](../../log/decisions/2026-05-11-freeze-prediction-solvernet.md)
+- Umbrella bd: `jinn-mono-2cl`
+
+## Cadence
+
+Two-track release model:
+
+- **Continuous canary on every merge to `main`.** GitHub Actions (`cargo/.github/workflows/npm-publish.yml`) publishes `<package.version>-canary.<sha8>` under the npm dist-tag `canary` within minutes of any PR merge that touches `client/**`. Operators on `npm install -g @jinn-network/client@canary` receive the rolling build.
+- **Weekly named minor every Monday.** A Monday cron creates a GitHub Release **draft** at 09:00 UTC. Captain reviews the draft (Hermes-style: build-name + highlights + known-issues + auto-aggregated PRs/closed-bd/stats), then publishes. Publish triggers npm `latest` and the CHANGELOG auto-mirror. Default `npm install -g @jinn-network/client` (no tag) gets the weekly named minor.
+
+Tag format on Monday cuts: dual — `v2026.MM.DD` (the human-readable build identifier) and `v0.N.0` (the semver for npm). Pre-v1 minors go `v0.N.0 → v0.N+1.0`. **v1.0.0 = the Monday cut that ships `jinn-mono-uy6v`** (SWE-rebench v2 donation flow on public testnet). Post-v1 epic close = major bump (`v1 → v2` for `jinn-mono-8psp` Hermes harness, `v2 → v3` for `jinn-mono-jnw9` self-modifying learner).
+
+**Bump heuristic** (cron's suggestion, Captain overrides): the Monday cron always suggests a minor bump. Captain manually overrides to major when an epic-major bd issue closes in the window. Conventional Commits drives section grouping in Release notes (Features / Fixes / Refactors / Chore / Docs / Tests), **not** per-merge semver bumps. Canary handles per-merge implicit patching.
+
+## Dist-tags
+
+- `canary` — rolling, every-merge build (`<v>-canary.<sha>`).
+- `latest` — Monday named minor.
+
+There is no `next` channel; `canary` is the rolling channel name we use. Operators who want the rolling build use `@canary`; operators who want stable get `latest` by default.
+
+## The shipping machine — process
+
+### Daily loop
+
+In `cargo/`:
+
+```
+claude
+```
+
+then:
+
+1. **Orient.** Invoke `eng-day` skill (or fallback: `bd ready` + `gh pr list --search 'is:open draft:false'`). Brief reports sprint progress, yesterday's shipped, today's top-3 guidance, drift flags.
+2. **Pick one piece of work** — a bd issue, a stale PR, or a design conversation. Run `bd show <id>` to read the work.
+3. **Execute according to shape** — the bd issue's `Run-mode` field declares the shape; the shape determines the skill chain, test discipline, design ceremony, and stacking policy (see §The shapes of work below).
+4. **Open PR(s).** PR title format: `<shape>(<optional scope>): <one-line summary>` (Conventional Commits). Template in `cargo/.github/PULL_REQUEST_TEMPLATE.md` prompts for problem-not-solution body, test plan, agent identity, Co-Authored-By trailer.
+5. **Review.** Human eyes on every PR (rule 4). No agent self-merge. Exception: `fix(incident)` allows reviewer relaxation with documented justification.
+6. **Merge → auto-canary.** `npm-publish.yml` fires on merge to main, publishes `<v>-canary.<sha>` under `canary`.
+7. **Close bd.** `bd close <id>`. The mirrored GitHub Issue (if any) auto-closes via PR linking.
+
+### Weekly retrace
+
+**Friday afternoon — triage.** The Friday triage workflow (`cargo/.github/workflows/friday-triage.yml`, currently `workflow_dispatch` only until cron is enabled) reads the bd ready queue, picks top-N priority bd issues (P0 + capped P1), invokes `cargo/scripts/bd-mirror` for each to open a public GitHub Issue with sprint label + Project board entry. Captain reviews on Friday and **rejects** anything that doesn't belong (close Issue, remove sprint label). Captain adds Issues by exception only. Default flow is *reject, not select*.
+
+**Monday morning — cut.** The Monday cron (`cargo/.github/workflows/release-notes-scaffold.yml`, currently `workflow_dispatch` only) creates a GitHub Release **draft** at 09:00 UTC. Captain edits build-name + highlights + known-issues, clicks Publish. Publish triggers:
+
+- `npm-publish.yml` (release event branch) → npm `latest`.
+- `cargo/.github/workflows/changelog-mirror.yml` → appends Release body to `cargo/client/CHANGELOG.md` under Unreleased.
+
+The Project board's Sprint view resets to the new Monday; shipped items move to the Roadmap view's Done column.
+
+## The shapes of work
+
+The handbook recognises seven shapes plus one emergency sub-flow. Each shape declares a **disposition** — when it applies, what discipline its container demands, what ceremony fits. The shape is declared in the bd issue's `Run-mode` field and replicated in the PR title prefix (Conventional Commits). If a bd issue does not fit one of these shapes, it is mis-scoped — split it or reshape it.
+
+The taxonomy is keyed to Conventional Commits prefixes so it composes with existing tooling: PR title → Release section grouping → CHANGELOG entry.
+
+**The per-shape skill chains below are v0 defaults, not canon.** Treat them as starting heuristics derived from current practice. See §Iterative refinement at the end of this section for how flows evolve as we use them.
+
+| Shape | Trigger | v0 skill chain | Test discipline | Design upfront | Stacking | Observed pitfall (2026-05-11) |
+|---|---|---|---|---|---|---|
+| **`fix`** — Bug fix | Failing test, user report, canary alert | `systematic-debugging` → `executing-plans` → `verification-before-completion` → `receiving-code-review` | Regression test **first** (rule 7) | Skipped — escalate to `refactor` if bug reveals architectural problem | Skipped — single PR | Proposing a fix before reproducing |
+| **`feat`** — Feature | bd issue with acceptance criteria; user request; spec need | (`brainstorming` if scope ambiguous) → `writing-plans` → `test-driven-development` → `executing-plans` or `dispatching-parallel-agents` → `verification-before-completion` → `receiving-code-review` | TDD (rule 7) | Required if scope ambiguous; optional if acceptance concrete | Allowed/encouraged for multi-task | Skipping TDD and discovering at PR time the design doesn't support testing |
+| **`refactor`** — Architecture / migration | Scaling problem, velocity drag, migration to a new pattern | `brainstorming` (**required**) → `writing-plans` → `test-driven-development` → `subagent-driven-development` → `executing-plans` → `verification-before-completion` → `receiving-code-review` | TDD + integration tests on migration / contract surfaces (rules 6 + 7) | **Required** — DR for big, spec for medium | **Required** — strangler-fig preferred; each layer ships independently | Big-bang refactor as one giant PR — reviewers reject |
+| **`spike`** — Research / exploration | Open "can we?" question; tech evaluation | `brainstorming` → exploratory work in a worktree → write finding as spec or DR | Skipped — output is a finding | The output IS the design | Skipped — spike code does not merge | Letting spike code drift back into a feature PR; not writing the finding |
+| **`chore`** — Deps, CI, dev tooling | Dependabot, CI tweak, dev-pain | `executing-plans` → `verification-before-completion` → `receiving-code-review` | Integration tests required if touches a dep (rule 6) | Skipped | Skipped | Batching dep upgrade with feature work |
+| **`docs`** — Documentation | Doc gap; canonical-doc amendment; runbook update | `executing-plans` → `receiving-code-review` | Skipped | Required if canonical (SPEC/BRAND/THESIS/GROWTH/GLOSSARY/CLAUDE/README per `cargo/spec/2026-04-28-canonical-docs.md`) — needs Discussion + CODEOWNERS approval | Skipped | Touching canonical docs without the Discussion ceremony |
+| **`test`** — Test-only | Coverage gap, flake fix, test refactor | `executing-plans` → `verification-before-completion` | Meta — the test IS the discipline | Skipped | Skipped | Adding tests that pass without exercising the surface |
+
+**Emergency sub-flow of `fix`:**
+
+`fix(incident)` — used when canary is broken, production is incident-mode, or a security disclosure lands. SOP: acknowledge in the incident thread; diagnose (revert is the default); ship the smallest possible patch with **relaxed review** (one reviewer, justification noted in PR body); the post-hoc regression test and proper-fix are **required follow-up beads** filed before the incident is closed. Rule 4 (review parity) explicitly allows relaxation here; rule 7 (regression test) defers but does not waive.
+
+**`Run-mode` values** used in bd issue bodies: `BUG-FIX` / `FEATURE` / `REFACTOR` / `SPIKE` / `CHORE` / `DOCS` / `TEST` / `INCIDENT` / `INTERACTIVE DESIGN`. The `INTERACTIVE DESIGN` value is the meta-shape used when the bd issue's job is to *produce a design doc* — its skill chain is `brainstorming` → spec → DR(s) → bd restructure, with no implementation in the same session.
+
+### Iterative refinement of shape flows
+
+The shape taxonomy above is the stable surface. The per-shape skill chains are v0 defaults — they will be wrong in places we haven't shipped enough work to know yet.
+
+Friction observed in a shape's flow → bd issue under `jinn-mono-2cl` → refinement, via one of three paths:
+
+1. **Author a new shape-specific skill.** If friction recurs and no existing skill covers it. New skill lands in `cargo/.claude/skills/` (in-repo, AI agents pick up via Claude Code skill loading); the shape's v0 skill chain in this handbook updates to invoke it.
+2. **Amend an existing skill.** If friction is in how an existing skill (e.g., `superpowers:systematic-debugging`) fits the shape's context. The amendment is itself a `docs` change in the relevant skill's repo.
+3. **Revise the handbook.** If the friction is taxonomic (e.g., `chore` should split into `chore(deps)` vs `chore(ci)`). `docs`-shape change against this file.
+
+For v0 the refinement mechanism is intentionally lightweight: file a bd under `jinn-mono-2cl` tagged with the shape it concerns, body describing the friction and the proposed refinement. No structured retro skill, no per-PR friction form, no end-of-sprint shape ceremony — until usage demonstrates a more disciplined mechanism would pay off.
+
+## AI workflow rules
+
+The eight rules below land in this handbook + [`cargo/CLAUDE.md`](../../CLAUDE.md) immediately. Rule 5 is a placeholder pending `jinn-mono-8qbc` (the self-modifying learner design).
+
+1. **Worktree-for-multi-agent.** Multi-agent or speculative subagent work uses `git worktree add cargo/.tasks/<id>`, not the primary checkout.
+2. **Beads frame problems, not solutions.** bd issue bodies = context + impact + needs-design-session or testable acceptance criteria. Solutions live in design sessions (`INTERACTIVE DESIGN` shape) or implementation plans, not in the bd body.
+3. **bd-as-SoR, not `MEMORY.md`.** Memory fragments across accounts and worktrees. Use `bd remember "..."` and `bd memories <keyword>` for persistent knowledge.
+4. **Agent PR review parity.** Codex / Opus / Sonnet / Claude PRs go through the same review gate as human PRs. No agent self-merge. Exception: `fix(incident)` allows reviewer relaxation with documented justification.
+5. **(Deferred — open)** Supervised-diff for the self-modifying learner. Phase A.5+ learner ships proposed changes as PRs against the repo; designated reviewer approves before merge. Concrete mechanism is open until `jinn-mono-8qbc` closes. **Status: open — see `jinn-mono-8qbc`.**
+6. **Integration tests > mocks for migration / contract surfaces.** Mock policy stays for the unit-test pyramid; migration tests must hit a real database or a forked chain (per `superpowers:test-driven-development`'s position on the test pyramid).
+7. **TDD for new features, regression test for fixes.** Per `superpowers:test-driven-development`. TDD on `feat` / `refactor`; regression-first on `fix`; deferred-not-waived on `fix(incident)`.
+8. **Auto-canary on main merge; Monday-only named minor.** Cadence policy from §Cadence above.
+9. **`canary` for rolling patches, `latest` for Monday named.** Dist-tag policy from §Dist-tags above.
+
+Rule-to-shape wiring is in §The shapes of work; the mapping is the load-bearing piece. Rules in the abstract are guidance; rules wired to shapes are operational.
+
+## Sprint surface — GitHub Project (v2)
+
+Per DR-2026-05-11-b, the canonical sprint board is a GitHub Project (v2) on `Jinn-Network/mono` named **Jinn engineering**.
+
+- **Status columns**: Open / In Progress / In Review / Shipped.
+- **Sprint field** (date): keyed to the upcoming Monday's date.
+- **Epic field** (single select): `uy6v` / `8psp` / `jnw9` / `9iq3` / `2cl` (extensible).
+- **Default view**: current sprint Status board.
+- **Roadmap view**: grouped by Epic in Now / Next / Later.
+
+**bd ↔ GitHub Issue boundary**: bd is the internal SoR. When (and only when) a bd issue is pulled into the upcoming sprint, the `cargo/scripts/bd-mirror` helper opens a public GitHub Issue with a curated subset of the bd body and adds it to the Project board with `Sprint = <next-monday-date>`. The Issue body ends with `Internal tracking: jinn-mono-<bd-id>` so the boundary is legible to external readers. Backlog stays in bd-only.
+
+The Friday triage cron (currently manual via `workflow_dispatch`) auto-mirrors top-N priority bd issues for the upcoming sprint. Captain reviews and **rejects** anything that doesn't belong. Default flow is reject, not select.
+
+## Building in public — substrate
+
+Per the umbrella `jinn-mono-2cl` and DR-2026-05-11-b:
+
+- **GitHub Projects (v2)** — public sprint board (this handbook §Sprint surface above).
+- **Public GitHub Issues** — the sprint-scoped mirrored Issues are the externally-visible "what we're working on right now" surface.
+- **GitHub Releases + auto-generated notes** — the devlog. Monday cuts. Released artifacts: `v2026.MM.DD` + `v0.N.0` dual tags.
+- **CHANGELOG.md** — `cargo/client/CHANGELOG.md` auto-mirrored from Release body on publish via `cargo/.github/workflows/changelog-mirror.yml`. npm-tarball-shipped.
+- **Repo-as-docs** — `cargo/docs/` (engineering, runbooks, specs, decisions). GitHub Pages-ready.
+- **GitHub Discussions** — RFCs / Q&A / governance prep through Phase 2.
+
+What we do **not** do (yet): GitHub Wiki (drifts), Discourse forum (premature — Discussions cover it), Discord/Telegram as engineering substrate (community engagement, not engineering), public bd mirror beyond sprint-scope (bd is internal by design).
+
+## Stacked PRs
+
+For features > 300 LOC the handbook expects stacked PRs. Each layer < 200 LOC, "one logical thing per layer that makes sense on its own" (Joe Buza, 2026). Reviewer reads bottom-up; merge in order; the stack auto-rebases.
+
+Tooling: `gh-stack` (GitHub-native CLI extension, April 2026) is the canonical reference. Graphite (`gt`) is allowed but not required. No CI enforcement — reviewers socially enforce by asking for stack-splits on PRs > 300 LOC without a clear single logical-thing.
+
+## Doc ladder
+
+- `cargo/spec/` — stable proposal-style ADRs.
+- `cargo/docs/superpowers/specs/` — in-progress design specs (output of `INTERACTIVE DESIGN` shape).
+- `cargo/docs/superpowers/plans/` — implementation plans (output of `writing-plans` skill).
+- `cargo/docs/runbooks/` — operational SOPs.
+- `cargo/log/decisions/` — ratified Decision Records (DRs).
+- `cargo/docs/engineering/handbook.md` — this file.
+- `cargo/CLAUDE.md` — agent-canonical surface for this repo, auto-loaded by Claude Code.
+
+## Open
+
+- **Rule 5 concrete mechanism.** Waits on `jinn-mono-8qbc` (self-modifying learner design).
+- **prepublishOnly hardening (jinn-mono-2cl.7).** Needs careful design about canary vs named release gating (full release-gate suite would slow canary publish from ~5 min to ~30 min on every merge). Open.
+- **Cron enablement for 2cl.2 + 2cl.11.** Both shipped with `workflow_dispatch` only; cron schedules commented out. Promote after first manual run validates.
+- **GitHub Project (v2) board creation.** Tracked as `jinn-mono-2cl.9`. External irreversible org-write; Captain does manually.

--- a/docs/superpowers/specs/2026-05-11-engineering-handbook-codesign.md
+++ b/docs/superpowers/specs/2026-05-11-engineering-handbook-codesign.md
@@ -1,0 +1,241 @@
+---
+title: Engineering handbook v1 — co-designed with the v1 release epics
+date: 2026-05-11
+status: draft
+authors: opus (proposed), oak (Captain attached)
+spec: docs/engineering/ (handbook precipitate), cargo/CLAUDE.md (canonical agent surface)
+supersedes-context-from: cargo/docs/proposals/2026-04-23-engineering-practices-cadence.md (referenced by jinn-mono-2cl; not on disk at time of writing)
+bd: jinn-mono-pgjj (this design), jinn-mono-2cl (handbook umbrella)
+related-bd: jinn-mono-uy6v, jinn-mono-9iq3, jinn-mono-8psp, jinn-mono-jnw9
+related-decisions: DR-2026-05-11-a (Prediction freeze), DR-2026-05-11-b (Engineering substrate — paired with this design)
+---
+
+## Context
+
+The 2026-05-11 backlog narrowing pass filed jinn-mono-2cl (engineering handbook v1) as a peer of v1 release work (jinn-mono-uy6v) and sibling epics (jinn-mono-9iq3 Prediction freeze, jinn-mono-8psp Hermes harness, jinn-mono-jnw9 self-modifying learner). A subsequent gap analysis found that 2cl and the epics are entangled in five concrete ways: 2cl.1's CI gate consumes uy6v.2's vitest list, 2cl.2's runbook reference overlaps with uy6v.5's evidence bundle, 2cl.5's CONTRIBUTING file is the same artifact as 9iq3.3's review guardrail, 2cl.4's handbook index needs 9iq3.2's freeze-note to be ratified first, and 2cl's AI-workflow rules include decisions (supervised-diff, agent PR review parity) that the jnw9 / 8psp design beads must close before promotion.
+
+Designing 2cl in isolation produces generic OSS-AI rules. Designing it as the consolidation of decisions the epics force produces a handbook grounded in the work this team is actually shipping. This document is that consolidation.
+
+The handbook is **Jinn-flavored**, not generic. Per BRAND.md the engineering substrate is itself a brand surface — the public sprint board, GitHub Releases, CHANGELOG, DRs, and specs are the visible artifacts that make the headless-brand posture legible. The shipping machine is not separate from the work; it is the work made public.
+
+## Threads designed (recap of locked picks)
+
+The eight threads in jinn-mono-pgjj are closed as follows:
+
+1. **Daily intent discipline.** Sprint container is a GitHub Project (v2) on `Jinn-Network/mono` with a Status board (Open / In Progress / In Review / Shipped), a custom Sprint field keyed to the upcoming Monday's date, and an Epic field (`uy6v` / `8psp` / `jnw9` / `9iq3` / `2cl`). A secondary Roadmap view groups by Epic in Now / Next / Later. The bd remains the internal system of record; only sprint-scoped bd issues mirror to public GitHub Issues, which are the Project board's items. The daily brief is the `eng-day` skill, modeled on `growth-day`.
+
+2. **Cross-references.** Merge 2cl.5 + 9iq3.3 (same artifact: CONTRIBUTING.md). Add blocks edges 2cl.1 → uy6v.2 (acceptance-gate vitest list) and 2cl.4 → 9iq3.2 (handbook cites ratified freeze note). Add a relates edge 2cl.2 ↔ uy6v.5 (same runbook §Evidence list, different artifacts).
+
+3. **AI workflow rule promotion.** Rules 1–4 + 6–9 are battle-tested and promote into AGENTS.md / docs/engineering/ immediately. Rule 5 (supervised-diff for the self-modifying learner) waits on jinn-mono-8qbc (the jnw9 design bead); until then the handbook records rule 5 as a placeholder pointing at the open design.
+
+4. **Gap-close shape.** Tighten 2cl.1 acceptance (absorb: replace manual `release:client`, add acceptance-gate invocation to publish path). Tighten 2cl.2 acceptance (absorb: cron schedule, scaffold content matches Hermes-style, drift mitigation). File two new sibling beads: 2cl.6 (tag-format dual policy `v2026.MM.DD` + `v0.N.0`) and 2cl.7 (`prepublishOnly` hardening — full release-gate suite). No new sub-epic; flat under 2cl.
+
+5. **Bump heuristic.** The Monday cron always suggests a minor bump. Captain manually overrides to major. Pre-v1 Monday cuts go v0.N → v0.N+1.0. v1.0.0 is the Monday cut that ships uy6v. Post-v1 epic close = major (8psp → v2.0.0, jnw9 → v3.0.0); other Mondays minor.
+
+6. **Release-notes scaffold.** Trigger: Monday cron (09:00 UTC). Output: a GitHub Release **draft** with mechanical inputs (merged PRs + authors, closed bd issues, contributors, line stats, suggested semver=minor) and placeholders for build-name + highlights + known-issues. Captain edits in the GitHub Release draft UI and clicks Publish. Release publish triggers npm `latest` (already wired in `cargo/.github/workflows/npm-publish.yml`).
+
+7. **CHANGELOG mirroring.** Workflow on Release publish appends the Release body as a new section in `cargo/client/CHANGELOG.md` under Unreleased. Existing per-release sections (0.1.3, 0.1.2, …) stay verbatim. No root CHANGELOG; the GitHub Releases page is the repo-wide narrative; the per-package CHANGELOG is the npm-consumer mirror only.
+
+8. **Dist-tag.** Keep `canary` as the rolling dist-tag. `latest` is Monday named. The original 2cl proposal of renaming `canary` → `next` is dropped — `canary` already matches the intent and the rename's deprecation cost exceeds its framing benefit.
+
+## The shipping machine — process
+
+The handbook describes one daily loop and one weekly retrace. Both fit on a single screen.
+
+### Daily loop
+
+Captain starts in `cargo/`:
+
+```
+cd cargo
+claude
+```
+
+Then:
+
+1. **Orient.** `eng day` (once jinn-mono-2cl.8 ships) reads the GitHub Project board, open PRs, and the bd ready queue, and prints a four-line brief: today's sprint progress against the upcoming Monday cut, yesterday's shipped, today's top-3 *guidance* actions (Captain picks; the skill does not auto-dispatch), and drift flags (canary status, sprint age > 7 days, PRs > 3 days stale, named-`latest` vs canary mismatch). Until 2cl.8 ships, the fallback is `bd ready` plus `gh pr list --search 'is:open draft:false'`.
+
+2. **Pick one piece of work.** Always a single unit: a bd issue, a stale PR to review, or a design conversation. `bd show <id>` reads the work; its body's `Run-mode` field tells you which flavor.
+
+3. **Execute** according to the work's **shape**. The shape is declared in the bd issue's `Run-mode` field and determines the skill chain, test discipline, design requirement, and stacking policy. See §The shapes of work below for the full taxonomy. The seven shapes are `fix`, `feat`, `refactor`, `spike`, `chore`, `docs`, `test` (plus `fix(incident)` as a sub-flow of `fix`). The shape also determines the Conventional Commits prefix that goes on the PR title, which propagates through to the Monday Release notes section grouping.
+
+4. **Open PR(s).** PR title format is `<shape>: <one-line summary>` or `<shape>(<scope>): <one-line summary>` per Conventional Commits — for example `fix: SWE typed payload fallback validation`, `feat(uy6v): live verdict-success on Base Sepolia`, `refactor: extract Harness selection from buildHarnesses`. The PR template prompts for: problem-not-solution body (rule 2), test plan, agent identity (`agent:opus` / `agent:codex` / `human` labels), and a `Co-Authored-By` trailer for AI commits.
+
+5. **Review (rule 4: agent PR review parity).** Every PR gets human eyes before merge. No agent self-merge. Codex / Opus / Sonnet / Claude PRs go through the same gate as human PRs. Reviewer may request a stack-split for any single PR that exceeds 300 LOC without an obvious single logical-thing. The one allowed relaxation is `fix(incident)` — see the incident sub-flow in §The shapes of work.
+
+6. **Merge → auto-ship canary.** `cargo/.github/workflows/npm-publish.yml` fires on every merge to main with paths matching `client/**` and publishes `<package.version>-canary.<sha8>` under the `canary` dist-tag. Operators on `npm i -g @jinn-network/client@canary` receive it within minutes.
+
+7. **Close bd.** `bd close <id>`. The Project board's mirrored GitHub Issue moves to the Shipped column (via Project automation on Issue close; the GitHub Issue is auto-closed via PR linking).
+
+### Weekly retrace
+
+**Friday afternoon — triage.** A Friday cron (jinn-mono-2cl.11 — to file) reads the bd ready queue, picks the top-N priority issues (P0 + P1, capped at sprint capacity), and auto-mirrors each to a public GitHub Issue with sprint label `sprint:<next-monday-date>`, epic label, and a footer `Internal tracking: jinn-mono-<id>`. The cron also adds the Issue to the Project board with `Sprint = <next-monday-date>`. Captain reviews on Friday afternoon and **rejects** any that don't belong (closing the GH Issue and removing the sprint label). Captain only adds Issues by exception. Default flow is *reject, not select*.
+
+**Monday morning — cut.** The Monday cron (09:00 UTC) computes the window since the last `v0.N.0` tag and opens a GitHub Release **draft** shaped like Hermes Agent's:
+
+```
+# v0.4.0 — "<build name placeholder>"
+2026-05-18 · Suggested bump: minor
+
+## Highlights
+- <placeholder — Captain edits>
+
+## Changes
+- (#125) Fix SWE typed payload fallback validation — @opus
+- (#126) Prepare SWE donation release gates — @oak
+- …
+
+## Closed this week
+- jinn-mono-uy6v.7 — Live verdict-success on Base Sepolia
+- …
+
+## Stats
+- 18 commits · 7 PRs · 12 files · +1,240 / -380 LOC · 3 contributors
+
+## Known issues
+- <placeholder>
+```
+
+Captain reviews, fills in build-name + highlights + known-issues, clicks Publish. Publish triggers:
+
+- `npm-publish.yml` (release branch of the workflow) → publishes `v0.4.0` under `latest`.
+- The CHANGELOG mirror workflow (jinn-mono-2cl.10) → appends the Release body to `cargo/client/CHANGELOG.md` under the Unreleased section.
+- Tags created: `client-v0.4.0` (current format) and `v2026.05.18` (date tag — once jinn-mono-2cl.6 ships dual tagging).
+
+The Project board's Sprint view resets to the new Monday's sprint; shipped items move to the Roadmap view's Done column.
+
+### The shapes of work
+
+The handbook recognises seven shapes of work plus one emergency sub-flow. Each shape has a distinct **disposition** — when it applies, what kind of discipline its container demands, what design ceremony fits. The shape is declared in the bd issue's `Run-mode` field and replicated in the PR title prefix (Conventional Commits) so it propagates through to Release notes section grouping. If a bd issue does not fit one of these shapes, it is mis-scoped — split it or reshape it.
+
+The taxonomy is keyed to Conventional Commits prefixes so it composes with existing tooling: PR title → Release section grouping → CHANGELOG entry. Note that the bump heuristic remains the one locked in Thread 5 (weekly named-minor; Captain overrides to major on epic close) — Conventional Commits here drives section grouping in Release notes and Release-notes scaffold readability, **not** per-merge semver bumps. The canary channel handles per-merge patch publishing implicitly (`<v>-canary.<sha>`).
+
+**Important — the per-shape skill chains below are v0 defaults, not canon.** They are starting heuristics derived from current practice (existing superpowers skills, recurring patterns Captain has noticed in 2026-Q2 work). They will be wrong in places we haven't shipped yet. The handbook treats them as inputs to an iterative refinement loop — see §Iterative refinement of shape flows at the end of this section. The shape *taxonomy* (which shapes exist, when each applies) is more stable than the *flows* (which skills, in what order, with which checkpoints).
+
+| Shape | Trigger | v0 skill chain | Test discipline | Design upfront | Stacking | Observed pitfall (as of 2026-05-11) |
+|---|---|---|---|---|---|---|
+| **`fix`** — Bug fix | Failing test, user report, canary alert | `systematic-debugging` → `executing-plans` → `verification-before-completion` → `receiving-code-review` | Regression test **first** (rule 7) | Skipped — escalate to `refactor` if bug reveals an architectural problem | Skipped — single PR | Proposing a fix before reproducing. The skill enforces: no fix without a reproducing test. |
+| **`feat`** — Feature | bd issue with acceptance criteria; user request; spec need | (`brainstorming` if scope ambiguous) → `writing-plans` → `test-driven-development` → `executing-plans` or `dispatching-parallel-agents` → `verification-before-completion` → `receiving-code-review` | TDD (rule 7) | Required if scope ambiguous; optional if acceptance criteria are concrete | Allowed and encouraged for multi-task features | Skipping TDD ("I'll add tests after") and discovering at PR time that the design doesn't support testing |
+| **`refactor`** — Architecture / migration | Scaling problem, velocity drag, migration to a new pattern | `brainstorming` (**required**) → `writing-plans` → `test-driven-development` → `subagent-driven-development` → `executing-plans` → `verification-before-completion` → `receiving-code-review` | TDD + integration tests on migration / contract surfaces (rules 6 + 7) | **Required** — DR for big refactors, spec for medium | **Required** — strangler-fig preferred; each layer must ship independently as a valid partial state | Big-bang refactor as one giant PR. The handbook explicitly forbids this; reviewers reject. |
+| **`spike`** — Research / exploration | Open "can we?" question; tech evaluation; performance investigation | `brainstorming` → exploratory work in a worktree → write the finding as a spec or DR | Skipped — output is a finding, not code | The output IS the design | Skipped — spike code does not merge to `main` | Letting spike code drift back into a feature PR; not writing the finding |
+| **`chore`** — Deps, CI, dev tooling | Dependabot, CI tweak, dev-pain | `executing-plans` → `verification-before-completion` → `receiving-code-review` | Integration tests required if it touches a dep (rule 6) | Skipped | Skipped | Batching a dep upgrade with feature work in one PR |
+| **`docs`** — Documentation | Doc gap; canonical-doc amendment; runbook update | `executing-plans` → `receiving-code-review` | Skipped (it's docs) | Required if canonical (SPEC/BRAND/THESIS/GROWTH/GLOSSARY/CLAUDE/README per `cargo/spec/2026-04-28-canonical-docs.md`) — needs a GitHub Discussion + CODEOWNERS approval | Skipped | Touching canonical docs without the Discussion ceremony |
+| **`test`** — Test-only | Coverage gap, flake fix, test refactor | `executing-plans` → `verification-before-completion` | Meta — the test IS the discipline | Skipped | Skipped | Adding tests that pass without actually exercising the surface |
+
+**Emergency sub-flow of `fix`:**
+
+`fix(incident)` — used when canary is broken, a production incident is open, or a security disclosure lands. SOP: acknowledge in the incident thread; diagnose (revert is the default; forward-fix only if revert fails); ship the smallest possible patch with **relaxed review** (one reviewer, justification noted in the PR body); the post-hoc regression test and proper-fix are **required** follow-up beads filed before the incident is closed. Test discipline is deferred but not waived. Common pitfall: not writing the postmortem; not filing the proper-fix follow-up bead. Rule 4 (PR review parity) explicitly allows relaxation here; rule 7 (regression test) defers but does not waive.
+
+**`Run-mode` values used in bd issues**: `BUG-FIX` / `FEATURE` / `REFACTOR` / `SPIKE` / `CHORE` / `DOCS` / `TEST` / `INCIDENT` / `INTERACTIVE DESIGN`. The `INTERACTIVE DESIGN` value is a meta-shape used when the bd issue's job is to *produce a design doc* (this very bd, jinn-mono-pgjj, is an example) — its skill chain is `brainstorming` → write spec → write DR(s) → bd restructure, with no implementation in the same session.
+
+**How the rules wire to shapes:**
+
+- Rule 1 (worktree-for-multi-agent): mandatory on `refactor` and large `feat` (parallel subagents); allowed on `spike`.
+- Rule 2 (problems-not-solutions bd body): mandatory on all shapes.
+- Rule 3 (bd-as-SoR): mandatory on all shapes.
+- Rule 4 (agent PR review parity): mandatory on all shapes **except** `fix(incident)`, where relaxation is allowed with documented justification.
+- Rule 5 (supervised-diff — deferred to jnw9): future — applies to the self-modifying learner's PRs across all shapes it touches.
+- Rule 6 (integration > mocks): mandatory on `refactor` and `chore`(deps).
+- Rule 7 (TDD / regression): TDD on `feat`/`refactor`; regression-first on `fix`; deferred-not-waived on `fix(incident)`.
+- Rule 8 (cadence: auto-canary, Monday named): mechanical, applies to every merge regardless of shape.
+- Rule 9 (`canary` rolling, `latest` Monday): mechanical, applies to every published version.
+
+### Iterative refinement of shape flows
+
+The shape taxonomy above is the stable surface. The per-shape skill chains (column 3) are v0 defaults — best guesses derived from current practice on 2026-05-11. They will be wrong in places we haven't shipped enough work to know yet.
+
+The handbook adopts an explicit iteration loop for the flows. The principle: **friction observed in a shape's flow → bd issue → refinement**. There are three refinement paths a friction signal can take:
+
+- **Author a new shape-specific skill.** When a friction recurs and no existing skill covers it (example: there is no current `eng-shape-retro` skill; if shape-level retros prove load-bearing one might be written). The new skill lands in `cargo/.claude/skills/` or `~/.claude/skills/` depending on scope, and the shape's v0 skill chain in this handbook updates to invoke it.
+- **Amend an existing skill.** When the friction is that an existing skill (e.g., `superpowers:systematic-debugging`) does not fit the shape's context well. The skill amendment is itself a `chore` or `docs` shape change in the relevant skill's repo, and the handbook's skill chain updates to reflect the amendment if its invocation changes.
+- **Revise the handbook.** When the friction is that the shape's *taxonomy* is wrong (e.g., what we called `chore` should split into `chore(deps)` vs `chore(ci)` because they want different SOPs). This is a `docs` change against `cargo/docs/engineering/handbook.md`.
+
+For v0 the mechanism is intentionally lightweight: file a bd issue under `jinn-mono-2cl` (the handbook umbrella) tagged with the shape it concerns, body describing the friction observed and the proposed refinement, and let it be picked up like any other engineering work. No structured retro skill, no per-PR friction form, no end-of-sprint shape ceremony — until usage demonstrates a more disciplined mechanism would pay off.
+
+The expected first refinements (best-guess places we'll feel friction first):
+
+- `feat` flow when scope is ambiguous in a way that `brainstorming` doesn't catch — may need a pre-`brainstorming` triage step.
+- `refactor` flow when strangler-fig is the right pattern but the team reaches for big-bang anyway — may need a `refactor-strangler` skill that scaffolds the layer structure.
+- `fix(incident)` flow when relaxed review meets "what's the proper-fix?" — may need an incident-postmortem skill that ensures the proper-fix bd is filed before incident close.
+
+These are guesses, not predictions. The shape-flow refinement mechanism captures whichever frictions actually surface, not the ones we anticipate.
+
+### Entry point
+
+The entry point is always `bd show <id>` followed by reading the `Run-mode` field. Cold-start has two equivalent paths:
+
+- **Skill-driven** (once 2cl.8 ships): `eng day` → presents top-3 with bd ids → `bd show <id>`.
+- **Manual** (today): `bd ready` → pick → `bd show <id>`.
+
+The work-unit is always the bd issue. Everything else composes off it.
+
+## AI workflow rules
+
+The 2cl umbrella locked nine rules. Eight promote to `cargo/CLAUDE.md` (the canonical agent surface for this repo — auto-loaded by Claude Code) and `cargo/docs/engineering/handbook.md` (the canonical handbook prose, written at jinn-mono-2cl.4) immediately:
+
+1. **Worktree-for-multi-agent.** Multi-agent or speculative subagent work uses `git worktree add cargo/.tasks/<id>`, not the primary checkout.
+2. **Beads frame problems, not solutions.** bd issue bodies = context + impact + needs-design-session or testable acceptance criteria; solutions live in design sessions or implementation plans.
+3. **bd-as-SoR, not `MEMORY.md`.** Memory fragments across accounts and worktrees. Use `bd remember` and `bd memories <keyword>` for persistent knowledge.
+4. **Agent PR review parity.** Codex / Opus / Sonnet / Claude PRs go through the same review gate as human PRs. No agent self-merge.
+5. **(Deferred)** Supervised-diff for the self-modifying learner. The Phase A.5+ learner ships proposed changes as PRs against the repo; designated reviewer approves before merge. The concrete mechanism is open until jinn-mono-8qbc closes; until then, the handbook records this as a placeholder.
+6. **Integration tests > mocks for migration / contract surfaces.** Mock policy stays for the unit-test pyramid; migration tests must hit a real database or a forked chain.
+7. **TDD for new features, regression test for fixes.** Per `superpowers:test-driven-development`.
+8. **Auto-canary on main merge; Monday-only named minor.** Cadence policy from the 2cl umbrella, refined in this design's Thread 5.
+9. **`canary` for rolling patches, `latest` for Monday named.** Updated from the umbrella's original `next` proposal per this design's Thread 8.
+
+Rule 5 lands as a stub when 2cl.4 (docs/engineering/ index) writes, with `Status: open — see jinn-mono-8qbc` and a link to the design bead. It promotes to a full rule when 8qbc ratifies.
+
+The rule-to-shape mapping (which rules apply to which work shapes) is documented in §The shapes of work above. The mapping is the load-bearing piece — rules in the abstract are guidance; rules wired to shapes are operational.
+
+## bd restructure
+
+The following actions land as part of this design closure:
+
+| Action | Bead | Detail |
+|---|---|---|
+| Merge | 9iq3.3 → 2cl.5 | 2cl.5 gains a "Prediction-freeze guardrail" section; 9iq3.3 closes as duplicate-merged |
+| Add blocks edge | 2cl.1 → uy6v.2 | acceptance-gate vitest list defined by uy6v.2 |
+| Add blocks edge | 2cl.4 → 9iq3.2 | handbook cites DR-2026-05-11-a after 9iq3.2 ratifies the freeze note |
+| Add relates edge | 2cl.2 ↔ uy6v.5 | same runbook §Evidence list, different artifacts |
+| New | jinn-mono-2cl.6 | Tag format dual policy (`v2026.MM.DD` date + `v0.N.0` semver) |
+| New | jinn-mono-2cl.7 | `prepublishOnly` hardening (invoke `release:operator-gate` + `release:donation-consumption`) |
+| New | jinn-mono-2cl.8 | `eng-day` skill modeled on `growth-day`, P2 (after uy6v ships) |
+| New | jinn-mono-2cl.9 | GH Project (v2) board setup: Status board + Sprint field + Epic field + Roadmap view |
+| New | jinn-mono-2cl.10 | CHANGELOG auto-mirror workflow on Release publish |
+| New | jinn-mono-2cl.11 | Friday triage cron: auto-mirror top-N priority bd → GH Issue + add to Project; Captain rejects |
+| New | jinn-mono-2cl.12 | `bd-mirror <bd-id> <sprint-date>` helper script (used by 2cl.11 cron + manual one-shots) |
+| Amend body | jinn-mono-2cl | drop `next` rename, fix stale proposal link, point at GH Project as sprint surface, cite DR-2026-05-11-b |
+
+Tighten existing acceptance criteria on 2cl.1 and 2cl.2 to absorb the gap-scan deltas (replace manual `release:client`, add acceptance-gate invocation to publish, Hermes-shaped scaffold content, drift mitigation explicit).
+
+## Open
+
+- **Rule 5 (supervised-diff) concrete mechanism.** Waits on jinn-mono-8qbc design closure.
+- **Hermes harness composition with rule 5.** Hermes has its own learning loop; whether that subsumes or composes with the Jinn-level learner is the question for jinn-mono-8psp.1.
+- **eng-day priority.** Filed as P2; revisit after uy6v ships. If the manual fallback (`bd ready` + `gh pr list`) is friction once the GH Project board is steady-state, promote to P1.
+- **Friday triage cron threshold.** Top-N defaults to "all P0 + capped P1 by Captain's set sprint-capacity" — the cap value is itself open. Suggest 8 issues / sprint as a starting heuristic; calibrate after two sprints.
+- **2cl.11 cron — auto-mirror conservative or aggressive?** Conservative version mirrors only P0; aggressive mirrors P0 + all P1. Pick at 2cl.11 design time.
+- **Shape-flow refinement mechanism v1 shape.** For v0 the mechanism is "file a bd under jinn-mono-2cl when friction surfaces" (per §Iterative refinement of shape flows). If by uy6v close the refinement beads cluster around a recurring pattern — e.g., shape retros becoming valuable, or per-PR friction notes proving load-bearing — file a follow-up design bead under jinn-mono-2cl for the v1 mechanism. Until then, no ceremony.
+
+## References
+
+Internal:
+- jinn-mono-pgjj (this design's bd)
+- jinn-mono-2cl (handbook umbrella)
+- jinn-mono-uy6v / 9iq3 / 8psp / jnw9 (related epics)
+- DR-2026-05-11-a — Prediction freeze (`cargo/log/decisions/2026-05-11-freeze-prediction-solvernet.md`)
+- DR-2026-05-11-b — Engineering substrate (`cargo/log/decisions/2026-05-11-engineering-substrate.md`) — paired with this design
+- `cargo/.github/workflows/npm-publish.yml` (current auto-publish wiring)
+- `cargo/.github/PULL_REQUEST_TEMPLATE.md` (current PR template — to extend in 2cl.3)
+- `cargo/client/CHANGELOG.md` (current changelog — to auto-mirror via 2cl.10)
+- `cargo/CLAUDE.md` (canonical agent surface for this repo — the handbook's eight ratified rules land here)
+- `cargo/BRAND.md` §Headless-brand posture (substrate-as-brand-surface rationale)
+- `cargo/docs/runbooks/swe-rebench-v2-public-testnet.md` §Acceptance Gates + §Evidence To Retain (consumed by 2cl.1 and 2cl.2)
+
+External:
+- Hermes Agent — weekly named cadence + cumulative release notes pattern: https://github.com/NousResearch/hermes-agent
+- GitHub `gh-stack` CLI extension (April 2026) for stacked PRs: https://www.infoq.com/news/2026/04/github-stacked-prs/
+- Graphite — stacked-PR tooling and Graphite Agent reference: https://graphite.dev
+- Conventional Commits — the shape-prefix SoR feeding PR titles → Release notes sections → CHANGELOG entries → semantic-bump heuristic: https://www.conventionalcommits.org
+- Other Internet — *Headless Brands* (the brand-posture frame BRAND.md inherits): https://otherinter.net/research/headless-brands/
+- Cloudflare — *The AI engineering stack we built internally* (agent-canonical-docs pattern reference): https://blog.cloudflare.com/internal-ai-engineering-stack/

--- a/log/decisions/2026-05-11-engineering-substrate.md
+++ b/log/decisions/2026-05-11-engineering-substrate.md
@@ -1,0 +1,69 @@
+---
+id: DR-2026-05-11-b
+title: Engineering substrate — bd as internal SoR; GitHub Projects (v2) as the public sprint surface; sprint-scoped bd→GH-Issue mirror
+date: 2026-05-11
+verb: Choose
+status: proposed
+authors: opus (proposed), oak (Captain attached)
+spec: docs/superpowers/specs/2026-05-11-engineering-handbook-codesign.md (this design)
+supersedes-context-from: (none — establishes substrate)
+---
+
+## Context
+
+The 2026-05-11 backlog narrowing pass promoted jinn-mono-2cl (engineering handbook v1) from P2 decision to P1 task. The umbrella body locks the cadence (auto-canary on every merge to main; Monday named-minor release with build-in-public devlog) and lists nine AI workflow rules. It defers two structural picks to a co-design with the v1 release epics: (i) what container holds the weekly sprint, and (ii) how that container relates to bd, the existing internal issue tracker.
+
+The handbook also commits to a *building-in-public substrate* — GitHub Projects (v2) for the public roadmap, public Issues with templates, GitHub Releases + auto-generated notes as the devlog, repo-as-docs, and GitHub Discussions for RFCs/Q&A through Phase 2. That commitment leaves the bd-vs-GitHub boundary ambiguous: is bd sunset in favor of GitHub Issues, mirrored to GitHub Issues, or kept as a private parallel tracker?
+
+This decision picks the boundary.
+
+## Decision
+
+**bd remains the internal system of record. GitHub Projects (v2) is the public sprint surface. The bridge is a sprint-scoped one-shot mirror: when (and only when) a bd issue is pulled into an upcoming sprint, it is mirrored to a public GitHub Issue and added to the Project board.**
+
+Concretely:
+
+- All engineering work originates as a bd issue. Backlog, drafts, exploratory needs-design-session bodies, and not-yet-scoped items live in bd only and are not visible publicly.
+- A single GitHub Project (v2) on `Jinn-Network/mono`, named "Jinn engineering", is the canonical sprint surface. Columns: Open / In Progress / In Review / Shipped. Custom fields: `Sprint` (date of the upcoming Monday cut) and `Epic` (one of `uy6v` / `8psp` / `jnw9` / `9iq3` / `2cl`, expandable as new epics file).
+- The default view is the current sprint's Status board. A secondary Roadmap view groups all open items by Epic in Now / Next / Later columns.
+- When a bd issue is pulled into the upcoming sprint, a small helper (jinn-mono-2cl.12 `bd-mirror` script) opens a public GitHub Issue with a curated subset of the bd body, applies labels (`epic:<id>`, `sprint:<date>`, `agent:opus`/`codex`/`human` for ownership), adds the Issue to the Project board, and sets `Sprint = <next-monday-date>`. The Issue body ends with `Internal tracking: jinn-mono-<bd-id>`.
+- A Friday cron (jinn-mono-2cl.11) auto-mirrors the top-N priority bd issues (default: all P0, capped P1) for the upcoming sprint. Captain reviews on Friday and **rejects** anything that doesn't belong (close the Issue, remove the sprint label). Captain adds Issues by exception only. The default flow is reject, not select.
+- On PR merge, the linked Issue closes automatically; Project automation moves it to Shipped.
+- bd issue close (`bd close <id>`) is the SoR signal that work is done. The Project mirror moves on PR-merge automation; the bd close is the canonical record.
+- The daily brief skill `eng-day` (jinn-mono-2cl.8) reads the Project board state via `gh project item-list`, joins with `bd ready` and `gh pr list`, and surfaces a top-3 guidance line for the Captain. The skill does not auto-dispatch.
+
+## Rationale
+
+Three reasons, in order of weight:
+
+- **bd's privacy is load-bearing.** bd issue bodies frequently contain exploratory `needs-design-session` framing, half-formed acceptance criteria, captain-internal notes, and references to runbooks that are not appropriate for an external audience. Forcing all of bd public would either (a) cause Captain to self-censor in bd and lose the exploratory cheapness, or (b) publish low-fidelity content that erodes the public surface's signal. Keeping bd private preserves the cost-of-thought advantage; mirroring only when scope-locked keeps the public surface curated.
+- **GitHub Projects already won on visibility.** The 2cl umbrella commits to building-in-public; GitHub Projects (v2), Issues, and Releases are the substrate every external contributor and AI agent already knows. A private bd UI would have to compete with that, and bd's value is the CLI ergonomics, not its UI. Splitting roles — bd for CLI-driven work, Projects for the public board — uses each tool's strength.
+- **Sprint-scoped mirror is cheap and reversible.** A one-shot bd → GitHub Issue creation script (`bd-mirror`) is ~30 lines. If the boundary later shifts (e.g., toward all-bd-public or all-GitHub-only), the script's call sites are a single cron + manual one-shots. Reversibility cost is low.
+
+## Alternatives considered and rejected
+
+- **Sunset bd; move all engineering to GitHub Issues + Projects.** Rejected for v1: bd's CLI ergonomics (`bd ready`, `bd remember`, `bd memories`, parent-child epics, sub-day pivots) are the daily-loop substrate; replacing them mid-release would slow uy6v's path to public testnet. May revisit after Phase 2.
+- **Mirror every bd issue to a GitHub Issue automatically.** Rejected: floods the public surface with exploratory bodies; defeats the curation that makes the Project board useful; leaks pre-design state to external readers.
+- **Keep bd entirely private and rely on Releases as the only public surface.** Rejected: the 2cl umbrella's building-in-public commitment is explicit, and Releases alone are a lagging artifact — visible only after work ships. Public Issues + Project make in-flight work legible, which is the substrate the BRAND.md headless-brand posture rests on.
+- **Use GitHub Milestones instead of Projects.** Rejected: Milestones are flat per-repo collections with limited views and no custom fields. Projects (v2) supports the Sprint + Epic fields and the Roadmap secondary view that this design needs.
+
+## Consequences
+
+- **bd** continues unchanged as the internal SoR. No data migration. The Friday cron and `bd-mirror` helper read from bd but do not write to it.
+- **GitHub Projects (v2) board** must be created at jinn-mono-2cl.9 implementation time, with the Status / Sprint / Epic schema and the two views (current sprint Status board + Roadmap grouped by Epic).
+- **PR template** (jinn-mono-2cl.3) gains a checkbox for "linked bd id" — written into the PR body as `Closes jinn-mono-<id>` so merge auto-closes the mirrored GitHub Issue.
+- **CONTRIBUTING.md / handbook** (jinn-mono-2cl.5 / 2cl.4) documents the mirror flow so external contributors know the public Issue's `Internal tracking:` footer points to private bd state they cannot read; the handbook also documents what they *can* expect (Issue body is sufficient context to file a PR).
+- **`eng-day` skill** (jinn-mono-2cl.8) implementation reads Project state via `gh project item-list`; the GitHub CLI requires a Project-scope PAT or fine-grained token. Document the auth setup once at skill author time.
+- **Discoverability** for external contributors: the GitHub Project board is the canonical "what is being worked on right now" surface; the Releases page is the lagging "what shipped" surface; GitHub Discussions is the RFC / Q&A surface. bd is invisible to them by design.
+- **Cost of misalignment**: if the Friday cron mirrors something Captain later rejects, the public Issue is closed within hours — minor noise. If Captain forgets to mirror a piece of work, it ships without a public surface footprint; the Release notes will still cite the PR and closed bd issues. Loss is graceful.
+
+## Open
+
+- **2cl.11 cron threshold.** Top-N defaults to "all P0 + capped P1." The cap value is itself open. Starting heuristic: 8 Issues per sprint; calibrate after two sprints.
+- **Mirror script location.** `cargo/scripts/bd-mirror` (shell or TypeScript) — decide at 2cl.12 implementation time.
+- **bd → Project sync direction.** This decision specifies write-only from bd to Project (via the mirror at sprint-pull time). If `bd close <id>` should also update the Project state directly (e.g., move the Project item to Shipped before PR merge auto-closes the Issue), that's a future optimization, not v1.
+- **Public-Issue body curation.** What gets stripped from the bd body when mirroring (captain-internal notes, references to private runbooks, exploratory framing) is a per-issue judgment today. A template or strip-rule may emerge; 2cl.12 implementation captures whatever pattern Captain finds useful.
+
+## Status
+
+Proposed by opus 2026-05-11 as the engineering-substrate decision paired with `docs/superpowers/specs/2026-05-11-engineering-handbook-codesign.md`. Ratification by Captain oak gates promotion to status=ratified.

--- a/log/decisions/2026-05-11-freeze-prediction-solvernet.md
+++ b/log/decisions/2026-05-11-freeze-prediction-solvernet.md
@@ -1,0 +1,62 @@
+---
+id: DR-2026-05-11-a
+title: Prediction SolverNet is frozen; SWE-rebench v2 is the sole operational SolverNet through v1+
+date: 2026-05-11
+verb: Steer
+status: ratified
+authors: oak (proposed and ratified)
+spec: GROWTH.md §3, §7; SPEC.md (Phase A narrative); CLAUDE.md (project overview)
+supersedes-context-from: DR-2026-05-07-h
+---
+
+## Context
+
+DR-2026-05-07-h locked SWE-rebench v2 as the operational launch SolverNet while leaving Prediction (Polymarket-derived) co-resident in the codebase and bd backlog. The `l2zl` epic and 11+ child issues continued to track Prediction build-out, the `uy6v` release epic was Polymarket-flavored in its body ("Launcher generator creates and posts tasks (Polymarket-derived)"), and contributor energy split between two SolverNets at exactly the moment the §3 recruit pitch needed to be sharp on one.
+
+The 2026-05-08 single-operator SWE-rebench v2 loop closure (DR-2026-05-08; task `45` posted → solved via Codex learner → settled with `score: 0` / `passed_match: false`) proved the loop runs but exposed how much remaining work — multi-operator dogfood, cross-operator donation consumption, canary fleet stability, verdict success, JINN reward distribution — is on the SWE-rebench v2 path specifically.
+
+## Decision
+
+**Prediction SolverNet is frozen as of 2026-05-11.** SWE-rebench v2 is the sole operational SolverNet through the first public testnet release and the immediate post-release window (Hermes harness integration, Phase A.5+ self-modifying learner).
+
+Concretely:
+
+- No new Prediction-flavored work is merged. Code review rejects Prediction-only changes; bug fixes against existing Prediction surfaces require explicit Captain approval citing why the fix is load-bearing for SWE-rebench v2 or shared infrastructure.
+- Existing Prediction code (Polymarket task generator, prediction.v0 / prediction.v1 contracts, prediction-flavored plugins and harness pieces) remains in place. It is not deleted. It is not maintained.
+- All `l2zl*` bd epics and Prediction-only child issues close as **deferred** with reason "Prediction frozen 2026-05-11 — DR-2026-05-11-a." SolverNet-agnostic bugs that happened to live under `l2zl.15.4.*` reparent under the SWE-rebench v2 release epic (`uy6v`).
+- Canonical docs (SPEC.md Phase A narrative, GROWTH.md §3 + §7, CLAUDE.md project overview) gain a short freeze note pointing at this DR.
+- The `uy6v` release epic body is rewritten to point at SWE-rebench v2 explicitly; its Polymarket-derived framing is removed.
+
+The recruit-time pitch remains *"help collectively train a swe-rebench v2 harness"* per DR-2026-05-07-h §Decision.
+
+## Rationale
+
+Three reasons, in order of weight:
+
+- **Focus during the launch window.** The first public testnet release is the §2 bottleneck. Splitting engineering or contributor energy across two SolverNets dilutes the pitch and slows the gate. DR-2026-05-07-h chose SWE-rebench v2 as the operational launch SolverNet but kept Prediction co-resident; in practice that co-residency consumed review cycles and bd-backlog churn without producing release-relevant artifacts. Freezing makes the focus structural rather than aspirational.
+- **The loop-closure evidence points at SWE-rebench v2.** As of 2026-05-08 the SWE-rebench v2 loop has closed end-to-end on Base Sepolia with real settlement; the Prediction loop has not been similarly demonstrated. Investing further in the un-demonstrated path during the launch window inverts the appropriate risk posture.
+- **Subsumption is plausible.** DR-2026-05-07-h §Open already flagged that SWE-rebench v2's task-generator may be parameterisable to consume other task sources. If that lands, Prediction-shaped tasks become a multi-source mode of SWE-rebench v2 rather than a separate SolverNet build-out. Freezing now preserves that option without committing to it.
+
+## Alternatives considered and rejected
+
+- **Continue co-residence (status quo).** Rejected: §2 bottleneck pressure makes the focus split a real cost, and the lack of a Prediction loop closure makes the Prediction investment higher-variance than the SWE-rebench v2 investment.
+- **Kill: delete Polymarket code, contracts, plugins; close all related bd issues as won't-do; canonical-doc pass to remove Prediction from SPEC/GROWTH/THESIS.** Rejected: forecloses the subsumption option from DR-2026-05-07-h §Open; introduces deletion-pass work during the launch window when capacity is already constrained. Preserving the code at zero maintenance cost is cheaper than re-deriving it if the subsumption question lands in Prediction's favour.
+- **Sunset: soft-deprecate with a 30-day sunset window post-v1, then kill.** Rejected: defers the freeze-cleanup work into the immediate post-v1 window when Hermes harness integration and the self-modifying learner are already loading that window. Plain freeze keeps the post-v1 window for Hermes and the learner.
+
+## Consequences
+
+- **SPEC.md** — Phase A narrative gains a one-line freeze note citing DR-2026-05-11-a; the Prediction SolverNet references stay as historical context.
+- **GROWTH.md** — §3 + §7 reflect that Prediction work is frozen; the pitch language stays anchored on SWE-rebench v2 per DR-2026-05-07-h.
+- **CLAUDE.md** — Project overview gains a freeze note so contributors and AI agents stop wandering into Prediction surfaces.
+- **bd backlog** — Prediction epics and child issues close as deferred; SolverNet-agnostic bugs reparent under `uy6v`; a new "EPIC: Freeze Prediction SolverNet (cleanup-tracked)" tracks the canonical-doc and review-guardrail work.
+- **Review policy** — Reviewers reject Prediction-only PRs unless the author cites Captain approval for shared-infrastructure rationale. Code-owners notes (CONTRIBUTING-style) capture the rule.
+- **Release epic `uy6v`** — Rewritten to point at SWE-rebench v2 explicitly. The `8qbc` Claude Code learner self-modification child moves out to a new Phase A.5+ self-modifying learner sibling epic.
+
+## Open
+
+- **Subsumption viability** (carried forward from DR-2026-05-07-h §Open). Revisit at the SWE-rebench v2 retro once two-source task generation has been exercised, or when the freeze is reviewed.
+- **Freeze review trigger.** Reviewed when one of: (a) SWE-rebench v2 ships v1 public testnet and Hermes harness lands, (b) external participant interest in Prediction emerges with credible operator capacity, (c) 90 days elapsed. Whichever fires first.
+
+## Status
+
+Proposed and ratified by Captain oak on 2026-05-11. Locked.

--- a/scripts/bd-mirror
+++ b/scripts/bd-mirror
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#
+# bd-mirror — mirror a bd issue to a public GitHub Issue and add it to
+# the "Jinn engineering" GitHub Project (v2) board with the given Sprint
+# field value.
+#
+# Implements jinn-mono-2cl.12 per the engineering handbook (cargo/docs/engineering/handbook.md)
+# and DR-2026-05-11-b (cargo/log/decisions/2026-05-11-engineering-substrate.md).
+#
+# Usage:
+#   cargo/scripts/bd-mirror <bd-id> <sprint-yyyy-mm-dd> [--labels label1,label2,...] [--dry-run]
+#
+# Behaviour:
+# - Reads bd issue via `bd show <id> --json`.
+# - Strips internal-only content from the body (notes prefixed "captain-only:",
+#   exploratory "needs-design-session" framing).
+# - Opens a public GitHub Issue on Jinn-Network/mono with:
+#   - Title: bd title
+#   - Body: curated description + "Internal tracking: jinn-mono-<id>" footer
+#   - Labels: epic:<parent-epic-id> + sprint:<yyyy-mm-dd> + agent:<owner> + any --labels
+# - Adds the new Issue to the "Jinn engineering" Project (v2).
+# - Sets the Project item's Sprint field to <yyyy-mm-dd>.
+# - Writes the GitHub Issue URL back to the bd issue as an external-ref.
+# - Idempotent: if the bd issue already has an external-ref pointing at a Jinn-Network/mono
+#   Issue, the script is a no-op (prints the existing Issue URL).
+#
+# Dependencies:
+# - bd (beads CLI) configured for this repo.
+# - gh (GitHub CLI) authenticated with project scope (`gh auth refresh -s project`).
+# - jq.
+#
+# Status: v0. The Project board (jinn-mono-2cl.9) must exist for the Project-add steps to
+# succeed; until then this script falls back to "Issue created, Project add skipped" mode.
+
+set -euo pipefail
+
+REPO="Jinn-Network/mono"
+PROJECT_TITLE="Jinn engineering"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: bd-mirror <bd-id> <sprint-yyyy-mm-dd> [--labels label1,label2,...] [--dry-run]
+
+Mirrors a bd issue to a public GitHub Issue on Jinn-Network/mono and adds it
+to the "Jinn engineering" GitHub Project (v2) board with Sprint = <date>.
+
+Idempotent: re-running with the same <bd-id> is a no-op (detects existing
+GitHub Issue via the bd issue's external-ref).
+EOF
+  exit 2
+}
+
+if [[ $# -lt 2 ]]; then
+  usage
+fi
+
+BD_ID="$1"
+SPRINT_DATE="$2"
+shift 2
+
+EXTRA_LABELS=""
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --labels)
+      EXTRA_LABELS="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    *)
+      echo "unknown arg: $1" >&2
+      usage
+      ;;
+  esac
+done
+
+# Validate the sprint date format.
+if ! [[ "$SPRINT_DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+  echo "error: sprint date must be yyyy-mm-dd, got: $SPRINT_DATE" >&2
+  exit 2
+fi
+
+# Read the bd issue.
+if ! BD_JSON="$(bd show "$BD_ID" --json 2>/dev/null)"; then
+  echo "error: bd show $BD_ID failed — does the bead exist?" >&2
+  exit 1
+fi
+
+BD_TITLE="$(echo "$BD_JSON" | jq -r '.title')"
+BD_DESCRIPTION="$(echo "$BD_JSON" | jq -r '.description // ""')"
+BD_PRIORITY="$(echo "$BD_JSON" | jq -r '.priority // "P2"')"
+BD_PARENT="$(echo "$BD_JSON" | jq -r '.parent_id // ""')"
+BD_OWNER="$(echo "$BD_JSON" | jq -r '.assignee // "human"')"
+BD_EXTERNAL_REF="$(echo "$BD_JSON" | jq -r '.external_ref // ""')"
+
+# Idempotency check: if external-ref points at a Jinn-Network/mono Issue, no-op.
+if [[ -n "$BD_EXTERNAL_REF" && "$BD_EXTERNAL_REF" == *"$REPO"* ]]; then
+  echo "$BD_ID already mirrored: $BD_EXTERNAL_REF"
+  exit 0
+fi
+
+# Curate the body: strip captain-only lines and "needs-design-session" framing.
+CURATED_BODY="$(echo "$BD_DESCRIPTION" | grep -v '^captain-only:' | sed '/needs-design-session/Id')"
+
+# Compose the epic label from the parent id (if present).
+EPIC_LABEL=""
+if [[ -n "$BD_PARENT" ]]; then
+  # Strip the jinn-mono- prefix and any trailing .N to get the epic short id.
+  EPIC_SHORT="$(echo "$BD_PARENT" | sed -e 's|^jinn-mono-||' -e 's|\..*$||')"
+  EPIC_LABEL="epic:$EPIC_SHORT"
+fi
+
+# Compose labels.
+LABELS="sprint:$SPRINT_DATE,agent:$BD_OWNER"
+if [[ -n "$EPIC_LABEL" ]]; then
+  LABELS="$EPIC_LABEL,$LABELS"
+fi
+if [[ -n "$EXTRA_LABELS" ]]; then
+  LABELS="$LABELS,$EXTRA_LABELS"
+fi
+
+# Compose the public Issue body.
+ISSUE_BODY="$(cat <<EOF
+$CURATED_BODY
+
+---
+Internal tracking: $BD_ID
+EOF
+)"
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "DRY RUN — would create GitHub Issue:"
+  echo "  Repo:   $REPO"
+  echo "  Title:  $BD_TITLE"
+  echo "  Labels: $LABELS"
+  echo "  Body:"
+  echo "$ISSUE_BODY" | sed 's/^/    /'
+  exit 0
+fi
+
+# Create the GitHub Issue.
+ISSUE_URL="$(gh issue create \
+  --repo "$REPO" \
+  --title "$BD_TITLE" \
+  --body "$ISSUE_BODY" \
+  --label "$LABELS")"
+
+echo "Created Issue: $ISSUE_URL"
+
+# Best-effort: add to the Project board and set Sprint field.
+# If the Project doesn't exist yet (jinn-mono-2cl.9 not landed), skip gracefully.
+PROJECT_NUMBER="$(gh project list --owner "${REPO%%/*}" --format json 2>/dev/null | \
+  jq -r --arg title "$PROJECT_TITLE" '.projects[] | select(.title == $title) | .number' | head -1 || true)"
+
+if [[ -z "$PROJECT_NUMBER" ]]; then
+  echo "note: project '$PROJECT_TITLE' not found on ${REPO%%/*} — Issue created but Project add skipped. Create the Project per jinn-mono-2cl.9."
+else
+  ITEM_ID="$(gh project item-add "$PROJECT_NUMBER" --owner "${REPO%%/*}" --url "$ISSUE_URL" --format json 2>/dev/null | jq -r '.id' || true)"
+  if [[ -n "$ITEM_ID" && "$ITEM_ID" != "null" ]]; then
+    # Set the Sprint field. Field id lookup: gh project field-list <project> --owner <owner>.
+    SPRINT_FIELD_ID="$(gh project field-list "$PROJECT_NUMBER" --owner "${REPO%%/*}" --format json 2>/dev/null | \
+      jq -r '.fields[] | select(.name == "Sprint") | .id' | head -1 || true)"
+    if [[ -n "$SPRINT_FIELD_ID" ]]; then
+      gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_NUMBER" --field-id "$SPRINT_FIELD_ID" --date "$SPRINT_DATE" 2>/dev/null \
+        || echo "note: failed to set Sprint field on Project item — manual fix needed."
+    fi
+  fi
+fi
+
+# Write the Issue URL back to bd as external-ref.
+bd update "$BD_ID" --external-ref "$ISSUE_URL" >/dev/null || \
+  echo "warning: failed to write external-ref back to $BD_ID — bd may need manual update."
+
+echo "Done: $BD_ID → $ISSUE_URL (sprint=$SPRINT_DATE)"

--- a/scripts/bd-mirror
+++ b/scripts/bd-mirror
@@ -104,7 +104,9 @@ if [[ -n "$BD_EXTERNAL_REF" && "$BD_EXTERNAL_REF" == *"$REPO"* ]]; then
 fi
 
 # Curate the body: strip captain-only lines and "needs-design-session" framing.
-CURATED_BODY="$(echo "$BD_DESCRIPTION" | grep -v '^captain-only:' | sed '/needs-design-session/Id')"
+# Use grep -iv (BSD/GNU compatible) instead of sed /I (GNU-only) so this works on
+# macOS where this script is also run manually by Captain.
+CURATED_BODY="$(echo "$BD_DESCRIPTION" | grep -v '^captain-only:' | grep -iv 'needs-design-session')"
 
 # Compose the epic label from the parent id (if present).
 EPIC_LABEL=""


### PR DESCRIPTION
## Summary

Closes jinn-mono-pgjj (Design: Engineering handbook co-design with v1 release epics).

This PR adds two artifacts:

- The engineering handbook v1 design doc — consolidates eight design threads from the pgjj brainstorm into a single spec covering cadence, sprint surface, work-shape taxonomy, AI workflow rules, and the bd restructure.
- DR-2026-05-11-b (proposed) — the substrate decision: bd remains internal SoR; GitHub Projects (v2) is the public sprint surface; sprint-scoped bd issues mirror to public GitHub Issues via a `bd-mirror` helper.

## What's in the design doc

- **Threads 1–8 locked**: GitHub Projects (v2) sprint board + sprint field + epic field; sprint-scoped bd→GH-Issue mirror (Friday cron auto-mirrors top-N priority, Captain rejects not selects); merge 9iq3.3 into 2cl.5; promote AI workflow rules 1–4 + 6–9 immediately, defer rule 5 to jnw9; gap-close via new sibling beads 2cl.6 (tag-format) + 2cl.7 (prepublishOnly hardening); weekly minor bump heuristic with Captain-overrides for epic majors; Hermes-style Monday GitHub Release draft cron; auto-mirror Release body → `cargo/client/CHANGELOG.md`; keep `canary` dist-tag (drop the rename-to-`next` proposal).
- **Process walkthrough** §The shipping machine: daily loop (orient via `eng-day` → pick → execute → ship), weekly retrace (Friday triage + Monday cut), entry point (always `bd show <id>`).
- **Work-shape taxonomy** §The shapes of work: seven shapes (`fix` / `feat` / `refactor` / `spike` / `chore` / `docs` / `test`) plus `fix(incident)` sub-flow, keyed to Conventional Commits, wired to specific skill chains + test discipline + design ceremony + stacking policy. Flows marked **v0** with an explicit §Iterative refinement of shape flows section (friction → bd under 2cl → new skill / amend skill / revise handbook).
- **bd restructure ledger**: executed in this same window — merges, edges, new children .6–.12, acceptance tightening, umbrella amendment. `jinn-mono-pgjj` closed.

## What's in the DR

DR-2026-05-11-b — Engineering substrate (proposed, paired with the design):

- bd remains internal SoR (privacy preserves exploratory framing; CLI ergonomics stay)
- GitHub Project (v2) "Jinn engineering" is the canonical sprint surface (Status board columns + Sprint date field + Epic single-select)
- `bd-mirror <bd-id> <sprint-date>` helper opens a curated public GH Issue, applies labels, adds to the Project board
- Friday triage cron auto-mirrors top-N priority bd → Captain rejects not selects
- Alternatives rejected: sunset bd; mirror every bd; Releases-only public surface; GitHub Milestones instead of Projects (each with rationale)
- Status: proposed — ratification by Captain gates promotion to ratified

## Note on DR-2026-05-11-a (Prediction freeze)

The design + DR-b cite **DR-2026-05-11-a** (`log/decisions/2026-05-11-freeze-prediction-solvernet.md`) as ratified. That DR file is present locally but **not in git yet** — it's untracked on disk and needs its own commit. The citations work in spirit but the file link is dangling until DR-a lands in a separate PR.

## Test plan

- [ ] Read the design doc end-to-end and confirm the locked picks across the eight threads match the design conversation.
- [ ] Read DR-2026-05-11-b and confirm the bd-vs-Projects boundary is clean; ratify by promoting status `proposed` → `ratified` after review.
- [ ] Verify the 2cl restructure landed: `bd show jinn-mono-2cl` should show children .1 through .12, the Amendments (2026-05-11, pgjj design) note in the umbrella body, 9iq3.3 closed as merged into 2cl.5, and the three edges (2cl.1→uy6v.2 blocks, 2cl.4→9iq3.2 blocks, 2cl.2↔uy6v.5 relates).
- [ ] Commit DR-2026-05-11-a (Prediction freeze) separately so the citations resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)