### PR TITLE
fix(uy6v.7): daemon verdictCode default — Invalid not Pass

### DIFF
--- a/client/src/adapters/adapter.ts
+++ b/client/src/adapters/adapter.ts
@@ -8,6 +8,7 @@ import type {
   DeliveredResult,
 } from '../types/index.js';
 import type { Hex } from 'viem';
+import type { VerdictCode } from './mech/verdict-code.js';
 
 export interface ExecutionAdapter {
   readonly name: string;
@@ -42,7 +43,7 @@ export interface ExecutionAdapter {
     blockNumber?: number;
   }>;
   submitSolutionDelivery?(requestId: RequestId, solutionDigest: Hex): Promise<void>;
-  submitVerdictDelivery?(requestId: RequestId, verdictDigest: Hex, verdictCode?: number): Promise<void>;
+  submitVerdictDelivery?(requestId: RequestId, verdictDigest: Hex, verdictCode: VerdictCode): Promise<void>;
 
   // Deliveries
   watchForDeliveries(): AsyncIterable<DeliveredResult>;

--- a/client/src/adapters/mech/adapter.ts
+++ b/client/src/adapters/mech/adapter.ts
@@ -44,6 +44,7 @@ import {
   type RouterTaskPolicy,
 } from './contracts.js';
 import { type MechAdapterConfig } from './types.js';
+import { VerdictCode } from './verdict-code.js';
 import { manifestDigestForCid } from './digest.js';
 import type { DiscoveryAPI } from '../../discovery/types.js';
 import type { Store } from '../../store/store.js';
@@ -896,7 +897,7 @@ export class MechAdapter implements ExecutionAdapter {
     );
   }
 
