### PR TITLE
fix(uy6v.8): SWE-rebench v2 eval loop — no verdicts on non-gradeable evals; source-only patches

### DIFF
--- a/client/src/cli/commands/solver-nets.ts
+++ b/client/src/cli/commands/solver-nets.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { parseArgs } from 'node:util';
@@ -218,6 +219,11 @@ const command: CommandModule = {
   jinn solver-nets remove-plugin <name> <source-or-name> [--config <path>]
   jinn solver-nets doctor <name> [--human|--json] [--config <path>]
   jinn solver-nets sample <name> [--closed-window]
+  jinn solver-nets validate-pool swe-rebench-v2 [--limit <n>] [--force]
+            Run the gold patch of each pool instance through the eval harness
+            and cache which instances are scorable; the generator then posts
+            only those. Requires Docker + \`jinn harnesses enable
+            swe-rebench-v2-evaluator\`.
 
 Output flags:
   --human   Render readable terminal output instead of JSON (supported by
@@ -236,6 +242,8 @@ Output flags:
         config: { type: 'string' },
         harness: { type: 'string' },
         'closed-window': { type: 'boolean' },
+        limit: { type: 'string' },
+        force: { type: 'boolean' },
         human: { type: 'boolean' },
         json: { type: 'boolean' },
       },
@@ -265,6 +273,65 @@ Output flags:
           .map((n) => `${n.name}  ${n.enabled ? 'enabled' : 'disabled'}  ${n.solverType}  harness=${n.harness ?? '(default)'}  plugins=${n.pluginCount}  generator=${n.taskGeneratorEnabled ? 'on' : 'off'}`)
           .join('\n');
       });
+      return;
+    }
+
+    if (subverb === 'validate-pool') {
+      if (name !== 'swe-rebench-v2') {
+        fail(ctx, 'solver-nets validate-pool currently supports only `swe-rebench-v2`');
+        return;
+      }
+      // The upstream eval harness must be set up (`jinn harnesses enable
+      // swe-rebench-v2-evaluator`) — that's where the eval.py repo lives.
+      const { readEnabledState, defaultSweRebenchV2EvaluatorImplStateDir } =
+        await import('../../harnesses/impls/swe-rebench-v2-evaluator/harness.js');
+      const enabled = readEnabledState(defaultSweRebenchV2EvaluatorImplStateDir());
+      if (!enabled || !existsSync(enabled.upstreamRepoDir)) {
+        fail(ctx, 'swe-rebench-v2 evaluator is not set up — run `jinn harnesses enable swe-rebench-v2-evaluator` first');
+        return;
+      }
+      const upstreamRepoDir = enabled.upstreamRepoDir;
+      // Docker must be reachable, or every gold-eval would be classified as
+      // ungradeable and the whole pool wrongly marked unscorable.
+      if (spawnSync('docker', ['info'], { stdio: 'ignore' }).status !== 0) {
+        fail(ctx, 'Docker daemon not reachable — start Docker, then re-run `jinn solver-nets validate-pool swe-rebench-v2`');
+        return;
+      }
+
+      const { loadSweRebenchV2Pool, getSweRebenchV2ValidatedPoolStore } = await import('../../solver-types/swe-rebench-v2.js');
+      const { HttpHfFetcher } = await import('../../harnesses/impls/swe-rebench-v2-evaluator/hf-fetcher.js');
+      const { PythonEvalRunner } = await import('../../harnesses/impls/swe-rebench-v2-evaluator/eval-runner.js');
+      const { validatePoolInstances, EVAL_SEMANTICS_VERSION } = await import('../../solver-types/_swe-rebench-v2-validated-pool.js');
+
+      const limitRaw = parsed.values['limit'] as string | undefined;
+      const limitParsed = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
+      const limit = Number.isFinite(limitParsed as number) && (limitParsed as number) > 0 ? (limitParsed as number) : undefined;
+      const force = Boolean(parsed.values['force']);
+
+      process.stderr.write('[validate-pool] loading the SWE-rebench v2 pool…\n');
+      const poolTasks = await loadSweRebenchV2Pool();
+      const store = getSweRebenchV2ValidatedPoolStore();
+      const summary = await validatePoolInstances(
+        poolTasks,
+        {
+          fetcher: new HttpHfFetcher(),
+          runner: new PythonEvalRunner({ upstreamRepoDir }),
+          store,
+          semanticsVersion: EVAL_SEMANTICS_VERSION,
+          log: (m) => process.stderr.write(`${m}\n`),
+        },
+        { limit, force },
+      );
+      emit(
+        ctx,
+        { verb: 'solver-nets validate-pool', solverNet: 'swe-rebench-v2', evalSemanticsVersion: EVAL_SEMANTICS_VERSION, poolSize: poolTasks.length, ...summary },
+        human,
+        json,
+        (v) => {
+          const s = v as { poolSize: number; checked: number; scorable: number; unscorable: number; skipped: number };
+          return `pool=${s.poolSize}  checked=${s.checked}  scorable=${s.scorable}  unscorable=${s.unscorable}  skipped(non-pytest)=${s.skipped}`;
+        },
+      );
       return;
     }
 

--- a/client/src/harnesses/impls/claude-code-learner/adapters/codex-code.ts
+++ b/client/src/harnesses/impls/claude-code-learner/adapters/codex-code.ts
@@ -122,6 +122,8 @@ function sweRebenchV2Guidance(inputs: TaskSessionInputs): string[] {
     '- Before planning, use Network Tools to search donated SWE execution data: call search_records, inspect_record, and acquire_artifact for useful donated IPFS records.',
     `- Submit the final swe-rebench-v2-solution.v1 payload by calling submit_typed_payload. Do not write ${inputs.workingDir}/.execute/solution-payload.json directly unless submit_typed_payload is unavailable; if fallback is required, write {"schemaVersion":"swe-rebench-v2-solution.v1","patch":"<unified diff>"} to that path.`,
     `- If you rely on the harvester git-diff fallback, the patch must be present as git diff output under ${inputs.workingDir}/repo.`,
+    `- Edit source files only. You may write tests to verify your fix locally, but test-file changes are discarded before grading — do not rely on them landing. The submitted patch must change source, not tests.`,
+    `- Your patch must apply cleanly with \`git apply\` from the base commit, so make the fix by editing files under ${inputs.workingDir}/repo and let the harness derive the diff via \`git diff\` rather than hand-writing the unified diff yourself.`,
   ];
 }
 

--- a/client/src/harnesses/impls/claude-code-learner/harvest.ts
+++ b/client/src/harnesses/impls/claude-code-learner/harvest.ts
@@ -7,6 +7,7 @@ import { SOLVER_TYPE_PAYLOADS, validatePayload } from '../../../types/payloads/i
 import type { OutputArtifact } from '../../../types/portfolio.js';
 import type { Task } from '../../../types/task.js';
 import type { Solution } from '../../types.js';
