### PR TITLE
chore(2cl.21): bd-mirror writes Sprint iteration + human Epic options

### DIFF
--- a/scripts/bd-mirror
+++ b/scripts/bd-mirror
@@ -46,8 +46,10 @@ ORG="${REPO%%/*}"
 PROJECT_TITLE="Jinn engineering"
 
 # bd epic short id -> public Epic single-select option name on the board.
-# Keep in sync with the board's Epic field (DR-2026-05-11-b). A case statement (not an
-# associative array) so this runs on macOS's bash 3.2 — `declare -A` is bash 4+ only.
+# Keep in sync with the board's Epic field (DR-2026-05-11-b) — when an epic ships and its
+# board column is removed, drop its entry here too (e.g. 280n "Discovery API", removed once
+# shipped). A case statement (not an associative array) so this runs on macOS's bash 3.2 —
+# `declare -A` is bash 4+ only.
 epic_option_for() {
   case "$1" in
     uy6v) echo "v1 public testnet" ;;
@@ -55,7 +57,6 @@ epic_option_for() {
     2cl)  echo "Engineering handbook" ;;
     46l8) echo "VPS deployment" ;;
     9iq3) echo "Prediction freeze" ;;
-    280n) echo "Discovery API" ;;
     *)    echo "" ;;
   esac
 }

--- a/scripts/bd-mirror
+++ b/scripts/bd-mirror
@@ -1,198 +1,224 @@
 #!/usr/bin/env bash
 #
-# bd-mirror — mirror a bd issue to a public GitHub Issue and add it to
-# the "Jinn engineering" GitHub Project (v2) board with the given Sprint
-# field value.
+# bd-mirror — mirror a bd issue to a public GitHub Issue and add it to the
+# "Jinn engineering" GitHub Project (v2) board with Sprint / Epic / Status set.
 #
-# Implements jinn-mono-2cl.12 per the engineering handbook (cargo/docs/engineering/handbook.md)
-# and DR-2026-05-11-b (cargo/log/decisions/2026-05-11-engineering-substrate.md).
+# Implements jinn-mono-2cl.12 + jinn-mono-2cl.21 per the engineering handbook
+# (cargo/docs/engineering/handbook.md) and DR-2026-05-11-b
+# (cargo/log/decisions/2026-05-11-engineering-substrate.md).
 #
 # Usage:
-#   cargo/scripts/bd-mirror <bd-id> <sprint-yyyy-mm-dd> [--labels label1,label2,...] [--dry-run]
+#   cargo/scripts/bd-mirror <bd-id> <sprint-spec> [options]
 #
-# Behaviour:
-# - Reads bd issue via `bd show <id> --json`.
-# - Strips internal-only content from the body (notes prefixed "captain-only:",
-#   exploratory "needs-design-session" framing).
-# - Opens a public GitHub Issue on Jinn-Network/mono with:
-#   - Title: bd title
-#   - Body: curated description + "Internal tracking: jinn-mono-<id>" footer
-#   - Labels: epic:<parent-epic-id> + sprint:<yyyy-mm-dd> + agent:<owner> + any --labels
-# - Adds the new Issue to the "Jinn engineering" Project (v2).
-# - Sets the Project item's Sprint field to <yyyy-mm-dd>.
-# - Writes the GitHub Issue URL back to the bd issue as an external-ref.
-# - Idempotent: if the bd issue already has an external-ref pointing at a Jinn-Network/mono
-#   Issue, the script is a no-op (prints the existing Issue URL).
+#   <sprint-spec>:
+#     @current        the iteration whose window contains today (latest start <= today)
+#     @next           the iteration immediately after @current
+#     none            don't set the Sprint field (Roadmap-only item)
+#     "<title>"       an exact iteration title, e.g. "Sprint 1"
 #
