### PR TITLE
chore(2cl.6): dual-tag releases with v2026.MM.DD alongside v<semver>

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -66,6 +66,12 @@ jobs:
                 ;;
               v*)
                 PUBLISH_VERSION="${RELEASE_TAG#v}"
+                # Guard against `v<garbage>` tags slipping through the `startsWith(v)` filter
+                # in the job-level `if:` (e.g. `vbeta`, `v-foo`). Require semver-shaped suffix.
+                if ! [[ "${PUBLISH_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+                  echo "::error::Release tag ${RELEASE_TAG} does not look like v<semver>; got version: ${PUBLISH_VERSION}"
+                  exit 1
+                fi
                 ;;
               *)
                 echo "::error::Stable client releases must use tags shaped like v<semver> or client-v<semver>"
@@ -112,10 +118,17 @@ jobs:
 
       # Dual-tag policy (jinn-mono-2cl.6, per the engineering handbook §Cadence): the published
       # release commit also receives a v2026.MM.DD date tag for human-readable build identification
-      # alongside the v<semver> tag that triggered this publish. Idempotent: if the date tag already
-      # exists (workflow re-run on the same release), the step is a no-op.
+      # alongside the v<semver> tag that triggered this publish.
+      #
+      # Scoped to `v*` tags only (the new format from the Monday scaffold workflow). Legacy
+      # `client-v*` releases are manual/pre-cadence and do not get a date tag — the dual-tag
+      # policy is intentionally part of the new cadence, not retrofitted.
+      #
+      # Idempotent: if the date tag already exists pointing at the same SHA, the step is a no-op.
+      # If it exists at a different SHA (two named releases on the same calendar day), the step
+      # errors and asks for manual reconciliation.
       - name: Create v2026.MM.DD date tag
-        if: steps.meta.outputs.dist_tag == 'latest'
+        if: steps.meta.outputs.dist_tag == 'latest' && startsWith(github.event.release.tag_name, 'v')
         working-directory: ${{ github.workspace }}
         shell: bash
         env:
@@ -126,8 +139,14 @@ jobs:
           # Use leading-zero %Y.%m.%d so May 18 is v2026.05.18, not v2026.5.18.
           DATE_TAG="$(date -u -d "$PUBLISHED_AT" +"v%Y.%m.%d")"
 
+          # actions/checkout@v5 does a shallow clone and may not have fetched the just-created
+          # release tag into refs/tags/. Fetch it explicitly before resolving.
+          git fetch --tags --depth=1 origin "${RELEASE_TAG}"
+
           # Resolve the SHA the release points at. The release event sets tag_name on the published
           # release, so the v<semver> tag was just created. We tag the same SHA with the date tag.
+          # `^{commit}` peels annotated tags (gh release create creates lightweight tags by default,
+          # but this is safe either way).
           SHA="$(git rev-parse "${RELEASE_TAG}^{commit}")"
 
           if git rev-parse --verify --quiet "refs/tags/${DATE_TAG}" >/dev/null; then

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,7 +10,10 @@ on:
 # Trusted publishing (OIDC): register this single workflow on npmjs for
 # @jinn-network/client. npm allows one trusted publisher config per package.
 permissions:
-  contents: read
+  # contents: write is required for the dual-tag step (jinn-mono-2cl.6) which creates
+  # and pushes the v2026.MM.DD date tag alongside the v<semver> tag. id-token: write
+  # remains for npm trusted publishing OIDC.
+  contents: write
   id-token: write
 
 defaults:
@@ -20,7 +23,7 @@ defaults:
 jobs:
   publish:
     name: Publish package
-    if: github.event_name == 'push' || startsWith(github.event.release.tag_name, 'client-v')
+    if: github.event_name == 'push' || startsWith(github.event.release.tag_name, 'client-v') || startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
     environment: npm-publish
     env:
@@ -52,12 +55,20 @@ jobs:
             DIST_TAG="canary"
           else
             RELEASE_TAG="${{ github.event.release.tag_name }}"
+            # Two accepted tag formats per the engineering handbook §Cadence:
+            # - v<semver>    (new format, used by the Monday scaffold workflow — jinn-mono-2cl.2)
+            # - client-v<semver>  (legacy format, kept for backwards-compatibility)
+            # The companion v2026.MM.DD date tag (jinn-mono-2cl.6) is created in a separate
+            # step after publish — it is NOT used as the npm-publish trigger.
             case "${RELEASE_TAG}" in
               client-v*)
                 PUBLISH_VERSION="${RELEASE_TAG#client-v}"
                 ;;
+              v*)
+                PUBLISH_VERSION="${RELEASE_TAG#v}"
+                ;;
               *)