+import { stripTestPathHunks } from './restoration-patch.js';
 
 const PHASE_ORDER = [
   'orient',
@@ -178,9 +179,9 @@ function maybeMaterializeSweRebenchPatchPayload(
     return null;
   }
 
-  let patch = '';
+  let rawPatch = '';
   try {
-    patch = execFileSync('git', ['-C', repoDir, 'diff', '--binary'], {
+    rawPatch = execFileSync('git', ['-C', repoDir, 'diff', '--binary'], {
       encoding: 'utf8',
       maxBuffer: 50 * 1024 * 1024,
     });
@@ -190,7 +191,20 @@ function maybeMaterializeSweRebenchPatchPayload(
     );
     return null;
   }
+  if (!rawPatch.trim()) {
+    return null;
+  }
+  // Drop the model's own test-file edits: the upstream eval applies the gold
+  // `test_patch` after the model patch with `set -e`, so model test changes
+  // either collide (3-way conflict → eval aborts) or pollute the test set. The
+  // restorer never sees the gold test_patch, so we strip on the producer side
+  // (matches standard SWE-bench, which resets test files before grading). See
+  // jinn-mono-uy6v.8.
+  const patch = stripTestPathHunks(rawPatch);
   if (!patch.trim()) {
+    console.warn(
+      '[claude-code-learner] harvestOutput: swe-rebench-v2 git diff contained only test-file changes; no source patch to submit.',
+    );
     return null;
   }
 
@@ -223,12 +237,15 @@ function normalizeTypedPayload(
   if (
     solverType === 'swe-rebench-v2.v1' &&
     role === 'restoration' &&
-    raw['schemaVersion'] === undefined &&
-    typeof raw['patch'] === 'string' &&
-    raw['patch'].trim()
+    typeof raw['patch'] === 'string'
   ) {
+    // Strip the model's own test-file edits regardless of whether the patch
+    // arrived hand-authored or was derived from `git diff` (idempotent on the
+    // latter). See jinn-mono-uy6v.8 / restoration-patch.ts.
+    const strippedPatch = stripTestPathHunks(raw['patch'] as string);
     payload = {
       ...raw,
+      patch: strippedPatch,
       schemaVersion: 'swe-rebench-v2-solution.v1',
     };
     writeFileSync(typedPayloadPath, JSON.stringify(payload, null, 2));
@@ -449,9 +466,13 @@ export function harvestOutput(workingDir: string, phaseRange?: string, task?: Ta
   const range = resolvePhaseRange(phaseRange);
   const requiredPhases = new Set<Phase>(REQUIRED_PHASES[range]);
   const typedPayloadPath = join(workingDir, '.execute', 'solution-payload.json');
+  // For swe-rebench-v2 restoration the `git diff` over the task checkout is the
+  // authoritative patch (always well-formed; agent-authored diffs are not).
+  // maybeMaterialize* returns null for any other case, so the agent-authored
+  // .execute/solution-payload.json path is preserved everywhere else.
   const rawTypedPayload =
-    readTypedPayloadJson(typedPayloadPath) ??
-    maybeMaterializeSweRebenchPatchPayload(workingDir, task);
+    maybeMaterializeSweRebenchPatchPayload(workingDir, task) ??
+    readTypedPayloadJson(typedPayloadPath);
   const typedPayload = rawTypedPayload
     ? normalizeTypedPayload(rawTypedPayload, task, typedPayloadPath)
     : null;

--- a/client/src/harnesses/impls/claude-code-learner/restoration-patch.ts
+++ b/client/src/harnesses/impls/claude-code-learner/restoration-patch.ts
@@ -1,0 +1,135 @@
+/**
+ * Helpers for sanitising a SWE-rebench v2 restoration patch before it is
+ * submitted as the solution payload.
+ *
+ * Two problems this guards against (see jinn-mono-uy6v.8):
+ *  1. Coding agents naturally write a regression test alongside their fix.
+ *     The upstream eval applies the model patch and then the *gold* `test_patch`
+ *     with `git apply --3way` and `set -e` — if the model patch already touched
+ *     the same test file the gold patch will conflict, abort the eval, and the
+ *     verdict is `passed_match:false` for a reason that has nothing to do with
+ *     the fix. Standard SWE-bench evaluation resets test files before applying
+ *     the gold test patch; since our restorer never sees the gold `test_patch`,
+ *     we approximate that by stripping test-path hunks on the producer side.
+ *  2. Hand-authored diffs (the `submit_typed_payload` / `.execute` fallback
+ *     path) sometimes drop the leading space on a context line, which makes
+ *     `git apply` reject the whole patch ("corrupt patch at line N"). A cheap
+ *     `git apply --numstat` parse catches that before the patch ships.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Whether `path` (a forward-slash repo-relative path) looks like a test file
+ * by common cross-language convention. Conservative on purpose: over-stripping
+ * a model's own test is harmless (the eval discards model test edits anyway),
+ * under-stripping risks the gold-test-patch conflict.
+ */
+export function isTestPath(path: string): boolean {
+  const p = path.replace(/^[ab]\//, '');
+  const segments = p.split('/');
+  const base = segments[segments.length - 1] ?? '';
+  // A directory segment that is exactly a conventional test directory.
+  for (const seg of segments.slice(0, -1)) {
+    if (seg === 'test' || seg === 'tests' || seg === '__tests__' || seg === 'testsuite' || seg === 'testsuites') {
+      return true;
+    }
+  }
+  // Filename conventions.
+  if (base === 'conftest.py') return true;
+  if (/^test_.*\.py$/.test(base) || /_test\.py$/.test(base)) return true;
+  if (/_test\.go$/.test(base)) return true;
+  if (/_test\.rs$/.test(base)) return true;
+  if (/\.(test|spec)\.(m?[jt]sx?|cjs)$/.test(base)) return true;
+  if (/(Test|Tests|IT)\.java$/.test(base)) return true;
+  if (/_(test|spec)\.rb$/.test(base) || /^test_.*\.rb$/.test(base)) return true;
+  return false;
+}
+
+/** Extract the a/ and b/ paths from a `diff --git` header line, if present. */
+function pathsFromDiffHeader(line: string): string[] {
+  // `diff --git a/foo/bar b/foo/bar` — paths may contain spaces but in practice
+  // for our repos they don't; take the two whitespace-delimited tokens after
+  // `diff --git`.
+  const m = /^diff --git (\S.*?) (\S.*)$/.exec(line);
+  if (!m) return [];
+  return [m[1]!.replace(/^a\//, ''), m[2]!.replace(/^b\//, '')];
+}
+
+/** Fallback: pull a path out of a `--- a/x` / `+++ b/x` line. */
+function pathFromMarkerLine(line: string): string | null {
+  const m = /^[-+]{3} ([ab]\/.+)$/.exec(line);
+  if (!m) return null;
+  return m[1]!.replace(/^[ab]\//, '');
+}
+
+/**
+ * Split a unified diff into per-file sections and drop the ones whose path
+ * (a/ or b/ side) is a test path. Returns the rejoined diff, or `''` if no
+ * non-test hunks remain.
+ *
+ * Splits only on `diff --git ` boundaries, so binary patches and rename
+ * headers are kept intact within a section.
+ */
+export function stripTestPathHunks(unifiedDiff: string): string {
+  if (!unifiedDiff.includes('diff --git ')) {
+    // Not a git-format multi-file diff — leave it alone (could be a single
+    // `--- a/x`/`+++ b/x` patch; not our concern to dissect here).
+    return unifiedDiff;
+  }
+  const lines = unifiedDiff.split('\n');
+  type Section = { paths: string[]; lines: string[] };
+  const sections: Section[] = [];
+  let current: Section | null = null;
+  for (const line of lines) {
+    if (line.startsWith('diff --git ')) {
+      current = { paths: pathsFromDiffHeader(line), lines: [line] };
+      sections.push(current);
+      continue;
+    }
+    if (!current) {
+      // Preamble before the first `diff --git ` (rare; e.g. a leading blank
+      // line). Keep it as a pseudo-section with no paths so it's preserved.
+      current = { paths: [], lines: [line] };
+      sections.push(current);
+      continue;
+    }
+    current.lines.push(line);
+    if (current.paths.length === 0) {
+      const p = pathFromMarkerLine(line);
+      if (p) current.paths.push(p);
+    }
+  }
+  const kept = sections.filter((s) => !s.paths.some(isTestPath));
+  if (kept.length === 0) return '';
+  // If every kept section is empty-path preamble only, treat as empty too.
+  if (!kept.some((s) => s.lines.some((l) => l.startsWith('diff --git ')))) return '';
+  const out = kept.flatMap((s) => s.lines).join('\n');
+  return out;
+}
+
+/**
+ * Cheap structural validation: have `git apply --numstat` parse the patch (no
+ * worktree changes, no base-blob lookups). Catches malformed unified diffs —
+ * "corrupt patch at line N", "unexpected line", etc. — before the patch is
+ * submitted as a verdict-bound solution payload.
+ */
+export function gitApplyParseCheck(repoDir: string, patch: string): { ok: true } | { ok: false; stderr: string } {
+  if (!patch.trim()) return { ok: false, stderr: 'empty patch' };
+  try {
+    execFileSync('git', ['-C', repoDir, 'apply', '--numstat', '-'], {
+      input: patch,
+      encoding: 'utf8',
+      stdio: ['pipe', 'ignore', 'pipe'],
+    });
+    return { ok: true };
+  } catch (err) {
+    const stderr =
+      typeof err === 'object' && err !== null && 'stderr' in err
+        ? String((err as { stderr: unknown }).stderr ?? '')
+        : err instanceof Error
+          ? err.message
+          : String(err);
+    return { ok: false, stderr: stderr.slice(0, 800) };
+  }
+}

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
@@ -3,6 +3,27 @@
  * SWE-rebench/SWE-rebench-V2 repo (MIT). Operators install the upstream
  * harness as a Python dependency; this runner shells out and parses the
  * structured JSON report.
+ *
+ * The upstream report item (`report.json` → `items[]`) has two shapes:
+ *  - success: `{ instance_id, from_fail_to_pass, failed_from_pass_to_pass,
+ *               passed_match, exit_code, log_path, error: "" }`
+ *  - setup error: `{ instance_id, from_fail_to_pass: [], failed_from_pass_to_pass:
+ *               [...all PASS_TO_PASS...], error: "<message>" }` (no exit_code /
+ *               passed_match / log_path)
+ *
+ * Two corrections this runner makes over the raw report:
+ *  1. We re-derive the verdict with SWE-bench "resolved" semantics —
+ *     `all FAIL_TO_PASS now pass AND no PASS_TO_PASS broke` — instead of
+ *     trusting `passed_match`, which upstream computes as
+ *     `{set of every test that passed} == {FAIL_TO_PASS ∪ PASS_TO_PASS}`.
+ *     That exact-set comparison makes any instance whose `test_cmd` runs more
+ *     (or fewer) than the named tests structurally unscorable, and penalises a
+ *     solver for adding an extra passing test. (jinn-mono-uy6v.8)
+ *  2. We refuse to return a verdict when the eval never actually graded the
+ *     solution (Docker unreachable, image pull/IO failure, model patch failed
+ *     to apply, install/test-setup failed, arch-incompatible image, upstream
+ *     setup error) — those become `EvalCouldNotGradeError`, which the harness
+ *     re-raises as `SkippableError` (no signed verdict).
  */
 
 import { spawn } from 'node:child_process';
@@ -12,13 +33,9 @@ import { isAbsolute, join } from 'node:path';
 import type { EvalRunner } from './index.js';
 
 /**
- * Thrown when the eval could not actually grade the solution — Docker
- * unavailable, image pull/IO failure, the model patch failed to apply, the
- * install/test-setup step failed, an arch-incompatible image crashed, the
- * upstream harness errored, etc. The caller MUST NOT turn this into a
- * `passed_match: false` verdict: there is no signal about the solver, only
- * about the operator's environment. The evaluator harness re-raises it as a
- * `SkippableError` so the engine records a skip (no delivered verdict).
+ * Thrown when the eval could not actually grade the solution. There is no
+ * signal about the solver here, only about the operator's environment — the
+ * caller MUST NOT turn this into a `passed_match: false` verdict.
  */
 export class EvalCouldNotGradeError extends Error {
   readonly reason: string;
@@ -43,27 +60,30 @@ export interface PythonEvalRunnerOptions {
 }
 
 /**
- * Known infra-abort signatures in the container output. Used only to produce
- * a human-readable `reason`; the load-bearing classifier is
- * "container exited non-zero AND no test was collected" (see below).
+ * Container-output signatures that mean the eval aborted before producing a
+ * usable result — i.e. the operator's environment is the problem, not the
+ * solver. Used both to classify (`reason`) and as the load-bearing gate:
+ * a "zero tests passed, non-zero exit" report is only treated as ungradeable
+ * when one of these is present; otherwise it's a (degenerate) real failure.
  */
 const INFRA_SIGNATURES: Array<{ rx: RegExp; reason: string }> = [
   { rx: /Cannot connect to the Docker daemon/i, reason: 'docker_unavailable' },
   { rx: /input\/output error/i, reason: 'docker_storage_io_error' },
-  { rx: /error: corrupt patch at line/i, reason: 'patch_corrupt' },
-  { rx: /patch does not apply|patch failed:/i, reason: 'patch_does_not_apply' },
+  { rx: /No such image|manifest unknown|pull access denied/i, reason: 'image_pull_failed' },
+  { rx: /error: corrupt patch at line|patch fragment without header/i, reason: 'patch_corrupt' },
+  { rx: /patch does not apply|error: patch failed:/i, reason: 'patch_does_not_apply' },
   { rx: /Applied patch to .+ with conflicts|^U \S/m, reason: 'patch_merge_conflict' },
   { rx: /: command not found/i, reason: 'test_command_not_found' },
   { rx: /Failed building editable|Failed to build installable wheels/i, reason: 'install_build_failed' },
   { rx: /No virtual environment found/i, reason: 'venv_missing' },
-  { rx: /exec format error|requested image's platform .* does not match/i, reason: 'image_arch_mismatch' },
+  { rx: /exec format error|the requested image's platform .* does not match/i, reason: 'image_arch_mismatch' },
 ];
 
-function classifyInfraReason(log: string): string {
+function matchInfraSignature(log: string): string | null {
   for (const { rx, reason } of INFRA_SIGNATURES) {
     if (rx.test(log)) return reason;
   }
-  return 'eval_aborted_before_tests';
+  return null;
 }
 
 function asStringArray(value: unknown): string[] {
@@ -135,28 +155,41 @@ export class PythonEvalRunner implements EvalRunner {
     } catch {
       await rm(tmp, { recursive: true, force: true });
       // The upstream harness never produced a report — it crashed before it
-      // could grade anything. Not a verdict about the solver.
+      // could grade anything.
       throw new EvalCouldNotGradeError(
-        classifyInfraReason(stderr + stdout),
+        matchInfraSignature(stderr + stdout) ?? 'eval_no_report',
         `python exitCode=${exitCode}; ${(stderr || stdout).slice(-800)}`,
       );
     }
 
-    // Upstream report item shape: { instance_id, exit_code (the docker-run
-    // exit code), passed_match, passed_expected, passed_actual, failed_actual,
-    // log_path, ... }.
     const items = Array.isArray(report.items) ? report.items : [];
     const item = items.find((i) => i['instance_id'] === INSTANCE_ID) ?? items[0] ?? {};
 
-    const containerExit = typeof item['exit_code'] === 'number' ? (item['exit_code'] as number) : exitCode;
-    const passedActual = asStringArray(item['passed_actual']);
-    const failedActual = asStringArray(item['failed_actual']);
+    // Setup-error shape: eval.py caught an exception (missing image_name,
+    // missing config, unknown log parser, …). No exit_code / passed_match.
+    const reportError = typeof item['error'] === 'string' ? (item['error'] as string).trim() : '';
+    if (reportError) {
+      await rm(tmp, { recursive: true, force: true });
+      throw new EvalCouldNotGradeError('eval_setup_error', reportError);
+    }
+    if (typeof item['exit_code'] !== 'number') {
+      await rm(tmp, { recursive: true, force: true });
+      throw new EvalCouldNotGradeError(
+        'eval_report_malformed',
+        `report item lacked exit_code: ${JSON.stringify(item).slice(0, 500)}`,
+      );
+    }
+
+    const containerExit = item['exit_code'] as number;
+    // `from_fail_to_pass`: FAIL_TO_PASS tests that now pass.
+    // `failed_from_pass_to_pass`: PASS_TO_PASS tests that no longer pass.
+    const fromFailToPass = asStringArray(item['from_fail_to_pass']);
+    const failedFromPassToPass = asStringArray(item['failed_from_pass_to_pass']);
 
     // The upstream eval.py writes the full container log to
-    // <upstreamRepoDir>/logs/<instance>_log.txt and records `log_path` in the
-    // report — sometimes relative to its own cwd (the upstream repo dir).
-    // Resolve it so the test-log artifact carries the real pytest/container
-    // output rather than just the progress bar.
+    // <upstreamRepoDir>/logs/<instance>_log.txt and records `log_path` —
+    // sometimes relative to its own cwd. Resolve it so the test-log artifact
+    // carries the real pytest/container output rather than just the progress bar.
     let logBody = '';
     const logPath = item['log_path'];
     if (typeof logPath === 'string' && logPath.length > 0) {
@@ -171,23 +204,32 @@ export class PythonEvalRunner implements EvalRunner {
 
     await rm(tmp, { recursive: true, force: true });
 
-    // The eval did not actually grade the solution if the container aborted
-    // (non-zero exit) before any expected test was collected. A genuine
-    // wrong-answer run still surfaces the FAIL_TO_PASS / PASS_TO_PASS tests in
-    // passed_actual / failed_actual, so this only catches infra aborts: Docker
-    // down, patch-apply failure, test-file merge conflict, install/setup
-    // failure, missing test command, arch-incompatible image, etc.
-    if (containerExit !== 0 && passedActual.length === 0 && failedActual.length === 0) {
-      throw new EvalCouldNotGradeError(
-        classifyInfraReason(fullLog || stderr),
-        (fullLog || stderr).slice(-800),
-      );
+    // Ungradeable iff: the container aborted (non-zero exit) AND no expected
+    // test of either kind was observed to pass (`from_fail_to_pass` empty and
+    // *every* PASS_TO_PASS landed in `failed_from_pass_to_pass`) AND the output
+    // matches a known infra-abort signature. A genuine wrong-answer run still
+    // shows the FAIL_TO_PASS test failing inside a normal pytest report (no
+    // infra signature), and a partially-passing run is clearly a real result —
+    // both go through as verdicts.
+    const noTestPassed =
+      fromFailToPass.length === 0 && failedFromPassToPass.length >= args.pass_to_pass.length;
+    if (containerExit !== 0 && noTestPassed) {
+      const infraReason = matchInfraSignature(fullLog || stderr);
+      if (infraReason) {
+        throw new EvalCouldNotGradeError(infraReason, (fullLog || stderr).slice(-800));
+      }
     }
 
+    // SWE-bench "resolved" semantics: all FAIL_TO_PASS now pass and no
+    // PASS_TO_PASS broke. (`from_fail_to_pass` is an intersection with the
+    // expected FAIL_TO_PASS set, so length equality means full coverage.)
+    const resolved =
+      fromFailToPass.length === args.fail_to_pass.length && failedFromPassToPass.length === 0;
+
     return {
-      passed_match: item['passed_match'] === true,
-      passed: passedActual,
-      failed: failedActual,
+      passed_match: resolved,
+      passed: fromFailToPass,
+      failed: failedFromPassToPass,
       log: fullLog,
       exitCode: containerExit,
     };

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
@@ -8,7 +8,7 @@
 import { spawn } from 'node:child_process';
 import { mkdtemp, writeFile, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 import type { EvalRunner } from './index.js';
 
 /**
@@ -115,6 +115,10 @@ export class PythonEvalRunner implements EvalRunner {
     const child = spawn(this.opts.pythonBin ?? 'python3', pyArgs, {
       cwd: this.opts.upstreamRepoDir,
       stdio: ['ignore', 'pipe', 'pipe'],
+      // SWE-rebench eval images are published for linux/amd64. Pin the platform
+      // so the upstream `docker run` is consistent on amd64 hosts and does not
+      // silently crash under arm64 emulation on dev machines.
+      env: { ...process.env, DOCKER_DEFAULT_PLATFORM: 'linux/amd64' },
     });
     let stderr = '';
     child.stderr.on('data', (d) => { stderr += d.toString(); });
@@ -148,11 +152,17 @@ export class PythonEvalRunner implements EvalRunner {
     const passedActual = asStringArray(item['passed_actual']);
     const failedActual = asStringArray(item['failed_actual']);
 
+    // The upstream eval.py writes the full container log to
+    // <upstreamRepoDir>/logs/<instance>_log.txt and records `log_path` in the
+    // report — sometimes relative to its own cwd (the upstream repo dir).
+    // Resolve it so the test-log artifact carries the real pytest/container
+    // output rather than just the progress bar.
     let logBody = '';
     const logPath = item['log_path'];
     if (typeof logPath === 'string' && logPath.length > 0) {
+      const resolved = isAbsolute(logPath) ? logPath : join(this.opts.upstreamRepoDir, logPath);
       try {
-        logBody = await readFile(logPath, 'utf8');
+        logBody = await readFile(resolved, 'utf8');
       } catch {
         logBody = '';
       }

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
@@ -11,6 +11,28 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { EvalRunner } from './index.js';
 
+/**
+ * Thrown when the eval could not actually grade the solution — Docker
+ * unavailable, image pull/IO failure, the model patch failed to apply, the
+ * install/test-setup step failed, an arch-incompatible image crashed, the
+ * upstream harness errored, etc. The caller MUST NOT turn this into a
+ * `passed_match: false` verdict: there is no signal about the solver, only
+ * about the operator's environment. The evaluator harness re-raises it as a
+ * `SkippableError` so the engine records a skip (no delivered verdict).
+ */
+export class EvalCouldNotGradeError extends Error {
+  readonly reason: string;
+  /** A short, redacted excerpt of the eval output, for diagnostics. */
+  readonly logExcerpt: string;
+
+  constructor(reason: string, logExcerpt = '') {
+    super(`swe-rebench-v2 eval could not grade the solution (${reason})`);
+    this.name = 'EvalCouldNotGradeError';
+    this.reason = reason;
+    this.logExcerpt = logExcerpt.slice(0, 1000);
+  }
+}
+
 export interface PythonEvalRunnerOptions {
   /** Path to the cloned SWE-rebench-V2 repo (cached locally). */
   upstreamRepoDir: string;
@@ -18,6 +40,34 @@ export interface PythonEvalRunnerOptions {
   pythonBin?: string;
   /** Workers for parallel eval (defaults to 1; we run one task at a time). */
   maxWorkers?: number;
+}
+
+/**
+ * Known infra-abort signatures in the container output. Used only to produce
+ * a human-readable `reason`; the load-bearing classifier is
+ * "container exited non-zero AND no test was collected" (see below).
+ */
+const INFRA_SIGNATURES: Array<{ rx: RegExp; reason: string }> = [
+  { rx: /Cannot connect to the Docker daemon/i, reason: 'docker_unavailable' },
+  { rx: /input\/output error/i, reason: 'docker_storage_io_error' },
+  { rx: /error: corrupt patch at line/i, reason: 'patch_corrupt' },
+  { rx: /patch does not apply|patch failed:/i, reason: 'patch_does_not_apply' },
+  { rx: /Applied patch to .+ with conflicts|^U \S/m, reason: 'patch_merge_conflict' },
+  { rx: /: command not found/i, reason: 'test_command_not_found' },
+  { rx: /Failed building editable|Failed to build installable wheels/i, reason: 'install_build_failed' },
+  { rx: /No virtual environment found/i, reason: 'venv_missing' },
+  { rx: /exec format error|requested image's platform .* does not match/i, reason: 'image_arch_mismatch' },
+];
+
+function classifyInfraReason(log: string): string {
+  for (const { rx, reason } of INFRA_SIGNATURES) {
+    if (rx.test(log)) return reason;
+  }
+  return 'eval_aborted_before_tests';
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : [];
 }
 
 export class PythonEvalRunner implements EvalRunner {
@@ -80,13 +130,23 @@ export class PythonEvalRunner implements EvalRunner {
       report = JSON.parse(await readFile(reportPath, 'utf8')) as typeof report;
     } catch {
       await rm(tmp, { recursive: true, force: true });
-      throw new Error(`Eval runner failed: exitCode=${exitCode}, stderr=${stderr.slice(-500)}`);
+      // The upstream harness never produced a report — it crashed before it
+      // could grade anything. Not a verdict about the solver.
+      throw new EvalCouldNotGradeError(
+        classifyInfraReason(stderr + stdout),
+        `python exitCode=${exitCode}; ${(stderr || stdout).slice(-800)}`,
+      );
     }
 
-    // Upstream report shape: { total, passed, items: [{instance_id, passed_match,
-    // from_fail_to_pass, failed_from_pass_to_pass, exit_code, log_path, error}] }.
+    // Upstream report item shape: { instance_id, exit_code (the docker-run
+    // exit code), passed_match, passed_expected, passed_actual, failed_actual,
+    // log_path, ... }.
     const items = Array.isArray(report.items) ? report.items : [];
     const item = items.find((i) => i['instance_id'] === INSTANCE_ID) ?? items[0] ?? {};
+
+    const containerExit = typeof item['exit_code'] === 'number' ? (item['exit_code'] as number) : exitCode;
+    const passedActual = asStringArray(item['passed_actual']);
+    const failedActual = asStringArray(item['failed_actual']);
 
     let logBody = '';
     const logPath = item['log_path'];
@@ -97,15 +157,29 @@ export class PythonEvalRunner implements EvalRunner {
         logBody = '';
       }
     }
+    const fullLog = stdout + logBody;
 
     await rm(tmp, { recursive: true, force: true });
 
+    // The eval did not actually grade the solution if the container aborted
+    // (non-zero exit) before any expected test was collected. A genuine
+    // wrong-answer run still surfaces the FAIL_TO_PASS / PASS_TO_PASS tests in
+    // passed_actual / failed_actual, so this only catches infra aborts: Docker
+    // down, patch-apply failure, test-file merge conflict, install/setup
+    // failure, missing test command, arch-incompatible image, etc.
+    if (containerExit !== 0 && passedActual.length === 0 && failedActual.length === 0) {
+      throw new EvalCouldNotGradeError(
+        classifyInfraReason(fullLog || stderr),
+        (fullLog || stderr).slice(-800),
+      );
+    }
+
     return {
       passed_match: item['passed_match'] === true,
-      passed: Array.isArray(item['from_fail_to_pass']) ? (item['from_fail_to_pass'] as string[]) : [],
-      failed: Array.isArray(item['failed_from_pass_to_pass']) ? (item['failed_from_pass_to_pass'] as string[]) : [],
-      log: stdout + logBody,
-      exitCode,
+      passed: passedActual,
+      failed: failedActual,
+      log: fullLog,
+      exitCode: containerExit,
     };
   }
 }

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
@@ -90,6 +90,40 @@ function asStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : [];
 }
 
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * The `install_config.test_cmd` array handed to `eval.py` (run line-by-line
+ * under `set -e` after the patch + gold test_patch are applied).
+ *
+ * For pytest instances we *override* the dataset's `test_cmd` with one that
+ * runs exactly the FAIL_TO_PASS ∪ PASS_TO_PASS node ids in the `-rA` summary
+ * format `parse_log_pytest` understands. Many dataset rows scope `test_cmd`
+ * to a whole file or the whole repo, or use `-v` — both make instances
+ * structurally unscorable (extra passing tests, or a parser-format mismatch)
+ * even when the fix is correct. Running exactly the named tests is the
+ * standard SWE-bench evaluation shape.
+ *
+ * For non-pytest log parsers (go / cargo / …) node-id semantics differ, so we
+ * fall back to the dataset's `test_cmd` verbatim and accept the limitation.
+ */
+function buildTestCommands(args: Parameters<EvalRunner['runEval']>[0]): string[] {
+  const install = normalizeCommands(args.install);
+  if (args.log_parser === 'parse_log_pytest') {
+    const nodeIds = [...args.fail_to_pass, ...args.pass_to_pass];
+    if (nodeIds.length > 0) {
+      const cmd = [
+        'python -m pytest --no-header -rA --tb=no -p no:cacheprovider',
+        ...nodeIds.map(shellQuote),
+      ].join(' ');
+      return [...install, cmd];
+    }
+  }
+  return [...install, ...normalizeCommands(args.test_cmd)];
+}
+
 export class PythonEvalRunner implements EvalRunner {
   constructor(private readonly opts: PythonEvalRunnerOptions) {}
 
@@ -109,10 +143,7 @@ export class PythonEvalRunner implements EvalRunner {
       PASS_TO_PASS: args.pass_to_pass,
       test_patch: args.test_patch,
       install_config: {
-        test_cmd: [
-          ...normalizeCommands(args.install),
-          ...normalizeCommands(args.test_cmd),
-        ],
+        test_cmd: buildTestCommands(args),
         log_parser: args.log_parser,
       },
     }];

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
@@ -90,6 +90,14 @@ function asStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : [];
 }
 
+/** The pinned `test_log` size cap (the tail is what matters — pytest's
+ *  summary + last failures live there). */
+const MAX_LOG_SIZE = 1024 * 1024;
+function capLogTail(log: string): string {
+  if (log.length <= MAX_LOG_SIZE) return log;
+  return `[… ${log.length - MAX_LOG_SIZE} bytes truncated …]\n${log.slice(-MAX_LOG_SIZE)}`;
+}
+
 function shellQuote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`;
 }
@@ -231,7 +239,10 @@ export class PythonEvalRunner implements EvalRunner {
         logBody = '';
       }
     }
-    const fullLog = stdout + logBody;
+    // Cap the log we hand back. The harness pins this verbatim to IPFS as the
+    // verdict's `test_log_cid` — a long pytest run can produce 10s of MB, and
+    // we only need the tail (pytest summary + last failures) to be useful.
+    const fullLog = capLogTail(stdout + logBody);
 
     await rm(tmp, { recursive: true, force: true });
 

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/harness.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/harness.ts
@@ -34,12 +34,12 @@ import type {
   ReadyStatus,
   Solution,
 } from '../../types.js';
-import { REQUIRES_LIVE_DAEMON_READINESS } from '../../types.js';
+import { REQUIRES_LIVE_DAEMON_READINESS, SkippableError } from '../../types.js';
 import type { Task } from '../../../types/task.js';
 import { SignedEnvelopeSchema } from '../../../types/envelope.js';
 import { uploadToIpfs } from '../../../adapters/mech/ipfs.js';
 import { SweRebenchV2Evaluator, type EvalRunner, type HfFetcher } from './index.js';
-import { PythonEvalRunner } from './eval-runner.js';
+import { PythonEvalRunner, EvalCouldNotGradeError } from './eval-runner.js';
 import { HttpHfFetcher } from './hf-fetcher.js';
 
 const DEFAULT_IPFS_REGISTRY_URL = 'https://registry.autonolas.tech';
@@ -279,7 +279,22 @@ export class SweRebenchV2EvaluatorHarness implements Harness {
       this.deps.runner ?? new PythonEvalRunner({ upstreamRepoDir: state.upstreamRepoDir });
     const evaluator = new SweRebenchV2Evaluator({ fetcher, runner });
 
-    const graded = await evaluator.grade({ task, solutionPayload });
+    let graded: Awaited<ReturnType<SweRebenchV2Evaluator['grade']>>;
+    try {
+      graded = await evaluator.grade({ task, solutionPayload });
+    } catch (err) {
+      if (err instanceof EvalCouldNotGradeError) {
+        // The eval never actually graded the solution (Docker down, patch
+        // failed to apply, install/test-setup failed, arch-incompatible
+        // image, …). There is no signal about the solver — emit no verdict.
+        // SkippableError → engine records a skip, nothing is delivered.
+        throw new SkippableError(
+          `eval_not_gradeable:${err.reason}`,
+          `${err.message}${err.logExcerpt ? `\n${err.logExcerpt}` : ''}`,
+        );
+      }
+      throw err;
+    }
 
     // Pin the test log to IPFS so anyone (evaluator dispute, audit, model
     // training) can fetch it anonymously by CID. The CID is surfaced via the

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/harness.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/harness.ts
@@ -145,6 +145,25 @@ export class SweRebenchV2EvaluatorHarness implements Harness {
         },
       };
     }
+    // Live Docker probe: the eval shells out to per-instance `docker run`
+    // images. Docker is validated at `jinn harnesses enable` time, but it can
+    // stop afterwards — re-check on every readiness probe so the daemon does
+    // not claim evaluation tasks it cannot grade. (Without this, a stopped
+    // Docker daemon turns every claimed eval into a bogus `passed_match:false`
+    // verdict — see jinn-mono-uy6v.8.)
+    const run = this.deps.runCommand ?? runCommand;
+    const dockerCheck = await run('docker', ['info']);
+    if (dockerCheck.exitCode !== 0) {
+      return {
+        ready: false,
+        reason: 'Docker daemon not reachable',
+        nextStep: {
+          description:
+            'Start Docker Desktop (or the docker daemon) — the SWE-rebench v2 evaluator runs per-instance Docker images. Once Docker is up the evaluator becomes ready automatically.',
+          url: 'https://docs.docker.com/get-docker/',
+        },
+      };
+    }
     return { ready: true };
   }
 

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/harness.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/harness.ts
@@ -19,6 +19,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { spawn, type SpawnOptions } from 'node:child_process';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import {
   SweRebenchV2TaskSchema,
@@ -85,12 +86,28 @@ export class SweRebenchV2EvaluatorHarness implements Harness {
   private readonly implStateDir: string | undefined;
   private readonly ipfsRegistryUrl: string;
   private readonly deps: NonNullable<SweRebenchV2EvaluatorHarnessOptions['_testDeps']>;
+  /** The engine's claim-eligibility check calls `isReady()` per candidate
+   *  task per tick (~17 Hz potential). Cache the live `docker info` result
+   *  for a short TTL so we don't spawn `docker` in a tight loop. */
+  private dockerCheckCache: { at: number; ok: boolean } | null = null;
+  private static readonly DOCKER_CHECK_TTL_MS = 5_000;
 
   constructor(opts: SweRebenchV2EvaluatorHarnessOptions = {}) {
     this.stub = opts.stub ?? false;
     this.implStateDir = opts.implStateDir;
     this.ipfsRegistryUrl = opts.ipfsRegistryUrl ?? DEFAULT_IPFS_REGISTRY_URL;
     this.deps = opts._testDeps ?? {};
+  }
+
+  private async isDockerReachable(now: number = Date.now()): Promise<boolean> {
+    const cached = this.dockerCheckCache;
+    if (cached && now - cached.at < SweRebenchV2EvaluatorHarness.DOCKER_CHECK_TTL_MS) {
+      return cached.ok;
+    }
+    const run = this.deps.runCommand ?? runCommand;
+    const r = await run('docker', ['info']);
+    this.dockerCheckCache = { at: now, ok: r.exitCode === 0 };
+    return this.dockerCheckCache.ok;
   }
 
   supports(ctx: { solverType: string; role?: 'restoration' | 'evaluation' }): boolean {
@@ -145,15 +162,13 @@ export class SweRebenchV2EvaluatorHarness implements Harness {
         },
       };
     }
-    // Live Docker probe: the eval shells out to per-instance `docker run`
-    // images. Docker is validated at `jinn harnesses enable` time, but it can
-    // stop afterwards — re-check on every readiness probe so the daemon does
+    // Live Docker probe (TTL-cached): the eval shells out to per-instance
+    // `docker run` images. Docker is validated at `jinn harnesses enable` time,
+    // but it can stop afterwards — re-check periodically so the daemon does
     // not claim evaluation tasks it cannot grade. (Without this, a stopped
     // Docker daemon turns every claimed eval into a bogus `passed_match:false`
     // verdict — see jinn-mono-uy6v.8.)
-    const run = this.deps.runCommand ?? runCommand;
-    const dockerCheck = await run('docker', ['info']);
-    if (dockerCheck.exitCode !== 0) {
+    if (!(await this.isDockerReachable())) {
       return {
         ready: false,
         reason: 'Docker daemon not reachable',
@@ -406,7 +421,17 @@ async function runCommand(
   });
 }
 
-function readEnabledState(implStateDir: string): EnabledState | null {
+/**
+ * The default `implStateDir` for the swe-rebench-v2 evaluator. The daemon
+ * normally injects this via `engine.implStateDirRoot`; consumers (e.g. the
+ * `validate-pool` CLI command) that need to locate the upstream eval repo
+ * without going through the daemon use this default.
+ */
+export function defaultSweRebenchV2EvaluatorImplStateDir(): string {
+  return join(process.env['HOME'] ?? homedir(), '.jinn-client', 'engine', 'impl-state', 'swe-rebench-v2-evaluator');
+}
+
+export function readEnabledState(implStateDir: string): EnabledState | null {
   const path = join(implStateDir, STATE_FILE);
   if (!existsSync(path)) return null;
   try {

--- a/client/src/solver-types/_swe-rebench-v2-validated-pool.ts
+++ b/client/src/solver-types/_swe-rebench-v2-validated-pool.ts
@@ -1,0 +1,253 @@
+/**
+ * Pool-validation gate for the swe-rebench-v2 task generator.
+ *
+ * SWE-rebench's leaderboard split contains instances that can't be scored in
+ * our eval environment — the dataset `test_cmd` runs a superset of the named
+ * tests, a `PASS_TO_PASS` test ERRORs without a service the container doesn't
+ * provide, the gold patch doesn't reproduce the expected transition, etc.
+ * Posting tasks for those just produces verdicts that say nothing about the
+ * solver. Standard practice (SWE-bench Verified by hand, SWE-rebench's pipeline
+ * automatically) is to validate each instance and only keep the scorable ones.
+ *
+ * `validatePoolInstances` does that validation: run the *gold* patch through
+ * our `PythonEvalRunner` and mark the instance scorable iff it resolves
+ * (`passed_match: true` under our SWE-bench "resolved" semantics). Results are
+ * cached per `(instance_id, evalSemanticsVersion)` in `<stateDir>/validated-pool.json`.
+ * The generator (`filterToScorablePool`) restricts its posting pool to the
+ * scorable set; absent validation data it falls back to Python-only instances
+ * (the languages our pytest `test_cmd` override supports) as a conservative floor.
+ *
+ * Refs: jinn-mono-uy6v.9.
+ */
+
+import { readFile, writeFile, mkdir, stat } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import type { PoolTask } from './_swe-rebench-v2-pool.js';
+import type { EvalRunner, HfFetcher } from '../harnesses/impls/swe-rebench-v2-evaluator/index.js';
+
+/**
+ * Bump when the eval grading semantics change (verdict re-derivation,
+ * ungradeable classification, test-command construction) so cached validation
+ * results from an older harness are treated as stale and re-checked. `'2'` =
+ * the SWE-bench "resolved" semantics + run-the-named-tests `test_cmd` override
+ * (jinn-mono-uy6v.8); `'1'` was the original exact-set `passed_match`.
+ */
+export const EVAL_SEMANTICS_VERSION = '2';
+
+const SCHEMA_VERSION = 'swe-rebench-v2-validated-pool.v1' as const;
+
+export interface ValidatedPoolEntry {
+  scorable: boolean;
+  /** Why scorable/unscorable — `'gold-patch-resolves'`, `'ungradeable:<reason>'`, etc. */
+  reason: string;
+  checkedAt: string; // ISO timestamp
+}
+
+interface ValidatedPoolFile {
+  schemaVersion: typeof SCHEMA_VERSION;
+  evalSemanticsVersion: string;
+  updatedAt: string;
+  entries: Record<string, ValidatedPoolEntry>;
+}
+
+function freshFile(evalSemanticsVersion: string): ValidatedPoolFile {
+  return { schemaVersion: SCHEMA_VERSION, evalSemanticsVersion, updatedAt: new Date().toISOString(), entries: {} };
+}
+
+function isValidFile(raw: unknown, evalSemanticsVersion: string): raw is ValidatedPoolFile {
+  return (
+    typeof raw === 'object' && raw !== null &&
+    (raw as ValidatedPoolFile).schemaVersion === SCHEMA_VERSION &&
+    (raw as ValidatedPoolFile).evalSemanticsVersion === evalSemanticsVersion &&
+    typeof (raw as ValidatedPoolFile).entries === 'object' && (raw as ValidatedPoolFile).entries !== null
+  );
+}
+
+export class ValidatedPoolStore {
+  private readonly file: string;
+  private cache: ValidatedPoolFile | null = null;
+  /** mtime-keyed cache for `getScorableIds`. The generator's tick reads this
+   *  every poll (every few seconds); the file only changes during infrequent
+   *  `validate-pool` CLI runs. Invalidate on mtime change. */
+  private scorableIdsCache: { mtimeMs: number; semanticsVersion: string; ids: Set<string> | null } | null = null;
+
+  constructor(opts: { stateDir: string }) {
+    this.file = join(opts.stateDir, 'validated-pool.json');
+  }
+
+  private async readRaw(): Promise<unknown> {
+    try {
+      return JSON.parse(await readFile(this.file, 'utf8'));
+    } catch {
+      return null;
+    }
+  }
+
+  private async loadForWrite(evalSemanticsVersion: string): Promise<ValidatedPoolFile> {
+    if (this.cache && this.cache.evalSemanticsVersion === evalSemanticsVersion) return this.cache;
+    const raw = await this.readRaw();
+    this.cache = isValidFile(raw, evalSemanticsVersion) ? raw : freshFile(evalSemanticsVersion);
+    return this.cache;
+  }
+
+  private async save(): Promise<void> {
+    if (!this.cache) return;
+    this.cache.updatedAt = new Date().toISOString();
+    await mkdir(dirname(this.file), { recursive: true });
+    await writeFile(this.file, JSON.stringify(this.cache, null, 2));
+  }
+
+  /** The set of instance ids known scorable for `evalSemanticsVersion`, or
+   *  `null` if there is no validation data for this semantics version (the
+   *  on-disk file is absent or built for a different version). Memoised by
+   *  mtime so the generator's tick doesn't re-parse the JSON every poll. */
+  async getScorableIds(evalSemanticsVersion: string): Promise<Set<string> | null> {
+    const mtimeMs = await stat(this.file).then((s) => s.mtimeMs).catch(() => -1);
+    const cached = this.scorableIdsCache;
+    if (cached && cached.mtimeMs === mtimeMs && cached.semanticsVersion === evalSemanticsVersion) {
+      return cached.ids;
+    }
+    const raw = await this.readRaw();
+    const ids = isValidFile(raw, evalSemanticsVersion)
+      ? new Set(Object.entries(raw.entries).filter(([, e]) => e.scorable).map(([id]) => id))
+      : null;
+    this.scorableIdsCache = { mtimeMs, semanticsVersion: evalSemanticsVersion, ids };
+    return ids;
+  }
+
+  /** The entry for `instanceId`, or `null` if not validated for this semantics version. */
+  async getEntry(instanceId: string, evalSemanticsVersion: string): Promise<ValidatedPoolEntry | null> {
+    const f = await this.loadForWrite(evalSemanticsVersion);
+    return f.entries[instanceId] ?? null;
+  }
+
+  async record(instanceId: string, entry: ValidatedPoolEntry, evalSemanticsVersion: string): Promise<void> {
+    const f = await this.loadForWrite(evalSemanticsVersion);
+    f.entries[instanceId] = entry;
+    await this.save();
+  }
+}
+
+/**
+ * Restrict the generator's posting pool to instances we can actually score.
+ * With validation data (`scorableIds` non-null): keep only the scorable set.
+ * Without it: fall back to Python-only instances — the conservative floor our
+ * pytest `test_cmd` override supports — and the caller should warn that the
+ * full gate (`jinn solver-nets validate-pool swe-rebench-v2`) hasn't been run.
+ *
+ * The `nebius/SWE-rebench-leaderboard` rows don't carry an explicit `language`
+ * field (it's `undefined`/`null` on every row), so we also infer from the
+ * patch file extensions — mirroring `inferLanguageFromPatch` in the solver-type.
+ */
+export function filterToScorablePool(
+  pool: PoolTask[],
+  scorableIds: Set<string> | null,
+): { pool: PoolTask[]; mode: 'validated' | 'python-floor' } {
+  if (scorableIds) {
+    return { pool: pool.filter((t) => scorableIds.has(t.instance_id)), mode: 'validated' };
+  }
+  return { pool: pool.filter(isPythonInstance), mode: 'python-floor' };
+}
+
+function isPythonInstance(task: PoolTask): boolean {
+  if (task.language === 'python') return true;
+  if (task.language && task.language !== 'python') return false;
+  // language unset → infer from `.py` in any patch path.
+  return looksPython(task.patch) || looksPython(task.test_patch);
+}
+
+function looksPython(patch: string | undefined): boolean {
+  if (!patch) return false;
+  // Match `--- a/<p>` / `+++ b/<p>` / `diff --git a/<p>` ending in .py
+  return /(?:^|\n)(?:---|\+\+\+|diff --git) [ab]\/\S+\.py(?:\s|$)/.test(patch);
+}
+
+export interface ValidatePoolDeps {
+  fetcher: HfFetcher;
+  runner: EvalRunner;
+  store: ValidatedPoolStore;
+  semanticsVersion: string;
+  log?: (msg: string) => void;
+}
+
+export interface ValidatePoolSummary {
+  checked: number;     // instances we ran the gold-eval for this run
+  scorable: number;    // of those, marked scorable
+  unscorable: number;  // of those, marked unscorable
+  skipped: number;     // non-Python instances we didn't even try
+}
+
+function nameOf(err: unknown): string {
+  return typeof err === 'object' && err !== null && typeof (err as { name?: unknown }).name === 'string'
+    ? (err as { name: string }).name : '';
+}
+function reasonOf(err: unknown): string {
+  return typeof err === 'object' && err !== null && typeof (err as { reason?: unknown }).reason === 'string'
+    ? (err as { reason: string }).reason : 'unknown';
+}
+
+/**
+ * Validate pool instances by running their gold patch through the eval harness.
+ * Idempotent: instances already recorded for `semanticsVersion` are skipped
+ * unless `opts.force`. `opts.limit` caps how many gold-evals one run does.
+ */
+export async function validatePoolInstances(
+  pool: PoolTask[],
+  deps: ValidatePoolDeps,
+  opts: { limit?: number; force?: boolean } = {},
+): Promise<ValidatePoolSummary> {
+  const log = deps.log ?? (() => {});
+  const summary: ValidatePoolSummary = { checked: 0, scorable: 0, unscorable: 0, skipped: 0 };
+  for (const task of pool) {
+    if (opts.limit != null && summary.checked >= opts.limit) break;
+
+    // Only pytest (Python) instances are supported by the eval-runner `test_cmd`
+    // override; everything else can't be scored cleanly today. The leaderboard
+    // rows don't carry an explicit language field — infer from the patch when
+    // unset.
+    if (!isPythonInstance(task)) {
+      await deps.store.record(task.instance_id, { scorable: false, reason: 'non-pytest-unsupported', checkedAt: new Date().toISOString() }, deps.semanticsVersion);
+      summary.skipped += 1;
+      continue;
+    }
+    if (!opts.force && (await deps.store.getEntry(task.instance_id, deps.semanticsVersion))) {
+      continue; // already validated for this semantics version
+    }
+    if (!task.patch || !task.test_patch) {
+      await deps.store.record(task.instance_id, { scorable: false, reason: 'missing-gold-patch', checkedAt: new Date().toISOString() }, deps.semanticsVersion);
+      summary.checked += 1; summary.unscorable += 1;
+      continue;
+    }
+
+    log(`[validate-pool] ${task.instance_id} …`);
+    let entry: ValidatedPoolEntry;
+    try {
+      const row = await deps.fetcher.fetchTaskRow({ hf_dataset: task.hf_dataset, hf_split: task.hf_split, instance_id: task.instance_id });
+      const res = await deps.runner.runEval({
+        instance_id: task.instance_id,
+        repo: task.repo ?? row.repo,
+        image: row.image_name,
+        patch: task.patch,
+        test_patch: row.test_patch ?? task.test_patch,
+        install: row.install_config.install,
+        test_cmd: row.install_config.test_cmd,
+        log_parser: row.install_config.log_parser,
+        fail_to_pass: row.FAIL_TO_PASS,
+        pass_to_pass: row.PASS_TO_PASS,
+      });
+      entry = res.passed_match
+        ? { scorable: true, reason: 'gold-patch-resolves', checkedAt: new Date().toISOString() }
+        : { scorable: false, reason: `gold-patch-not-resolved (f2p ${res.passed.length}, p2p_broke ${res.failed.length})`, checkedAt: new Date().toISOString() };
+    } catch (err) {
+      const reason = nameOf(err) === 'EvalCouldNotGradeError'
+        ? `ungradeable:${reasonOf(err)}`
+        : `error:${(err instanceof Error ? err.message : String(err)).slice(0, 200)}`;
+      entry = { scorable: false, reason, checkedAt: new Date().toISOString() };
+    }
+    await deps.store.record(task.instance_id, entry, deps.semanticsVersion);
+    summary.checked += 1;
+    if (entry.scorable) summary.scorable += 1; else summary.unscorable += 1;
+    log(`[validate-pool] ${task.instance_id} → ${entry.scorable ? 'SCORABLE' : 'unscorable'} (${entry.reason})`);
+  }
+  return summary;
+}

--- a/client/src/solver-types/swe-rebench-v2.ts
+++ b/client/src/solver-types/swe-rebench-v2.ts
@@ -27,13 +27,18 @@ import {
 } from './swe-rebench-v2-auto.js';
 import { GeneratorStateStore } from './_swe-rebench-v2-state.js';
 import {
+  ValidatedPoolStore,
+  filterToScorablePool,
+  EVAL_SEMANTICS_VERSION,
+} from './_swe-rebench-v2-validated-pool.js';
+import {
   buildHistoricalPool,
   fetchHfSplit,
   listMonthlyPartitions,
   type PoolTask,
 } from './_swe-rebench-v2-pool.js';
 
-const HF_DATASET = 'nebius/SWE-rebench-leaderboard';
+export const HF_DATASET = 'nebius/SWE-rebench-leaderboard';
 const SOLVER_TYPE = 'swe-rebench-v2.v1';
 const CONTRACT_ID = 'swe-rebench-v2';
 const CONTRACT_VERSION = 'v1';
@@ -96,6 +101,31 @@ interface InternalSweRebenchV2GeneratorConfig extends SweRebenchV2AutoConfig {
 
 function defaultStateDir(): string {
   return join(process.env['HOME'] ?? homedir(), '.jinn-client', 'swe-rebench-v2');
+}
+
+/**
+ * Load the full historical SWE-rebench v2 pool from the HF datasets-server.
+ * Throws if the splits listing is empty or unreachable. Shared by the
+ * generator's pool refresh and the `validate-pool` CLI command.
+ */
+export async function loadSweRebenchV2Pool(): Promise<PoolTask[]> {
+  const splitsUrl = `https://datasets-server.huggingface.co/splits?dataset=${encodeURIComponent(HF_DATASET)}`;
+  const response = await fetch(splitsUrl);
+  if (!response.ok) throw new Error(`HF splits fetch failed: ${response.status}`);
+  const json = (await response.json()) as { splits?: Array<{ split: string }> };
+  const months = listMonthlyPartitions((json.splits ?? []).map((s) => s.split));
+  if (months.length === 0) {
+    throw new Error('HF datasets-server returned no monthly partitions for the SWE-rebench v2 pool');
+  }
+  return buildHistoricalPool({
+    months,
+    fetchSplit: (split) => fetchHfSplit({ dataset: HF_DATASET, split, limit: 100 }),
+  });
+}
+
+/** A {@link ValidatedPoolStore} rooted at the swe-rebench-v2 generator's state dir. */
+export function getSweRebenchV2ValidatedPoolStore(stateDir?: string): ValidatedPoolStore {
+  return new ValidatedPoolStore({ stateDir: stateDir ?? defaultStateDir() });
 }
 
 function positiveInt(value: unknown, fallback: number): number {
@@ -243,9 +273,11 @@ async function maybeSignTask(
  */
 function makeSweRebenchV2Generator(config: InternalSweRebenchV2GeneratorConfig): SweRebenchV2GeneratorTick {
   const stateStore = new GeneratorStateStore({ stateDir: config.stateDir });
+  const validatedPoolStore = new ValidatedPoolStore({ stateDir: config.stateDir });
 
   let pool: PoolTask[] = [];
   let poolLoadedAt = 0;
+  let floorWarned = false;
   let lastPostedLanguage: string | undefined;
   let lastPollAt: string | undefined;
   let lastPollSummary: SweRebenchV2GeneratorStateSnapshot['lastPollSummary'];
@@ -255,20 +287,7 @@ function makeSweRebenchV2Generator(config: InternalSweRebenchV2GeneratorConfig):
 
   async function refreshPool(): Promise<void> {
     try {
-      // Fetch available splits from the HF datasets-server
-      const splitsUrl = `https://datasets-server.huggingface.co/splits?dataset=${encodeURIComponent(HF_DATASET)}`;
-      const response = await fetch(splitsUrl);
-      if (!response.ok) throw new Error(`HF splits fetch failed: ${response.status}`);
-      const json = (await response.json()) as { splits?: Array<{ split: string }> };
-      const splitNames = (json.splits ?? []).map((s) => s.split);
-      const months = listMonthlyPartitions(splitNames);
-      if (months.length === 0) return;
-
-      pool = await buildHistoricalPool({
-        months,
-        fetchSplit: (split) =>
-          fetchHfSplit({ dataset: HF_DATASET, split, limit: 100 }),
-      });
+      pool = await loadSweRebenchV2Pool();
       poolLoadedAt = Date.now();
     } catch (err) {
       // Non-fatal: keep the existing pool if already loaded
@@ -301,9 +320,26 @@ function makeSweRebenchV2Generator(config: InternalSweRebenchV2GeneratorConfig):
     }
     lastPollAt = new Date(now).toISOString();
 
+    // Restrict to instances we can actually score (validated gold-patch pool),
+    // or — absent validation data — to Python instances (the floor our pytest
+    // test_cmd override supports). See jinn-mono-uy6v.9.
+    const scorableIds = await validatedPoolStore.getScorableIds(EVAL_SEMANTICS_VERSION);
+    const { pool: eligiblePool, mode: poolMode } = filterToScorablePool(pool, scorableIds);
+    if (poolMode === 'python-floor' && !floorWarned) {
+      floorWarned = true;
+      console.warn(
+        `[swe-rebench-v2-gen] no pool-validation data — restricting to ${eligiblePool.length} Python instance(s) of ${pool.length}; run \`jinn solver-nets validate-pool swe-rebench-v2\` to validate the full pool.`,
+      );
+    }
+    if (eligiblePool.length === 0) {
+      lastPollSummary = { poolSize: 0, posted: 0, skipped: 0 };
+      lastError = undefined;
+      return null;
+    }
+
     // Load all counters for eligible tasks
     const counters = new Map<string, { posted: number; successful: number; last_posted_at: number }>();
-    for (const task of pool) {
+    for (const task of eligiblePool) {
       counters.set(task.instance_id, await stateStore.getCounters(task.instance_id));
     }
 
@@ -312,20 +348,20 @@ function makeSweRebenchV2Generator(config: InternalSweRebenchV2GeneratorConfig):
       ...Array.from(counters.values(), (c) => c.last_posted_at),
     );
     if (mostRecentPostedAt > 0 && now - mostRecentPostedAt < genConfig.cooldown_ms) {
-      lastPollSummary = { poolSize: pool.length, posted: 0, skipped: pool.length };
+      lastPollSummary = { poolSize: eligiblePool.length, posted: 0, skipped: eligiblePool.length };
       lastError = undefined;
       return null;
     }
 
     const candidate = selectNextPostingCandidate({
-      pool,
+      pool: eligiblePool,
       counters,
       config: genConfig,
       now,
       lastPostedLanguage,
     });
     if (!candidate) {
-      lastPollSummary = { poolSize: pool.length, posted: 0, skipped: pool.length };
+      lastPollSummary = { poolSize: eligiblePool.length, posted: 0, skipped: eligiblePool.length };
       lastError = undefined;
       return null;
     }
@@ -381,7 +417,7 @@ function makeSweRebenchV2Generator(config: InternalSweRebenchV2GeneratorConfig):
     };
 
     console.log(`[swe-rebench-v2-gen] posting ${candidate.instance_id}`);
-    lastPollSummary = { poolSize: pool.length, posted: 1, skipped: 0 };
+    lastPollSummary = { poolSize: eligiblePool.length, posted: 1, skipped: 0 };
     lastError = undefined;
     return maybeSignTask(task, { creator: config.creator, createdAt: now });
   };

--- a/client/test/harnesses/impls/claude-code-learner/codex-code-adapter.test.ts
+++ b/client/test/harnesses/impls/claude-code-learner/codex-code-adapter.test.ts
@@ -230,6 +230,8 @@ describe('CodexCodeHarnessAdapter', () => {
       expect(promptArg).toContain('Do not write');
       expect(promptArg).toContain('"schemaVersion":"swe-rebench-v2-solution.v1"');
       expect(promptArg).toContain(`${workingDir}/.execute/solution-payload.json`);
+      expect(promptArg).toMatch(/test files? .* discarded|discarded before grading/i);
+      expect(promptArg).toMatch(/edit source files? only|source files? only/i);
       expect(promptArg).not.toContain('submit_typed_payload, or write');
       expect(promptArg).not.toContain('submission tool or write the expected payload file');
       expect(promptArg).not.toContain('claude-code-learner:learn');

--- a/client/test/harnesses/impls/claude-code-learner/harvest.test.ts
+++ b/client/test/harnesses/impls/claude-code-learner/harvest.test.ts
@@ -631,6 +631,71 @@ describe('harvestOutput — generic typed-payload path', () => {
     expect(JSON.parse(readFileSync(payloadPath, 'utf8'))).toEqual(out.solutionPayload);
   });
 
+  function makeRepoWithDiff(workingDir: string): string {
+    const repoDir = join(workingDir, 'repo');
+    mkdirSync(repoDir, { recursive: true });
+    execFileSync('git', ['init', '-q'], { cwd: repoDir });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repoDir });
+    execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: repoDir });
+    writeFileSync(join(repoDir, 'example.py'), 'old = True\n');
+    mkdirSync(join(repoDir, 'tests'), { recursive: true });
+    writeFileSync(join(repoDir, 'tests', 'test_example.py'), 'def test_old():\n    assert True\n');
+    execFileSync('git', ['add', '.'], { cwd: repoDir });
+    execFileSync('git', ['commit', '-qm', 'base'], { cwd: repoDir });
+    // The model edits the source AND adds a regression test (normal agent behaviour).
+    writeFileSync(join(repoDir, 'example.py'), 'old = False\n');
+    writeFileSync(
+      join(repoDir, 'tests', 'test_example.py'),
+      'def test_old():\n    assert True\n\ndef test_new():\n    assert True\n',
+    );
+    return repoDir;
+  }
+
+  it('strips test-file changes from the materialized git-diff restoration patch', () => {
+    rmSync(workingDir, { recursive: true, force: true });
+    mkdirSync(workingDir, { recursive: true });
+    makeRepoWithDiff(workingDir);
+
+    const out = harvestOutput(workingDir, undefined, {
+      id: 'task-1',
+      description: 'd',
+      solverType: 'swe-rebench-v2.v1',
+      role: 'restoration',
+    } as never);
+
+    const patch = (out.solutionPayload as Record<string, unknown>).patch as string;
+    expect(patch).toContain('example.py');
+    expect(patch).toContain('old = False');
+    expect(patch).not.toContain('tests/test_example.py');
+    expect(patch).not.toContain('test_new');
+  });
+
+  it('prefers the git-diff harvest over a stale agent-authored solution-payload.json for swe-rebench restoration', () => {
+    rmSync(workingDir, { recursive: true, force: true });
+    mkdirSync(workingDir, { recursive: true });
+    makeRepoWithDiff(workingDir);
+    const dir = join(workingDir, '.execute');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'solution-payload.json'),
+      JSON.stringify({
+        schemaVersion: 'swe-rebench-v2-solution.v1',
+        patch: 'diff --git a/STALE.py b/STALE.py\n--- a/STALE.py\n+++ b/STALE.py\n@@ -1 +1 @@\n-x\n+y\n',
+      }),
+    );
+
+    const out = harvestOutput(workingDir, undefined, {
+      id: 'task-1',
+      description: 'd',
+      solverType: 'swe-rebench-v2.v1',
+      role: 'restoration',
+    } as never);
+
+    const patch = (out.solutionPayload as Record<string, unknown>).patch as string;
+    expect(patch).toContain('example.py');
+    expect(patch).not.toContain('STALE');
+  });
+
   it('falls through to phase-artifact-only shape when no typed payload was submitted', () => {
     // No .execute/solution-payload.json written.
     const out = harvestOutput(workingDir, undefined, {

--- a/client/test/harnesses/impls/claude-code-learner/restoration-patch.test.ts
+++ b/client/test/harnesses/impls/claude-code-learner/restoration-patch.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  isTestPath,
+  stripTestPathHunks,
+  gitApplyParseCheck,
+} from '../../../../src/harnesses/impls/claude-code-learner/restoration-patch.js';
+
+describe('isTestPath', () => {
+  it('flags conventional test directories', () => {
+    expect(isTestPath('pkg/tests/test_x.py')).toBe(true);
+    expect(isTestPath('a/test/foo.c')).toBe(true);
+    expect(isTestPath('src/__tests__/x.test.ts')).toBe(true);
+    expect(isTestPath('src/main/java/com/x/Foo.java')).toBe(false);
+    expect(isTestPath('src/test/java/com/x/FooTest.java')).toBe(true);
+  });
+
+  it('flags conventional test filenames', () => {
+    expect(isTestPath('pkg/test_graph.py')).toBe(true);
+    expect(isTestPath('pkg/graph_test.py')).toBe(true);
+    expect(isTestPath('pkg/conftest.py')).toBe(true);
+    expect(isTestPath('internal/foo_test.go')).toBe(true);
+    expect(isTestPath('src/foo.test.tsx')).toBe(true);
+    expect(isTestPath('src/foo.spec.js')).toBe(true);
+    expect(isTestPath('com/x/FooTests.java')).toBe(true);
+  });
+
+  it('does not flag plain source files', () => {
+    expect(isTestPath('pkg/graph.py')).toBe(false);
+    expect(isTestPath('src/index.ts')).toBe(false);
+    expect(isTestPath('internal/foo.go')).toBe(false);
+    expect(isTestPath('contrib/latest.py')).toBe(false); // not test_*; not *_test
+  });
+});
+
+describe('stripTestPathHunks', () => {
+  it('removes whole diff sections for test paths but keeps source sections', () => {
+    const patch = [
+      'diff --git a/src/foo.py b/src/foo.py',
+      'index 1111111..2222222 100644',
+      '--- a/src/foo.py',
+      '+++ b/src/foo.py',
+      '@@ -1 +1 @@',
+      '-old',
+      '+new',
+      'diff --git a/tests/test_foo.py b/tests/test_foo.py',
+      'index 3333333..4444444 100644',
+      '--- a/tests/test_foo.py',
+      '+++ b/tests/test_foo.py',
+      '@@ -10,3 +10,9 @@',
+      ' def test_existing():',
+      '     pass',
+      '+',
+      '+def test_new():',
+      '+    assert True',
+      '',
+    ].join('\n');
+    const out = stripTestPathHunks(patch);
+    expect(out).toContain('a/src/foo.py');
+    expect(out).not.toContain('tests/test_foo.py');
+    expect(out).not.toContain('def test_new');
+  });
+
+  it('returns empty string when only test sections remain', () => {
+    const patch = [
+      'diff --git a/tests/test_foo.py b/tests/test_foo.py',
+      '--- a/tests/test_foo.py',
+      '+++ b/tests/test_foo.py',
+      '@@ -1 +1 @@',
+      '-a',
+      '+b',
+      '',
+    ].join('\n');
+    expect(stripTestPathHunks(patch)).toBe('');
+  });
+
+  it('drops a rename whose old or new side is a test path', () => {
+    const patch = [
+      'diff --git a/src/old_name.py b/tests/test_relocated.py',
+      'similarity index 100%',
+      'rename from src/old_name.py',
+      'rename to tests/test_relocated.py',
+      'diff --git a/src/keep.py b/src/keep.py',
+      '--- a/src/keep.py',
+      '+++ b/src/keep.py',
+      '@@ -1 +1 @@',
+      '-x',
+      '+y',
+      '',
+    ].join('\n');
+    const out = stripTestPathHunks(patch);
+    expect(out).toContain('src/keep.py');
+    expect(out).not.toContain('test_relocated');
+  });
+
+  it('is idempotent and leaves an all-source patch untouched', () => {
+    const patch = [
+      'diff --git a/src/a.py b/src/a.py',
+      '--- a/src/a.py',
+      '+++ b/src/a.py',
+      '@@ -1 +1 @@',
+      '-1',
+      '+2',
+      '',
+    ].join('\n');
+    const once = stripTestPathHunks(patch);
+    expect(once).toContain('src/a.py');
+    expect(stripTestPathHunks(once)).toBe(once);
+  });
+
+  it('passes through a non-git-format patch unchanged', () => {
+    const patch = '--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b\n';
+    expect(stripTestPathHunks(patch)).toBe(patch);
+  });
+});
+
+describe('gitApplyParseCheck', () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  });
+
+  function makeRepo(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'restoration-patch-test-'));
+    dirs.push(dir);
+    execFileSync('git', ['init', '-q'], { cwd: dir });
+    execFileSync('git', ['config', 'user.email', 't@e.x'], { cwd: dir });
+    execFileSync('git', ['config', 'user.name', 't'], { cwd: dir });
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(join(dir, 'src', 'a.py'), 'old = True\nkeep = 1\n');
+    execFileSync('git', ['add', '.'], { cwd: dir });
+    execFileSync('git', ['commit', '-qm', 'base'], { cwd: dir });
+    return dir;
+  }
+
+  it('accepts a well-formed diff', () => {
+    const dir = makeRepo();
+    const patch = [
+      'diff --git a/src/a.py b/src/a.py',
+      '--- a/src/a.py',
+      '+++ b/src/a.py',
+      '@@ -1,2 +1,2 @@',
+      '-old = True',
+      '+old = False',
+      ' keep = 1',
+      '',
+    ].join('\n');
+    expect(gitApplyParseCheck(dir, patch)).toEqual({ ok: true });
+  });
+
+  it('rejects a malformed diff (context line missing its leading space)', () => {
+    const dir = makeRepo();
+    const patch = [
+      'diff --git a/src/a.py b/src/a.py',
+      '--- a/src/a.py',
+      '+++ b/src/a.py',
+      '@@ -1,2 +1,2 @@',
+      '-old = True',
+      '+old = False',
+      'keep = 1', // <-- should be ' keep = 1' — corruption
+      '',
+    ].join('\n');
+    const r = gitApplyParseCheck(dir, patch);
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects an empty patch', () => {
+    const dir = makeRepo();
+    expect(gitApplyParseCheck(dir, '   ').ok).toBe(false);
+  });
+});

--- a/client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts
+++ b/client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts
@@ -105,12 +105,35 @@ describe('PythonEvalRunner', () => {
     const observedTask = JSON.parse(readFileSync(join(upstreamRepoDir, 'observed-task.json'), 'utf8'));
     expect(observedTask.instance_id).toBe('astronomer__astronomer-cosmos-2332');
     expect(observedTask.repo).toBe('jinn/testbed');
-    expect(observedTask.install_config.test_cmd).toEqual([
-      'pip install -e .',
-      'pytest tests/dbt/test_graph.py',
-    ]);
     expect(result.passed_match).toBe(true);
     expect(result.passed).toEqual(['test_a']);
+  });
+
+  it('overrides test_cmd to run exactly the FAIL_TO_PASS ∪ PASS_TO_PASS node ids for pytest instances', async () => {
+    const upstreamRepoDir = makeUpstreamFixture();
+    await new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 }).runEval({
+      ...REQUEST,
+      fail_to_pass: ['tests/a.py::test_x'],
+      pass_to_pass: ['tests/a.py::test_y', 'tests/a.py::test_z[0]'],
+    });
+    const observedTask = JSON.parse(readFileSync(join(upstreamRepoDir, 'observed-task.json'), 'utf8'));
+    expect(observedTask.install_config.test_cmd).toEqual([
+      'pip install -e .',
+      `python -m pytest --no-header -rA --tb=no -p no:cacheprovider 'tests/a.py::test_x' 'tests/a.py::test_y' 'tests/a.py::test_z[0]'`,
+    ]);
+    // The dataset's broad/`-v` test command is not used.
+    expect(observedTask.install_config.test_cmd.join('\n')).not.toContain('tests/dbt/test_graph.py');
+  });
+
+  it('falls back to the dataset test_cmd verbatim for non-pytest log parsers', async () => {
+    const upstreamRepoDir = makeUpstreamFixture();
+    await new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 }).runEval({
+      ...REQUEST,
+      log_parser: 'parse_log_go',
+      test_cmd: 'go test ./...',
+    });
+    const observedTask = JSON.parse(readFileSync(join(upstreamRepoDir, 'observed-task.json'), 'utf8'));
+    expect(observedTask.install_config.test_cmd).toEqual(['pip install -e .', 'go test ./...']);
   });
 
   it('pins the docker platform to linux/amd64 for the eval subprocess', async () => {

--- a/client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts
+++ b/client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts
@@ -31,6 +31,7 @@ function makeUpstreamFixture(opts: {
   writeFileSync(join(scriptsDir, 'eval.py'), `
 import argparse
 import json
+import os
 from pathlib import Path
 
 parser = argparse.ArgumentParser()
@@ -43,6 +44,7 @@ args = parser.parse_args()
 tasks = json.loads(Path(args.json).read_text())
 Path("observed-task.json").write_text(json.dumps(tasks[0]))
 Path("observed-patches.json").write_text(Path(args.patches).read_text())
+Path("observed-env.txt").write_text(os.environ.get("DOCKER_DEFAULT_PLATFORM", ""))
 Path("observed-log.txt").write_text(${JSON.stringify(logBody)})
 
 # Real upstream item shape: instance_id, exit_code (the docker-run exit code),
@@ -155,6 +157,23 @@ describe('PythonEvalRunner', () => {
     });
     const runner = new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 });
     await expect(runner.runEval(REQUEST)).rejects.toThrow(/grade/i);
+  });
+
+  it('pins the docker platform to linux/amd64 for the eval subprocess', async () => {
+    const upstreamRepoDir = makeUpstreamFixture();
+    const runner = new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 });
+    await runner.runEval(REQUEST);
+    expect(readFileSync(join(upstreamRepoDir, 'observed-env.txt'), 'utf8')).toBe('linux/amd64');
+  });
+
+  it('resolves a relative report log_path against the upstream repo dir', async () => {
+    const upstreamRepoDir = makeUpstreamFixture({
+      reportItem: { log_path: 'observed-log.txt' }, // relative, as upstream eval.py writes it
+      logBody: 'PYTEST OUTPUT HERE',
+    });
+    const runner = new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 });
+    const result = await runner.runEval(REQUEST);
+    expect(result.log).toContain('PYTEST OUTPUT HERE');
   });
 
   it('throws EvalCouldNotGradeError when the report file is missing/unparseable', async () => {

--- a/client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts
+++ b/client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts
@@ -10,12 +10,15 @@ import {
 const tempDirs: string[] = [];
 
 /**
- * Build a fake upstream `scripts.eval` repo. By default it writes a report
- * item shaped like the real upstream output for a passing run; pass
- * `reportItem` to override fields (e.g. simulate a Docker-down abort).
+ * Build a fake upstream `scripts.eval` repo. The fake `eval.py` writes a report
+ * item shaped like the *real* upstream output:
+ *   success     : { instance_id, from_fail_to_pass[], failed_from_pass_to_pass[],
+ *                   passed_match, exit_code, log_path, error: "" }
+ *   setup error : { instance_id, from_fail_to_pass: [], failed_from_pass_to_pass:
+ *                   [...PASS_TO_PASS...], error: "<message>" }   (no exit_code etc.)
  *
- * `logBody` is written to `observed-log.txt` and referenced via the item's
- * `log_path`.
+ * `reportItem` overrides fields on the success shape; passing `{ error: "..." }`
+ * switches to the setup-error shape.
  */
 function makeUpstreamFixture(opts: {
   reportItem?: Record<string, unknown>;
@@ -27,7 +30,7 @@ function makeUpstreamFixture(opts: {
   mkdirSync(scriptsDir, { recursive: true });
   writeFileSync(join(scriptsDir, '__init__.py'), '');
   const itemOverride = JSON.stringify(opts.reportItem ?? {});
-  const logBody = opts.logBody ?? 'ok';
+  const logBody = opts.logBody ?? 'test session starts\ntest_a PASSED\ntest_b PASSED\n2 passed';
   writeFileSync(join(scriptsDir, 'eval.py'), `
 import argparse
 import json
@@ -47,25 +50,28 @@ Path("observed-patches.json").write_text(Path(args.patches).read_text())
 Path("observed-env.txt").write_text(os.environ.get("DOCKER_DEFAULT_PLATFORM", ""))
 Path("observed-log.txt").write_text(${JSON.stringify(logBody)})
 
-# Real upstream item shape: instance_id, exit_code (the docker-run exit code),
-# passed_match, passed_expected, passed_actual, failed_actual, log_path, ...
-default_item = {
-  "instance_id": tasks[0]["instance_id"],
-  "exit_code": 0,
-  "passed_match": True,
-  "passed_actual": ["test_a"],
-  "failed_actual": [],
-  "log_path": str(Path("observed-log.txt").resolve()),
-}
 override = json.loads(${JSON.stringify(itemOverride)})
-default_item.update(override)
-default_item["instance_id"] = tasks[0]["instance_id"]
+if isinstance(override.get("error"), str) and override.get("error"):
+  item = {
+    "instance_id": tasks[0]["instance_id"],
+    "from_fail_to_pass": [],
+    "failed_from_pass_to_pass": list(tasks[0].get("PASS_TO_PASS", [])),
+    "error": override["error"],
+  }
+else:
+  item = {
+    "instance_id": tasks[0]["instance_id"],
+    "from_fail_to_pass": list(tasks[0].get("FAIL_TO_PASS", [])),
+    "failed_from_pass_to_pass": [],
+    "passed_match": True,
+    "exit_code": 0,
+    "log_path": str(Path("observed-log.txt").resolve()),
+    "error": "",
+  }
+  item.update(override)
+  item["instance_id"] = tasks[0]["instance_id"]
 
-Path(args.report_json).write_text(json.dumps({
-  "total": 1,
-  "passed": 1 if default_item.get("passed_match") else 0,
-  "items": [default_item],
-}))
+Path(args.report_json).write_text(json.dumps({"total": 1, "items": [item]}))
 `);
   chmodSync(join(scriptsDir, 'eval.py'), 0o755);
   return dir;
@@ -94,7 +100,6 @@ describe('PythonEvalRunner', () => {
   it('passes the real instance id and uses the SWE-rebench /testbed container workdir slug', async () => {
     const upstreamRepoDir = makeUpstreamFixture();
     const runner = new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 });
-
     const result = await runner.runEval(REQUEST);
 
     const observedTask = JSON.parse(readFileSync(join(upstreamRepoDir, 'observed-task.json'), 'utf8'));
@@ -108,72 +113,90 @@ describe('PythonEvalRunner', () => {
     expect(result.passed).toEqual(['test_a']);
   });
 
-  it('returns passed_match=false (a genuine wrong-answer) when the suite ran but the FAIL_TO_PASS test still fails', async () => {
-    // The container exited non-zero (pytest reports failures) but tests DID
-    // run: PASS_TO_PASS passed, the FAIL_TO_PASS test failed. This must be
-    // graded as a real verdict, not misclassified as an infra abort.
-    const upstreamRepoDir = makeUpstreamFixture({
-      reportItem: {
-        exit_code: 1,
-        passed_match: false,
-        passed_actual: ['test_b'],
-        failed_actual: ['test_a'],
-      },
-      logBody: 'test session starts\ntest_a FAILED\ntest_b PASSED\n1 failed, 1 passed',
-    });
-    const runner = new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 });
-    const result = await runner.runEval(REQUEST);
-    expect(result.passed_match).toBe(false);
-    expect(result.failed).toContain('test_a');
-  });
-
-  it('throws EvalCouldNotGradeError when Docker is unreachable (no test collected, container exit non-zero)', async () => {
-    const upstreamRepoDir = makeUpstreamFixture({
-      reportItem: {
-        exit_code: 125,
-        passed_match: false,
-        passed_actual: [],
-        failed_actual: [],
-      },
-      logBody:
-        'docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?',
-    });
-    const runner = new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 });
-    const err = await runner.runEval(REQUEST).catch((e: unknown) => e);
-    expect(err).toBeInstanceOf(EvalCouldNotGradeError);
-    expect((err as EvalCouldNotGradeError).reason).toBe('docker_unavailable');
-  });
-
-  it('throws EvalCouldNotGradeError when the patch failed to apply (git apply aborted before tests)', async () => {
-    const upstreamRepoDir = makeUpstreamFixture({
-      reportItem: {
-        exit_code: 1,
-        passed_match: false,
-        passed_actual: [],
-        failed_actual: [],
-      },
-      logBody:
-        'Checking patch src/foo.py...\nerror: corrupt patch at line 30',
-    });
-    const runner = new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 });
-    await expect(runner.runEval(REQUEST)).rejects.toThrow(/grade/i);
-  });
-
   it('pins the docker platform to linux/amd64 for the eval subprocess', async () => {
     const upstreamRepoDir = makeUpstreamFixture();
-    const runner = new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 });
-    await runner.runEval(REQUEST);
+    await new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 }).runEval(REQUEST);
     expect(readFileSync(join(upstreamRepoDir, 'observed-env.txt'), 'utf8')).toBe('linux/amd64');
   });
 
   it('resolves a relative report log_path against the upstream repo dir', async () => {
     const upstreamRepoDir = makeUpstreamFixture({
-      reportItem: { log_path: 'observed-log.txt' }, // relative, as upstream eval.py writes it
+      reportItem: { log_path: 'observed-log.txt' },
       logBody: 'PYTEST OUTPUT HERE',
     });
-    const runner = new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 });
-    const result = await runner.runEval(REQUEST);
+    const result = await new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 }).runEval(REQUEST);
     expect(result.log).toContain('PYTEST OUTPUT HERE');
+  });
+
+  it('re-derives a PASS verdict (SWE-bench resolved semantics) even when upstream passed_match is false', async () => {
+    // FAIL_TO_PASS passed, no PASS_TO_PASS broke — the fix is good. Upstream's
+    // `passed_match` is false only because the run also passed many other
+    // (unlisted) tests; we re-derive the correct verdict.
+    const upstreamRepoDir = makeUpstreamFixture({
+      reportItem: {
+        from_fail_to_pass: ['test_a'],
+        failed_from_pass_to_pass: [],
+        passed_match: false,            // upstream's exact-set comparison
+        exit_code: 1,                   // pytest exits non-zero — unlisted tests failed
+      },
+      logBody: 'test session starts\ntest_a PASSED\ntest_b PASSED\nunrelated_x FAILED\n1 failed, 1729 passed',
+    });
+    const result = await new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 }).runEval(REQUEST);
+    expect(result.passed_match).toBe(true);
+  });
+
+  it('returns passed_match=false (a genuine wrong-answer) when the FAIL_TO_PASS test still fails — not an infra abort', async () => {
+    const upstreamRepoDir = makeUpstreamFixture({
+      reportItem: {
+        from_fail_to_pass: [],          // FAIL_TO_PASS did not pass
+        failed_from_pass_to_pass: [],   // PASS_TO_PASS still pass
+        passed_match: false,
+        exit_code: 1,
+      },
+      logBody: 'test session starts\ntest_a FAILED\ntest_b PASSED\n1 failed, 1 passed',
+    });
+    const result = await new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 }).runEval(REQUEST);
+    expect(result.passed_match).toBe(false);
+    expect(result.passed).toEqual([]);
+  });
+
+  it('throws EvalCouldNotGradeError when Docker is unreachable (no test passed, non-zero exit, infra signature)', async () => {
+    const upstreamRepoDir = makeUpstreamFixture({
+      reportItem: {
+        from_fail_to_pass: [],
+        failed_from_pass_to_pass: ['test_b'], // every PASS_TO_PASS "broke" → nothing ran
+        passed_match: false,
+        exit_code: 125,
+      },
+      logBody: 'docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?',
+    });
+    const err = await new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 }).runEval(REQUEST).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(EvalCouldNotGradeError);
+    expect((err as EvalCouldNotGradeError).reason).toBe('docker_unavailable');
+  });
+
+  it('throws EvalCouldNotGradeError when the model patch failed to apply (git apply aborted before tests)', async () => {
+    const upstreamRepoDir = makeUpstreamFixture({
+      reportItem: {
+        from_fail_to_pass: [],
+        failed_from_pass_to_pass: ['test_b'],
+        passed_match: false,
+        exit_code: 1,
+      },
+      logBody: 'Checking patch src/foo.py...\nerror: corrupt patch at line 30',
+    });
+    const err = await new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 }).runEval(REQUEST).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(EvalCouldNotGradeError);
+    expect((err as EvalCouldNotGradeError).reason).toBe('patch_corrupt');
+  });
+
+  it('throws EvalCouldNotGradeError on the upstream setup-error report shape (e.g. missing image_name)', async () => {
+    const upstreamRepoDir = makeUpstreamFixture({
+      reportItem: { error: 'Task astronomer__astronomer-cosmos-2332 missing top-level image_name.' },
+    });
+    const err = await new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 }).runEval(REQUEST).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(EvalCouldNotGradeError);
+    expect((err as EvalCouldNotGradeError).reason).toBe('eval_setup_error');
   });
 
   it('throws EvalCouldNotGradeError when the report file is missing/unparseable', async () => {
@@ -182,10 +205,9 @@ describe('PythonEvalRunner', () => {
     const scriptsDir = join(dir, 'scripts');
     mkdirSync(scriptsDir, { recursive: true });
     writeFileSync(join(scriptsDir, '__init__.py'), '');
-    // eval.py that never writes the report.
     writeFileSync(join(scriptsDir, 'eval.py'), 'import sys\nsys.exit(2)\n');
     chmodSync(join(scriptsDir, 'eval.py'), 0o755);
-    const runner = new PythonEvalRunner({ upstreamRepoDir: dir, maxWorkers: 1 });
-    await expect(runner.runEval(REQUEST)).rejects.toBeInstanceOf(EvalCouldNotGradeError);
+    await expect(new PythonEvalRunner({ upstreamRepoDir: dir, maxWorkers: 1 }).runEval(REQUEST))
+      .rejects.toBeInstanceOf(EvalCouldNotGradeError);
   });
 });

--- a/client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts
+++ b/client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts
@@ -2,16 +2,32 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { PythonEvalRunner } from '../../../../src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.js';
+import {
+  PythonEvalRunner,
+  EvalCouldNotGradeError,
+} from '../../../../src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.js';
 
 const tempDirs: string[] = [];
 
-function makeUpstreamFixture(): string {
+/**
+ * Build a fake upstream `scripts.eval` repo. By default it writes a report
+ * item shaped like the real upstream output for a passing run; pass
+ * `reportItem` to override fields (e.g. simulate a Docker-down abort).
+ *
+ * `logBody` is written to `observed-log.txt` and referenced via the item's
+ * `log_path`.
+ */
+function makeUpstreamFixture(opts: {
+  reportItem?: Record<string, unknown>;
+  logBody?: string;
+} = {}): string {
   const dir = mkdtempSync(join(tmpdir(), 'swe-rebench-eval-runner-test-'));
   tempDirs.push(dir);
   const scriptsDir = join(dir, 'scripts');
   mkdirSync(scriptsDir, { recursive: true });
   writeFileSync(join(scriptsDir, '__init__.py'), '');
+  const itemOverride = JSON.stringify(opts.reportItem ?? {});
+  const logBody = opts.logBody ?? 'ok';
   writeFileSync(join(scriptsDir, 'eval.py'), `
 import argparse
 import json
@@ -27,24 +43,44 @@ args = parser.parse_args()
 tasks = json.loads(Path(args.json).read_text())
 Path("observed-task.json").write_text(json.dumps(tasks[0]))
 Path("observed-patches.json").write_text(Path(args.patches).read_text())
-Path("observed-log.txt").write_text("ok")
+Path("observed-log.txt").write_text(${JSON.stringify(logBody)})
+
+# Real upstream item shape: instance_id, exit_code (the docker-run exit code),
+# passed_match, passed_expected, passed_actual, failed_actual, log_path, ...
+default_item = {
+  "instance_id": tasks[0]["instance_id"],
+  "exit_code": 0,
+  "passed_match": True,
+  "passed_actual": ["test_a"],
+  "failed_actual": [],
+  "log_path": str(Path("observed-log.txt").resolve()),
+}
+override = json.loads(${JSON.stringify(itemOverride)})
+default_item.update(override)
+default_item["instance_id"] = tasks[0]["instance_id"]
+
 Path(args.report_json).write_text(json.dumps({
   "total": 1,
-  "passed": 1,
-  "items": [{
-    "instance_id": tasks[0]["instance_id"],
-    "passed_match": True,
-    "from_fail_to_pass": ["test_a"],
-    "failed_from_pass_to_pass": [],
-    "exit_code": 0,
-    "log_path": str(Path("observed-log.txt").resolve()),
-    "error": "",
-  }],
+  "passed": 1 if default_item.get("passed_match") else 0,
+  "items": [default_item],
 }))
 `);
   chmodSync(join(scriptsDir, 'eval.py'), 0o755);
   return dir;
 }
+
+const REQUEST = {
+  instance_id: 'astronomer__astronomer-cosmos-2332',
+  repo: 'astronomer/astronomer-cosmos',
+  image: 'swerebench/sweb.eval.x86_64.astronomer_1776_astronomer-cosmos-2332:latest',
+  patch: 'diff --git a/a b/a\n',
+  test_patch: 'diff --git a/t b/t\n',
+  install: 'pip install -e .',
+  test_cmd: 'pytest tests/dbt/test_graph.py',
+  log_parser: 'parse_log_pytest',
+  fail_to_pass: ['test_a'],
+  pass_to_pass: ['test_b'],
+} as const;
 
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
@@ -57,18 +93,7 @@ describe('PythonEvalRunner', () => {
     const upstreamRepoDir = makeUpstreamFixture();
     const runner = new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 });
 
-    const result = await runner.runEval({
-      instance_id: 'astronomer__astronomer-cosmos-2332',
-      repo: 'astronomer/astronomer-cosmos',
-      image: 'swerebench/sweb.eval.x86_64.astronomer_1776_astronomer-cosmos-2332:latest',
-      patch: 'diff --git a/a b/a\n',
-      test_patch: 'diff --git a/t b/t\n',
-      install: 'pip install -e .',
-      test_cmd: 'pytest tests/dbt/test_graph.py',
-      log_parser: 'parse_log_pytest',
-      fail_to_pass: ['test_a'],
-      pass_to_pass: ['test_b'],
-    });
+    const result = await runner.runEval(REQUEST);
 
     const observedTask = JSON.parse(readFileSync(join(upstreamRepoDir, 'observed-task.json'), 'utf8'));
     expect(observedTask.instance_id).toBe('astronomer__astronomer-cosmos-2332');
@@ -79,5 +104,69 @@ describe('PythonEvalRunner', () => {
     ]);
     expect(result.passed_match).toBe(true);
     expect(result.passed).toEqual(['test_a']);
+  });
+
+  it('returns passed_match=false (a genuine wrong-answer) when the suite ran but the FAIL_TO_PASS test still fails', async () => {
+    // The container exited non-zero (pytest reports failures) but tests DID
+    // run: PASS_TO_PASS passed, the FAIL_TO_PASS test failed. This must be
+    // graded as a real verdict, not misclassified as an infra abort.
+    const upstreamRepoDir = makeUpstreamFixture({
+      reportItem: {
+        exit_code: 1,
+        passed_match: false,
+        passed_actual: ['test_b'],
+        failed_actual: ['test_a'],
+      },
+      logBody: 'test session starts\ntest_a FAILED\ntest_b PASSED\n1 failed, 1 passed',
+    });
+    const runner = new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 });
+    const result = await runner.runEval(REQUEST);
+    expect(result.passed_match).toBe(false);
+    expect(result.failed).toContain('test_a');
+  });
+
+  it('throws EvalCouldNotGradeError when Docker is unreachable (no test collected, container exit non-zero)', async () => {
+    const upstreamRepoDir = makeUpstreamFixture({
+      reportItem: {
+        exit_code: 125,
+        passed_match: false,
+        passed_actual: [],
+        failed_actual: [],
+      },
+      logBody:
+        'docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?',
+    });
+    const runner = new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 });
+    const err = await runner.runEval(REQUEST).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(EvalCouldNotGradeError);
+    expect((err as EvalCouldNotGradeError).reason).toBe('docker_unavailable');
+  });
+
+  it('throws EvalCouldNotGradeError when the patch failed to apply (git apply aborted before tests)', async () => {
+    const upstreamRepoDir = makeUpstreamFixture({
+      reportItem: {
+        exit_code: 1,
+        passed_match: false,
+        passed_actual: [],
+        failed_actual: [],
+      },
+      logBody:
+        'Checking patch src/foo.py...\nerror: corrupt patch at line 30',
+    });
+    const runner = new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 });
+    await expect(runner.runEval(REQUEST)).rejects.toThrow(/grade/i);
+  });
+
+  it('throws EvalCouldNotGradeError when the report file is missing/unparseable', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'swe-rebench-eval-runner-test-'));
+    tempDirs.push(dir);
+    const scriptsDir = join(dir, 'scripts');
+    mkdirSync(scriptsDir, { recursive: true });
+    writeFileSync(join(scriptsDir, '__init__.py'), '');
+    // eval.py that never writes the report.
+    writeFileSync(join(scriptsDir, 'eval.py'), 'import sys\nsys.exit(2)\n');
+    chmodSync(join(scriptsDir, 'eval.py'), 0o755);
+    const runner = new PythonEvalRunner({ upstreamRepoDir: dir, maxWorkers: 1 });
+    await expect(runner.runEval(REQUEST)).rejects.toBeInstanceOf(EvalCouldNotGradeError);
   });
 });

--- a/client/test/harnesses/impls/swe-rebench-v2-evaluator/harness.test.ts
+++ b/client/test/harnesses/impls/swe-rebench-v2-evaluator/harness.test.ts
@@ -200,6 +200,19 @@ describe('SweRebenchV2EvaluatorHarness — isReady', () => {
     expect(runCommand).toHaveBeenCalledWith('docker', ['info']);
   });
 
+  it('caches the docker info probe across rapid isReady() calls (claim-loop hot path)', async () => {
+    makeEnabledMarker(implStateDir, join(implStateDir, 'upstream'));
+    const runCommand = vi.fn(async (bin: string) =>
+      bin === 'docker' ? { exitCode: 0, stdout: 'ok', stderr: '' } : { exitCode: 0, stdout: '', stderr: '' },
+    );
+    const h = new SweRebenchV2EvaluatorHarness({ implStateDir, _testDeps: { runCommand } });
+    for (let i = 0; i < 25; i++) {
+      const r = await h.isReady();
+      expect(r.ready).toBe(true);
+    }
+    expect(runCommand).toHaveBeenCalledTimes(1);
+  });
+
   it('reports not-ready when upstream repo dir is missing despite a marker', async () => {
     // Marker pointing at a non-existent dir.
     writeFileSync(

--- a/client/test/harnesses/impls/swe-rebench-v2-evaluator/harness.test.ts
+++ b/client/test/harnesses/impls/swe-rebench-v2-evaluator/harness.test.ts
@@ -414,6 +414,35 @@ describe('SweRebenchV2EvaluatorHarness — run', () => {
     expect((sol.verdictPayload as Record<string, unknown>)['passed_match']).toBe(false);
   });
 
+  it('does not produce a verdict when the eval could not grade the solution (skips instead)', async () => {
+    const { EvalCouldNotGradeError } = await import(
+      '../../../../src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.js'
+    );
+    const { SkippableError } = await import('../../../../src/harnesses/types.js');
+    const uploadToIpfs = vi.fn().mockResolvedValue('bafy-should-not-be-called');
+    const runner = {
+      runEval: vi
+        .fn()
+        .mockRejectedValue(
+          new EvalCouldNotGradeError(
+            'docker_unavailable',
+            'docker: Cannot connect to the Docker daemon',
+          ),
+        ),
+    };
+    const harness = new SweRebenchV2EvaluatorHarness({
+      implStateDir,
+      _testDeps: { fetcher: makeFakeFetcher(), runner, uploadToIpfs },
+    });
+    const ctx = buildHarnessContext(
+      implStateDir,
+      buildEvaluationTask(buildSolverEnvelope()),
+    );
+    await expect(harness.run(ctx)).rejects.toBeInstanceOf(SkippableError);
+    expect(uploadToIpfs).not.toHaveBeenCalled();
+    expect(existsSync(join(ctx.workingDir, 'swe-rebench-v2-verdict.json'))).toBe(false);
+  });
+
   it('throws when the envelope is not swe-rebench-v2.v1/restoration', async () => {
     const wrongEnvelope = buildSolverEnvelope({ solverType: 'prediction.v1' });
     const harness = new SweRebenchV2EvaluatorHarness({

--- a/client/test/harnesses/impls/swe-rebench-v2-evaluator/harness.test.ts
+++ b/client/test/harnesses/impls/swe-rebench-v2-evaluator/harness.test.ts
@@ -164,11 +164,40 @@ describe('SweRebenchV2EvaluatorHarness — isReady', () => {
     expect(r.reason).toBe('implStateDir not configured');
   });
 
-  it('reports ready when state file + upstream repo are present', async () => {
+  function dockerOk() {
+    return vi.fn(async (bin: string) =>
+      bin === 'docker'
+        ? { exitCode: 0, stdout: 'Server Version: 27.0.0', stderr: '' }
+        : { exitCode: 0, stdout: '', stderr: '' },
+    );
+  }
+
+  it('reports ready when state file + upstream repo are present and Docker is reachable', async () => {
     makeEnabledMarker(implStateDir, join(implStateDir, 'upstream'));
-    const h = new SweRebenchV2EvaluatorHarness({ implStateDir });
+    const h = new SweRebenchV2EvaluatorHarness({
+      implStateDir,
+      _testDeps: { runCommand: dockerOk() },
+    });
     const r = await h.isReady();
     expect(r.ready).toBe(true);
+  });
+
+  it('reports not-ready when Docker is unreachable, even with a valid enable marker', async () => {
+    makeEnabledMarker(implStateDir, join(implStateDir, 'upstream'));
+    const runCommand = vi.fn(async (bin: string) =>
+      bin === 'docker'
+        ? { exitCode: 1, stdout: '', stderr: 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock.' }
+        : { exitCode: 0, stdout: '', stderr: '' },
+    );
+    const h = new SweRebenchV2EvaluatorHarness({
+      implStateDir,
+      _testDeps: { runCommand },
+    });
+    const r = await h.isReady();
+    expect(r.ready).toBe(false);
+    expect(r.reason).toMatch(/docker/i);
+    expect(r.nextStep?.description).toMatch(/docker/i);
+    expect(runCommand).toHaveBeenCalledWith('docker', ['info']);
   });
 
   it('reports not-ready when upstream repo dir is missing despite a marker', async () => {

--- a/client/test/solver-types/swe-rebench-v2-validated-pool.test.ts
+++ b/client/test/solver-types/swe-rebench-v2-validated-pool.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  ValidatedPoolStore,
+  filterToScorablePool,
+  validatePoolInstances,
+  EVAL_SEMANTICS_VERSION,
+} from '../../src/solver-types/_swe-rebench-v2-validated-pool.js';
+import type { PoolTask } from '../../src/solver-types/_swe-rebench-v2-pool.js';
+
+const tmps: string[] = [];
+function tmpDir(): string {
+  const d = mkdtempSync(join(tmpdir(), 'swe-validated-pool-test-'));
+  tmps.push(d);
+  return d;
+}
+afterEach(() => {
+  for (const d of tmps.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+function poolTask(id: string, overrides: Partial<PoolTask> = {}): PoolTask {
+  return {
+    instance_id: id,
+    hf_dataset: 'nebius/SWE-rebench-leaderboard',
+    hf_split: '2026_02',
+    repo: 'acme/widget',
+    base_commit: 'deadbeef',
+    language: 'python',
+    patch: 'diff --git a/src/x.py b/src/x.py\n--- a/src/x.py\n+++ b/src/x.py\n@@ -1 +1 @@\n-a\n+b\n',
+    test_patch: 'diff --git a/tests/test_x.py b/tests/test_x.py\n--- a/tests/test_x.py\n+++ b/tests/test_x.py\n@@ -1 +1 @@\n-c\n+d\n',
+    ...overrides,
+  };
+}
+
+describe('ValidatedPoolStore', () => {
+  it('records entries and round-trips them via getEntry / getScorableIds', async () => {
+    const dir = tmpDir();
+    const store = new ValidatedPoolStore({ stateDir: dir });
+    await store.record('a__1', { scorable: true, reason: 'gold-patch-resolves', checkedAt: '2026-05-13T00:00:00Z' }, EVAL_SEMANTICS_VERSION);
+    await store.record('a__2', { scorable: false, reason: 'ungradeable:docker_unavailable', checkedAt: '2026-05-13T00:00:01Z' }, EVAL_SEMANTICS_VERSION);
+    expect((await store.getEntry('a__1', EVAL_SEMANTICS_VERSION))?.scorable).toBe(true);
+    expect((await store.getEntry('a__2', EVAL_SEMANTICS_VERSION))?.scorable).toBe(false);
+    expect(await store.getEntry('a__3', EVAL_SEMANTICS_VERSION)).toBeNull();
+    const scorable = await store.getScorableIds(EVAL_SEMANTICS_VERSION);
+    expect(scorable).toEqual(new Set(['a__1']));
+    expect(existsSync(join(dir, 'validated-pool.json'))).toBe(true);
+  });
+
+  it('getScorableIds returns null when the file is absent or built for a different semantics version', async () => {
+    const dir = tmpDir();
+    const store = new ValidatedPoolStore({ stateDir: dir });
+    expect(await store.getScorableIds(EVAL_SEMANTICS_VERSION)).toBeNull();
+    await store.record('a__1', { scorable: true, reason: 'ok', checkedAt: '2026-05-13T00:00:00Z' }, EVAL_SEMANTICS_VERSION);
+    expect(await store.getScorableIds(EVAL_SEMANTICS_VERSION)).toEqual(new Set(['a__1']));
+    // Same file, different semantics version → treated as no data.
+    expect(await store.getScorableIds('999')).toBeNull();
+  });
+
+  it('treats entries from a stale semantics version as not-yet-validated (re-validatable)', async () => {
+    const dir = tmpDir();
+    // Hand-write a file built for an old semantics version.
+    writeFileSync(join(dir, 'validated-pool.json'), JSON.stringify({
+      schemaVersion: 'swe-rebench-v2-validated-pool.v1',
+      evalSemanticsVersion: 'OLD',
+      updatedAt: '2026-01-01T00:00:00Z',
+      entries: { a__1: { scorable: true, reason: 'ok', checkedAt: '2026-01-01T00:00:00Z' } },
+    }));
+    const store = new ValidatedPoolStore({ stateDir: dir });
+    expect(await store.getEntry('a__1', EVAL_SEMANTICS_VERSION)).toBeNull();
+    expect(await store.getScorableIds(EVAL_SEMANTICS_VERSION)).toBeNull();
+  });
+});
+
+describe('filterToScorablePool', () => {
+  const pool: PoolTask[] = [
+    poolTask('a__1'),
+    poolTask('a__2'),
+    poolTask('go__1', { language: 'go' }),
+    poolTask('rust__1', { language: 'rust' }),
+  ];
+
+  it('restricts to validated-scorable instances when validation data is present', () => {
+    const { pool: out, mode } = filterToScorablePool(pool, new Set(['a__1', 'go__1']));
+    expect(mode).toBe('validated');
+    expect(out.map((t) => t.instance_id)).toEqual(['a__1', 'go__1']);
+  });
+
+  it('falls back to Python-only instances when no validation data exists', () => {
+    const { pool: out, mode } = filterToScorablePool(pool, null);
+    expect(mode).toBe('python-floor');
+    expect(out.map((t) => t.instance_id)).toEqual(['a__1', 'a__2']);
+  });
+
+  it('infers Python from .py paths in the patch when the language field is unset (as the leaderboard rows are)', () => {
+    const inferred: PoolTask[] = [
+      poolTask('a__inferred_py', { language: undefined, patch: 'diff --git a/src/foo.py b/src/foo.py\n--- a/src/foo.py\n+++ b/src/foo.py\n@@ -1 +1 @@\n-a\n+b\n' }),
+      poolTask('a__inferred_go', { language: undefined, patch: 'diff --git a/x.go b/x.go\n--- a/x.go\n+++ b/x.go\n@@ -1 +1 @@\n-a\n+b\n', test_patch: undefined }),
+    ];
+    const { pool: out } = filterToScorablePool(inferred, null);
+    expect(out.map((t) => t.instance_id)).toEqual(['a__inferred_py']);
+  });
+});
+
+describe('validatePoolInstances', () => {
+  function makeRunner(byId: Record<string, { passed_match: boolean; passed?: string[]; failed?: string[] } | Error>) {
+    return {
+      runEval: vi.fn(async (args: { instance_id: string }) => {
+        const v = byId[args.instance_id];
+        if (v instanceof Error) throw v;
+        if (!v) throw new Error(`no stub for ${args.instance_id}`);
+        return { passed_match: v.passed_match, passed: v.passed ?? [], failed: v.failed ?? [], log: '', exitCode: v.passed_match ? 0 : 1 };
+      }),
+    };
+  }
+  function makeFetcher() {
+    return {
+      fetchTaskRow: vi.fn(async (a: { instance_id: string }) => ({
+        instance_id: a.instance_id, repo: 'acme/widget',
+        image_name: `swerebench/sweb.eval.x86_64.acme_1776_${a.instance_id}:latest`,
+        FAIL_TO_PASS: ['tests/test_x.py::test_new'], PASS_TO_PASS: ['tests/test_x.py::test_old'],
+        test_patch: 'diff --git a/tests/test_x.py b/tests/test_x.py\n',
+        install_config: { install: 'pip install -e .', test_cmd: 'pytest tests/', log_parser: 'parse_log_pytest' },
+      })),
+    };
+  }
+
+  it('marks an instance scorable when the gold patch resolves, unscorable otherwise', async () => {
+    const dir = tmpDir();
+    const store = new ValidatedPoolStore({ stateDir: dir });
+    const runner = makeRunner({
+      a__pass: { passed_match: true, passed: ['tests/test_x.py::test_new'] },
+      a__fail: { passed_match: false, passed: [], failed: [] },
+      a__ungradeable: Object.assign(new Error('eval could not grade'), { name: 'EvalCouldNotGradeError', reason: 'docker_unavailable' }),
+    });
+    const summary = await validatePoolInstances(
+      [poolTask('a__pass'), poolTask('a__fail'), poolTask('a__ungradeable')],
+      { fetcher: makeFetcher(), runner, store, semanticsVersion: EVAL_SEMANTICS_VERSION },
+    );
+    expect(summary).toMatchObject({ checked: 3, scorable: 1, unscorable: 2, skipped: 0 });
+    expect((await store.getEntry('a__pass', EVAL_SEMANTICS_VERSION))?.scorable).toBe(true);
+    expect((await store.getEntry('a__fail', EVAL_SEMANTICS_VERSION))?.scorable).toBe(false);
+    const ung = await store.getEntry('a__ungradeable', EVAL_SEMANTICS_VERSION);
+    expect(ung?.scorable).toBe(false);
+    expect(ung?.reason).toMatch(/docker_unavailable/);
+  });
+
+  it('skips non-Python instances (records them unscorable, never invokes the runner)', async () => {
+    const dir = tmpDir();
+    const store = new ValidatedPoolStore({ stateDir: dir });
+    const runner = makeRunner({});
+    const summary = await validatePoolInstances(
+      [poolTask('go__1', { language: 'go' })],
+      { fetcher: makeFetcher(), runner, store, semanticsVersion: EVAL_SEMANTICS_VERSION },
+    );
+    expect(summary).toMatchObject({ checked: 0, skipped: 1 });
+    expect(runner.runEval).not.toHaveBeenCalled();
+    expect((await store.getEntry('go__1', EVAL_SEMANTICS_VERSION))?.scorable).toBe(false);
+  });
+
+  it('skips already-validated instances unless force is set', async () => {
+    const dir = tmpDir();
+    const store = new ValidatedPoolStore({ stateDir: dir });
+    await store.record('a__1', { scorable: true, reason: 'ok', checkedAt: '2026-05-13T00:00:00Z' }, EVAL_SEMANTICS_VERSION);
+    const runner = makeRunner({ a__1: { passed_match: false } });
+    const s1 = await validatePoolInstances([poolTask('a__1')], { fetcher: makeFetcher(), runner, store, semanticsVersion: EVAL_SEMANTICS_VERSION });
+    expect(s1.checked).toBe(0);
+    expect(runner.runEval).not.toHaveBeenCalled();
+    const s2 = await validatePoolInstances([poolTask('a__1')], { fetcher: makeFetcher(), runner, store, semanticsVersion: EVAL_SEMANTICS_VERSION }, { force: true });
+    expect(s2.checked).toBe(1);
+    expect(runner.runEval).toHaveBeenCalledTimes(1);
+    expect((await store.getEntry('a__1', EVAL_SEMANTICS_VERSION))?.scorable).toBe(false);
+  });
+
+  it('honors the limit on how many instances it validates in one run', async () => {
+    const dir = tmpDir();
+    const store = new ValidatedPoolStore({ stateDir: dir });
+    const runner = makeRunner({ a__1: { passed_match: true }, a__2: { passed_match: true }, a__3: { passed_match: true } });
+    const summary = await validatePoolInstances(
+      [poolTask('a__1'), poolTask('a__2'), poolTask('a__3')],
+      { fetcher: makeFetcher(), runner, store, semanticsVersion: EVAL_SEMANTICS_VERSION },
+      { limit: 2 },
+    );
+    expect(summary.checked).toBe(2);
+    expect(runner.runEval).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Fixes the SWE-rebench v2 evaluation loop so it stops emitting structurally-meaningless verdicts. Closes the code half of `jinn-mono-uy6v.8` / #182; blocks #161 (live verdict-success + JINN distribution).

**Why** — a 2026-05-12 audit (n=80 eval container logs) found the model's patch is only put on trial in ~6 of 80 runs; the other ~74 "failures" never grade the model and every infra failure was being signed as an on-chain `passed_match:false` verdict. Buckets: 46 Docker-down, 12 corrupt-patch, 7 test-file-collision, ~6 env-mismatch, 6 actually-graded (1 pass).

### Commits (stack on one branch; review commit-by-commit)

1. **`fix(uy6v.8): evaluator emits no verdict when the eval couldn't grade the solution`** — new `EvalCouldNotGradeError` in `eval-runner.ts` (classifies "container exit≠0 AND no expected test collected" as an infra abort — Docker-down, patch-apply failure, test-file conflict, install failure, arch-incompatible image, missing report); `harness.run()` re-raises it as `SkippableError` → engine records a skip, no verdict delivered, no test log pinned. A genuine wrong-answer run (FAIL_TO_PASS ran and failed) is still graded. Also fixes `passed`/`failed` to read the real upstream `passed_actual`/`failed_actual`. **(AC1)**
2. **`fix(uy6v.8): live Docker readiness gate on the SWE-rebench v2 evaluator`** — `isReady()` now probes `docker info` after the marker/upstream-repo checks; on failure → not-ready, so the engine's claim-eligibility check skips evaluation tasks until Docker is back (Docker was only validated once, at `jinn harnesses enable` time). **(AC2)**
3. **`fix(uy6v.8): SWE-rebench v2 restoration submits a source-only patch from git diff`** — new `restoration-patch.ts` (`stripTestPathHunks`, `isTestPath`, `gitApplyParseCheck`); `harvest.ts` now prefers the `git diff` over the task checkout over any agent-authored `.execute/solution-payload.json` for swe-rebench restoration, and strips test-path hunks from whichever patch wins (an all-test diff yields no submission → run re-attempted). Standard SWE-bench resets test files before grading; this approximates that on the producer side, since the restorer never sees the gold `test_patch`. Prompt updated: edit source only, test changes are discarded, let the harness derive the diff. **(AC3)**
4. **`fix(uy6v.8): pin SWE-rebench eval to linux/amd64 + capture the real container log`** — `DOCKER_DEFAULT_PLATFORM=linux/amd64` on the eval subprocess; resolve a relative report `log_path` against `upstreamRepoDir` so the pinned test-log artifact carries the actual pytest output, not just the progress bar.

### Tests

Regression-test-first throughout. New/changed tests in `swe-rebench-v2-evaluator/{eval-runner,harness}.test.ts` and `claude-code-learner/{restoration-patch,harvest,codex-code-adapter}.test.ts`. Full client suite green (`yarn test`: 3194 passed / 4 skipped); `yarn typecheck` clean.

### Not in this PR (follow-ups / manual)

- **AC4 re-baseline** (manual, post-merge): re-run the existing backlog on a linux/amd64 operator; the infra verdict buckets should → 0; report the actual pass rate over ≥50 graded attempts.
- Local loop smoke (Docker stopped → no `passed_match:false` verdicts produced; Docker up → eval reaches the grading stage) — run before merge.
- Stricter producer-side patch validation wired into harvest (`gitApplyParseCheck` is implemented + tested but not wired — would need fixture churn across the suite); auto-retry of `SkippableError`-skipped evals; an upstream `eval.py` PR (reset test paths before the gold patch / exit non-zero on infra failure) — all noted in the bead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
