### PR TITLE
docs: clarify terminal unresolved verdicts

### DIFF
--- a/docs/superpowers/plans/2026-05-02-prediction-solvernet-v1-task-lifecycle.md
+++ b/docs/superpowers/plans/2026-05-02-prediction-solvernet-v1-task-lifecycle.md
@@ -324,7 +324,7 @@ Verdict enum:
 - `SCORED`: valid Solution, market resolved YES/NO, scores emitted.
 - `REJECTED`: invalid or late Solution; excluded from Brier aggregates.
 - `INVALID`: market cancelled, invalid, ambiguous, duplicate-mismatched, or otherwise final non-scored.
-- `INDETERMINATE`: temporary unresolved/evaluator-unavailable state; retry later.
+- `INDETERMINATE`: historical label in this plan for a delivered Unresolved verdict. As of `jinn-mono-04wq`, delivered Unresolved is terminal alongside Pass / Fail / Invalid; it is not a retry-later delivery state. Retry happens only before verdict delivery through Stage 5's off-chain `PreconditionResolverRegistry`.
 
 Brier formula:
 
@@ -519,7 +519,7 @@ Dashboard supporting metrics:
 - weekly trend
 - distinct active Solver safe addresses
 - distinct forecast rounds
-- invalid/rejected/indeterminate rates
+- terminal Invalid / Rejected / Unresolved rates (`INDETERMINATE` here is the historical Prediction v1 label for delivered terminal Unresolved)
 - per-operator and per-Harness slices
 
 Agent learning:

--- a/spec/2026-05-05-solvernet-creation-and-launch.md
+++ b/spec/2026-05-05-solvernet-creation-and-launch.md
@@ -168,6 +168,7 @@ Paused means:
 
 - no new tasks are posted by the launcher generator
 - existing tasks continue through normal lifecycle (claim → submit → verdict → settle)
+- verdict delivery follows the post-`jinn-mono-04wq` rule: Unresolved is terminal alongside Pass / Fail / Invalid; retry happens only before a verdict through the off-chain Stage 5 `PreconditionResolverRegistry`
 - operators see that the SolverNet is not currently producing new work
 - launchers can resume to return to launched
 
@@ -715,6 +716,7 @@ The full plan with ordering, dependencies, and per-step verification lives at `d
 | 9 | Operator-side discovery bootstrap | None — registry is global; subgraph query is unfiltered |
 | 10 | Launch atomicity / failure recovery | Forward-only checkpointed state machine; per-phase progress in launched record; crash-resume on daemon restart |
 | 11 | Lifecycle action surface | Pause + Resume + Retire; in-flight tasks drain naturally; no Cancel; Retire requires typed-name confirmation |
+| 12 | Verdict terminality cutover | As of `jinn-mono-04wq`, Unresolved is terminal alongside Pass / Fail / Invalid; no slot-reopen or router budget-refund path remains for Unresolved, and the off-chain Stage 5 `PreconditionResolverRegistry` is the only retry mechanism |
 
 ## 18. Remaining open questions
 


### PR DESCRIPTION
## Summary
- Documents the post-`jinn-mono-04wq` rule in the SolverNet creation spec: Unresolved is terminal alongside Pass / Fail / Invalid.
- Clarifies that retry happens only before verdict delivery through the off-chain Stage 5 `PreconditionResolverRegistry`.
- Records that no slot-reopen or router budget-refund path remains for Unresolved.

## Canonical docs
- `SPEC.md` was audited and had no stale Unresolved prose, so no canonical-doc PR or Discussion is required.

## Validation
- `bd show jinn-mono-04wq`
- Code spot-check: `TaskCoordinator` has no `unresolvedVerdictCount`; `recordVerdict` increments `validVerdictCount` for every delivered verdict.
- Targeted `rg` audit across the bead-listed docs.
- `git diff --check`

Internal tracking: jinn-mono-pxsm