### PR TITLE
Fix Docker testnet acceptance gate

### DIFF
--- a/client/docker-compose.acceptance.yml
+++ b/client/docker-compose.acceptance.yml
@@ -12,6 +12,8 @@ services:
   jinn-acceptance-daemon:
     image: ${JINN_ACCEPTANCE_IMAGE:-jinn-client:acceptance-local}
     restart: "no"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       JINN_PASSWORD: ${JINN_PASSWORD}
       # Non-interactive Claude auth. `claude setup-token` prints an OAT that
@@ -19,6 +21,9 @@ services:
       # flow needed. Keeps the daemon runnable in a headless container.
       CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
       JINN_DISABLE_AUTO_TASKS: ${JINN_DISABLE_AUTO_TASKS:-1}
+      JINN_NO_UI: ${JINN_NO_UI:-1}
+      JINN_POLYMARKET_GAMMA_BASE_URL: ${JINN_POLYMARKET_GAMMA_BASE_URL:-}
+      JINN_POLYMARKET_CLOB_BASE_URL: ${JINN_POLYMARKET_CLOB_BASE_URL:-}
       NO_COLOR: ${NO_COLOR:-1}
     volumes:
       - jinn-acceptance-data:/data

--- a/client/scripts/lib/acceptance-artifacts.mjs
+++ b/client/scripts/lib/acceptance-artifacts.mjs
@@ -106,6 +106,11 @@ export function readArtifactProgress(dbPath, taskIds) {
   }
 }
 
