### PR TITLE
fix: LauncherLaunched dashboard hot-apply config form is template-unaware (renders Polymarket fields for any contract)

### DIFF
--- a/client/src/api/solvernets-endpoints.ts
+++ b/client/src/api/solvernets-endpoints.ts
@@ -74,7 +74,10 @@ import type {
   PendingGeneratorSpawn,
   SolverNetCatalogCache,
 } from '../solvernets/daemon-init.js';
-import { resolveContractFromSolverNetId } from '../solvernets/launched-record-dispatcher.js';
+import {
+  resolveLaunchedRecordContract,
+  type LaunchedRecordContractRef,
+} from '../solvernets/launched-record-dispatcher.js';
 import type {
   SignerWithAgentEoa,
   SolverNetManifestSummary,
@@ -312,12 +315,11 @@ const SweRebenchV2GeneratorConfigPatchSchema = z
     }
   });
 
-function isRecordForContract(
-  record: LaunchedSolverNetRecord,
+function isContractRefFor(
+  contract: LaunchedRecordContractRef | null,
   id: string,
   version: string,
 ): boolean {
-  const contract = resolveContractFromSolverNetId(record.solverNetId);
   return contract?.id === id && contract.version === version;
 }
 
@@ -339,6 +341,7 @@ function defaultSweRebenchV2ClaimPolicy(): {
 
 function mergeGeneratorConfigPatchForRecord(
   record: LaunchedSolverNetRecord,
+  contract: LaunchedRecordContractRef | null,
   patch: Record<string, unknown>,
 ): Record<string, unknown> {
   const nextConfig: Record<string, unknown> = {
@@ -346,7 +349,7 @@ function mergeGeneratorConfigPatchForRecord(
     ...patch,
   };
   if (
-    isRecordForContract(record, 'swe-rebench-v2', 'v1') &&
+    isContractRefFor(contract, 'swe-rebench-v2', 'v1') &&
     typeof patch.claimPolicy === 'object' &&
     patch.claimPolicy !== null
   ) {
@@ -364,10 +367,26 @@ function mergeGeneratorConfigPatchForRecord(
 }
 
 function validateSweRebenchV2EffectiveConfig(
-  record: LaunchedSolverNetRecord,
+  contract: LaunchedRecordContractRef | null,
   config: Record<string, unknown>,
-): string | undefined {
-  if (!isRecordForContract(record, 'swe-rebench-v2', 'v1')) return undefined;
+): { path: string; message: string } | undefined {
+  if (!isContractRefFor(contract, 'swe-rebench-v2', 'v1')) return undefined;
+  const targetSuccesses = typeof config.N_target_successes === 'number'
+    ? config.N_target_successes
+    : undefined;
+  const maxPostingsPerTask = typeof config.N_max_postings_per_task === 'number'
+    ? config.N_max_postings_per_task
+    : undefined;
+  if (
+    targetSuccesses !== undefined &&
+    maxPostingsPerTask !== undefined &&
+    maxPostingsPerTask < targetSuccesses
+  ) {
+    return {
+      path: 'N_max_postings_per_task',
+      message: 'must be >= N_target_successes',
+    };
+  }
   const defaults = defaultSweRebenchV2ClaimPolicy();
   const rawPolicy =
     typeof config.claimPolicy === 'object' && config.claimPolicy !== null
@@ -380,16 +399,19 @@ function validateSweRebenchV2EffectiveConfig(
     ? rawPolicy.maxClaimsPerOperator
     : defaults.maxClaimsPerOperator;
   if (maxClaimsPerOperator > maxClaims) {
-    return 'claimPolicy.maxClaimsPerOperator must be <= claimPolicy.maxClaims';
+    return {
+      path: 'claimPolicy.maxClaimsPerOperator',
+      message: 'claimPolicy.maxClaimsPerOperator must be <= claimPolicy.maxClaims',
+    };
   }
   return undefined;
 }
 
 function parseGeneratorConfigPatchForRecord(
-  record: LaunchedSolverNetRecord,
+  contract: LaunchedRecordContractRef | null,
   raw: unknown,
 ): z.SafeParseReturnType<unknown, Record<string, unknown>> {
-  if (isRecordForContract(record, 'swe-rebench-v2', 'v1')) {
+  if (isContractRefFor(contract, 'swe-rebench-v2', 'v1')) {
     return SweRebenchV2GeneratorConfigPatchSchema.safeParse(raw);
   }
   return PredictionV1GeneratorConfigPatchSchema.safeParse(raw);
@@ -1252,7 +1274,8 @@ export function registerSolverNetsEndpoints(
       return c.json({ error: 'record_not_found', message: `Unknown record: ${id}` }, 404);
     }
 
-    const parsed = parseGeneratorConfigPatchForRecord(record, raw);
+    const contract = await resolveLaunchedRecordContract(record);
+    const parsed = parseGeneratorConfigPatchForRecord(contract, raw);
     if (!parsed.success) {
       const issues = zodIssuesForResponse(parsed.error);
       return c.json(
@@ -1268,8 +1291,8 @@ export function registerSolverNetsEndpoints(
 
     // Patch semantics: merge the provided fields over the existing config.
     // Operators editing one field shouldn't have to re-send the rest.
-    const nextConfig = mergeGeneratorConfigPatchForRecord(record, parsed.data);
-    const effectiveConfigError = validateSweRebenchV2EffectiveConfig(record, nextConfig);
+    const nextConfig = mergeGeneratorConfigPatchForRecord(record, contract, parsed.data);
+    const effectiveConfigError = validateSweRebenchV2EffectiveConfig(contract, nextConfig);
     if (effectiveConfigError) {
       return c.json(
         {
@@ -1277,11 +1300,11 @@ export function registerSolverNetsEndpoints(
           kind: 'schema_validation_failed',
           issues: [
             {
-              path: 'claimPolicy.maxClaimsPerOperator',
-              message: effectiveConfigError,
+              path: effectiveConfigError.path,
+              message: effectiveConfigError.message,
             },
           ],
-          message: effectiveConfigError,
+          message: effectiveConfigError.message,
         },
         400,
       );

--- a/client/src/api/solvernets-endpoints.ts
+++ b/client/src/api/solvernets-endpoints.ts
@@ -395,6 +395,16 @@ function parseGeneratorConfigPatchForRecord(
   return PredictionV1GeneratorConfigPatchSchema.safeParse(raw);
 }
 
+function zodIssuesForResponse(error: z.ZodError): Array<{
+  path: string;
+  message: string;
+}> {
+  return error.issues.map((issue) => ({
+    path: issue.path.join('.') || '<body>',
+    message: issue.message,
+  }));
+}
+
 // ── Launch helpers ──────────────────────────────────────────────────────────
 
 interface DraftCompletenessResult {
@@ -1244,12 +1254,13 @@ export function registerSolverNetsEndpoints(
 
     const parsed = parseGeneratorConfigPatchForRecord(record, raw);
     if (!parsed.success) {
+      const issues = zodIssuesForResponse(parsed.error);
       return c.json(
         {
           error: 'invalid_body',
-          message: parsed.error.issues
-            .map((i) => `${i.path.join('.') || '<body>'}: ${i.message}`)
-            .join('; '),
+          kind: 'schema_validation_failed',
+          issues,
+          message: issues.map((i) => `${i.path}: ${i.message}`).join('; '),
         },
         400,
       );
@@ -1263,6 +1274,13 @@ export function registerSolverNetsEndpoints(
       return c.json(
         {
           error: 'invalid_body',
+          kind: 'schema_validation_failed',
+          issues: [
+            {
+              path: 'claimPolicy.maxClaimsPerOperator',
+              message: effectiveConfigError,
+            },
+          ],
           message: effectiveConfigError,
         },
         400,

--- a/client/src/dashboard/spa/src/pages/LauncherLaunched.test.tsx
+++ b/client/src/dashboard/spa/src/pages/LauncherLaunched.test.tsx
@@ -329,6 +329,48 @@ describe('LauncherLaunchedPage', () => {
     );
   });
 
+  it('hot-apply: renders the swe-rebench-v2 config form from the launched manifest template', async () => {
+    vi.mocked(api.solvernets.get).mockResolvedValue(
+      buildRecord({ generatorConfig: {}, summary: undefined }),
+    );
+    const predictionManifest = buildManifest();
+    vi.mocked(api.solvernets.getManifest).mockResolvedValue({
+      ...buildManifestResponse(),
+      manifest: buildManifest({
+        name: 'SWE-rebench v2',
+        contract: {
+          ...predictionManifest.contract,
+          id: 'swe-rebench-v2',
+          version: 'v1',
+          claimPolicyDefaults: {
+            mode: 'parallel',
+            maxClaims: 50,
+            maxClaimsPerOperator: 5,
+            claimLeaseTtlSeconds: 3600,
+          },
+        },
+      }),
+    });
+
+    wrap(<LauncherLaunchedPage solverNetId="sn-1" pollIntervalMs={10_000} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('launcher-launched-generator-toggle')).toBeTruthy(),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('launcher-launched-name').textContent).toBe(
+        'SWE-rebench v2',
+      ),
+    );
+    fireEvent.click(screen.getByTestId('launcher-launched-generator-toggle'));
+
+    expect(screen.getByTestId('launcher-launched-generator-N_target_successes')).toBeTruthy();
+    expect(
+      screen.getByTestId('launcher-launched-generator-N_max_postings_per_task'),
+    ).toBeTruthy();
+    expect(screen.getByTestId('launcher-launched-generator-cooldown_ms')).toBeTruthy();
+    expect(screen.queryByTestId('launcher-launched-generator-cadenceMs')).toBeNull();
+  });
+
   it('terminal record (retired) shows no actions', async () => {
     vi.mocked(api.solvernets.get).mockResolvedValue(buildRecord({ status: 'retired' }));
     vi.mocked(api.solvernets.getManifest).mockResolvedValue(buildManifestResponse());

--- a/client/src/dashboard/spa/src/pages/LauncherLaunched.tsx
+++ b/client/src/dashboard/spa/src/pages/LauncherLaunched.tsx
@@ -13,6 +13,10 @@ import { PauseRetireDialog } from './launcher-launched/PauseRetireDialog.js';
 import { SpendPanel } from './launcher-launched/SpendPanel.js';
 import { StatusHeader } from './launcher-launched/StatusHeader.js';
 import { TasksPanel } from './launcher-launched/TasksPanel.js';
+import {
+  TEMPLATES_BY_KEY,
+  type CreateWizardTemplate,
+} from './launcher-create/templates.js';
 
 /**
  * Post-launch dashboard for `/launcher/launched/:solverNetId`.
@@ -147,6 +151,7 @@ export function LauncherLaunchedPage({
 
   const record = recordQuery.data;
   const manifest = manifestQuery.data?.manifest;
+  const template = resolveLaunchedTemplate(record, manifest);
   const solverNetName = manifest?.name ?? record.summary?.name ?? record.solverNetId;
 
   return (
@@ -168,6 +173,7 @@ export function LauncherLaunchedPage({
       <GeneratorPanel
         record={record}
         manifest={manifest}
+        template={template}
         onSave={async (patch) => {
           await generatorMutation.mutateAsync(patch);
         }}
@@ -218,6 +224,19 @@ function formatManifestLoadError(error: unknown): string {
     return `Manifest unavailable from local cache or registry (${message})`;
   }
   return message;
+}
+
+function resolveLaunchedTemplate(
+  record: LaunchedSolverNetRecord,
+  manifest: RegistryManifestResponse['manifest'] | undefined,
+): CreateWizardTemplate | undefined {
+  const contract = manifest?.contract ?? (
+    record.summary
+      ? { id: record.summary.contractId, version: record.summary.contractVersion }
+      : undefined
+  );
+  if (!contract) return undefined;
+  return TEMPLATES_BY_KEY[`${contract.id}.${contract.version}`];
 }
 
 function ErrorBanner({

--- a/client/src/dashboard/spa/src/pages/launcher-launched/GeneratorPanel.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher-launched/GeneratorPanel.tsx
@@ -4,6 +4,7 @@ import type {
   LaunchedSolverNetRecord,
   SolverNetManifestV1,
 } from '../../api/types.js';
+import type { CreateWizardTemplate } from '../launcher-create/templates.js';
 import { formatTimestamp } from './helpers.js';
 
 /**
@@ -28,6 +29,7 @@ const SWE_REBENCH_V2_MIN_COOLDOWN_MS = 60_000;
 export interface GeneratorPanelProps {
   record: LaunchedSolverNetRecord;
   manifest?: SolverNetManifestV1;
+  template?: CreateWizardTemplate;
   onSave: (patch: Partial<GeneratorConfig>) => Promise<void>;
 }
 
@@ -262,7 +264,13 @@ export function buildSweRebenchV2Patch(
   };
 }
 
-function isSweRebenchV2Record(record: LaunchedSolverNetRecord): boolean {
+function isSweRebenchV2Record(
+  record: LaunchedSolverNetRecord,
+  template?: CreateWizardTemplate,
+): boolean {
+  if (template) {
+    return template.id === 'swe-rebench-v2' && template.version === 'v1';
+  }
   if (
     record.summary?.contractId === 'swe-rebench-v2' &&
     record.summary.contractVersion === 'v1'
@@ -277,8 +285,13 @@ function isSweRebenchV2Record(record: LaunchedSolverNetRecord): boolean {
   );
 }
 
-export function GeneratorPanel({ record, manifest, onSave }: GeneratorPanelProps): JSX.Element {
-  if (isSweRebenchV2Record(record)) {
+export function GeneratorPanel({
+  record,
+  manifest,
+  template,
+  onSave,
+}: GeneratorPanelProps): JSX.Element {
+  if (isSweRebenchV2Record(record, template)) {
     return <SweRebenchV2GeneratorPanel record={record} manifest={manifest} onSave={onSave} />;
   }
   return <PredictionGeneratorPanel record={record} onSave={onSave} />;

--- a/client/test/api/solvernets-endpoints.test.ts
+++ b/client/test/api/solvernets-endpoints.test.ts
@@ -1243,6 +1243,42 @@ describe('PATCH /v1/solvernets/launched/:id/generator-config (Task 14)', () => {
     expect(body.message).toMatch(/maxClaimsPerOperator/);
   });
 
+  it('rejects prediction-shaped patches for swe-rebench-v2 records with schema issues', async () => {
+    const pendingGenerators = { current: [] as PendingGeneratorSpawn[] };
+    const launchBundle = makeLaunchDeps({ store, pendingGenerators });
+    const { app } = buildTestApp({ store, launch: launchBundle.launch });
+    const launched: LaunchedSolverNetRecord = {
+      ...makeOwnedRecord({
+        solverNetId: '5474_swe-rebench-v2-v1_edb172d3',
+        status: 'paused',
+      }),
+      generatorEnabled: true,
+      generatorConfig: {
+        N_target_successes: 5,
+        N_max_postings_per_task: 15,
+        cooldown_ms: 86_400_000,
+      },
+    };
+    await store.writeRecord(launched);
+
+    const res = await app.request(
+      `/v1/solvernets/launched/${launched.solverNetId}/generator-config`,
+      {
+        method: 'PATCH',
+        headers: authHeaders(),
+        body: JSON.stringify({ cadenceMs: 60_000, maxOpenRounds: 3 }),
+      },
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      kind?: string;
+      issues?: Array<{ message: string }>;
+    };
+    expect(body.kind).toBe('schema_validation_failed');
+    expect(body.issues?.some((issue) => issue.message.includes('cadenceMs'))).toBe(true);
+  });
+
   it('rejects unknown record id with 404', async () => {
     const pendingGenerators = { current: [] as PendingGeneratorSpawn[] };
     const launchBundle = makeLaunchDeps({ store, pendingGenerators });

--- a/client/test/api/solvernets-endpoints.test.ts
+++ b/client/test/api/solvernets-endpoints.test.ts
@@ -1211,6 +1211,53 @@ describe('PATCH /v1/solvernets/launched/:id/generator-config (Task 14)', () => {
     });
   });
 
+  it('uses the manifest contract before solverNetId when validating generator config patches', async () => {
+    const pendingGenerators = { current: [] as PendingGeneratorSpawn[] };
+    const launchBundle = makeLaunchDeps({ store, pendingGenerators });
+    const { app } = buildTestApp({ store, launch: launchBundle.launch });
+    const solverNetId = 'legacy-swe-record';
+    const cid = 'bafylegacyswemanifest1234567890';
+    const baseManifest = makeManifest({ solverNetId, manifestCid: cid });
+    const sweManifest: SolverNetManifestV1 = {
+      ...baseManifest,
+      contract: {
+        ...baseManifest.contract,
+        id: 'swe-rebench-v2',
+        version: 'v1',
+      },
+    };
+    const manifestPath = await store.writeManifestCache(cid, sweManifest);
+    const launched: LaunchedSolverNetRecord = {
+      ...makeOwnedRecord({ solverNetId, status: 'paused' }),
+      manifestCid: cid,
+      manifestHash: manifestHash(sweManifest),
+      manifestPath,
+      generatorEnabled: true,
+      generatorConfig: {
+        N_target_successes: 5,
+        N_max_postings_per_task: 15,
+        cooldown_ms: 86_400_000,
+      },
+    };
+    await store.writeRecord(launched);
+
+    const res = await app.request(
+      `/v1/solvernets/launched/${launched.solverNetId}/generator-config`,
+      {
+        method: 'PATCH',
+        headers: authHeaders(),
+        body: JSON.stringify({ cooldown_ms: 300_000 }),
+      },
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      N_target_successes: 5,
+      N_max_postings_per_task: 15,
+      cooldown_ms: 300_000,
+    });
+  });
+
   it('rejects swe-rebench-v2 claim policy with per-operator claims above max claims', async () => {
     const pendingGenerators = { current: [] as PendingGeneratorSpawn[] };
     const launchBundle = makeLaunchDeps({ store, pendingGenerators });
@@ -1241,6 +1288,47 @@ describe('PATCH /v1/solvernets/launched/:id/generator-config (Task 14)', () => {
     expect(res.status).toBe(400);
     const body = (await res.json()) as { message?: string };
     expect(body.message).toMatch(/maxClaimsPerOperator/);
+  });
+
+  it('rejects partial swe-rebench-v2 patches that violate merged posting invariants', async () => {
+    const pendingGenerators = { current: [] as PendingGeneratorSpawn[] };
+    const launchBundle = makeLaunchDeps({ store, pendingGenerators });
+    const { app } = buildTestApp({ store, launch: launchBundle.launch });
+    const launched: LaunchedSolverNetRecord = {
+      ...makeOwnedRecord({
+        solverNetId: '5474_swe-rebench-v2-v1_edb172d3',
+        status: 'paused',
+      }),
+      generatorEnabled: true,
+      generatorConfig: {
+        N_target_successes: 5,
+        N_max_postings_per_task: 15,
+        cooldown_ms: 86_400_000,
+      },
+    };
+    await store.writeRecord(launched);
+
+    const res = await app.request(
+      `/v1/solvernets/launched/${launched.solverNetId}/generator-config`,
+      {
+        method: 'PATCH',
+        headers: authHeaders(),
+        body: JSON.stringify({ N_target_successes: 20 }),
+      },
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      message?: string;
+      issues?: Array<{ path: string; message: string }>;
+    };
+    expect(body.message).toMatch(/N_target_successes/);
+    expect(body.issues).toContainEqual({
+      path: 'N_max_postings_per_task',
+      message: 'must be >= N_target_successes',
+    });
+    const onDisk = await store.loadRecord(launched.solverNetId);
+    expect(onDisk?.generatorConfig).toEqual(launched.generatorConfig);
   });
 
   it('rejects prediction-shaped patches for swe-rebench-v2 records with schema issues', async () => {


### PR DESCRIPTION
## Summary

- Resolve the launched SolverNet template from the manifest/record and pass it into the hot-apply generator panel.
- Dispatch SWE-rebench launched records to the SWE generator fields instead of the prediction.v1 fallback.
- Validate generator-config PATCH bodies against the launched template shape and reject mismatches with kind=schema_validation_failed and issues.

## Stack

Base PR: https://github.com/Jinn-Network/mono/pull/170

## Validation

- cd client && yarn vitest run src/dashboard/spa/src/pages/LauncherLaunched.test.tsx --testNamePattern "swe-rebench-v2 config form"
- cd client && yarn vitest run test/api/solvernets-endpoints.test.ts --testNamePattern "prediction-shaped patches"
- cd client && yarn vitest run test/api/solvernets-endpoints.test.ts src/dashboard/spa/src/pages/LauncherLaunched.test.tsx src/dashboard/spa/src/pages/launcher-launched/GeneratorPanel.test.tsx
- cd client && yarn typecheck
- cd client && yarn vitest run --testTimeout=15000 (full suite passed: 396 files, 3176 tests, 4 skipped)

Note: exact cd client && yarn typecheck && yarn test was attempted twice and failed both times in pre-existing test/earning/bootstrap.test.ts cases that exceed Vitest default 5s timeout under full-suite load. The same bootstrap file passes in isolation, and the full suite passes with only --testTimeout=15000 raised.