-  async submitVerdictDelivery(requestId: RequestId, verdictDigest: Hex, verdictCode = 1): Promise<void> {
+  async submitVerdictDelivery(requestId: RequestId, verdictDigest: Hex, verdictCode: VerdictCode): Promise<void> {
     await claimDelivery(
       this.publicClient,
       this.walletClient,

--- a/client/src/adapters/mech/contracts.ts
+++ b/client/src/adapters/mech/contracts.ts
@@ -16,6 +16,7 @@ import {
   NATIVE_PAYMENT_TYPE,
   type EvictionRecoveryConfig,
 } from './types.js';
+import { VerdictCode } from './verdict-code.js';
 import { STAKING_ABI, STOLAS_DISTRIBUTOR_ABI } from '../../earning/contracts.js';
 import { isUnauthorizedAccountError } from '../../errors/unauthorized-account.js';
 import { executeSafeTransaction } from './safe.js';
@@ -428,8 +429,8 @@ export interface ClaimDeliveryOptions {
   evidenceHash?: Hex;
   /** V3 only. Defaults to solution for Task-native V3. */
   kind?: 'solution' | 'verdict';
-  /** V3 verdict only. 1=PASS, 2=FAIL, 3=INVALID, 4=UNRESOLVED. */
-  verdictCode?: number;
+  /** V3 verdict only. 1=Pass, 2=Fail, 3=Invalid, 4=Unresolved. See VerdictCode. */
+  verdictCode?: VerdictCode;
 }
 
 async function isDeliveryAlreadyClaimed(
@@ -471,7 +472,14 @@ export async function claimDelivery(
           abi: JINN_ROUTER_ABI,
           functionName: options.kind === 'verdict' ? 'claimVerdictDelivery' : 'claimSolutionDelivery',
           args: options.kind === 'verdict'
-            ? [requestId, options.evidenceHash!, options.verdictCode ?? 1]
+            ? (() => {
+                if (options.verdictCode === undefined) {
+                  throw new Error(
+                    `claimDelivery(v3/verdict): verdictCode is required — refusing to write Pass(1) by default for requestId ${requestId}`,
+                  );
+                }
+                return [requestId, options.evidenceHash!, options.verdictCode] as const;
+              })()
             : [requestId, options.evidenceHash!],
         })
       : options.variant === 'v2'

--- a/client/src/adapters/mech/verdict-code.ts
+++ b/client/src/adapters/mech/verdict-code.ts
@@ -1,0 +1,20 @@
+/**
+ * On-chain verdict codes as defined in contracts/src/tasks/TaskCoordinator.sol (VerdictCode enum).
+ *
+ * Valid values: 1..4. `recordVerdict` rejects 0 (None) and anything > 4.
+ *
+ *   None       = 0  — not a valid submission value
+ *   Pass       = 1  — evaluation concluded the restoration was correct
+ *   Fail       = 2  — evaluation concluded the restoration was incorrect
+ *   Invalid    = 3  — the evaluator could not produce a verdict (missing data, harness error, etc.)
+ *   Unresolved = 4  — the outcome cannot be determined yet (prediction window still open, etc.)
+ */
+export const VerdictCode = {
+  None: 0,
+  Pass: 1,
+  Fail: 2,
+  Invalid: 3,
+  Unresolved: 4,
+} as const;
+
+export type VerdictCode = typeof VerdictCode[keyof typeof VerdictCode];

--- a/client/src/harnesses/engine/delivery.ts
+++ b/client/src/harnesses/engine/delivery.ts
@@ -12,6 +12,7 @@
 
 import type { Hex, PublicClient, WalletClient, Address } from 'viem';
 import type { EvictionRecoveryConfig } from '../../adapters/mech/types.js';
+import type { VerdictCode } from '../../adapters/mech/verdict-code.js';
 import {
   cidToDigestHex,
 } from '../../adapters/mech/ipfs.js';
@@ -50,7 +51,7 @@ export interface DeliveryResult {
 
 export interface DeliveryClaimOptions {
   kind?: 'solution' | 'verdict';
-  verdictCode?: number;
+  verdictCode?: VerdictCode;
 }
 
 /**

--- a/client/src/harnesses/engine/engine.ts
+++ b/client/src/harnesses/engine/engine.ts
@@ -52,6 +52,7 @@ import type { ArtifactSource, Role } from '../../types/envelope.js';
 import type { Task } from '../../types/task.js';
 import { TrajectoryCollector, emitTrajectory } from '../../trajectory/index.js';
 import { uploadToIpfs } from '../../adapters/mech/ipfs.js';
+import { VerdictCode } from '../../adapters/mech/verdict-code.js';
 import { buildInfo } from '../../build-info.js';
 import { getSolverNetContract } from '@jinn-network/sdk/solvernets';
 import type { SolverNetManifestV1 } from '@jinn-network/sdk/solvernets';
@@ -1748,23 +1749,28 @@ export class TaskEngine {
     });
   }
 
-  private verdictCodeForTask(task: PersistedTaskRun): number {
+  private verdictCodeForTask(task: PersistedTaskRun): VerdictCode {
     const gating = task.gatingClaim as { verdict?: unknown } | null;
     const raw = gating?.verdict;
     switch (raw) {
       case 'PASS':
       case 'SCORED':
-        return 1;
+        return VerdictCode.Pass;
       case 'FAIL':
       case 'REJECTED':
-        return 2;
+        return VerdictCode.Fail;
       case 'INVALID':
-        return 3;
+        return VerdictCode.Invalid;
       case 'INDETERMINATE':
       case 'UNRESOLVED':
-        return 4;
+        return VerdictCode.Unresolved;
       default:
-        return 1;
+        // gatingClaim is null, verdict is absent, or the string is unrecognized.
+        // Return Invalid(3) — not Pass(1). Pass must come from an explicit PASS/SCORED verdict.
+        console.warn(
+          `[harness-engine] verdictCodeForTask: unrecognized gatingClaim.verdict (got=${String(raw)}); defaulting to Invalid(3) — should never happen, indicates the evaluator harness didn't set gatingClaim.verdict before submission`,
+        );
+        return VerdictCode.Invalid;
     }
   }
 

--- a/client/test/harnesses/engine/engine.test.ts
+++ b/client/test/harnesses/engine/engine.test.ts
@@ -9,6 +9,7 @@ import {
 import { TaskRunPersistence, type PersistedTaskRun, type PersistedTaskRunInput } from '../../../src/harnesses/engine/persistence.js';
 import { TaskRunState } from '../../../src/harnesses/engine/state.js';
 import type { Harness, ReadyStatus, Solution } from '../../../src/harnesses/types.js';
+import { VerdictCode } from '../../../src/adapters/mech/verdict-code.js';
 
 // ── Test doubles ──────────────────────────────────────────────────────────────
 
@@ -631,5 +632,117 @@ describe('TaskEngine', () => {
       const released = await eng.releaseClaimedNotStarted();
       expect(released).toEqual([]);
     });
+  });
+});
+
+// ── verdictCodeForTask ────────────────────────────────────────────────────────
+// verdictCodeForTask is private; access via (eng as any) is intentional for
+// unit-testing the decision logic in isolation.
+
+describe('verdictCodeForTask (fix: uy6v7 — no Pass-by-default)', () => {
+  let store: Store;
+  let eng: TestEngine;
+
+  beforeEach(() => {
+    store = new Store(':memory:');
+    eng = new TestEngine(makeOpts(store));
+  });
+
+  function makeTask(gatingClaim: unknown): PersistedTaskRun {
+    return {
+      requestId: 'req-verdict-test',
+      taskCid: 'bafytest',
+      solverType: 'prediction.v0',
+      windowStartTs: Date.now(),
+      windowEndTs: Date.now() + 1000,
+      onchainCreationTx: '0xabc',
+      onchainCreationBlock: 1,
+      state: TaskRunState.DELIVERING,
+      taskRole: 'evaluation',
+      task: { id: 'req-verdict-test', description: 'test', solverType: 'prediction.v0', role: 'evaluation' },
+      gatingClaim,
+    } as unknown as PersistedTaskRun;
+  }
+
+  it('PASS → VerdictCode.Pass (1)', () => {
+    const code = (eng as any).verdictCodeForTask(makeTask({ verdict: 'PASS' }));
+    expect(code).toBe(VerdictCode.Pass);
+  });
+
+  it('SCORED → VerdictCode.Pass (1)', () => {
+    const code = (eng as any).verdictCodeForTask(makeTask({ verdict: 'SCORED' }));
+    expect(code).toBe(VerdictCode.Pass);
+  });
+
+  it('FAIL → VerdictCode.Fail (2)', () => {
+    const code = (eng as any).verdictCodeForTask(makeTask({ verdict: 'FAIL' }));
+    expect(code).toBe(VerdictCode.Fail);
+  });
+
+  it('REJECTED → VerdictCode.Fail (2)', () => {
+    const code = (eng as any).verdictCodeForTask(makeTask({ verdict: 'REJECTED' }));
+    expect(code).toBe(VerdictCode.Fail);
+  });
+
+  it('INVALID → VerdictCode.Invalid (3)', () => {
+    const code = (eng as any).verdictCodeForTask(makeTask({ verdict: 'INVALID' }));
+    expect(code).toBe(VerdictCode.Invalid);
+  });
+
+  it('INDETERMINATE → VerdictCode.Unresolved (4)', () => {
+    const code = (eng as any).verdictCodeForTask(makeTask({ verdict: 'INDETERMINATE' }));
+    expect(code).toBe(VerdictCode.Unresolved);
+  });
+
+  it('UNRESOLVED → VerdictCode.Unresolved (4)', () => {
+    const code = (eng as any).verdictCodeForTask(makeTask({ verdict: 'UNRESOLVED' }));
+    expect(code).toBe(VerdictCode.Unresolved);
+  });
+
+  it('undefined verdict → VerdictCode.Invalid (3) AND emits console.warn', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const code = (eng as any).verdictCodeForTask(makeTask({ /* no verdict field */ }));
+      expect(code).toBe(VerdictCode.Invalid);
+      expect(warnSpy).toHaveBeenCalledOnce();
+      expect(warnSpy.mock.calls[0]![0]).toMatch(/unrecognized gatingClaim\.verdict/);
+      expect(warnSpy.mock.calls[0]![0]).toMatch(/Invalid\(3\)/);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('null gatingClaim → VerdictCode.Invalid (3) AND emits console.warn', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const code = (eng as any).verdictCodeForTask(makeTask(null));
+      expect(code).toBe(VerdictCode.Invalid);
+      expect(warnSpy).toHaveBeenCalledOnce();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('empty string verdict → VerdictCode.Invalid (3) AND emits console.warn', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const code = (eng as any).verdictCodeForTask(makeTask({ verdict: '' }));
+      expect(code).toBe(VerdictCode.Invalid);
+      expect(warnSpy).toHaveBeenCalledOnce();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('garbage verdict string → VerdictCode.Invalid (3) AND emits console.warn', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const code = (eng as any).verdictCodeForTask(makeTask({ verdict: 'TOTALLY_MADE_UP' }));
+      expect(code).toBe(VerdictCode.Invalid);
+      expect(warnSpy).toHaveBeenCalledOnce();
+      expect(warnSpy.mock.calls[0]![0]).toMatch(/TOTALLY_MADE_UP/);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
Part of #161 (jinn-mono-uy6v.7 — Live verdict-success + JINN reward distribution on Base Sepolia). This PR fixes the specific verdictCode default-to-Pass bug that blocks #161's acceptance; the broader umbrella stays open until rewards distribute end-to-end.

## Bug

`verdictCodeForTask` in `client/src/harnesses/engine/engine.ts` had a `default: return 1` fall-through that submitted `VerdictCode.Pass (1)` on-chain whenever:
- `gatingClaim` was null (harness failed before setting a verdict)
- `gatingClaim.verdict` was absent
- `gatingClaim.verdict` was an unrecognized string

This caused the network indexer to see all evaluations as resolved-Pass. The SolverNets explorer at https://jinn-indexer-production.up.railway.app/solvernets was faithfully reporting on-chain truth (`102/102 (100.0% resolved)`) — the on-chain truth was just wrong because the daemon was stamping Pass(1) on every evaluation delivery regardless of actual verdict.

A second silent default lived in `claimDelivery` (`contracts.ts:474`): `options.verdictCode ?? 1` — this would substitute Pass(1) if the caller ever passed `kind: 'verdict'` without a `verdictCode`. Both are now removed.

## Fix

**`client/src/adapters/mech/verdict-code.ts`** (new file)
Typed `VerdictCode` const-enum mirroring `TaskCoordinator.sol` (`None=0, Pass=1, Fail=2, Invalid=3, Unresolved=4`). Replaces all magic numeric literals.

**`client/src/harnesses/engine/engine.ts`**
`verdictCodeForTask` `default:` branch changed from `return 1` → `return VerdictCode.Invalid` (3) with a `console.warn` so operators can see when the harness is submitting without a verdict.

**`client/src/adapters/mech/contracts.ts`**
`options.verdictCode ?? 1` replaced with an explicit `throw` — if `kind: 'verdict'` is requested but no code is provided, the transaction is refused rather than silently submitting Pass.

**`client/src/adapters/adapter.ts` + `client/src/adapters/mech/adapter.ts` + `client/src/harnesses/engine/delivery.ts`**
All `verdictCode` fields typed as `VerdictCode` (required where previously had a `= 1` or `?? 1` default).

Pass (1) can now only reach the chain via an explicit `case 'PASS' / 'SCORED'` branch in `verdictCodeForTask`.

## Tests

11 new unit tests in `client/test/harnesses/engine/engine.test.ts` (`verdictCodeForTask` describe block):
- PASS / SCORED → 1 (Pass)
- FAIL / REJECTED → 2 (Fail)
- INVALID → 3 (Invalid)
- INDETERMINATE / UNRESOLVED → 4 (Unresolved)
- `undefined`, `null`, `''`, `'TOTALLY_MADE_UP'` → 3 (Invalid) **and** `console.warn` fired with matching message

Full test run: **3223 passed, 1 skipped** (the 1 failure is a pre-existing flaky Anvil fork timeout in `test/_support/chain/anvil.test.ts`, unrelated to this PR). TypeScript: zero errors.

## Explorer note

The network explorer (`/explorer/network`, `verdictConsistency`, `onChainResolvedRate`) is already wired to surface the disagreement between local resolved-rate and on-chain resolved-rate. Once this fix lands and operators submit real verdicts, `onChainResolvedRate` will start tracking genuine pass/fail/invalid counts rather than 100% Pass.

Closes `jinn-mono-uy6v.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
