### PR TITLE
fix: purge canonical-plugin traces from operator surfaces (jinn-mono-l2zl.15.4.2)

### DIFF
--- a/client/skills/jinn-operator/SKILL.md
+++ b/client/skills/jinn-operator/SKILL.md
@@ -204,7 +204,7 @@ SolverPlugins are scoped to SolverNets, not injected globally into Harnesses:
 
 - `jinn solver-nets set-harness prediction <harness>` changes the Harness used for restoration Tasks.
 - `jinn solver-nets add-plugin prediction <source>` attaches an extra SolverPlugin to only that SolverNet.
-- `jinn solver-nets doctor prediction` validates the canonical plugin, extra plugins, schemas, and Harness wiring.
+- `jinn solver-nets doctor prediction` validates the configured runtime plugins, the schemas the SolverNet contract registry pins, and Harness wiring. Add `--human` for a readable summary instead of JSON.
 
 ### Disabling
 

--- a/client/src/cli/commands/solver-nets.ts
+++ b/client/src/cli/commands/solver-nets.ts
@@ -3,6 +3,7 @@ import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { parseArgs } from 'node:util';
 import type { CommandContext, CommandModule } from '../command.js';
+import { emitResult } from '../output.js';
 import { loadConfig } from '../../config.js';
 import { buildHarnesses } from '../../harnesses/impls/index.js';
 import { canonicalHarnessName, CLAUDE_CODE_HARNESS, harnessNameMatches } from '../../harnesses/names.js';
@@ -10,6 +11,7 @@ import { loadSolverNets } from '../../solver-nets/registry.js';
 import {
   buildPredictionOperatorStatus,
   runPredictionSample,
+  type PredictionOperatorStatus,
 } from '../../solver-nets/prediction-operator-ux.js';
 
 const DEFAULT_CONFIG_PATH = join(homedir(), '.jinn-client', 'config.json');
@@ -67,6 +69,50 @@ function sourceOf(entry: SolverPluginEntry): string {
   return typeof entry === 'string' ? entry : entry.source;
 }
 
+/**
+ * Strip legacy fields (e.g. `canonicalPlugin`, `referencePlugins`) from a
+ * persisted operator config block before display.
+ *
+ * The runtime model is layered substrate (auto-injected Network Tools +
+ * contract `defaultRuntimePlugins` + operator `plugins[]`); the single
+ * primary-plugin model was removed by jinn-mono-l2zl.14 and is no longer
+ * configurable. Operator configs written before that change may still carry
+ * `canonicalPlugin` on disk, but operators must not see it surfaced as a
+ * current concept.
+ *
+ * If a legacy `canonicalPlugin.source` is present and not already in
+ * `plugins[]`, it is promoted into `plugins[]` so display-time sanitization
+ * does not silently discard operator intent.
+ */
+const LEGACY_SOLVERNET_FIELDS = new Set(['canonicalPlugin', 'referencePlugins']);
+
+function sanitizeLegacySolverNet(raw: unknown): SolverNetConfig {
+  if (typeof raw !== 'object' || raw === null) {
+    // Malformed config slot (`null`, number, string) — emit a safe minimal
+    // shape rather than letting the bad value reach the renderer or JSON
+    // envelope. `readConfig` uses `JSON.parse` without zod, so any shape can
+    // slip through here.
+    return { solverType: 'unknown' };
+  }
+  const source = raw as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (LEGACY_SOLVERNET_FIELDS.has(key)) continue;
+    out[key] = value;
+  }
+  const legacyCanonical = source['canonicalPlugin'];
+  if (legacyCanonical && typeof legacyCanonical === 'object') {
+    const legacySource = (legacyCanonical as { source?: unknown }).source;
+    if (typeof legacySource === 'string' && legacySource.length > 0) {
+      const current = Array.isArray(out['plugins']) ? (out['plugins'] as SolverPluginEntry[]) : [];
+      if (!current.some((entry) => sourceOf(entry) === legacySource)) {
+        out['plugins'] = [...current, legacySource];
+      }
+    }
+  }
+  return out as unknown as SolverNetConfig;
+}
+
 function writeJson(ctx: CommandContext, value: unknown): void {
   ctx.writer.write(JSON.stringify(value, null, 2) + '\n');
 }