-# Dependencies:
-# - bd (beads CLI) configured for this repo.
-# - gh (GitHub CLI) authenticated with project scope (`gh auth refresh -s project`).
-# - jq.
+#   options:
+#     --status <Todo|In Progress|Done>   Project Status (default: Todo)
+#     --epic <option-name>               override the Epic option (default: derived from the
+#                                        bead's parent epic via the EPIC_MAP table below)
+#     --labels l1,l2,...                 extra GitHub Issue labels (auto-created if missing)
+#     --update                           if the bead is already mirrored, don't create a new
+#                                        Issue — just re-apply Sprint/Epic/Status to its
+#                                        existing Project item (lets you move items between sprints)
+#     --dry-run                          print what would happen; change nothing
 #
-# Status: v0.1. The Project board (jinn-mono-2cl.9) exists as of 2026-05-11
-# (https://github.com/orgs/Jinn-Network/projects/1). The Project-add steps will succeed when
-# the gh CLI token has the `project` scope; otherwise this script falls back to
-# "Issue created, Project add skipped" mode.
+# Idempotent: if the bead already has an external-ref into the repo, no-op (or, with
+# --update, re-apply the Project fields to the existing item).
+#
+# Dependencies: bd, gh (authenticated with `project` scope — `gh auth refresh -s project`), jq.
 #
 # Changelog:
-# - v0.1 (jinn-mono-2cl.13, 2026-05-11): fix bd JSON parsing — `bd show --json` returns an array
-#   not a bare object (index with .[0]); `.parent` not `.parent_id`; fall back through
-#   .assignee → .owner → "human" for the agent: label.
+# - v0.2 (jinn-mono-2cl.21, 2026-05-12): Sprint field is an Iteration (not a Date) — resolve
+#   @current/@next/<title> to an iteration id and set with --iteration-id. Epic is set to the
+#   human-readable single-select option (mapped from the bead's parent epic via EPIC_MAP), not a
+#   raw bd id. Added Status setting (--status) and --update (move between sprints). Auto-create
+#   any missing GitHub labels before use. Use the Project's GraphQL node id for item-edit.
+# - v0.1 (jinn-mono-2cl.13, 2026-05-11): fix bd JSON parsing (array index, .parent, owner fallback).
 
 set -euo pipefail
 
 REPO="Jinn-Network/mono"
+ORG="${REPO%%/*}"
 PROJECT_TITLE="Jinn engineering"
+
+# bd epic short id -> public Epic single-select option name on the board.
+# Keep in sync with the board's Epic field (DR-2026-05-11-b). A case statement (not an
+# associative array) so this runs on macOS's bash 3.2 — `declare -A` is bash 4+ only.
+epic_option_for() {
+  case "$1" in
+    uy6v) echo "v1 public testnet" ;;
+    8psp) echo "Hermes harness" ;;
+    2cl)  echo "Engineering handbook" ;;
+    46l8) echo "VPS deployment" ;;
+    9iq3) echo "Prediction freeze" ;;
+    280n) echo "Discovery API" ;;
+    *)    echo "" ;;
+  esac
+}
 
 usage() {
   cat >&2 <<'EOF'
-Usage: bd-mirror <bd-id> <sprint-yyyy-mm-dd> [--labels label1,label2,...] [--dry-run]
+Usage: bd-mirror <bd-id> <sprint-spec> [--status NAME] [--epic NAME] [--labels l1,l2] [--update] [--dry-run]
 
-Mirrors a bd issue to a public GitHub Issue on Jinn-Network/mono and adds it
-to the "Jinn engineering" GitHub Project (v2) board with Sprint = <date>.
+  <sprint-spec>: @current | @next | none | "<iteration title>"
 
-Idempotent: re-running with the same <bd-id> is a no-op (detects existing
-GitHub Issue via the bd issue's external-ref).
+Mirrors a bd issue to a public GitHub Issue on Jinn-Network/mono and adds it to the
+"Jinn engineering" GitHub Project (v2) board, setting the Sprint (iteration), Epic
+(single-select, mapped from the bead's parent epic), and Status fields.
+
+Idempotent: re-running with the same <bd-id> is a no-op; pass --update to re-apply
+the Project fields to an already-mirrored bead (e.g. to move it to a new sprint).
 EOF
   exit 2
 }
 
-if [[ $# -lt 2 ]]; then
-  usage
-fi
+[[ $# -lt 2 ]] && usage
 
-BD_ID="$1"
-SPRINT_DATE="$2"
-shift 2
-
-EXTRA_LABELS=""
-DRY_RUN=0
-
+BD_ID="$1"; SPRINT_SPEC="$2"; shift 2
+EXTRA_LABELS=""; STATUS_NAME="Todo"; EPIC_OVERRIDE=""; DRY_RUN=0; UPDATE_ONLY=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --labels)
-      EXTRA_LABELS="$2"
-      shift 2
-      ;;
-    --dry-run)
-      DRY_RUN=1
-      shift
-      ;;
-    *)
-      echo "unknown arg: $1" >&2
-      usage
-      ;;
+    --labels)  EXTRA_LABELS="$2"; shift 2 ;;
+    --status)  STATUS_NAME="$2"; shift 2 ;;
+    --epic)    EPIC_OVERRIDE="$2"; shift 2 ;;
+    --update)  UPDATE_ONLY=1; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    *) echo "unknown arg: $1" >&2; usage ;;
   esac
 done
 
