### PR TITLE
fix(2cl.13): correct bd JSON field references in bd-mirror

### DIFF
--- a/scripts/bd-mirror
+++ b/scripts/bd-mirror
@@ -29,8 +29,15 @@
 # - gh (GitHub CLI) authenticated with project scope (`gh auth refresh -s project`).
 # - jq.
 #
-# Status: v0. The Project board (jinn-mono-2cl.9) must exist for the Project-add steps to
-# succeed; until then this script falls back to "Issue created, Project add skipped" mode.
+# Status: v0.1. The Project board (jinn-mono-2cl.9) exists as of 2026-05-11
+# (https://github.com/orgs/Jinn-Network/projects/1). The Project-add steps will succeed when
+# the gh CLI token has the `project` scope; otherwise this script falls back to
+# "Issue created, Project add skipped" mode.
+#
+# Changelog:
+# - v0.1 (jinn-mono-2cl.13, 2026-05-11): fix bd JSON parsing — `bd show --json` returns an array
+#   not a bare object (index with .[0]); `.parent` not `.parent_id`; fall back through
+#   .assignee → .owner → "human" for the agent: label.
 
 set -euo pipefail
 
@@ -85,16 +92,25 @@ if ! [[ "$SPRINT_DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
 fi
 
 # Read the bd issue.
-if ! BD_JSON="$(bd show "$BD_ID" --json 2>/dev/null)"; then
+# Note: `bd show --json` returns a JSON ARRAY of one element, not a bare object.
+# Use jq's `.[0]` to extract the single element before reading fields.
+if ! BD_JSON="$(bd show "$BD_ID" --json 2>/dev/null | jq '.[0]')"; then
   echo "error: bd show $BD_ID failed — does the bead exist?" >&2
   exit 1
 fi
+if [[ -z "$BD_JSON" || "$BD_JSON" == "null" ]]; then
+  echo "error: bd show $BD_ID returned no data — does the bead exist?" >&2
+  exit 1
+fi
 
-BD_TITLE="$(echo "$BD_JSON" | jq -r '.title')"
+BD_TITLE="$(echo "$BD_JSON" | jq -r '.title // ""')"
 BD_DESCRIPTION="$(echo "$BD_JSON" | jq -r '.description // ""')"
-BD_PRIORITY="$(echo "$BD_JSON" | jq -r '.priority // "P2"')"
-BD_PARENT="$(echo "$BD_JSON" | jq -r '.parent_id // ""')"
-BD_OWNER="$(echo "$BD_JSON" | jq -r '.assignee // "human"')"
+BD_PRIORITY="$(echo "$BD_JSON" | jq -r '.priority // 2')"
+# Parent is the top-level `.parent` field (not `.parent_id`). It's null on epics/orphans.
+BD_PARENT="$(echo "$BD_JSON" | jq -r '.parent // ""')"
+# `.assignee` is set by `bd update <id> --claim` and bd's CLI flows; falls back to the legacy
+# email-shaped `.owner` and finally to "human" so the agent: label always has a value.
+BD_OWNER="$(echo "$BD_JSON" | jq -r '.assignee // .owner // "human"')"
 BD_EXTERNAL_REF="$(echo "$BD_JSON" | jq -r '.external_ref // ""')"
 
 # Idempotency check: if external-ref points at a Jinn-Network/mono Issue, no-op.

--- a/scripts/bd-mirror
+++ b/scripts/bd-mirror
@@ -110,7 +110,9 @@ BD_PRIORITY="$(echo "$BD_JSON" | jq -r '.priority // 2')"
 BD_PARENT="$(echo "$BD_JSON" | jq -r '.parent // ""')"
 # `.assignee` is set by `bd update <id> --claim` and bd's CLI flows; falls back to the legacy
 # email-shaped `.owner` and finally to "human" so the agent: label always has a value.
-BD_OWNER="$(echo "$BD_JSON" | jq -r '.assignee // .owner // "human"')"
+# Note: jq's `//` only triggers on null/false, not empty strings. Some bd versions may emit
+# `""` for unset string fields; the explicit filter handles both `null` and `""`.
+BD_OWNER="$(echo "$BD_JSON" | jq -r '[.assignee, .owner, "human"] | map(select(. != null and . != "")) | .[0]')"
 BD_EXTERNAL_REF="$(echo "$BD_JSON" | jq -r '.external_ref // ""')"
 
 # Idempotency check: if external-ref points at a Jinn-Network/mono Issue, no-op.


### PR DESCRIPTION
## Summary

Closes jinn-mono-2cl.13. Bug-fix per the handbook's iterative-refinement loop — friction surfaced when running `scripts/bd-mirror` against real bd JSON for the first time after PR #128 merged. Shape: `fix` / `chore` (small focused bug fix in a script).

The v0 script (shipped via jinn-mono-2cl.12 in PR #128) was written before testing against real bd JSON output and contained three field-shape errors. This PR corrects them. Verified end-to-end against `jinn-mono-2cl.13` with `--dry-run`.

## Linked bd

Closes jinn-mono-2cl.13.

## Test plan

Manual verification in the worktree:

- `--dry-run` against `jinn-mono-2cl.13` — title, description, labels (`epic:2cl,sprint:2026-05-18,agent:opus`), body footer all correct.
- Idempotency: setting `.external_ref` and re-running yields `jinn-mono-2cl.13 already mirrored: <url>` and exits 0 without creating a duplicate Issue.
- Edge: passing a non-existent bd id yields a clean error and exit 1.

## Agent identity

AI-authored (Claude Opus 4.7). Co-Authored-By trailer in the commit.

## Fixes

1. **JSON array vs object.** `bd show <id> --json` returns a JSON array, not a bare object. The original jq queries operated on the array and returned `null` for every field. Now extracts the first element with `jq '.[0]'` and validates the result is non-null.

2. **`.parent_id` → `.parent`.** The parent reference is the top-level `.parent` field (which is `null` on epics / orphans). The original `.parent_id` doesn't exist.

3. **Assignee fallback chain.** `.assignee → .owner → "human"`. `.assignee` is set by `bd update <id> --claim`; `.owner` is the email-shaped legacy field used for older beads that pre-date assignee.

## Non-changes (reviewer of PR #128 was incorrect about these)

- `bd update --external-ref` IS supported (verified via `bd update --help`). The script's idempotency mechanism reads `.external_ref` and writes via that flag.
- `.external_ref` IS a top-level field in bd's JSON output (returns `null` when unset, not missing).

## Side effect

Retroactively set `external_ref` on `jinn-mono-2cl` → https://github.com/Jinn-Network/mono/issues/130 (the manually-mirrored umbrella from earlier today) so future `bd-mirror` runs are no-ops on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)