### PR TITLE
fix: /v1/solvernets/registry/:cid 404s for just-launched manifests when no subgraph is configured

### DIFF
--- a/client/src/api/solvernets-endpoints.ts
+++ b/client/src/api/solvernets-endpoints.ts
@@ -64,6 +64,7 @@ import {
   type SolverNetStore,
 } from '../solvernets/store.js';
 import {
+  manifestHash,
   signManifest,
   type UnsignedSolverNetManifestV1,
 } from '../solvernets/manifest.js';
@@ -585,6 +586,7 @@ async function tryGetOwnedCachedManifest(
     const manifest = await store.loadManifestCache(record.manifestPath);
     if (!manifest) continue;
     if (manifest.solverNetId !== record.solverNetId) continue;
+    if (manifestHash(manifest) !== record.manifestHash) continue;
     return { record, manifest };
   }
   return null;
@@ -594,14 +596,16 @@ function localLifecycleForRecord(record: LaunchedSolverNetRecord): {
   status: 'launched' | 'paused' | 'retired';
   statusUpdatedAt: string;
   sourceBlock: number;
-} {
+} | null {
+  const sourceBlock = record.registry.metadataBlockNumber;
+  if (sourceBlock === undefined) return null;
   return {
     status:
       record.status === 'paused' || record.status === 'retired'
         ? record.status
         : 'launched',
     statusUpdatedAt: record.statusUpdatedAt,
-    sourceBlock: record.registry.metadataBlockNumber ?? 0,
+    sourceBlock,
   };
 }
 
@@ -1484,10 +1488,13 @@ export function registerSolverNetsEndpoints(
       );
     }
     if (ownedCached) {
-      return c.json({
-        manifest: ownedCached.manifest,
-        lifecycle: localLifecycleForRecord(ownedCached.record),
-      });
+      const lifecycle = localLifecycleForRecord(ownedCached.record);
+      if (lifecycle) {
+        return c.json({
+          manifest: ownedCached.manifest,
+          lifecycle,
+        });
+      }
     }
 
     if (!deps.registry) {

--- a/client/src/api/solvernets-endpoints.ts
+++ b/client/src/api/solvernets-endpoints.ts
@@ -572,6 +572,39 @@ async function tryGetSummary(
   }
 }
 
