### PR TITLE
chore(2cl.15): allow .claude/skills/ to be tracked in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,14 @@
 .worktrees/
 node_modules/
-.claude/
+
+# .claude/ is operator-local (settings.json, worktrees, DS_Store) by default,
+# but shareable skill prose lives at .claude/skills/<name>/SKILL.md and must
+# be tracked so every contributor's Claude Code instance auto-discovers it
+# (jinn-mono-2cl.15). Sub-paths inside .claude/skills/ that are themselves
+# operator-local (e.g. cached state files) can be added back here with
+# explicit .claude/skills/<name>/<path> ignore rules.
+.claude/*
+!.claude/skills/
 
 # Beads / Dolt files (added by bd init)
 .beads


### PR DESCRIPTION
## Summary

Closes jinn-mono-2cl.15. Shape: `chore` (gitignore policy fix). One file changed.

## Linked bd

Closes jinn-mono-2cl.15.

## What changes

`cargo/.gitignore`: replace `.claude/` (block-all) with `.claude/*` + `!.claude/skills/` (block-except-skills).

## Why

Two problems with the previous policy:

1. **Reality drift.** 10 skills are already tracked in git (force-added historically). Examples: `.claude/skills/eng-day/SKILL.md`, `.claude/skills/growth-day/SKILL.md`, etc. Gitignore claimed to ignore them; git tracked them anyway (gitignore is for *untracked* files). Policy didn't match reality.

2. **Fragile convention.** Every new skill or modification required `git add -f`. PR #128 used force-add for `eng-day` and called the convention "fragile" in the handbook §Open. Modifications to tracked skill files didn't appear in plain `git add .`.

## Verified

```
$ git check-ignore -v .claude/skills/eng-day/SKILL.md   →  NOT ignored ✓
$ git check-ignore -v .claude/settings.json             →  ignored ✓
$ git check-ignore -v .claude/worktrees/foo             →  ignored ✓
$ git check-ignore -v .claude/.DS_Store                 →  ignored ✓
```

All four cases behave correctly.

## Agent identity

AI-authored (Claude Opus 4.7). Co-Authored-By trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)