### PR TITLE
fix: friday-triage.yml YAML parse error (embedded python dedent)

### DIFF
--- a/.github/workflows/friday-triage.yml
+++ b/.github/workflows/friday-triage.yml
@@ -73,14 +73,9 @@ jobs:
           if [ -n "$INPUT" ]; then
             DATE="$INPUT"
           else
-            # Default: next Monday from today.
-            DATE="$(date -u -d 'next Monday' +%Y-%m-%d 2>/dev/null || python3 -c "
-import datetime
-today = datetime.datetime.utcnow().date()
-days_ahead = (0 - today.weekday()) % 7
-days_ahead = days_ahead if days_ahead != 0 else 7
-print((today + datetime.timedelta(days=days_ahead)).isoformat())
-")"
+            # Default: next Monday from today. The runner is ubuntu-latest (GNU date),
+            # which handles relative-date strings natively — no fallback needed.
+            DATE="$(date -u -d 'next Monday' +%Y-%m-%d)"
           fi
           echo "date=$DATE" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

Shape: `fix`. Bug found during bucket-A workflow validation: `friday-triage.yml` (shipped in PR #128) has a YAML parse error — the embedded `python3 -c "..."` fallback dedents below the `run: |` block scalar, so YAML ends the block early and chokes on `import datetime` as a non-key.

GitHub's lenient parser didn't reject the file but mis-handled the `on:` block: the workflow fired on `push` (4 failed runs on today's PR merges), `gh workflow run` reported "does not have 'workflow_dispatch' trigger", and `gh workflow list` showed it by file path instead of its `name:`.

## Linked bd

No bd — this is a same-day hotfix on the just-shipped 2cl substrate. (If we want a bead for the postmortem: the underlying lesson is "lint workflow YAML before merge"; could be filed as a 2cl follow-up if worth tracking.)

## What changes

`.github/workflows/friday-triage.yml`: drop the `python3 -c` date fallback. The runner is `ubuntu-latest` (GNU coreutils); `date -u -d 'next Monday' +%Y-%m-%d` works natively. The fallback was an over-cautious portability hedge that introduced the bug.

## Regression test (run before merge)

```
$ python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/friday-triage.yml')); print(list((d.get('on') or d.get(True)).keys()))"
['workflow_dispatch']
```

YAML parses clean; `on:` resolves to `workflow_dispatch` only — no push trigger.

## Impact

The 4 failed `friday-triage.yml` runs on main today were harmless (the workflow's bd-CLI probe exits gracefully when bd isn't installed). This stops the noise + makes the workflow `gh workflow run`-able.

## Agent identity

AI-authored (Claude Opus 4.7). Co-Authored-By trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)