### PR TITLE
feat(uy6v.9): SWE-rebench v2 pool-validation gate — generator posts only scorable instances

### DIFF
--- a/client/src/cli/commands/solver-nets.ts
+++ b/client/src/cli/commands/solver-nets.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { parseArgs } from 'node:util';
@@ -218,6 +219,11 @@ const command: CommandModule = {
   jinn solver-nets remove-plugin <name> <source-or-name> [--config <path>]
   jinn solver-nets doctor <name> [--human|--json] [--config <path>]
   jinn solver-nets sample <name> [--closed-window]
+  jinn solver-nets validate-pool swe-rebench-v2 [--limit <n>] [--force]
+            Run the gold patch of each pool instance through the eval harness
+            and cache which instances are scorable; the generator then posts
+            only those. Requires Docker + \`jinn harnesses enable
+            swe-rebench-v2-evaluator\`.
 
 Output flags:
   --human   Render readable terminal output instead of JSON (supported by
@@ -236,6 +242,8 @@ Output flags:
         config: { type: 'string' },
         harness: { type: 'string' },
         'closed-window': { type: 'boolean' },
+        limit: { type: 'string' },
+        force: { type: 'boolean' },
         human: { type: 'boolean' },
         json: { type: 'boolean' },
       },
@@ -265,6 +273,67 @@ Output flags:
           .map((n) => `${n.name}  ${n.enabled ? 'enabled' : 'disabled'}  ${n.solverType}  harness=${n.harness ?? '(default)'}  plugins=${n.pluginCount}  generator=${n.taskGeneratorEnabled ? 'on' : 'off'}`)
           .join('\n');
       });
+      return;
+    }
+
+    if (subverb === 'validate-pool') {
+      if (name !== 'swe-rebench-v2') {
+        fail(ctx, 'solver-nets validate-pool currently supports only `swe-rebench-v2`');
+        return;
+      }
+      // The upstream eval harness must be set up (`jinn harnesses enable
+      // swe-rebench-v2-evaluator`) — that's where the eval.py repo lives.
+      const evalStatePath = join(homedir(), '.jinn-client', 'engine', 'impl-state', 'swe-rebench-v2-evaluator', 'state.json');
+      let upstreamRepoDir: string | undefined;
+      try {
+        const s = JSON.parse(readFileSync(evalStatePath, 'utf-8')) as { upstreamRepoDir?: string };
+        upstreamRepoDir = typeof s.upstreamRepoDir === 'string' ? s.upstreamRepoDir : undefined;
+      } catch { /* fall through to the error below */ }
+      if (!upstreamRepoDir || !existsSync(upstreamRepoDir)) {
+        fail(ctx, 'swe-rebench-v2 evaluator is not set up — run `jinn harnesses enable swe-rebench-v2-evaluator` first');
+        return;
+      }
+      // Docker must be reachable, or every gold-eval would be classified as
+      // ungradeable and the whole pool wrongly marked unscorable.
+      if (spawnSync('docker', ['info'], { stdio: 'ignore' }).status !== 0) {
+        fail(ctx, 'Docker daemon not reachable — start Docker, then re-run `jinn solver-nets validate-pool swe-rebench-v2`');
+        return;
+      }
+
+      const { loadSweRebenchV2Pool, getSweRebenchV2ValidatedPoolStore } = await import('../../solver-types/swe-rebench-v2.js');
+      const { HttpHfFetcher } = await import('../../harnesses/impls/swe-rebench-v2-evaluator/hf-fetcher.js');
+      const { PythonEvalRunner } = await import('../../harnesses/impls/swe-rebench-v2-evaluator/eval-runner.js');
+      const { validatePoolInstances, EVAL_SEMANTICS_VERSION } = await import('../../solver-types/_swe-rebench-v2-validated-pool.js');
+
+      const limitRaw = parsed.values['limit'] as string | undefined;
+      const limitParsed = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
+      const limit = Number.isFinite(limitParsed as number) && (limitParsed as number) > 0 ? (limitParsed as number) : undefined;
+      const force = Boolean(parsed.values['force']);
+
+      process.stderr.write('[validate-pool] loading the SWE-rebench v2 pool…\n');
+      const poolTasks = await loadSweRebenchV2Pool();
+      const store = getSweRebenchV2ValidatedPoolStore();
+      const summary = await validatePoolInstances(
+        poolTasks,
+        {
+          fetcher: new HttpHfFetcher(),
+          runner: new PythonEvalRunner({ upstreamRepoDir }),
+          store,
+          semanticsVersion: EVAL_SEMANTICS_VERSION,
+          log: (m) => process.stderr.write(`${m}\n`),
+        },
+        { limit, force },
+      );
+      emit(
+        ctx,
+        { verb: 'solver-nets validate-pool', solverNet: 'swe-rebench-v2', evalSemanticsVersion: EVAL_SEMANTICS_VERSION, poolSize: poolTasks.length, ...summary },
+        human,
+        json,
+        (v) => {
+          const s = v as { poolSize: number; checked: number; scorable: number; unscorable: number; skipped: number };
+          return `pool=${s.poolSize}  checked=${s.checked}  scorable=${s.scorable}  unscorable=${s.unscorable}  skipped(non-pytest)=${s.skipped}`;
+        },
+      );
       return;
     }
 

--- a/client/src/cli/commands/solver-nets.ts
+++ b/client/src/cli/commands/solver-nets.ts
@@ -283,16 +283,14 @@ Output flags:
       }
       // The upstream eval harness must be set up (`jinn harnesses enable
       // swe-rebench-v2-evaluator`) — that's where the eval.py repo lives.