+async function tryGetOwnedCachedManifest(
+  store: SolverNetStore,
+  manifestCid: string,
+): Promise<{
+  record: LaunchedSolverNetRecord;
+  manifest: SolverNetManifestV1;
+} | null> {
+  const records = await store.loadOwnedRecords();
+  for (const record of records) {
+    if (record.manifestCid !== manifestCid || !record.manifestPath) continue;
+    const manifest = await store.loadManifestCache(record.manifestPath);
+    if (!manifest) continue;
+    if (manifest.solverNetId !== record.solverNetId) continue;
+    return { record, manifest };
+  }
+  return null;
+}
+
+function localLifecycleForRecord(record: LaunchedSolverNetRecord): {
+  status: 'launched' | 'paused' | 'retired';
+  statusUpdatedAt: string;
+  sourceBlock: number;
+} {
+  return {
+    status:
+      record.status === 'paused' || record.status === 'retired'
+        ? record.status
+        : 'launched',
+    statusUpdatedAt: record.statusUpdatedAt,
+    sourceBlock: record.registry.metadataBlockNumber ?? 0,
+  };
+}
+
 // ── Implementation ──────────────────────────────────────────────────────────
 
 export function registerSolverNetsEndpoints(
@@ -1427,23 +1460,53 @@ export function registerSolverNetsEndpoints(
   // (path-traversal, decimals, empty) so we never round-trip them to IPFS,
   // but the registry client does the canonical check.
   app.get('/v1/solvernets/registry/:cid', async (c) => {
+    const cid = c.req.param('cid');
+    if (!cid) {
+      return c.json(
+        {
+          error: 'invalid_cid',
+          message: `cid does not look like a CID: ${cid ?? '<empty>'}`,
+        },
+        400,
+      );
+    }
+
+    let ownedCached: Awaited<ReturnType<typeof tryGetOwnedCachedManifest>>;
+    try {
+      ownedCached = await tryGetOwnedCachedManifest(store, cid);
+    } catch (err) {
+      return c.json(
+        {
+          error: 'store_read_failed',
+          message: err instanceof Error ? err.message : String(err),
+        },
+        500,
+      );
+    }
+    if (ownedCached) {
+      return c.json({
+        manifest: ownedCached.manifest,
+        lifecycle: localLifecycleForRecord(ownedCached.record),
+      });
+    }
+
     if (!deps.registry) {
       return c.json(
         {
           error: 'registry_unavailable',
-          message: 'registry client is not configured',
+          message:
+            'registry client is not configured and no owned cached manifest matched this cid',
         },
         503,
       );
     }
     const registry = deps.registry;
 
-    const cid = c.req.param('cid');
-    if (!cid || !CID_SHAPE_REGEX.test(cid)) {
+    if (!CID_SHAPE_REGEX.test(cid)) {
       return c.json(
         {
           error: 'invalid_cid',
-          message: `cid does not look like a CID: ${cid ?? '<empty>'}`,
+          message: `cid does not look like a CID: ${cid}`,
         },
         400,
       );

--- a/client/src/api/solvernets-endpoints.ts
+++ b/client/src/api/solvernets-endpoints.ts
@@ -74,7 +74,10 @@ import type {
   PendingGeneratorSpawn,
   SolverNetCatalogCache,
 } from '../solvernets/daemon-init.js';
-import { resolveContractFromSolverNetId } from '../solvernets/launched-record-dispatcher.js';
+import {
+  resolveLaunchedRecordContract,
+  type LaunchedRecordContractRef,
+} from '../solvernets/launched-record-dispatcher.js';
 import type {
   SignerWithAgentEoa,
   SolverNetManifestSummary,
@@ -312,12 +315,11 @@ const SweRebenchV2GeneratorConfigPatchSchema = z
     }
   });
 
-function isRecordForContract(
-  record: LaunchedSolverNetRecord,
+function isContractRefFor(
+  contract: LaunchedRecordContractRef | null,
   id: string,
   version: string,
 ): boolean {
-  const contract = resolveContractFromSolverNetId(record.solverNetId);
   return contract?.id === id && contract.version === version;
 }
 
@@ -339,6 +341,7 @@ function defaultSweRebenchV2ClaimPolicy(): {
 
 function mergeGeneratorConfigPatchForRecord(
   record: LaunchedSolverNetRecord,
+  contract: LaunchedRecordContractRef | null,
   patch: Record<string, unknown>,
 ): Record<string, unknown> {
   const nextConfig: Record<string, unknown> = {
@@ -346,7 +349,7 @@ function mergeGeneratorConfigPatchForRecord(
     ...patch,
   };
   if (
-    isRecordForContract(record, 'swe-rebench-v2', 'v1') &&
+    isContractRefFor(contract, 'swe-rebench-v2', 'v1') &&
     typeof patch.claimPolicy === 'object' &&
     patch.claimPolicy !== null
   ) {
@@ -364,10 +367,26 @@ function mergeGeneratorConfigPatchForRecord(
 }
 
 function validateSweRebenchV2EffectiveConfig(
-  record: LaunchedSolverNetRecord,
+  contract: LaunchedRecordContractRef | null,
   config: Record<string, unknown>,
-): string | undefined {
-  if (!isRecordForContract(record, 'swe-rebench-v2', 'v1')) return undefined;
+): { path: string; message: string } | undefined {
+  if (!isContractRefFor(contract, 'swe-rebench-v2', 'v1')) return undefined;
+  const targetSuccesses = typeof config.N_target_successes === 'number'
+    ? config.N_target_successes
+    : undefined;
+  const maxPostingsPerTask = typeof config.N_max_postings_per_task === 'number'
+    ? config.N_max_postings_per_task
+    : undefined;
+  if (
+    targetSuccesses !== undefined &&
+    maxPostingsPerTask !== undefined &&
+    maxPostingsPerTask < targetSuccesses
+  ) {
+    return {
+      path: 'N_max_postings_per_task',
+      message: 'must be >= N_target_successes',
+    };
+  }
   const defaults = defaultSweRebenchV2ClaimPolicy();
   const rawPolicy =
     typeof config.claimPolicy === 'object' && config.claimPolicy !== null
@@ -380,19 +399,32 @@ function validateSweRebenchV2EffectiveConfig(
     ? rawPolicy.maxClaimsPerOperator
     : defaults.maxClaimsPerOperator;
   if (maxClaimsPerOperator > maxClaims) {
-    return 'claimPolicy.maxClaimsPerOperator must be <= claimPolicy.maxClaims';
+    return {
+      path: 'claimPolicy.maxClaimsPerOperator',
+      message: 'claimPolicy.maxClaimsPerOperator must be <= claimPolicy.maxClaims',
+    };
   }
   return undefined;
 }
 
 function parseGeneratorConfigPatchForRecord(
-  record: LaunchedSolverNetRecord,
+  contract: LaunchedRecordContractRef | null,
   raw: unknown,
 ): z.SafeParseReturnType<unknown, Record<string, unknown>> {
-  if (isRecordForContract(record, 'swe-rebench-v2', 'v1')) {
+  if (isContractRefFor(contract, 'swe-rebench-v2', 'v1')) {
     return SweRebenchV2GeneratorConfigPatchSchema.safeParse(raw);
   }
   return PredictionV1GeneratorConfigPatchSchema.safeParse(raw);
+}
+
+function zodIssuesForResponse(error: z.ZodError): Array<{
+  path: string;
+  message: string;
+}> {
+  return error.issues.map((issue) => ({
+    path: issue.path.join('.') || '<body>',
+    message: issue.message,
+  }));
 }
 
 // ── Launch helpers ──────────────────────────────────────────────────────────
@@ -1242,14 +1274,16 @@ export function registerSolverNetsEndpoints(
       return c.json({ error: 'record_not_found', message: `Unknown record: ${id}` }, 404);
     }
 
-    const parsed = parseGeneratorConfigPatchForRecord(record, raw);
+    const contract = await resolveLaunchedRecordContract(record);
+    const parsed = parseGeneratorConfigPatchForRecord(contract, raw);
     if (!parsed.success) {
+      const issues = zodIssuesForResponse(parsed.error);
       return c.json(
         {
           error: 'invalid_body',
-          message: parsed.error.issues
-            .map((i) => `${i.path.join('.') || '<body>'}: ${i.message}`)
-            .join('; '),
+          kind: 'schema_validation_failed',
+          issues,
+          message: issues.map((i) => `${i.path}: ${i.message}`).join('; '),
         },
         400,
       );
@@ -1257,13 +1291,20 @@ export function registerSolverNetsEndpoints(
 
     // Patch semantics: merge the provided fields over the existing config.
     // Operators editing one field shouldn't have to re-send the rest.
-    const nextConfig = mergeGeneratorConfigPatchForRecord(record, parsed.data);
-    const effectiveConfigError = validateSweRebenchV2EffectiveConfig(record, nextConfig);
+    const nextConfig = mergeGeneratorConfigPatchForRecord(record, contract, parsed.data);
+    const effectiveConfigError = validateSweRebenchV2EffectiveConfig(contract, nextConfig);
     if (effectiveConfigError) {
       return c.json(
         {
           error: 'invalid_body',
-          message: effectiveConfigError,
+          kind: 'schema_validation_failed',
+          issues: [
+            {
+              path: effectiveConfigError.path,
+              message: effectiveConfigError.message,
+            },
+          ],
+          message: effectiveConfigError.message,
         },
         400,
       );

--- a/client/src/dashboard/spa/src/pages/LauncherLaunched.test.tsx
+++ b/client/src/dashboard/spa/src/pages/LauncherLaunched.test.tsx
@@ -329,6 +329,48 @@ describe('LauncherLaunchedPage', () => {
     );
   });
 
+  it('hot-apply: renders the swe-rebench-v2 config form from the launched manifest template', async () => {
+    vi.mocked(api.solvernets.get).mockResolvedValue(
+      buildRecord({ generatorConfig: {}, summary: undefined }),
+    );
+    const predictionManifest = buildManifest();
+    vi.mocked(api.solvernets.getManifest).mockResolvedValue({
+      ...buildManifestResponse(),
+      manifest: buildManifest({
+        name: 'SWE-rebench v2',
+        contract: {
+          ...predictionManifest.contract,
+          id: 'swe-rebench-v2',
+          version: 'v1',
+          claimPolicyDefaults: {
+            mode: 'parallel',
+            maxClaims: 50,
+            maxClaimsPerOperator: 5,
+            claimLeaseTtlSeconds: 3600,
+          },
+        },
+      }),
+    });
+
+    wrap(<LauncherLaunchedPage solverNetId="sn-1" pollIntervalMs={10_000} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('launcher-launched-generator-toggle')).toBeTruthy(),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('launcher-launched-name').textContent).toBe(
+        'SWE-rebench v2',
+      ),
+    );
+    fireEvent.click(screen.getByTestId('launcher-launched-generator-toggle'));
+
+    expect(screen.getByTestId('launcher-launched-generator-N_target_successes')).toBeTruthy();
+    expect(
+      screen.getByTestId('launcher-launched-generator-N_max_postings_per_task'),
+    ).toBeTruthy();
+    expect(screen.getByTestId('launcher-launched-generator-cooldown_ms')).toBeTruthy();
+    expect(screen.queryByTestId('launcher-launched-generator-cadenceMs')).toBeNull();
+  });
+
   it('terminal record (retired) shows no actions', async () => {
     vi.mocked(api.solvernets.get).mockResolvedValue(buildRecord({ status: 'retired' }));
     vi.mocked(api.solvernets.getManifest).mockResolvedValue(buildManifestResponse());

--- a/client/src/dashboard/spa/src/pages/LauncherLaunched.tsx
+++ b/client/src/dashboard/spa/src/pages/LauncherLaunched.tsx
@@ -13,6 +13,10 @@ import { PauseRetireDialog } from './launcher-launched/PauseRetireDialog.js';
 import { SpendPanel } from './launcher-launched/SpendPanel.js';
 import { StatusHeader } from './launcher-launched/StatusHeader.js';
 import { TasksPanel } from './launcher-launched/TasksPanel.js';
+import {
+  TEMPLATES_BY_KEY,
+  type CreateWizardTemplate,
+} from './launcher-create/templates.js';
 
 /**
  * Post-launch dashboard for `/launcher/launched/:solverNetId`.
@@ -147,6 +151,7 @@ export function LauncherLaunchedPage({
 
   const record = recordQuery.data;
   const manifest = manifestQuery.data?.manifest;
+  const template = resolveLaunchedTemplate(record, manifest);
   const solverNetName = manifest?.name ?? record.summary?.name ?? record.solverNetId;
 
   return (
@@ -168,6 +173,7 @@ export function LauncherLaunchedPage({
       <GeneratorPanel
         record={record}
         manifest={manifest}
+        template={template}
         onSave={async (patch) => {
           await generatorMutation.mutateAsync(patch);
         }}
@@ -218,6 +224,19 @@ function formatManifestLoadError(error: unknown): string {
     return `Manifest unavailable from local cache or registry (${message})`;
   }
   return message;
+}
+
+function resolveLaunchedTemplate(
+  record: LaunchedSolverNetRecord,
+  manifest: RegistryManifestResponse['manifest'] | undefined,
+): CreateWizardTemplate | undefined {
+  const contract = manifest?.contract ?? (
+    record.summary
+      ? { id: record.summary.contractId, version: record.summary.contractVersion }
+      : undefined
+  );
+  if (!contract) return undefined;
+  return TEMPLATES_BY_KEY[`${contract.id}.${contract.version}`];
 }
 
 function ErrorBanner({

--- a/client/src/dashboard/spa/src/pages/LauncherLaunched.tsx
+++ b/client/src/dashboard/spa/src/pages/LauncherLaunched.tsx
@@ -188,9 +188,7 @@ export function LauncherLaunchedPage({
           }}
         >
           Failed to load manifest:{' '}
-          {manifestQuery.error instanceof Error
-            ? manifestQuery.error.message
-            : 'unknown error'}
+          {formatManifestLoadError(manifestQuery.error)}
         </p>
       )}
 
@@ -212,6 +210,14 @@ export function LauncherLaunchedPage({
       />
     </main>
   );
+}
+
+function formatManifestLoadError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error ?? 'unknown error');
+  if (/404|manifest_not_found|registry_unavailable/i.test(message)) {
+    return `Manifest unavailable from local cache or registry (${message})`;
+  }
+  return message;
 }
 
 function ErrorBanner({

--- a/client/src/dashboard/spa/src/pages/launcher-launched/GeneratorPanel.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher-launched/GeneratorPanel.tsx
@@ -4,6 +4,7 @@ import type {
   LaunchedSolverNetRecord,
   SolverNetManifestV1,
 } from '../../api/types.js';
+import type { CreateWizardTemplate } from '../launcher-create/templates.js';
 import { formatTimestamp } from './helpers.js';
 
 /**
@@ -28,6 +29,7 @@ const SWE_REBENCH_V2_MIN_COOLDOWN_MS = 60_000;
 export interface GeneratorPanelProps {
   record: LaunchedSolverNetRecord;
   manifest?: SolverNetManifestV1;
+  template?: CreateWizardTemplate;
   onSave: (patch: Partial<GeneratorConfig>) => Promise<void>;
 }
 
@@ -262,7 +264,13 @@ export function buildSweRebenchV2Patch(
   };
 }
 
-function isSweRebenchV2Record(record: LaunchedSolverNetRecord): boolean {
+function isSweRebenchV2Record(
+  record: LaunchedSolverNetRecord,
+  template?: CreateWizardTemplate,
+): boolean {
+  if (template) {
+    return template.id === 'swe-rebench-v2' && template.version === 'v1';
+  }
   if (
     record.summary?.contractId === 'swe-rebench-v2' &&
     record.summary.contractVersion === 'v1'
@@ -277,8 +285,13 @@ function isSweRebenchV2Record(record: LaunchedSolverNetRecord): boolean {
   );
 }
 
-export function GeneratorPanel({ record, manifest, onSave }: GeneratorPanelProps): JSX.Element {
-  if (isSweRebenchV2Record(record)) {
+export function GeneratorPanel({
+  record,
+  manifest,
+  template,
+  onSave,
+}: GeneratorPanelProps): JSX.Element {
+  if (isSweRebenchV2Record(record, template)) {
     return <SweRebenchV2GeneratorPanel record={record} manifest={manifest} onSave={onSave} />;
   }
   return <PredictionGeneratorPanel record={record} onSave={onSave} />;

--- a/client/src/solvernets/launch-state-machine.ts
+++ b/client/src/solvernets/launch-state-machine.ts
@@ -162,10 +162,15 @@ export class LaunchAction {
 
     // Phase 2 — recording. Atomic-write the record before any on-chain side
     // effect. From here on, all retries flow through `resume()`.
+    const manifestPath = await this.deps.store.writeManifestCache(
+      manifestCid,
+      args.manifest,
+    );
     const initialRecord: LaunchedSolverNetRecord = {
       schemaVersion: 'solvernet.launched.v1',
       solverNetId: args.manifest.solverNetId,
       manifestCid,
+      manifestPath,
       manifestHash: manifestHash(args.manifest),
       launcherAgentId: args.signer.agentId,
       launcherSafeAddress: args.manifest.launcher.safeAddress,

--- a/client/src/solvernets/store.ts
+++ b/client/src/solvernets/store.ts
@@ -19,6 +19,10 @@ import { mkdir, readFile, readdir, rename, rm, writeFile } from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import { z } from 'zod';
+import {
+  SolverNetManifestV1Schema,
+  type SolverNetManifestV1,
+} from '@jinn-network/sdk/solvernets';
 
 // ── Schemas ────────────────────────────────────────────────────────────────
 
@@ -162,6 +166,7 @@ export const DEFAULT_JINN_CLIENT_DIR = path.join(os.homedir(), '.jinn-client');
 const SOLVERNETS_SUBDIR = 'solvernets';
 const LAUNCHED_SUBDIR = 'launched';
 const DRAFTS_SUBDIR = 'drafts';
+const MANIFESTS_SUBDIR = 'manifests';
 
 function resolveLaunchedDir(baseDir: string): string {
   return path.join(baseDir, SOLVERNETS_SUBDIR, LAUNCHED_SUBDIR);
@@ -169,6 +174,10 @@ function resolveLaunchedDir(baseDir: string): string {
 
 function resolveDraftsDir(baseDir: string): string {
   return path.join(baseDir, SOLVERNETS_SUBDIR, DRAFTS_SUBDIR);
+}
+
+function resolveManifestsDir(baseDir: string): string {
+  return path.join(baseDir, SOLVERNETS_SUBDIR, MANIFESTS_SUBDIR);
 }
 
 // ── Atomic write helper ────────────────────────────────────────────────────
@@ -276,6 +285,11 @@ export interface SolverNetStore {
   loadRecord(solverNetId: string): Promise<LaunchedSolverNetRecord | null>;
   writeRecord(record: LaunchedSolverNetRecord): Promise<void>;
   deleteRecord(solverNetId: string): Promise<void>;
+  writeManifestCache(
+    manifestCid: string,
+    manifest: SolverNetManifestV1,
+  ): Promise<string>;
+  loadManifestCache(manifestPath: string): Promise<SolverNetManifestV1 | null>;
 
   // Drafts
   loadDraft(draftId: string): Promise<DraftSolverNetRecord | null>;
@@ -297,8 +311,9 @@ export function createSolverNetStore(opts: SolverNetStoreOptions = {}): SolverNe
   const baseDir = opts.baseDir ?? DEFAULT_JINN_CLIENT_DIR;
   const launchedDir = resolveLaunchedDir(baseDir);
   const draftsDir = resolveDraftsDir(baseDir);
+  const manifestsDir = resolveManifestsDir(baseDir);
 
-  function assertSafeId(id: string, kind: 'solverNetId' | 'draftId'): void {
+  function assertSafeId(id: string, kind: 'solverNetId' | 'draftId' | 'manifestCid'): void {
     const result = SafeId.safeParse(id);
     if (!result.success) {
       const message = result.error.issues[0]?.message ?? 'invalid id';
@@ -312,6 +327,10 @@ export function createSolverNetStore(opts: SolverNetStoreOptions = {}): SolverNe
   function draftPath(draftId: string): string {
     assertSafeId(draftId, 'draftId');
     return path.join(draftsDir, `${draftId}.json`);
+  }
+  function manifestCachePath(manifestCid: string): string {
+    assertSafeId(manifestCid, 'manifestCid');
+    return path.join(manifestsDir, `${manifestCid}.json`);
   }
 
   return {
@@ -330,6 +349,29 @@ export function createSolverNetStore(opts: SolverNetStoreOptions = {}): SolverNe
 
     async deleteRecord(solverNetId) {
       await deleteIfExists(launchedPath(solverNetId));
+    },
+
+    async writeManifestCache(manifestCid, manifest) {
+      const validated = SolverNetManifestV1Schema.parse(manifest);
+      const filePath = manifestCachePath(manifestCid);
+      await writeJsonAtomic(filePath, validated);
+      return filePath;
+    },
+
+    async loadManifestCache(manifestPath) {
+      const resolved = path.resolve(manifestPath);
+      const allowedRoot = path.resolve(manifestsDir);
+      if (resolved !== allowedRoot && !resolved.startsWith(`${allowedRoot}${path.sep}`)) {
+        console.error(
+          `[solvernet-store] Refusing to read manifest cache outside ${allowedRoot}: ${manifestPath}`,
+        );
+        return null;
+      }
+      return readAndParse(
+        resolved,
+        SolverNetManifestV1Schema,
+        'solvernet manifest cache',
+      );
     },
 
     async loadDraft(draftId) {

--- a/client/test/api/solvernets-endpoints.test.ts
+++ b/client/test/api/solvernets-endpoints.test.ts
@@ -1211,6 +1211,53 @@ describe('PATCH /v1/solvernets/launched/:id/generator-config (Task 14)', () => {
     });
   });
 
+  it('uses the manifest contract before solverNetId when validating generator config patches', async () => {
+    const pendingGenerators = { current: [] as PendingGeneratorSpawn[] };
+    const launchBundle = makeLaunchDeps({ store, pendingGenerators });
+    const { app } = buildTestApp({ store, launch: launchBundle.launch });
+    const solverNetId = 'legacy-swe-record';
+    const cid = 'bafylegacyswemanifest1234567890';
+    const baseManifest = makeManifest({ solverNetId, manifestCid: cid });
+    const sweManifest: SolverNetManifestV1 = {
+      ...baseManifest,
+      contract: {
+        ...baseManifest.contract,
+        id: 'swe-rebench-v2',
+        version: 'v1',
+      },
+    };
+    const manifestPath = await store.writeManifestCache(cid, sweManifest);
+    const launched: LaunchedSolverNetRecord = {
+      ...makeOwnedRecord({ solverNetId, status: 'paused' }),
+      manifestCid: cid,
+      manifestHash: manifestHash(sweManifest),
+      manifestPath,
+      generatorEnabled: true,
+      generatorConfig: {
+        N_target_successes: 5,
+        N_max_postings_per_task: 15,
+        cooldown_ms: 86_400_000,
+      },
+    };
+    await store.writeRecord(launched);
+
+    const res = await app.request(
+      `/v1/solvernets/launched/${launched.solverNetId}/generator-config`,
+      {
+        method: 'PATCH',
+        headers: authHeaders(),
+        body: JSON.stringify({ cooldown_ms: 300_000 }),
+      },
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      N_target_successes: 5,
+      N_max_postings_per_task: 15,
+      cooldown_ms: 300_000,
+    });
+  });
+
   it('rejects swe-rebench-v2 claim policy with per-operator claims above max claims', async () => {
     const pendingGenerators = { current: [] as PendingGeneratorSpawn[] };
     const launchBundle = makeLaunchDeps({ store, pendingGenerators });
@@ -1241,6 +1288,83 @@ describe('PATCH /v1/solvernets/launched/:id/generator-config (Task 14)', () => {
     expect(res.status).toBe(400);
     const body = (await res.json()) as { message?: string };
     expect(body.message).toMatch(/maxClaimsPerOperator/);
+  });
+
+  it('rejects partial swe-rebench-v2 patches that violate merged posting invariants', async () => {
+    const pendingGenerators = { current: [] as PendingGeneratorSpawn[] };
+    const launchBundle = makeLaunchDeps({ store, pendingGenerators });
+    const { app } = buildTestApp({ store, launch: launchBundle.launch });
+    const launched: LaunchedSolverNetRecord = {
+      ...makeOwnedRecord({
+        solverNetId: '5474_swe-rebench-v2-v1_edb172d3',
+        status: 'paused',
+      }),
+      generatorEnabled: true,
+      generatorConfig: {
+        N_target_successes: 5,
+        N_max_postings_per_task: 15,
+        cooldown_ms: 86_400_000,
+      },
+    };
+    await store.writeRecord(launched);
+
+    const res = await app.request(
+      `/v1/solvernets/launched/${launched.solverNetId}/generator-config`,
+      {
+        method: 'PATCH',
+        headers: authHeaders(),
+        body: JSON.stringify({ N_target_successes: 20 }),
+      },
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      message?: string;
+      issues?: Array<{ path: string; message: string }>;
+    };
+    expect(body.message).toMatch(/N_target_successes/);
+    expect(body.issues).toContainEqual({
+      path: 'N_max_postings_per_task',
+      message: 'must be >= N_target_successes',
+    });
+    const onDisk = await store.loadRecord(launched.solverNetId);
+    expect(onDisk?.generatorConfig).toEqual(launched.generatorConfig);
+  });
+
+  it('rejects prediction-shaped patches for swe-rebench-v2 records with schema issues', async () => {
+    const pendingGenerators = { current: [] as PendingGeneratorSpawn[] };
+    const launchBundle = makeLaunchDeps({ store, pendingGenerators });
+    const { app } = buildTestApp({ store, launch: launchBundle.launch });
+    const launched: LaunchedSolverNetRecord = {
+      ...makeOwnedRecord({
+        solverNetId: '5474_swe-rebench-v2-v1_edb172d3',
+        status: 'paused',
+      }),
+      generatorEnabled: true,
+      generatorConfig: {
+        N_target_successes: 5,
+        N_max_postings_per_task: 15,
+        cooldown_ms: 86_400_000,
+      },
+    };
+    await store.writeRecord(launched);
+
+    const res = await app.request(
+      `/v1/solvernets/launched/${launched.solverNetId}/generator-config`,
+      {
+        method: 'PATCH',
+        headers: authHeaders(),
+        body: JSON.stringify({ cadenceMs: 60_000, maxOpenRounds: 3 }),
+      },
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      kind?: string;
+      issues?: Array<{ message: string }>;
+    };
+    expect(body.kind).toBe('schema_validation_failed');
+    expect(body.issues?.some((issue) => issue.message.includes('cadenceMs'))).toBe(true);
   });
 
   it('rejects unknown record id with 404', async () => {

--- a/client/test/api/solvernets-endpoints.test.ts
+++ b/client/test/api/solvernets-endpoints.test.ts
@@ -30,6 +30,7 @@ import {
   LaunchAction,
   type LaunchActionDeps,
 } from '../../src/solvernets/launch-state-machine.js';
+import { manifestHash } from '../../src/solvernets/manifest.js';
 import {
   LifecycleTransition,
   type LifecycleTransitionDeps,
@@ -2009,6 +2010,7 @@ describe('GET /v1/solvernets/registry/:cid (Task 15)', () => {
     await store.writeRecord({
       ...makeOwnedRecord({ solverNetId: 'owned-local', status: 'launched' }),
       manifestCid: cid,
+      manifestHash: manifestHash(manifest),
       manifestPath,
     });
 
@@ -2036,6 +2038,67 @@ describe('GET /v1/solvernets/registry/:cid (Task 15)', () => {
     });
     expect(registry.getManifestCalls).toEqual([]);
   });
+
+  it('ignores an owned cached manifest whose canonical hash does not match the record', async () => {
+    const cid = 'bafyownedhashmismatch1234567890';
+    const manifest = makeManifest({
+      solverNetId: 'owned-hash-mismatch',
+      manifestCid: cid,
+    });
+    const manifestPath = await store.writeManifestCache(cid, manifest);
+    await store.writeRecord({
+      ...makeOwnedRecord({ solverNetId: 'owned-hash-mismatch', status: 'launched' }),
+      manifestCid: cid,
+      manifestHash: `0x${'11'.repeat(32)}`,
+      manifestPath,
+    });
+
+    const { app } = buildTestApp({ store });
+
+    const res = await app.request(`/v1/solvernets/registry/${cid}`, {
+      method: 'GET',
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('registry_unavailable');
+  });
+
+  it.each(['launching', 'failed'] as const)(
+    'does not serve an owned cached %s manifest before the lifecycle is anchored',
+    async (status) => {
+      const cid = `bafyowned${status}prebroadcast1234567890`;
+      const solverNetId = `owned-${status}-prebroadcast`;
+      const manifest = makeManifest({ solverNetId, manifestCid: cid });
+      const manifestPath = await store.writeManifestCache(cid, manifest);
+      await store.writeRecord({
+        ...makeOwnedRecord({ solverNetId, status }),
+        manifestCid: cid,
+        manifestHash: manifestHash(manifest),
+        manifestPath,
+        registry: {},
+        launchProgress: {
+          phase: 'broadcasting',
+          attemptCount: status === 'failed' ? 3 : 0,
+          ...(status === 'failed'
+            ? { txError: { message: 'setMetadata failed', at: '2026-05-06T00:00:00.000Z' } }
+            : {}),
+        },
+      });
+
+      const { app } = buildTestApp({ store });
+
+      const res = await app.request(`/v1/solvernets/registry/${cid}`, {
+        method: 'GET',
+        headers: authHeaders(),
+      });
+
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe('registry_unavailable');
+    },
+  );
 
   it('happy path: returns the manifest + lifecycle status', async () => {
     const cid = 'bafyabcdef1234567890';

--- a/client/test/api/solvernets-endpoints.test.ts
+++ b/client/test/api/solvernets-endpoints.test.ts
@@ -1524,22 +1524,40 @@ function makeManifest(args: {
       id: 'prediction',
       version: 'v1',
       schemas: { task: {}, solution: {}, verdict: {} },
-      claimPolicyDefaults: {},
-      credentialRequirements: [],
-      evaluationFunction: { name: 'eq', inputs: [] },
-      aggregationFunction: { name: 'majority', inputs: [] },
+      claimPolicyDefaults: {
+        mode: 'parallel',
+        maxClaims: 10,
+        maxClaimsPerOperator: 1,
+        claimLeaseTtlSeconds: 600,
+      },
+      credentialRequirements: { creator: [], solver: [], evaluator: [] },
+      evaluationFunction: {
+        id: 'prediction.brier-loss.v1',
+        deterministic: true,
+        inputs: ['solution', 'resolution'],
+        output: 'verdict',
+        implementation: 'jinn:harness:prediction-v1-evaluator',
+      },
+      aggregationFunction: {
+        id: 'prediction.trailing-mean-brier-spread.v1',
+        deterministic: true,
+        inputs: ['verdict[]'],
+        output: 'score',
+        windowDays: 30,
+      },
     },
     solutionPriceWei: '1000000000000000',
     verdictPriceWei: '500000000000000',
     openRoles: ['solver', 'evaluator'],
+    ...(args.manifestCid ? { registry: { manifestCid: args.manifestCid } } : {}),
     createdAt: '2026-05-06T00:00:00.000Z',
     launchedAt: '2026-05-06T00:00:00.000Z',
     signature: {
-      scheme: 'eip191',
+      alg: 'eip-191',
       signer: '0x2222222222222222222222222222222222222222',
-      signature: `0x${'cc'.repeat(65)}`,
+      value: `0x${'cc'.repeat(65)}`,
     },
-  } as unknown as SolverNetManifestV1;
+  };
 }
 
 /**
@@ -1979,6 +1997,44 @@ describe('GET /v1/solvernets/registry/:cid (Task 15)', () => {
     expect(res.status).toBe(503);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe('registry_unavailable');
+  });
+
+  it('returns an owned cached manifest without requiring the registry client', async () => {
+    const cid = 'bafyownedmanifestcache1234567890';
+    const manifest = makeManifest({
+      solverNetId: 'owned-local',
+      manifestCid: cid,
+    });
+    const manifestPath = await store.writeManifestCache(cid, manifest);
+    await store.writeRecord({
+      ...makeOwnedRecord({ solverNetId: 'owned-local', status: 'launched' }),
+      manifestCid: cid,
+      manifestPath,
+    });
+
+    const registry = makeMockRegistryGet({
+      getManifestError: new Error('registry should not be touched'),
+    });
+    const { app } = buildTestApp({ store, registry });
+
+    const res = await app.request(`/v1/solvernets/registry/${cid}`, {
+      method: 'GET',
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      manifest: SolverNetManifestV1;
+      lifecycle: { status: string; sourceBlock: number };
+    };
+    expect(body.manifest.name).toBe('owned-local');
+    expect(body.manifest.solutionPriceWei).toBe('1000000000000000');
+    expect(body.lifecycle).toEqual({
+      status: 'launched',
+      statusUpdatedAt: '2026-05-06T00:00:00.000Z',
+      sourceBlock: 100,
+    });
+    expect(registry.getManifestCalls).toEqual([]);
   });
 
   it('happy path: returns the manifest + lifecycle status', async () => {

--- a/client/test/dashboard/solvernet-flow.e2e.test.ts
+++ b/client/test/dashboard/solvernet-flow.e2e.test.ts
@@ -626,6 +626,11 @@ test('Launcher happy-path: walks Create wizard and lands on the post-launch dash
     /launched/i,
     { timeout: 10_000 },
   );
+  await expect(page.getByTestId('launcher-launched-name')).toContainText(
+    'Polymarket forecasts',
+  );
+  await expect(page.getByTestId('launcher-launched-spend-solution-price')).not.toHaveText('—');
+  await expect(page.getByTestId('launcher-launched-spend-verdict-price')).not.toHaveText('—');
 
   // Daemon-side assertions: the launch fired exactly once against our
   // draft and the launched record is being polled.

--- a/client/test/solvernets/launch-state-machine.test.ts
+++ b/client/test/solvernets/launch-state-machine.test.ts
@@ -334,6 +334,7 @@ describe('LaunchAction.launch — happy path', () => {
     expect(record.launchProgress).toBeUndefined();
     expect(record.solverNetId).toBe(manifest.solverNetId);
     expect(record.manifestCid).toBeTruthy();
+    expect(record.manifestPath).toContain(record.manifestCid);
     expect(record.manifestHash).toBe(manifestHash(manifest));
     expect(record.launcherAgentId).toBe(signer.agentId);
     expect(record.launcherSafeAddress.toLowerCase()).toBe(
@@ -352,6 +353,8 @@ describe('LaunchAction.launch — happy path', () => {
     // Persisted record on disk equals returned record.
     const onDisk = await store.loadRecord(record.solverNetId);
     expect(onDisk).toEqual(record);
+    const cachedManifest = await store.loadManifestCache(record.manifestPath!);
+    expect(cachedManifest?.solverNetId).toBe(manifest.solverNetId);
   });
 
   it('persists progress before each side effect (checkpoint visible after each phase)', async () => {


### PR DESCRIPTION
## Summary

- Cache launched SolverNet manifests locally during the recording phase and persist manifestPath on the owned launched record.
- Teach /v1/solvernets/registry/:cid to serve an owned cached manifest before falling back to registry discovery.
- Improve the launched dashboard manifest-load error copy and cover the owned-record dashboard path.

## Validation

- cd client && yarn vitest run test/api/solvernets-endpoints.test.ts --testNamePattern "owned cached manifest"
- cd client && yarn vitest run test/solvernets/launch-state-machine.test.ts --testNamePattern "progresses through all 5 phases"
- cd client && yarn vitest run test/api/solvernets-endpoints.test.ts test/solvernets/launch-state-machine.test.ts
- cd client && yarn typecheck
- cd client && yarn vitest run --testTimeout=15000 (full suite passed: 396 files, 3176 tests, 4 skipped)

Note: exact cd client && yarn typecheck && yarn test was attempted twice and failed both times in pre-existing test/earning/bootstrap.test.ts cases that exceed Vitest default 5s timeout under full-suite load. The same bootstrap file passes in isolation, and the full suite passes with only --testTimeout=15000 raised.