+export function cycleTaskId(taskId) {
+  if (typeof taskId !== 'string') return taskId;
+  return taskId.replace(/:evaluation:\d+$/u, '');
+}
+
 /**
  * Aggregate artifacts produced after `runStartAt` (ISO 8601), grouped by
  * `task_id`. A cycle is complete when both a `restoration-result`
@@ -132,17 +137,18 @@ export function summarizeRunWindowArtifacts(rows, runStartAt) {
     if (typeof sinceSqlite === 'string' && row.created_at) {
       if (row.created_at < sinceSqlite) continue;
     }
-    let entry = byTaskId.get(row.task_id);
+    const taskId = cycleTaskId(row.task_id);
+    let entry = byTaskId.get(taskId);
     if (!entry) {
       entry = {
-        taskId: row.task_id,
+        taskId,
         restorationRequestId: null,
         evaluationRequestId: null,
         restorationOk: false,
         evaluationOk: false,
         latestArtifactAt: null,
       };
-      byTaskId.set(row.task_id, entry);
+      byTaskId.set(taskId, entry);
     }
     const tags = new Set(normalizeTags(row.tags));
     if (tags.has('restoration-result')) {
@@ -165,8 +171,9 @@ export function summarizeRunWindowArtifacts(rows, runStartAt) {
 
 /**
  * Read artifacts produced after `runStartAt` whose task_id matches
- * the auto-generated `prediction.v0` prefix, then summarise as run-window
- * cycles. Returns the same shape regardless of whether the DB exists.
+ * the legacy auto-generated `prediction.v0` prefix, then summarise as
+ * run-window cycles. The Docker release gate uses its own task-id-scoped
+ * query, but this helper is retained for host/legacy drills.
  */
 export function readRunWindowArtifactProgress(dbPath, runStartAt) {
   if (!existsSync(dbPath)) {

--- a/client/scripts/lib/acceptance-operator-config.mjs
+++ b/client/scripts/lib/acceptance-operator-config.mjs
@@ -44,11 +44,10 @@ export function resolveAcceptanceRpcUrl(env = process.env) {
 }
 
 /**
- * Acceptance gate posts no static Tasks. The protocol loop is
- * exercised via the testnet auto-task generator (solverType=prediction.v0,
- * id prefix `pred-v0-auto-…`) which the daemon registers automatically when
- * `network=testnet` and `JINN_DISABLE_AUTO_TASKS` is not set. The gate
- * tracks any prediction.v0 cycles created after `runStartAt`.
+ * Acceptance gate posts no static Tasks through daemon config. The Docker
+ * gate seeds a manifest-backed prediction.v1 task and submits it from a
+ * separate CLI process so the daemon must discover, claim, solve, evaluate,
+ * and settle through the same Task-native path as a public operator.
  */
 export function buildAcceptanceTasks(_runIdSuffix) {
   return [];
@@ -74,12 +73,10 @@ export function buildOperatorClientConfig({ rpcUrl, clientHome, runIdSuffix, env
     targetServices: toInt(env['JINN_TESTNET_ACCEPTANCE_TARGET_SERVICES'], 1),
     minEoaGasWei: env['JINN_TESTNET_ACCEPTANCE_MIN_EOA_GAS_WEI'] ?? '1000000000000000',
     minSafeEthWei: env['JINN_TESTNET_ACCEPTANCE_MIN_SAFE_ETH_WEI'] ?? '200000000000000',
-    // Tighten prediction.v0 auto-cycles for the gate so one round-trip lands
-    // inside the 20-min timeout (default operator setup uses 600000 / 300000).
+    // Kept for legacy prediction.v0 ad-hoc drills; the Docker release gate
+    // now drives prediction.v1 by submitting a live manifest-backed task.
     predictionV0WindowMs: toInt(env['JINN_PREDICTION_V0_WINDOW_MS'], 120_000),
     predictionV0ResolveGapMs: toInt(env['JINN_PREDICTION_V0_RESOLVE_GAP_MS'], 60_000),
-    // Keep harness selection on the deterministic prediction.v0 defaults for
-    // the gate. SolverPlugins still load through the normal daemon defaults.
     tasks: buildAcceptanceTasks(runIdSuffix),
     operator: {
       publicEndpoint: env['JINN_TESTNET_ACCEPTANCE_OPERATOR_PUBLIC_ENDPOINT']

--- a/client/scripts/lib/docker-acceptance.mjs
+++ b/client/scripts/lib/docker-acceptance.mjs
@@ -73,13 +73,14 @@ export function buildDockerComposeEnv({
     JINN_POLL_INTERVAL_MS: String(pollIntervalMs),
     JINN_REWARD_CLAIM_INTERVAL_MS: String(rewardClaimIntervalMs),
     JINN_TARGET_SERVICES: String(targetServices),
-    // Release acceptance gates on prediction.v0 cycles produced by the
-    // testnet auto-task generator (solverType=prediction.v0, id prefix
-    // `pred-v0-auto-…`). Leaving auto-tasks enabled is required for the
-    // gate to observe the protocol loop end-to-end.
-    JINN_DISABLE_AUTO_TASKS: merged['JINN_DISABLE_AUTO_TASKS'] ?? '0',
+    // Release acceptance submits a manifest-backed prediction.v1 task from a
+    // one-off CLI process, then the daemon discovers and completes it through
+    // the normal Task-native path. Auto generators are not required.
+    JINN_DISABLE_AUTO_TASKS: merged['JINN_DISABLE_AUTO_TASKS'] ?? '1',
     JINN_PREDICTION_V0_WINDOW_MS: merged['JINN_PREDICTION_V0_WINDOW_MS'] ?? '120000',
     JINN_PREDICTION_V0_RESOLVE_GAP_MS: merged['JINN_PREDICTION_V0_RESOLVE_GAP_MS'] ?? '60000',
+    JINN_POLYMARKET_GAMMA_BASE_URL: merged['JINN_POLYMARKET_GAMMA_BASE_URL'] ?? '',
+    JINN_POLYMARKET_CLOB_BASE_URL: merged['JINN_POLYMARKET_CLOB_BASE_URL'] ?? '',
     // Non-interactive Claude auth: output of `claude setup-token`. When set,
     // the daemon inside the container uses it directly and no keychain /
     // libsecret / browser login is required.

--- a/client/scripts/testnet-acceptance-docker.mjs
+++ b/client/scripts/testnet-acceptance-docker.mjs
@@ -10,6 +10,7 @@
 
 import { spawnSync } from 'node:child_process';
 import { appendFileSync, chmodSync, mkdirSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
 import { dirname, join, resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 import { fileURLToPath } from 'node:url';
@@ -231,12 +232,13 @@ function warnIfBranchLagsMain() {
   }
 }
 
-function queryDockerArtifactRows(composeEnvPath, runStartAt, evidenceBase) {
+function queryDockerArtifactRows(composeEnvPath, runStartAt, evidenceBase, taskId) {
   const script = `
     import Database from 'better-sqlite3';
     import { existsSync } from 'node:fs';
     const dbPath = '/data/jinn.db';
     const since = process.argv[1];
+    const taskId = process.argv[2];
     if (!existsSync(dbPath)) {
       console.log('[]');
       process.exit(0);
@@ -246,10 +248,10 @@ function queryDockerArtifactRows(composeEnvPath, runStartAt, evidenceBase) {
       const rows = db.prepare(
         \`SELECT task_id, request_id, title, tags, outcome, created_at
             FROM artifacts
-           WHERE task_id LIKE 'pred-v0-auto-%'
+           WHERE (task_id = ? OR task_id LIKE ?)
              AND created_at >= ?
            ORDER BY created_at ASC\`,
-      ).all(since);
+      ).all(taskId, \`\${taskId}:evaluation:%\`, since);
       console.log(JSON.stringify(rows));
     } finally {
       db.close();
@@ -269,6 +271,7 @@ function queryDockerArtifactRows(composeEnvPath, runStartAt, evidenceBase) {
       '-e',
       script,
       isoToSqliteTimestamp(runStartAt),
+      taskId,
     ]),
     {
       cwd: clientRoot,
@@ -277,6 +280,241 @@ function queryDockerArtifactRows(composeEnvPath, runStartAt, evidenceBase) {
   );
   expectExit(result, [0], 'docker artifact query');
   return parseJsonStdout(result.stdout, 'docker-artifact-query');
+}
+
+async function startPolymarketFixtureServer() {
+  const now = Date.now();
+  const endDate = new Date(now + 48 * 60 * 60 * 1000).toISOString();
+  const market = {
+    id: 'acceptance-market-1',
+    marketId: 'acceptance-market-1',
+    conditionId: '0xacceptancecondition00000000000000000000000000000000000000000000000001',
+    slug: 'release-acceptance-market',
+    question: 'Will the release acceptance fixture remain unresolved during this gate?',
+    description: 'Deterministic local Polymarket-compatible fixture for release acceptance.',
+    rules: 'This fixture is intentionally unresolved while the gate runs.',
+    endDateIso: endDate,
+    active: true,
+    closed: false,
+    archived: false,
+    outcomes: JSON.stringify(['YES', 'NO']),
+    clobTokenIds: JSON.stringify(['acceptance-yes-token', 'acceptance-no-token']),
+    liquidity: '100000',
+    volume24hr: '50000',
+    url: '',
+  };
+  const book = {
+    bids: [{ price: '0.49', size: '100' }],
+    asks: [{ price: '0.51', size: '100' }],
+    timestamp: Date.now(),
+  };
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+    res.setHeader('content-type', 'application/json');
+    if (url.pathname === '/markets') {
+      res.end(JSON.stringify([market]));
+      return;
+    }
+    if (url.pathname === `/markets/${market.id}`) {
+      res.end(JSON.stringify(market));
+      return;
+    }
+    if (url.pathname === '/book') {
+      res.end(JSON.stringify(book));
+      return;
+    }
+    res.statusCode = 404;
+    res.end(JSON.stringify({ error: 'not found' }));
+  });
+
+  await new Promise((resolvePromise, rejectPromise) => {
+    server.once('error', rejectPromise);
+    server.listen(0, '0.0.0.0', () => {
+      server.off('error', rejectPromise);
+      resolvePromise();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('polymarket fixture server did not bind to a TCP port');
+  }
+  const dockerBaseUrl = `http://host.docker.internal:${address.port}`;
+  market.url = `${dockerBaseUrl}/markets/${market.id}`;
+  return {
+    server,
+    localBaseUrl: `http://127.0.0.1:${address.port}`,
+    dockerBaseUrl,
+    market,
+    marketUrl: market.url,
+    yesTokenId: 'acceptance-yes-token',
+    noTokenId: 'acceptance-no-token',
+    orderbook: {
+      sampledAt: new Date(book.timestamp).toISOString(),
+      bestBidYes: '0.4900',
+      bestAskYes: '0.5100',
+      midpointYes: '0.5000',
+      spread: '0.0200',
+      source: 'polymarket-clob',
+    },
+  };
+}
+
+function buildAcceptanceSeedScript(runId, fixture) {
+  return `
+    import { readFileSync, writeFileSync } from 'node:fs';
+    import { uploadToIpfs } from './dist/adapters/mech/ipfs.js';
+
+    const runId = ${JSON.stringify(runId)};
+    const fixture = ${JSON.stringify(fixture)};
+    const config = JSON.parse(readFileSync('/acceptance/config.json', 'utf8'));
+    const state = JSON.parse(readFileSync('/data/earning/earning_state.json', 'utf8'));
+    const service = (state.services ?? []).find((svc) =>
+      svc.step === 'complete' && svc.safe_address && svc.agent_address && svc.agent_id
+    );
+    if (!service) {
+      throw new Error('acceptance seed: no complete service with Safe, agent EOA, and agent id');
+    }
+
+    const nowIso = new Date().toISOString();
+    const solverNetId = 'acceptance_prediction-v1_' + runId.replace(/[^a-zA-Z0-9_.-]/g, '_');
+    const manifest = {
+      schemaVersion: 'solvernet.manifest.v1',
+      solverNetId,
+      network: 'base-sepolia',
+      name: 'Release acceptance Prediction v1',
+      description: 'Release acceptance SolverNet manifest for the public testnet gate.',
+      launcher: {
+        safeAddress: service.safe_address,
+        agentEoa: service.agent_address,
+        agentId: String(service.agent_id),
+      },
+      contract: {
+        id: 'prediction',
+        version: 'v1',
+        schemas: {
+          task: { type: 'object' },
+          solution: { type: 'object' },
+          verdict: { type: 'object' },
+        },
+        claimPolicyDefaults: {
+          mode: 'parallel',
+          maxClaims: 10,
+          maxClaimsPerOperator: 1,
+          claimLeaseTtlSeconds: 600,
+        },
+        credentialRequirements: {
+          creator: [],
+          solver: [],
+          evaluator: [],
+        },
+        evaluationFunction: {
+          id: 'prediction.brier-loss.v1',
+          deterministic: true,
+          inputs: ['prediction.v1 Task', 'prediction.v1 Solution', 'Polymarket/UMA resolution'],
+          output: 'prediction.v1 Verdict',
+          implementation: 'jinn:harness:prediction-v1-evaluator',
+        },
+        aggregationFunction: {
+          id: 'prediction.trailing-mean-brier-spread.v1',
+          deterministic: true,
+          inputs: ['SCORED prediction.v1 Verdicts'],
+          output: 'score',
+          windowDays: 30,
+        },
+      },
+      solutionPriceWei: '0',
+      verdictPriceWei: '0',
+      openRoles: ['solver', 'evaluator'],
+      createdAt: nowIso,
+      launchedAt: nowIso,
+      signature: {
+        alg: 'eip-191',
+        signer: service.agent_address,
+        value: '0x' + '00'.repeat(65),
+      },
+    };
+    const manifestCid = await uploadToIpfs(
+      config.ipfsRegistryUrl ?? 'https://registry.autonolas.tech',
+      manifest,
+    );
+
+    const now = Date.now();
+    const selected = fixture.market;
+    const selectedOrderbook = fixture.orderbook;
+    const taskPath = '/data/release-acceptance-task.json';
+    const taskTemplate = {
+      solverType: 'prediction.v1',
+      window: {
+        startTs: now,
+        endTs: now + 10 * 60 * 1000,
+      },
+      claimPolicy: {
+        mode: 'parallel',
+        maxClaims: 10,
+        maxClaimsPerOperator: 1,
+        claimLeaseTtlSeconds: 600,
+      },
+      spec: {
+        question: {
+          kind: 'binary',
+          text: selected.question,
+          yesLabel: 'YES',
+          noLabel: 'NO',
+        },
+        source: {
+          type: 'prediction-market',
+          venue: 'polymarket',
+          url: fixture.marketUrl,
+          identifiers: {
+            marketId: selected.id,
+            conditionId: selected.conditionId,
+            yesTokenId: fixture.yesTokenId,
+            noTokenId: fixture.noTokenId,
+          },
+        },
+        resolution: {
+          expectedResolutionTime: selected.endDateIso,
+          rulesText: selected.rules,
+          rulesUrl: fixture.marketUrl,
+          timezone: 'UTC',
+        },
+        consensusSnapshot: {
+          sampledAt: selectedOrderbook.sampledAt,
+          probabilityYes: selectedOrderbook.midpointYes,
+          method: 'best-bid-ask-midpoint',
+          bestBidYes: selectedOrderbook.bestBidYes,
+          bestAskYes: selectedOrderbook.bestAskYes,
+          spread: selectedOrderbook.spread,
+          source: 'polymarket-clob',
+        },
+        eligibilitySnapshot: {
+          sampledAt: new Date(now).toISOString(),
+          timeToResolutionHours: Number(((Date.parse(selected.endDateIso) - now) / 3600000).toFixed(2)),
+          liquidityUsd: selected.liquidity,
+          volume24hUsd: selected.volume24hr,
+          orderbookAgeSeconds: Math.max(0, Math.round((now - Date.parse(selectedOrderbook.sampledAt)) / 1000)),
+          selectionReason: 'release-acceptance-live-polymarket-cycle',
+        },
+      },
+      eligibility: {
+        maxSubmissionDelayMs: 60000,
+        acceptanceRunId: runId,
+      },
+    };
+    writeFileSync(taskPath, JSON.stringify(taskTemplate, null, 2) + '\\n', 'utf8');
+    console.log(JSON.stringify({
+      manifestCid,
+      solverNetId,
+      taskPath,
+      market: {
+        marketId: selected.marketId,
+        conditionId: selected.conditionId,
+        question: selected.question,
+        url: fixture.marketUrl,
+        resolutionStatus: 'unresolved',
+      },
+    }));
+  `;
 }
 
 async function sleep(ms) {
@@ -326,6 +564,7 @@ async function main() {
   const configPath = dockerAcceptanceConfigPath(clientRoot);
   const composeEnvPath = dockerAcceptanceComposeEnvPath(clientRoot);
   const runId = makeRunId();
+  const acceptanceTaskId = `release-acceptance-${runId}`;
   const evidenceDir = resolve(
     parsed.values['evidence-dir'] ?? join(dockerAcceptanceEvidenceRoot(clientRoot), runId),
   );
@@ -339,12 +578,24 @@ async function main() {
 
   ensureDir(workspaceRoot);
   ensureDir(evidenceDir);
+  const polymarketFixture = await startPolymarketFixtureServer();
+  let polymarketFixtureClosed = false;
+  const closePolymarketFixture = async () => {
+    if (polymarketFixtureClosed) return;
+    polymarketFixtureClosed = true;
+    await new Promise((resolvePromise) => polymarketFixture.server.close(resolvePromise));
+  };
+  const acceptanceEnv = {
+    ...gateEnv,
+    JINN_POLYMARKET_GAMMA_BASE_URL: polymarketFixture.dockerBaseUrl,
+    JINN_POLYMARKET_CLOB_BASE_URL: polymarketFixture.dockerBaseUrl,
+  };
 
   const config = buildOperatorClientConfig({
     rpcUrl,
     clientHome: '/data',
     runIdSuffix: runId,
-    env: gateEnv,
+    env: acceptanceEnv,
   });
   if (targetCycles < 1) {
     fail(`target-cycles (${targetCycles}) must be >= 1.`);
@@ -354,7 +605,7 @@ async function main() {
 
   const composeEnv = buildDockerComposeEnv({
     clientRoot,
-    env: gateEnv,
+    env: acceptanceEnv,
     imageTag,
     configPath,
   });
@@ -371,7 +622,14 @@ async function main() {
     dirty,
     composeEnvPath,
     configPath,
-    cycleSubstrate: 'prediction.v0',
+    cycleSubstrate: 'prediction.v1',
+    acceptanceTaskId,
+    polymarketFixture: {
+      localBaseUrl: polymarketFixture.localBaseUrl,
+      dockerBaseUrl: polymarketFixture.dockerBaseUrl,
+      marketId: polymarketFixture.market.id,
+      conditionId: polymarketFixture.market.conditionId,
+    },
     dataVolume: composeEnv.JINN_ACCEPTANCE_DATA_VOLUME,
     claudeVolume: composeEnv.JINN_ACCEPTANCE_CLAUDE_VOLUME,
   });
@@ -491,30 +749,73 @@ async function main() {
       fail('bootstrap: expected at least one complete service', bootstrap);
     }
 
-    const baselineStatus = parseJsonStdout(runJinn(['status', '--json'], '11-status-before').stdout, 'status-before');
-    const baselineRewards = parseJsonStdout(runJinn(['rewards', '--json'], '12-rewards-before').stdout, 'rewards-before');
-    const baselineHistory = parseJsonStdout(runJinnRaw(['history', '--limit', '500', '--json'], '13-history-before').stdout, 'history-before');
-    // runStartAt is the lower bound for cycle attribution: any prediction.v0
-    // artifacts created at or after this timestamp belong to this gate run.
+    const seed = parseJsonStdout(
+      runCompose([
+        'run',
+        '--rm',
+        '-T',
+        '--no-deps',
+        '--entrypoint',
+        'node',
+        composeService,
+        '--input-type=module',
+        '-e',
+        buildAcceptanceSeedScript(runId, {
+          market: polymarketFixture.market,
+          marketUrl: polymarketFixture.marketUrl,
+          yesTokenId: polymarketFixture.yesTokenId,
+          noTokenId: polymarketFixture.noTokenId,
+          orderbook: polymarketFixture.orderbook,
+        }),
+      ], '11-seed-acceptance-task').stdout,
+      'acceptance-seed',
+    );
+    writeJson(join(evidenceDir, '11-seed-acceptance-task.json'), seed);
+
+    config.joinedSolverNets = {
+      ...(config.joinedSolverNets ?? {}),
+      [seed.manifestCid]: {
+        manifestCid: seed.manifestCid,
+        name: 'Release acceptance Prediction v1',
+        contract: { id: 'prediction', version: 'v1' },
+        roles: ['solver', 'evaluator'],
+        harness: 'prediction-v1-baseline',
+      },
+    };
+    writeJson(configPath, config);
+
+    const baselineStatus = parseJsonStdout(runJinn(['status', '--json'], '12-status-before').stdout, 'status-before');
+    const baselineRewards = parseJsonStdout(runJinn(['rewards', '--json'], '13-rewards-before').stdout, 'rewards-before');
+    const baselineHistory = parseJsonStdout(runJinnRaw(['history', '--limit', '500', '--json'], '14-history-before').stdout, 'history-before');
+    // runStartAt is the lower bound for cycle attribution: any prediction.v1
+    // artifacts for acceptanceTaskId created at or after this timestamp belong
+    // to this gate run.
     const runStartAt = new Date().toISOString();
-    const baselineRows = queryDockerArtifactRows(composeEnvPath, runStartAt, join(evidenceDir, '14-artifacts-before'));
+    const baselineRows = queryDockerArtifactRows(
+      composeEnvPath,
+      runStartAt,
+      join(evidenceDir, '15-artifacts-before'),
+      acceptanceTaskId,
+    );
     const baselineArtifacts = summarizeRunWindowArtifacts(baselineRows, runStartAt);
     writeJson(join(evidenceDir, 'baseline-summary.json'), {
       historyCounts: countHistoryKinds(baselineHistory),
       runStartAt,
-      cycleSubstrate: 'prediction.v0',
+      cycleSubstrate: 'prediction.v1',
+      acceptanceTaskId,
+      acceptanceSeed: seed,
       artifactProgress: baselineArtifacts.byTaskId,
       pendingRewardsWei: sumPendingRewards(baselineRewards).toString(),
       status: baselineStatus,
     });
 
-    runCompose(['up', '-d', composeService], '15-compose-up', [0]);
+    runCompose(['up', '-d', composeService], '16-compose-up', [0]);
 
     let startup = null;
     const startupStartedAt = Date.now();
     while (Date.now() - startupStartedAt < 60_000) {
-      const logs = runCompose(['logs', '--no-color', composeService], '16-logs-startup', [0]);
-      writeFileSync(join(evidenceDir, '16-daemon.logs.txt'), logs.stdout, 'utf8');
+      const logs = runCompose(['logs', '--no-color', composeService], '17-logs-startup', [0]);
+      writeFileSync(join(evidenceDir, '17-daemon.logs.txt'), logs.stdout, 'utf8');
       const lines = logs.stdout.split('\n').map((line) => line.trim()).filter(Boolean);
       for (const rawLine of lines) {
         // Docker Compose prefixes lines with "<service>  | "; strip that.
@@ -536,17 +837,45 @@ async function main() {
     }
     if (!startup) {
       fail('daemon did not emit daemon_started within 60s', {
-        logsPath: join(evidenceDir, '16-daemon.logs.txt'),
+        logsPath: join(evidenceDir, '17-daemon.logs.txt'),
       });
     }
-    writeJson(join(evidenceDir, '16-run.startup.json'), startup);
+    writeJson(join(evidenceDir, '17-run.startup.json'), startup);
+
+    const submit = parseJsonStdout(
+      runJinnRaw([
+        'tasks',
+        'submit',
+        '--id',
+        acceptanceTaskId,
+        '--description',
+        'Release acceptance prediction.v1 protocol cycle',
+        '--solver-type',
+        'prediction.v1',
+        '--manifest-cid',
+        seed.manifestCid,
+        '--spec-file',
+        seed.taskPath,
+        '--yes',
+        '--json',
+        '--config',
+        '/acceptance/config.json',
+      ], '18-submit-acceptance-task').stdout,
+      'submit-acceptance-task',
+    );
+    writeJson(join(evidenceDir, '18-submit-acceptance-task.json'), submit);
 
     let observed = null;
-    const pollPath = join(evidenceDir, '17-cycle-poll.jsonl');
+    const pollPath = join(evidenceDir, '19-cycle-poll.jsonl');
     const pollStartedAt = Date.now();
     while (Date.now() - pollStartedAt < timeoutMs) {
-      const status = parseJsonStdout(runJinn(['status', '--json'], '17-status-poll').stdout, 'status-poll');
-      const rows = queryDockerArtifactRows(composeEnvPath, runStartAt, join(evidenceDir, '17-artifacts-poll'));
+      const status = parseJsonStdout(runJinn(['status', '--json'], '19-status-poll').stdout, 'status-poll');
+      const rows = queryDockerArtifactRows(
+        composeEnvPath,
+        runStartAt,
+        join(evidenceDir, '19-artifacts-poll'),
+        acceptanceTaskId,
+      );
       const artifactProgress = summarizeRunWindowArtifacts(rows, runStartAt);
       const snapshot = {
         at: new Date().toISOString(),
@@ -565,8 +894,8 @@ async function main() {
       await sleep(pollMs);
     }
 
-    const logsAfter = runCompose(['logs', '--no-color', '--timestamps', composeService], '18-logs-final', [0]);
-    writeFileSync(join(evidenceDir, '18-daemon.logs.txt'), logsAfter.stdout, 'utf8');
+    const logsAfter = runCompose(['logs', '--no-color', '--timestamps', composeService], '20-logs-final', [0]);
+    writeFileSync(join(evidenceDir, '20-daemon.logs.txt'), logsAfter.stdout, 'utf8');
 
     if (!observed) {
       fail(`Timed out waiting for ${targetCycles} new protocol cycles`, {
@@ -575,20 +904,25 @@ async function main() {
       });
     }
 
-    const stop = parseJsonStdout(runJinnRaw(['stop', '--json'], '19-stop').stdout, 'stop');
+    const stop = parseJsonStdout(runJinnRaw(['stop', '--json'], '21-stop').stdout, 'stop');
     await sleep(10_000);
 
-    const fleet = parseJsonStdout(runJinn(['fleet', '--json'], '20-fleet-after').stdout, 'fleet-after');
-    const statusAfter = parseJsonStdout(runJinn(['status', '--json'], '21-status-after').stdout, 'status-after');
-    const rewardsBeforeClaim = parseJsonStdout(runJinn(['rewards', '--json'], '22-rewards-before-claim').stdout, 'rewards-before-claim');
-    const historyAfter = parseJsonStdout(runJinnRaw(['history', '--limit', '500', '--json'], '23-history-after').stdout, 'history-after');
+    const fleet = parseJsonStdout(runJinn(['fleet', '--json'], '22-fleet-after').stdout, 'fleet-after');
+    const statusAfter = parseJsonStdout(runJinn(['status', '--json'], '23-status-after').stdout, 'status-after');
+    const rewardsBeforeClaim = parseJsonStdout(runJinn(['rewards', '--json'], '24-rewards-before-claim').stdout, 'rewards-before-claim');
+    const historyAfter = parseJsonStdout(runJinnRaw(['history', '--limit', '500', '--json'], '25-history-after').stdout, 'history-after');
     const artifactsAfter = summarizeRunWindowArtifacts(
-      queryDockerArtifactRows(composeEnvPath, runStartAt, join(evidenceDir, '24-artifacts-after')),
+      queryDockerArtifactRows(
+        composeEnvPath,
+        runStartAt,
+        join(evidenceDir, '26-artifacts-after'),
+        acceptanceTaskId,
+      ),
       runStartAt,
     );
-    writeJson(join(evidenceDir, '24-artifacts-after.json'), artifactsAfter);
+    writeJson(join(evidenceDir, '26-artifacts-after.json'), artifactsAfter);
 
-    const claim = parseJsonStdout(runJinn(['claim-rewards', '--yes', '--json'], '25-claim-rewards').stdout, 'claim-rewards');
+    const claim = parseJsonStdout(runJinn(['claim-rewards', '--yes', '--json'], '27-claim-rewards').stdout, 'claim-rewards');
     const pendingBeforeClaim = sumPendingRewards(rewardsBeforeClaim);
     const rewardClaimMode = pendingBeforeClaim > 0n ? 'submitted' : 'no-pending';
     if (pendingBeforeClaim > 0n && (claim.submitted ?? 0) <= 0) {
@@ -615,10 +949,13 @@ async function main() {
       version,
       doctor,
       bootstrap,
+      acceptanceTaskId,
+      acceptanceSeed: seed,
+      submit,
       startup,
       stop,
       runStartAt,
-      cycleSubstrate: 'prediction.v0',
+      cycleSubstrate: 'prediction.v1',
       observedCompletedCycles: observed.artifactProgress.completedCycles,
       observedArtifactProgress: observed.artifactProgress.byTaskId,
       pendingRewardsBeforeClaimWei: pendingBeforeClaim.toString(),
@@ -645,6 +982,7 @@ async function main() {
       cwd: clientRoot,
       evidenceBase: join(evidenceDir, '99-compose-down'),
     });
+    await closePolymarketFixture();
   }
 }
 

--- a/client/src/cli/open-browser.ts
+++ b/client/src/cli/open-browser.ts
@@ -10,7 +10,11 @@ export function openBrowser(url: string): void {
             : platform === 'win32'  ? 'start'
             : 'xdg-open';
   try {
-    spawn(cmd, [url], { detached: true, stdio: 'ignore' }).unref();
+    const child = spawn(cmd, [url], { detached: true, stdio: 'ignore' });
+    child.on('error', () => {
+      // best-effort; never crash the daemon over a failed browser launch
+    });
+    child.unref();
   } catch {
     // best-effort; never crash the daemon over a failed browser launch
   }

--- a/client/src/harnesses/impls/index.ts
+++ b/client/src/harnesses/impls/index.ts
@@ -67,6 +67,10 @@ export interface HarnessEnv {
   codexPath?: string;
   /** Default Codex model when a SolverNet does not specify one. */
   codexModel?: string;
+  /** Optional Polymarket Gamma API override for acceptance or private mirrors. */
+  polymarketGammaBaseUrl?: string;
+  /** Optional Polymarket CLOB API override for acceptance or private mirrors. */
+  polymarketClobBaseUrl?: string;
   /**
    * Root for impl-scoped state dirs (e.g. hyperliquid api-wallet). Defaults under
    * `~/.jinn-client/engine/impl-state` when unset — wired from `config.engine` in main.
@@ -160,7 +164,10 @@ export function buildHarnesses(env: HarnessEnv): Harness[] {
   out.push(
     isStub
       ? new PredictionV1Evaluator({ stub: true })
-      : new PredictionV1Evaluator(),
+      : new PredictionV1Evaluator({
+          ...(env.polymarketGammaBaseUrl ? { gammaBaseUrl: env.polymarketGammaBaseUrl } : {}),
+          ...(env.polymarketClobBaseUrl ? { clobBaseUrl: env.polymarketClobBaseUrl } : {}),
+        }),
   );
   out.push(
     new PredictionApyV0BaselineImpl({

--- a/client/src/harnesses/impls/prediction-v1-evaluator/index.ts
+++ b/client/src/harnesses/impls/prediction-v1-evaluator/index.ts
@@ -38,6 +38,8 @@ type Check = {
 
 export interface PredictionV1EvaluatorConfig {
   stub?: boolean;
+  gammaBaseUrl?: string;
+  clobBaseUrl?: string;
   _testDeps?: {
     getResolution?: typeof getResolution;
   };
@@ -208,7 +210,13 @@ export class PredictionV1Evaluator implements Harness {
     sourceUrl: string,
   ): Promise<ResolutionSnapshot> {
     const read = this.config._testDeps?.getResolution ?? getResolution;
-    return read({ marketId, conditionId, sourceUrl });
+    return read({
+      marketId,
+      conditionId,
+      sourceUrl,
+      ...(this.config.gammaBaseUrl ? { gammaBaseUrl: this.config.gammaBaseUrl } : {}),
+      ...(this.config.clobBaseUrl ? { clobBaseUrl: this.config.clobBaseUrl } : {}),
+    });
   }
 }
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1655,6 +1655,12 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     daemonApiToken: apiToken,
     implStateDirRoot: config.engine.implStateDirRoot,
     ipfsRegistryUrl: config.ipfsRegistryUrl,
+    ...(process.env['JINN_POLYMARKET_GAMMA_BASE_URL']
+      ? { polymarketGammaBaseUrl: process.env['JINN_POLYMARKET_GAMMA_BASE_URL'] }
+      : {}),
+    ...(process.env['JINN_POLYMARKET_CLOB_BASE_URL']
+      ? { polymarketClobBaseUrl: process.env['JINN_POLYMARKET_CLOB_BASE_URL'] }
+      : {}),
     externalImpls,
     disabledNames: config.harnesses?.disabled,
     corpusEnv,

--- a/client/test/cli/open-browser.test.ts
+++ b/client/test/cli/open-browser.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  spawn: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  spawn: mocks.spawn,
+}));
+
+import { openBrowser } from '../../src/cli/open-browser.js';
+
+describe('openBrowser', () => {
+  beforeEach(() => {
+    mocks.spawn.mockReset();
+  });
+
+  it('swallows async launcher errors from missing browser helpers', () => {
+    const child = {
+      on: vi.fn(),
+      unref: vi.fn(),
+    };
+    mocks.spawn.mockReturnValue(child);
+
+    openBrowser('http://127.0.0.1:7331/?k=test');
+
+    expect(child.on).toHaveBeenCalledWith('error', expect.any(Function));
+    expect(child.unref).toHaveBeenCalled();
+    const handler = child.on.mock.calls.find(([event]) => event === 'error')?.[1];
+    expect(() => handler?.(new Error('spawn xdg-open ENOENT'))).not.toThrow();
+  });
+
+  it('swallows synchronous spawn failures', () => {
+    mocks.spawn.mockImplementation(() => {
+      throw new Error('spawn failed');
+    });
+
+    expect(() => openBrowser('http://127.0.0.1:7331/?k=test')).not.toThrow();
+  });
+});

--- a/client/test/scripts/docker-acceptance.test.ts
+++ b/client/test/scripts/docker-acceptance.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
 import {
   buildDockerComposeEnv,
   dockerAcceptanceComposeEnvPath,
@@ -13,9 +14,10 @@ import {
   hasDockerAcceptanceClaudeToken,
   resolveDockerAcceptanceBaseEnv,
 } from '../../scripts/lib/docker-acceptance.mjs';
-import { isoToSqliteTimestamp, summarizeArtifactRows, summarizeRunWindowArtifacts } from '../../scripts/lib/acceptance-artifacts.mjs';
+import { cycleTaskId, isoToSqliteTimestamp, summarizeArtifactRows, summarizeRunWindowArtifacts } from '../../scripts/lib/acceptance-artifacts.mjs';
 
 const tempDirs: string[] = [];
+const repoClientRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
 function makeClientRoot(): string {
   const root = mkdtempSync(join(tmpdir(), 'jinn-docker-acceptance-'));
@@ -65,13 +67,22 @@ describe('docker acceptance helpers', () => {
     expect(composeEnv.JINN_ACCEPTANCE_IMAGE).toBe('jinn-client:test');
     expect(composeEnv.JINN_PASSWORD).toBe('secret');
     expect(composeEnv.JINN_RPC_URL).toBe('https://public.example');
-    expect(composeEnv.JINN_DISABLE_AUTO_TASKS).toBe('0');
+    expect(composeEnv.JINN_DISABLE_AUTO_TASKS).toBe('1');
     expect(composeEnv.JINN_PREDICTION_V0_WINDOW_MS).toBe('120000');
     expect(composeEnv.JINN_PREDICTION_V0_RESOLVE_GAP_MS).toBe('60000');
+    expect(composeEnv.JINN_POLYMARKET_GAMMA_BASE_URL).toBe('');
+    expect(composeEnv.JINN_POLYMARKET_CLOB_BASE_URL).toBe('');
     expect(composeEnv.JINN_ACCEPTANCE_CONFIG_FILE).toBe(dockerAcceptanceConfigPath(clientRoot));
     expect(dockerAcceptanceWorkspaceRoot(clientRoot)).toBe(join(clientRoot, '.acceptance'));
     expect(dockerAcceptanceComposeEnvPath(clientRoot)).toBe(join(clientRoot, '.acceptance', 'docker-compose.env'));
     expect(dockerAcceptanceEvidenceRoot(clientRoot)).toBe(join(clientRoot, 'acceptance-runs'));
+  });
+
+  it('maps host.docker.internal for Linux Docker acceptance fixtures', () => {
+    const compose = readFileSync(join(repoClientRoot, 'docker-compose.acceptance.yml'), 'utf8');
+
+    expect(compose).toContain('extra_hosts:');
+    expect(compose).toContain('"host.docker.internal:host-gateway"');
   });
 
   it('formats env files in sorted key order', () => {
@@ -190,6 +201,38 @@ describe('summarizeRunWindowArtifacts', () => {
     const cycle2 = summary.byTaskId.find((e) => e.taskId === 'pred-v0-auto-1714464120000');
     expect(cycle2?.restorationOk).toBe(true);
     expect(cycle2?.evaluationOk).toBe(false);
+  });
+
+  it('groups Task-native evaluation suffixes back to the restoration task id', () => {
+    const summary = summarizeRunWindowArtifacts(
+      [
+        {
+          task_id: 'release-acceptance-1',
+          request_id: '0xrestreq',
+          tags: '["restoration-result"]',
+          outcome: 'SUCCESS',
+          created_at: '2026-04-30 10:03:00',
+        },
+        {
+          task_id: 'release-acceptance-1:evaluation:0',
+          request_id: '0xevalreq',
+          tags: '["evaluation-verdict"]',
+          outcome: 'SUCCESS',
+          created_at: '2026-04-30 10:04:00',
+        },
+      ],
+      runStartAt,
+    );
+
+    expect(cycleTaskId('release-acceptance-1:evaluation:0')).toBe('release-acceptance-1');
+    expect(summary.completedCycles).toBe(1);
+    expect(summary.byTaskId).toEqual([
+      expect.objectContaining({
+        taskId: 'release-acceptance-1',
+        restorationOk: true,
+        evaluationOk: true,
+      }),
+    ]);
   });
 
   it('excludes rows created before runStartAt (SQLite TEXT format comparison)', () => {


### PR DESCRIPTION
## Summary
- make browser auto-open best-effort so headless Docker runs do not crash on missing `xdg-open`
- move Docker testnet acceptance from retired auto-task assumptions to a manifest-backed `prediction.v1` task submitted through `jinn tasks submit`
- use a local Polymarket-compatible fixture for acceptance and group Task-native restoration/evaluation artifacts into one observed cycle

## Verification
- `yarn vitest run test/scripts/docker-acceptance.test.ts test/cli/open-browser.test.ts test/cli/run-no-ui.test.ts test/harnesses/impls/prediction-v1-evaluator/index.test.ts`
- `yarn typecheck`
- `yarn release:testnet-acceptance`

Acceptance evidence: `/Users/adrianobradley/harbor/jinn-mono/cargo/client/acceptance-runs/2026-05-12T20-21-02-158Z-n787jk`

Notes: this keeps the public-release gate on the current Task-native operator path instead of re-enabling the retired prediction.v0 auto generator. Captain should review/merge; I am not self-merging.