-# Validate the sprint date format.
-if ! [[ "$SPRINT_DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
-  echo "error: sprint date must be yyyy-mm-dd, got: $SPRINT_DATE" >&2
-  exit 2
-fi
+TODAY="$(date -u +%Y-%m-%d)"
 
-# Read the bd issue.
-# Note: `bd show --json` returns a JSON ARRAY of one element, not a bare object.
-# Use jq's `.[0]` to extract the single element before reading fields.
-if ! BD_JSON="$(bd show "$BD_ID" --json 2>/dev/null | jq '.[0]')"; then
-  echo "error: bd show $BD_ID failed — does the bead exist?" >&2
-  exit 1
+# --- read the bd issue -------------------------------------------------------
+if ! BD_JSON="$(bd show "$BD_ID" --json 2>/dev/null | jq '.[0]')" || [[ -z "$BD_JSON" || "$BD_JSON" == "null" ]]; then
+  echo "error: bd show $BD_ID returned no data — does the bead exist?" >&2; exit 1
 fi
-if [[ -z "$BD_JSON" || "$BD_JSON" == "null" ]]; then
-  echo "error: bd show $BD_ID returned no data — does the bead exist?" >&2
-  exit 1
-fi
-
 BD_TITLE="$(echo "$BD_JSON" | jq -r '.title // ""')"
 BD_DESCRIPTION="$(echo "$BD_JSON" | jq -r '.description // ""')"
-BD_PRIORITY="$(echo "$BD_JSON" | jq -r '.priority // 2')"
-# Parent is the top-level `.parent` field (not `.parent_id`). It's null on epics/orphans.
 BD_PARENT="$(echo "$BD_JSON" | jq -r '.parent // ""')"
-# `.assignee` is set by `bd update <id> --claim` and bd's CLI flows; falls back to the legacy
-# email-shaped `.owner` and finally to "human" so the agent: label always has a value.
-# Note: jq's `//` only triggers on null/false, not empty strings. Some bd versions may emit
-# `""` for unset string fields; the explicit filter handles both `null` and `""`.
 BD_OWNER="$(echo "$BD_JSON" | jq -r '[.assignee, .owner, "human"] | map(select(. != null and . != "")) | .[0]')"
 BD_EXTERNAL_REF="$(echo "$BD_JSON" | jq -r '.external_ref // ""')"
 
-# Idempotency check: if external-ref points at a Jinn-Network/mono Issue, no-op.
-if [[ -n "$BD_EXTERNAL_REF" && "$BD_EXTERNAL_REF" == *"$REPO"* ]]; then
-  echo "$BD_ID already mirrored: $BD_EXTERNAL_REF"
-  exit 0
-fi
-
-# Curate the body: strip captain-only lines and "needs-design-session" framing.
-# Use grep -iv (BSD/GNU compatible) instead of sed /I (GNU-only) so this works on
-# macOS where this script is also run manually by Captain.
-CURATED_BODY="$(echo "$BD_DESCRIPTION" | grep -v '^captain-only:' | grep -iv 'needs-design-session')"
-
-# Compose the epic label from the parent id (if present).
-EPIC_LABEL=""
+# Epic short id: from the parent (strip jinn-mono- and any .N tail); if no parent and the
+# bead's own short id has no dotted suffix, the bead is itself an epic — use its own id.
+SELF_SHORT="${BD_ID#jinn-mono-}"
 if [[ -n "$BD_PARENT" ]]; then
-  # Strip the jinn-mono- prefix and any trailing .N to get the epic short id.
-  EPIC_SHORT="$(echo "$BD_PARENT" | sed -e 's|^jinn-mono-||' -e 's|\..*$||')"
-  EPIC_LABEL="epic:$EPIC_SHORT"
+  EPIC_SHORT="$(echo "${BD_PARENT#jinn-mono-}" | sed 's|\..*$||')"
+elif [[ "$SELF_SHORT" != *.* ]]; then
+  EPIC_SHORT="$SELF_SHORT"
+else
+  EPIC_SHORT=""
 fi
 
-# Compose labels.
-LABELS="sprint:$SPRINT_DATE,agent:$BD_OWNER"
-if [[ -n "$EPIC_LABEL" ]]; then
-  LABELS="$EPIC_LABEL,$LABELS"
-fi
-if [[ -n "$EXTRA_LABELS" ]]; then
-  LABELS="$LABELS,$EXTRA_LABELS"
+# Epic option name: --epic override > epic_option_for(epic-short) > (unset).
+if [[ -n "$EPIC_OVERRIDE" ]]; then
+  EPIC_OPTION_NAME="$EPIC_OVERRIDE"
+else
+  EPIC_OPTION_NAME="$([[ -n "$EPIC_SHORT" ]] && epic_option_for "$EPIC_SHORT" || true)"
+  [[ -n "$EPIC_SHORT" && -z "$EPIC_OPTION_NAME" ]] && echo "note: no Epic mapping for '$EPIC_SHORT' — Epic left unset (pass --epic to set it)." >&2
 fi
 
-# Compose the public Issue body.
-ISSUE_BODY="$(cat <<EOF
-$CURATED_BODY
+# --- resolve Project + field metadata ---------------------------------------
+PROJECT_JSON="$(gh project list --owner "$ORG" --format json 2>/dev/null || echo '{}')"
+PROJECT_NUMBER="$(echo "$PROJECT_JSON" | jq -r --arg t "$PROJECT_TITLE" '.projects[]? | select(.title==$t) | .number' | head -1)"
+PROJECT_NODE_ID="$(echo "$PROJECT_JSON" | jq -r --arg t "$PROJECT_TITLE" '.projects[]? | select(.title==$t) | .id' | head -1)"
+if [[ -z "$PROJECT_NUMBER" || -z "$PROJECT_NODE_ID" ]]; then
+  echo "error: Project '$PROJECT_TITLE' not found on $ORG (token needs 'project' scope: \`gh auth refresh -s project\`)." >&2; exit 1
+fi
 
----
-Internal tracking: $BD_ID
-EOF
-)"
+FIELDS_JSON="$(gh project field-list "$PROJECT_NUMBER" --owner "$ORG" --format json 2>/dev/null || echo '{}')"
+SPRINT_FIELD_ID="$(echo "$FIELDS_JSON" | jq -r '.fields[]? | select(.name=="Sprint") | .id' | head -1)"
+EPIC_FIELD_ID="$(echo "$FIELDS_JSON" | jq -r '.fields[]? | select(.name=="Epic") | .id' | head -1)"
+STATUS_FIELD_ID="$(echo "$FIELDS_JSON" | jq -r '.fields[]? | select(.name=="Status") | .id' | head -1)"
+
+lookup_option() { # <field-name> <option-name>
+  echo "$FIELDS_JSON" | jq -r --arg f "$1" --arg o "$2" '.fields[]? | select(.name==$f) | .options[]? | select(.name==$o) | .id' | head -1
+}
+field_options() { echo "$FIELDS_JSON" | jq -r --arg f "$1" '.fields[]? | select(.name==$f) | .options | map(.name) | join(", ")'; }
+
+STATUS_OPTION_ID="$(lookup_option Status "$STATUS_NAME")"
+[[ -z "$STATUS_OPTION_ID" ]] && { echo "error: Status option '$STATUS_NAME' not found (have: $(field_options Status))." >&2; exit 1; }
+EPIC_OPTION_ID=""
+if [[ -n "$EPIC_OPTION_NAME" ]]; then
+  EPIC_OPTION_ID="$(lookup_option Epic "$EPIC_OPTION_NAME")"
+  [[ -z "$EPIC_OPTION_ID" ]] && { echo "error: Epic option '$EPIC_OPTION_NAME' not found (have: $(field_options Epic))." >&2; exit 1; }
+fi
+
+# Sprint iteration (gh project field-list omits iteration configs — use GraphQL).
+SPRINT_ITER_ID=""; SPRINT_ITER_TITLE=""
+if [[ "$SPRINT_SPEC" != "none" ]]; then
+  ITER_JSON="$(gh api graphql -f query='
+    query($org:String!,$num:Int!){ organization(login:$org){ projectV2(number:$num){
+      field(name:"Sprint"){ ... on ProjectV2IterationField { configuration {
+        iterations { id title startDate } completedIterations { id title startDate } } } } } } }' \
+    -F org="$ORG" -F num="$PROJECT_NUMBER" 2>/dev/null \
+    | jq -c '[(.data.organization.projectV2.field.configuration.iterations // [])[],
+              (.data.organization.projectV2.field.configuration.completedIterations // [])[]]' || echo '[]')"
+  case "$SPRINT_SPEC" in
+    @current) SEL="$(echo "$ITER_JSON" | jq -r --arg d "$TODAY" 'map(select(.startDate<=$d)) | sort_by(.startDate) | last | if .==null then "" else "\(.id)\t\(.title)" end')" ;;
+    @next)    SEL="$(echo "$ITER_JSON" | jq -r --arg d "$TODAY" 'sort_by(.startDate) as $s | ($s | map(.startDate<=$d) | index(false)) as $i | if $i==null then "" else ($s[$i]|"\(.id)\t\(.title)") end')" ;;
+    *)        SEL="$(echo "$ITER_JSON" | jq -r --arg t "$SPRINT_SPEC" '.[] | select(.title==$t) | "\(.id)\t\(.title)"' | head -1)" ;;
+  esac
+  [[ -z "$SEL" ]] && { echo "error: can't resolve sprint '$SPRINT_SPEC' (iterations: $(echo "$ITER_JSON" | jq -r 'map(.title)|join(", ")'))." >&2; exit 1; }
+  SPRINT_ITER_ID="${SEL%%$'\t'*}"; SPRINT_ITER_TITLE="${SEL#*$'\t'}"
+fi
+
+# --- apply fields to a Project item -----------------------------------------
+set_item_fields() {
+  local item_id="$1"
+  [[ -n "$SPRINT_ITER_ID" ]] && { gh project item-edit --id "$item_id" --project-id "$PROJECT_NODE_ID" --field-id "$SPRINT_FIELD_ID" --iteration-id "$SPRINT_ITER_ID" >/dev/null || echo "warning: set Sprint failed on $item_id" >&2; }
+  [[ -n "$EPIC_OPTION_ID" ]] && { gh project item-edit --id "$item_id" --project-id "$PROJECT_NODE_ID" --field-id "$EPIC_FIELD_ID" --single-select-option-id "$EPIC_OPTION_ID" >/dev/null || echo "warning: set Epic failed on $item_id" >&2; }
+  gh project item-edit --id "$item_id" --project-id "$PROJECT_NODE_ID" --field-id "$STATUS_FIELD_ID" --single-select-option-id "$STATUS_OPTION_ID" >/dev/null || echo "warning: set Status failed on $item_id" >&2
+}
+
+# --- idempotency / --update --------------------------------------------------
+if [[ -n "$BD_EXTERNAL_REF" && "$BD_EXTERNAL_REF" == *"$REPO"* ]]; then
+  if [[ "$UPDATE_ONLY" -eq 1 ]]; then
+    [[ "$DRY_RUN" -eq 1 ]] && { echo "DRY RUN — would re-apply (sprint=${SPRINT_ITER_TITLE:-none} epic=${EPIC_OPTION_NAME:-none} status=$STATUS_NAME) to the item for $BD_EXTERNAL_REF"; exit 0; }
+    ITEM_ID="$(gh project item-list "$PROJECT_NUMBER" --owner "$ORG" --format json --limit 500 2>/dev/null | jq -r --arg u "$BD_EXTERNAL_REF" '.items[]? | select(.content.url==$u) | .id' | head -1)"
+    [[ -z "$ITEM_ID" || "$ITEM_ID" == "null" ]] && { echo "error: $BD_ID maps to $BD_EXTERNAL_REF but no matching Project item found." >&2; exit 1; }
+    set_item_fields "$ITEM_ID"
+    echo "Updated $BD_ID ($BD_EXTERNAL_REF): sprint=${SPRINT_ITER_TITLE:-none} epic=${EPIC_OPTION_NAME:-none} status=$STATUS_NAME"; exit 0
+  fi
+  echo "$BD_ID already mirrored: $BD_EXTERNAL_REF (pass --update to re-apply Sprint/Epic/Status)"; exit 0
+fi
+
+# --- compose + create the Issue ---------------------------------------------
+CURATED_BODY="$(echo "$BD_DESCRIPTION" | grep -v '^captain-only:' | grep -iv 'needs-design-session' || true)"
+ISSUE_BODY="$(printf '%s\n\n---\nInternal tracking: %s\n' "$CURATED_BODY" "$BD_ID")"
+
+LABELS=("agent:$BD_OWNER")
+[[ -n "$EPIC_SHORT" ]] && LABELS=("epic:$EPIC_SHORT" "${LABELS[@]}")
+[[ -n "$SPRINT_ITER_TITLE" ]] && LABELS+=("sprint:$(echo "$SPRINT_ITER_TITLE" | tr 'A-Z ' 'a-z-')")
+if [[ -n "$EXTRA_LABELS" ]]; then IFS=',' read -ra EX <<< "$EXTRA_LABELS"; LABELS+=("${EX[@]}"); fi
+LABEL_CSV="$(IFS=,; echo "${LABELS[*]}")"
 
 if [[ "$DRY_RUN" -eq 1 ]]; then
-  echo "DRY RUN — would create GitHub Issue:"
-  echo "  Repo:   $REPO"
-  echo "  Title:  $BD_TITLE"
-  echo "  Labels: $LABELS"
-  echo "  Body:"
-  echo "$ISSUE_BODY" | sed 's/^/    /'
+  cat <<EOF
+DRY RUN — would mirror $BD_ID:
+  Title:  $BD_TITLE
+  Labels: $LABEL_CSV
+  Sprint: ${SPRINT_ITER_TITLE:-(none)}
+  Epic:   ${EPIC_OPTION_NAME:-(none)}
+  Status: $STATUS_NAME
+  Body:
+$(echo "$ISSUE_BODY" | sed 's/^/    /')
+EOF
   exit 0
 fi
 
-# Create the GitHub Issue.
-ISSUE_URL="$(gh issue create \
-  --repo "$REPO" \
-  --title "$BD_TITLE" \
-  --body "$ISSUE_BODY" \
-  --label "$LABELS")"
+for l in "${LABELS[@]}"; do gh label create "$l" --repo "$REPO" >/dev/null 2>&1 || true; done
 
+ISSUE_URL="$(gh issue create --repo "$REPO" --title "$BD_TITLE" --body "$ISSUE_BODY" --label "$LABEL_CSV")"
 echo "Created Issue: $ISSUE_URL"
 
-# Best-effort: add to the Project board and set Sprint field.
-# If the Project doesn't exist yet (jinn-mono-2cl.9 not landed), skip gracefully.
-PROJECT_NUMBER="$(gh project list --owner "${REPO%%/*}" --format json 2>/dev/null | \
-  jq -r --arg title "$PROJECT_TITLE" '.projects[] | select(.title == $title) | .number' | head -1 || true)"
+ITEM_ID="$(gh project item-add "$PROJECT_NUMBER" --owner "$ORG" --url "$ISSUE_URL" --format json 2>/dev/null | jq -r '.id')"
+if [[ -n "$ITEM_ID" && "$ITEM_ID" != "null" ]]; then set_item_fields "$ITEM_ID"
+else echo "warning: failed to add $ISSUE_URL to the Project board — add it manually." >&2; fi
 
-if [[ -z "$PROJECT_NUMBER" ]]; then
-  echo "note: project '$PROJECT_TITLE' not found on ${REPO%%/*} — Issue created but Project add skipped. Create the Project per jinn-mono-2cl.9."
-else
-  ITEM_ID="$(gh project item-add "$PROJECT_NUMBER" --owner "${REPO%%/*}" --url "$ISSUE_URL" --format json 2>/dev/null | jq -r '.id' || true)"
-  if [[ -n "$ITEM_ID" && "$ITEM_ID" != "null" ]]; then
-    # Set the Sprint field. Field id lookup: gh project field-list <project> --owner <owner>.
-    SPRINT_FIELD_ID="$(gh project field-list "$PROJECT_NUMBER" --owner "${REPO%%/*}" --format json 2>/dev/null | \
-      jq -r '.fields[] | select(.name == "Sprint") | .id' | head -1 || true)"
-    if [[ -n "$SPRINT_FIELD_ID" ]]; then
-      gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_NUMBER" --field-id "$SPRINT_FIELD_ID" --date "$SPRINT_DATE" 2>/dev/null \
-        || echo "note: failed to set Sprint field on Project item — manual fix needed."
-    fi
-  fi
-fi
-
-# Write the Issue URL back to bd as external-ref.
-bd update "$BD_ID" --external-ref "$ISSUE_URL" >/dev/null || \
-  echo "warning: failed to write external-ref back to $BD_ID — bd may need manual update."
-
-echo "Done: $BD_ID → $ISSUE_URL (sprint=$SPRINT_DATE)"
+bd update "$BD_ID" --external-ref "$ISSUE_URL" >/dev/null || echo "warning: failed to write external-ref back to $BD_ID." >&2
+echo "Done: $BD_ID → $ISSUE_URL (sprint=${SPRINT_ITER_TITLE:-none} epic=${EPIC_OPTION_NAME:-none} status=$STATUS_NAME)"

--- a/scripts/bd-mirror
+++ b/scripts/bd-mirror
@@ -58,6 +58,7 @@ epic_option_for() {
     46l8) echo "VPS deployment" ;;
     9iq3) echo "Prediction freeze" ;;
     ebu7) echo "Network explorer" ;;
+    lrjn|vh74) echo "Operator app" ;;   # embedded agent + per-harness auth flows
     *)    echo "" ;;
   esac
 }

--- a/scripts/bd-mirror
+++ b/scripts/bd-mirror
@@ -19,7 +19,7 @@
 #   options:
 #     --status <Todo|In Progress|Done>   Project Status (default: Todo)
 #     --epic <option-name>               override the Epic option (default: derived from the
-#                                        bead's parent epic via the EPIC_MAP table below)
+#                                        bead's parent epic via epic_option_for() below)
 #     --labels l1,l2,...                 extra GitHub Issue labels (auto-created if missing)
 #     --update                           if the bead is already mirrored, don't create a new
 #                                        Issue — just re-apply Sprint/Epic/Status to its
@@ -34,8 +34,8 @@
 # Changelog:
 # - v0.2 (jinn-mono-2cl.21, 2026-05-12): Sprint field is an Iteration (not a Date) — resolve
 #   @current/@next/<title> to an iteration id and set with --iteration-id. Epic is set to the
-#   human-readable single-select option (mapped from the bead's parent epic via EPIC_MAP), not a
-#   raw bd id. Added Status setting (--status) and --update (move between sprints). Auto-create
+#   human-readable single-select option (mapped from the bead's parent epic via epic_option_for()),
+#   not a raw bd id. Added Status setting (--status) and --update (move between sprints). Auto-create
 #   any missing GitHub labels before use. Use the Project's GraphQL node id for item-edit.
 # - v0.1 (jinn-mono-2cl.13, 2026-05-11): fix bd JSON parsing (array index, .parent, owner fallback).
 

--- a/scripts/bd-mirror
+++ b/scripts/bd-mirror
@@ -57,6 +57,7 @@ epic_option_for() {
     2cl)  echo "Engineering handbook" ;;
     46l8) echo "VPS deployment" ;;
     9iq3) echo "Prediction freeze" ;;
+    ebu7) echo "Network explorer" ;;
     *)    echo "" ;;
   esac
 }


### PR DESCRIPTION
## Problem

The "Jinn engineering" Project (v2) board changed shape after `bd-mirror` v0.1 was written:
- **Sprint** is now an **Iteration** field, not a Date — so `bd-mirror`'s `--date` write fails.
- **Epic** carries **human-readable option names** ("v1 public testnet", "Hermes harness", …) mapped from the bead's parent epic — `bd-mirror` was writing raw bd ids, which don't exist as options.

So the Friday auto-mirror cron + manual `bd-mirror` calls were broken against the live board.

## Change

`bd-mirror` v0.2 (`scripts/bd-mirror`):
- Sprint arg is now `@current` / `@next` / `none` / `"<iteration title>"`; resolved to an iteration id by **lexical date comparison only** (no GNU-only `date -d` — this runs on macOS too) and set via `gh project item-edit --iteration-id`.
- Epic set to the single-select option from `epic_option_for()` — a `case` statement, **not** `declare -A` (macOS ships bash 3.2, which has no associative arrays); `--epic NAME` overrides.
- New `--status NAME` (default `Todo`) sets the Project Status single-select.
- New `--update`: re-apply Sprint/Epic/Status to an already-mirrored bead's Project item (move items between sprints) without creating a duplicate Issue.
- Auto-create any missing GitHub labels before `gh issue create` (it errors on unknown labels).
- Use the Project's GraphQL **node id** for `item-edit --project-id`.

## Verification (dogfooded)

Ran the new script to populate the board for the post-triage state:
- Sprint 1: updated #151 (Cut v0.1.4), created #154 (Hermes-as-operator-harness), #155 (self-eval bypass decision), #156 (acceptance-gate suite); added PRs #140–#145 (Hermes stack) to the board under Epic "Hermes harness" / Sprint 1.
- Roadmap: created #157 (uy6v epic), #158 (8psp epic), #159 (46l8 epic), #160/#161/#162 (uy6v.4/.7/.1), #163 (9iq3) — each with the right Epic, no sprint.
- `--update` and the idempotency no-op both exercised; `--dry-run` checked against uy6v.6 / 8psp / 46l8 / 9iq3.

Note: this commit was briefly mis-landed on `codex/land-discovery-stack` due to a parallel-agent collision in the shared main checkout — cherry-picked onto this branch; `codex/land-discovery-stack` reset back to `f188cc30` (matches origin, the bad commit never reached the remote). Reinforces AI-workflow rule 1 (worktrees for concurrent work).

Closes jinn-mono-2cl.21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)