-                echo "::error::Stable client releases must use tags shaped like client-vX.Y.Z"
+                echo "::error::Stable client releases must use tags shaped like v<semver> or client-v<semver>"
                 exit 1
                 ;;
             esac
@@ -98,3 +109,43 @@ jobs:
         run: |
           unset NODE_AUTH_TOKEN
           npm publish --access public
+
+      # Dual-tag policy (jinn-mono-2cl.6, per the engineering handbook §Cadence): the published
+      # release commit also receives a v2026.MM.DD date tag for human-readable build identification
+      # alongside the v<semver> tag that triggered this publish. Idempotent: if the date tag already
+      # exists (workflow re-run on the same release), the step is a no-op.
+      - name: Create v2026.MM.DD date tag
+        if: steps.meta.outputs.dist_tag == 'latest'
+        working-directory: ${{ github.workspace }}
+        shell: bash
+        env:
+          PUBLISHED_AT: ${{ github.event.release.published_at }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          # Format the date from the release's published_at (ISO 8601 from GitHub).
+          # Use leading-zero %Y.%m.%d so May 18 is v2026.05.18, not v2026.5.18.
+          DATE_TAG="$(date -u -d "$PUBLISHED_AT" +"v%Y.%m.%d")"
+
+          # Resolve the SHA the release points at. The release event sets tag_name on the published
+          # release, so the v<semver> tag was just created. We tag the same SHA with the date tag.
+          SHA="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+
+          if git rev-parse --verify --quiet "refs/tags/${DATE_TAG}" >/dev/null; then
+            EXISTING_SHA="$(git rev-parse "${DATE_TAG}^{commit}")"
+            if [ "${EXISTING_SHA}" = "${SHA}" ]; then
+              echo "::notice::date tag ${DATE_TAG} already exists at the same SHA (${SHA}); no-op"
+              exit 0
+            else
+              echo "::error::date tag ${DATE_TAG} already exists but points at ${EXISTING_SHA}, not ${SHA}. Manual reconciliation required (likely two named releases on the same calendar day)."
+              exit 1
+            fi
+          fi
+
+          # Configure git identity for the tag push. Use github-actions[bot] so the tag is
+          # attributed to CI, not a human.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag "${DATE_TAG}" "${SHA}"
+          git push origin "${DATE_TAG}"
+          echo "::notice::Created date tag ${DATE_TAG} pointing at ${SHA} (alongside ${RELEASE_TAG})"


### PR DESCRIPTION
## Summary

Closes jinn-mono-2cl.6. Shape: `chore` (CI workflow change). Implements the dual-tag policy from the engineering handbook §Cadence.

## Linked bd

Closes jinn-mono-2cl.6.

## What changes

Single file: `.github/workflows/npm-publish.yml`.

- **Job `if:` accepts `v*`** in addition to `client-v*`. The Monday scaffold workflow (jinn-mono-2cl.2) creates draft Releases with tag `v<semver>`; previously the publish job would skip those tags entirely. Both formats now fire publish.
- **Tag-format `case` statement** parses both `v<semver>` and legacy `client-v<semver>` into a clean semver for the npm publish step.
- **New step `Create v2026.MM.DD date tag`** runs after Publish stable. Formats the date from `github.event.release.published_at`; creates a new tag pointing at the same SHA as the `v<semver>` tag; pushes via `github-actions[bot]` identity. Idempotent on workflow re-runs.
- **Permissions**: `contents: write` (was `read`) so the tag push is authorized. `id-token: write` retained for npm trusted publishing OIDC.

## Test plan

- [ ] Trigger the Monday scaffold manually (`gh workflow run "Monday release-notes scaffold"`) → produces a draft Release with tag `v0.4.0`.
- [ ] Captain edits + publishes the draft → fires `release: published` event.
- [ ] `npm-publish.yml` runs; `Resolve publish metadata` parses `v0.4.0` → `PUBLISH_VERSION=0.4.0`. Existing publish flow proceeds.
- [ ] `Create v2026.MM.DD date tag` step computes `v2026.05.MM` from the publish date and pushes the tag.
- [ ] Verify both tags resolve to the same SHA: `git fetch && git rev-parse v0.4.0 && git rev-parse v2026.05.MM` should print the same SHA twice.

## Agent identity

AI-authored (Claude Opus 4.7). Co-Authored-By trailer.

## Non-changes

- The canary (push to main) publish path is unchanged.
- The `client-v*` legacy tag format continues to work for any existing release scripts that produce it.
- No package.json or test changes.

## Sanity-checked

Date format simulation in Python (matches GNU `date -u -d "..." +"v%Y.%m.%d"` on the Ubuntu runner):

```
Input:  2026-05-18T09:00:00Z
Output: v2026.05.18
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)