-      const evalStatePath = join(homedir(), '.jinn-client', 'engine', 'impl-state', 'swe-rebench-v2-evaluator', 'state.json');
-      let upstreamRepoDir: string | undefined;
-      try {
-        const s = JSON.parse(readFileSync(evalStatePath, 'utf-8')) as { upstreamRepoDir?: string };
-        upstreamRepoDir = typeof s.upstreamRepoDir === 'string' ? s.upstreamRepoDir : undefined;
-      } catch { /* fall through to the error below */ }
-      if (!upstreamRepoDir || !existsSync(upstreamRepoDir)) {
+      const { readEnabledState, defaultSweRebenchV2EvaluatorImplStateDir } =
+        await import('../../harnesses/impls/swe-rebench-v2-evaluator/harness.js');
+      const enabled = readEnabledState(defaultSweRebenchV2EvaluatorImplStateDir());
+      if (!enabled || !existsSync(enabled.upstreamRepoDir)) {
         fail(ctx, 'swe-rebench-v2 evaluator is not set up — run `jinn harnesses enable swe-rebench-v2-evaluator` first');
         return;
       }
+      const upstreamRepoDir = enabled.upstreamRepoDir;
       // Docker must be reachable, or every gold-eval would be classified as
       // ungradeable and the whole pool wrongly marked unscorable.
       if (spawnSync('docker', ['info'], { stdio: 'ignore' }).status !== 0) {

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
@@ -90,6 +90,14 @@ function asStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : [];
 }
 
+/** The pinned `test_log` size cap (the tail is what matters — pytest's
+ *  summary + last failures live there). */
+const MAX_LOG_SIZE = 1024 * 1024;
+function capLogTail(log: string): string {
+  if (log.length <= MAX_LOG_SIZE) return log;
+  return `[… ${log.length - MAX_LOG_SIZE} bytes truncated …]\n${log.slice(-MAX_LOG_SIZE)}`;
+}
+
 function shellQuote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`;
 }
@@ -231,7 +239,10 @@ export class PythonEvalRunner implements EvalRunner {
         logBody = '';
       }
     }
-    const fullLog = stdout + logBody;
+    // Cap the log we hand back. The harness pins this verbatim to IPFS as the
+    // verdict's `test_log_cid` — a long pytest run can produce 10s of MB, and
+    // we only need the tail (pytest summary + last failures) to be useful.
+    const fullLog = capLogTail(stdout + logBody);
 
     await rm(tmp, { recursive: true, force: true });
 

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/harness.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/harness.ts
@@ -19,6 +19,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { spawn, type SpawnOptions } from 'node:child_process';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import {
   SweRebenchV2TaskSchema,
@@ -85,12 +86,28 @@ export class SweRebenchV2EvaluatorHarness implements Harness {
   private readonly implStateDir: string | undefined;
   private readonly ipfsRegistryUrl: string;
   private readonly deps: NonNullable<SweRebenchV2EvaluatorHarnessOptions['_testDeps']>;
+  /** The engine's claim-eligibility check calls `isReady()` per candidate
+   *  task per tick (~17 Hz potential). Cache the live `docker info` result
+   *  for a short TTL so we don't spawn `docker` in a tight loop. */
+  private dockerCheckCache: { at: number; ok: boolean } | null = null;
+  private static readonly DOCKER_CHECK_TTL_MS = 5_000;
 
   constructor(opts: SweRebenchV2EvaluatorHarnessOptions = {}) {
     this.stub = opts.stub ?? false;
     this.implStateDir = opts.implStateDir;
     this.ipfsRegistryUrl = opts.ipfsRegistryUrl ?? DEFAULT_IPFS_REGISTRY_URL;
     this.deps = opts._testDeps ?? {};
+  }
+
+  private async isDockerReachable(now: number = Date.now()): Promise<boolean> {
+    const cached = this.dockerCheckCache;
+    if (cached && now - cached.at < SweRebenchV2EvaluatorHarness.DOCKER_CHECK_TTL_MS) {
+      return cached.ok;
+    }
+    const run = this.deps.runCommand ?? runCommand;
+    const r = await run('docker', ['info']);
+    this.dockerCheckCache = { at: now, ok: r.exitCode === 0 };
+    return this.dockerCheckCache.ok;
   }
 
   supports(ctx: { solverType: string; role?: 'restoration' | 'evaluation' }): boolean {
@@ -145,15 +162,13 @@ export class SweRebenchV2EvaluatorHarness implements Harness {
         },
       };
     }
-    // Live Docker probe: the eval shells out to per-instance `docker run`
-    // images. Docker is validated at `jinn harnesses enable` time, but it can
-    // stop afterwards — re-check on every readiness probe so the daemon does
+    // Live Docker probe (TTL-cached): the eval shells out to per-instance
+    // `docker run` images. Docker is validated at `jinn harnesses enable` time,
+    // but it can stop afterwards — re-check periodically so the daemon does
     // not claim evaluation tasks it cannot grade. (Without this, a stopped
     // Docker daemon turns every claimed eval into a bogus `passed_match:false`
     // verdict — see jinn-mono-uy6v.8.)
-    const run = this.deps.runCommand ?? runCommand;
-    const dockerCheck = await run('docker', ['info']);
-    if (dockerCheck.exitCode !== 0) {
+    if (!(await this.isDockerReachable())) {
       return {
         ready: false,
         reason: 'Docker daemon not reachable',
@@ -406,7 +421,17 @@ async function runCommand(
   });
 }
 
-function readEnabledState(implStateDir: string): EnabledState | null {
+/**
+ * The default `implStateDir` for the swe-rebench-v2 evaluator. The daemon
+ * normally injects this via `engine.implStateDirRoot`; consumers (e.g. the
+ * `validate-pool` CLI command) that need to locate the upstream eval repo
+ * without going through the daemon use this default.
+ */
+export function defaultSweRebenchV2EvaluatorImplStateDir(): string {
+  return join(process.env['HOME'] ?? homedir(), '.jinn-client', 'engine', 'impl-state', 'swe-rebench-v2-evaluator');
+}
+
+export function readEnabledState(implStateDir: string): EnabledState | null {
   const path = join(implStateDir, STATE_FILE);
   if (!existsSync(path)) return null;
   try {

--- a/client/src/solver-types/_swe-rebench-v2-validated-pool.ts
+++ b/client/src/solver-types/_swe-rebench-v2-validated-pool.ts
@@ -1,0 +1,221 @@
+/**
+ * Pool-validation gate for the swe-rebench-v2 task generator.
+ *
+ * SWE-rebench's leaderboard split contains instances that can't be scored in
+ * our eval environment — the dataset `test_cmd` runs a superset of the named
+ * tests, a `PASS_TO_PASS` test ERRORs without a service the container doesn't
+ * provide, the gold patch doesn't reproduce the expected transition, etc.
+ * Posting tasks for those just produces verdicts that say nothing about the
+ * solver. Standard practice (SWE-bench Verified by hand, SWE-rebench's pipeline
+ * automatically) is to validate each instance and only keep the scorable ones.
+ *
+ * `validatePoolInstances` does that validation: run the *gold* patch through
+ * our `PythonEvalRunner` and mark the instance scorable iff it resolves
+ * (`passed_match: true` under our SWE-bench "resolved" semantics). Results are
+ * cached per `(instance_id, evalSemanticsVersion)` in `<stateDir>/validated-pool.json`.
+ * The generator (`filterToScorablePool`) restricts its posting pool to the
+ * scorable set; absent validation data it falls back to Python-only instances
+ * (the languages our pytest `test_cmd` override supports) as a conservative floor.
+ *
+ * Refs: jinn-mono-uy6v.9.
+ */
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import type { PoolTask } from './_swe-rebench-v2-pool.js';
+import type { EvalRunner, HfFetcher } from '../harnesses/impls/swe-rebench-v2-evaluator/index.js';
+
+/**
+ * Bump when the eval grading semantics change (verdict re-derivation,
+ * ungradeable classification, test-command construction) so cached validation
+ * results from an older harness are treated as stale and re-checked. `'2'` =
+ * the SWE-bench "resolved" semantics + run-the-named-tests `test_cmd` override
+ * (jinn-mono-uy6v.8); `'1'` was the original exact-set `passed_match`.
+ */
+export const EVAL_SEMANTICS_VERSION = '2';
+
+const SCHEMA_VERSION = 'swe-rebench-v2-validated-pool.v1' as const;
+
+export interface ValidatedPoolEntry {
+  scorable: boolean;
+  /** Why scorable/unscorable — `'gold-patch-resolves'`, `'ungradeable:<reason>'`, etc. */
+  reason: string;
+  checkedAt: string; // ISO timestamp
+}
+
+interface ValidatedPoolFile {
+  schemaVersion: typeof SCHEMA_VERSION;
+  evalSemanticsVersion: string;
+  updatedAt: string;
+  entries: Record<string, ValidatedPoolEntry>;
+}
+
+function freshFile(evalSemanticsVersion: string): ValidatedPoolFile {
+  return { schemaVersion: SCHEMA_VERSION, evalSemanticsVersion, updatedAt: new Date().toISOString(), entries: {} };
+}
+
+function isValidFile(raw: unknown, evalSemanticsVersion: string): raw is ValidatedPoolFile {
+  return (
+    typeof raw === 'object' && raw !== null &&
+    (raw as ValidatedPoolFile).schemaVersion === SCHEMA_VERSION &&
+    (raw as ValidatedPoolFile).evalSemanticsVersion === evalSemanticsVersion &&
+    typeof (raw as ValidatedPoolFile).entries === 'object' && (raw as ValidatedPoolFile).entries !== null
+  );
+}
+
+export class ValidatedPoolStore {
+  private readonly file: string;
+  private cache: ValidatedPoolFile | null = null;
+
+  constructor(opts: { stateDir: string }) {
+    this.file = join(opts.stateDir, 'validated-pool.json');
+  }
+
+  private async readRaw(): Promise<unknown> {
+    try {
+      return JSON.parse(await readFile(this.file, 'utf8'));
+    } catch {
+      return null;
+    }
+  }
+
+  private async loadForWrite(evalSemanticsVersion: string): Promise<ValidatedPoolFile> {
+    if (this.cache && this.cache.evalSemanticsVersion === evalSemanticsVersion) return this.cache;
+    const raw = await this.readRaw();
+    this.cache = isValidFile(raw, evalSemanticsVersion) ? raw : freshFile(evalSemanticsVersion);
+    return this.cache;
+  }
+
+  private async save(): Promise<void> {
+    if (!this.cache) return;
+    this.cache.updatedAt = new Date().toISOString();
+    await mkdir(dirname(this.file), { recursive: true });
+    await writeFile(this.file, JSON.stringify(this.cache, null, 2));
+  }
+
+  /** The set of instance ids known scorable for `evalSemanticsVersion`, or
+   *  `null` if there is no validation data for this semantics version (the
+   *  on-disk file is absent or built for a different version). */
+  async getScorableIds(evalSemanticsVersion: string): Promise<Set<string> | null> {
+    const raw = await this.readRaw();
+    if (!isValidFile(raw, evalSemanticsVersion)) return null;
+    return new Set(Object.entries(raw.entries).filter(([, e]) => e.scorable).map(([id]) => id));
+  }
+
+  /** The entry for `instanceId`, or `null` if not validated for this semantics version. */
+  async getEntry(instanceId: string, evalSemanticsVersion: string): Promise<ValidatedPoolEntry | null> {
+    const f = await this.loadForWrite(evalSemanticsVersion);
+    return f.entries[instanceId] ?? null;
+  }
+
+  async record(instanceId: string, entry: ValidatedPoolEntry, evalSemanticsVersion: string): Promise<void> {
+    const f = await this.loadForWrite(evalSemanticsVersion);
+    f.entries[instanceId] = entry;
+    await this.save();
+  }
+}
+
+/**
+ * Restrict the generator's posting pool to instances we can actually score.
+ * With validation data (`scorableIds` non-null): keep only the scorable set.
+ * Without it: fall back to Python-only instances — the conservative floor our
+ * pytest `test_cmd` override supports — and the caller should warn that the
+ * full gate (`jinn solver-nets validate-pool swe-rebench-v2`) hasn't been run.
+ */
+export function filterToScorablePool(
+  pool: PoolTask[],
+  scorableIds: Set<string> | null,
+): { pool: PoolTask[]; mode: 'validated' | 'python-floor' } {
+  if (scorableIds) {
+    return { pool: pool.filter((t) => scorableIds.has(t.instance_id)), mode: 'validated' };
+  }
+  return { pool: pool.filter((t) => (t.language ?? '') === 'python'), mode: 'python-floor' };
+}
+
+export interface ValidatePoolDeps {
+  fetcher: HfFetcher;
+  runner: EvalRunner;
+  store: ValidatedPoolStore;
+  semanticsVersion: string;
+  log?: (msg: string) => void;
+}
+
+export interface ValidatePoolSummary {
+  checked: number;     // instances we ran the gold-eval for this run
+  scorable: number;    // of those, marked scorable
+  unscorable: number;  // of those, marked unscorable
+  skipped: number;     // non-Python instances we didn't even try
+}
+
+function nameOf(err: unknown): string {
+  return typeof err === 'object' && err !== null && typeof (err as { name?: unknown }).name === 'string'
+    ? (err as { name: string }).name : '';
+}
+function reasonOf(err: unknown): string {
+  return typeof err === 'object' && err !== null && typeof (err as { reason?: unknown }).reason === 'string'
+    ? (err as { reason: string }).reason : 'unknown';
+}
+
+/**
+ * Validate pool instances by running their gold patch through the eval harness.
+ * Idempotent: instances already recorded for `semanticsVersion` are skipped
+ * unless `opts.force`. `opts.limit` caps how many gold-evals one run does.
+ */
+export async function validatePoolInstances(
+  pool: PoolTask[],
+  deps: ValidatePoolDeps,
+  opts: { limit?: number; force?: boolean } = {},
+): Promise<ValidatePoolSummary> {
+  const log = deps.log ?? (() => {});
+  const summary: ValidatePoolSummary = { checked: 0, scorable: 0, unscorable: 0, skipped: 0 };
+  for (const task of pool) {
+    if (opts.limit != null && summary.checked >= opts.limit) break;
+
+    // Only pytest (Python) instances are supported by the eval-runner `test_cmd`
+    // override; everything else can't be scored cleanly today.
+    if ((task.language ?? '') !== 'python') {
+      await deps.store.record(task.instance_id, { scorable: false, reason: 'non-pytest-unsupported', checkedAt: new Date().toISOString() }, deps.semanticsVersion);
+      summary.skipped += 1;
+      continue;
+    }
+    if (!opts.force && (await deps.store.getEntry(task.instance_id, deps.semanticsVersion))) {
+      continue; // already validated for this semantics version
+    }
+    if (!task.patch || !task.test_patch) {
+      await deps.store.record(task.instance_id, { scorable: false, reason: 'missing-gold-patch', checkedAt: new Date().toISOString() }, deps.semanticsVersion);
+      summary.checked += 1; summary.unscorable += 1;
+      continue;
+    }
+
+    log(`[validate-pool] ${task.instance_id} …`);
+    let entry: ValidatedPoolEntry;
+    try {
+      const row = await deps.fetcher.fetchTaskRow({ hf_dataset: task.hf_dataset, hf_split: task.hf_split, instance_id: task.instance_id });
+      const res = await deps.runner.runEval({
+        instance_id: task.instance_id,
+        repo: task.repo ?? row.repo,
+        image: row.image_name,
+        patch: task.patch,
+        test_patch: row.test_patch ?? task.test_patch,
+        install: row.install_config.install,
+        test_cmd: row.install_config.test_cmd,
+        log_parser: row.install_config.log_parser,
+        fail_to_pass: row.FAIL_TO_PASS,
+        pass_to_pass: row.PASS_TO_PASS,
+      });
+      entry = res.passed_match
+        ? { scorable: true, reason: 'gold-patch-resolves', checkedAt: new Date().toISOString() }
+        : { scorable: false, reason: `gold-patch-not-resolved (f2p ${res.passed.length}, p2p_broke ${res.failed.length})`, checkedAt: new Date().toISOString() };
+    } catch (err) {
+      const reason = nameOf(err) === 'EvalCouldNotGradeError'
+        ? `ungradeable:${reasonOf(err)}`
+        : `error:${(err instanceof Error ? err.message : String(err)).slice(0, 200)}`;
+      entry = { scorable: false, reason, checkedAt: new Date().toISOString() };
+    }
+    await deps.store.record(task.instance_id, entry, deps.semanticsVersion);
+    summary.checked += 1;
+    if (entry.scorable) summary.scorable += 1; else summary.unscorable += 1;
+    log(`[validate-pool] ${task.instance_id} → ${entry.scorable ? 'SCORABLE' : 'unscorable'} (${entry.reason})`);
+  }
+  return summary;
+}

--- a/client/src/solver-types/_swe-rebench-v2-validated-pool.ts
+++ b/client/src/solver-types/_swe-rebench-v2-validated-pool.ts
@@ -121,6 +121,10 @@ export class ValidatedPoolStore {
  * Without it: fall back to Python-only instances — the conservative floor our
  * pytest `test_cmd` override supports — and the caller should warn that the
  * full gate (`jinn solver-nets validate-pool swe-rebench-v2`) hasn't been run.
+ *
+ * The `nebius/SWE-rebench-leaderboard` rows don't carry an explicit `language`
+ * field (it's `undefined`/`null` on every row), so we also infer from the
+ * patch file extensions — mirroring `inferLanguageFromPatch` in the solver-type.
  */
 export function filterToScorablePool(
   pool: PoolTask[],
@@ -129,7 +133,20 @@ export function filterToScorablePool(
   if (scorableIds) {
     return { pool: pool.filter((t) => scorableIds.has(t.instance_id)), mode: 'validated' };
   }
-  return { pool: pool.filter((t) => (t.language ?? '') === 'python'), mode: 'python-floor' };
+  return { pool: pool.filter(isPythonInstance), mode: 'python-floor' };
+}
+
+function isPythonInstance(task: PoolTask): boolean {
+  if (task.language === 'python') return true;
+  if (task.language && task.language !== 'python') return false;
+  // language unset → infer from `.py` in any patch path.
+  return looksPython(task.patch) || looksPython(task.test_patch);
+}
+
+function looksPython(patch: string | undefined): boolean {
+  if (!patch) return false;
+  // Match `--- a/<p>` / `+++ b/<p>` / `diff --git a/<p>` ending in .py
+  return /(?:^|\n)(?:---|\+\+\+|diff --git) [ab]\/\S+\.py(?:\s|$)/.test(patch);
 }
 
 export interface ValidatePoolDeps {
@@ -172,8 +189,10 @@ export async function validatePoolInstances(
     if (opts.limit != null && summary.checked >= opts.limit) break;
 
     // Only pytest (Python) instances are supported by the eval-runner `test_cmd`
-    // override; everything else can't be scored cleanly today.
-    if ((task.language ?? '') !== 'python') {
+    // override; everything else can't be scored cleanly today. The leaderboard
+    // rows don't carry an explicit language field — infer from the patch when
+    // unset.
+    if (!isPythonInstance(task)) {
       await deps.store.record(task.instance_id, { scorable: false, reason: 'non-pytest-unsupported', checkedAt: new Date().toISOString() }, deps.semanticsVersion);
       summary.skipped += 1;
       continue;

--- a/client/src/solver-types/_swe-rebench-v2-validated-pool.ts
+++ b/client/src/solver-types/_swe-rebench-v2-validated-pool.ts
@@ -20,7 +20,7 @@
  * Refs: jinn-mono-uy6v.9.
  */
 
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { readFile, writeFile, mkdir, stat } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import type { PoolTask } from './_swe-rebench-v2-pool.js';
 import type { EvalRunner, HfFetcher } from '../harnesses/impls/swe-rebench-v2-evaluator/index.js';
@@ -66,6 +66,10 @@ function isValidFile(raw: unknown, evalSemanticsVersion: string): raw is Validat
 export class ValidatedPoolStore {
   private readonly file: string;
   private cache: ValidatedPoolFile | null = null;
+  /** mtime-keyed cache for `getScorableIds`. The generator's tick reads this
+   *  every poll (every few seconds); the file only changes during infrequent
+   *  `validate-pool` CLI runs. Invalidate on mtime change. */
+  private scorableIdsCache: { mtimeMs: number; semanticsVersion: string; ids: Set<string> | null } | null = null;
 
   constructor(opts: { stateDir: string }) {
     this.file = join(opts.stateDir, 'validated-pool.json');
@@ -95,11 +99,20 @@ export class ValidatedPoolStore {
 
   /** The set of instance ids known scorable for `evalSemanticsVersion`, or
    *  `null` if there is no validation data for this semantics version (the
-   *  on-disk file is absent or built for a different version). */
+   *  on-disk file is absent or built for a different version). Memoised by
+   *  mtime so the generator's tick doesn't re-parse the JSON every poll. */
   async getScorableIds(evalSemanticsVersion: string): Promise<Set<string> | null> {
+    const mtimeMs = await stat(this.file).then((s) => s.mtimeMs).catch(() => -1);
+    const cached = this.scorableIdsCache;
+    if (cached && cached.mtimeMs === mtimeMs && cached.semanticsVersion === evalSemanticsVersion) {
+      return cached.ids;
+    }
     const raw = await this.readRaw();
-    if (!isValidFile(raw, evalSemanticsVersion)) return null;
-    return new Set(Object.entries(raw.entries).filter(([, e]) => e.scorable).map(([id]) => id));
+    const ids = isValidFile(raw, evalSemanticsVersion)
+      ? new Set(Object.entries(raw.entries).filter(([, e]) => e.scorable).map(([id]) => id))
+      : null;
+    this.scorableIdsCache = { mtimeMs, semanticsVersion: evalSemanticsVersion, ids };
+    return ids;
   }
 
   /** The entry for `instanceId`, or `null` if not validated for this semantics version. */

--- a/client/src/solver-types/swe-rebench-v2.ts
+++ b/client/src/solver-types/swe-rebench-v2.ts
@@ -27,6 +27,11 @@ import {
 } from './swe-rebench-v2-auto.js';
 import { GeneratorStateStore } from './_swe-rebench-v2-state.js';
 import {
+  ValidatedPoolStore,
+  filterToScorablePool,
+  EVAL_SEMANTICS_VERSION,
+} from './_swe-rebench-v2-validated-pool.js';
+import {
   buildHistoricalPool,
   fetchHfSplit,
   listMonthlyPartitions,
@@ -243,9 +248,11 @@ async function maybeSignTask(
  */
 function makeSweRebenchV2Generator(config: InternalSweRebenchV2GeneratorConfig): SweRebenchV2GeneratorTick {
   const stateStore = new GeneratorStateStore({ stateDir: config.stateDir });
+  const validatedPoolStore = new ValidatedPoolStore({ stateDir: config.stateDir });
 
   let pool: PoolTask[] = [];
   let poolLoadedAt = 0;
+  let floorWarned = false;
   let lastPostedLanguage: string | undefined;
   let lastPollAt: string | undefined;
   let lastPollSummary: SweRebenchV2GeneratorStateSnapshot['lastPollSummary'];
@@ -301,9 +308,26 @@ function makeSweRebenchV2Generator(config: InternalSweRebenchV2GeneratorConfig):
     }
     lastPollAt = new Date(now).toISOString();
 
+    // Restrict to instances we can actually score (validated gold-patch pool),
+    // or — absent validation data — to Python instances (the floor our pytest
+    // test_cmd override supports). See jinn-mono-uy6v.9.
+    const scorableIds = await validatedPoolStore.getScorableIds(EVAL_SEMANTICS_VERSION);
+    const { pool: eligiblePool, mode: poolMode } = filterToScorablePool(pool, scorableIds);
+    if (poolMode === 'python-floor' && !floorWarned) {
+      floorWarned = true;
+      console.warn(
+        `[swe-rebench-v2-gen] no pool-validation data — restricting to ${eligiblePool.length} Python instance(s) of ${pool.length}; run \`jinn solver-nets validate-pool swe-rebench-v2\` to validate the full pool.`,
+      );
+    }
+    if (eligiblePool.length === 0) {
+      lastPollSummary = { poolSize: 0, posted: 0, skipped: 0 };
+      lastError = undefined;
+      return null;
+    }
+
     // Load all counters for eligible tasks
     const counters = new Map<string, { posted: number; successful: number; last_posted_at: number }>();
