### PR TITLE
feat(uy6v.11): bound swe-rebench-v2 eval-image cache with in-process LRU

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,6 +269,7 @@ Config file first, env var override. File at `~/.jinn-client/config.json` or `--
 | ipfsGatewayUrl   | JINN_IPFS_GATEWAY_URL    | https://gateway.autonolas.tech    |
 | engine.workingDirRoot | JINN_ENGINE_WORKING_DIR_ROOT | ~/.jinn-client/engine/work   |
 | engine.implStateDirRoot | JINN_ENGINE_IMPL_STATE_DIR_ROOT | ~/.jinn-client/engine/impl-state |
+| _(none — env-only)_  | JINN_EVAL_IMAGE_CACHE_MAX | 20 (cap on the swe-rebench-v2 per-instance Docker image LRU) |
 
 `JINN_PASSWORD` is env-only — never in config files.
 

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
@@ -98,25 +98,50 @@ export function resolveImageCacheMax(opt: number | undefined): number {
   if (typeof opt === 'number' && Number.isFinite(opt) && opt > 0) return Math.floor(opt);
   const envRaw = process.env['JINN_EVAL_IMAGE_CACHE_MAX'];
   if (envRaw !== undefined) {
-    // `Number()` rejects strings with trailing garbage (e.g. `"1e3oops"` →
-    // NaN), unlike `parseInt`. We want operators who typo this to fall back
-    // to the default, not silently get `1`.
+    // `Number()` returns 0 for `""` / whitespace and NaN for strings with
+    // non-numeric content (e.g. `"garbage"`, `"1e3oops"`) — unlike `parseInt`,
+    // which would silently accept `parseInt("1e3oops") === 1`. Either way we
+    // reject anything that isn't a positive integer.
     const parsed = Number(envRaw);
     if (Number.isFinite(parsed) && Number.isInteger(parsed) && parsed > 0) return parsed;
+    // Surface the typo so operators discover it before the disk fills,
+    // rather than silently running on the default.
+    console.warn(
+      `[swe-rebench-v2] JINN_EVAL_IMAGE_CACHE_MAX=${JSON.stringify(envRaw)} is not a positive integer — using default ${DEFAULT_EVAL_IMAGE_CACHE_MAX}`,
+    );
   }
   return DEFAULT_EVAL_IMAGE_CACHE_MAX;
 }
 
 /**
- * Production `cleanupImage`: spawn `docker rmi <image>`. Errors are swallowed
- * — a missing/failed `docker rmi` is operationally tolerable (cache will
- * remain bloated for a while; not a correctness failure).
+ * Production `cleanupImage`: spawn `docker rmi <image>`. Errors are tolerated
+ * — a missing/failed `docker rmi` is operationally survivable (the image
+ * stays on disk; cache stays bloated for a while; not a correctness failure)
+ * — but we warn on non-zero exit and on failed-to-spawn so a persistently-flaky
+ * daemon (or a permission slip) becomes visible before disks fill. Silent
+ * leaks were the original failure mode `jinn-mono-uy6v.11` exists to fix.
+ *
+ * We listen on `'exit'` rather than `'close'` and route stdio to `'ignore'`
+ * so the resolve path doesn't depend on parent-side stream draining (which
+ * can fail to fire `'close'` cleanly when piped without backpressure on the
+ * right tick). The image tag + exit code is sufficient signal; operators can
+ * grep the docker daemon log for the underlying reason.
  */
 function defaultCleanupImage(image: string): Promise<void> {
   return new Promise((resolve) => {
     const child = spawn('docker', ['rmi', image], { stdio: ['ignore', 'ignore', 'ignore'] });
-    child.on('close', () => resolve());
-    child.on('error', () => resolve());
+    child.on('exit', (code, signal) => {
+      if (code !== 0) {
+        const status =
+          code !== null ? `exited ${code}` : `terminated by signal ${signal ?? 'unknown'}`;
+        console.warn(`[swe-rebench-v2] docker rmi ${image} ${status}`);
+      }
+      resolve();
+    });
+    child.on('error', (err) => {
+      console.warn(`[swe-rebench-v2] docker rmi ${image} failed to spawn: ${err.message}`);
+      resolve();
+    });
   });
 }
 

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
@@ -94,12 +94,15 @@ export interface PythonEvalRunnerOptions {
  */
 export const DEFAULT_EVAL_IMAGE_CACHE_MAX = 20;
 
-function resolveImageCacheMax(opt: number | undefined): number {
+export function resolveImageCacheMax(opt: number | undefined): number {
   if (typeof opt === 'number' && Number.isFinite(opt) && opt > 0) return Math.floor(opt);
   const envRaw = process.env['JINN_EVAL_IMAGE_CACHE_MAX'];
   if (envRaw !== undefined) {
-    const parsed = Number.parseInt(envRaw, 10);
-    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+    // `Number()` rejects strings with trailing garbage (e.g. `"1e3oops"` →
+    // NaN), unlike `parseInt`. We want operators who typo this to fall back
+    // to the default, not silently get `1`.
+    const parsed = Number(envRaw);
+    if (Number.isFinite(parsed) && Number.isInteger(parsed) && parsed > 0) return parsed;
   }
   return DEFAULT_EVAL_IMAGE_CACHE_MAX;
 }
@@ -240,10 +243,13 @@ export class PythonEvalRunner implements EvalRunner {
       this.imageLru.delete(oldest);
       try {
         await this.cleanupImage(oldest);
-      } catch {
-        // Swallow — see `cleanupImage` contract. Best-effort GC: a failed
-        // rmi leaves the image on disk but doesn't break the loop, and the
-        // LRU has already moved on.
+      } catch (err) {
+        // Best-effort GC: a failed rmi leaves the image on disk but mustn't
+        // break the loop. Warn so a flaky `docker` (or a permission slip)
+        // becomes visible before disks fill — silent leaks were the whole
+        // problem this bead exists to fix.
+        const reason = err instanceof Error ? err.message : String(err);
+        console.warn(`[swe-rebench-v2] eval-image cleanup failed for ${oldest}: ${reason}`);
       }
     }
   }

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
@@ -57,6 +57,64 @@ export interface PythonEvalRunnerOptions {
   pythonBin?: string;
   /** Workers for parallel eval (defaults to 1; we run one task at a time). */
   maxWorkers?: number;
+  /**
+   * Max number of distinct eval images to keep in the local Docker cache.
+   * The runner tracks an in-process LRU keyed by image tag; once usage exceeds
+   * this cap, the least-recently-used images are removed via
+   * {@link PythonEvalRunnerOptions.cleanupImage}.
+   *
+   * The leaderboard pool has hundreds of unique instances at ~3 GB/image, so
+   * an unbounded cache fills operator disks in days (jinn-mono-uy6v.11).
+   *
+   * Default: `process.env.JINN_EVAL_IMAGE_CACHE_MAX` parsed as an integer, or
+   * `DEFAULT_EVAL_IMAGE_CACHE_MAX` (20) if unset/invalid.
+   */
+  imageCacheMax?: number;
+  /**
+   * Removes an image from the local Docker cache (or no-ops if the operator
+   * has chosen not to GC). Called for each eviction from the LRU.
+   *
+   * Defaults to `docker rmi <image>` via the system `docker` binary. Test
+   * suites inject a stub to capture the eviction order without shelling out.
+   *
+   * Implementations MUST NOT throw — failures should be swallowed (logged
+   * elsewhere if desired) so a missing/failed `docker rmi` never escapes
+   * `runEval`. The runner enforces this defensively too.
+   */
+  cleanupImage?: (image: string) => Promise<void>;
+}
+
+/**
+ * Default cap on the per-instance Docker image cache when no explicit
+ * `imageCacheMax` and no `JINN_EVAL_IMAGE_CACHE_MAX` env var are configured.
+ *
+ * 20 images × ~3 GB/image ≈ 60 GB working set — small enough that even a
+ * 256 GB disk has headroom, large enough that the steady-state loop on a
+ * frequently-repeating subset of the pool rarely re-pulls.
+ */
+export const DEFAULT_EVAL_IMAGE_CACHE_MAX = 20;
+
+function resolveImageCacheMax(opt: number | undefined): number {
+  if (typeof opt === 'number' && Number.isFinite(opt) && opt > 0) return Math.floor(opt);
+  const envRaw = process.env['JINN_EVAL_IMAGE_CACHE_MAX'];
+  if (envRaw !== undefined) {
+    const parsed = Number.parseInt(envRaw, 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_EVAL_IMAGE_CACHE_MAX;
+}
+
+/**
+ * Production `cleanupImage`: spawn `docker rmi <image>`. Errors are swallowed
+ * — a missing/failed `docker rmi` is operationally tolerable (cache will
+ * remain bloated for a while; not a correctness failure).
+ */
+function defaultCleanupImage(image: string): Promise<void> {
+  return new Promise((resolve) => {
+    const child = spawn('docker', ['rmi', image], { stdio: ['ignore', 'ignore', 'ignore'] });
+    child.on('close', () => resolve());
+    child.on('error', () => resolve());
+  });
 }
 
 /**
@@ -133,9 +191,64 @@ function buildTestCommands(args: Parameters<EvalRunner['runEval']>[0]): string[]
 }
 
 export class PythonEvalRunner implements EvalRunner {
-  constructor(private readonly opts: PythonEvalRunnerOptions) {}
+  /**
+   * LRU of image tags whose Docker layers may be cached locally. Stored as a
+   * `Set<string>` because `Set` preserves insertion order; we delete-then-add
+   * to refresh recency and `next()` on the keys iterator to find the
+   * least-recently-used entry.
+   */
+  private readonly imageLru = new Set<string>();
+  private readonly imageCacheMax: number;
+  private readonly cleanupImage: (image: string) => Promise<void>;
+
+  constructor(private readonly opts: PythonEvalRunnerOptions) {
+    this.imageCacheMax = resolveImageCacheMax(opts.imageCacheMax);
+    this.cleanupImage = opts.cleanupImage ?? defaultCleanupImage;
+  }
 
   async runEval(args: Parameters<EvalRunner['runEval']>[0]): ReturnType<EvalRunner['runEval']> {
+    try {
+      return await this.runEvalImpl(args);
+    } finally {
+      // Always record the image and run GC — even when the eval threw. A
+      // pull-and-crash failure (Docker storage IO error, image_arch_mismatch,
+      // patch_corrupt, eval_no_report) still left an image on disk; we must
+      // count it toward the cache cap so the failure path can't leak the LRU.
+      await this.recordImageUsage(args.image);
+    }
+  }
+
+  /**
+   * Move `image` to the most-recently-used slot of the in-process LRU; if the
+   * set now exceeds {@link imageCacheMax}, evict the oldest entries via
+   * {@link cleanupImage}. Eviction failures are swallowed so a flaky
+   * `docker rmi` cannot escape `runEval`.
+   *
+   * The cap is enforced after the just-used image is inserted: the
+   * just-evaluated image is the *most* recent, so repeat-evals of recently
+   * used instances never re-pull. Only when more than N distinct images have
+   * been used does the oldest get rmi'd.
+   */
+  private async recordImageUsage(image: string): Promise<void> {
+    if (!image) return;
+    // Refresh recency: delete-then-add reinserts at the tail of the set.
+    this.imageLru.delete(image);
+    this.imageLru.add(image);
+    while (this.imageLru.size > this.imageCacheMax) {
+      const oldest = this.imageLru.values().next().value;
+      if (!oldest) break;
+      this.imageLru.delete(oldest);
+      try {
+        await this.cleanupImage(oldest);
+      } catch {
+        // Swallow — see `cleanupImage` contract. Best-effort GC: a failed
+        // rmi leaves the image on disk but doesn't break the loop, and the
+        // LRU has already moved on.
+      }
+    }
+  }
+
+  private async runEvalImpl(args: Parameters<EvalRunner['runEval']>[0]): ReturnType<EvalRunner['runEval']> {
     const tmp = await mkdtemp(join(tmpdir(), 'swerebench-eval-'));
     // Single-task runner: eval.py matches the patch override by instance_id.
     const INSTANCE_ID = args.instance_id;

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/harness.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/harness.ts
@@ -40,7 +40,11 @@ import type { Task } from '../../../types/task.js';
 import { SignedEnvelopeSchema } from '../../../types/envelope.js';
 import { uploadToIpfs } from '../../../adapters/mech/ipfs.js';
 import { SweRebenchV2Evaluator, type EvalRunner, type HfFetcher } from './index.js';
-import { PythonEvalRunner, EvalCouldNotGradeError } from './eval-runner.js';
+import {
+  PythonEvalRunner,
+  EvalCouldNotGradeError,
+  type PythonEvalRunnerOptions,
+} from './eval-runner.js';
 import { HttpHfFetcher } from './hf-fetcher.js';
 
 const DEFAULT_IPFS_REGISTRY_URL = 'https://registry.autonolas.tech';
@@ -73,7 +77,21 @@ export interface SweRebenchV2EvaluatorHarnessOptions {
   _testDeps?: {
     runCommand?: typeof runCommand;
     fetcher?: HfFetcher;
+    /**
+     * Per-call runner override. When set, used directly on every `run()` —
+     * the harness skips the lazy/cached path. Tests that need a fresh mock
+     * per call typically also rebuild the harness per call, so this is
+     * effectively a single-runner override.
+     */
     runner?: EvalRunner;
+    /**
+     * Factory used to construct the cached runner the first time `run()`
+     * fires (and only then). Tests use this to verify the runner is reused
+     * across `run()` calls — the {@link runner} instance-injection point
+     * makes that test invisible because it short-circuits caching entirely.
+     * Defaults to `(opts) => new PythonEvalRunner(opts)`.
+     */
+    makeRunner?: (opts: PythonEvalRunnerOptions) => EvalRunner;
     uploadToIpfs?: typeof uploadToIpfs;
   };
 }
@@ -91,12 +109,39 @@ export class SweRebenchV2EvaluatorHarness implements Harness {
    *  for a short TTL so we don't spawn `docker` in a tight loop. */
   private dockerCheckCache: { at: number; ok: boolean } | null = null;
   private static readonly DOCKER_CHECK_TTL_MS = 5_000;
+  /**
+   * Lazily-constructed runner reused across every `run()` call for the
+   * lifetime of this harness instance. The harness is registered once at
+   * boot (`buildHarnesses()` in `impls/index.ts`), so a cached runner here
+   * persists for the daemon lifetime. The runner holds the in-process LRU
+   * of eval-image tags; without this caching the LRU is rebuilt empty per
+   * call and the disk-budget bead (jinn-mono-uy6v.11) is a no-op.
+   */
+  private cachedRunner: EvalRunner | undefined;
 
   constructor(opts: SweRebenchV2EvaluatorHarnessOptions = {}) {
     this.stub = opts.stub ?? false;
     this.implStateDir = opts.implStateDir;
     this.ipfsRegistryUrl = opts.ipfsRegistryUrl ?? DEFAULT_IPFS_REGISTRY_URL;
     this.deps = opts._testDeps ?? {};
+  }
+
+  /**
+   * Resolve the {@link EvalRunner} used for a `run()` invocation. The
+   * runner is constructed lazily on the first call and reused thereafter so
+   * the LRU image cache (`jinn-mono-uy6v.11`) actually accumulates across
+   * evaluations. A {@link _testDeps.runner} override bypasses caching for
+   * tests that want a fresh mock per call.
+   */
+  private getRunner(upstreamRepoDir: string): EvalRunner {
+    if (this.deps.runner) return this.deps.runner;
+    if (!this.cachedRunner) {
+      const make =
+        this.deps.makeRunner ??
+        ((opts: PythonEvalRunnerOptions) => new PythonEvalRunner(opts));
+      this.cachedRunner = make({ upstreamRepoDir });
+    }
+    return this.cachedRunner;
   }
 
   private async isDockerReachable(now: number = Date.now()): Promise<boolean> {
@@ -309,8 +354,7 @@ export class SweRebenchV2EvaluatorHarness implements Harness {
     const solutionPayload = SweRebenchV2SolutionPayloadSchema.parse(envelope.payload);
 
     const fetcher: HfFetcher = this.deps.fetcher ?? new HttpHfFetcher();
-    const runner: EvalRunner =
-      this.deps.runner ?? new PythonEvalRunner({ upstreamRepoDir: state.upstreamRepoDir });
+    const runner: EvalRunner = this.getRunner(state.upstreamRepoDir);
     const evaluator = new SweRebenchV2Evaluator({ fetcher, runner });
 
     let graded: Awaited<ReturnType<SweRebenchV2Evaluator['grade']>>;

--- a/client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts
+++ b/client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts
@@ -5,6 +5,8 @@ import { join } from 'node:path';
 import {
   PythonEvalRunner,
   EvalCouldNotGradeError,
+  DEFAULT_EVAL_IMAGE_CACHE_MAX,
+  resolveImageCacheMax,
 } from '../../../../src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.js';
 
 const tempDirs: string[] = [];
@@ -386,6 +388,28 @@ describe('PythonEvalRunner', () => {
       expect(log).toContain('rmi');
       expect(log).toContain('img-1:latest');
       expect(log).not.toContain('img-2:latest');
+    });
+
+    it('falls back to DEFAULT_EVAL_IMAGE_CACHE_MAX when the env var is invalid (0 / negative / non-numeric / empty)', () => {
+      const prev = process.env['JINN_EVAL_IMAGE_CACHE_MAX'];
+      try {
+        for (const garbage of ['0', '-5', 'garbage', '', '  ', '1e3oops']) {
+          process.env['JINN_EVAL_IMAGE_CACHE_MAX'] = garbage;
+          expect(resolveImageCacheMax(undefined)).toBe(DEFAULT_EVAL_IMAGE_CACHE_MAX);
+        }
+        // Sanity: a valid positive integer is honored.
+        process.env['JINN_EVAL_IMAGE_CACHE_MAX'] = '7';
+        expect(resolveImageCacheMax(undefined)).toBe(7);
+        // Explicit option always wins over env (positive option short-circuits).
+        process.env['JINN_EVAL_IMAGE_CACHE_MAX'] = '999';
+        expect(resolveImageCacheMax(3)).toBe(3);
+        // Invalid explicit option falls through to the env.
+        expect(resolveImageCacheMax(0)).toBe(999);
+        expect(resolveImageCacheMax(-1)).toBe(999);
+      } finally {
+        if (prev === undefined) delete process.env['JINN_EVAL_IMAGE_CACHE_MAX'];
+        else process.env['JINN_EVAL_IMAGE_CACHE_MAX'] = prev;
+      }
     });
   });
 });

--- a/client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts
+++ b/client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts
@@ -233,4 +233,159 @@ describe('PythonEvalRunner', () => {
     await expect(new PythonEvalRunner({ upstreamRepoDir: dir, maxWorkers: 1 }).runEval(REQUEST))
       .rejects.toBeInstanceOf(EvalCouldNotGradeError);
   });
+
+  // jinn-mono-uy6v.11 — bound the per-instance Docker image cache so a
+  // long-running operator daemon does not accumulate ~3 GB/image until the
+  // disk fills. The runner keeps an in-process LRU of image names; when more
+  // than `imageCacheMax` distinct images have been used, the least-recently
+  // used ones are removed via the injected `cleanupImage` hook (which
+  // defaults to `docker rmi <image>` in production).
+  describe('LRU image cache GC (jinn-mono-uy6v.11)', () => {
+    it('does NOT remove any image while distinct usages ≤ cap (keeps repeat-evals fast)', async () => {
+      const upstreamRepoDir = makeUpstreamFixture();
+      const removed: string[] = [];
+      const runner = new PythonEvalRunner({
+        upstreamRepoDir,
+        maxWorkers: 1,
+        imageCacheMax: 3,
+        cleanupImage: async (image) => { removed.push(image); },
+      });
+      await runner.runEval({ ...REQUEST, instance_id: 'i1', image: 'img-1:latest' });
+      await runner.runEval({ ...REQUEST, instance_id: 'i2', image: 'img-2:latest' });
+      await runner.runEval({ ...REQUEST, instance_id: 'i3', image: 'img-3:latest' });
+      // Cache is full but not over capacity — nothing should be GC'd yet.
+      expect(removed).toEqual([]);
+    });
+
+    it('evicts the least-recently-used image once usage exceeds the cap', async () => {
+      const upstreamRepoDir = makeUpstreamFixture();
+      const removed: string[] = [];
+      const runner = new PythonEvalRunner({
+        upstreamRepoDir,
+        maxWorkers: 1,
+        imageCacheMax: 2,
+        cleanupImage: async (image) => { removed.push(image); },
+      });
+      await runner.runEval({ ...REQUEST, instance_id: 'i1', image: 'img-1:latest' });
+      await runner.runEval({ ...REQUEST, instance_id: 'i2', image: 'img-2:latest' });
+      // Third distinct image — must evict the oldest (img-1).
+      await runner.runEval({ ...REQUEST, instance_id: 'i3', image: 'img-3:latest' });
+      expect(removed).toEqual(['img-1:latest']);
+      // Fourth — must evict the now-oldest (img-2).
+      await runner.runEval({ ...REQUEST, instance_id: 'i4', image: 'img-4:latest' });
+      expect(removed).toEqual(['img-1:latest', 'img-2:latest']);
+    });
+
+    it('refreshes LRU order on repeat-eval — re-using an image protects it from eviction', async () => {
+      const upstreamRepoDir = makeUpstreamFixture();
+      const removed: string[] = [];
+      const runner = new PythonEvalRunner({
+        upstreamRepoDir,
+        maxWorkers: 1,
+        imageCacheMax: 2,
+        cleanupImage: async (image) => { removed.push(image); },
+      });
+      await runner.runEval({ ...REQUEST, instance_id: 'i1', image: 'img-1:latest' });
+      await runner.runEval({ ...REQUEST, instance_id: 'i2', image: 'img-2:latest' });
+      // Re-use img-1 — now img-2 is the oldest.
+      await runner.runEval({ ...REQUEST, instance_id: 'i1-repeat', image: 'img-1:latest' });
+      expect(removed).toEqual([]);
+      // A new distinct image evicts img-2, not img-1.
+      await runner.runEval({ ...REQUEST, instance_id: 'i3', image: 'img-3:latest' });
+      expect(removed).toEqual(['img-2:latest']);
+    });
+
+    it('records the image in the LRU even when the eval throws EvalCouldNotGradeError', async () => {
+      // Cap of 1 — every new distinct image evicts the previous one. This
+      // proves cleanup runs in the failure path too (acceptance: cleanup must
+      // not be conditional on the success path).
+      const failingFixture = makeUpstreamFixture({
+        reportItem: { error: 'Task missing top-level image_name.' },
+      });
+      const removed: string[] = [];
+      const runner = new PythonEvalRunner({
+        upstreamRepoDir: failingFixture,
+        maxWorkers: 1,
+        imageCacheMax: 1,
+        cleanupImage: async (image) => { removed.push(image); },
+      });
+      await expect(runner.runEval({ ...REQUEST, instance_id: 'i1', image: 'img-1:latest' }))
+        .rejects.toBeInstanceOf(EvalCouldNotGradeError);
+      // A second distinct image — even after a failure — must evict the first.
+      await expect(runner.runEval({ ...REQUEST, instance_id: 'i2', image: 'img-2:latest' }))
+        .rejects.toBeInstanceOf(EvalCouldNotGradeError);
+      expect(removed).toEqual(['img-1:latest']);
+    });
+
+    it('also records the image in the LRU when the report is missing/unparseable (no-report failure path)', async () => {
+      // eval.py exits non-zero with no report file — runEval throws
+      // EvalCouldNotGradeError('eval_no_report'). The image must still be
+      // tracked for GC, otherwise pull-and-crash failures leak the cache.
+      const dir = mkdtempSync(join(tmpdir(), 'swe-rebench-eval-runner-test-'));
+      tempDirs.push(dir);
+      const scriptsDir = join(dir, 'scripts');
+      mkdirSync(scriptsDir, { recursive: true });
+      writeFileSync(join(scriptsDir, '__init__.py'), '');
+      writeFileSync(join(scriptsDir, 'eval.py'), 'import sys\nsys.exit(2)\n');
+      chmodSync(join(scriptsDir, 'eval.py'), 0o755);
+
+      const removed: string[] = [];
+      const runner = new PythonEvalRunner({
+        upstreamRepoDir: dir,
+        maxWorkers: 1,
+        imageCacheMax: 1,
+        cleanupImage: async (image) => { removed.push(image); },
+      });
+      await expect(runner.runEval({ ...REQUEST, instance_id: 'i1', image: 'img-1:latest' }))
+        .rejects.toBeInstanceOf(EvalCouldNotGradeError);
+      await expect(runner.runEval({ ...REQUEST, instance_id: 'i2', image: 'img-2:latest' }))
+        .rejects.toBeInstanceOf(EvalCouldNotGradeError);
+      expect(removed).toEqual(['img-1:latest']);
+    });
+
+    it('swallows cleanupImage errors so a failing docker rmi never escapes runEval', async () => {
+      const upstreamRepoDir = makeUpstreamFixture();
+      const runner = new PythonEvalRunner({
+        upstreamRepoDir,
+        maxWorkers: 1,
+        imageCacheMax: 1,
+        cleanupImage: async () => { throw new Error('rmi blew up'); },
+      });
+      await runner.runEval({ ...REQUEST, instance_id: 'i1', image: 'img-1:latest' });
+      // The second call would trigger cleanupImage(img-1). It must complete
+      // normally and return the graded result.
+      const result = await runner.runEval({ ...REQUEST, instance_id: 'i2', image: 'img-2:latest' });
+      expect(result.passed_match).toBe(true);
+    });
+
+    it('reads the default cap from JINN_EVAL_IMAGE_CACHE_MAX when neither imageCacheMax nor cleanupImage is configured', async () => {
+      const upstreamRepoDir = makeUpstreamFixture();
+      const prev = process.env['JINN_EVAL_IMAGE_CACHE_MAX'];
+      const prevPath = process.env['PATH'];
+      // Stub `docker` on PATH with a script that records the rmi target and
+      // returns 0. Cap=1 → second distinct image triggers rmi of the first.
+      const stubDir = mkdtempSync(join(tmpdir(), 'swe-rebench-docker-stub-'));
+      tempDirs.push(stubDir);
+      const logPath = join(stubDir, 'rmi.log');
+      writeFileSync(join(stubDir, 'docker'), `#!/usr/bin/env bash\necho "$@" >> ${JSON.stringify(logPath)}\nexit 0\n`);
+      chmodSync(join(stubDir, 'docker'), 0o755);
+
+      process.env['JINN_EVAL_IMAGE_CACHE_MAX'] = '1';
+      process.env['PATH'] = `${stubDir}:${prevPath}`;
+      try {
+        const runner = new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 });
+        await runner.runEval({ ...REQUEST, instance_id: 'i1', image: 'img-1:latest' });
+        await runner.runEval({ ...REQUEST, instance_id: 'i2', image: 'img-2:latest' });
+      } finally {
+        if (prev === undefined) delete process.env['JINN_EVAL_IMAGE_CACHE_MAX'];
+        else process.env['JINN_EVAL_IMAGE_CACHE_MAX'] = prev;
+        if (prevPath === undefined) delete process.env['PATH'];
+        else process.env['PATH'] = prevPath;
+      }
+      const log = readFileSync(logPath, 'utf8');
+      expect(log).toContain('rmi');
+      expect(log).toContain('img-1:latest');
+      expect(log).not.toContain('img-2:latest');
+    });
+  });
 });

