### PR TITLE
discovery: DiscoveryAPI interface + OnchainDiscoveryAPI floor + callsite migration

### DIFF
--- a/client/src/adapters/mech/adapter.ts
+++ b/client/src/adapters/mech/adapter.ts
@@ -46,9 +46,8 @@ import {
 import { type MechAdapterConfig } from './types.js';
 import {
   manifestDigestForCid,
-  queryClaimableTaskCandidates,
-  type SubgraphTaskCandidate,
 } from './task-subgraph.js';
+import type { DiscoveryAPI } from '../../discovery/types.js';
 import type { Store } from '../../store/store.js';
 import { withRecoverableRetry } from '../../tx-retry.js';
 import { formatRpcError } from '../../rpc-error-context.js';
@@ -544,23 +543,27 @@ export class MechAdapter implements ExecutionAdapter {
 
   private async *discoverSubgraphRestorationTasks(): AsyncIterable<TaskAnnouncement> {
     const discovery = this.config.taskDiscovery;
-    const subgraphUrl = discovery?.subgraphUrl;
+    const discoveryApi: DiscoveryAPI | undefined = discovery?.discoveryApi;
     const solverNetManifestCids = discovery?.solverNetManifestCids ?? [];
-    if (!subgraphUrl || solverNetManifestCids.length === 0) return;
 
-    let candidates: SubgraphTaskCandidate[];
+    // Without a DiscoveryAPI or SolverNet manifest CIDs there is nothing to
+    // discover via this path. The legacy subgraphUrl is handled in config.ts
+    // normalization (mapped to discovery: { mode: 'http-subgraph', ... }) and
+    // the resulting DiscoveryAPI is injected here. Direct subgraph calls are
+    // no longer supported from this method.
+    if (!discoveryApi || solverNetManifestCids.length === 0) return;
+
+    let candidates;
     try {
-      candidates = await queryClaimableTaskCandidates({
-        url: subgraphUrl,
+      candidates = await discoveryApi.findClaimableTasks({
         solverNetManifestCids,
         operatorAddress: this.config.safeAddress,
-        pageSize: discovery.pageSize,
-        maxPages: discovery.maxPages,
-        fetchImpl: discovery.fetchImpl,
+        pageSize: discovery?.pageSize,
+        maxPages: discovery?.maxPages,
       });
     } catch (err) {
       console.error(
-        '[mech] task subgraph discovery failed:',
+        '[mech] task discovery (DiscoveryAPI) failed:',
         err instanceof Error ? err.message : err,
       );
       return;
@@ -570,6 +573,11 @@ export class MechAdapter implements ExecutionAdapter {
       if (!this.isDiscoveryTaskAllowed(candidate.taskId)) continue;
       if (this.claimedRestorationTaskIds.has(candidate.taskId)) continue;
 
+      // Verify claimability per backend: HttpSubgraphDiscoveryAPI cannot run
+      // canClaimTask (no on-chain simulation), so this check is load-bearing
+      // for that path. OnchainDiscoveryAPI already filters internally; this
+      // is redundant there. TODO: add a DiscoveryAPI capability flag so the
+      // onchain path can skip the extra simulateContract round-trip.
       const claimable = await canClaimTask(
         this.publicClient,
         this.config.safeAddress,

--- a/client/src/adapters/mech/types.ts
+++ b/client/src/adapters/mech/types.ts
@@ -1,4 +1,5 @@
 import type { Address, WalletClient } from 'viem';
+import type { DiscoveryAPI } from '../../discovery/types.js';
 
 export interface EvictionRecoveryConfig {
   serviceId: number;
@@ -24,6 +25,14 @@ export interface MechAdapterConfig {
    * the adapter still verifies claimability on-chain before yielding work.
    */
   taskDiscovery?: {
+    /**
+     * DiscoveryAPI instance for finding claimable tasks. When provided,
+     * replaces direct subgraph calls in discoverSubgraphRestorationTasks.
+     * If absent but subgraphUrl is set, a deprecation warning is emitted and
+     * the legacy direct-subgraph path is used (via the injected discovery API).
+     */
+    discoveryApi?: DiscoveryAPI;
+    /** @deprecated Pass discoveryApi instead. Legacy: direct subgraph URL. */
     subgraphUrl?: string;
     solverNetManifestCids?: string[];
     /**

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -150,6 +150,37 @@ export const JinnConfigSchema = z.object({
   subgraphUrl: z.string().optional(),
 
   /**
+   * Discovery backend configuration.
+   *
+   * Spec: spec/2026-05-11-discovery-api-and-shared-indexer.md §9.1.
+   *
+   * mode:
+   *   'http'           — HTTP client pointing at a shared indexer (default per spec §4, but
+   *                      requires 280n.4's HttpDiscoveryAPI — throws at boot until that ships).
+   *   'http-subgraph'  — transitional: wraps the existing hosted The Graph subgraph behind
+   *                      the DiscoveryAPI interface (ships with 280n.3). Removed in 280n.6.
+   *   'embedded'       — embedded Ponder in-process (ships in 280n.5 — throws until then).
+   *   'onchain'        — direct RPC getLogs; always-live floor; no indexer required.
+   *
+   * TODO(280n.4): flip default to 'http' once HttpDiscoveryAPI lands and a
+   * default URL is configured.
+   *
+   * Env overrides: JINN_DISCOVERY_MODE, JINN_DISCOVERY_URL,
+   * JINN_DISCOVERY_FALLBACK (1|true|yes to enable, 0|false|no to disable).
+   *
+   * Legacy `subgraphUrl` is accepted with a deprecation warning and maps to
+   * mode: 'http-subgraph' automatically. The mapping happens at loadConfig
+   * normalisation time, not at the type level.
+   */
+  discovery: z
+    .object({
+      mode: z.enum(['http', 'http-subgraph', 'embedded', 'onchain']).optional(),
+      url: z.string().optional(),
+      fallbackToOnchain: z.boolean().optional(),
+    })
+    .optional(),
+
+  /**
    * Narrow task discovery to specific on-chain task ids. This is primarily
    * for live acceptance gates that must avoid claiming unrelated public
    * backlog while proving one fresh task path.
@@ -703,6 +734,23 @@ export function loadConfig(configPath?: string): JinnConfig {
   if (env['JINN_RUNTIME_MODE'])      merged.runtimeMode = env['JINN_RUNTIME_MODE'];
   if (env['JINN_PEERS'])             merged.peers = env['JINN_PEERS'];
   if (env['JINN_SUBGRAPH_URL'])      merged.subgraphUrl = env['JINN_SUBGRAPH_URL'];
+
+  // Discovery block env overrides
+  if (env['JINN_DISCOVERY_MODE'] || env['JINN_DISCOVERY_URL'] || env['JINN_DISCOVERY_FALLBACK'] !== undefined) {
+    const prevDiscovery = typeof merged['discovery'] === 'object' && merged['discovery'] !== null
+      ? (merged['discovery'] as Record<string, unknown>)
+      : {};
+    const fallbackRaw = env['JINN_DISCOVERY_FALLBACK'];
+    const fallbackToOnchain = fallbackRaw !== undefined
+      ? !(['0', 'false', 'no'].includes(fallbackRaw.trim().toLowerCase()))
+      : undefined;
+    merged['discovery'] = {
+      ...prevDiscovery,
+      ...(env['JINN_DISCOVERY_MODE'] ? { mode: env['JINN_DISCOVERY_MODE'] } : {}),
+      ...(env['JINN_DISCOVERY_URL'] ? { url: env['JINN_DISCOVERY_URL'] } : {}),
+      ...(fallbackToOnchain !== undefined ? { fallbackToOnchain } : {}),
+    };
+  }
   if (env['JINN_NODE_ENDPOINT'])     merged.nodeEndpoint = env['JINN_NODE_ENDPOINT'];
   if (env['JINN_IPFS_REGISTRY_URL']) merged.ipfsRegistryUrl = env['JINN_IPFS_REGISTRY_URL'];
   if (env['JINN_IPFS_GATEWAY_URL'])  merged.ipfsGatewayUrl = env['JINN_IPFS_GATEWAY_URL'];
@@ -823,6 +871,28 @@ export function loadConfig(configPath?: string): JinnConfig {
   const resolvedNetwork = merged.network === 'testnet' ? 'testnet' : 'mainnet';
   if (resolvedNetwork === 'testnet' && merged.subgraphUrl === undefined) {
     merged.subgraphUrl = DEFAULT_TESTNET_SUBGRAPH_URL;
+  }
+
+  // Legacy `subgraphUrl` → `discovery` normalization.
+  // When `subgraphUrl` is set but `discovery` has no explicit mode, map it
+  // to http-subgraph with a deprecation warning.
+  //
+  // TODO(280n.6): remove this block when subgraphUrl is retired.
+  const hasSubgraphUrl = typeof merged.subgraphUrl === 'string' && (merged.subgraphUrl as string).trim().length > 0;
+  const discoveryBlock = typeof merged['discovery'] === 'object' && merged['discovery'] !== null
+    ? (merged['discovery'] as { mode?: string; url?: string; fallbackToOnchain?: boolean })
+    : null;
+  if (hasSubgraphUrl && (!discoveryBlock || !discoveryBlock.mode)) {
+    console.warn(
+      '[config] subgraphUrl is deprecated. Mapping to discovery: { mode: "http-subgraph", url: <subgraphUrl> }. ' +
+      'Migrate to discovery.mode in your config file. The hosted subgraph will be removed in 280n.6.',
+    );
+    merged['discovery'] = {
+      ...(discoveryBlock ?? {}),
+      mode: 'http-subgraph',
+      url: merged.subgraphUrl as string,
+      fallbackToOnchain: discoveryBlock?.fallbackToOnchain ?? true,
+    };
   }
 
   // Keep the legacy BASE_RPC_URL override for Base mainnet only. Testnet must

--- a/client/src/corpus/index.ts
+++ b/client/src/corpus/index.ts
@@ -73,6 +73,31 @@ export function createCorpus(opts: CorpusOptions, deps: InternalDeps = {}): Corp
   const acquireFn = deps.acquireFn;
 
   async function query(q: CorpusQuery): Promise<EnvelopeRef[]> {
+    // When a DiscoveryAPI is injected, delegate entirely — the corpus library
+    // no longer owns the subgraph-vs-onchain split. The DiscoveryAPI handles
+    // the split internally (primary + fallback via withFallback).
+    if (opts.discovery) {
+      try {
+        const refs = await opts.discovery.queryEnvelopes(q);
+        const deduped = new Map<string, EnvelopeRef>();
+        for (const ref of refs) {
+          if (!deduped.has(ref.manifestCid)) deduped.set(ref.manifestCid, ref);
+        }
+        return [...deduped.values()];
+      } catch (err) {
+        throw new Error(`corpus query failed (discovery): ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    // Legacy path: subgraphUrl and/or onchain options. TODO(jinn-mono-280n.6):
+    // remove this branch once subgraphUrl is retired and all callers pass
+    // opts.discovery.
+    if (opts.subgraphUrl) {
+      console.warn(
+        '[corpus] opts.subgraphUrl is deprecated. Pass a DiscoveryAPI via opts.discovery instead.',
+      );
+    }
+
     const refs: EnvelopeRef[] = [];
     const warnings: string[] = [];
     let successfulSources = 0;

--- a/client/src/corpus/types.ts
+++ b/client/src/corpus/types.ts
@@ -9,6 +9,7 @@ import type { Store } from '../store/store.js';
 import type { ArtifactSource, EvidenceTier, Role, SignedEnvelope } from '../types/envelope.js';
 
 export interface CorpusOptions {
+  /** @deprecated Use `discovery` instead. Legacy subgraph URL for corpus queries. */
   subgraphUrl?: string;
   ipfsGatewayUrl: string;
   store: Store;
@@ -16,6 +17,17 @@ export interface CorpusOptions {
   selfSafeAddress: string;
   routeResolver?: RouteResolver;
   onchain?: import('./onchain-query.js').OnchainCorpusQueryOptions;
+  /**
+   * DiscoveryAPI instance for envelope queries. When provided, replaces both
+   * the legacy `subgraphUrl` subgraph path and the `onchain` path — the corpus
+   * library delegates queryEnvelopes to the DiscoveryAPI and no longer owns
+   * the subgraph-vs-onchain split internally.
+   *
+   * When both `discovery` and `subgraphUrl`/`onchain` are set, `discovery`
+   * takes precedence. The legacy paths are still honoured when absent for
+   * backwards compatibility.
+   */
+  discovery?: import('../discovery/types.js').DiscoveryAPI;
 }
 
 export interface CorpusQuery {

--- a/client/src/discovery/factory.ts
+++ b/client/src/discovery/factory.ts
@@ -1,0 +1,136 @@
+/**
+ * createDiscoveryAPI factory — builds a DiscoveryAPI from the daemon config.
+ *
+ * Selects the primary implementation per config.discovery.mode, always builds
+ * an OnchainDiscoveryAPI floor, and returns a withFallback composition when
+ * fallbackToOnchain is true (the default).
+ *
+ * Spec: spec/2026-05-11-discovery-api-and-shared-indexer.md §9.1–9.2.
+ */
+
+import type { DiscoveryAPI } from './types.js';
+import { withFallback } from './with-fallback.js';
+import { createOnchainDiscoveryAPI } from './onchain.js';
+import { createHttpSubgraphDiscoveryAPI } from './http-subgraph.js';
+import type { SubgraphClient } from '../solvernets/registry-client-erc8004.js';
+
+// ── Deps bag ──────────────────────────────────────────────────────────────────
+
+/**
+ * Runtime deps required by the implementations. The factory extracts what it
+ * needs per mode — unknown fields are silently ignored.
+ */
+export interface DiscoveryFactoryDeps {
+  /** RPC endpoint URL for the on-chain floor. */
+  rpcUrl?: string;
+  /** Chain ID (8453 = Base mainnet, 84532 = Base Sepolia). */
+  chainId: number;
+  /** JinnRouter proxy address — required by the on-chain floor for findClaimableTasks. */
+  routerAddress?: `0x${string}`;
+  /** IdentityRegistry address — required by the on-chain floor for SolverNet / envelope queries. */
+  identityRegistryAddress?: `0x${string}`;
+  /** Operator Safe multisig address — required by the on-chain floor for canClaimTask simulation. */
+  safeAddress?: `0x${string}`;
+  /** Operator mech contract address — required by the on-chain floor for canClaimTask simulation. */
+  mechAddress?: `0x${string}`;
+  /** Lower bound block for on-chain scans. */
+  taskDiscoveryFromBlock?: bigint | number;
+  /**
+   * Subgraph client for SolverNet manifest events — required when mode is
+   * 'http-subgraph'. Injected here so callers control the instance lifecycle
+   * and tests can provide a stub.
+   */
+  subgraphClient?: SubgraphClient;
+  /** Fetch implementation (for testability). Defaults to globalThis.fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+// ── Discovery config type (mirrors config.ts) ─────────────────────────────────
+
+export interface DiscoveryConfig {
+  mode?: 'http' | 'http-subgraph' | 'embedded' | 'onchain';
+  url?: string;
+  fallbackToOnchain?: boolean;
+}
+
+// ── Factory ───────────────────────────────────────────────────────────────────
+
+/**
+ * Build a DiscoveryAPI from the daemon's discovery config block.
+ *
+ * Modes:
+ *   - 'onchain'       → returns the floor alone (no fallback needed)
+ *   - 'http-subgraph' → wraps the transitional subgraph adapter with the floor
+ *   - 'http'          → not yet shipped (280n.4); throws at boot
+ *   - 'embedded'      → not yet shipped (280n.5); throws at boot
+ *
+ * When `fallbackToOnchain` is true (default), the primary is wrapped in
+ * withFallback(primary, floor). When false, the primary is returned directly.
+ */
+export function createDiscoveryAPI(
+  config: DiscoveryConfig,
+  deps: DiscoveryFactoryDeps,
+): DiscoveryAPI {
+  const mode = config.mode ?? 'onchain';
+  const fallbackToOnchain = config.fallbackToOnchain ?? true;
+
+  // Always build the on-chain floor — it's the always-live fallback.
+  const floor = createOnchainDiscoveryAPI({
+    rpcUrl: deps.rpcUrl,
+    chainId: deps.chainId,
+    routerAddress: deps.routerAddress,
+    identityRegistryAddress: deps.identityRegistryAddress,
+    safeAddress: deps.safeAddress,
+    mechAddress: deps.mechAddress,
+    taskDiscoveryFromBlock: deps.taskDiscoveryFromBlock,
+  });
+
+  if (mode === 'onchain') {
+    // For the floor-only mode, return directly — withFallback(floor, floor)
+    // would be pointless overhead.
+    return floor;
+  }
+
+  if (mode === 'http') {
+    // TODO(280n.4): instantiate HttpDiscoveryAPI once it ships.
+    throw new Error(
+      'discovery.mode="http" is not yet available. ' +
+      'HttpDiscoveryAPI ships in jinn-mono-280n.4. ' +
+      'Use mode="http-subgraph" (transitional) or mode="onchain" for now.',
+    );
+  }
+
+  if (mode === 'embedded') {
+    // TODO(280n.5): instantiate EmbeddedPonderDiscoveryAPI once it ships.
+    throw new Error(
+      'discovery.mode="embedded" is not yet available. ' +
+      'EmbeddedPonderDiscoveryAPI ships in jinn-mono-280n.5. ' +
+      'Use mode="http-subgraph" (transitional) or mode="onchain" for now.',
+    );
+  }
+
+  // mode === 'http-subgraph' — transitional wrapper
+  if (!deps.subgraphClient) {
+    throw new Error(
+      'discovery.mode="http-subgraph" requires deps.subgraphClient to be provided. ' +
+      'Pass the SubgraphClient instance from daemon-init.',
+    );
+  }
+  if (!config.url) {
+    throw new Error(
+      'discovery.mode="http-subgraph" requires discovery.url (or legacy subgraphUrl) to be set.',
+    );
+  }
+
+  const primary = createHttpSubgraphDiscoveryAPI({
+    subgraphUrl: config.url,
+    subgraphClient: deps.subgraphClient,
+    fetchImpl: deps.fetchImpl,
+  });
+
+  if (!fallbackToOnchain) {
+    return primary;
+  }
+
+  return withFallback(primary, floor);
+}

--- a/client/src/discovery/http-subgraph.ts
+++ b/client/src/discovery/http-subgraph.ts
@@ -1,0 +1,214 @@
+/**
+ * HttpSubgraphDiscoveryAPI — transitional DiscoveryAPI backed by the existing
+ * subgraph clients.
+ *
+ * This is a thin adapter that wraps the existing subgraph helpers behind the
+ * DiscoveryAPI interface. It exists only for the migration window — it will
+ * be removed when jinn-mono-280n.6 retires the hosted subgraph dependency
+ * entirely.
+ *
+ * Errors from the upstream subgraph clients are wrapped in
+ * DiscoveryUnavailableError so the withFallback chain can engage when the
+ * subgraph 429s or times out — directly addressing the failure mode in
+ * jinn-mono-uy6v.1.1.
+ *
+ * Spec: spec/2026-05-11-discovery-api-and-shared-indexer.md §9.2 (callsite
+ * migration — transitional wrapper).
+ *
+ * TODO(280n.6): delete this file once the hosted subgraph is fully removed.
+ */
+
+import type { DiscoveryAPI, ClaimableTaskCandidate } from './types.js';
+import { DiscoveryUnavailableError } from './types.js';
+import type { SolverNetManifestSummary, SolverNetLifecycleStatus } from '../solvernets/registry-client.js';
+import type { EnvelopeRef, CorpusQuery } from '../corpus/types.js';
+import {
+  queryClaimableTaskCandidates,
+} from '../adapters/mech/task-subgraph.js';
+import type { SubgraphClient } from '../solvernets/registry-client-erc8004.js';
+import { resolveMostRecentWins } from '../solvernets/most-recent-wins.js';
+import { runCorpusQuery } from '../corpus/query.js';
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const SOLVERNET_MANIFEST_KEY_PREFIX = 'solvernet-manifest:';
+
+// ── Options ───────────────────────────────────────────────────────────────────
+
+export interface HttpSubgraphDiscoveryAPIOptions {
+  /** Subgraph GraphQL endpoint URL. */
+  subgraphUrl: string;
+  /**
+   * Subgraph client for SolverNet manifest events (listLaunchedSolverNets /
+   * getLifecycleStatus). Injected so tests can provide a stub without
+   * reaching the network.
+   */
+  subgraphClient: SubgraphClient;
+  /** Fetch implementation (for testability). Defaults to globalThis.fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+// ── Factory ────────────────────────────────────────────────────────────────────
+
+/**
+ * Creates a transitional DiscoveryAPI backed by the existing subgraph clients.
+ *
+ * All four DiscoveryAPI methods delegate to existing subgraph helpers:
+ *
+ * - `findClaimableTasks`        → `queryClaimableTaskCandidates` from task-subgraph.ts
+ * - `listLaunchedSolverNets`    → SubgraphClient.fetchSetMetadataEvents + most-recent-wins
+ * - `getLifecycleStatus`        → SubgraphClient.fetchSetMetadataEventsForCid + most-recent-wins
+ * - `queryEnvelopes`            → `runCorpusQuery` from corpus/query.ts
+ *
+ * Errors from the upstream clients are wrapped in DiscoveryUnavailableError.
+ */
+export function createHttpSubgraphDiscoveryAPI(
+  opts: HttpSubgraphDiscoveryAPIOptions,
+): DiscoveryAPI {
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  const { subgraphUrl, subgraphClient } = opts;
+
+  // ── findClaimableTasks ─────────────────────────────────────────────────────
+
+  async function findClaimableTasks(args: {
+    solverNetManifestCids: string[];
+    operatorAddress: `0x${string}`;
+    nowSeconds?: number;
+    pageSize?: number;
+    maxPages?: number;
+  }): Promise<ClaimableTaskCandidate[]> {
+    let candidates;
+    try {
+      candidates = await queryClaimableTaskCandidates({
+        url: subgraphUrl,
+        solverNetManifestCids: args.solverNetManifestCids,
+        operatorAddress: args.operatorAddress,
+        nowSeconds: args.nowSeconds,
+        pageSize: args.pageSize,
+        maxPages: args.maxPages,
+        fetchImpl,
+      });
+    } catch (err) {
+      throw new DiscoveryUnavailableError(
+        `HttpSubgraphDiscoveryAPI.findClaimableTasks: subgraph query failed`,
+        err,
+      );
+    }
+
+    // SubgraphTaskCandidate and ClaimableTaskCandidate have the same shape;
+    // no field transformation needed — just pass through.
+    return candidates as ClaimableTaskCandidate[];
+  }
+
+  // ── listLaunchedSolverNets ─────────────────────────────────────────────────
+
+  async function listLaunchedSolverNets(args?: {
+    launcherAgentId?: string;
+    status?: Array<'launched' | 'paused' | 'retired'>;
+  }): Promise<SolverNetManifestSummary[]> {
+    let events;
+    try {
+      events = await subgraphClient.fetchSetMetadataEvents({
+        keyPrefix: SOLVERNET_MANIFEST_KEY_PREFIX,
+      });
+    } catch (err) {
+      throw new DiscoveryUnavailableError(
+        `HttpSubgraphDiscoveryAPI.listLaunchedSolverNets: subgraph query failed`,
+        err,
+      );
+    }
+
+    const resolved = resolveMostRecentWins(events);
+
+    const out: SolverNetManifestSummary[] = [];
+    for (const row of resolved) {
+      if (
+        args?.launcherAgentId !== undefined &&
+        row.launcherAgentId !== args.launcherAgentId
+      ) {
+        continue;
+      }
+      if (args?.status !== undefined && !args.status.includes(row.status)) {
+        continue;
+      }
+
+      // The subgraph floor can only populate fields derivable from on-chain
+      // events without an IPFS fetch. Callers that need the full manifest body
+      // (name, network, solutionPriceWei, etc.) should call getManifest on the
+      // registry client directly.
+      out.push({
+        manifestCid: row.manifestCid,
+        solverNetId: row.manifestCid,        // best-effort: cid as id
+        name: '',                             // requires IPFS fetch
+        network: '',                          // requires IPFS fetch
+        launcherAgentId: row.launcherAgentId,
+        launcherSafeAddress: '0x0000000000000000000000000000000000000000',
+        status: row.status,
+        statusUpdatedAt: row.statusUpdatedAt,
+        contractId: '',                       // requires IPFS fetch
+        contractVersion: '',                  // requires IPFS fetch
+        solutionPriceWei: '0',               // requires IPFS fetch
+        verdictPriceWei: '0',                // requires IPFS fetch
+        openRoles: [],                        // requires IPFS fetch
+        anchorBlock: row.anchorBlock,
+      });
+    }
+
+    return out;
+  }
+
+  // ── getLifecycleStatus ─────────────────────────────────────────────────────
+
+  async function getLifecycleStatus(
+    manifestCid: string,
+  ): Promise<SolverNetLifecycleStatus | undefined> {
+    let events;
+    try {
+      events = await subgraphClient.fetchSetMetadataEventsForCid({ manifestCid });
+    } catch (err) {
+      throw new DiscoveryUnavailableError(
+        `HttpSubgraphDiscoveryAPI.getLifecycleStatus: subgraph query failed`,
+        err,
+      );
+    }
+
+    if (events.length === 0) return undefined;
+
+    const resolved = resolveMostRecentWins(events);
+    if (resolved.length === 0) return undefined;
+
+    // Pick the most-recent across all launchers
+    const latest = resolved.reduce((acc, cur) => {
+      if (cur.anchorBlock !== acc.anchorBlock) {
+        return cur.anchorBlock > acc.anchorBlock ? cur : acc;
+      }
+      return cur.anchorTransactionIndex > acc.anchorTransactionIndex ? cur : acc;
+    });
+
+    return {
+      status: latest.status,
+      statusUpdatedAt: latest.statusUpdatedAt,
+      sourceBlock: latest.anchorBlock,
+    };
+  }
+
+  // ── queryEnvelopes ─────────────────────────────────────────────────────────
+
+  async function queryEnvelopes(query: CorpusQuery): Promise<EnvelopeRef[]> {
+    try {
+      return await runCorpusQuery(subgraphUrl, query, fetchImpl);
+    } catch (err) {
+      throw new DiscoveryUnavailableError(
+        `HttpSubgraphDiscoveryAPI.queryEnvelopes: subgraph query failed`,
+        err,
+      );
+    }
+  }
+
+  return {
+    findClaimableTasks,
+    listLaunchedSolverNets,
+    getLifecycleStatus,
+    queryEnvelopes,
+  };
+}

--- a/client/src/discovery/index.ts
+++ b/client/src/discovery/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Discovery module barrel.
+ *
+ * Exports the DiscoveryAPI interface, shared types, error class, and the
+ * withFallback wrapper. Concrete implementations (OnchainDiscoveryAPI,
+ * HttpDiscoveryAPI) live in follow-up tasks and are not exported here until
+ * they land.
+ */
+
+export type {
+  DiscoveryAPI,
+  ClaimableTaskCandidate,
+  SolverNetLifecycleStatus,
+  SolverNetManifestSummary,
+  EnvelopeRef,
+  CorpusQuery,
+} from './types.js';
+
+export { DiscoveryUnavailableError } from './types.js';
+
+export { withFallback } from './with-fallback.js';
+export type { WithFallbackOptions } from './with-fallback.js';

--- a/client/src/discovery/index.ts
+++ b/client/src/discovery/index.ts
@@ -20,3 +20,12 @@ export { DiscoveryUnavailableError } from './types.js';
 
 export { withFallback } from './with-fallback.js';
 export type { WithFallbackOptions } from './with-fallback.js';
+
+export { createOnchainDiscoveryAPI } from './onchain.js';
+export type { OnchainDiscoveryAPIOptions, OnchainCursorCache } from './onchain.js';
+
+export { createHttpSubgraphDiscoveryAPI } from './http-subgraph.js';
+export type { HttpSubgraphDiscoveryAPIOptions } from './http-subgraph.js';
+
+export { createDiscoveryAPI } from './factory.js';
+export type { DiscoveryFactoryDeps, DiscoveryConfig } from './factory.js';

--- a/client/src/discovery/onchain.ts
+++ b/client/src/discovery/onchain.ts
@@ -1,0 +1,716 @@
+/**
+ * OnchainDiscoveryAPI — always-live floor implementation of DiscoveryAPI.
+ *
+ * Implements all four DiscoveryAPI methods backed by viem `getLogs` RPC reads
+ * against JinnRouter and IdentityRegistry contracts. No indexer required;
+ * this is the floor that keeps the daemon functional during indexer outages.
+ *
+ * Design choices:
+ *
+ * - `findClaimableTasks` enumerates `TaskCreated` events from a known start
+ *   block, filters by manifest digest(s), then multicalls `canClaimTask` in
+ *   parallel batches to check current claimability. Attempt counts are derived
+ *   from `TaskAttemptCreated` event logs grouped client-side.
+ *
+ * - `listLaunchedSolverNets` / `getLifecycleStatus` read `MetadataSet` events
+ *   from IdentityRegistry (key prefix `solvernet-manifest:`) and fold via the
+ *   existing `resolveMostRecentWins` helper.
+ *
+ * - `queryEnvelopes` delegates to the existing `runOnchainCorpusQuery`.
+ *
+ * - `cursorCache` is an optional injection point: when provided, the start
+ *   block for future scans is advanced to the current head after each
+ *   successful scan, so repeated calls avoid re-scanning history.
+ *
+ * Spec: spec/2026-05-11-discovery-api-and-shared-indexer.md §6.3.
+ */
+
+import {
+  createPublicClient,
+  decodeEventLog,
+  http,
+  type Address,
+  type Hex,
+  type PublicClient,
+} from 'viem';
+import { base, baseSepolia } from 'viem/chains';
+import type { DiscoveryAPI, ClaimableTaskCandidate, SolverNetManifestSummary, SolverNetLifecycleStatus } from './types.js';
+import { DiscoveryUnavailableError } from './types.js';
+import type { EnvelopeRef, CorpusQuery } from '../corpus/types.js';
+import { runOnchainCorpusQuery, DEFAULT_EXECUTION_DISCOVERY_FROM_BLOCK, DEFAULT_IDENTITY_REGISTRY_BY_CHAIN_ID } from '../corpus/onchain-query.js';
+import { JINN_ROUTER_ABI } from '../adapters/mech/types.js';
+import { canClaimTask } from '../adapters/mech/contracts.js';
+import { manifestDigestForCid } from '../adapters/mech/task-subgraph.js';
+import { resolveMostRecentWins, type SetMetadataEvent, type SetMetadataLifecyclePayload } from '../solvernets/most-recent-wins.js';
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const DEFAULT_PAGE_SIZE = 100;
+const DEFAULT_MAX_PAGES = 5;
+const DEFAULT_CHUNK_BLOCKS = 9_999n;
+
+/** Default JinnRouter addresses by chain ID. */
+const DEFAULT_ROUTER_BY_CHAIN_ID: Record<number, Address> = {
+  8453: '0xfFa7118A3D820cd4E820010837D65FAfF463181B',  // Base mainnet
+  // Base Sepolia is loaded from deployment artifact; no fixed default
+};
+
+/** Concurrency cap for parallel canClaimTask calls. */
+const CLAIM_CHECK_CONCURRENCY = 8;
+
+const SOLVERNET_MANIFEST_KEY_PREFIX = 'solvernet-manifest:';
+
+// ── ABI fragments ─────────────────────────────────────────────────────────────
+
+const IDENTITY_METADATA_ABI = [
+  {
+    type: 'event',
+    name: 'MetadataSet',
+    inputs: [
+      { name: 'agentId', type: 'uint256', indexed: true },
+      { name: 'indexedMetadataKey', type: 'string', indexed: true },
+      { name: 'metadataKey', type: 'string', indexed: false },
+      { name: 'metadataValue', type: 'bytes', indexed: false },
+    ],
+  },
+] as const;
+
+// ── Options ───────────────────────────────────────────────────────────────────
+
+export interface OnchainCursorCache {
+  /** Highest block scanned for a given label. Returns null if never scanned. */
+  read(label: string): bigint | null;
+  /** Persist highest block scanned. */
+  write(label: string, block: bigint): void;
+}
+
+/**
+ * Operator context required by findClaimableTasks. Optional because other
+ * DiscoveryAPI methods (listLaunchedSolverNets, getLifecycleStatus,
+ * queryEnvelopes) do not need them. If absent, findClaimableTasks throws
+ * DiscoveryUnavailableError.
+ */
+export interface OnchainDiscoveryAPIOptions {
+  rpcUrl?: string;
+  chainId: number;
+  /** JinnRouter proxy address. Defaults to chain-specific well-known address. */
+  routerAddress?: `0x${string}`;
+  /** IdentityRegistry address. Defaults to chain-specific well-known address. */
+  identityRegistryAddress?: `0x${string}`;
+  /** Operator Safe multisig address. Required by findClaimableTasks for canClaimTask simulation. */
+  safeAddress?: `0x${string}`;
+  /** Operator priority mech contract address. Required by findClaimableTasks for canClaimTask simulation. */
+  mechAddress?: `0x${string}`;
+  /** Lower bound block for TaskCreated / MetadataSet scans. Defaults to chain-specific well-known block. */
+  taskDiscoveryFromBlock?: bigint | number;
+  /** Block range per getLogs chunk. Default: 9999. */
+  chunkBlocks?: bigint | number;
+  /** Optional pre-built viem PublicClient (for testing). */
+  publicClient?: PublicClient;
+  /** Optional cursor cache to avoid re-scanning history on repeated calls. */
+  cursorCache?: OnchainCursorCache;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function chainForId(chainId: number) {
+  return chainId === 84532 ? baseSepolia : base;
+}
+
+function toBigInt(value: bigint | number | undefined, fallback: bigint): bigint {
+  if (value === undefined) return fallback;
+  if (typeof value === 'bigint') return value;
+  return BigInt(Math.max(0, Math.floor(value)));
+}
+
+/**
+ * Resolve the start block for a scan. Priority order:
+ *  1. cursorCache.read(label) — advance past already-scanned history
+ *  2. opts.taskDiscoveryFromBlock — explicit override
+ *  3. DEFAULT_EXECUTION_DISCOVERY_FROM_BLOCK[chainId] — chain default
+ *  4. currentBlock (no history)
+ */
+function resolveFromBlock(
+  opts: OnchainDiscoveryAPIOptions,
+  cursorLabel: string,
+  currentBlock: bigint,
+): bigint {
+  // Cursor takes priority — avoid re-scanning history
+  const cached = opts.cursorCache?.read(cursorLabel);
+  if (cached !== null && cached !== undefined) {
+    return cached > currentBlock ? currentBlock : cached;
+  }
+
+  const defaultFromBlock =
+    DEFAULT_EXECUTION_DISCOVERY_FROM_BLOCK[opts.chainId] ?? currentBlock;
+
+  return toBigInt(opts.taskDiscoveryFromBlock, defaultFromBlock);
+}
+
+/** Decode a MetadataSet log into a SetMetadataEvent or null if not a solvernet-manifest event. */
+function decodeSolvernetMetadataLog(log: {
+  data: Hex;
+  topics: readonly Hex[];
+  blockNumber: bigint | null;
+  transactionIndex: number | null;
+}): SetMetadataEvent | null {
+  let decoded: {
+    eventName: 'MetadataSet';
+    args: {
+      agentId: bigint;
+      metadataKey: string;
+      metadataValue: Hex;
+    };
+  };
+  try {
+    decoded = decodeEventLog({
+      abi: IDENTITY_METADATA_ABI,
+      data: log.data,
+      topics: log.topics as [`0x${string}`, ...`0x${string}`[]],
+    }) as typeof decoded;
+  } catch {
+    return null;
+  }
+
+  if (decoded.eventName !== 'MetadataSet') return null;
+  if (!decoded.args.metadataKey.startsWith(SOLVERNET_MANIFEST_KEY_PREFIX)) return null;
+
+  // Decode the lifecycle payload — it's JCS-canonical UTF-8 JSON
+  let payload: SetMetadataLifecyclePayload;
+  try {
+    const text = new TextDecoder().decode(
+      Buffer.from(decoded.args.metadataValue.slice(2), 'hex'),
+    );
+    payload = JSON.parse(text) as SetMetadataLifecyclePayload;
+    if (!payload.status || !payload.at || !payload.hash) return null;
+  } catch {
+    return null;
+  }
+
+  return {
+    agentId: decoded.args.agentId.toString(),
+    key: decoded.args.metadataKey,
+    payload,
+    blockNumber: Number(log.blockNumber ?? 0n),
+    transactionIndex: log.transactionIndex ?? 0,
+  };
+}
+
+/**
+ * Scan logs in chunks. When `maxResults` is provided, scans newest-first
+ * (from `toBlock` down to `fromBlock`) and stops as soon as `maxResults`
+ * items have been accumulated — avoiding scanning the entire history when
+ * only a bounded result set is needed. Without `maxResults`, scans
+ * oldest-first (standard order).
+ */
+async function scanLogsInChunks<T>(
+  getLogs: (fromBlock: bigint, toBlock: bigint) => Promise<T[]>,
+  fromBlock: bigint,
+  toBlock: bigint,
+  chunkBlocks: bigint,
+  maxResults?: number,
+): Promise<T[]> {
+  const results: T[] = [];
+
+  if (maxResults !== undefined) {
+    // Newest-first scan with early exit
+    for (let end = toBlock; end >= fromBlock && results.length < maxResults; ) {
+      const start = end > chunkBlocks && end - chunkBlocks + 1n > fromBlock
+        ? end - chunkBlocks + 1n
+        : fromBlock;
+      const chunk = await getLogs(start, end);
+      results.push(...chunk);
+      if (start === fromBlock) break;
+      end = start - 1n;
+    }
+  } else {
+    // Oldest-first scan
+    for (let start = fromBlock; start <= toBlock; start += chunkBlocks + 1n) {
+      const end = start + chunkBlocks > toBlock ? toBlock : start + chunkBlocks;
+      const chunk = await getLogs(start, end);
+      results.push(...chunk);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Run a list of async tasks with a concurrency cap.
+ *
+ * Tasks are responsible for handling their own errors and returning a
+ * result-shaped value (e.g. `{ ok: false }` on failure). If a task throws
+ * anyway, the slot is silently released and processing continues — the thrown
+ * result is not included in the output array.
+ *
+ * @internal Exported for unit testing only.
+ */
+export async function limitedConcurrency<T>(
+  tasks: Array<() => Promise<T>>,
+  concurrency: number,
+): Promise<T[]> {
+  const results: T[] = [];
+  const queue = [...tasks];
+
+  async function runNext(): Promise<void> {
+    const task = queue.shift();
+    if (!task) return;
+    try {
+      results.push(await task());
+    } catch {
+      // task threw; slot continues processing queue
+    }
+    await runNext();
+  }
+
+  const workers = Array.from({ length: Math.min(concurrency, tasks.length) }, () => runNext());
+  await Promise.all(workers);
+  return results;
+}
+
+// ── Factory ───────────────────────────────────────────────────────────────────
+
+/**
+ * Creates an `OnchainDiscoveryAPI` instance backed by viem `getLogs`.
+ *
+ * This is the always-live floor: no indexer required, works as long as the
+ * configured RPC endpoint is reachable.
+ */
+export function createOnchainDiscoveryAPI(opts: OnchainDiscoveryAPIOptions): DiscoveryAPI {
+  const routerAddress: Address = (opts.routerAddress ??
+    DEFAULT_ROUTER_BY_CHAIN_ID[opts.chainId]) as Address;
+
+  const identityRegistryAddress: Address | undefined = (opts.identityRegistryAddress ??
+    DEFAULT_IDENTITY_REGISTRY_BY_CHAIN_ID[opts.chainId]) as Address | undefined;
+
+  const chunk = toBigInt(opts.chunkBlocks, DEFAULT_CHUNK_BLOCKS);
+
+  function getClient(): Pick<PublicClient, 'getBlockNumber' | 'getLogs' | 'simulateContract'> {
+    return opts.publicClient ?? createPublicClient({
+      chain: chainForId(opts.chainId),
+      transport: http(opts.rpcUrl),
+    });
+  }
+
+  // ── findClaimableTasks ─────────────────────────────────────────────────────
+
+  async function findClaimableTasks(args: {
+    solverNetManifestCids: string[];
+    operatorAddress: `0x${string}`;
+    nowSeconds?: number;
+    pageSize?: number;
+    maxPages?: number;
+  }): Promise<ClaimableTaskCandidate[]> {
+    if (!opts.safeAddress || !opts.mechAddress) {
+      throw new DiscoveryUnavailableError(
+        'OnchainDiscoveryAPI.findClaimableTasks requires safeAddress and mechAddress in options',
+      );
+    }
+
+    const manifestCids = Array.from(new Set(args.solverNetManifestCids.filter(Boolean)));
+    if (manifestCids.length === 0) return [];
+    if (!routerAddress) throw new DiscoveryUnavailableError(
+      `OnchainDiscoveryAPI: no routerAddress configured for chainId=${opts.chainId}`,
+    );
+
+    const pageSize = Math.min(100, Math.max(1, args.pageSize ?? DEFAULT_PAGE_SIZE));
+    const maxPages = Math.max(1, args.maxPages ?? DEFAULT_MAX_PAGES);
+    const maxResults = pageSize * maxPages;
+
+    const client = getClient();
+
+    let currentBlock: bigint;
+    try {
+      currentBlock = await (client as PublicClient).getBlockNumber();
+    } catch (err) {
+      throw new DiscoveryUnavailableError(
+        `OnchainDiscoveryAPI.findClaimableTasks: failed to get block number`,
+        err,
+      );
+    }
+
+    const fromBlock = resolveFromBlock(opts, 'tasks', currentBlock);
+
+    // Compute manifest digests for each CID
+    const manifestDigests = manifestCids.map((cid) => ({
+      cid,
+      digest: manifestDigestForCid(cid).toLowerCase() as Hex,
+    }));
+    const digestSet = new Set(manifestDigests.map((d) => d.digest));
+
+    // Scan TaskCreated events
+    let taskCreatedLogs: Array<{
+      taskId: string;
+      taskCidDigest: Hex;
+      manifestDigest: Hex;
+      maxClaims: number;
+      blockNumber: number;
+      transactionHash?: Hex;
+    }>;
+    try {
+      taskCreatedLogs = await scanLogsInChunks(
+        async (start, end) => {
+          const logs = await (client as PublicClient).getLogs({
+            address: routerAddress,
+            fromBlock: start,
+            toBlock: end,
+          });
+          const decoded: typeof taskCreatedLogs = [];
+          for (const log of logs) {
+            try {
+              const event = decodeEventLog({
+                abi: JINN_ROUTER_ABI,
+                data: log.data,
+                topics: log.topics,
+              });
+              if (event.eventName !== 'TaskCreated') continue;
+              const evArgs = event.args as {
+                taskId: bigint;
+                taskCidDigest: Hex;
+                manifestDigest: Hex;
+                maxClaims: number;
+              };
+              const digestLower = (evArgs.manifestDigest as string).toLowerCase() as Hex;
+              if (!digestSet.has(digestLower)) continue;
+              decoded.push({
+                taskId: String(evArgs.taskId),
+                taskCidDigest: evArgs.taskCidDigest,
+                manifestDigest: evArgs.manifestDigest,
+                maxClaims: Number(evArgs.maxClaims),
+                blockNumber: log.blockNumber != null ? Number(log.blockNumber) : 0,
+                transactionHash: log.transactionHash ?? undefined,
+              });
+            } catch {
+              // Not a TaskCreated event or decode error — skip
+            }
+          }
+          return decoded;
+        },
+        fromBlock,
+        currentBlock,
+        chunk,
+        maxResults,
+      );
+    } catch (err) {
+      if (err instanceof DiscoveryUnavailableError) throw err;
+      throw new DiscoveryUnavailableError(
+        `OnchainDiscoveryAPI.findClaimableTasks: getLogs for TaskCreated failed`,
+        err,
+      );
+    }
+
+    // De-duplicate by taskId (keep first occurrence)
+    const seen = new Set<string>();
+    const uniqueTasks = taskCreatedLogs.filter((t) => {
+      if (seen.has(t.taskId)) return false;
+      seen.add(t.taskId);
+      return true;
+    });
+
+    // Apply canClaimTask eligibility checks (safeAddress + mechAddress validated above)
+    const eligibleTasks: typeof uniqueTasks = [];
+
+    const safeAddress = opts.safeAddress as Address;
+    const mechAddress = opts.mechAddress as Address;
+
+    const checkTasks = uniqueTasks.map((task) => async () => {
+      try {
+        const result = await canClaimTask(
+          client as PublicClient,
+          safeAddress,
+          routerAddress,
+          task.taskId,
+          mechAddress,
+        );
+        return { task, ok: result.ok };
+      } catch {
+        return { task, ok: false };
+      }
+    });
+
+    const claimCheckResults = await limitedConcurrency(checkTasks, CLAIM_CHECK_CONCURRENCY);
+    for (const r of claimCheckResults) {
+      if (r.ok) eligibleTasks.push(r.task);
+    }
+
+    // Get attempt counts via TaskAttemptCreated events for eligible tasks
+    let attemptLogs: Array<{ taskId: string; operator: string }>;
+    try {
+      const eligibleTaskIds = new Set(eligibleTasks.map((t) => t.taskId));
+      attemptLogs = await scanLogsInChunks(
+        async (start, end) => {
+          const logs = await (client as PublicClient).getLogs({
+            address: routerAddress,
+            fromBlock: start,
+            toBlock: end,
+          });
+          const decoded: Array<{ taskId: string; operator: string }> = [];
+          for (const log of logs) {
+            try {
+              const event = decodeEventLog({
+                abi: JINN_ROUTER_ABI,
+                data: log.data,
+                topics: log.topics,
+              });
+              if (event.eventName !== 'TaskAttemptCreated') continue;
+              const evArgs = event.args as { taskId: bigint; operator: Address };
+              const taskIdStr = String(evArgs.taskId);
+              if (!eligibleTaskIds.has(taskIdStr)) continue;
+              decoded.push({
+                taskId: taskIdStr,
+                operator: evArgs.operator.toLowerCase(),
+              });
+            } catch {
+              // Not a TaskAttemptCreated event — skip
+            }
+          }
+          return decoded;
+        },
+        fromBlock,
+        currentBlock,
+        chunk,
+      );
+    } catch (err) {
+      if (err instanceof DiscoveryUnavailableError) throw err;
+      throw new DiscoveryUnavailableError(
+        `OnchainDiscoveryAPI.findClaimableTasks: getLogs for TaskAttemptCreated failed`,
+        err,
+      );
+    }
+
+    // Group attempt counts
+    const attemptCountByTaskId = new Map<string, number>();
+    const operatorAttemptCountByTaskId = new Map<string, number>();
+    const operatorLower = args.operatorAddress.toLowerCase();
+
+    for (const attempt of attemptLogs) {
+      attemptCountByTaskId.set(
+        attempt.taskId,
+        (attemptCountByTaskId.get(attempt.taskId) ?? 0) + 1,
+      );
+      if (attempt.operator === operatorLower) {
+        operatorAttemptCountByTaskId.set(
+          attempt.taskId,
+          (operatorAttemptCountByTaskId.get(attempt.taskId) ?? 0) + 1,
+        );
+      }
+    }
+
+    // Build ClaimableTaskCandidate results
+    const results: ClaimableTaskCandidate[] = [];
+
+    for (const task of eligibleTasks) {
+      if (results.length >= maxResults) break;
+
+      const normalizedDigest = (task.manifestDigest as string).toLowerCase() as Hex;
+
+      const candidate: ClaimableTaskCandidate = {
+        taskId: task.taskId,
+        taskCidDigest: task.taskCidDigest,
+        manifestDigest: normalizedDigest,
+        createdAtBlock: task.blockNumber || undefined,
+        createdAtTx: task.transactionHash,
+        maxClaims: task.maxClaims > 0 ? task.maxClaims : undefined,
+        attemptCount: attemptCountByTaskId.get(task.taskId) ?? 0,
+        operatorAttemptCount: operatorAttemptCountByTaskId.get(task.taskId) ?? 0,
+      };
+      results.push(candidate);
+    }
+
+    // Sort by taskId ascending (matches subgraph ordering)
+    results.sort((a, b) => Number(BigInt(a.taskId) - BigInt(b.taskId)));
+
+    // Update cursor cache
+    opts.cursorCache?.write('tasks', currentBlock);
+
+    return results;
+  }
+
+  // ── SolverNet helpers ──────────────────────────────────────────────────────
+
+  async function scanSolvernetMetadataEvents(): Promise<{
+    events: SetMetadataEvent[];
+    currentBlock: bigint;
+  }> {
+    if (!identityRegistryAddress) {
+      return { events: [], currentBlock: 0n };
+    }
+
+    const client = getClient();
+    let currentBlock: bigint;
+    try {
+      currentBlock = await (client as PublicClient).getBlockNumber();
+    } catch (err) {
+      throw new DiscoveryUnavailableError(
+        `OnchainDiscoveryAPI: failed to get block number`,
+        err,
+      );
+    }
+
+    const fromBlock = resolveFromBlock(opts, 'solvernets', currentBlock);
+
+    let events: SetMetadataEvent[];
+    try {
+      events = await scanLogsInChunks(
+        async (start, end) => {
+          const logs = await (client as PublicClient).getLogs({
+            address: identityRegistryAddress,
+            fromBlock: start,
+            toBlock: end,
+          });
+          const decoded: SetMetadataEvent[] = [];
+          for (const log of logs) {
+            const event = decodeSolvernetMetadataLog(log as {
+              data: Hex;
+              topics: readonly Hex[];
+              blockNumber: bigint | null;
+              transactionIndex: number | null;
+            });
+            if (event) decoded.push(event);
+          }
+          return decoded;
+        },
+        fromBlock,
+        currentBlock,
+        chunk,
+      );
+    } catch (err) {
+      if (err instanceof DiscoveryUnavailableError) throw err;
+      throw new DiscoveryUnavailableError(
+        `OnchainDiscoveryAPI: getLogs for MetadataSet failed`,
+        err,
+      );
+    }
+
+    // Update cursor cache on success so both listLaunchedSolverNets and
+    // getLifecycleStatus advance the scan window after every successful call.
+    if (currentBlock > 0n) {
+      opts.cursorCache?.write('solvernets', currentBlock);
+    }
+
+    return { events, currentBlock };
+  }
+
+  // ── listLaunchedSolverNets ─────────────────────────────────────────────────
+
+  async function listLaunchedSolverNets(args?: {
+    launcherAgentId?: string;
+    status?: Array<'launched' | 'paused' | 'retired'>;
+  }): Promise<SolverNetManifestSummary[]> {
+    let events: SetMetadataEvent[];
+
+    try {
+      const scanned = await scanSolvernetMetadataEvents();
+      events = scanned.events;
+    } catch (err) {
+      if (err instanceof DiscoveryUnavailableError) throw err;
+      throw new DiscoveryUnavailableError(
+        `OnchainDiscoveryAPI.listLaunchedSolverNets: scan failed`,
+        err,
+      );
+    }
+
+    const resolved = resolveMostRecentWins(events);
+
+    // Filter and project into SolverNetManifestSummary
+    const out: SolverNetManifestSummary[] = [];
+    for (const row of resolved) {
+      if (args?.launcherAgentId !== undefined && row.launcherAgentId !== args.launcherAgentId) {
+        continue;
+      }
+      if (args?.status !== undefined && !args.status.includes(row.status)) {
+        continue;
+      }
+
+      // The on-chain floor cannot fetch manifest bodies from IPFS (that's
+      // retrieval, not discovery). We populate only what we can derive
+      // from the on-chain events. Fields we can't fill are set to empty/default.
+      out.push({
+        manifestCid: row.manifestCid,
+        solverNetId: row.manifestCid,     // best-effort: cid as id
+        name: '',                          // requires IPFS fetch
+        network: '',                       // requires IPFS fetch
+        launcherAgentId: row.launcherAgentId,
+        launcherSafeAddress: '0x0000000000000000000000000000000000000000',
+        status: row.status,
+        statusUpdatedAt: row.statusUpdatedAt,
+        contractId: '',                    // requires IPFS fetch
+        contractVersion: '',               // requires IPFS fetch
+        solutionPriceWei: '0',            // requires IPFS fetch
+        verdictPriceWei: '0',             // requires IPFS fetch
+        openRoles: [],                     // requires IPFS fetch
+        anchorBlock: row.anchorBlock,
+      });
+    }
+
+    return out;
+  }
+
+  // ── getLifecycleStatus ─────────────────────────────────────────────────────
+
+  async function getLifecycleStatus(manifestCid: string): Promise<SolverNetLifecycleStatus | undefined> {
+    let events: SetMetadataEvent[];
+
+    try {
+      const scanned = await scanSolvernetMetadataEvents();
+      events = scanned.events;
+    } catch (err) {
+      if (err instanceof DiscoveryUnavailableError) throw err;
+      throw new DiscoveryUnavailableError(
+        `OnchainDiscoveryAPI.getLifecycleStatus: scan failed`,
+        err,
+      );
+    }
+
+    // Filter to events for this specific cid
+    const key = `${SOLVERNET_MANIFEST_KEY_PREFIX}${manifestCid}`;
+    const cidEvents = events.filter((e) => e.key === key);
+
+    if (cidEvents.length === 0) return undefined;
+
+    const resolved = resolveMostRecentWins(cidEvents);
+    if (resolved.length === 0) return undefined;
+
+    // Pick the most-recent across all launchers
+    const latest = resolved.reduce((acc, cur) => {
+      if (cur.anchorBlock !== acc.anchorBlock) {
+        return cur.anchorBlock > acc.anchorBlock ? cur : acc;
+      }
+      return cur.anchorTransactionIndex > acc.anchorTransactionIndex ? cur : acc;
+    });
+
+    return {
+      status: latest.status,
+      statusUpdatedAt: latest.statusUpdatedAt,
+      sourceBlock: latest.anchorBlock,
+    };
+  }
+
+  // ── queryEnvelopes ─────────────────────────────────────────────────────────
+
+  async function queryEnvelopes(query: CorpusQuery): Promise<EnvelopeRef[]> {
+    try {
+      return await runOnchainCorpusQuery(query, {
+        rpcUrl: opts.rpcUrl,
+        chainId: opts.chainId,
+        identityRegistryAddress: identityRegistryAddress as Address | undefined,
+        fromBlock: opts.taskDiscoveryFromBlock,
+        chunkBlocks: opts.chunkBlocks,
+        publicClient: opts.publicClient as Pick<PublicClient, 'getBlockNumber' | 'getLogs'> | undefined,
+      });
+    } catch (err) {
+      if (err instanceof DiscoveryUnavailableError) throw err;
+      throw new DiscoveryUnavailableError(
+        `OnchainDiscoveryAPI.queryEnvelopes: onchain query failed`,
+        err,
+      );
+    }
+  }
+
+  return {
+    findClaimableTasks,
+    listLaunchedSolverNets,
+    getLifecycleStatus,
+    queryEnvelopes,
+  };
+}

--- a/client/src/discovery/onchain.ts
+++ b/client/src/discovery/onchain.ts
@@ -213,7 +213,11 @@ async function scanLogsInChunks<T>(
   const results: T[] = [];
 
   if (maxResults !== undefined) {
-    // Newest-first scan with early exit
+    // Newest-first scan with early exit. Each chunk is [start, end] inclusive,
+    // i.e. `chunkBlocks` blocks wide (one fewer than the oldest-first branch's
+    // `chunkBlocks + 1`); this is harmless — `end = start - 1n` on the next
+    // iteration means chunks neither overlap nor skip blocks at the boundary —
+    // and not worth complicating the index arithmetic to make symmetric.
     for (let end = toBlock; end >= fromBlock && results.length < maxResults; ) {
       const start = end > chunkBlocks && end - chunkBlocks + 1n > fromBlock
         ? end - chunkBlocks + 1n
@@ -224,7 +228,9 @@ async function scanLogsInChunks<T>(
       end = start - 1n;
     }
   } else {
-    // Oldest-first scan
+    // Oldest-first scan. Each chunk is [start, start + chunkBlocks] inclusive,
+    // and the next iteration starts at `start + chunkBlocks + 1n` — no overlap,
+    // no gap.
     for (let start = fromBlock; start <= toBlock; start += chunkBlocks + 1n) {
       const end = start + chunkBlocks > toBlock ? toBlock : start + chunkBlocks;
       const chunk = await getLogs(start, end);
@@ -407,13 +413,23 @@ export function createOnchainDiscoveryAPI(opts: OnchainDiscoveryAPIOptions): Dis
       return true;
     });
 
+    // Cap the candidate set BEFORE the canClaimTask fan-out: scanLogsInChunks
+    // accumulates whole getLogs chunks, so taskCreatedLogs can be far larger
+    // than maxResults. Without this trim, findClaimableTasks would run a
+    // simulateContract RPC (at concurrency CLAIM_CHECK_CONCURRENCY) on every
+    // scanned TaskCreated row before any cap applies. The scan ran newest-first
+    // (see scanLogsInChunks), so the head of `uniqueTasks` is the newest tasks —
+    // keep those. Note this differs from the subgraph's server-side window
+    // filter; here we approximate it with a client-side newest-first cap.
+    const cappedTasks = uniqueTasks.slice(0, maxResults);
+
     // Apply canClaimTask eligibility checks (safeAddress + mechAddress validated above)
-    const eligibleTasks: typeof uniqueTasks = [];
+    const eligibleTasks: typeof cappedTasks = [];
 
     const safeAddress = opts.safeAddress as Address;
     const mechAddress = opts.mechAddress as Address;
 
-    const checkTasks = uniqueTasks.map((task) => async () => {
+    const checkTasks = cappedTasks.map((task) => async () => {
       try {
         const result = await canClaimTask(
           client as PublicClient,

--- a/client/src/discovery/types.ts
+++ b/client/src/discovery/types.ts
@@ -1,0 +1,124 @@
+/**
+ * DiscoveryAPI interface and shared types.
+ *
+ * The interface abstracts the daemon's read-side discovery queries (claimable
+ * tasks, SolverNet manifests, corpus envelopes) from the backing store. Three
+ * implementations exist: HttpDiscoveryAPI, EmbeddedPonderDiscoveryAPI, and
+ * OnchainDiscoveryAPI. Callers always hold a DiscoveryAPI — they never depend
+ * on a specific backing.
+ *
+ * Spec: spec/2026-05-11-discovery-api-and-shared-indexer.md §5.
+ */
+
+// ── Re-exports from sibling modules ─────────────────────────────────────────
+
+// SolverNetManifestSummary is the canonical catalog-row shape used by both the
+// registry client and the DiscoveryAPI; re-exported here so consumers of
+// discovery only need one import path.
+export type { SolverNetManifestSummary, SolverNetLifecycleStatus } from '../solvernets/registry-client.js';
+
+// EnvelopeRef and CorpusQuery are the corpus library's public types; discovery
+// returns them directly so the corpus library can wrap DiscoveryAPI without
+// an impedance mismatch.
+export type { EnvelopeRef, CorpusQuery } from '../corpus/types.js';
+
+// ── Local imports used in the interface ─────────────────────────────────────
+
+import type { SolverNetManifestSummary, SolverNetLifecycleStatus } from '../solvernets/registry-client.js';
+import type { EnvelopeRef, CorpusQuery } from '../corpus/types.js';
+
+// ── New types ────────────────────────────────────────────────────────────────
+
+/**
+ * A single task candidate that can be claimed by the operator.
+ *
+ * This is the same shape as `SubgraphTaskCandidate` in
+ * `client/src/adapters/mech/task-subgraph.ts`, renamed and re-homed here as
+ * the canonical type. The subgraph module retains its own definition until
+ * callsite migration (jinn-mono-280n.3) lands and the old file is retired.
+ */
+export interface ClaimableTaskCandidate {
+  taskId: string;
+  taskCidDigest: `0x${string}`;
+  manifestDigest: `0x${string}`;
+  createdAtBlock?: number;
+  createdAtTx?: `0x${string}`;
+  claimWindowEnd?: number;
+  maxClaims?: number;
+  attemptCount: number;
+  operatorAttemptCount: number;
+}
+
+// ── Interface ────────────────────────────────────────────────────────────────
+
+/**
+ * Read-only discovery interface. Abstracts the daemon's read-side queries so
+ * the backing (HTTP indexer, embedded Ponder, or direct on-chain RPC) can be
+ * swapped without changing call-sites.
+ *
+ * Each method may throw `DiscoveryUnavailableError` when the backing is
+ * temporarily unavailable. The `withFallback` wrapper catches these and routes
+ * to the floor implementation for the duration of the outage.
+ */
+export interface DiscoveryAPI {
+  /**
+   * Returns claimable task candidates for a set of SolverNet manifests,
+   * filtered to tasks the given operator has not yet attempted.
+   *
+   * Replaces `queryClaimableTaskCandidates` in
+   * `client/src/adapters/mech/task-subgraph.ts`.
+   */
+  findClaimableTasks(args: {
+    solverNetManifestCids: string[];
+    operatorAddress: `0x${string}`;
+    nowSeconds?: number;
+    pageSize?: number;
+    maxPages?: number;
+  }): Promise<ClaimableTaskCandidate[]>;
+
+  /**
+   * Returns launched SolverNet manifest summaries, optionally filtered by
+   * launcher agent or lifecycle status.
+   *
+   * Replaces the subgraph fetcher in
+   * `client/src/solvernets/registry-client-erc8004.ts`.
+   */
+  listLaunchedSolverNets(args?: {
+    launcherAgentId?: string;
+    status?: Array<'launched' | 'paused' | 'retired'>;
+  }): Promise<SolverNetManifestSummary[]>;
+
+  /**
+   * Returns the current lifecycle status for a given manifest CID, or
+   * `undefined` if no lifecycle events have been recorded for it yet.
+   */
+  getLifecycleStatus(manifestCid: string): Promise<SolverNetLifecycleStatus | undefined>;
+
+  /**
+   * Returns envelope refs matching the query. Refs only — byte retrieval is
+   * done by the corpus library on demand.
+   *
+   * Replaces the subgraph branch of `corpus/index.ts::query`.
+   */
+  queryEnvelopes(query: CorpusQuery): Promise<EnvelopeRef[]>;
+}
+
+// ── Error ────────────────────────────────────────────────────────────────────
+
+/**
+ * Thrown by a DiscoveryAPI implementation when it is temporarily unable to
+ * serve a request — e.g. indexer unreachable, embedded Ponder still syncing,
+ * hosted subgraph 5xx.
+ *
+ * The `withFallback` wrapper catches this class (plus network-shaped errors)
+ * and routes to the floor implementation for the duration of the outage.
+ */
+export class DiscoveryUnavailableError extends Error {
+  override readonly cause?: unknown;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'DiscoveryUnavailableError';
+    this.cause = cause;
+  }
+}

--- a/client/src/discovery/with-fallback.ts
+++ b/client/src/discovery/with-fallback.ts
@@ -1,0 +1,196 @@
+/**
+ * withFallback — DiscoveryAPI wrapper with health-tracking and floor routing.
+ *
+ * Wraps a primary DiscoveryAPI implementation with a floor (fallback)
+ * implementation. On each method call the primary is tried first. If it throws
+ * a `DiscoveryUnavailableError` or a network-shaped error, the call is routed
+ * to the floor and the result returned to the caller as if nothing happened.
+ *
+ * Health tracking: after `unhealthyThreshold` consecutive primary failures the
+ * primary is skipped entirely for `retryAfterMs` milliseconds (degraded mode).
+ * A single `console.warn` is emitted when the primary enters degraded mode so
+ * operators can see why their daemon is running slowly. After the window
+ * elapses the wrapper probes the primary again on the next call.
+ *
+ * Spec: spec/2026-05-11-discovery-api-and-shared-indexer.md §9.3.
+ */
+
+import type { DiscoveryAPI } from './types.js';
+import { DiscoveryUnavailableError } from './types.js';
+
+// ── Network-error classifier ─────────────────────────────────────────────────
+
+/**
+ * Returns true for errors that indicate a transient infrastructure failure
+ * rather than a logical error from the backing. We classify these the same way
+ * as `isTransientEthReadError` in `chain-read-errors.ts` — the daemon should
+ * route to the floor rather than propagate them to the caller.
+ */
+function isNetworkError(error: unknown): boolean {
+  if (error instanceof DiscoveryUnavailableError) return true;
+  if (!(error instanceof Error)) return false;
+
+  // Code-based check mirrors `isTransientEthReadError` in chain-read-errors.ts.
+  // Viem/RPC errors often carry a `.code` property with no matching message substring.
+  const code = (error as { code?: string }).code;
+  if (code === 'SERVER_ERROR' || code === 'TIMEOUT' || code === 'NETWORK_ERROR') {
+    return true;
+  }
+
+  const msg = error.message.toLowerCase();
+
+  if (
+    msg.includes('fetch failed') ||
+    msg.includes('network error') ||
+    msg.includes('econnreset') ||
+    msg.includes('etimedout') ||
+    msg.includes('socket hang up') ||
+    msg.includes('connection refused') ||
+    msg.includes('connect timeout') ||
+    msg.includes('request timed out') ||
+    msg.includes('timeout')
+  ) {
+    return true;
+  }
+
+  if (
+    msg.includes('429') ||
+    msg.includes('rate limit') ||
+    msg.includes('too many requests') ||
+    msg.includes('502') ||
+    msg.includes('503') ||
+    msg.includes('bad gateway') ||
+    msg.includes('service unavailable')
+  ) {
+    return true;
+  }
+
+  if (
+    msg.includes('-32603') ||
+    msg.includes('internal json-rpc error') ||
+    msg.includes('-32005')
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+// ── Options ──────────────────────────────────────────────────────────────────
+
+export interface WithFallbackOptions {
+  /**
+   * Number of consecutive primary failures before the primary is marked
+   * unhealthy and skipped for `retryAfterMs`.
+   * @default 3
+   */
+  unhealthyThreshold?: number;
+  /**
+   * How long (ms) to skip the primary after it enters degraded mode. After
+   * this window the next call will probe the primary again.
+   * @default 60_000
+   */
+  retryAfterMs?: number;
+}
+
+// ── Implementation ───────────────────────────────────────────────────────────
+
+/**
+ * Wraps `primary` with health tracking and routes failing calls to `floor`.
+ *
+ * Returns a new DiscoveryAPI that is transparent when the primary is healthy
+ * and invisible when the primary is in degraded mode — callers receive floor
+ * results without an error.
+ */
+export function withFallback(
+  primary: DiscoveryAPI,
+  floor: DiscoveryAPI,
+  opts: WithFallbackOptions = {},
+): DiscoveryAPI {
+  const unhealthyThreshold = opts.unhealthyThreshold ?? 3;
+  const retryAfterMs = opts.retryAfterMs ?? 60_000;
+
+  let consecutiveFailures = 0;
+  let degradedSince: number | null = null;
+
+  function isPrimaryHealthy(): boolean {
+    if (degradedSince === null) return true;
+    if (Date.now() - degradedSince >= retryAfterMs) {
+      // Probe window has elapsed — re-engage primary.
+      degradedSince = null;
+      consecutiveFailures = 0;
+      return true;
+    }
+    return false;
+  }
+
+  function recordPrimaryFailure(): void {
+    consecutiveFailures += 1;
+    if (consecutiveFailures >= unhealthyThreshold && degradedSince === null) {
+      degradedSince = Date.now();
+      console.warn(
+        `[discovery] primary DiscoveryAPI marked unhealthy after ${consecutiveFailures} consecutive failures. ` +
+        `Routing to floor implementation for ${retryAfterMs}ms.`,
+      );
+    }
+  }
+
+  function recordPrimarySuccess(): void {
+    consecutiveFailures = 0;
+    degradedSince = null;
+  }
+
+  /**
+   * Shared dispatch helper. Tries the primary (unless in degraded mode), falls
+   * back to the floor on network/unavailable errors.
+   */
+  async function dispatch<T>(
+    primaryFn: () => Promise<T>,
+    floorFn: () => Promise<T>,
+  ): Promise<T> {
+    if (isPrimaryHealthy()) {
+      try {
+        const result = await primaryFn();
+        recordPrimarySuccess();
+        return result;
+      } catch (err) {
+        if (isNetworkError(err)) {
+          recordPrimaryFailure();
+          return floorFn();
+        }
+        throw err;
+      }
+    }
+    return floorFn();
+  }
+
+  return {
+    findClaimableTasks(args) {
+      return dispatch(
+        () => primary.findClaimableTasks(args),
+        () => floor.findClaimableTasks(args),
+      );
+    },
+
+    listLaunchedSolverNets(args) {
+      return dispatch(
+        () => primary.listLaunchedSolverNets(args),
+        () => floor.listLaunchedSolverNets(args),
+      );
+    },
+
+    getLifecycleStatus(manifestCid) {
+      return dispatch(
+        () => primary.getLifecycleStatus(manifestCid),
+        () => floor.getLifecycleStatus(manifestCid),
+      );
+    },
+
+    queryEnvelopes(query) {
+      return dispatch(
+        () => primary.queryEnvelopes(query),
+        () => floor.queryEnvelopes(query),
+      );
+    },
+  };
+}

--- a/client/src/discovery/with-fallback.ts
+++ b/client/src/discovery/with-fallback.ts
@@ -112,13 +112,22 @@ export function withFallback(
 
   let consecutiveFailures = 0;
   let degradedSince: number | null = null;
+  // True when the next primary call is a probe — the first attempt after the
+  // `retryAfterMs` degraded window elapsed. A probe that fails should re-degrade
+  // immediately rather than burn `unhealthyThreshold` more failed round-trips
+  // before re-entering degraded mode; this flag lets `recordPrimaryFailure`
+  // distinguish "probe failed" from "Nth consecutive failure from a fresh
+  // healthy state". It is only set after a degraded→retry cycle, so first-boot
+  // behaviour (degrade after N failures) is unchanged.
+  let nextCallIsProbe = false;
 
   function isPrimaryHealthy(): boolean {
     if (degradedSince === null) return true;
     if (Date.now() - degradedSince >= retryAfterMs) {
-      // Probe window has elapsed — re-engage primary.
+      // Probe window has elapsed — re-engage primary on a probe call.
       degradedSince = null;
       consecutiveFailures = 0;
+      nextCallIsProbe = true;
       return true;
     }
     return false;
@@ -126,11 +135,17 @@ export function withFallback(
 
   function recordPrimaryFailure(): void {
     consecutiveFailures += 1;
-    if (consecutiveFailures >= unhealthyThreshold && degradedSince === null) {
+    const wasProbe = nextCallIsProbe;
+    nextCallIsProbe = false;
+    if (degradedSince !== null) return;
+    // A failed probe (the call right after the retry window) means the primary
+    // is still broken — go straight back to degraded mode rather than waiting
+    // for `unhealthyThreshold` more failures.
+    if (wasProbe || consecutiveFailures >= unhealthyThreshold) {
       degradedSince = Date.now();
       console.warn(
-        `[discovery] primary DiscoveryAPI marked unhealthy after ${consecutiveFailures} consecutive failures. ` +
-        `Routing to floor implementation for ${retryAfterMs}ms.`,
+        `[discovery] primary DiscoveryAPI marked unhealthy after ${consecutiveFailures} consecutive failure(s)` +
+        `${wasProbe ? ' (failed probe)' : ''}. Routing to floor implementation for ${retryAfterMs}ms.`,
       );
     }
   }
@@ -138,6 +153,7 @@ export function withFallback(
   function recordPrimarySuccess(): void {
     consecutiveFailures = 0;
     degradedSince = null;
+    nextCallIsProbe = false;
   }
 
   /**

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1457,6 +1457,64 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     .filter((entry) => entry.roles.includes('solver'))
     .map((entry) => entry.manifestCid);
 
+  // ── DiscoveryAPI construction ─────────────────────────────────────────────
+  // Build the shared DiscoveryAPI used by MechAdapter (task discovery),
+  // the SolverNet registry client (lifecycle status), and the corpus library
+  // (envelope discovery). See spec/2026-05-11-discovery-api-and-shared-indexer.md §9.
+  let sharedDiscoveryApi: import('./discovery/types.js').DiscoveryAPI | undefined;
+  {
+    const { createDiscoveryAPI } = await import('./discovery/factory.js');
+    const discoveryConfig = config.discovery;
+    if (discoveryConfig) {
+      // A discovery block was explicitly set (or normalized from subgraphUrl).
+      let subgraphClientForDiscovery: import('./solvernets/registry-client-erc8004.js').SubgraphClient | undefined;
+      if (discoveryConfig.mode === 'http-subgraph') {
+        const { createGraphqlSubgraphClient, createNoopSubgraphClient } = await import('./solvernets/daemon-init.js');
+        subgraphClientForDiscovery = discoveryConfig.url?.trim()
+          ? createGraphqlSubgraphClient({ url: discoveryConfig.url })
+          : createNoopSubgraphClient();
+      }
+      try {
+        sharedDiscoveryApi = createDiscoveryAPI(discoveryConfig, {
+          rpcUrl: config.rpcUrl,
+          chainId: config.network === 'testnet' ? 84532 : 8453,
+          routerAddress: ROUTER_ADDRESS,
+          identityRegistryAddress: identityRegistryAddress ?? undefined,
+          safeAddress,
+          mechAddress: mechAddress ?? undefined,
+          taskDiscoveryFromBlock: config.network === 'testnet' ? 41_153_291 : 25_000_000,
+          subgraphClient: subgraphClientForDiscovery,
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`[main] DiscoveryAPI construction failed: ${msg} — falling back to onchain discovery`);
+        const { createOnchainDiscoveryAPI } = await import('./discovery/onchain.js');
+        sharedDiscoveryApi = createOnchainDiscoveryAPI({
+          rpcUrl: config.rpcUrl,
+          chainId: config.network === 'testnet' ? 84532 : 8453,
+          routerAddress: ROUTER_ADDRESS,
+          identityRegistryAddress: identityRegistryAddress ?? undefined,
+          safeAddress,
+          mechAddress: mechAddress ?? undefined,
+          taskDiscoveryFromBlock: config.network === 'testnet' ? 41_153_291 : 25_000_000,
+        });
+      }
+    } else {
+      // No discovery config — default to onchain floor (no subgraphUrl in config).
+      // TODO(280n.4): flip default to 'http' once HttpDiscoveryAPI lands.
+      const { createOnchainDiscoveryAPI } = await import('./discovery/onchain.js');
+      sharedDiscoveryApi = createOnchainDiscoveryAPI({
+        rpcUrl: config.rpcUrl,
+        chainId: config.network === 'testnet' ? 84532 : 8453,
+        routerAddress: ROUTER_ADDRESS,
+        identityRegistryAddress: identityRegistryAddress ?? undefined,
+        safeAddress,
+        mechAddress: mechAddress ?? undefined,
+        taskDiscoveryFromBlock: config.network === 'testnet' ? 41_153_291 : 25_000_000,
+      });
+    }
+  }
+
   const adapter = new MechAdapter({
     rpcUrl: config.rpcUrl,
     mechMarketplaceAddress: MARKETPLACE_ADDRESS,
@@ -1472,7 +1530,7 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     evictionRecovery,
     taskDiscovery: taskDiscoveryManifestCids.length > 0
       ? {
-          ...(config.subgraphUrl ? { subgraphUrl: config.subgraphUrl } : {}),
+          discoveryApi: sharedDiscoveryApi,
           solverNetManifestCids: taskDiscoveryManifestCids,
           onchainFromBlock: config.network === 'testnet' ? 41_153_291 : 25_000_000,
           ...(config.taskDiscoveryAllowedTaskIds?.length
@@ -1837,6 +1895,7 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
       ipfs: solverNetIpfs,
       publisher: solverNetPublisher,
       subgraph: solverNetSubgraph,
+      discoveryApi: sharedDiscoveryApi,
       network: 'base-sepolia',
     });
     solverNetRegistryClientForEngine = solverNetRegistryClient;
@@ -2004,15 +2063,22 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
   // Enabled when either the optional subgraph accelerator or canonical
   // on-chain ERC-8004/IPFS discovery is configured. Otherwise the API route is
   // absent and MCP falls back to local-only behaviour with a warning.
-  const corpusFactory = (config.subgraphUrl?.trim() || identityRegistryAddress)
+  // The corpus is always enabled when a DiscoveryAPI is available (which is
+  // always true after 280n.3 — the onchain floor is always constructed).
+  // The legacy condition (subgraphUrl || identityRegistryAddress) is kept for
+  // backwards compatibility with callers that don't use the new path.
+  const corpusFactory = (sharedDiscoveryApi || config.subgraphUrl?.trim() || identityRegistryAddress)
     ? (store: Store) =>
         (corpusForApi = createCorpus({
-          ...(config.subgraphUrl?.trim() ? { subgraphUrl: config.subgraphUrl } : {}),
+          // Prefer DiscoveryAPI when available (280n.3 migration).
+          ...(sharedDiscoveryApi ? { discovery: sharedDiscoveryApi } : {}),
+          // Legacy fallbacks kept for backwards compatibility.
+          ...(!sharedDiscoveryApi && config.subgraphUrl?.trim() ? { subgraphUrl: config.subgraphUrl } : {}),
           ipfsGatewayUrl: config.ipfsGatewayUrl,
           store,
           signer: { privateKey: agentPrivateKey },
           selfSafeAddress: safeAddress,
-          ...(identityRegistryAddress
+          ...(!sharedDiscoveryApi && identityRegistryAddress
             ? {
                 onchain: {
                   rpcUrl: config.rpcUrl,
@@ -2026,7 +2092,7 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     : undefined;
   if (!corpusFactory) {
     console.warn(
-      '[main] Corpus disabled (no subgraphUrl or on-chain identity registry); ' +
+      '[main] Corpus disabled (no DiscoveryAPI, subgraphUrl, or on-chain identity registry); ' +
         'MCP record lookup and artifact acquisition network branches will be unavailable.',
     );
   }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1463,7 +1463,20 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
   // (envelope discovery). See spec/2026-05-11-discovery-api-and-shared-indexer.md §9.
   let sharedDiscoveryApi: import('./discovery/types.js').DiscoveryAPI | undefined;
   {
-    const { createDiscoveryAPI } = await import('./discovery/factory.js');
+    const onchainFloorOpts = {
+      rpcUrl: config.rpcUrl,
+      chainId: config.network === 'testnet' ? 84532 : 8453,
+      routerAddress: ROUTER_ADDRESS,
+      identityRegistryAddress: identityRegistryAddress ?? undefined,
+      safeAddress,
+      mechAddress: mechAddress ?? undefined,
+      taskDiscoveryFromBlock: config.network === 'testnet' ? 41_153_291 : 25_000_000,
+    } as const;
+    async function buildOnchainFloor(): Promise<import('./discovery/types.js').DiscoveryAPI> {
+      const { createOnchainDiscoveryAPI } = await import('./discovery/onchain.js');
+      return createOnchainDiscoveryAPI(onchainFloorOpts);
+    }
+
     const discoveryConfig = config.discovery;
     if (discoveryConfig) {
       // A discovery block was explicitly set (or normalized from subgraphUrl).
@@ -1475,43 +1488,20 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
           : createNoopSubgraphClient();
       }
       try {
+        const { createDiscoveryAPI } = await import('./discovery/factory.js');
         sharedDiscoveryApi = createDiscoveryAPI(discoveryConfig, {
-          rpcUrl: config.rpcUrl,
-          chainId: config.network === 'testnet' ? 84532 : 8453,
-          routerAddress: ROUTER_ADDRESS,
-          identityRegistryAddress: identityRegistryAddress ?? undefined,
-          safeAddress,
-          mechAddress: mechAddress ?? undefined,
-          taskDiscoveryFromBlock: config.network === 'testnet' ? 41_153_291 : 25_000_000,
+          ...onchainFloorOpts,
           subgraphClient: subgraphClientForDiscovery,
         });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.warn(`[main] DiscoveryAPI construction failed: ${msg} — falling back to onchain discovery`);
-        const { createOnchainDiscoveryAPI } = await import('./discovery/onchain.js');
-        sharedDiscoveryApi = createOnchainDiscoveryAPI({
-          rpcUrl: config.rpcUrl,
-          chainId: config.network === 'testnet' ? 84532 : 8453,
-          routerAddress: ROUTER_ADDRESS,
-          identityRegistryAddress: identityRegistryAddress ?? undefined,
-          safeAddress,
-          mechAddress: mechAddress ?? undefined,
-          taskDiscoveryFromBlock: config.network === 'testnet' ? 41_153_291 : 25_000_000,
-        });
+        sharedDiscoveryApi = await buildOnchainFloor();
       }
     } else {
       // No discovery config — default to onchain floor (no subgraphUrl in config).
       // TODO(280n.4): flip default to 'http' once HttpDiscoveryAPI lands.
-      const { createOnchainDiscoveryAPI } = await import('./discovery/onchain.js');
-      sharedDiscoveryApi = createOnchainDiscoveryAPI({
-        rpcUrl: config.rpcUrl,
-        chainId: config.network === 'testnet' ? 84532 : 8453,
-        routerAddress: ROUTER_ADDRESS,
-        identityRegistryAddress: identityRegistryAddress ?? undefined,
-        safeAddress,
-        mechAddress: mechAddress ?? undefined,
-        taskDiscoveryFromBlock: config.network === 'testnet' ? 41_153_291 : 25_000_000,
-      });
+      sharedDiscoveryApi = await buildOnchainFloor();
     }
   }
 

--- a/client/src/solvernets/daemon-init.ts
+++ b/client/src/solvernets/daemon-init.ts
@@ -76,6 +76,7 @@ import {
   type LifecycleTransitionDeps,
 } from './lifecycle-transitions.js';
 import type { SolverNetRegistryClient, SolverNetManifestSummary } from './registry-client.js';
+import type { DiscoveryAPI } from '../discovery/types.js';
 import type { LaunchedSolverNetRecord, SolverNetStore } from './store.js';
 
 // Import viem types lazily-named — keep the runtime import scoped so unit
@@ -639,12 +640,14 @@ export function createDefaultRegistryClient(args: {
   ipfs: IpfsClient;
   publisher: MetadataPublisher;
   subgraph: SubgraphClient;
+  discoveryApi?: DiscoveryAPI;
   network: 'base-sepolia' | 'base';
 }): SolverNetRegistryClient {
   return new IdentityRegistryBackedSolverNetRegistryClient({
     ipfs: args.ipfs,
     publisher: args.publisher,
     subgraph: args.subgraph,
+    discoveryApi: args.discoveryApi,
     network: args.network,
   });
 }

--- a/client/src/solvernets/registry-client-erc8004.ts
+++ b/client/src/solvernets/registry-client-erc8004.ts
@@ -67,6 +67,7 @@ import type {
   SolverNetManifestSummary,
   SignerWithAgentEoa,
 } from './registry-client.js';
+import type { DiscoveryAPI } from '../discovery/types.js';
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -166,6 +167,21 @@ export interface IdentityRegistryBackedSolverNetRegistryClientConfig {
   publisher: MetadataPublisher;
   subgraph: SubgraphClient;
   /**
+   * DiscoveryAPI instance for `listLaunched` and `getLifecycleStatus`.
+   *
+   * When provided, these read methods delegate to the DiscoveryAPI instead of
+   * calling `this.subgraph` directly. This allows the registry client to be
+   * backed by any DiscoveryAPI implementation (onchain, http-subgraph, etc.)
+   * without changing its interface.
+   *
+   * When absent, the legacy `subgraph` client is used directly (backwards
+   * compatibility).
+   *
+   * NOTE: `getManifest` and publish paths always use `this.ipfs` and
+   * `this.subgraph` directly — discovery only covers the list/status read paths.
+   */
+  discoveryApi?: DiscoveryAPI;
+  /**
    * Network for which this client serves operator catalog rows. Used to
    * filter `listLaunched` summaries — manifests record their target network
    * in `manifest.network` per spec §7.
@@ -199,6 +215,7 @@ export class IdentityRegistryBackedSolverNetRegistryClient
   private readonly ipfs: IpfsClient;
   private readonly publisher: MetadataPublisher;
   private readonly subgraph: SubgraphClient;
+  private readonly discoveryApi: DiscoveryAPI | undefined;
   private readonly network: 'base-sepolia' | 'base';
   private readonly now: () => Date;
 
@@ -231,6 +248,7 @@ export class IdentityRegistryBackedSolverNetRegistryClient
     this.ipfs = config.ipfs;
     this.publisher = config.publisher;
     this.subgraph = config.subgraph;
+    this.discoveryApi = config.discoveryApi;
     this.network = config.network;
     this.now = config.now ?? (() => new Date());
   }
@@ -350,27 +368,35 @@ export class IdentityRegistryBackedSolverNetRegistryClient
     statusFilter?: Array<'launched' | 'paused' | 'retired'>;
     sinceBlock?: number;
   }): Promise<SolverNetManifestSummary[]> {
-    const events = await this.subgraph.fetchSetMetadataEvents({
-      keyPrefix: SOLVERNET_MANIFEST_KEY_PREFIX,
-      ...(args.sinceBlock !== undefined ? { sinceBlock: args.sinceBlock } : {}),
-    });
+    // Discovery is now the only supported path for listing launched SolverNets.
+    // Direct subgraph calls are no longer supported from this method — the
+    // DiscoveryAPI abstraction wraps the subgraph (or onchain RPC) and is the
+    // single callsite for read-side discovery queries.
+    if (!this.discoveryApi) {
+      throw new Error(
+        'listLaunched requires a DiscoveryAPI to be injected at construction time. ' +
+        'Pass discoveryApi in the IdentityRegistryBackedSolverNetRegistryClientConfig.',
+      );
+    }
 
-    const resolved = resolveMostRecentWins(events);
+    // Step 1: Obtain coarse summaries (manifestCid + lifecycle status) from
+    // the DiscoveryAPI. The http-subgraph implementation folds
+    // resolveMostRecentWins internally; the onchain implementation scans logs.
+    // Note: listLaunchedSolverNets does not accept sinceBlock — that arg was
+    // a subgraph optimisation that does not translate to the abstract interface.
+    const rawSummaries = await this.discoveryApi.listLaunchedSolverNets(
+      args.statusFilter !== undefined ? { status: args.statusFilter } : undefined,
+    );
 
-    const filterByStatus = args.statusFilter;
+    // Step 2: For each summary, fetch the full manifest body from IPFS.
+    // This enriches the coarse summary (which has empty name/network/prices)
+    // with the fields that come only from the manifest body.
     const out: SolverNetManifestSummary[] = [];
 
-    for (const row of resolved) {
-      if (filterByStatus !== undefined && !filterByStatus.includes(row.status)) {
-        continue;
-      }
-
-      // Fetch the manifest body so we can populate the catalog-row fields.
-      // Cache hit avoids the IPFS round-trip for rows we've published or
-      // read in this process.
+    for (const row of rawSummaries) {
       let manifest: SolverNetManifestV1;
       try {
-        manifest = await this.fetchAndValidateManifest(row.manifestCid, row.manifestHash);
+        manifest = await this.fetchAndValidateManifest(row.manifestCid);
       } catch {
         // Skip rows whose IPFS body can't be fetched/validated. Operators
         // see "missing/tampered manifest" rows nowhere, which is
@@ -470,6 +496,18 @@ export class IdentityRegistryBackedSolverNetRegistryClient
     statusUpdatedAt: string;
     sourceBlock: number;
   }> {
+    // Delegate to DiscoveryAPI when available (280n.3 migration).
+    if (this.discoveryApi) {
+      const result = await this.discoveryApi.getLifecycleStatus(args.manifestCid);
+      if (result === undefined) {
+        throw new Error(
+          `no setMetadata events for manifestCid ${args.manifestCid}`,
+        );
+      }
+      return result;
+    }
+
+    // Legacy path: direct subgraph call.
     const events = await this.subgraph.fetchSetMetadataEventsForCid({
       manifestCid: args.manifestCid,
     });

--- a/client/src/solvernets/registry-client.ts
+++ b/client/src/solvernets/registry-client.ts
@@ -21,6 +21,19 @@ import type { SolverNetManifestV1 } from '@jinn-network/sdk/solvernets';
 // ── Supporting types ────────────────────────────────────────────────────────
 
 /**
+ * Current lifecycle status of a SolverNet manifest.
+ *
+ * Returned by `SolverNetRegistryClient.getLifecycleStatus`. This is the
+ * canonical definition; `client/src/discovery/types.ts` re-exports it so
+ * consumers of the discovery layer only need one import path.
+ */
+export interface SolverNetLifecycleStatus {
+  status: 'launched' | 'paused' | 'retired';
+  statusUpdatedAt: string;
+  sourceBlock: number;
+}
+
+/**
  * Minimal "ready to sign" handle for the launcher's agent EOA. Held by the
  * registry client implementation to (a) sign manifests via `signManifest` and
  * (b) send the on-chain `setMetadata` tx that anchors the manifest CID.
@@ -126,9 +139,5 @@ export interface SolverNetRegistryClient {
 
   getLifecycleStatus(args: {
     manifestCid: string;
-  }): Promise<{
-    status: 'launched' | 'paused' | 'retired';
-    statusUpdatedAt: string;
-    sourceBlock: number;
-  }>;
+  }): Promise<SolverNetLifecycleStatus>;
 }

--- a/client/test/adapters/mech/adapter.test.ts
+++ b/client/test/adapters/mech/adapter.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { MechAdapterConfig } from '../../../src/adapters/mech/types.js';
 import type { SignedTaskV1 } from '../../../src/types/task-document.js';
+import type { DiscoveryAPI, ClaimableTaskCandidate } from '../../../src/discovery/types.js';
+import { DiscoveryUnavailableError } from '../../../src/discovery/types.js';
 
 const HOISTED = vi.hoisted(() => {
   const REQUEST_ID = ('0x' + 'aa'.repeat(32)) as `0x${string}`;
@@ -288,13 +290,12 @@ describe('MechAdapter TaskCoordinator flow', () => {
     await adapter.stop();
   });
 
-  it('watchForTasks yields subgraph-discovered claimable backlog tasks', async () => {
+  it('watchForTasks yields discoveryApi-discovered claimable backlog tasks', async () => {
     const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
-    const { queryClaimableTaskCandidates } = await import('../../../src/adapters/mech/task-subgraph.js');
     const { canClaimTask, claimTask } = await import('../../../src/adapters/mech/contracts.js');
     const { fetchSignedTaskFromIpfs } = await import('../../../src/adapters/mech/ipfs.js');
 
-    vi.mocked(queryClaimableTaskCandidates).mockResolvedValueOnce([{
+    const candidate: ClaimableTaskCandidate = {
       taskId: '42',
       taskCidDigest: TASK_CID_DIGEST,
       manifestDigest: MANIFEST_DIGEST,
@@ -302,13 +303,19 @@ describe('MechAdapter TaskCoordinator flow', () => {
       createdAtTx: TX_HASH,
       attemptCount: 0,
       operatorAttemptCount: 0,
-    }]);
-    vi.mocked(fetchSignedTaskFromIpfs).mockResolvedValueOnce(signedTask({ id: 'subgraph-task' }));
+    };
+    const mockDiscoveryApi: DiscoveryAPI = {
+      findClaimableTasks: vi.fn().mockResolvedValueOnce([candidate]),
+      listLaunchedSolverNets: vi.fn().mockResolvedValue([]),
+      getLifecycleStatus: vi.fn().mockResolvedValue(undefined),
+      queryEnvelopes: vi.fn().mockResolvedValue([]),
+    };
+    vi.mocked(fetchSignedTaskFromIpfs).mockResolvedValueOnce(signedTask({ id: 'discovery-task' }));
 
     const adapter = new MechAdapter({
       ...TEST_CONFIG,
       taskDiscovery: {
-        subgraphUrl: 'https://subgraph.example/graphql',
+        discoveryApi: mockDiscoveryApi,
         solverNetManifestCids: ['bafyfixturecid'],
       },
     });
@@ -318,8 +325,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
     const gen = adapter.watchForTasks()[Symbol.asyncIterator]();
     const { value } = await gen.next();
 
-    expect(queryClaimableTaskCandidates).toHaveBeenCalledWith(expect.objectContaining({
-      url: 'https://subgraph.example/graphql',
+    expect(mockDiscoveryApi.findClaimableTasks).toHaveBeenCalledWith(expect.objectContaining({
       solverNetManifestCids: ['bafyfixturecid'],
       operatorAddress: TEST_CONFIG.safeAddress,
     }));
@@ -335,7 +341,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
       taskCid: TASK_CID,
       onchainCreationTx: TX_HASH,
       onchainCreationBlock: 80,
-      task: { id: 'subgraph-task' },
+      task: { id: 'discovery-task' },
     });
 
     await adapter.claimTask(value!.taskId);
@@ -352,38 +358,42 @@ describe('MechAdapter TaskCoordinator flow', () => {
     await adapter.stop();
   });
 
-  it('subgraph discovery yields one backlog task per polling pass', async () => {
+  it('discovery yields one backlog task per polling pass', async () => {
     const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
-    const { queryClaimableTaskCandidates } = await import('../../../src/adapters/mech/task-subgraph.js');
     const { canClaimTask } = await import('../../../src/adapters/mech/contracts.js');
     const { fetchSignedTaskFromIpfs } = await import('../../../src/adapters/mech/ipfs.js');
 
-    vi.mocked(queryClaimableTaskCandidates).mockResolvedValueOnce([
-      {
-        taskId: '42',
-        taskCidDigest: TASK_CID_DIGEST,
-        manifestDigest: MANIFEST_DIGEST,
-        createdAtBlock: 80,
-        createdAtTx: TX_HASH,
-        attemptCount: 0,
-        operatorAttemptCount: 0,
-      },
-      {
-        taskId: '43',
-        taskCidDigest: TASK_CID_DIGEST,
-        manifestDigest: MANIFEST_DIGEST,
-        createdAtBlock: 81,
-        createdAtTx: TX_HASH,
-        attemptCount: 0,
-        operatorAttemptCount: 0,
-      },
-    ]);
-    vi.mocked(fetchSignedTaskFromIpfs).mockResolvedValueOnce(signedTask({ id: 'first-subgraph-task' }));
+    const mockDiscoveryApi: DiscoveryAPI = {
+      findClaimableTasks: vi.fn().mockResolvedValueOnce([
+        {
+          taskId: '42',
+          taskCidDigest: TASK_CID_DIGEST,
+          manifestDigest: MANIFEST_DIGEST,
+          createdAtBlock: 80,
+          createdAtTx: TX_HASH,
+          attemptCount: 0,
+          operatorAttemptCount: 0,
+        },
+        {
+          taskId: '43',
+          taskCidDigest: TASK_CID_DIGEST,
+          manifestDigest: MANIFEST_DIGEST,
+          createdAtBlock: 81,
+          createdAtTx: TX_HASH,
+          attemptCount: 0,
+          operatorAttemptCount: 0,
+        },
+      ]),
+      listLaunchedSolverNets: vi.fn().mockResolvedValue([]),
+      getLifecycleStatus: vi.fn().mockResolvedValue(undefined),
+      queryEnvelopes: vi.fn().mockResolvedValue([]),
+    };
+    vi.mocked(fetchSignedTaskFromIpfs).mockResolvedValueOnce(signedTask({ id: 'first-discovery-task' }));
 
     const adapter = new MechAdapter({
       ...TEST_CONFIG,
       taskDiscovery: {
-        subgraphUrl: 'https://subgraph.example/graphql',
+        discoveryApi: mockDiscoveryApi,
         solverNetManifestCids: ['bafyfixturecid'],
       },
     });
@@ -395,7 +405,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
 
     expect(first.value).toMatchObject({
       taskId: '42',
-      task: { id: 'first-subgraph-task' },
+      task: { id: 'first-discovery-task' },
     });
     expect(second.done).toBe(true);
     expect(canClaimTask).toHaveBeenCalledTimes(1);
@@ -404,38 +414,42 @@ describe('MechAdapter TaskCoordinator flow', () => {
     await adapter.stop();
   });
 
-  it('subgraph discovery honors an explicit task id scope', async () => {
+  it('discovery honors an explicit task id scope', async () => {
     const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
-    const { queryClaimableTaskCandidates } = await import('../../../src/adapters/mech/task-subgraph.js');
     const { canClaimTask } = await import('../../../src/adapters/mech/contracts.js');
     const { fetchSignedTaskFromIpfs } = await import('../../../src/adapters/mech/ipfs.js');
 
-    vi.mocked(queryClaimableTaskCandidates).mockResolvedValueOnce([
-      {
-        taskId: '42',
-        taskCidDigest: TASK_CID_DIGEST,
-        manifestDigest: MANIFEST_DIGEST,
-        createdAtBlock: 80,
-        createdAtTx: TX_HASH,
-        attemptCount: 0,
-        operatorAttemptCount: 0,
-      },
-      {
-        taskId: '43',
-        taskCidDigest: TASK_CID_DIGEST,
-        manifestDigest: MANIFEST_DIGEST,
-        createdAtBlock: 81,
-        createdAtTx: TX_HASH,
-        attemptCount: 0,
-        operatorAttemptCount: 0,
-      },
-    ]);
-    vi.mocked(fetchSignedTaskFromIpfs).mockResolvedValueOnce(signedTask({ id: 'scoped-subgraph-task' }));
+    const mockDiscoveryApi: DiscoveryAPI = {
+      findClaimableTasks: vi.fn().mockResolvedValueOnce([
+        {
+          taskId: '42',
+          taskCidDigest: TASK_CID_DIGEST,
+          manifestDigest: MANIFEST_DIGEST,
+          createdAtBlock: 80,
+          createdAtTx: TX_HASH,
+          attemptCount: 0,
+          operatorAttemptCount: 0,
+        },
+        {
+          taskId: '43',
+          taskCidDigest: TASK_CID_DIGEST,
+          manifestDigest: MANIFEST_DIGEST,
+          createdAtBlock: 81,
+          createdAtTx: TX_HASH,
+          attemptCount: 0,
+          operatorAttemptCount: 0,
+        },
+      ]),
+      listLaunchedSolverNets: vi.fn().mockResolvedValue([]),
+      getLifecycleStatus: vi.fn().mockResolvedValue(undefined),
+      queryEnvelopes: vi.fn().mockResolvedValue([]),
+    };
+    vi.mocked(fetchSignedTaskFromIpfs).mockResolvedValueOnce(signedTask({ id: 'scoped-discovery-task' }));
 
     const adapter = new MechAdapter({
       ...TEST_CONFIG,
       taskDiscovery: {
-        subgraphUrl: 'https://subgraph.example/graphql',
+        discoveryApi: mockDiscoveryApi,
         solverNetManifestCids: ['bafyfixturecid'],
         allowedTaskIds: ['43'],
       },
@@ -447,7 +461,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
 
     expect(first.value).toMatchObject({
       taskId: '43',
-      task: { id: 'scoped-subgraph-task' },
+      task: { id: 'scoped-discovery-task' },
     });
     expect(canClaimTask).toHaveBeenCalledTimes(1);
     expect(canClaimTask).toHaveBeenCalledWith(
@@ -461,14 +475,20 @@ describe('MechAdapter TaskCoordinator flow', () => {
     await adapter.stop();
   });
 
-  it('falls back to canonical TaskCreated logs when configured subgraph discovery fails', async () => {
+  it('falls back to canonical TaskCreated logs when discoveryApi fails', async () => {
     const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
     const { decodeTaskCreatedLogs } = await import('../../../src/adapters/mech/contracts.js');
     const { fetchSignedTaskFromIpfs } = await import('../../../src/adapters/mech/ipfs.js');
-    const { queryClaimableTaskCandidates } = await import('../../../src/adapters/mech/task-subgraph.js');
     const manifestCid = 'bafyfixturecid';
 
-    vi.mocked(queryClaimableTaskCandidates).mockRejectedValueOnce(new Error('subgraph HTTP 429'));
+    const mockDiscoveryApi: DiscoveryAPI = {
+      findClaimableTasks: vi.fn().mockRejectedValueOnce(
+        new DiscoveryUnavailableError('discovery HTTP 429'),
+      ),
+      listLaunchedSolverNets: vi.fn().mockResolvedValue([]),
+      getLifecycleStatus: vi.fn().mockResolvedValue(undefined),
+      queryEnvelopes: vi.fn().mockResolvedValue([]),
+    };
     vi.mocked(decodeTaskCreatedLogs).mockReturnValueOnce([{
       taskId: '44',
       taskCidDigest: TASK_CID_DIGEST,
@@ -482,7 +502,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
     const adapter = new MechAdapter({
       ...TEST_CONFIG,
       taskDiscovery: {
-        subgraphUrl: 'https://subgraph.example/graphql',
+        discoveryApi: mockDiscoveryApi,
         solverNetManifestCids: [manifestCid],
         onchainFromBlock: 100,
       },

--- a/client/test/config.test.ts
+++ b/client/test/config.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, rm, writeFile } from 'fs/promises';
 import os from 'os';
 import path from 'path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DEFAULT_TESTNET_SUBGRAPH_URL, loadConfig, buildConfigProvenance } from '../src/config.js';
 
 describe('loadConfig RPC override handling', () => {
@@ -941,5 +941,88 @@ describe('capture config', () => {
     process.env['JINN_CAPTURES_LLM_PROXY_PORT'] = '7451';
     const cfg = loadConfig(configPath);
     expect(cfg.captures.llmProxy).toEqual({ enabled: true, port: 7451 });
+  });
+});
+
+describe('loadConfig legacy subgraphUrl → discovery normalization', () => {
+  const dirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+    vi.restoreAllMocks();
+    delete process.env['JINN_SUBGRAPH_URL'];
+    delete process.env['JINN_NETWORK'];
+  });
+
+  async function writeConfigFile(contents: Record<string, unknown>): Promise<string> {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'jinn-config-'));
+    dirs.push(dir);
+    const configPath = path.join(dir, 'config.json');
+    await writeFile(configPath, JSON.stringify(contents, null, 2));
+    return configPath;
+  }
+
+  it('maps subgraphUrl to discovery.mode=http-subgraph and emits a deprecation warning', async () => {
+    const configPath = await writeConfigFile({
+      subgraphUrl: 'https://example.com/subgraph',
+    });
+    delete process.env['JINN_SUBGRAPH_URL'];
+    delete process.env['JINN_NETWORK'];
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const config = loadConfig(configPath);
+
+    expect(config.discovery?.mode).toBe('http-subgraph');
+    expect(config.discovery?.url).toBe('https://example.com/subgraph');
+    expect(config.discovery?.fallbackToOnchain).toBe(true);
+
+    const warnCalls = warnSpy.mock.calls.map((args) => String(args[0]));
+    const deprecationWarning = warnCalls.find(
+      (msg) => msg.includes('subgraphUrl') || msg.includes('deprecated'),
+    );
+    expect(deprecationWarning).toBeDefined();
+  });
+
+  it('does not map subgraphUrl when discovery.mode is already set', async () => {
+    const configPath = await writeConfigFile({
+      subgraphUrl: 'https://example.com/subgraph',
+      discovery: { mode: 'onchain' },
+    });
+    delete process.env['JINN_SUBGRAPH_URL'];
+    delete process.env['JINN_NETWORK'];
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const config = loadConfig(configPath);
+
+    // discovery.mode was already set — subgraphUrl mapping should not override it
+    expect(config.discovery?.mode).toBe('onchain');
+
+    // No deprecation warning about subgraphUrl → discovery mapping should be emitted
+    const warnCalls = warnSpy.mock.calls.map((args) => String(args[0]));
+    const mappingWarning = warnCalls.find(
+      (msg) => msg.includes('Mapping to discovery'),
+    );
+    expect(mappingWarning).toBeUndefined();
+  });
+
+  it('maps JINN_SUBGRAPH_URL env var to discovery.mode=http-subgraph', async () => {
+    const configPath = await writeConfigFile({});
+    process.env['JINN_SUBGRAPH_URL'] = 'https://env.example.com/subgraph';
+    delete process.env['JINN_NETWORK'];
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const config = loadConfig(configPath);
+
+    expect(config.discovery?.mode).toBe('http-subgraph');
+    expect(config.discovery?.url).toBe('https://env.example.com/subgraph');
+
+    const warnCalls = warnSpy.mock.calls.map((args) => String(args[0]));
+    const deprecationWarning = warnCalls.find(
+      (msg) => msg.includes('subgraphUrl') || msg.includes('deprecated'),
+    );
+    expect(deprecationWarning).toBeDefined();
   });
 });

--- a/client/test/discovery/factory.test.ts
+++ b/client/test/discovery/factory.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for createDiscoveryAPI factory.
+ *
+ * Verifies:
+ *  - mode: 'onchain'       → returns the floor alone (no withFallback wrapping)
+ *  - mode: 'http-subgraph' → returns a withFallback composition
+ *  - mode: 'http'          → throws (HttpDiscoveryAPI not yet shipped)
+ *  - mode: 'embedded'      → throws (Embedded not yet shipped)
+ *  - legacy subgraphUrl    → is mapped to http-subgraph mode (tested via config normalization)
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createDiscoveryAPI } from '../../src/discovery/factory.js';
+import type { SubgraphClient } from '../../src/solvernets/registry-client-erc8004.js';
+
+// ── Deps fixture ──────────────────────────────────────────────────────────────
+
+const CHAIN_ID = 84532; // Base Sepolia testnet
+
+const noopSubgraphClient: SubgraphClient = {
+  fetchSetMetadataEvents: vi.fn().mockResolvedValue([]),
+  fetchSetMetadataEventsForCid: vi.fn().mockResolvedValue([]),
+};
+
+const baseDeps = {
+  chainId: CHAIN_ID,
+  rpcUrl: 'http://localhost:8545',
+  routerAddress: ('0x' + 'ff'.repeat(20)) as `0x${string}`,
+  identityRegistryAddress: ('0x' + '11'.repeat(20)) as `0x${string}`,
+  safeAddress: ('0x' + '44'.repeat(20)) as `0x${string}`,
+  mechAddress: ('0x' + '55'.repeat(20)) as `0x${string}`,
+};
+
+// ── mode: 'onchain' ────────────────────────────────────────────────────────────
+
+describe('createDiscoveryAPI(mode=onchain)', () => {
+  it('returns a DiscoveryAPI with all four methods', () => {
+    const api = createDiscoveryAPI({ mode: 'onchain' }, baseDeps);
+
+    expect(typeof api.findClaimableTasks).toBe('function');
+    expect(typeof api.listLaunchedSolverNets).toBe('function');
+    expect(typeof api.getLifecycleStatus).toBe('function');
+    expect(typeof api.queryEnvelopes).toBe('function');
+  });
+
+  it('does not wrap in withFallback — it IS the floor', () => {
+    // When mode is 'onchain' we return the floor alone; the floor itself should
+    // work. We can verify this by calling listLaunchedSolverNets (which hits
+    // IdentityRegistry getLogs) and seeing it throw DiscoveryUnavailableError
+    // (no real RPC) rather than a logic error.
+    const api = createDiscoveryAPI({ mode: 'onchain' }, { ...baseDeps, rpcUrl: 'http://localhost:9999' });
+
+    // We won't actually call it (no RPC) — just confirm the object has the
+    // right shape.
+    expect(api).toHaveProperty('findClaimableTasks');
+    expect(api).toHaveProperty('listLaunchedSolverNets');
+    expect(api).toHaveProperty('getLifecycleStatus');
+    expect(api).toHaveProperty('queryEnvelopes');
+  });
+
+  it('respects an explicit fallbackToOnchain: false (no-op for onchain mode)', () => {
+    // For onchain mode, fallbackToOnchain is irrelevant — we return the floor.
+    const api = createDiscoveryAPI({ mode: 'onchain', fallbackToOnchain: false }, baseDeps);
+    expect(api).toHaveProperty('findClaimableTasks');
+  });
+});
+
+// ── mode: 'http-subgraph' ──────────────────────────────────────────────────────
+
+describe('createDiscoveryAPI(mode=http-subgraph)', () => {
+  it('returns a DiscoveryAPI with all four methods when subgraphClient and url are provided', () => {
+    const api = createDiscoveryAPI(
+      {
+        mode: 'http-subgraph',
+        url: 'https://subgraph.test/graphql',
+        fallbackToOnchain: true,
+      },
+      { ...baseDeps, subgraphClient: noopSubgraphClient },
+    );
+
+    expect(typeof api.findClaimableTasks).toBe('function');
+    expect(typeof api.listLaunchedSolverNets).toBe('function');
+    expect(typeof api.getLifecycleStatus).toBe('function');
+    expect(typeof api.queryEnvelopes).toBe('function');
+  });
+
+  it('throws when subgraphClient is missing', () => {
+    expect(() =>
+      createDiscoveryAPI(
+        { mode: 'http-subgraph', url: 'https://subgraph.test/graphql' },
+        baseDeps, // no subgraphClient
+      ),
+    ).toThrow(/subgraphClient/);
+  });
+
+  it('throws when url is missing', () => {
+    expect(() =>
+      createDiscoveryAPI(
+        { mode: 'http-subgraph' }, // no url
+        { ...baseDeps, subgraphClient: noopSubgraphClient },
+      ),
+    ).toThrow(/discovery\.url/);
+  });
+
+  it('returns the primary directly when fallbackToOnchain is false', () => {
+    // With fallbackToOnchain: false the api is the HttpSubgraphDiscoveryAPI
+    // directly, not wrapped in withFallback. We verify via behavior: when the
+    // primary subgraph fails, the call should propagate (not fall back).
+    const failingSubgraph: SubgraphClient = {
+      fetchSetMetadataEvents: vi.fn().mockRejectedValue(new Error('subgraph down')),
+      fetchSetMetadataEventsForCid: vi.fn().mockRejectedValue(new Error('subgraph down')),
+    };
+
+    const api = createDiscoveryAPI(
+      {
+        mode: 'http-subgraph',
+        url: 'https://subgraph.test/graphql',
+        fallbackToOnchain: false,
+      },
+      { ...baseDeps, subgraphClient: failingSubgraph },
+    );
+
+    // DiscoveryUnavailableError should propagate (not be silently swallowed)
+    return expect(api.listLaunchedSolverNets()).rejects.toThrow();
+  });
+});
+
+// ── mode: 'http' ───────────────────────────────────────────────────────────────
+
+describe('createDiscoveryAPI(mode=http)', () => {
+  it('throws because HttpDiscoveryAPI is not yet shipped (280n.4)', () => {
+    expect(() =>
+      createDiscoveryAPI({ mode: 'http', url: 'https://discovery.example.com' }, baseDeps),
+    ).toThrow(/280n\.4/);
+  });
+});
+
+// ── mode: 'embedded' ──────────────────────────────────────────────────────────
+
+describe('createDiscoveryAPI(mode=embedded)', () => {
+  it('throws because EmbeddedPonderDiscoveryAPI is not yet shipped (280n.5)', () => {
+    expect(() =>
+      createDiscoveryAPI({ mode: 'embedded' }, baseDeps),
+    ).toThrow(/280n\.5/);
+  });
+});
+
+// ── default mode ──────────────────────────────────────────────────────────────
+
+describe('createDiscoveryAPI(no mode)', () => {
+  it('defaults to onchain when no mode is specified', () => {
+    // No mode provided → falls back to 'onchain'.
+    const api = createDiscoveryAPI({}, baseDeps);
+    expect(api).toHaveProperty('findClaimableTasks');
+    expect(api).toHaveProperty('queryEnvelopes');
+  });
+});

--- a/client/test/discovery/http-subgraph.test.ts
+++ b/client/test/discovery/http-subgraph.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Tests for HttpSubgraphDiscoveryAPI — the transitional DiscoveryAPI backed by
+ * the existing subgraph clients.
+ *
+ * Verifies:
+ *  1. Each of the four methods delegates correctly to the underlying subgraph client.
+ *  2. Errors from the underlying clients get wrapped in DiscoveryUnavailableError.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SubgraphClient } from '../../src/solvernets/registry-client-erc8004.js';
+import type { SetMetadataEvent } from '../../src/solvernets/most-recent-wins.js';
+import { createHttpSubgraphDiscoveryAPI } from '../../src/discovery/http-subgraph.js';
+import { DiscoveryUnavailableError } from '../../src/discovery/types.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const MANIFEST_CID = 'bafyManifestCid1';
+const MANIFEST_CID_2 = 'bafyManifestCid2';
+const AGENT_ID = '5474';
+
+function makeSetMetadataEvent(cid: string, status: 'launched' | 'paused' | 'retired', blockNumber = 100): SetMetadataEvent {
+  return {
+    agentId: AGENT_ID,
+    key: `solvernet-manifest:${cid}`,
+    payload: {
+      schemaVersion: 'solvernet.lifecycle.v1',
+      status,
+      at: '2026-05-11T00:00:00.000Z',
+      hash: '0x' + 'a'.repeat(64) as `0x${string}`,
+    },
+    blockNumber,
+    transactionIndex: 0,
+  };
+}
+
+function makeSubgraphClient(overrides: Partial<SubgraphClient> = {}): SubgraphClient {
+  return {
+    fetchSetMetadataEvents: vi.fn().mockResolvedValue([]),
+    fetchSetMetadataEventsForCid: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+}
+
+// ── findClaimableTasks ─────────────────────────────────────────────────────────
+
+describe('HttpSubgraphDiscoveryAPI.findClaimableTasks', () => {
+  it('delegates to queryClaimableTaskCandidates and returns ClaimableTaskCandidate[]', async () => {
+    const taskId = '42';
+    const fakeFetch = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: {
+            tasks: [{
+              taskId,
+              taskCidDigest: '0x' + 'cc'.repeat(32),
+              manifestDigest: '0x' + '99'.repeat(32),
+              createdAtBlock: '100',
+              createdAtTx: '0x' + '12'.repeat(32),
+              maxClaims: 10,
+              claimWindowEnd: '9999999999',
+              attempts: [],
+              operatorAttempts: [],
+            }],
+          },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+
+    const api = createHttpSubgraphDiscoveryAPI({
+      subgraphUrl: 'https://subgraph.test/graphql',
+      subgraphClient: makeSubgraphClient(),
+      fetchImpl: fakeFetch,
+    });
+
+    const results = await api.findClaimableTasks({
+      solverNetManifestCids: [MANIFEST_CID],
+      operatorAddress: '0x' + 'aa'.repeat(20) as `0x${string}`,
+    });
+
+    expect(fakeFetch).toHaveBeenCalledWith(
+      'https://subgraph.test/graphql',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(results).toHaveLength(1);
+    expect(results[0].taskId).toBe(taskId);
+    expect(results[0].attemptCount).toBe(0);
+    expect(results[0].operatorAttemptCount).toBe(0);
+  });
+
+  it('wraps subgraph HTTP errors in DiscoveryUnavailableError', async () => {
+    const fakeFetch = vi.fn().mockResolvedValueOnce(
+      new Response('rate limited', { status: 429 }),
+    );
+
+    const api = createHttpSubgraphDiscoveryAPI({
+      subgraphUrl: 'https://subgraph.test/graphql',
+      subgraphClient: makeSubgraphClient(),
+      fetchImpl: fakeFetch,
+    });
+
+    await expect(
+      api.findClaimableTasks({
+        solverNetManifestCids: [MANIFEST_CID],
+        operatorAddress: '0x' + 'aa'.repeat(20) as `0x${string}`,
+      }),
+    ).rejects.toBeInstanceOf(DiscoveryUnavailableError);
+  });
+
+  it('wraps network fetch errors in DiscoveryUnavailableError', async () => {
+    const fakeFetch = vi.fn().mockRejectedValueOnce(new Error('fetch failed'));
+
+    const api = createHttpSubgraphDiscoveryAPI({
+      subgraphUrl: 'https://subgraph.test/graphql',
+      subgraphClient: makeSubgraphClient(),
+      fetchImpl: fakeFetch,
+    });
+
+    await expect(
+      api.findClaimableTasks({
+        solverNetManifestCids: [MANIFEST_CID],
+        operatorAddress: '0x' + 'aa'.repeat(20) as `0x${string}`,
+      }),
+    ).rejects.toBeInstanceOf(DiscoveryUnavailableError);
+  });
+
+  it('returns empty when no manifest CIDs supplied', async () => {
+    const fakeFetch = vi.fn();
+
+    const api = createHttpSubgraphDiscoveryAPI({
+      subgraphUrl: 'https://subgraph.test/graphql',
+      subgraphClient: makeSubgraphClient(),
+      fetchImpl: fakeFetch,
+    });
+
+    const results = await api.findClaimableTasks({
+      solverNetManifestCids: [],
+      operatorAddress: '0x' + 'aa'.repeat(20) as `0x${string}`,
+    });
+
+    expect(results).toHaveLength(0);
+    expect(fakeFetch).not.toHaveBeenCalled();
+  });
+});
+
+// ── listLaunchedSolverNets ─────────────────────────────────────────────────────
+
+describe('HttpSubgraphDiscoveryAPI.listLaunchedSolverNets', () => {
+  it('delegates to subgraphClient.fetchSetMetadataEvents and returns summaries', async () => {
+    const events = [
+      makeSetMetadataEvent(MANIFEST_CID, 'launched', 100),
+      makeSetMetadataEvent(MANIFEST_CID_2, 'paused', 200),
+    ];
+    const subgraphClient = makeSubgraphClient({
+      fetchSetMetadataEvents: vi.fn().mockResolvedValue(events),
+    });
+
+    const api = createHttpSubgraphDiscoveryAPI({
+      subgraphUrl: 'https://subgraph.test/graphql',
+      subgraphClient,
+      fetchImpl: vi.fn(),
+    });
+
+    const summaries = await api.listLaunchedSolverNets();
+
+    expect(subgraphClient.fetchSetMetadataEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ keyPrefix: 'solvernet-manifest:' }),
+    );
+    expect(summaries).toHaveLength(2);
+    expect(summaries.map((s) => s.status)).toEqual(expect.arrayContaining(['launched', 'paused']));
+  });
+
+  it('filters by status when requested', async () => {
+    const events = [
+      makeSetMetadataEvent(MANIFEST_CID, 'launched', 100),
+      makeSetMetadataEvent(MANIFEST_CID_2, 'paused', 200),
+    ];
+    const subgraphClient = makeSubgraphClient({
+      fetchSetMetadataEvents: vi.fn().mockResolvedValue(events),
+    });
+
+    const api = createHttpSubgraphDiscoveryAPI({
+      subgraphUrl: 'https://subgraph.test/graphql',
+      subgraphClient,
+      fetchImpl: vi.fn(),
+    });
+
+    const summaries = await api.listLaunchedSolverNets({ status: ['launched'] });
+
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0].status).toBe('launched');
+  });
+
+  it('wraps subgraphClient errors in DiscoveryUnavailableError', async () => {
+    const subgraphClient = makeSubgraphClient({
+      fetchSetMetadataEvents: vi.fn().mockRejectedValue(new Error('subgraph 503')),
+    });
+
+    const api = createHttpSubgraphDiscoveryAPI({
+      subgraphUrl: 'https://subgraph.test/graphql',
+      subgraphClient,
+      fetchImpl: vi.fn(),
+    });
+
+    await expect(api.listLaunchedSolverNets()).rejects.toBeInstanceOf(DiscoveryUnavailableError);
+  });
+});
+
+// ── getLifecycleStatus ─────────────────────────────────────────────────────────
+
+describe('HttpSubgraphDiscoveryAPI.getLifecycleStatus', () => {
+  it('delegates to subgraphClient.fetchSetMetadataEventsForCid and returns status', async () => {
+    const events = [makeSetMetadataEvent(MANIFEST_CID, 'launched', 150)];
+    const subgraphClient = makeSubgraphClient({
+      fetchSetMetadataEventsForCid: vi.fn().mockResolvedValue(events),
+    });
+
+    const api = createHttpSubgraphDiscoveryAPI({
+      subgraphUrl: 'https://subgraph.test/graphql',
+      subgraphClient,
+      fetchImpl: vi.fn(),
+    });
+
+    const result = await api.getLifecycleStatus(MANIFEST_CID);
+
+    expect(subgraphClient.fetchSetMetadataEventsForCid).toHaveBeenCalledWith({ manifestCid: MANIFEST_CID });
+    expect(result).toMatchObject({
+      status: 'launched',
+      sourceBlock: 150,
+    });
+  });
+
+  it('returns undefined when no events found for cid', async () => {
+    const subgraphClient = makeSubgraphClient({
+      fetchSetMetadataEventsForCid: vi.fn().mockResolvedValue([]),
+    });
+
+    const api = createHttpSubgraphDiscoveryAPI({
+      subgraphUrl: 'https://subgraph.test/graphql',
+      subgraphClient,
+      fetchImpl: vi.fn(),
+    });
+
+    const result = await api.getLifecycleStatus(MANIFEST_CID);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('wraps subgraphClient errors in DiscoveryUnavailableError', async () => {
+    const subgraphClient = makeSubgraphClient({
+      fetchSetMetadataEventsForCid: vi.fn().mockRejectedValue(new Error('subgraph timeout')),
+    });
+
+    const api = createHttpSubgraphDiscoveryAPI({
+      subgraphUrl: 'https://subgraph.test/graphql',
+      subgraphClient,
+      fetchImpl: vi.fn(),
+    });
+
+    await expect(api.getLifecycleStatus(MANIFEST_CID)).rejects.toBeInstanceOf(DiscoveryUnavailableError);
+  });
+});
+
+// ── queryEnvelopes ─────────────────────────────────────────────────────────────
+
+describe('HttpSubgraphDiscoveryAPI.queryEnvelopes', () => {
+  it('delegates to runCorpusQuery (subgraph fetch) and returns EnvelopeRef[]', async () => {
+    const fakeFetch = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: {
+            executions: [{
+              id: '1-0xabc',
+              manifestCid: MANIFEST_CID,
+              manifestHash: '0x' + 'a'.repeat(64),
+              tier: 'COMMITTED',
+              publishedAt: '1745978400',
+              operator: { id: '1', agentId: '1', owner: '0x' + '2'.repeat(40), agentWallet: '0x' + '3'.repeat(40) },
+            }],
+          },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+
+    const api = createHttpSubgraphDiscoveryAPI({
+      subgraphUrl: 'https://subgraph.test/graphql',
+      subgraphClient: makeSubgraphClient(),
+      fetchImpl: fakeFetch,
+    });
+
+    const refs = await api.queryEnvelopes({ limit: 5 });
+
+    expect(fakeFetch).toHaveBeenCalledWith(
+      'https://subgraph.test/graphql',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(refs).toHaveLength(1);
+    expect(refs[0].manifestCid).toBe(MANIFEST_CID);
+    expect(refs[0].evidenceTier).toBe('committed');
+  });
+
+  it('wraps subgraph HTTP errors in DiscoveryUnavailableError', async () => {
+    const fakeFetch = vi.fn().mockResolvedValueOnce(
+      new Response('bad gateway', { status: 502 }),
+    );
+
+    const api = createHttpSubgraphDiscoveryAPI({
+      subgraphUrl: 'https://subgraph.test/graphql',
+      subgraphClient: makeSubgraphClient(),
+      fetchImpl: fakeFetch,
+    });
+
+    await expect(api.queryEnvelopes({ limit: 5 })).rejects.toBeInstanceOf(DiscoveryUnavailableError);
+  });
+
+  it('wraps network errors in DiscoveryUnavailableError', async () => {
+    const fakeFetch = vi.fn().mockRejectedValueOnce(new TypeError('network error'));
+
+    const api = createHttpSubgraphDiscoveryAPI({
+      subgraphUrl: 'https://subgraph.test/graphql',
+      subgraphClient: makeSubgraphClient(),
+      fetchImpl: fakeFetch,
+    });
+
+    await expect(api.queryEnvelopes({ limit: 5 })).rejects.toBeInstanceOf(DiscoveryUnavailableError);
+  });
+});

--- a/client/test/discovery/onchain.test.ts
+++ b/client/test/discovery/onchain.test.ts
@@ -565,6 +565,43 @@ describe('OnchainDiscoveryAPI — findClaimableTasks', () => {
     expect(result.length).toBeLessThanOrEqual(10);
   });
 
+  it('caps the canClaimTask fan-out at maxResults even when getLogs returns far more TaskCreated events', async () => {
+    // getLogs returns 50 TaskCreated rows in one chunk; maxResults = pageSize(2) * maxPages(2) = 4.
+    // Without the pre-fan-out trim, canClaimTask (simulateContract) would run 50 times.
+    const taskLogs = Array.from({ length: 50 }, (_, i) =>
+      buildTaskCreatedLog(
+        BigInt(i + 1),
+        MANIFEST_DIGEST,
+        `0x${String(i).padStart(64, '0')}` as Hex,
+        5,
+        BigInt(100 + i),
+      ),
+    );
+    const mockClient = buildMockClient([taskLogs, []]);
+    mockClient.simulateContract.mockResolvedValue({ result: undefined }); // canClaimTask passes
+
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      routerAddress: ROUTER,
+      safeAddress: SAFE_ADDRESS,
+      mechAddress: MECH_ADDRESS,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+
+    const result = await api.findClaimableTasks({
+      solverNetManifestCids: [MANIFEST_CID],
+      operatorAddress: OPERATOR_ADDRESS,
+      pageSize: 2,
+      maxPages: 2,
+    });
+
+    // simulateContract (canClaimTask) invoked at most maxResults (4) times.
+    expect(mockClient.simulateContract.mock.calls.length).toBeLessThanOrEqual(4);
+    // Returned candidate list is also capped.
+    expect(result.length).toBeLessThanOrEqual(4);
+  });
+
   it('throws DiscoveryUnavailableError on getBlockNumber RPC failure', async () => {
     const mockClient = {
       getBlockNumber: vi.fn(async () => { throw new Error('RPC connection refused'); }),

--- a/client/test/discovery/onchain.test.ts
+++ b/client/test/discovery/onchain.test.ts
@@ -1,0 +1,734 @@
+/**
+ * Tests for OnchainDiscoveryAPI — the always-live floor implementation of DiscoveryAPI.
+ *
+ * Uses viem mock PublicClient injection to avoid hitting real RPCs.
+ *
+ * Coverage:
+ * - queryEnvelopes delegates to runOnchainCorpusQuery
+ * - listLaunchedSolverNets with no args returns fold of mocked MetadataSet events
+ * - listLaunchedSolverNets filters by status correctly
+ * - getLifecycleStatus returns undefined for unknown manifestCid
+ * - findClaimableTasks with one matching task: TaskCreated → canClaimTask ok → returns candidate
+ * - findClaimableTasks with canClaimTask rejecting a candidate: filtered out
+ * - findClaimableTasks with multiple TaskAttemptCreated events: attempt counts computed
+ * - findClaimableTasks respects pageSize and maxPages bounds
+ * - RPC failure → throws DiscoveryUnavailableError
+ * - cursorCache.write called with current head after successful scan
+ * - cursorCache.read used to advance start block
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  encodeAbiParameters,
+  encodeEventTopics,
+  type Hex,
+  type Log,
+} from 'viem';
+import { createOnchainDiscoveryAPI, limitedConcurrency, type OnchainCursorCache } from '../../src/discovery/onchain.js';
+import { DiscoveryUnavailableError } from '../../src/discovery/types.js';
+import { manifestDigestForCid } from '../../src/adapters/mech/task-subgraph.js';
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const CHAIN_ID = 8453;
+const ROUTER = '0xfFa7118A3D820cd4E820010837D65FAfF463181B' as `0x${string}`;
+const IDENTITY_REGISTRY = '0x8004A169FB4a3325136EB29fA0ceB6D2e539a432' as `0x${string}`;
+const SAFE_ADDRESS = `0x${'aa'.repeat(20)}` as `0x${string}`;
+const MECH_ADDRESS = `0x${'bb'.repeat(20)}` as `0x${string}`;
+const OPERATOR_ADDRESS = SAFE_ADDRESS;
+const CURRENT_BLOCK = 9_999n;
+
+const MANIFEST_CID = 'bafyTestManifest';
+const MANIFEST_DIGEST = manifestDigestForCid(MANIFEST_CID);
+
+// ── ABIs for encoding test data ──────────────────────────────────────────────
+
+const TASK_CREATED_ABI = [
+  {
+    type: 'event',
+    name: 'TaskCreated',
+    inputs: [
+      { name: 'creator', type: 'address', indexed: true },
+      { name: 'taskId', type: 'uint256', indexed: true },
+      { name: 'manifestDigest', type: 'bytes32', indexed: true },
+      { name: 'taskCidDigest', type: 'bytes32', indexed: false },
+      { name: 'maxClaims', type: 'uint16', indexed: false },
+      { name: 'requiredVerdicts', type: 'uint16', indexed: false },
+      { name: 'solutionBudget', type: 'uint256', indexed: false },
+      { name: 'verdictBudget', type: 'uint256', indexed: false },
+    ],
+  },
+] as const;
+
+const TASK_ATTEMPT_CREATED_ABI = [
+  {
+    type: 'event',
+    name: 'TaskAttemptCreated',
+    inputs: [
+      { name: 'taskId', type: 'uint256', indexed: true },
+      { name: 'attemptIndex', type: 'uint32', indexed: true },
+      { name: 'requestId', type: 'bytes32', indexed: true },
+      { name: 'operator', type: 'address', indexed: false },
+      { name: 'priorityMech', type: 'address', indexed: false },
+      { name: 'deliveryRate', type: 'uint256', indexed: false },
+    ],
+  },
+] as const;
+
+const METADATA_ABI = [
+  {
+    type: 'event',
+    name: 'MetadataSet',
+    inputs: [
+      { name: 'agentId', type: 'uint256', indexed: true },
+      { name: 'indexedMetadataKey', type: 'string', indexed: true },
+      { name: 'metadataKey', type: 'string', indexed: false },
+      { name: 'metadataValue', type: 'bytes', indexed: false },
+    ],
+  },
+] as const;
+
+// ── Log builders ──────────────────────────────────────────────────────────────
+
+/** Build a minimal TaskCreated Log using encodeEventTopics + encodeAbiParameters. */
+function buildTaskCreatedLog(
+  taskId: bigint,
+  manifestDigest: Hex,
+  taskCidDigest: Hex,
+  maxClaims: number,
+  blockNumber: bigint,
+  txHash?: Hex,
+): Log {
+  const creator = `0x${'cc'.repeat(20)}` as `0x${string}`;
+  const topics = encodeEventTopics({
+    abi: TASK_CREATED_ABI,
+    eventName: 'TaskCreated',
+    args: { creator, taskId, manifestDigest },
+  });
+  const data = encodeAbiParameters(
+    [
+      { name: 'taskCidDigest', type: 'bytes32' },
+      { name: 'maxClaims', type: 'uint16' },
+      { name: 'requiredVerdicts', type: 'uint16' },
+      { name: 'solutionBudget', type: 'uint256' },
+      { name: 'verdictBudget', type: 'uint256' },
+    ],
+    [taskCidDigest, maxClaims, 1, 1000n, 500n],
+  );
+  return {
+    address: ROUTER,
+    data,
+    topics,
+    blockNumber,
+    blockHash: `0x${'00'.repeat(32)}` as Hex,
+    transactionHash: txHash ?? `0x${'11'.repeat(32)}` as Hex,
+    transactionIndex: 0,
+    logIndex: 0,
+    removed: false,
+  } as unknown as Log;
+}
+
+/** Build a minimal TaskAttemptCreated Log. */
+function buildTaskAttemptCreatedLog(
+  taskId: bigint,
+  attemptIndex: number,
+  requestId: Hex,
+  operator: `0x${string}`,
+  blockNumber: bigint,
+): Log {
+  const topics = encodeEventTopics({
+    abi: TASK_ATTEMPT_CREATED_ABI,
+    eventName: 'TaskAttemptCreated',
+    args: { taskId, attemptIndex, requestId },
+  });
+  const data = encodeAbiParameters(
+    [
+      { name: 'operator', type: 'address' },
+      { name: 'priorityMech', type: 'address' },
+      { name: 'deliveryRate', type: 'uint256' },
+    ],
+    [operator, MECH_ADDRESS, 99n],
+  );
+  return {
+    address: ROUTER,
+    data,
+    topics,
+    blockNumber,
+    blockHash: `0x${'00'.repeat(32)}` as Hex,
+    transactionHash: `0x${'22'.repeat(32)}` as Hex,
+    transactionIndex: 0,
+    logIndex: 0,
+    removed: false,
+  } as unknown as Log;
+}
+
+/** Build a MetadataSet log for a solvernet-manifest key with a lifecycle payload. */
+function buildSolvernetMetadataLog(
+  agentId: bigint,
+  manifestCid: string,
+  status: 'launched' | 'paused' | 'retired',
+  blockNumber: bigint,
+  transactionIndex = 0,
+): Log {
+  const metadataKey = `solvernet-manifest:${manifestCid}`;
+  const payload = JSON.stringify({
+    schemaVersion: 'solvernet.lifecycle.v1',
+    status,
+    at: '2026-05-11T00:00:00Z',
+    hash: `0x${'ab'.repeat(32)}` as Hex,
+  });
+  const valueBytes = new TextEncoder().encode(payload);
+  const valueHex = ('0x' + Buffer.from(valueBytes).toString('hex')) as Hex;
+
+  const topics = encodeEventTopics({
+    abi: METADATA_ABI,
+    eventName: 'MetadataSet',
+    args: { agentId, indexedMetadataKey: metadataKey },
+  });
+  const data = encodeAbiParameters(
+    [
+      { name: 'metadataKey', type: 'string' },
+      { name: 'metadataValue', type: 'bytes' },
+    ],
+    [metadataKey, valueHex],
+  );
+
+  return {
+    address: IDENTITY_REGISTRY,
+    data,
+    topics,
+    blockNumber,
+    blockHash: `0x${'00'.repeat(32)}` as Hex,
+    transactionHash: `0x${'33'.repeat(32)}` as Hex,
+    transactionIndex,
+    logIndex: 0,
+    removed: false,
+  } as unknown as Log;
+}
+
+// ── Mock client builder ───────────────────────────────────────────────────────
+
+/** Build a mock PublicClient with a queue of log batches per getLogs call. */
+function buildMockClient(logsByCall: Log[][]): {
+  getBlockNumber: ReturnType<typeof vi.fn>;
+  getLogs: ReturnType<typeof vi.fn>;
+  simulateContract: ReturnType<typeof vi.fn>;
+} {
+  let callIndex = 0;
+  return {
+    getBlockNumber: vi.fn(async () => CURRENT_BLOCK),
+    getLogs: vi.fn(async () => {
+      const batch = logsByCall[callIndex] ?? [];
+      callIndex++;
+      return batch;
+    }),
+    simulateContract: vi.fn(async () => {
+      // Default: simulate success (canClaimTask passes)
+      return { result: undefined };
+    }),
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('OnchainDiscoveryAPI — queryEnvelopes', () => {
+  it('delegates to runOnchainCorpusQuery and returns envelope refs', async () => {
+    // The simplest path: no logs found, returns empty array
+    const mockClient = buildMockClient([[]]);
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+
+    const result = await api.queryEnvelopes({ solverType: 'prediction.v0' });
+    expect(Array.isArray(result)).toBe(true);
+    // getLogs was called (delegated to runOnchainCorpusQuery)
+    expect(mockClient.getLogs).toHaveBeenCalled();
+  });
+});
+
+describe('OnchainDiscoveryAPI — listLaunchedSolverNets', () => {
+  it('returns resolved lifecycle rows from MetadataSet events', async () => {
+    const log = buildSolvernetMetadataLog(42n, MANIFEST_CID, 'launched', 5_000n);
+    const mockClient = buildMockClient([[log]]);
+
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      identityRegistryAddress: IDENTITY_REGISTRY,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+
+    const result = await api.listLaunchedSolverNets();
+    expect(result).toHaveLength(1);
+    expect(result[0].manifestCid).toBe(MANIFEST_CID);
+    expect(result[0].status).toBe('launched');
+    expect(result[0].launcherAgentId).toBe('42');
+  });
+
+  it('returns empty array when no MetadataSet events found', async () => {
+    const mockClient = buildMockClient([[]]); // no logs
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      identityRegistryAddress: IDENTITY_REGISTRY,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+
+    const result = await api.listLaunchedSolverNets();
+    expect(result).toHaveLength(0);
+  });
+
+  it('filters by status=launched, excluding paused', async () => {
+    const log1 = buildSolvernetMetadataLog(1n, 'cid-launched', 'launched', 5_000n);
+    const log2 = buildSolvernetMetadataLog(2n, 'cid-paused', 'paused', 5_001n);
+    const mockClient = buildMockClient([[log1, log2]]);
+
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      identityRegistryAddress: IDENTITY_REGISTRY,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+
+    const result = await api.listLaunchedSolverNets({ status: ['launched'] });
+    expect(result).toHaveLength(1);
+    expect(result[0].manifestCid).toBe('cid-launched');
+    expect(result[0].status).toBe('launched');
+  });
+
+  it('filters by launcherAgentId', async () => {
+    const log1 = buildSolvernetMetadataLog(10n, 'cid-agent-10', 'launched', 5_000n);
+    const log2 = buildSolvernetMetadataLog(20n, 'cid-agent-20', 'launched', 5_001n);
+    const mockClient = buildMockClient([[log1, log2]]);
+
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      identityRegistryAddress: IDENTITY_REGISTRY,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+
+    const result = await api.listLaunchedSolverNets({ launcherAgentId: '10' });
+    expect(result).toHaveLength(1);
+    expect(result[0].launcherAgentId).toBe('10');
+  });
+
+  it('picks the most recent event per (agentId, cid) tuple (most-recent-wins)', async () => {
+    const log1 = buildSolvernetMetadataLog(1n, MANIFEST_CID, 'launched', 5_000n, 0);
+    const log2 = buildSolvernetMetadataLog(1n, MANIFEST_CID, 'paused', 5_001n, 0);
+    const mockClient = buildMockClient([[log1, log2]]);
+
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      identityRegistryAddress: IDENTITY_REGISTRY,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+
+    const result = await api.listLaunchedSolverNets();
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe('paused');
+  });
+});
+
+describe('OnchainDiscoveryAPI — getLifecycleStatus', () => {
+  it('returns undefined for an unknown manifestCid', async () => {
+    const mockClient = buildMockClient([[]]); // no logs
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      identityRegistryAddress: IDENTITY_REGISTRY,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+
+    const result = await api.getLifecycleStatus('unknown-cid-xyz');
+    expect(result).toBeUndefined();
+  });
+
+  it('returns the lifecycle status for a known manifestCid', async () => {
+    const log = buildSolvernetMetadataLog(42n, MANIFEST_CID, 'launched', 5_000n);
+    const mockClient = buildMockClient([[log]]);
+
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      identityRegistryAddress: IDENTITY_REGISTRY,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+
+    const result = await api.getLifecycleStatus(MANIFEST_CID);
+    expect(result).toBeDefined();
+    expect(result?.status).toBe('launched');
+    expect(result?.sourceBlock).toBe(5_000);
+  });
+
+  it('returns undefined for a different cid even if other events exist', async () => {
+    const log = buildSolvernetMetadataLog(42n, 'some-other-cid', 'launched', 5_000n);
+    const mockClient = buildMockClient([[log]]);
+
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      identityRegistryAddress: IDENTITY_REGISTRY,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+
+    const result = await api.getLifecycleStatus(MANIFEST_CID);
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('OnchainDiscoveryAPI — findClaimableTasks', () => {
+  it('returns empty array when no manifest CIDs provided', async () => {
+    const mockClient = buildMockClient([]);
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      routerAddress: ROUTER,
+      safeAddress: SAFE_ADDRESS,
+      mechAddress: MECH_ADDRESS,
+      publicClient: mockClient as never,
+    });
+
+    const result = await api.findClaimableTasks({
+      solverNetManifestCids: [],
+      operatorAddress: OPERATOR_ADDRESS,
+    });
+    expect(result).toHaveLength(0);
+    expect(mockClient.getLogs).not.toHaveBeenCalled();
+  });
+
+  it('returns one candidate when TaskCreated matches and canClaimTask passes', async () => {
+    const taskId = 1n;
+    const taskCidDigest = `0x${'cc'.repeat(32)}` as Hex;
+    const txHash = `0x${'11'.repeat(32)}` as Hex;
+
+    const taskLog = buildTaskCreatedLog(taskId, MANIFEST_DIGEST, taskCidDigest, 5, 5_000n, txHash);
+
+    // First getLogs call: TaskCreated events. Second: TaskAttemptCreated events.
+    const mockClient = buildMockClient([[taskLog], []]);
+    mockClient.simulateContract.mockResolvedValue({ result: undefined }); // canClaimTask passes
+
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      routerAddress: ROUTER,
+      safeAddress: SAFE_ADDRESS,
+      mechAddress: MECH_ADDRESS,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+
+    const result = await api.findClaimableTasks({
+      solverNetManifestCids: [MANIFEST_CID],
+      operatorAddress: OPERATOR_ADDRESS,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].taskId).toBe('1');
+    expect(result[0].attemptCount).toBe(0);
+    expect(result[0].operatorAttemptCount).toBe(0);
+    expect(result[0].createdAtBlock).toBe(5_000);
+    expect(result[0].createdAtTx).toBe(txHash);
+    expect(result[0].maxClaims).toBe(5);
+  });
+
+  it('filters out a candidate when canClaimTask returns ok=false', async () => {
+    const taskLog = buildTaskCreatedLog(1n, MANIFEST_DIGEST, `0x${'dd'.repeat(32)}` as Hex, 3, 5_000n);
+    const mockClient = buildMockClient([[taskLog], []]);
+    // canClaimTask rejects (simulate revert)
+    mockClient.simulateContract.mockRejectedValue(new Error('ClaimWindowClosed'));
+
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      routerAddress: ROUTER,
+      safeAddress: SAFE_ADDRESS,
+      mechAddress: MECH_ADDRESS,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+
+    const result = await api.findClaimableTasks({
+      solverNetManifestCids: [MANIFEST_CID],
+      operatorAddress: OPERATOR_ADDRESS,
+    });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('throws DiscoveryUnavailableError when safeAddress is missing', async () => {
+    const mockClient = buildMockClient([]);
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      routerAddress: ROUTER,
+      mechAddress: MECH_ADDRESS,
+      // No safeAddress
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+
+    await expect(
+      api.findClaimableTasks({
+        solverNetManifestCids: [MANIFEST_CID],
+        operatorAddress: OPERATOR_ADDRESS,
+      }),
+    ).rejects.toThrow(DiscoveryUnavailableError);
+    expect(mockClient.getLogs).not.toHaveBeenCalled();
+  });
+
+  it('throws DiscoveryUnavailableError when mechAddress is missing', async () => {
+    const mockClient = buildMockClient([]);
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      routerAddress: ROUTER,
+      safeAddress: SAFE_ADDRESS,
+      // No mechAddress
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+
+    await expect(
+      api.findClaimableTasks({
+        solverNetManifestCids: [MANIFEST_CID],
+        operatorAddress: OPERATOR_ADDRESS,
+      }),
+    ).rejects.toThrow(DiscoveryUnavailableError);
+    expect(mockClient.getLogs).not.toHaveBeenCalled();
+  });
+
+  it('computes attemptCount and operatorAttemptCount from TaskAttemptCreated events', async () => {
+    const taskId = 5n;
+    const taskLog = buildTaskCreatedLog(taskId, MANIFEST_DIGEST, `0x${'ff'.repeat(32)}` as Hex, 10, 5_000n);
+
+    // Two attempts: one from operator, one from another address
+    const attempt1 = buildTaskAttemptCreatedLog(
+      taskId, 0, `0x${'a1'.repeat(32)}` as Hex, OPERATOR_ADDRESS, 5_001n,
+    );
+    const attempt2 = buildTaskAttemptCreatedLog(
+      taskId, 1, `0x${'a2'.repeat(32)}` as Hex, `0x${'ff'.repeat(20)}` as `0x${string}`, 5_002n,
+    );
+
+    const mockClient = buildMockClient([[taskLog], [attempt1, attempt2]]);
+    mockClient.simulateContract.mockResolvedValue({ result: undefined }); // canClaimTask passes
+
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      routerAddress: ROUTER,
+      safeAddress: SAFE_ADDRESS,
+      mechAddress: MECH_ADDRESS,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+
+    const result = await api.findClaimableTasks({
+      solverNetManifestCids: [MANIFEST_CID],
+      operatorAddress: OPERATOR_ADDRESS,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].taskId).toBe('5');
+    expect(result[0].attemptCount).toBe(2);
+    expect(result[0].operatorAttemptCount).toBe(1);
+  });
+
+  it('respects pageSize and maxPages bounds', async () => {
+    // Create 12 tasks
+    const taskLogs = Array.from({ length: 12 }, (_, i) =>
+      buildTaskCreatedLog(
+        BigInt(i + 1),
+        MANIFEST_DIGEST,
+        `0x${String(i).padStart(64, '0')}` as Hex,
+        5,
+        BigInt(100 + i),
+      ),
+    );
+    const mockClient = buildMockClient([taskLogs, []]);
+    mockClient.simulateContract.mockResolvedValue({ result: undefined }); // canClaimTask passes
+
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      routerAddress: ROUTER,
+      safeAddress: SAFE_ADDRESS,
+      mechAddress: MECH_ADDRESS,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+
+    const result = await api.findClaimableTasks({
+      solverNetManifestCids: [MANIFEST_CID],
+      operatorAddress: OPERATOR_ADDRESS,
+      pageSize: 5,
+      maxPages: 2,
+    });
+
+    // pageSize * maxPages = 10
+    expect(result.length).toBeLessThanOrEqual(10);
+  });
+
+  it('throws DiscoveryUnavailableError on getBlockNumber RPC failure', async () => {
+    const mockClient = {
+      getBlockNumber: vi.fn(async () => { throw new Error('RPC connection refused'); }),
+      getLogs: vi.fn(async () => []),
+      simulateContract: vi.fn(async () => ({ result: undefined })),
+    };
+
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      routerAddress: ROUTER,
+      safeAddress: SAFE_ADDRESS,
+      mechAddress: MECH_ADDRESS,
+      publicClient: mockClient as never,
+    });
+
+    await expect(
+      api.findClaimableTasks({
+        solverNetManifestCids: [MANIFEST_CID],
+        operatorAddress: OPERATOR_ADDRESS,
+      }),
+    ).rejects.toThrow(DiscoveryUnavailableError);
+  });
+
+  it('throws DiscoveryUnavailableError when getLogs itself fails', async () => {
+    const mockClient = {
+      getBlockNumber: vi.fn(async () => CURRENT_BLOCK),
+      getLogs: vi.fn(async () => { throw new Error('fetch failed: connection reset'); }),
+      simulateContract: vi.fn(async () => ({ result: undefined })),
+    };
+
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      routerAddress: ROUTER,
+      safeAddress: SAFE_ADDRESS,
+      mechAddress: MECH_ADDRESS,
+      // taskDiscoveryFromBlock set so we don't hit DEFAULT that might skip this
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+
+    await expect(
+      api.findClaimableTasks({
+        solverNetManifestCids: [MANIFEST_CID],
+        operatorAddress: OPERATOR_ADDRESS,
+      }),
+    ).rejects.toThrow(DiscoveryUnavailableError);
+  });
+});
+
+describe('OnchainDiscoveryAPI — cursorCache', () => {
+  it('cursorCache.write is called with the current head after a successful task scan', async () => {
+    const mockClient = buildMockClient([[], []]);
+    mockClient.simulateContract.mockResolvedValue({ result: undefined });
+    const cache: OnchainCursorCache = {
+      read: vi.fn(() => null),
+      write: vi.fn(),
+    };
+
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      routerAddress: ROUTER,
+      safeAddress: SAFE_ADDRESS,
+      mechAddress: MECH_ADDRESS,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+      cursorCache: cache,
+    });
+
+    await api.findClaimableTasks({
+      solverNetManifestCids: [MANIFEST_CID],
+      operatorAddress: OPERATOR_ADDRESS,
+    });
+
+    expect(cache.write).toHaveBeenCalledWith('tasks', CURRENT_BLOCK);
+  });
+
+  it('cursorCache.read is used as the start block when available', async () => {
+    const CACHED_BLOCK = 5_000n;
+    const cache: OnchainCursorCache = {
+      read: vi.fn(() => CACHED_BLOCK),
+      write: vi.fn(),
+    };
+
+    const mockClient = buildMockClient([[], []]);
+    mockClient.simulateContract.mockResolvedValue({ result: undefined });
+
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      routerAddress: ROUTER,
+      safeAddress: SAFE_ADDRESS,
+      mechAddress: MECH_ADDRESS,
+      publicClient: mockClient as never,
+      cursorCache: cache,
+    });
+
+    await api.findClaimableTasks({
+      solverNetManifestCids: [MANIFEST_CID],
+      operatorAddress: OPERATOR_ADDRESS,
+    });
+
+    expect(cache.read).toHaveBeenCalledWith('tasks');
+
+    // The getLogs call should start from CACHED_BLOCK (5_000n), not from the default start block
+    const getLogsCall = mockClient.getLogs.mock.calls[0][0];
+    expect(getLogsCall.fromBlock).toBe(CACHED_BLOCK);
+  });
+
+  it('cursorCache.write is called with current head for solvernets scan', async () => {
+    const mockClient = buildMockClient([[]]); // one getLogs call for MetadataSet
+    const cache: OnchainCursorCache = {
+      read: vi.fn(() => null),
+      write: vi.fn(),
+    };
+
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      identityRegistryAddress: IDENTITY_REGISTRY,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+      cursorCache: cache,
+    });
+
+    await api.listLaunchedSolverNets();
+    expect(cache.write).toHaveBeenCalledWith('solvernets', CURRENT_BLOCK);
+  });
+
+  it('cursorCache.write is called with current head after getLifecycleStatus scan', async () => {
+    const mockClient = buildMockClient([[]]); // one getLogs call for MetadataSet
+    const cache: OnchainCursorCache = {
+      read: vi.fn(() => null),
+      write: vi.fn(),
+    };
+
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      identityRegistryAddress: IDENTITY_REGISTRY,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+      cursorCache: cache,
+    });
+
+    await api.getLifecycleStatus('unknown-cid');
+    expect(cache.write).toHaveBeenCalledWith('solvernets', CURRENT_BLOCK);
+  });
+});
+
+describe('limitedConcurrency — partial-failure resilience', () => {
+  it('continues processing and returns results from non-throwing tasks when one task throws', async () => {
+    const tasks = [
+      async () => 1,
+      async () => 2,
+      async (): Promise<number> => { throw new Error('task 3 failed'); },
+      async () => 4,
+      async () => 5,
+    ];
+
+    const results = await limitedConcurrency(tasks, 3);
+
+    // The throwing task's slot is skipped; 4 results are returned
+    expect(results).toHaveLength(4);
+    expect(results).toContain(1);
+    expect(results).toContain(2);
+    expect(results).toContain(4);
+    expect(results).toContain(5);
+    expect(results).not.toContain(3);
+  });
+});

--- a/client/test/discovery/with-fallback.test.ts
+++ b/client/test/discovery/with-fallback.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Tests for `withFallback` — the DiscoveryAPI health-tracking fallback wrapper.
+ *
+ * Covers:
+ * - Primary success → floor not called
+ * - Primary throws DiscoveryUnavailableError → floor called, result returned
+ * - Primary throws network-shaped error → floor called
+ * - After unhealthyThreshold consecutive failures, primary skipped until
+ *   retryAfterMs elapses (fake timers)
+ * - After retryAfterMs, primary is probed again
+ * - console.warn emitted exactly once on entering degraded mode
+ * - All four DiscoveryAPI methods exercised through the wrapper
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { withFallback, type WithFallbackOptions } from '../../src/discovery/with-fallback.js';
+import {
+  DiscoveryUnavailableError,
+  type DiscoveryAPI,
+  type ClaimableTaskCandidate,
+  type SolverNetManifestSummary,
+  type SolverNetLifecycleStatus,
+  type EnvelopeRef,
+} from '../../src/discovery/types.js';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const OPERATOR_ADDRESS = `0x${'ab'.repeat(20)}` as `0x${string}`;
+
+const TASK_CANDIDATE: ClaimableTaskCandidate = {
+  taskId: '1',
+  taskCidDigest: `0x${'11'.repeat(32)}`,
+  manifestDigest: `0x${'22'.repeat(32)}`,
+  attemptCount: 0,
+  operatorAttemptCount: 0,
+};
+
+const SOLVER_NET_SUMMARY: SolverNetManifestSummary = {
+  manifestCid: 'bafyTest',
+  solverNetId: 'sn-001',
+  name: 'Test SolverNet',
+  network: 'base',
+  launcherAgentId: '42',
+  launcherSafeAddress: `0x${'cc'.repeat(20)}`,
+  status: 'launched',
+  statusUpdatedAt: '2026-05-11T00:00:00Z',
+  contractId: 'jinn-router-v3',
+  contractVersion: '3.0.0',
+  solutionPriceWei: '1000000000000000',
+  verdictPriceWei: '500000000000000',
+  openRoles: ['solver'],
+  anchorBlock: 12345678,
+};
+
+const LIFECYCLE_STATUS: SolverNetLifecycleStatus = {
+  status: 'launched',
+  statusUpdatedAt: '2026-05-11T00:00:00Z',
+  sourceBlock: 12345678,
+};
+
+const ENVELOPE_REF: EnvelopeRef = {
+  manifestCid: 'bafyEnvelope',
+  manifestHash: '0x' + 'aa'.repeat(32),
+  operator: { agentId: '99', safeAddress: `0x${'dd'.repeat(20)}` },
+  evidenceTier: 'committed',
+  publishedAt: 1715385600,
+};
+
+// ── Stub builder ─────────────────────────────────────────────────────────────
+
+type MethodName = keyof DiscoveryAPI;
+
+/**
+ * Returns a stub DiscoveryAPI where each method resolves immediately. Pass
+ * `overrides` to replace specific methods with mocks or throwing fns.
+ */
+function makeStub(overrides?: Partial<Record<MethodName, DiscoveryAPI[MethodName]>>): DiscoveryAPI {
+  const defaults: DiscoveryAPI = {
+    findClaimableTasks: vi.fn(async () => [TASK_CANDIDATE]),
+    listLaunchedSolverNets: vi.fn(async () => [SOLVER_NET_SUMMARY]),
+    getLifecycleStatus: vi.fn(async () => LIFECYCLE_STATUS),
+    queryEnvelopes: vi.fn(async () => [ENVELOPE_REF]),
+  };
+  return { ...defaults, ...(overrides ?? {}) };
+}
+
+/**
+ * Returns a stub where every method throws the given error.
+ */
+function makeThrowingStub(error: Error): DiscoveryAPI {
+  return {
+    findClaimableTasks: vi.fn(async () => { throw error; }),
+    listLaunchedSolverNets: vi.fn(async () => { throw error; }),
+    getLifecycleStatus: vi.fn(async () => { throw error; }),
+    queryEnvelopes: vi.fn(async () => { throw error; }),
+  };
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeWrapper(
+  primary: DiscoveryAPI,
+  floor: DiscoveryAPI,
+  opts?: WithFallbackOptions,
+): DiscoveryAPI {
+  return withFallback(primary, floor, opts);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('withFallback — basic routing', () => {
+  it('returns primary result and does not call floor on success', async () => {
+    const primary = makeStub();
+    const floor = makeStub();
+    const api = makeWrapper(primary, floor);
+
+    const result = await api.findClaimableTasks({
+      solverNetManifestCids: ['bafyA'],
+      operatorAddress: OPERATOR_ADDRESS,
+    });
+
+    expect(result).toEqual([TASK_CANDIDATE]);
+    expect(floor.findClaimableTasks).not.toHaveBeenCalled();
+  });
+
+  it('routes to floor and returns floor result when primary throws DiscoveryUnavailableError', async () => {
+    const error = new DiscoveryUnavailableError('indexer down');
+    const primary = makeThrowingStub(error);
+    const floorResult: ClaimableTaskCandidate[] = [];
+    const floor = makeStub({ findClaimableTasks: vi.fn(async () => floorResult) });
+    const api = makeWrapper(primary, floor);
+
+    const result = await api.findClaimableTasks({
+      solverNetManifestCids: ['bafyA'],
+      operatorAddress: OPERATOR_ADDRESS,
+    });
+
+    expect(result).toBe(floorResult);
+    expect(floor.findClaimableTasks).toHaveBeenCalledOnce();
+  });
+
+  it('routes to floor when primary throws a "fetch failed" network error', async () => {
+    const error = new Error('fetch failed');
+    const primary = makeThrowingStub(error);
+    const floor = makeStub();
+    const api = makeWrapper(primary, floor);
+
+    await api.findClaimableTasks({
+      solverNetManifestCids: ['bafyA'],
+      operatorAddress: OPERATOR_ADDRESS,
+    });
+
+    expect(floor.findClaimableTasks).toHaveBeenCalledOnce();
+  });
+
+  it('routes to floor when primary throws a timeout error', async () => {
+    const error = new Error('request timed out');
+    const primary = makeThrowingStub(error);
+    const floor = makeStub();
+    const api = makeWrapper(primary, floor);
+
+    await api.findClaimableTasks({
+      solverNetManifestCids: [],
+      operatorAddress: OPERATOR_ADDRESS,
+    });
+
+    expect(floor.findClaimableTasks).toHaveBeenCalledOnce();
+  });
+
+  it('routes to floor when primary throws an error with code SERVER_ERROR and no matching message', async () => {
+    // Simulates viem/RPC errors that carry a `.code` property but whose `.message`
+    // does not include any of the substring checks — proves the code-based path is reached.
+    const error = Object.assign(new Error('something opaque'), { code: 'SERVER_ERROR' });
+    const primary = makeThrowingStub(error);
+    const floor = makeStub();
+    const api = makeWrapper(primary, floor);
+
+    await api.findClaimableTasks({ solverNetManifestCids: [], operatorAddress: OPERATOR_ADDRESS });
+
+    expect(floor.findClaimableTasks).toHaveBeenCalledOnce();
+  });
+
+  it('propagates non-network errors from the primary without calling floor', async () => {
+    const error = new TypeError('unexpected schema change');
+    const primary = makeThrowingStub(error);
+    const floor = makeStub();
+    const api = makeWrapper(primary, floor);
+
+    await expect(
+      api.findClaimableTasks({ solverNetManifestCids: [], operatorAddress: OPERATOR_ADDRESS }),
+    ).rejects.toThrow('unexpected schema change');
+
+    expect(floor.findClaimableTasks).not.toHaveBeenCalled();
+  });
+});
+
+describe('withFallback — degraded mode', () => {
+  it('marks primary unhealthy and skips it after unhealthyThreshold consecutive failures', async () => {
+    vi.useFakeTimers();
+    const THRESHOLD = 3;
+    const error = new DiscoveryUnavailableError('down');
+    const primary = makeThrowingStub(error);
+    const floor = makeStub();
+    const api = makeWrapper(primary, floor, { unhealthyThreshold: THRESHOLD, retryAfterMs: 60_000 });
+
+    // Three calls to hit the threshold.
+    for (let i = 0; i < THRESHOLD; i++) {
+      await api.findClaimableTasks({ solverNetManifestCids: [], operatorAddress: OPERATOR_ADDRESS });
+    }
+
+    // After threshold, primary should be skipped.
+    vi.clearAllMocks();
+    await api.findClaimableTasks({ solverNetManifestCids: [], operatorAddress: OPERATOR_ADDRESS });
+
+    expect(primary.findClaimableTasks).not.toHaveBeenCalled();
+    expect(floor.findClaimableTasks).toHaveBeenCalledOnce();
+  });
+
+  it('re-engages primary after retryAfterMs has elapsed', async () => {
+    vi.useFakeTimers();
+    const THRESHOLD = 3;
+    const RETRY_MS = 60_000;
+    const error = new DiscoveryUnavailableError('down');
+    const primary = makeThrowingStub(error);
+    const floor = makeStub();
+    const api = makeWrapper(primary, floor, { unhealthyThreshold: THRESHOLD, retryAfterMs: RETRY_MS });
+
+    // Exhaust threshold.
+    for (let i = 0; i < THRESHOLD; i++) {
+      await api.findClaimableTasks({ solverNetManifestCids: [], operatorAddress: OPERATOR_ADDRESS });
+    }
+
+    // Advance time past retry window.
+    vi.advanceTimersByTime(RETRY_MS + 1);
+
+    // Reset mocks so we can observe who gets called on the next call.
+    vi.clearAllMocks();
+
+    // Primary is now healthy-again stub (succeeds).
+    const workingPrimary: DiscoveryAPI = {
+      ...primary,
+      findClaimableTasks: vi.fn(async () => [TASK_CANDIDATE]),
+    };
+    // We need a fresh withFallback referencing the new primary? No — the
+    // original primary stub still throws. The point is that the wrapper
+    // *attempts* the primary. Let's verify it calls primary again.
+
+    // Re-stub to resolve on next attempt so we can confirm the probe happened.
+    (primary.findClaimableTasks as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+
+    await api.findClaimableTasks({ solverNetManifestCids: [], operatorAddress: OPERATOR_ADDRESS });
+
+    expect(primary.findClaimableTasks).toHaveBeenCalledOnce();
+  });
+
+  it('emits console.warn exactly once when entering degraded mode', async () => {
+    vi.useFakeTimers();
+    const THRESHOLD = 2;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const error = new DiscoveryUnavailableError('down');
+    const primary = makeThrowingStub(error);
+    const floor = makeStub();
+    const api = makeWrapper(primary, floor, { unhealthyThreshold: THRESHOLD, retryAfterMs: 60_000 });
+
+    // Call enough times to trigger degraded mode and then some.
+    for (let i = 0; i < THRESHOLD + 3; i++) {
+      await api.findClaimableTasks({ solverNetManifestCids: [], operatorAddress: OPERATOR_ADDRESS });
+    }
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0]?.[0]).toContain('unhealthy');
+  });
+});
+
+describe('withFallback — all four methods', () => {
+  /**
+   * Parameterized check: each method on the wrapper routes to the floor when
+   * the primary throws DiscoveryUnavailableError.
+   */
+  const ERROR = new DiscoveryUnavailableError('unavailable');
+
+  it('findClaimableTasks routes to floor on DiscoveryUnavailableError', async () => {
+    const primary = makeThrowingStub(ERROR);
+    const floor = makeStub();
+    const api = makeWrapper(primary, floor);
+
+    const result = await api.findClaimableTasks({
+      solverNetManifestCids: ['bafyA'],
+      operatorAddress: OPERATOR_ADDRESS,
+    });
+
+    expect(result).toEqual([TASK_CANDIDATE]);
+    expect(floor.findClaimableTasks).toHaveBeenCalledOnce();
+  });
+
+  it('listLaunchedSolverNets routes to floor on DiscoveryUnavailableError', async () => {
+    const primary = makeThrowingStub(ERROR);
+    const floor = makeStub();
+    const api = makeWrapper(primary, floor);
+
+    const result = await api.listLaunchedSolverNets({ launcherAgentId: '42' });
+
+    expect(result).toEqual([SOLVER_NET_SUMMARY]);
+    expect(floor.listLaunchedSolverNets).toHaveBeenCalledOnce();
+  });
+
+  it('getLifecycleStatus routes to floor on DiscoveryUnavailableError', async () => {
+    const primary = makeThrowingStub(ERROR);
+    const floor = makeStub();
+    const api = makeWrapper(primary, floor);
+
+    const result = await api.getLifecycleStatus('bafyTest');
+
+    expect(result).toEqual(LIFECYCLE_STATUS);
+    expect(floor.getLifecycleStatus).toHaveBeenCalledOnce();
+  });
+
+  it('queryEnvelopes routes to floor on DiscoveryUnavailableError', async () => {
+    const primary = makeThrowingStub(ERROR);
+    const floor = makeStub();
+    const api = makeWrapper(primary, floor);
+
+    const result = await api.queryEnvelopes({ solverType: 'prediction.v0' });
+
+    expect(result).toEqual([ENVELOPE_REF]);
+    expect(floor.queryEnvelopes).toHaveBeenCalledOnce();
+  });
+});
+
+describe('DiscoveryUnavailableError', () => {
+  it('has the expected name and message', () => {
+    const err = new DiscoveryUnavailableError('test error');
+    expect(err.name).toBe('DiscoveryUnavailableError');
+    expect(err.message).toBe('test error');
+    expect(err instanceof Error).toBe(true);
+  });
+
+  it('stores an optional cause', () => {
+    const inner = new Error('root cause');
+    const err = new DiscoveryUnavailableError('wrapped', inner);
+    expect(err.cause).toBe(inner);
+  });
+});

--- a/client/test/discovery/with-fallback.test.ts
+++ b/client/test/discovery/with-fallback.test.ts
@@ -261,6 +261,38 @@ describe('withFallback — degraded mode', () => {
     expect(primary.findClaimableTasks).toHaveBeenCalledOnce();
   });
 
+  it('re-degrades immediately when the post-window probe fails with a network error', async () => {
+    vi.useFakeTimers();
+    const THRESHOLD = 3;
+    const RETRY_MS = 60_000;
+    const netErr = new DiscoveryUnavailableError('down');
+    // Primary fails on every call (probe included).
+    const primary = makeThrowingStub(netErr);
+    const floor = makeStub();
+    const api = makeWrapper(primary, floor, { unhealthyThreshold: THRESHOLD, retryAfterMs: RETRY_MS });
+
+    // Exhaust the threshold → degraded.
+    for (let i = 0; i < THRESHOLD; i++) {
+      await api.findClaimableTasks({ solverNetManifestCids: [], operatorAddress: OPERATOR_ADDRESS });
+    }
+
+    // Advance past the retry window so the next call is a probe.
+    vi.advanceTimersByTime(RETRY_MS + 1);
+    vi.clearAllMocks();
+
+    // Probe call — primary is attempted and fails with a network error.
+    await api.findClaimableTasks({ solverNetManifestCids: [], operatorAddress: OPERATOR_ADDRESS });
+    expect(primary.findClaimableTasks).toHaveBeenCalledOnce();
+    expect(floor.findClaimableTasks).toHaveBeenCalledOnce();
+
+    // Next call must route straight to the floor again — the failed probe
+    // re-degraded immediately, without needing `unhealthyThreshold` more failures.
+    vi.clearAllMocks();
+    await api.findClaimableTasks({ solverNetManifestCids: [], operatorAddress: OPERATOR_ADDRESS });
+    expect(primary.findClaimableTasks).not.toHaveBeenCalled();
+    expect(floor.findClaimableTasks).toHaveBeenCalledOnce();
+  });
+
   it('emits console.warn exactly once when entering degraded mode', async () => {
     vi.useFakeTimers();
     const THRESHOLD = 2;

--- a/client/test/solvernets/registry-client-erc8004.test.ts
+++ b/client/test/solvernets/registry-client-erc8004.test.ts
@@ -20,8 +20,9 @@ import {
   type IpfsClient,
   type SubgraphClient,
   type SetMetadataPublishResult,
+  SOLVERNET_MANIFEST_KEY_PREFIX,
 } from '../../src/solvernets/registry-client-erc8004.js';
-import type { SignerWithAgentEoa } from '../../src/solvernets/registry-client.js';
+import type { SignerWithAgentEoa, SolverNetManifestSummary } from '../../src/solvernets/registry-client.js';
 import {
   signManifest,
   manifestHash,
@@ -29,7 +30,11 @@ import {
   type UnsignedSolverNetManifestV1,
 } from '../../src/solvernets/manifest.js';
 import { canonicalJson } from '../../src/harnesses/engine/canonical-json.js';
-import type { SetMetadataEvent } from '../../src/solvernets/most-recent-wins.js';
+import {
+  resolveMostRecentWins,
+  type SetMetadataEvent,
+} from '../../src/solvernets/most-recent-wins.js';
+import type { DiscoveryAPI, SolverNetLifecycleStatus } from '../../src/discovery/types.js';
 
 /**
  * Heuristic for "this object looks like a SolverNetManifestV1". We only
@@ -254,6 +259,74 @@ function makeMockSubgraph(): SubgraphClient & {
   };
 }
 
+// ── Mock DiscoveryAPI ──────────────────────────────────────────────────────
+
+/**
+ * Minimal DiscoveryAPI mock backed by the mock subgraph. Used by listLaunched
+ * tests to inject a discoveryApi without wiring up a full HTTP subgraph client.
+ *
+ * `listLaunchedSolverNets` folds resolveMostRecentWins over the subgraph
+ * events (mirroring HttpSubgraphDiscoveryAPI) and returns coarse summaries.
+ * The registry client then enriches each summary with an IPFS fetch.
+ */
+function makeMockDiscoveryApi(subgraph: SubgraphClient): DiscoveryAPI & {
+  listLaunchedCalls: number;
+} {
+  let listLaunchedCalls = 0;
+
+  return {
+    get listLaunchedCalls() { return listLaunchedCalls; },
+
+    async listLaunchedSolverNets(args?: {
+      launcherAgentId?: string;
+      status?: Array<'launched' | 'paused' | 'retired'>;
+    }): Promise<SolverNetManifestSummary[]> {
+      listLaunchedCalls += 1;
+      const events = await subgraph.fetchSetMetadataEvents({
+        keyPrefix: SOLVERNET_MANIFEST_KEY_PREFIX,
+      });
+      const resolved = resolveMostRecentWins(events);
+      const out: SolverNetManifestSummary[] = [];
+      for (const row of resolved) {
+        if (args?.launcherAgentId !== undefined && row.launcherAgentId !== args.launcherAgentId) continue;
+        if (args?.status !== undefined && !args.status.includes(row.status)) continue;
+        out.push({
+          manifestCid: row.manifestCid,
+          solverNetId: row.manifestCid,
+          name: '',
+          network: '',
+          launcherAgentId: row.launcherAgentId,
+          launcherSafeAddress: '0x0000000000000000000000000000000000000000',
+          status: row.status,
+          statusUpdatedAt: row.statusUpdatedAt,
+          contractId: '',
+          contractVersion: '',
+          solutionPriceWei: '0',
+          verdictPriceWei: '0',
+          openRoles: [],
+          anchorBlock: row.anchorBlock,
+        });
+      }
+      return out;
+    },
+
+    async getLifecycleStatus(manifestCid: string): Promise<SolverNetLifecycleStatus | undefined> {
+      const events = await subgraph.fetchSetMetadataEventsForCid({ manifestCid });
+      if (events.length === 0) return undefined;
+      const resolved = resolveMostRecentWins(events);
+      if (resolved.length === 0) return undefined;
+      const latest = resolved.reduce((acc, cur) => {
+        if (cur.anchorBlock !== acc.anchorBlock) return cur.anchorBlock > acc.anchorBlock ? cur : acc;
+        return cur.anchorTransactionIndex > acc.anchorTransactionIndex ? cur : acc;
+      });
+      return { status: latest.status, statusUpdatedAt: latest.statusUpdatedAt, sourceBlock: latest.anchorBlock };
+    },
+
+    async findClaimableTasks() { return []; },
+    async queryEnvelopes() { return []; },
+  };
+}
+
 // ── Tests: publishManifest ──────────────────────────────────────────────────
 
 describe('IdentityRegistryBackedSolverNetRegistryClient.publishManifest', () => {
@@ -464,14 +537,16 @@ describe('IdentityRegistryBackedSolverNetRegistryClient.publishLifecycleTransiti
 // ── Tests: listLaunched ─────────────────────────────────────────────────────
 
 describe('IdentityRegistryBackedSolverNetRegistryClient.listLaunched', () => {
-  it('returns summaries from subgraph events with most-recent-wins applied', async () => {
+  it('returns summaries from discoveryApi with IPFS enrichment applied', async () => {
     const ipfs = makeMockIpfs();
     const publisher = makeMockPublisher();
     const subgraph = makeMockSubgraph();
+    const discoveryApi = makeMockDiscoveryApi(subgraph);
     const client = new IdentityRegistryBackedSolverNetRegistryClient({
       ipfs,
       publisher,
       subgraph,
+      discoveryApi,
       network: 'base-sepolia',
     });
 
@@ -480,7 +555,7 @@ describe('IdentityRegistryBackedSolverNetRegistryClient.listLaunched', () => {
     const cid = launch.manifestCid;
     const hash = manifestHash(manifest);
 
-    // Inject events into the subgraph mock.
+    // Inject events into the subgraph mock (which the discoveryApi reads).
     subgraph.events.push(
       {
         agentId: '5474',
@@ -505,6 +580,7 @@ describe('IdentityRegistryBackedSolverNetRegistryClient.listLaunched', () => {
     expect(s.status).toBe('paused');
     expect(s.statusUpdatedAt).toBe('2026-05-06T01:00:00Z');
     expect(s.anchorBlock).toBe(200);
+    // IPFS-enriched fields come from the manifest body:
     expect(s.solverNetId).toBe(manifest.solverNetId);
     expect(s.name).toBe(manifest.name);
     expect(s.network).toBe(manifest.network);
@@ -517,7 +593,25 @@ describe('IdentityRegistryBackedSolverNetRegistryClient.listLaunched', () => {
     expect(s.openRoles).toEqual(manifest.openRoles);
   });
 
-  it('passes keyPrefix=solvernet-manifest: to the subgraph (no agentId filter)', async () => {
+  it('delegates discovery to discoveryApi.listLaunchedSolverNets (not direct subgraph)', async () => {
+    const ipfs = makeMockIpfs();
+    const publisher = makeMockPublisher();
+    const subgraph = makeMockSubgraph();
+    const discoveryApi = makeMockDiscoveryApi(subgraph);
+    const client = new IdentityRegistryBackedSolverNetRegistryClient({
+      ipfs,
+      publisher,
+      subgraph,
+      discoveryApi,
+      network: 'base-sepolia',
+    });
+
+    await client.listLaunched({ network: 'base-sepolia' });
+    // discoveryApi was called exactly once for the list operation
+    expect(discoveryApi.listLaunchedCalls).toBe(1);
+  });
+
+  it('throws if no discoveryApi is injected (no silent subgraph fallback)', async () => {
     const ipfs = makeMockIpfs();
     const publisher = makeMockPublisher();
     const subgraph = makeMockSubgraph();
@@ -526,21 +620,24 @@ describe('IdentityRegistryBackedSolverNetRegistryClient.listLaunched', () => {
       publisher,
       subgraph,
       network: 'base-sepolia',
+      // discoveryApi intentionally absent
     });
 
-    await client.listLaunched({ network: 'base-sepolia' });
-    expect(subgraph.fetchByPrefixCalls).toHaveLength(1);
-    expect(subgraph.fetchByPrefixCalls[0]!.keyPrefix).toBe('solvernet-manifest:');
+    await expect(client.listLaunched({ network: 'base-sepolia' })).rejects.toThrow(
+      /requires a DiscoveryAPI/,
+    );
   });
 
   it('filters by status (statusFilter)', async () => {
     const ipfs = makeMockIpfs();
     const publisher = makeMockPublisher();
     const subgraph = makeMockSubgraph();
+    const discoveryApi = makeMockDiscoveryApi(subgraph);
     const client = new IdentityRegistryBackedSolverNetRegistryClient({
       ipfs,
       publisher,
       subgraph,
+      discoveryApi,
       network: 'base-sepolia',
     });
 
@@ -590,29 +687,38 @@ describe('IdentityRegistryBackedSolverNetRegistryClient.listLaunched', () => {
     expect(both).toHaveLength(2);
   });
 
-  it('filters by sinceBlock (forwarded to subgraph)', async () => {
+  it('sinceBlock is accepted but does not filter discoveryApi results (DiscoveryAPI has no sinceBlock)', async () => {
+    // sinceBlock was a subgraph-only optimisation. With discoveryApi, the arg
+    // is accepted by the interface for forwards-compatibility but is not
+    // forwarded to listLaunchedSolverNets (which does not support it).
     const ipfs = makeMockIpfs();
     const publisher = makeMockPublisher();
     const subgraph = makeMockSubgraph();
+    const discoveryApi = makeMockDiscoveryApi(subgraph);
     const client = new IdentityRegistryBackedSolverNetRegistryClient({
       ipfs,
       publisher,
       subgraph,
+      discoveryApi,
       network: 'base-sepolia',
     });
 
-    await client.listLaunched({ network: 'base-sepolia', sinceBlock: 500 });
-    expect(subgraph.fetchByPrefixCalls[0]!.sinceBlock).toBe(500);
+    // Should not throw; result is empty because subgraph has no events.
+    const result = await client.listLaunched({ network: 'base-sepolia', sinceBlock: 500 });
+    expect(result).toEqual([]);
+    expect(discoveryApi.listLaunchedCalls).toBe(1);
   });
 
   it('filters out manifests for a different network', async () => {
     const ipfs = makeMockIpfs();
     const publisher = makeMockPublisher();
     const subgraph = makeMockSubgraph();
+    const discoveryApi = makeMockDiscoveryApi(subgraph);
     const client = new IdentityRegistryBackedSolverNetRegistryClient({
       ipfs,
       publisher,
       subgraph,
+      discoveryApi,
       network: 'base-sepolia',
     });
 

--- a/spec/2026-05-11-discovery-api-and-shared-indexer.md
+++ b/spec/2026-05-11-discovery-api-and-shared-indexer.md
@@ -1,0 +1,268 @@
+# Discovery API and shared indexer
+
+- **Date:** 2026-05-11 (v0.1 draft)
+- **Author:** Oak with Opus
+- **Status:** Design draft — ready for review
+- **Version:** 0.1
+- **Related:**
+  - `spec/2026-04-30-phase-a-umbrella.md` (corpus library as the "first app" / programmatic library; `routeResolver` seam)
+  - `spec/2026-05-05-solvernet-creation-and-launch.md` §13 (registry client interface designed to be swappable)
+  - `spec/2026-05-registry-discovery.md` (external impl registry — sibling discovery problem)
+  - `client/src/corpus/index.ts`, `client/src/corpus/onchain-query.ts` (existing on-chain discovery path)
+  - `client/src/adapters/mech/task-subgraph.ts` (the load-bearing subgraph dependency)
+  - `client/src/solvernets/registry-client.ts`, `client/src/solvernets/most-recent-wins.ts` (SolverNet manifest registry)
+  - `client/src/erc8004/subgraph.ts` (stub; peer/artifact backfill path, currently inactive)
+
+## 1. Purpose
+
+Define how the daemon performs read-side discovery (claimable tasks, SolverNet manifests, corpus envelopes) without a runtime dependency on a third-party hosted subgraph that requires a centralized API key.
+
+The decision: introduce a `DiscoveryAPI` interface, ship two implementations of it (HTTP-to-shared-indexer, embedded-Ponder), and keep a direct on-chain RPC path as the always-available fallback. The default daemon configuration points at a shared indexer **privately operated by the daemon's current maintainer** (Oak), running on personal infrastructure as part of a private app. It is not protocol infrastructure and not Jinn-the-project-operated. Operators who want full autonomy flip a config flag to run the indexer embedded in their own daemon; operators who later prefer a different default point at a different URL.
+
+## 2. Problem
+
+The daemon currently has three subgraph callsites. Two are inactive or already have an alternative; one is load-bearing.
+
+### 2.1 Load-bearing: task claim discovery
+
+`client/src/adapters/mech/task-subgraph.ts` → `client/src/adapters/mech/adapter.ts:545-580` (`discoverSubgraphRestorationTasks`).
+
+The `CLAIMABLE_TASKS_QUERY` filters JinnRouter `Task` entities by `manifestDigest`, time-windowed `claimWindowStart_lte` / `claimWindowEnd_gte`, `refunded: false`, `finalized: false`, joined with `attempts` and `operatorAttempts` to compute per-task and per-operator attempt counts. The delivery-watcher loop polls this constantly.
+
+The query is the only place in the daemon where a real *join* is required — attempt counts per `(task, operator)`. Reproducing this against raw RPC requires enumerating `AttemptSubmitted` events and grouping client-side, i.e. building a small purpose-built indexer.
+
+### 2.2 Already neutralised: corpus discovery
+
+`client/src/corpus/query.ts` (subgraph path) coexists with `client/src/corpus/onchain-query.ts` (direct `IdentityRegistry.MetadataSet` event scan via viem `getLogs`). `client/src/corpus/index.ts:79-92` runs whichever is configured, merging refs and surfacing per-source warnings. The corpus library is *not* blocked by this spec — its on-chain mode already works.
+
+### 2.3 Mechanically swappable: SolverNet manifest registry
+
+`client/src/solvernets/registry-client-erc8004.ts` reads `IdentityRegistry.setMetadata` events keyed `solvernet-manifest:*` and folds them via `most-recent-wins.ts` into current lifecycle status. The fold is a pure function over an event array. Swapping the event source from subgraph to `getLogs` is mechanical. `spec/2026-05-05-solvernet-creation-and-launch.md` §13 already calls this out as a day-1 backing meant to be replaceable.
+
+### 2.4 Inactive: peer-discovery / artifact backfill
+
+`client/src/erc8004/subgraph.ts` is a stub returning empty arrays pending the rebuilt Jinn subgraph (bead `jinn-mono-fud`). Not load-bearing.
+
+### 2.5 What "centralized API key" actually buys us today
+
+A hosted Graph subgraph with an API key gives the daemon: indexed task tables with joins, low latency, no per-operator infra, no cold-start sync. The cost is a single Jinn-controlled API key that operators implicitly depend on, with no failover when the key is revoked, the hosted service is deprecated, or quotas are exceeded. This is the dependency this spec removes.
+
+## 3. Non-goals
+
+- **Decentralised indexer network selection.** Subsquid, The Graph decentralised network, peer-gossip indexing — out of scope. They remain available as future `DiscoveryAPI` implementations.
+- **Marketplace UI / consumer app.** This spec defines the discovery substrate the marketplace will consume; the marketplace itself is a separate spec.
+- **Removing IPFS / content-layer dependencies.** Manifest fetches still go through IPFS gateways (Autonolas by default). x402 still gates per-artifact bytes. This spec is about *discovery*, not *retrieval*.
+- **Changing the on-chain schema.** No new contracts, no new events. The daemon already produces all the data this spec consumes.
+
+## 4. Decision summary
+
+1. **One interface, three implementations.** A new `DiscoveryAPI` interface in `client/src/discovery/` abstracts the read-side queries the daemon currently issues against the subgraph. Three implementations ship: `HttpDiscoveryAPI` (calls a shared indexer over HTTP/GraphQL), `EmbeddedPonderDiscoveryAPI` (runs Ponder in-process), and `OnchainDiscoveryAPI` (direct RPC `getLogs` + multicall; the fallback path).
+2. **Same Ponder schema, two deployment targets.** Ponder lives in `packages/indexer/` and is compiled once. The HTTP service deploys it on a Jinn-operated VPS; the embedded mode runs it inside the daemon process. No fork.
+3. **HTTP-to-shared-indexer is the default.** Default daemon configuration points at the URL of an indexer privately operated by the daemon's current maintainer (Oak). This is one operator's app, not protocol infrastructure. Operators flip a config field to switch to embedded mode or to point at a different host.
+4. **On-chain fallback is always live.** If the chosen primary implementation fails (VPS unreachable, embedded Ponder still syncing, hosted subgraph 5xx), the daemon falls back to `OnchainDiscoveryAPI` for the duration of the outage. Slower but functional. Operators stay live during indexer outages.
+5. **Hosted Graph subgraph is removed, not retained as a fallback.** Once `DiscoveryAPI` ships, `subgraphUrl` callsites move to the new interface. The Graph dependency leaves the runtime.
+
+## 5. The DiscoveryAPI interface
+
+The interface captures *what the daemon needs to know*, not the storage backend. The shape is deliberately narrow:
+
+```ts
+// client/src/discovery/types.ts (illustrative)
+
+export interface DiscoveryAPI {
+  /**
+   * Claimable tasks for a set of SolverNet manifests, filtered by operator.
+   * Replaces `queryClaimableTaskCandidates` in task-subgraph.ts.
+   */
+  findClaimableTasks(args: {
+    solverNetManifestCids: string[];
+    operatorAddress: `0x${string}`;
+    nowSeconds?: number;
+    pageSize?: number;
+    maxPages?: number;
+  }): Promise<ClaimableTaskCandidate[]>;
+
+  /**
+   * SolverNet manifest registry — launched-instance summaries with
+   * current lifecycle status. Replaces the subgraph fetcher in
+   * `registry-client-erc8004.ts`.
+   */
+  listLaunchedSolverNets(args?: {
+    launcherAgentId?: string;
+    status?: Array<'launched' | 'paused' | 'retired'>;
+  }): Promise<SolverNetManifestSummary[]>;
+
+  getLifecycleStatus(
+    manifestCid: string,
+  ): Promise<SolverNetLifecycleStatus | undefined>;
+
+  /**
+   * Corpus envelope discovery — refs only, not bytes. The corpus
+   * library wraps this and adds manifest fetch / acquire / hash verify.
+   */
+  queryEnvelopes(query: CorpusQuery): Promise<EnvelopeRef[]>;
+}
+```
+
+Notes:
+
+- The interface returns the same shapes the existing subgraph callers already consume (`SubgraphTaskCandidate` → renamed `ClaimableTaskCandidate`; `SolverNetManifestSummary` already exists; `EnvelopeRef` is the corpus library's existing type). No call-site changes beyond swapping the injected dependency.
+- Each method is independently implementable. An implementation may throw `DiscoveryUnavailableError` for any subset of methods; the fallback chain catches and retries against the next implementation.
+- No write surface. Manifest publication, lifecycle transitions, and ERC-8004 metadata writes continue to go directly on-chain through the existing publishers (`registry-client-erc8004.ts`, `IdentityPublisher`, etc.). `DiscoveryAPI` is read-only.
+
+## 6. Implementations
+
+### 6.1 `HttpDiscoveryAPI` — default
+
+Thin HTTP client. Talks to a privately-operated indexer service over a versioned HTTP/GraphQL endpoint. The current default points at an instance run by the daemon's maintainer (Oak) on personal VPS infrastructure. Default URL ships in `client/src/config.ts` (`DEFAULT_TESTNET_DISCOVERY_URL`, `DEFAULT_MAINNET_DISCOVERY_URL`), env-overridable via `JINN_DISCOVERY_URL` so any operator can repoint at a different host without touching the binary.
+
+The HTTP service exposes Ponder's auto-generated GraphQL endpoint plus a small adapter layer that maps the four `DiscoveryAPI` methods to GraphQL queries. The adapter lives in the indexer package so the wire contract is colocated with the schema. Any operator who deploys the indexer package gets the same wire contract for free.
+
+API stability: the HTTP endpoint is a real versioned API. Breaking changes require a new path prefix (`/v2/...`) and a deprecation window for `/v1/...`. The daemon pins to a major version; minor changes are additive. Because the indexer is privately operated, the maintainer is the API owner and the only party who can promise stability — operators who depend on a third-party host inherit that host's stability discipline, which is a per-host trust decision.
+
+### 6.2 `EmbeddedPonderDiscoveryAPI` — opt-in
+
+Runs Ponder in-process as a ninth daemon loop. Same schema and handlers as the HTTP service; just a different deployment target.
+
+Operator UX:
+
+- Cold start: pulls a recent indexed-state snapshot from IPFS (CID published in the daemon release artifact) and replays from snapshot height. New operators reach head in minutes, not hours.
+- Steady state: tails events via the operator's configured `rpcUrl`. Uses HyperSync as the upstream when available; falls back to plain RPC.
+- Storage: SQLite under `~/.jinn-client/indexer/`. Schema version baked into the path so daemon upgrades that change the schema re-sync cleanly from snapshot.
+- RAM: ~300 MB steady state, ~600 MB during initial sync.
+
+Failure mode: if embedded Ponder is mid-sync or has crashed, the daemon's fallback chain routes reads to `OnchainDiscoveryAPI` until embedded mode reports `head_within_n_blocks`. The daemon never blocks on indexer sync.
+
+### 6.3 `OnchainDiscoveryAPI` — fallback
+
+Direct RPC via viem `getLogs` + multicall, no indexer state. Implements the same interface but with caveats:
+
+- `findClaimableTasks`: enumerates `TaskCreated` events from a known start block, multicalls current `finalized` / `refunded` state, enumerates `AttemptSubmitted` events and groups client-side. Bounded result set (only active claim windows), but slow on cold scans. Caches results in the daemon's existing SQLite for the duration of the daemon process.
+- `listLaunchedSolverNets` / `getLifecycleStatus`: reads `IdentityRegistry.MetadataSet` events directly (the same path `corpus/onchain-query.ts` already implements), folds via `most-recent-wins.ts`.
+- `queryEnvelopes`: delegates to the existing `runOnchainCorpusQuery` in `corpus/onchain-query.ts`.
+
+The on-chain implementation is the **always-live floor**. The daemon ships with it enabled and uses it as the primary if no other implementation is configured. This is the property that lets the daemon boot working even before any VPS is deployed.
+
+## 7. Ponder schema
+
+The Ponder package indexes four event sources, each producing one entity:
+
+| Entity | Source events | Used by |
+|---|---|---|
+| `Task` | `JinnRouter.TaskCreated`, `TaskFinalized`, `TaskRefunded` | `findClaimableTasks` |
+| `Attempt` | `JinnRouter.AttemptSubmitted`, `AttemptResolved` | `findClaimableTasks` (joined with Task) |
+| `SolverNetManifest` | `IdentityRegistry.MetadataSet` (key prefix `solvernet-manifest:`) | `listLaunchedSolverNets`, `getLifecycleStatus` |
+| `Envelope` | `IdentityRegistry.MetadataSet` (envelope keys per ERC-8004 spec) | `queryEnvelopes` |
+
+The schema is **deliberately narrow at v0.1**: it replaces today's three subgraph callsites and nothing more. Phase B.2 reputation entities, Phase C marketplace-specific entities, and any other future query domains are additive — they slot in as new entities + handlers without renaming or restructuring the existing four.
+
+Schema version is bumped on any breaking change to existing entities and triggers a re-sync from the bundled snapshot. Pure-additive changes do not bump the version.
+
+## 8. Deployment shapes
+
+### 8.1 Default (HTTP-to-shared-indexer)
+
+- The daemon's current maintainer (Oak) privately deploys the Ponder service on a personal VPS.
+- Domain: chosen by the operator running the indexer; current default URL ships in `config.ts` and is operator-overridable. Not anchored to a `jinn.network` subdomain — the indexer is not protocol infrastructure and should not appear to be.
+- Backed by: HyperSync upstream, Postgres for steady state, S3 (or equivalent) for snapshot publishing.
+- Snapshot cron publishes `~/.jinn-client/indexer/`-shaped SQLite snapshot to IPFS once per epoch; CID is committed on-chain via the maintainer's EOA so embedded-mode operators can verify it.
+- Cost owner: the maintainer personally. Not material at current scale (~$20-200/month). The protocol does not subsidise it and Jinn-the-project carries no obligation for its uptime.
+
+### 8.2 Embedded (operator-local Ponder)
+
+- Operator sets `discovery.mode: 'embedded'` in `~/.jinn-client/config.json`.
+- Daemon spawns Ponder in-process on boot, restores from the bundled snapshot, then tails events.
+- No external service dependency. RPC quota is the operator's own.
+
+### 8.3 On-chain (always-live floor)
+
+- Daemon falls back to this automatically when the configured primary is unhealthy.
+- Operators can pin to on-chain mode explicitly via `discovery.mode: 'onchain'`; useful for testing, air-gapped setups, or maximum-trust-minimisation operators willing to eat latency.
+
+## 9. Daemon-side integration
+
+### 9.1 Config surface
+
+Two new fields under a single `discovery` block (replaces today's loose `subgraphUrl`):
+
+```jsonc
+{
+  "discovery": {
+    "mode": "http" | "embedded" | "onchain", // default: "http"
+    "url": "https://discovery.jinn.network", // when mode = http
+    "fallbackToOnchain": true                // default: true; on-chain floor always honored
+  }
+}
+```
+
+Env overrides: `JINN_DISCOVERY_MODE`, `JINN_DISCOVERY_URL`, `JINN_DISCOVERY_FALLBACK`. `subgraphUrl` is removed (breaking config change — flagged in release notes; `DEFAULT_TESTNET_SUBGRAPH_URL` deletion in `config.ts:825` is part of the migration).
+
+### 9.2 Callsite migration
+
+Three current callsites move from "construct subgraph client; pass URL" to "inject `DiscoveryAPI`; call method":
+
+1. `adapters/mech/adapter.ts:545-580` — `discoverSubgraphRestorationTasks` → `discoverClaimableTasks`. The HTTP `taskDiscovery` config block collapses into the `discovery` block.
+2. `solvernets/registry-client-erc8004.ts` — currently constructs its own subgraph fetcher; switches to consuming the injected `DiscoveryAPI`.
+3. `corpus/index.ts` — `createCorpus({ subgraphUrl, onchain, ... })` becomes `createCorpus({ discovery, ... })`. The corpus library no longer owns the subgraph-vs-onchain split; that's `DiscoveryAPI`'s job.
+
+### 9.3 Fallback chain
+
+```
+primary = build(mode)                  // http | embedded | onchain
+floor   = build('onchain')             // always
+discovery = withFallback(primary, floor, { unhealthyThreshold, retryAfter })
+```
+
+`withFallback` is a small wrapper that catches `DiscoveryUnavailableError` and network errors from the primary, routes to the floor for the duration of the outage, and probes the primary periodically to re-engage. Exposed through telemetry so operators can see which path served each query.
+
+## 10. Trust model
+
+What each implementation guarantees:
+
+- **`HttpDiscoveryAPI`**: trusts the operator of the configured URL to report tasks and envelopes accurately. Worst-case lie: hide existing tasks/envelopes from the operator (denial of opportunity) or surface stale entries (wasted claim attempts). Cannot fabricate envelopes that pass downstream verification — the corpus library hash-verifies content against the manifest at retrieval time. Cannot fabricate task state that passes downstream verification — the daemon multicalls the JinnRouter contract before claiming (`canClaimTask` in `adapter.ts`).
+- **`EmbeddedPonderDiscoveryAPI`**: trusts only the operator's own RPC endpoint (and HyperSync if configured). No third-party in the discovery path.
+- **`OnchainDiscoveryAPI`**: trusts only the operator's RPC endpoint.
+
+Hash-verification at the content layer (corpus library) and on-chain state verification at the claim layer (`canClaimTask`) bound the damage any discovery-layer dishonesty can do. This is the property that makes the default `HttpDiscoveryAPI` mode safe for the network: a misbehaving shared indexer can degrade UX but cannot corrupt outcomes.
+
+## 11. Migration plan (high level)
+
+Detailed steps land as beads issues. The shape:
+
+1. **Ponder package + schema.** Stand up `packages/indexer/` with the four-entity schema. CI builds it. No deployment yet.
+2. **DiscoveryAPI interface + OnchainDiscoveryAPI.** Land the interface and the always-live floor implementation in `client/src/discovery/`. Wire it behind a feature flag; existing subgraph paths untouched.
+3. **Callsite migration.** Move the three callsites (task discovery, SolverNet registry, corpus) to consume `DiscoveryAPI`. Subgraph paths become one implementation of the interface, gated by `discovery.mode: 'http-subgraph'` (a transitional implementation that delegates to the existing subgraph client — kept only for the migration window).
+4. **HttpDiscoveryAPI + VPS deployment.** Deploy Ponder to the VPS. Cut over the default `discovery.url` to the new endpoint. Transitional `http-subgraph` mode remains for one release cycle as an escape hatch.
+5. **EmbeddedPonderDiscoveryAPI.** Wire Ponder as an in-process loop. Snapshot publication + verification pipeline. Document operator opt-in.
+6. **Remove subgraph callsites.** Drop `task-subgraph.ts`, the subgraph branch in `corpus/index.ts`, the subgraph fetcher in `registry-client-erc8004.ts`, the `subgraphUrl` config field, the transitional `http-subgraph` mode, and the stub `erc8004/subgraph.ts`. The Graph API key dependency leaves the system.
+
+## 12. Federation path (out of scope for v0.1)
+
+The HTTP service is intentionally not branded as protocol infrastructure. It's a privately-operated indexer that the daemon's current maintainer happens to run, and the daemon's `discovery.url` is operator-chosen — the default just happens to point at the maintainer's instance.
+
+This matters: there is no "Jinn-operated indexer" anywhere in the runtime. The protocol does not run infrastructure; participants do. The current default exists because one participant (Oak) chose to run one and ship the daemon pointing at it. That choice is observable in the default config and reversible by any operator at any time.
+
+When a second party wants to run their own app + indexer, they:
+
+1. Stand up their own Ponder deployment (same `packages/indexer/` package, different VPS).
+2. Operators who want to align with that app set `discovery.url: 'https://<their-host>/'`.
+
+No protocol changes. No coordination. This is the headless-brand shape made literal: protocol stays minimal, surfaces vary, operators choose alignment. Multiple privately-operated indexers can coexist on the same protocol from day one — the only thing v0.1 doesn't ship is a *discovery-of-discovery* layer to help operators find alternatives. They find them by word-of-mouth or by reading config docs, which is fine for the current participant count.
+
+A future spec may introduce a discovery-of-discovery layer (a list of known indexer endpoints anchored on-chain or in IPFS, possibly weighted by some operator-signal). v0.1 does not need it; pointing at a URL is enough.
+
+## 13. Open questions
+
+1. **GraphQL vs. JSON-RPC-style HTTP for the wire format.** Ponder ships GraphQL natively; the daemon already speaks GraphQL today. Default to GraphQL unless a concrete reason to differ surfaces in implementation. Worth a one-line answer in v0.2.
+2. **Snapshot frequency and size.** What's an acceptable lag for embedded-mode cold start — daily? hourly? The size of the indexed state per release dictates this. Decide during implementation; not gating for v0.1.
+3. **Telemetry on fallback engagement.** Should the daemon report when it's falling back to on-chain mode? Likely yes (operator visibility), via the existing telemetry channel. Confirm shape during integration.
+4. **HyperSync availability and pricing model.** Embedded mode benefits massively from HyperSync but inherits its availability. Need to confirm current SLA / pricing / contingency for the embedded path. Not blocking; plain RPC works as a slower upstream.
+5. **What to do with `erc8004/subgraph.ts`.** The stub references bead `jinn-mono-fud` for an upcoming Jinn-specific subgraph. Either roll that work into the Ponder schema (preferred — it's the same data domain) or close the bead as superseded. Decide during implementation.
+
+## 14. References
+
+- `spec/2026-04-30-phase-a-umbrella.md` — corpus library as the first programmatic-library "app"; `routeResolver` seam that this spec generalises into `DiscoveryAPI`.
+- `spec/2026-05-05-solvernet-creation-and-launch.md` §13 — registry client interface designed to be swappable; the day-1 subgraph backing this spec replaces.
+- `client/src/corpus/onchain-query.ts` — the working on-chain discovery path that `OnchainDiscoveryAPI` extends to cover all three query domains.
+- `client/src/adapters/mech/task-subgraph.ts` — the load-bearing callsite this spec migrates.
+- Ponder — https://ponder.sh — the indexer framework chosen for both deployment shapes.


### PR DESCRIPTION
## Summary

Phase 1 of the epic to remove the hosted-subgraph runtime dependency (jinn-mono-280n). Ships:

- **Spec** (`spec/2026-05-11-discovery-api-and-shared-indexer.md`, v0.1 draft) — overall architecture and migration plan for the epic.
- **`DiscoveryAPI` interface + types + `withFallback` wrapper** (`client/src/discovery/{types,with-fallback,index}.ts`) — the abstraction the daemon now talks to for read-side discovery.
- **`OnchainDiscoveryAPI` always-live floor** (`client/src/discovery/onchain.ts`) — direct viem `getLogs` + multicall implementation; works against any operator-configured RPC, no third-party indexer required.
- **`HttpSubgraphDiscoveryAPI` transitional impl** (`client/src/discovery/http-subgraph.ts`) — wraps the existing hosted-subgraph clients behind the new interface; errors wrapped in `DiscoveryUnavailableError` so the fallback chain engages on 429/timeout.
- **`createDiscoveryAPI` factory** (`client/src/discovery/factory.ts`) + new `discovery` config block — selects primary backend (`http-subgraph` / `onchain` today; `http` / `embedded` reserved for jinn-mono-280n.4 and .5).
- **Three callsites migrated** to consume `DiscoveryAPI`: task discovery in `adapters/mech/adapter.ts`, SolverNet registry in `solvernets/registry-client-erc8004.ts`, corpus library in `corpus/index.ts`. Legacy `subgraphUrl` config field accepted with a deprecation warning that maps to the transitional mode.

## Direct unblock for jinn-mono-uy6v.1.1 (P0)

The hosted Graph Studio 429 that's been failing the release gate can now be sidestepped two ways:

1. `discovery.mode: 'onchain'` — bypass hosted-subgraph entirely; daemon falls through to direct RPC reads.
2. `discovery.mode: 'http-subgraph'` with `fallbackToOnchain: true` (default) — keep current subgraph behavior; the fallback chain automatically routes to the on-chain floor when the subgraph returns 429/5xx.

## Closes

- jinn-mono-280n.2 — DiscoveryAPI interface + OnchainDiscoveryAPI floor
- jinn-mono-280n.3 — Migrate three subgraph callsites to DiscoveryAPI

## Remaining in epic (stacked branch follows)

- jinn-mono-280n.1 — Ponder indexer package (independent; can land in any order)
- jinn-mono-280n.4 — HttpDiscoveryAPI client + privately-operated VPS deployment (needs .1)
- jinn-mono-280n.5 — EmbeddedPonderDiscoveryAPI (needs .1)
- jinn-mono-280n.6 — Drop subgraph entirely (needs .3 ✅ + .4)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 3151 tests pass, 4 pre-existing skips, no new regressions
- [x] Spec compliance review passed (DiscoveryAPI signatures, error wrapping, deprecation mapping, three callsites all wired through the new interface)
- [x] Code quality review passed (helper reuse, chunked getLogs newest-first early exit, throwing-task resilience in `limitedConcurrency`, cursor cache semantics)
- [ ] Reviewer to verify release-gate unblock with `discovery.mode: 'onchain'` against testnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)