-    for (const task of pool) {
+    for (const task of eligiblePool) {
       counters.set(task.instance_id, await stateStore.getCounters(task.instance_id));
     }
 
@@ -312,20 +336,20 @@ function makeSweRebenchV2Generator(config: InternalSweRebenchV2GeneratorConfig):
       ...Array.from(counters.values(), (c) => c.last_posted_at),
     );
     if (mostRecentPostedAt > 0 && now - mostRecentPostedAt < genConfig.cooldown_ms) {
-      lastPollSummary = { poolSize: pool.length, posted: 0, skipped: pool.length };
+      lastPollSummary = { poolSize: eligiblePool.length, posted: 0, skipped: eligiblePool.length };
       lastError = undefined;
       return null;
     }
 
     const candidate = selectNextPostingCandidate({
-      pool,
+      pool: eligiblePool,
       counters,
       config: genConfig,
       now,
       lastPostedLanguage,
     });
     if (!candidate) {
-      lastPollSummary = { poolSize: pool.length, posted: 0, skipped: pool.length };
+      lastPollSummary = { poolSize: eligiblePool.length, posted: 0, skipped: eligiblePool.length };
       lastError = undefined;
       return null;
     }
@@ -381,7 +405,7 @@ function makeSweRebenchV2Generator(config: InternalSweRebenchV2GeneratorConfig):
     };
 
     console.log(`[swe-rebench-v2-gen] posting ${candidate.instance_id}`);