--- a/client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts
+++ b/client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -392,14 +392,27 @@ describe('PythonEvalRunner', () => {
 
     it('falls back to DEFAULT_EVAL_IMAGE_CACHE_MAX when the env var is invalid (0 / negative / non-numeric / empty)', () => {
       const prev = process.env['JINN_EVAL_IMAGE_CACHE_MAX'];
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
       try {
-        for (const garbage of ['0', '-5', 'garbage', '', '  ', '1e3oops']) {
+        const invalidInputs = ['0', '-5', 'garbage', '', '  ', '1e3oops'];
+        for (const garbage of invalidInputs) {
+          warn.mockClear();
           process.env['JINN_EVAL_IMAGE_CACHE_MAX'] = garbage;
           expect(resolveImageCacheMax(undefined)).toBe(DEFAULT_EVAL_IMAGE_CACHE_MAX);
+          // Operators who mistype the env var get a loud signal — silent
+          // fallback was the original review finding here. The literal value
+          // is interpolated so trailing whitespace / empty-string typos are
+          // unambiguous in the log.
+          expect(warn).toHaveBeenCalledTimes(1);
+          expect(warn).toHaveBeenCalledWith(
+            expect.stringContaining(`JINN_EVAL_IMAGE_CACHE_MAX=${JSON.stringify(garbage)}`),
+          );
         }
-        // Sanity: a valid positive integer is honored.
+        // Sanity: a valid positive integer is honored and does NOT warn.
+        warn.mockClear();
         process.env['JINN_EVAL_IMAGE_CACHE_MAX'] = '7';
         expect(resolveImageCacheMax(undefined)).toBe(7);
+        expect(warn).not.toHaveBeenCalled();
         // Explicit option always wins over env (positive option short-circuits).
         process.env['JINN_EVAL_IMAGE_CACHE_MAX'] = '999';
         expect(resolveImageCacheMax(3)).toBe(3);
@@ -409,7 +422,46 @@ describe('PythonEvalRunner', () => {
       } finally {
         if (prev === undefined) delete process.env['JINN_EVAL_IMAGE_CACHE_MAX'];
         else process.env['JINN_EVAL_IMAGE_CACHE_MAX'] = prev;
+        warn.mockRestore();
       }
+    });
+
+    it('warns when the production docker rmi cleanup exits non-zero so a flaky daemon is visible (jinn-mono-uy6v.11)', async () => {
+      // Stub `docker` on PATH with a script that exits non-zero — simulating
+      // "image is in use by container", "permission denied", or a daemon
+      // restart. Pre-fix, `defaultCleanupImage` swallowed errors silently, so
+      // operators had zero visibility into a persistently-failing `docker rmi`
+      // until the disk filled.
+      const upstreamRepoDir = makeUpstreamFixture();
+      const prevPath = process.env['PATH'];
+      const prevCacheMax = process.env['JINN_EVAL_IMAGE_CACHE_MAX'];
+      const stubDir = mkdtempSync(join(tmpdir(), 'swe-rebench-docker-rmi-fail-stub-'));
+      tempDirs.push(stubDir);
+      writeFileSync(join(stubDir, 'docker'), '#!/usr/bin/env bash\nexit 1\n');
+      chmodSync(join(stubDir, 'docker'), 0o755);
+
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      process.env['PATH'] = `${stubDir}:${prevPath ?? ''}`;
+      process.env['JINN_EVAL_IMAGE_CACHE_MAX'] = '1';
+      let warnCalls: string[] = [];
+      try {
+        const runner = new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 });
+        await runner.runEval({ ...REQUEST, instance_id: 'i1', image: 'img-1:latest' });
+        // Second distinct image → triggers cleanup of img-1 → docker stub exits 1.
+        await runner.runEval({ ...REQUEST, instance_id: 'i2', image: 'img-2:latest' });
+        warnCalls = warn.mock.calls.map((c) => String(c[0]));
+      } finally {
+        if (prevPath === undefined) delete process.env['PATH'];
+        else process.env['PATH'] = prevPath;
+        if (prevCacheMax === undefined) delete process.env['JINN_EVAL_IMAGE_CACHE_MAX'];
+        else process.env['JINN_EVAL_IMAGE_CACHE_MAX'] = prevCacheMax;
+        warn.mockRestore();
+      }
+      // Warn fired with the image tag + non-zero exit code. (Captured before
+      // mockRestore so a captures-after-restore quirk can't be the failure.)
+      const cleanupWarn = warnCalls.find((m) => m.includes('docker rmi img-1:latest'));
+      expect(cleanupWarn).toBeTruthy();
+      expect(cleanupWarn).toContain('exited 1');
     });
   });
 });

