### PR TITLE
fix(uy6v.10): emit verdict in swe-rebench-v2 gating so reputation hook fires

### DIFF
--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/harness.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/harness.ts
@@ -363,11 +363,19 @@ export class SweRebenchV2EvaluatorHarness implements Harness {
       'utf8',
     );
 
+    // Derive the engine-facing `verdict` from `passed_match`. The engine's
+    // reputation-feedback hook (and `verdictCodeForTask` for the on-chain
+    // verdict tag in `claimDelivery`) keys on `gating.verdict`. Before this
+    // mapping, the hook silently no-op'd on every swe-rebench-v2 delivery and
+    // every verdict tag defaulted to PASS — see jinn-mono-uy6v.10.
+    const verdict: 'PASS' | 'FAIL' = verdictPayload.passed_match ? 'PASS' : 'FAIL';
+
     return {
       venueRef: { name: 'swe-rebench-v2' },
       gating: {
         score: verdictPayload.score,
         passed_match: verdictPayload.passed_match,
+        verdict,
       },
       informational: {
         instance_id: task.instance_id,

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/harness.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/harness.ts
@@ -48,6 +48,12 @@ const UPSTREAM_REPO_URL = 'https://github.com/SWE-rebench/SWE-rebench-V2.git';
 const STATE_FILE = 'state.json';
 const ENABLE_CLI = 'jinn harnesses enable swe-rebench-v2-evaluator';
 
+/** The two verdict values emitted by this evaluator. The broader registry
+ *  shape (`reputation.ts`) also recognises `'INDETERMINATE'` / `'REJECTED'`,
+ *  but swe-rebench v2 grades are binary: the gold tests either resolve or
+ *  they don't. Mirrors the pattern in `prediction-v0-evaluator/types.ts`. */
+type SweRebenchVerdict = 'PASS' | 'FAIL';
+
 interface EnabledState {
   schemaVersion: 'swe-rebench-v2-evaluator-state.v1';
   enabled: true;
@@ -368,7 +374,7 @@ export class SweRebenchV2EvaluatorHarness implements Harness {
     // verdict tag in `claimDelivery`) keys on `gating.verdict`. Before this
     // mapping, the hook silently no-op'd on every swe-rebench-v2 delivery and
     // every verdict tag defaulted to PASS — see jinn-mono-uy6v.10.
-    const verdict: 'PASS' | 'FAIL' = verdictPayload.passed_match ? 'PASS' : 'FAIL';
+    const verdict: SweRebenchVerdict = verdictPayload.passed_match ? 'PASS' : 'FAIL';
 
     return {
       venueRef: { name: 'swe-rebench-v2' },

--- a/client/test/harnesses/engine/engine-reputation-feedback.test.ts
+++ b/client/test/harnesses/engine/engine-reputation-feedback.test.ts
@@ -125,6 +125,15 @@ interface SeedOptions {
   taskRole: 'restoration' | 'evaluation';
   verdict: 'PASS' | 'FAIL' | 'REJECTED' | 'INDETERMINATE' | null;
   inlineHarnessManifest: boolean;
+  /**
+   * Override the full `gatingClaim` shape persisted at POST_SNAPSHOT. When
+   * provided, supersedes the default `{ verdict, score }` derived from
+   * `opts.verdict` — used to assert engine behaviour against harness-specific
+   * gating shapes (e.g. swe-rebench-v2's `{ score, passed_match, verdict }`).
+   */
+  gatingClaimOverride?: Record<string, unknown>;
+  /** Override the persisted `solverType` (default `portfolio.v0`). */
+  solverType?: string;
 }
 
 async function seedDelivering(
@@ -133,11 +142,12 @@ async function seedDelivering(
   opts: SeedOptions,
 ): Promise<void> {
   const now = Date.now() - 1000;
+  const solverType = opts.solverType ?? 'portfolio.v0';
   const task: PersistedTaskRunInput['task'] = {
     id: requestId,
     description: 'eval test',
     role: opts.taskRole,
-    solverType: 'portfolio.v0',
+    solverType,
     ...(opts.taskRole === 'evaluation' && opts.inlineHarnessManifest
       ? {
           context: { restorationResult: buildInlinedRestorationResult() },
@@ -151,7 +161,7 @@ async function seedDelivering(
     taskCid: 'bafyintent',
     onchainCreationTx: '0xdeadbeef',
     onchainCreationBlock: 100,
-    solverType: 'portfolio.v0',
+    solverType,
     taskRole: opts.taskRole,
     windowStartTs: now,
     windowEndTs: now + 86_400_000,
@@ -173,7 +183,7 @@ async function seedDelivering(
     postSnapshotCapturedAt: now,
     postSnapshotPayload: { capturedAt: now, hlTime: 0 },
     fillsPayload: [],
-    gatingClaim: opts.verdict ? { verdict: opts.verdict, score: '0.5' } : {},
+    gatingClaim: opts.gatingClaimOverride ?? (opts.verdict ? { verdict: opts.verdict, score: '0.5' } : {}),
   });
   p.transition(requestId, TaskRunState.PACKAGING, {
     manifestCid: 'bafyEvalManifest',
@@ -469,5 +479,138 @@ describe('Engine reputation feedback wiring (jinn-mono-yg4)', () => {
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('could not extract harness manifest hash'),
     );
+  });
+
+  // ── swe-rebench-v2 regression coverage (jinn-mono-uy6v.10) ─────────────────
+  //
+  // Before the fix, the swe-rebench-v2-evaluator harness emitted
+  // `gating: { score, passed_match }` (no `verdict` field). The engine's
+  // feedback hook reads `gatingClaim.verdict`, so the hook silently no-op'd
+  // on every verdict and the agent-reputation registry was never updated.
+  //
+  // The harness now derives `verdict: 'PASS' | 'FAIL'` from `passed_match`
+  // and includes it in `gating`. These tests pin that the engine reads it
+  // and submits feedback for both PASS and FAIL deliveries.
+
+  it('swe-rebench-v2 passed_match=true gating → PASS feedback (score=100)', async () => {
+    const registry = makeRegistry();
+    const resolveAgentId = vi
+      .fn<(h: Hex) => Promise<ResolvedAgent | null>>()
+      .mockResolvedValue({
+        agentId: RESTORER_AGENT_ID,
+        manifestCid: RESTORER_MANIFEST_CID_FROM_SUBGRAPH,
+      });
+
+    const engine = new TestEngine(
+      makeOpts(store, {
+        reputationFeedback: { client: registry, resolveAgentId },
+      }),
+    );
+    const requestId = '0xrid-swe-rebench-pass';
+    await seedDelivering(engine, requestId, {
+      taskRole: 'evaluation',
+      verdict: 'PASS',
+      inlineHarnessManifest: true,
+      solverType: 'swe-rebench-v2.v1',
+      // Real shape emitted by SweRebenchV2EvaluatorHarness.run() on a passing
+      // grade. The `verdict` field is what the engine's feedback hook keys on.
+      gatingClaimOverride: { score: 1, passed_match: true, verdict: 'PASS' },
+    });
+
+    await engine.process(requestId);
+
+    const intent = engine.testPersistence.getByRequestId(requestId)!;
+    expect(intent.state).toBe(TaskRunState.COMPLETE);
+
+    expect(resolveAgentId).toHaveBeenCalledWith(RESTORER_EVIDENCE_HASH);
+    expect(registry.giveFeedback).toHaveBeenCalledOnce();
+    expect(registry.giveFeedback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        harnessAgentId: RESTORER_AGENT_ID,
+        score: 100,
+        scoreDecimals: 2,
+        manifestRef: `manifest:${RESTORER_MANIFEST_CID_FROM_SUBGRAPH}`,
+        manifestHash: RESTORER_EVIDENCE_HASH,
+        tag1: 'swe-rebench-v2.v1',
+      }),
+    );
+  });
+
+  it('swe-rebench-v2 passed_match=false gating → FAIL feedback (score=0)', async () => {
+    const registry = makeRegistry();
+    const resolveAgentId = vi
+      .fn<(h: Hex) => Promise<ResolvedAgent | null>>()
+      .mockResolvedValue({
+        agentId: RESTORER_AGENT_ID,
+        manifestCid: RESTORER_MANIFEST_CID_FROM_SUBGRAPH,
+      });
+
+    const engine = new TestEngine(
+      makeOpts(store, {
+        reputationFeedback: { client: registry, resolveAgentId },
+      }),
+    );
+    const requestId = '0xrid-swe-rebench-fail';
+    await seedDelivering(engine, requestId, {
+      taskRole: 'evaluation',
+      verdict: 'FAIL',
+      inlineHarnessManifest: true,
+      solverType: 'swe-rebench-v2.v1',
+      gatingClaimOverride: { score: 0, passed_match: false, verdict: 'FAIL' },
+    });
+
+    await engine.process(requestId);
+
+    const intent = engine.testPersistence.getByRequestId(requestId)!;
+    expect(intent.state).toBe(TaskRunState.COMPLETE);
+
+    expect(registry.giveFeedback).toHaveBeenCalledOnce();
+    expect(registry.giveFeedback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        harnessAgentId: RESTORER_AGENT_ID,
+        score: 0,
+        scoreDecimals: 2,
+        tag1: 'swe-rebench-v2.v1',
+      }),
+    );
+  });
+
+  it('swe-rebench-v2 pre-fix gating shape (no verdict field) → skip log surfaces (regression guard)', async () => {
+    // This pins the pre-fix bug: a gatingClaim that carries score + passed_match
+    // but NO `verdict` field is exactly what the live daemon was producing
+    // (uy6v.10). The hook MUST skip with the recognisable log and never call
+    // giveFeedback — so if a future harness regresses to that shape, this test
+    // catches it loudly (no more silent no-op).
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const registry = makeRegistry();
+    const resolveAgentId = vi
+      .fn<(h: Hex) => Promise<ResolvedAgent | null>>()
+      .mockResolvedValue({
+        agentId: RESTORER_AGENT_ID,
+        manifestCid: RESTORER_MANIFEST_CID_FROM_SUBGRAPH,
+      });
+
+    const engine = new TestEngine(
+      makeOpts(store, {
+        reputationFeedback: { client: registry, resolveAgentId },
+      }),
+    );
+    const requestId = '0xrid-swe-rebench-pre-fix';
+    await seedDelivering(engine, requestId, {
+      taskRole: 'evaluation',
+      verdict: 'PASS',
+      inlineHarnessManifest: true,
+      solverType: 'swe-rebench-v2.v1',
+      // The exact shape the harness used to emit before uy6v.10.
+      gatingClaimOverride: { score: 1, passed_match: true },
+    });
+
+    await engine.process(requestId);
+
+    expect(registry.giveFeedback).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('reputation feedback skipped — gatingClaim has no recognised verdict'),
+    );
+    warn.mockRestore();
   });
 });

--- a/client/test/harnesses/engine/engine-reputation-feedback.test.ts
+++ b/client/test/harnesses/engine/engine-reputation-feedback.test.ts
@@ -27,6 +27,7 @@ import {
 } from '../../../src/harnesses/engine/persistence.js';
 import { TaskRunState } from '../../../src/harnesses/engine/state.js';
 import type { ReputationRegistryClient, ResolvedAgent } from '../../../src/erc8004/index.js';
+import { claimDelivery as mockedClaimDelivery } from '../../../src/adapters/mech/contracts.js';
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
@@ -217,6 +218,10 @@ describe('Engine reputation feedback wiring (jinn-mono-yg4)', () => {
 
   beforeEach(() => {
     store = new Store(':memory:');
+    // Engine.verdictCodeForTask flows into claimDelivery's `verdictCode`
+    // argument — reset between tests so per-test assertions on call args
+    // are not polluted by sibling tests.
+    vi.mocked(mockedClaimDelivery).mockClear();
   });
   afterEach(() => {
     store.close();
@@ -573,6 +578,89 @@ describe('Engine reputation feedback wiring (jinn-mono-yg4)', () => {
         tag1: 'swe-rebench-v2.v1',
       }),
     );
+  });
+
+  // ── On-chain verdictCode pinning (jinn-mono-uy6v.10 review) ───────────────
+  //
+  // `verdictCodeForTask` reads `gatingClaim.verdict` and maps PASS→1, FAIL→2,
+  // INVALID→3, INDETERMINATE/UNRESOLVED→4. The `default` arm silently returns
+  // 1 (PASS) — so any gatingClaim without a recognised `verdict` field tags
+  // the on-chain delivery as PASS regardless of test outcome. This was the
+  // secondary half of uy6v.10: the live daemon's pre-fix swe-rebench-v2
+  // verdicts tagged FAIL deliveries as PASS on chain. The harness fix above
+  // (verdict in gating) closes the live path; these tests pin the mapping so
+  // a future harness that emits `verdict: 'FAIL'` actually lands as 2 on
+  // chain, and the silent-PASS default for the missing-verdict case is
+  // documented (regression bait for the next harness that forgets it).
+  function lastClaimVerdictCode(): number | undefined {
+    const calls = vi.mocked(mockedClaimDelivery).mock.calls;
+    if (calls.length === 0) return undefined;
+    const lastCall = calls[calls.length - 1]!;
+    const options = lastCall[5] as { verdictCode?: number };
+    return options.verdictCode;
+  }
+
+  it('swe-rebench-v2 verdict=FAIL gating → on-chain claimDelivery tagged with FAIL code (2)', async () => {
+    const engine = new TestEngine(makeOpts(store));
+    const requestId = '0xrid-verdictcode-fail';
+    await seedDelivering(engine, requestId, {
+      taskRole: 'evaluation',
+      verdict: 'FAIL',
+      inlineHarnessManifest: true,
+      solverType: 'swe-rebench-v2.v1',
+      gatingClaimOverride: { score: 0, passed_match: false, verdict: 'FAIL' },
+    });
+
+    await engine.process(requestId);
+
+    expect(engine.testPersistence.getByRequestId(requestId)!.state).toBe(
+      TaskRunState.COMPLETE,
+    );
+    expect(lastClaimVerdictCode()).toBe(2);
+  });
+
+  it('swe-rebench-v2 verdict=PASS gating → on-chain claimDelivery tagged with PASS code (1)', async () => {
+    const engine = new TestEngine(makeOpts(store));
+    const requestId = '0xrid-verdictcode-pass';
+    await seedDelivering(engine, requestId, {
+      taskRole: 'evaluation',
+      verdict: 'PASS',
+      inlineHarnessManifest: true,
+      solverType: 'swe-rebench-v2.v1',
+      gatingClaimOverride: { score: 1, passed_match: true, verdict: 'PASS' },
+    });
+
+    await engine.process(requestId);
+
+    expect(engine.testPersistence.getByRequestId(requestId)!.state).toBe(
+      TaskRunState.COMPLETE,
+    );
+    expect(lastClaimVerdictCode()).toBe(1);
+  });
+
+  it('pre-fix gating shape (no verdict field) still tags on-chain delivery as PASS (1) — documents the silent fallback', async () => {
+    // This pins the known fallback at engine.ts `verdictCodeForTask.default`:
+    // a missing/unrecognised `verdict` returns 1 (PASS). The harness fix in
+    // this PR removes the live trigger of this branch, but the engine still
+    // silently defaults to PASS for any future harness that emits the
+    // pre-fix shape. A regression here means a new harness can silently
+    // mis-tag every verdict as PASS — exactly the failure mode uy6v.10
+    // surfaced. If we later harden `verdictCodeForTask` to throw or default
+    // to UNRESOLVED (4) on missing verdict, this test's expected value
+    // changes — that's the intended signal.
+    const engine = new TestEngine(makeOpts(store));
+    const requestId = '0xrid-verdictcode-prefix';
+    await seedDelivering(engine, requestId, {
+      taskRole: 'evaluation',
+      verdict: 'PASS', // ignored by the override below
+      inlineHarnessManifest: true,
+      solverType: 'swe-rebench-v2.v1',
+      gatingClaimOverride: { score: 0, passed_match: false }, // no `verdict`
+    });
+
+    await engine.process(requestId);
+
+    expect(lastClaimVerdictCode()).toBe(1);
   });
 
   it('swe-rebench-v2 pre-fix gating shape (no verdict field) → skip log surfaces (regression guard)', async () => {

--- a/client/test/harnesses/impls/swe-rebench-v2-evaluator/harness.test.ts
+++ b/client/test/harnesses/impls/swe-rebench-v2-evaluator/harness.test.ts
@@ -386,7 +386,10 @@ describe('SweRebenchV2EvaluatorHarness — run', () => {
 
     const sol = await harness.run(ctx);
 
-    expect(sol.gating).toEqual({ score: 1, passed_match: true });
+    // gating MUST include `verdict` ('PASS'|'FAIL') — the engine's reputation
+    // feedback hook keys on this field (jinn-mono-uy6v.10). passed_match=true
+    // → 'PASS'; passed_match=false → 'FAIL'.
+    expect(sol.gating).toEqual({ score: 1, passed_match: true, verdict: 'PASS' });
     expect(sol.verdictPayload).toMatchObject({
       schemaVersion: 'swe-rebench-v2-verdict.v1',
       score: 1,
@@ -454,6 +457,11 @@ describe('SweRebenchV2EvaluatorHarness — run', () => {
     const sol = await harness.run(ctx);
     expect((sol.verdictPayload as Record<string, unknown>)['score']).toBe(0);
     expect((sol.verdictPayload as Record<string, unknown>)['passed_match']).toBe(false);
+    // Failing-grade gating MUST carry `verdict: 'FAIL'` so the engine's
+    // reputation feedback hook records a 0-score on the harness's agent NFT
+    // (jinn-mono-uy6v.10). Before this fix the field was missing and the hook
+    // silently no-op'd on every verdict.
+    expect(sol.gating).toEqual({ score: 0, passed_match: false, verdict: 'FAIL' });
   });
 
   it('does not produce a verdict when the eval could not grade the solution (skips instead)', async () => {


### PR DESCRIPTION
## Bug

The new swe-rebench-v2-evaluator harness was returning `gating: { score, passed_match }` with no `verdict` field. The engine's reputation-feedback hook keys on `gatingClaim.verdict`, so for every verdict-bearing delivery the hook emitted a silent skip log and never submitted an ERC-8004 `ReputationRegistry.giveFeedback` tx:

```
[harness-engine] <rid>: reputation feedback skipped — gatingClaim has no recognised verdict (got=undefined)
```

Live-verified on Base Sepolia 2026-05-13: **9/9 of the new daemon's swe-rebench-v2 verdicts hit this path**. Five of the nine were `passed_match: true` — all of those PASS verdicts should have been minting reputation; none did.

**Impact**: `uy6v.7`'s acceptance criterion — "live verdicts AND JINN reward distribution on Base Sepolia" — had its first half satisfied (verdicts flowing) but the second half blocked. The swe-rebench v2 SolverNet's distribution contract consults the reputation registry; with no reputation accruing, no JINN flows; release-epic gate stays unmet. The bug is *silent* — the verdict still posts on chain, only the reputation update is missing — easy to overlook in review.

**Secondary**: `verdictCodeForTask` in the engine also reads `gating.verdict` and silently defaults to PASS (1) when undefined — so the on-chain verdict tag in `claimDelivery` was being misrecorded as PASS for *every* swe-rebench-v2 delivery regardless of test outcome. Same fix resolves both.

## Root cause

`SweRebenchV2EvaluatorHarness.run()` in `client/src/harnesses/impls/swe-rebench-v2-evaluator/harness.ts` emitted

```ts
return {
  ...
  gating: { score, passed_match },   // no `verdict` field
  ...
};
```

Every other evaluator in the repo (`prediction-v0-evaluator`, `prediction-v1-evaluator`, `portfolio-v0-evaluator`, `prediction-apy-v0-evaluator`) emits `verdict: 'PASS' | 'FAIL' | 'INDETERMINATE' | 'REJECTED'` in `gating`. swe-rebench-v2 was the outlier and silently broke the engine's reputation-feedback contract.

## Fix

Option B (harness aligns to engine contract — all other evaluators already do this). Map `passed_match` → `'PASS' | 'FAIL'` and include in `gating`:

```ts
const verdict: 'PASS' | 'FAIL' = verdictPayload.passed_match ? 'PASS' : 'FAIL';
return {
  ...
  gating: { score, passed_match, verdict },
  ...
};
```

Chosen over Option A (teach engine to recognise swe-rebench-v2's bespoke shape) because Option B has the smaller blast radius and matches what 4 other evaluators already do.

## Regression coverage

- `client/test/harnesses/engine/engine-reputation-feedback.test.ts` — three new cases pinning swe-rebench-v2 gating shape through the engine:
  - PASS gating → `giveFeedback(score=100, tag1='swe-rebench-v2.v1')`
  - FAIL gating → `giveFeedback(score=0, ...)`
  - **Pre-fix shape (no `verdict`) → still emits the recognisable skip log** so the regression can't recur silently. If a future harness ships with the pre-fix shape, this test catches it loudly.
- `client/test/harnesses/impls/swe-rebench-v2-evaluator/harness.test.ts` — passing/failing-grade tests now assert `verdict: 'PASS'|'FAIL'` is present in `sol.gating`.

## Verification

- `tsc --noEmit` — zero errors
- `vitest run` — 3217 passing / 4 skipped (one unrelated `anvil.test.ts` port-bind flake that retries clean)

## Acceptance criteria check

- [x] Eval delivery from swe-rebench v2 evaluator no longer prints `reputation feedback skipped — gatingClaim has no recognised verdict` (regression test `engine-reputation-feedback.test.ts`).
- [x] Registry-update code path is reached for both `passed_match: true` (score=100) and `passed_match: false` (score=0).
- [x] Existing reputation-feedback tests cover the swe-rebench v2 gating shape (extended `engine-reputation-feedback.test.ts` + `harness.test.ts`).
- [ ] Live on-chain feedback tx — must be observed on Base Sepolia after this PR ships canary; not testable from this PR.

Refs `jinn-mono-uy6v.10`, GH parent #182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