-    lastPollSummary = { poolSize: pool.length, posted: 1, skipped: 0 };
+    lastPollSummary = { poolSize: eligiblePool.length, posted: 1, skipped: 0 };
     lastError = undefined;
     return maybeSignTask(task, { creator: config.creator, createdAt: now });
   };

--- a/client/src/solver-types/swe-rebench-v2.ts
+++ b/client/src/solver-types/swe-rebench-v2.ts
@@ -38,7 +38,7 @@ import {
   type PoolTask,
 } from './_swe-rebench-v2-pool.js';
 
-const HF_DATASET = 'nebius/SWE-rebench-leaderboard';
+export const HF_DATASET = 'nebius/SWE-rebench-leaderboard';
 const SOLVER_TYPE = 'swe-rebench-v2.v1';
 const CONTRACT_ID = 'swe-rebench-v2';
 const CONTRACT_VERSION = 'v1';
@@ -101,6 +101,31 @@ interface InternalSweRebenchV2GeneratorConfig extends SweRebenchV2AutoConfig {
 
 function defaultStateDir(): string {
   return join(process.env['HOME'] ?? homedir(), '.jinn-client', 'swe-rebench-v2');
+}
+
+/**
+ * Load the full historical SWE-rebench v2 pool from the HF datasets-server.
+ * Throws if the splits listing is empty or unreachable. Shared by the
+ * generator's pool refresh and the `validate-pool` CLI command.
+ */
+export async function loadSweRebenchV2Pool(): Promise<PoolTask[]> {
+  const splitsUrl = `https://datasets-server.huggingface.co/splits?dataset=${encodeURIComponent(HF_DATASET)}`;
+  const response = await fetch(splitsUrl);
+  if (!response.ok) throw new Error(`HF splits fetch failed: ${response.status}`);
+  const json = (await response.json()) as { splits?: Array<{ split: string }> };
+  const months = listMonthlyPartitions((json.splits ?? []).map((s) => s.split));
+  if (months.length === 0) {
+    throw new Error('HF datasets-server returned no monthly partitions for the SWE-rebench v2 pool');
+  }
+  return buildHistoricalPool({
+    months,
+    fetchSplit: (split) => fetchHfSplit({ dataset: HF_DATASET, split, limit: 100 }),
+  });
+}
+
+/** A {@link ValidatedPoolStore} rooted at the swe-rebench-v2 generator's state dir. */
+export function getSweRebenchV2ValidatedPoolStore(stateDir?: string): ValidatedPoolStore {
+  return new ValidatedPoolStore({ stateDir: stateDir ?? defaultStateDir() });
 }
 
 function positiveInt(value: unknown, fallback: number): number {
@@ -262,20 +287,7 @@ function makeSweRebenchV2Generator(config: InternalSweRebenchV2GeneratorConfig):
 
   async function refreshPool(): Promise<void> {
     try {
-      // Fetch available splits from the HF datasets-server
-      const splitsUrl = `https://datasets-server.huggingface.co/splits?dataset=${encodeURIComponent(HF_DATASET)}`;
-      const response = await fetch(splitsUrl);
-      if (!response.ok) throw new Error(`HF splits fetch failed: ${response.status}`);
-      const json = (await response.json()) as { splits?: Array<{ split: string }> };
-      const splitNames = (json.splits ?? []).map((s) => s.split);
-      const months = listMonthlyPartitions(splitNames);
-      if (months.length === 0) return;
-
-      pool = await buildHistoricalPool({
-        months,
-        fetchSplit: (split) =>
-          fetchHfSplit({ dataset: HF_DATASET, split, limit: 100 }),
-      });
+      pool = await loadSweRebenchV2Pool();
       poolLoadedAt = Date.now();
     } catch (err) {
       // Non-fatal: keep the existing pool if already loaded

--- a/client/test/harnesses/impls/swe-rebench-v2-evaluator/harness.test.ts
+++ b/client/test/harnesses/impls/swe-rebench-v2-evaluator/harness.test.ts
@@ -200,6 +200,19 @@ describe('SweRebenchV2EvaluatorHarness — isReady', () => {
     expect(runCommand).toHaveBeenCalledWith('docker', ['info']);
   });
 
+  it('caches the docker info probe across rapid isReady() calls (claim-loop hot path)', async () => {
+    makeEnabledMarker(implStateDir, join(implStateDir, 'upstream'));
+    const runCommand = vi.fn(async (bin: string) =>
+      bin === 'docker' ? { exitCode: 0, stdout: 'ok', stderr: '' } : { exitCode: 0, stdout: '', stderr: '' },
+    );
+    const h = new SweRebenchV2EvaluatorHarness({ implStateDir, _testDeps: { runCommand } });
+    for (let i = 0; i < 25; i++) {
+      const r = await h.isReady();
+      expect(r.ready).toBe(true);
+    }
+    expect(runCommand).toHaveBeenCalledTimes(1);
+  });
+
   it('reports not-ready when upstream repo dir is missing despite a marker', async () => {
     // Marker pointing at a non-existent dir.
     writeFileSync(

--- a/client/test/solver-types/swe-rebench-v2-validated-pool.test.ts
+++ b/client/test/solver-types/swe-rebench-v2-validated-pool.test.ts
@@ -92,6 +92,15 @@ describe('filterToScorablePool', () => {
     expect(mode).toBe('python-floor');
     expect(out.map((t) => t.instance_id)).toEqual(['a__1', 'a__2']);
   });
+
+  it('infers Python from .py paths in the patch when the language field is unset (as the leaderboard rows are)', () => {
+    const inferred: PoolTask[] = [
+      poolTask('a__inferred_py', { language: undefined, patch: 'diff --git a/src/foo.py b/src/foo.py\n--- a/src/foo.py\n+++ b/src/foo.py\n@@ -1 +1 @@\n-a\n+b\n' }),
+      poolTask('a__inferred_go', { language: undefined, patch: 'diff --git a/x.go b/x.go\n--- a/x.go\n+++ b/x.go\n@@ -1 +1 @@\n-a\n+b\n', test_patch: undefined }),
+    ];
+    const { pool: out } = filterToScorablePool(inferred, null);
+    expect(out.map((t) => t.instance_id)).toEqual(['a__inferred_py']);
+  });
 });
 
 describe('validatePoolInstances', () => {

--- a/client/test/solver-types/swe-rebench-v2-validated-pool.test.ts
+++ b/client/test/solver-types/swe-rebench-v2-validated-pool.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  ValidatedPoolStore,
+  filterToScorablePool,
+  validatePoolInstances,
+  EVAL_SEMANTICS_VERSION,
+} from '../../src/solver-types/_swe-rebench-v2-validated-pool.js';
+import type { PoolTask } from '../../src/solver-types/_swe-rebench-v2-pool.js';
+
+const tmps: string[] = [];
+function tmpDir(): string {
+  const d = mkdtempSync(join(tmpdir(), 'swe-validated-pool-test-'));
+  tmps.push(d);
+  return d;
+}
+afterEach(() => {
+  for (const d of tmps.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+function poolTask(id: string, overrides: Partial<PoolTask> = {}): PoolTask {
+  return {
+    instance_id: id,
+    hf_dataset: 'nebius/SWE-rebench-leaderboard',
+    hf_split: '2026_02',
+    repo: 'acme/widget',
+    base_commit: 'deadbeef',
+    language: 'python',
+    patch: 'diff --git a/src/x.py b/src/x.py\n--- a/src/x.py\n+++ b/src/x.py\n@@ -1 +1 @@\n-a\n+b\n',
+    test_patch: 'diff --git a/tests/test_x.py b/tests/test_x.py\n--- a/tests/test_x.py\n+++ b/tests/test_x.py\n@@ -1 +1 @@\n-c\n+d\n',
+    ...overrides,
+  };
+}
+
+describe('ValidatedPoolStore', () => {
+  it('records entries and round-trips them via getEntry / getScorableIds', async () => {
+    const dir = tmpDir();
+    const store = new ValidatedPoolStore({ stateDir: dir });
+    await store.record('a__1', { scorable: true, reason: 'gold-patch-resolves', checkedAt: '2026-05-13T00:00:00Z' }, EVAL_SEMANTICS_VERSION);
+    await store.record('a__2', { scorable: false, reason: 'ungradeable:docker_unavailable', checkedAt: '2026-05-13T00:00:01Z' }, EVAL_SEMANTICS_VERSION);
+    expect((await store.getEntry('a__1', EVAL_SEMANTICS_VERSION))?.scorable).toBe(true);
+    expect((await store.getEntry('a__2', EVAL_SEMANTICS_VERSION))?.scorable).toBe(false);
+    expect(await store.getEntry('a__3', EVAL_SEMANTICS_VERSION)).toBeNull();
+    const scorable = await store.getScorableIds(EVAL_SEMANTICS_VERSION);
+    expect(scorable).toEqual(new Set(['a__1']));
+    expect(existsSync(join(dir, 'validated-pool.json'))).toBe(true);
+  });
+
+  it('getScorableIds returns null when the file is absent or built for a different semantics version', async () => {
+    const dir = tmpDir();
+    const store = new ValidatedPoolStore({ stateDir: dir });
+    expect(await store.getScorableIds(EVAL_SEMANTICS_VERSION)).toBeNull();
+    await store.record('a__1', { scorable: true, reason: 'ok', checkedAt: '2026-05-13T00:00:00Z' }, EVAL_SEMANTICS_VERSION);
+    expect(await store.getScorableIds(EVAL_SEMANTICS_VERSION)).toEqual(new Set(['a__1']));
+    // Same file, different semantics version → treated as no data.
+    expect(await store.getScorableIds('999')).toBeNull();
+  });
+
+  it('treats entries from a stale semantics version as not-yet-validated (re-validatable)', async () => {
+    const dir = tmpDir();
+    // Hand-write a file built for an old semantics version.
+    writeFileSync(join(dir, 'validated-pool.json'), JSON.stringify({
+      schemaVersion: 'swe-rebench-v2-validated-pool.v1',
+      evalSemanticsVersion: 'OLD',
+      updatedAt: '2026-01-01T00:00:00Z',
+      entries: { a__1: { scorable: true, reason: 'ok', checkedAt: '2026-01-01T00:00:00Z' } },
+    }));
+    const store = new ValidatedPoolStore({ stateDir: dir });
+    expect(await store.getEntry('a__1', EVAL_SEMANTICS_VERSION)).toBeNull();
+    expect(await store.getScorableIds(EVAL_SEMANTICS_VERSION)).toBeNull();
+  });
+});
+
+describe('filterToScorablePool', () => {
+  const pool: PoolTask[] = [
+    poolTask('a__1'),
+    poolTask('a__2'),
+    poolTask('go__1', { language: 'go' }),
+    poolTask('rust__1', { language: 'rust' }),
+  ];
+
+  it('restricts to validated-scorable instances when validation data is present', () => {
+    const { pool: out, mode } = filterToScorablePool(pool, new Set(['a__1', 'go__1']));
+    expect(mode).toBe('validated');
+    expect(out.map((t) => t.instance_id)).toEqual(['a__1', 'go__1']);
+  });
+
+  it('falls back to Python-only instances when no validation data exists', () => {
+    const { pool: out, mode } = filterToScorablePool(pool, null);
+    expect(mode).toBe('python-floor');
+    expect(out.map((t) => t.instance_id)).toEqual(['a__1', 'a__2']);
+  });
+});
+
+describe('validatePoolInstances', () => {
+  function makeRunner(byId: Record<string, { passed_match: boolean; passed?: string[]; failed?: string[] } | Error>) {
+    return {
+      runEval: vi.fn(async (args: { instance_id: string }) => {
+        const v = byId[args.instance_id];
+        if (v instanceof Error) throw v;
+        if (!v) throw new Error(`no stub for ${args.instance_id}`);
+        return { passed_match: v.passed_match, passed: v.passed ?? [], failed: v.failed ?? [], log: '', exitCode: v.passed_match ? 0 : 1 };
+      }),
+    };
+  }
+  function makeFetcher() {
+    return {
+      fetchTaskRow: vi.fn(async (a: { instance_id: string }) => ({
+        instance_id: a.instance_id, repo: 'acme/widget',
+        image_name: `swerebench/sweb.eval.x86_64.acme_1776_${a.instance_id}:latest`,
+        FAIL_TO_PASS: ['tests/test_x.py::test_new'], PASS_TO_PASS: ['tests/test_x.py::test_old'],
+        test_patch: 'diff --git a/tests/test_x.py b/tests/test_x.py\n',
+        install_config: { install: 'pip install -e .', test_cmd: 'pytest tests/', log_parser: 'parse_log_pytest' },
+      })),
+    };
+  }
+
+  it('marks an instance scorable when the gold patch resolves, unscorable otherwise', async () => {
+    const dir = tmpDir();
+    const store = new ValidatedPoolStore({ stateDir: dir });
+    const runner = makeRunner({
+      a__pass: { passed_match: true, passed: ['tests/test_x.py::test_new'] },
+      a__fail: { passed_match: false, passed: [], failed: [] },
+      a__ungradeable: Object.assign(new Error('eval could not grade'), { name: 'EvalCouldNotGradeError', reason: 'docker_unavailable' }),
+    });
+    const summary = await validatePoolInstances(
+      [poolTask('a__pass'), poolTask('a__fail'), poolTask('a__ungradeable')],
+      { fetcher: makeFetcher(), runner, store, semanticsVersion: EVAL_SEMANTICS_VERSION },
+    );
+    expect(summary).toMatchObject({ checked: 3, scorable: 1, unscorable: 2, skipped: 0 });
+    expect((await store.getEntry('a__pass', EVAL_SEMANTICS_VERSION))?.scorable).toBe(true);
+    expect((await store.getEntry('a__fail', EVAL_SEMANTICS_VERSION))?.scorable).toBe(false);
+    const ung = await store.getEntry('a__ungradeable', EVAL_SEMANTICS_VERSION);
+    expect(ung?.scorable).toBe(false);
+    expect(ung?.reason).toMatch(/docker_unavailable/);
+  });
+
+  it('skips non-Python instances (records them unscorable, never invokes the runner)', async () => {
+    const dir = tmpDir();
+    const store = new ValidatedPoolStore({ stateDir: dir });
+    const runner = makeRunner({});
+    const summary = await validatePoolInstances(
+      [poolTask('go__1', { language: 'go' })],
+      { fetcher: makeFetcher(), runner, store, semanticsVersion: EVAL_SEMANTICS_VERSION },
+    );
+    expect(summary).toMatchObject({ checked: 0, skipped: 1 });
+    expect(runner.runEval).not.toHaveBeenCalled();
+    expect((await store.getEntry('go__1', EVAL_SEMANTICS_VERSION))?.scorable).toBe(false);
+  });
+
+  it('skips already-validated instances unless force is set', async () => {
+    const dir = tmpDir();
+    const store = new ValidatedPoolStore({ stateDir: dir });
+    await store.record('a__1', { scorable: true, reason: 'ok', checkedAt: '2026-05-13T00:00:00Z' }, EVAL_SEMANTICS_VERSION);
+    const runner = makeRunner({ a__1: { passed_match: false } });
+    const s1 = await validatePoolInstances([poolTask('a__1')], { fetcher: makeFetcher(), runner, store, semanticsVersion: EVAL_SEMANTICS_VERSION });
+    expect(s1.checked).toBe(0);
+    expect(runner.runEval).not.toHaveBeenCalled();
+    const s2 = await validatePoolInstances([poolTask('a__1')], { fetcher: makeFetcher(), runner, store, semanticsVersion: EVAL_SEMANTICS_VERSION }, { force: true });
+    expect(s2.checked).toBe(1);
+    expect(runner.runEval).toHaveBeenCalledTimes(1);
+    expect((await store.getEntry('a__1', EVAL_SEMANTICS_VERSION))?.scorable).toBe(false);
+  });
+
+  it('honors the limit on how many instances it validates in one run', async () => {
+    const dir = tmpDir();
+    const store = new ValidatedPoolStore({ stateDir: dir });
+    const runner = makeRunner({ a__1: { passed_match: true }, a__2: { passed_match: true }, a__3: { passed_match: true } });
+    const summary = await validatePoolInstances(
+      [poolTask('a__1'), poolTask('a__2'), poolTask('a__3')],
+      { fetcher: makeFetcher(), runner, store, semanticsVersion: EVAL_SEMANTICS_VERSION },
+      { limit: 2 },
+    );
+    expect(summary.checked).toBe(2);
+    expect(runner.runEval).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Stacked on **#183**. Implements the generator-side pool-validation gate from `jinn-mono-uy6v.9` — the "curation" half of the optimal approach: only post tasks for SWE-rebench v2 instances we can actually score in our eval environment. (Standard practice: SWE-bench Verified does this by hand, SWE-rebench's pipeline automatically.)

### Commits (on top of #183)
1. **`feat(uy6v.9): pool-validation gate — generator posts only scorable swe-rebench-v2 instances`** — `_swe-rebench-v2-validated-pool.ts`: `ValidatedPoolStore` (`<stateDir>/validated-pool.json`, keyed by `(instance_id, EVAL_SEMANTICS_VERSION='2')`; stale-version entries treated as re-validatable), `validatePoolInstances(...)` (runs the *gold* patch through `PythonEvalRunner`, marks an instance scorable iff it resolves; idempotent; skips non-Python; honours `limit`), `filterToScorablePool(...)` (restrict to the validated set; absent data, fall back to Python-only). The generator tick (`swe-rebench-v2.ts`) now restricts its posting pool to `filterToScorablePool(...)` before counters / `selectNextPostingCandidate` / poll-summary, and warns once on the Python-floor fallback. A daemon with no validation data therefore stops posting non-Python tasks (which it can't grade anyway).
2. **`feat(uy6v.9): jinn solver-nets validate-pool swe-rebench-v2 (the gate's operator surface)`** — the CLI that populates `validated-pool.json`: `jinn solver-nets validate-pool swe-rebench-v2 [--limit <n>] [--force]`. Loads the full pool from the HF datasets-server, runs each gold patch through the real `PythonEvalRunner`, records scorability. Guards: requires `jinn harnesses enable swe-rebench-v2-evaluator` + a reachable Docker daemon (else every gold-eval would be misclassified ungradeable → whole pool wrongly unscorable). Idempotent; chunkable via `--limit`.

### Tests
Regression-test-first for the mechanism (`test/solver-types/swe-rebench-v2-validated-pool.test.ts`): store roundtrip + staleness; `filterToScorablePool` validated vs python-floor; `validatePoolInstances` scorable / not-resolved / ungradeable / non-Python-skip / already-validated-skip / limit. The CLI handler is integration glue over the tested `validatePoolInstances` (guard clauses smoke-checked). Full client suite green (3207 pass / 4 skip); typecheck clean.

### Spike data (partial — `jinn-mono-uy6v.9` quantification)
Ran a gold-patch scorability sweep over 13 instances (8 dataset splits) with #183's resolved semantics but **before** the run-the-named-tests `test_cmd` override (commit `a520a2c1`, also in #183): **9/13 SCORABLE**, 3 `UNSCORABLE_VERDICT` (`tox-3666` 1/28 P2P broke; `pymdown-extensions-2807` 81/715; `PyPSA-1404` gold patch didn't fix the F2P test — pytest collection error, exit 2), 1 `UNGRADEABLE` (`clustershell-592` `test_command_not_found`). 3 of the 4 non-scorable are Class-1 "we ran the wrong command" — the `test_cmd` override should recover `clustershell` outright and very likely `tox-3666`/`pymdown` (those P2P "breaks" look like whole-suite ordering artifacts). `PyPSA-1404` looks genuinely broken (collection error even with the gold patch) → exactly what this gate filters out. Predicted post-override scorable rate ≈ 85–90%.

### Remaining (follow-ups, noted on the bead)
- Re-run the scorability sweep against the **post-`a520a2c1`** harness for the real before/after; run `jinn solver-nets validate-pool swe-rebench-v2` on a clean linux/amd64 operator to populate the allowlist for the live generator.
- Revisit the Python-floor fallback and possible non-pytest `test_cmd` overrides (Go/Rust/…) once the pool data is in.
- (Bigger, only if the gate shows it's worth it) enable Docker-in-Docker / service provisioning for the handful of instances whose `PASS_TO_PASS` tests need a DB/service; an upstream PR to `SWE-rebench/SWE-rebench-V2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