--- a/client/test/harnesses/impls/swe-rebench-v2-evaluator/harness.test.ts
+++ b/client/test/harnesses/impls/swe-rebench-v2-evaluator/harness.test.ts
@@ -508,4 +508,52 @@ describe('SweRebenchV2EvaluatorHarness — run', () => {
     );
     await expect(harness.run(ctx)).rejects.toThrow(/not enabled/);
   });
+
+  it('reuses a single EvalRunner across run() calls so the LRU image cache accumulates (jinn-mono-uy6v.11)', async () => {
+    // Regression: pre-fix, `new PythonEvalRunner(...)` was constructed inside
+    // each `run()` call, so the in-process LRU image cache was rebuilt empty
+    // every invocation and `cleanupImage` never fired in production. The
+    // existing LRU-eviction tests didn't catch this because they exercise
+    // PythonEvalRunner directly. This test pins the harness→runner wiring:
+    // the runner factory must be invoked exactly once across multiple run()
+    // calls, regardless of how many distinct tasks the harness grades.
+    const makeRunner = vi.fn(() => ({
+      runEval: vi.fn().mockResolvedValue({
+        passed_match: true,
+        passed: ['test_a', 'test_b'],
+        failed: [],
+        log: 'ok',
+        exitCode: 0,
+      }),
+    }));
+    const harness = new SweRebenchV2EvaluatorHarness({
+      implStateDir,
+      _testDeps: {
+        fetcher: makeFakeFetcher(),
+        makeRunner,
+        uploadToIpfs: vi.fn().mockResolvedValue('bafy-test-log'),
+      },
+    });
+    const ctx1 = buildHarnessContext(
+      implStateDir,
+      buildEvaluationTask(buildSolverEnvelope()),
+    );
+    const ctx2 = buildHarnessContext(
+      implStateDir,
+      buildEvaluationTask(buildSolverEnvelope()),
+    );
+    await harness.run(ctx1);
+    await harness.run(ctx2);
+    expect(makeRunner).toHaveBeenCalledTimes(1);
+    // The factory is also expected to receive the upstream repo dir from the
+    // enabled state — guards against a future refactor that passes the wrong
+    // path and silently creates a broken runner.
+    expect(makeRunner).toHaveBeenCalledWith(
+      expect.objectContaining({ upstreamRepoDir: expect.any(String) }),
+    );
+    // Sanity: both runs actually invoked runEval — proves the harness is
+    // exercising the cached runner, not falling back to anything else.
+    const runner = makeRunner.mock.results[0]?.value as { runEval: ReturnType<typeof vi.fn> };
+    expect(runner.runEval).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
## Why

The SWE-rebench v2 evaluator pulls a per-instance Docker image (`swerebench/sweb.eval.x86_64.<repo>_1776_<instance>:latest`, 1–8 GB each, ~3 GB avg). Upstream `eval.py` uses `docker run --rm` so the *container* is cleaned, but the *image* stays cached locally. The leaderboard pool has 741 unique instances; if all were pulled, the cache would balloon to ~2–5 TB.

Observed live (2026-05-13): ~16 verdicts/hour. Day-1 unique-instance pulls trend 50–100 → 150–300 GB on day 1, settling lower as repeats accumulate. A 1 TB operator disk fills in ~2–3 weeks of continuous operation; smaller disks faster. Operators currently have to manually `docker image prune` or watch disk usage.

## What

`PythonEvalRunner` now tracks an in-process LRU of image tags. After each `runEval` — success or thrown `EvalCouldNotGradeError`, via a `finally` block — the just-used image is bumped to the most-recent slot; when the set exceeds the configured cap, the least-recently-used image is removed via the injected `cleanupImage` hook (default: `docker rmi <image>` via `spawn`, errors swallowed best-effort).

Key properties:

- **Repeat-evals of recently-used instances never re-pull.** Refresh-on-use moves the image to the most-recent slot before the cap is checked, so the just-evaluated image is never the eviction target. Only the genuinely-oldest entries are rmi'd.
- **Cleanup runs on every terminal exit path.** The `recordImageUsage` call lives in `finally`, so a pull-and-crash failure (Docker storage IO error, image_arch_mismatch, patch_corrupt, eval_no_report, upstream setup-error) still counts toward the cap — the failure path can't leak the LRU.
- **Best-effort GC.** `cleanupImage` errors are swallowed: a failed `docker rmi` leaves the image on disk for the next eviction attempt but never escapes `runEval`.
- **Process-lifetime LRU.** No persistence — daemon restarts re-discover the cache state by usage; that's acceptable (worst case is re-pulling a recently-used image once after restart).

## Operator knob

`JINN_EVAL_IMAGE_CACHE_MAX` (env-only, mirrored in the canonical config table in `CLAUDE.md`).

- **Default: 20.** At ~3 GB/image average, that's a ~60 GB steady-state working set — small enough that even a 256 GB SSD has headroom, large enough that frequently-repeating subsets of the pool rarely re-pull.
- **Programmatic overrides.** `PythonEvalRunnerOptions.imageCacheMax` takes precedence over the env var (used by the test suite; available to callers that build `PythonEvalRunner` directly, e.g. `validate-pool`).

I picked **20** over 10 because at ~3 GB/instance the absolute disk cost is bounded (60 GB) and the leaderboard's verdict mix re-uses instances often enough that a too-aggressive cap would visibly increase repeat-pull traffic. Operators on small disks can lower it via the env var; nothing in the loop depends on a particular value.

## Tests (TDD)

Six new tests in `client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts`, all under a `LRU image cache GC (jinn-mono-uy6v.11)` describe block:

1. No eviction while distinct usages ≤ cap (keeps repeat-evals fast).
2. Oldest evicted once usage exceeds the cap (FIFO eviction order).
3. Refresh-on-repeat protects recently-used images from eviction.
4. Cleanup runs on the upstream setup-error failure path.
5. Cleanup runs on the no-report (eval.py crashed) failure path.
6. A throwing `cleanupImage` never escapes `runEval`.
7. The env-var default is honoured by the production `docker rmi` path (verified by stubbing `docker` on PATH and inspecting the recorded args).

Existing 11 `PythonEvalRunner` tests still pass. Full vitest run: 3218 passing locally (2 pre-existing unrelated flakes: an anvil-fork timing test and a hyperliquid testnet round-trip).

## Out of scope

Wider Docker cache management (base-image layers, build caches) and pre-fetching / cache-warming. This PR is the per-instance eval images specifically.

Refs jinn-mono-uy6v.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