@@ -74,6 +120,68 @@ function writeJson(ctx: CommandContext, value: unknown): void {
 function fail(ctx: CommandContext, message: string): void {
   writeJson(ctx, { error: { code: 'invalid_invocation', message } });
   ctx.exit(1);
+}
+
+function emit(ctx: CommandContext, value: unknown, human: boolean, json: boolean, render: (v: unknown) => string): void {
+  emitResult(value, render, {
+    json,
+    human,
+    writer: ctx.writer,
+    stdoutIsTty: ctx.stdoutIsTty,
+    noColor: Boolean(ctx.env['NO_COLOR']),
+  });
+}
+
+function renderSolverNetHuman(value: unknown): string {
+  const v = value as { name?: string; configPath?: string; solverNet?: Partial<SolverNetConfig> };
+  const net: Partial<SolverNetConfig> = v.solverNet ?? {};
+  const plugins = (net.plugins ?? []).map((p) => sourceOf(p));
+  const lines = [
+    `SolverNet: ${v.name ?? '(unknown)'}`,
+    `  configPath: ${v.configPath ?? '(unknown)'}`,
+    `  enabled: ${net.enabled ?? '(default true)'}`,
+    `  solverType: ${net.solverType ?? '(unset)'}`,
+    `  harness: ${net.harness ?? '(default)'}`,
+    `  plugins: ${plugins.length === 0 ? '(none)' : plugins.join(', ')}`,
+    `  taskGenerator: ${net.taskGenerator?.enabled === false ? 'disabled' : 'enabled'}`,
+  ];
+  return lines.join('\n');
+}
+
+function renderPredictionStatusHuman(value: unknown): string {
+  const status = value as PredictionOperatorStatus & { verb?: string; configPath?: string };
+  const lines = [
+    `SolverNet: ${status.solverNet.name}`,
+    `  configPath: ${status.configPath}`,
+    `  enabled: ${status.solverNet.enabled}`,
+    `  solverType: ${status.solverNet.solverType}`,
+    `  roles: ${status.solverNet.roles.join(', ') || '(none)'}`,
+    `  harness: ${status.solverNet.harness ?? '(unset)'}`,
+    `  taskGenerator: ${status.solverNet.taskGeneratorEnabled ? 'enabled' : 'disabled'}`,
+    `  status: ${status.ok ? 'OK' : 'attention needed'}`,
+  ];
+  if (status.runtimePlugins.length > 0) {
+    lines.push('  runtimePlugins:');
+    for (const plugin of status.runtimePlugins) {
+      lines.push(`    - ${plugin.name ?? plugin.source ?? '(unknown)'} [${plugin.provenance}]`);
+    }
+  }
+  if (status.harness) {
+    const readiness = status.harness.readiness.ready ? 'ready' : `not ready (${status.harness.readiness.reason})`;
+    lines.push(`  harnessDetail: ${status.harness.name} v${status.harness.version} — ${readiness}`);
+  }
+  if (status.diagnostics.length > 0) {
+    lines.push('Diagnostics:');
+    for (const diagnostic of status.diagnostics) {
+      lines.push(`  ${diagnostic.severity.toUpperCase()}  ${diagnostic.code}: ${diagnostic.message}`);
+      if (diagnostic.nextAction?.cli) {
+        lines.push(`    next: ${diagnostic.nextAction.cli}`);
+      }
+    }
+  }
+  lines.push(`Next: ${status.nextAction.description}`);
+  if (status.nextAction.cli) lines.push(`  cli: ${status.nextAction.cli}`);
+  return lines.join('\n');
 }
 
 function enableArgs(rest: string[]): Record<string, string | undefined> {
@@ -101,15 +209,20 @@ const command: CommandModule = {
   name: 'solver-nets',
   summary: 'Manage SolverNet activation, Harness selection, and SolverNet-scoped plugins',
   helpText: `Usage:
-  jinn solver-nets list [--config <path>]
-  jinn solver-nets show <name> [--config <path>]
+  jinn solver-nets list [--human|--json] [--config <path>]
+  jinn solver-nets show <name> [--human|--json] [--config <path>]
   jinn solver-nets enable <name> [--harness <name>] [--config <path>]
   jinn solver-nets disable <name> [--config <path>]
   jinn solver-nets set-harness <name> <harness> [--config <path>]
   jinn solver-nets add-plugin <name> <source> [--config <path>]
   jinn solver-nets remove-plugin <name> <source-or-name> [--config <path>]
-  jinn solver-nets doctor <name> [--config <path>]
-  jinn solver-nets sample <name> [--closed-window]`,
+  jinn solver-nets doctor <name> [--human|--json] [--config <path>]
+  jinn solver-nets sample <name> [--closed-window]
+
+Output flags:
+  --human   Render readable terminal output instead of JSON (supported by
+            list, show, doctor).
+  --json    Force JSON output (the default).`,
 
   async run(ctx) {
     const [subverb, ...rest] = ctx.argv;
@@ -123,13 +236,17 @@ const command: CommandModule = {
         config: { type: 'string' },
         harness: { type: 'string' },
         'closed-window': { type: 'boolean' },
+        human: { type: 'boolean' },
+        json: { type: 'boolean' },
       },
     });
+    const human = Boolean(parsed.values['human']);
+    const json = Boolean(parsed.values['json']);
     const [name, arg2] = parsed.positionals;
 
     if (!subverb || subverb === 'list') {
       const loaded = loadConfig(configPath);
-      writeJson(ctx, {
+      const value = {
         verb: 'solver-nets list',
         configPath,
         solverNets: Object.entries(loaded.solverNets).map(([netName, net]) => ({
@@ -140,6 +257,13 @@ const command: CommandModule = {
           pluginCount: net.plugins.length,
           taskGeneratorEnabled: net.taskGenerator.enabled,
         })),
+      };
+      emit(ctx, value, human, json, (v) => {
+        const list = v as typeof value;
+        if (list.solverNets.length === 0) return 'No SolverNets configured.';
+        return list.solverNets
+          .map((n) => `${n.name}  ${n.enabled ? 'enabled' : 'disabled'}  ${n.solverType}  harness=${n.harness ?? '(default)'}  plugins=${n.pluginCount}  generator=${n.taskGeneratorEnabled ? 'on' : 'off'}`)
+          .join('\n');
       });
       return;
     }
@@ -160,7 +284,14 @@ const command: CommandModule = {
     }
 
     if (subverb === 'show') {
-      writeJson(ctx, { verb: `solver-nets ${subverb}`, configPath, name, solverNet: net });
+      const sanitized = sanitizeLegacySolverNet(net);
+      emit(
+        ctx,
+        { verb: `solver-nets ${subverb}`, configPath, name, solverNet: sanitized },
+        human,
+        json,
+        renderSolverNetHuman,
+      );
       return;
     }
 
@@ -168,10 +299,23 @@ const command: CommandModule = {
       if (net.solverType === 'prediction.v1') {
         const loaded = loadConfig(configPath);
         const status = await buildPredictionOperatorStatus({ config: loaded, configPath, name });
-        writeJson(ctx, { verb: 'solver-nets doctor', ...status });
+        emit(
+          ctx,
+          { verb: 'solver-nets doctor', ...status },
+          human,
+          json,
+          renderPredictionStatusHuman,
+        );
         return;
       }
-      writeJson(ctx, { verb: 'solver-nets doctor', configPath, name, solverNet: net });
+      const sanitized = sanitizeLegacySolverNet(net);
+      emit(
+        ctx,
+        { verb: 'solver-nets doctor', configPath, name, solverNet: sanitized },
+        human,
+        json,
+        renderSolverNetHuman,
+      );
       return;
     }
 

--- a/client/src/dashboard/spa/src/pages/configuration/PluginPicker.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/PluginPicker.tsx
@@ -55,7 +55,7 @@ function displayName(name: string): string {
   return DISPLAY_NAMES[name] ?? name;
 }
 
-function canonicalPluginName(value: string): string {
+function stripBundledPrefix(value: string): string {
   return value.startsWith(BUNDLED_PREFIX) ? value.slice(BUNDLED_PREFIX.length) : value;
 }
 
@@ -67,7 +67,7 @@ function uniquePluginValues(values: string[]): string[] {
   const seen = new Set<string>();
   const out: string[] = [];
   for (const value of values) {
-    const name = canonicalPluginName(value);
+    const name = stripBundledPrefix(value);
     if (seen.has(name)) continue;
     seen.add(name);
     out.push(value);
@@ -95,7 +95,7 @@ function buildOptions(available: CatalogPluginOption[], selected: string[]): Plu
     });
   }
   for (const value of selected) {
-    const name = canonicalPluginName(value);
+    const name = stripBundledPrefix(value);
     if (seen.has(name)) continue;
     seen.add(name);
     out.push({
@@ -126,8 +126,8 @@ export function PluginPicker({
   const [open, setOpen] = useState(false);
   const [confirmRemove, setConfirmRemove] = useState<PluginOption | null>(null);
   const options = useMemo(() => buildOptions(available, selected), [available, selected]);
-  const selectedSet = new Set(selected.map(canonicalPluginName));
-  const disabledDefaultSet = new Set(disabledDefaultPlugins.map(canonicalPluginName));
+  const selectedSet = new Set(selected.map(stripBundledPrefix));
+  const disabledDefaultSet = new Set(disabledDefaultPlugins.map(stripBundledPrefix));
   const activeSet = new Set(selectedSet);
   for (const option of options) {
     if (option.defaultIncluded && !disabledDefaultSet.has(option.name)) {
@@ -149,7 +149,7 @@ export function PluginPicker({
 
   const addOption = (option: PluginOption): void => {
     const nextDisabled = option.defaultIncluded
-      ? disabledDefaultPlugins.filter((name) => canonicalPluginName(name) !== option.name)
+      ? disabledDefaultPlugins.filter((name) => stripBundledPrefix(name) !== option.name)
       : disabledDefaultPlugins;
     const nextSelected = option.defaultIncluded
       ? selected
@@ -167,7 +167,7 @@ export function PluginPicker({
       return;
     }
     onChange(
-      selected.filter((name) => canonicalPluginName(name) !== option.name),
+      selected.filter((name) => stripBundledPrefix(name) !== option.name),
       disabledDefaultPlugins,
     );
   };

--- a/client/test/cli/commands/solver-nets.test.ts
+++ b/client/test/cli/commands/solver-nets.test.ts
@@ -499,4 +499,158 @@ describe('solver-nets command', () => {
     expect(text).not.toMatch(/start the daemon/i);
     expect(text).toMatch(/waiting for tasks/i);
   });
+
+  describe('legacy canonical-plugin config sanitization', () => {
+    it('strips canonicalPlugin and referencePlugins from solver-nets show output for legacy SolverNet entries', async () => {
+      const legacyConfig = {
+        solverNets: {
+          legacy: {
+            enabled: true,
+            solverType: 'prediction.v0',
+            harness: 'claude-code-learner',
+            canonicalPlugin: { source: 'bundled:jinn-prediction-plugin' },
+            referencePlugins: ['npm:@example/old-reference-plugin'],
+            plugins: [],
+            taskGenerator: { enabled: true },
+          },
+        },
+      };
+      const configPath = tempConfig(legacyConfig);
+      const result = await runSolverNets(['show', 'legacy', '--config', configPath]);
+
+      expect(result.exits).toEqual([]);
+      const envelope = result.envelope;
+      expect(envelope['solverNet']).not.toHaveProperty('canonicalPlugin');
+      expect(envelope['solverNet']).not.toHaveProperty('referencePlugins');
+      // Legacy source was promoted into plugins[] so display sanitization does
+      // not silently discard operator intent.
+      expect(envelope['solverNet']['plugins']).toContain('bundled:jinn-prediction-plugin');
+      // referencePlugins entries are dropped — they were never live runtime
+      // substrate and the abandoned reference-plugin concept must not surface.
+      expect(envelope['solverNet']['plugins']).not.toContain('npm:@example/old-reference-plugin');
+    });
+
+    it('returns a safe minimal shape when a SolverNet entry is malformed (not an object)', async () => {
+      const malformedConfig = {
+        solverNets: {
+          broken: 42 as unknown as object,
+        },
+      };
+      const configPath = tempConfig(malformedConfig);
+      const result = await runSolverNets(['show', 'broken', '--config', configPath]);
+
+      expect(result.exits).toEqual([]);
+      const envelope = result.envelope;
+      // Sanitizer must not emit the raw scalar — that would propagate
+      // malformed config into operator-facing surfaces.
+      expect(typeof envelope['solverNet']).toBe('object');
+      expect(envelope['solverNet']).not.toBe(null);
+    });
+
+    it('strips canonicalPlugin from solver-nets doctor output for non-prediction.v1 SolverNets', async () => {
+      const legacyConfig = {
+        solverNets: {
+          legacy: {
+            enabled: true,
+            solverType: 'prediction.v0',
+            harness: 'claude-code-learner',
+            canonicalPlugin: { source: 'bundled:jinn-prediction-plugin' },
+            referencePlugins: ['bundled:jinn-prediction-plugin'],
+            plugins: [],
+            taskGenerator: { enabled: true },
+          },
+        },
+      };
+      const configPath = tempConfig(legacyConfig);
+      const result = await runSolverNets(['doctor', 'legacy', '--config', configPath]);
+
+      expect(result.exits).toEqual([]);
+      const envelope = result.envelope;
+      expect(envelope['verb']).toBe('solver-nets doctor');
+      expect(envelope['solverNet']).not.toHaveProperty('canonicalPlugin');
+      expect(envelope['solverNet']).not.toHaveProperty('referencePlugins');
+    });
+
+    it('does not duplicate plugins when canonicalPlugin.source already appears in plugins[]', async () => {
+      const legacyConfig = {
+        solverNets: {
+          legacy: {
+            enabled: true,
+            solverType: 'prediction.v0',
+            harness: 'claude-code-learner',
+            canonicalPlugin: { source: 'bundled:jinn-prediction-plugin' },
+            plugins: ['bundled:jinn-prediction-plugin'],
+            taskGenerator: { enabled: true },
+          },
+        },
+      };
+      const configPath = tempConfig(legacyConfig);
+      const result = await runSolverNets(['show', 'legacy', '--config', configPath]);
+
+      const plugins = result.envelope['solverNet']['plugins'] as unknown[];
+      const occurrences = plugins.filter((entry) => entry === 'bundled:jinn-prediction-plugin').length;
+      expect(occurrences).toBe(1);
+    });
+  });
+
+  describe('--human output mode', () => {
+    it('solver-nets doctor --human emits readable text, not JSON, for prediction.v1', async () => {
+      const configPath = tempConfig(predictionConfig());
+      const made = makeCommandCtx({ argv: ['doctor', 'prediction', '--human', '--config', configPath] });
+      await solverNetsCommand.run(made.ctx);
+      const raw = made.writes.join('');
+
+      expect(made.exits).toEqual([]);
+      // First write must not be a JSON object header (which is what `--human`
+      // is meant to suppress per docs/runbooks operator dogfood evidence).
+      expect(raw.trim().startsWith('{')).toBe(false);
+      expect(raw).toContain('SolverNet: prediction');
+      expect(raw).toContain('solverType: prediction.v1');
+    });
+
+    it('solver-nets show --human emits readable text for arbitrary SolverNet entries', async () => {
+      const legacyConfig = {
+        solverNets: {
+          legacy: {
+            enabled: true,
+            solverType: 'prediction.v0',
+            harness: 'claude-code-learner',
+            plugins: ['bundled:jinn-prediction-plugin'],
+            taskGenerator: { enabled: true },
+          },
+        },
+      };
+      const configPath = tempConfig(legacyConfig);
+      const made = makeCommandCtx({ argv: ['show', 'legacy', '--human', '--config', configPath] });
+      await solverNetsCommand.run(made.ctx);
+      const raw = made.writes.join('');
+
+      expect(made.exits).toEqual([]);
+      expect(raw.trim().startsWith('{')).toBe(false);
+      expect(raw).toContain('SolverNet: legacy');
+      expect(raw).toContain('plugins: bundled:jinn-prediction-plugin');
+    });
+
+    it('solver-nets doctor without --human keeps JSON output (default behaviour)', async () => {
+      const configPath = tempConfig(predictionConfig());
+      const result = await runSolverNets(['doctor', 'prediction', '--config', configPath]);
+
+      expect(result.exits).toEqual([]);
+      // runSolverNets already JSON.parses the writes — proves output remains JSON.
+      expect(result.envelope['verb']).toBe('solver-nets doctor');
+    });
+
+    it('solver-nets list --human emits readable text, not JSON', async () => {
+      const configPath = tempConfig(predictionConfig());
+      const made = makeCommandCtx({ argv: ['list', '--human', '--config', configPath] });
+      await solverNetsCommand.run(made.ctx);
+      const raw = made.writes.join('');
+
+      expect(made.exits).toEqual([]);
+      // Help text advertises --human for list as well — verify it is honored.
+      expect(raw.trim().startsWith('{')).toBe(false);
+      expect(raw).toContain('prediction');
+      expect(raw).toContain('prediction.v1');
+    });
+  });
 });

--- a/docs/superpowers/plans/2026-05-02-prediction-solvernet-v1-task-lifecycle.md
+++ b/docs/superpowers/plans/2026-05-02-prediction-solvernet-v1-task-lifecycle.md
@@ -1,7 +1,7 @@
 # Prediction SolverNet v1 Task lifecycle
 
 **Date:** 2026-05-02  
-**Status:** Decision and implementation handoff  
+**Status:** Historical — superseded for the canonical-plugin sections by `spec/2026-05-01-harness-pack-architecture.md` v0.9 changelog (2026-05-04), which removed `canonicalPlugin` from the runtime model in favour of layered substrate (auto-injected Network Tools + contract `defaultRuntimePlugins` + operator `plugins[]`). The lifecycle, eligibility, generator, and scoring sections of this plan are still load-bearing for `prediction.v1`; treat references to a "canonical plugin" here as historical decision text describing the model in force on 2026-05-02 and not as current instruction. Prediction SolverNet operational launch is additionally frozen per DR-2026-05-11-a (`log/decisions/2026-05-11-freeze-prediction-solvernet.md`).  
 **Primary bead:** `jinn-mono-l2zl.1`  
 **Related beads:** `jinn-mono-l2zl`, `jinn-mono-kod`, `jinn-mono-twut`, `jinn-mono-xp33`, `jinn-mono-l2zl.2`, `jinn-mono-l2zl.3`, `jinn-mono-l2zl.4`
 
@@ -450,6 +450,8 @@ interface ResolutionSnapshot {
 ```
 
 ### 10.5 Solver-facing MCP tools
+
+> **Historical note (2026-05-04):** "Canonical plugin" wording in this section refers to the abandoned single-primary-plugin model removed by `spec/2026-05-01-harness-pack-architecture.md` v0.9. Read it as "the operator-configured prediction runtime plugin." The current model layers Network Tools (auto-injected) + contract `defaultRuntimePlugins` + operator `plugins[]`.
 
 The canonical plugin should expose task-scoped tools first:
 

--- a/spec/2026-05-01-harness-pack-architecture.md
+++ b/spec/2026-05-01-harness-pack-architecture.md
@@ -137,7 +137,7 @@ Two levels with distinct concerns; primitives at each level keep clean boundarie
 - **Level 1 is persistent.** A SolverNet is defined once and runs continuously. Its objective accumulates as Tasks resolve.
 - **Level 2 is ephemeral.** Each Task is posted, claimed, solved, scored, settled, indexed.
 - **The join key is the SolverType identifier (a string).** The IPFS Task payload carries top-level `solverType`; the daemon looks up the contract by that key, validates `task.spec` against the contract's schemas, and dispatches to the SolverNet's Harness (or operator-overridden Harness via `bySolverType`).
-- **Plugins are layered, not unique-per-SolverNet.** Network Tools is auto-injected. Contract `defaultRuntimePlugins` come next. Operator-configured plugins come last. De-dup by source and by name. No "one canonical plugin" lock-in — substrate composes.
+- **Plugins are layered, not unique-per-SolverNet.** Network Tools is auto-injected. Contract `defaultRuntimePlugins` come next. Operator-configured plugins come last. De-dup by source and by name. Substrate composes; no single primary-plugin slot.
 - **SolverPlugin and Harness are independent.** Plugin ships substrate; Harness owns the runtime (flow, improve-phase, tunables).
 
 The clean separation: **SolverNet contract registry supplies *shape and protocol authority*; SolverPlugin supplies *substrate (tools + skills)*; Harness supplies *how to actually run it*; SolverNet config supplies *what we're trying to improve and which substrate to add*; Task supplies *the specific thing to solve right now*.**
@@ -162,7 +162,7 @@ A SolverNet is a composition pattern declared in operator config:
 }
 ```
 
-The SolverType-level data the operator does not see in this config — the schemas, evaluator, aggregation function, and default substrate — is fixed by the SolverNet contract registry (§5.6). The operator does not declare schemas or a "canonical plugin"; the contract owns those, and the daemon auto-resolves `defaultRuntimePlugins` plus the auto-injected Network Tools plugin. The operator's `plugins[]` array adds substrate on top.
+The SolverType-level data the operator does not see in this config — the schemas, evaluator, aggregation function, and default substrate — is fixed by the SolverNet contract registry (§5.6). The operator does not declare schemas; the contract owns them, and the daemon auto-resolves `defaultRuntimePlugins` plus the auto-injected Network Tools plugin. The operator's `plugins[]` array adds substrate on top.
 
 A SolverNet is **not a protocol object**. JinnRouter doesn't know about SolverNets; it knows about Tasks with `solverType` identifiers. The SolverNet is operator-side coordination — the way a daemon decides "for a Task whose `solverType` matches a SolverNet I have enabled, here is the substrate (contract defaults + auto-injected runtime + my configured extras), the Harness to start with, and the Objective to roll the verdict score into."
 


### PR DESCRIPTION
## Summary

Closes the operator-facing cleanup half of the abandoned canonical-plugin model. The runtime was removed in `jinn-mono-l2zl.14`; this PR finishes the dogfood-discovered user-facing and documentation tail (`jinn-mono-l2zl.15.4.2`).

- `solver-nets list|show|doctor` now sanitize legacy persisted-config fields (`canonicalPlugin`, `referencePlugins`) before display; a legacy `canonicalPlugin.source` is silently promoted into `plugins[]` so operator intent isn't lost. Malformed config slots fall back to a safe minimal shape.
- `solver-nets list|show|doctor` honor `--human` for readable terminal output; default JSON behaviour preserved.
- SPA `PluginPicker` helper renamed `canonicalPluginName` → `stripBundledPrefix` (collided with banned terminology; was internal-only).
- `client/skills/jinn-operator/SKILL.md`, `spec/2026-05-01-harness-pack-architecture.md`, and `docs/superpowers/plans/2026-05-02-prediction-solvernet-v1-task-lifecycle.md` updated to drop in-body canonical-plugin wording. Historical changelog / explicitly-marked-historical sections are preserved per the bd acceptance criteria.

## Verification

- `yarn typecheck` clean
- SPA `tsc -b` clean
- `client/test/cli/commands/solver-nets.test.ts` — 27/27 pass (19 existing + 8 new)
- Final repo grep: only allowed references remain (v0.9 changelog line, historical-marked plan doc, sanitizer impl/comments)

## Test plan

- [x] `yarn typecheck`
- [x] `npx vitest run test/cli/commands/solver-nets.test.ts`
- [x] SPA `tsc -b`
- [x] Repo grep — `rg 'canonicalPlugin|canonical[- _]plugin|referencePlugins'` returns only allowed historical / impl references
- [ ] Reviewer to verify the bd's "silently migrated or sanitized to runtime plugins before display" criterion is met by display-time sanitization (no disk migration; documented in commit body)

bd: `jinn-mono-l2zl.15.4.2`
Parent epic: `jinn-mono-uy6v` (First public release — SWE-rebench v2 donation flow on Base Sepolia)
Work shape: `fix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)