### PR TITLE
feat(gbut): publish executor.model in jinn.execution.v1 envelope

### DIFF
--- a/client/src/harnesses/engine/engine.ts
+++ b/client/src/harnesses/engine/engine.ts
@@ -287,6 +287,12 @@ export interface TaskEngineOptions {
     defaultPriceUsdc: string;
     perArtifactTypePrice: Record<string, string>;
     donation?: { enabled: boolean };
+    /**
+     * Daemon-wide default LLM model identifier (from JinnConfig.claudeModel).
+     * Used as the fallback when a SolverNet does not specify its own model.
+     * Stamped into executor.model in the assembled envelope (jinn-mono-gbut).
+     */
+    claudeModel?: string;
   };
   /**
    * Harness execution mode from operator config (JinnConfig.harness.mode).
@@ -1465,6 +1471,10 @@ export class TaskEngine {
         // Propagate the harness execution mode (train | frozen) so the
         // envelope records whether implStateDir was locked during this run.
         mode: executorMode,
+        // LLM model: prefer SolverNet-specific override, fall back to daemon-wide
+        // default from operatorConfig.claudeModel (jinn-mono-gbut, gh#191).
+        // Left undefined when neither is set — the field is optional in the schema.
+        model: solverNet?.model ?? this.operatorConfig?.claudeModel,
       },
       evidenceTier,
       trajectory: envelopeTrajectory,

--- a/client/src/harnesses/engine/envelope-assembly.ts
+++ b/client/src/harnesses/engine/envelope-assembly.ts
@@ -47,6 +47,12 @@ export interface EnvelopeInputs {
       measurement: string;
     };
     mode?: 'train' | 'frozen';
+    /**
+     * Underlying LLM model identifier this attempt was run against (e.g.
+     * 'claude-haiku-4-5-20251001', 'claude-sonnet-4-6'). When present,
+     * stamped directly into the envelope's executor.model field (jinn-mono-gbut).
+     */
+    model?: string;
   };
   evidenceTier?: EvidenceTier;
   attestation?: SignedEnvelope['attestation'];

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1720,6 +1720,9 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     defaultPriceUsdc: operatorDefaultPrice,
     perArtifactTypePrice: operatorPerTypePrice,
     donation: { enabled: donationEnabled },
+    // Daemon-wide LLM model — stamped as executor.model fallback in envelopes
+    // when a SolverNet does not specify its own model (jinn-mono-gbut, gh#191).
+    claudeModel: config.claudeModel,
   };
 
   // Envelope assembly deps: sign envelopes with agent EOA private key

--- a/client/src/types/envelope.ts
+++ b/client/src/types/envelope.ts
@@ -79,6 +79,15 @@ const ExecutorSchema = z.object({
    * treat undefined as 'train' (the legacy behaviour).
    */
   mode: z.enum(['train', 'frozen']).optional(),
+  /**
+   * Underlying LLM model identifier this attempt was run against (e.g.
+   * 'claude-haiku-4-5-20251001', 'claude-sonnet-4-6', 'codex-defaults').
+   * Optional for back-compat: envelopes produced before this field was
+   * introduced lack it. Sourced from solverNet.model / claudeModel runtime
+   * config; stamped at envelope-assembly time. Indexer reads this for the
+   * network explorer's composition.byModel facet (jinn-mono-gbut, gh#191).
+   */
+  model: z.string().optional(),
 });
 
 const AttestationSchema = z.object({

--- a/client/test/harnesses/engine/envelope-assembly.test.ts
+++ b/client/test/harnesses/engine/envelope-assembly.test.ts
@@ -154,4 +154,28 @@ describe('assembleAndSignEnvelope', () => {
     const result = await assembleAndSignEnvelope(baseInputs, deps);
     expect(result.envelope.schemaVersion).toBe('jinn.execution.v1');
   });
+
+  describe('executor.model stamping (jinn-mono-gbut, gh#191)', () => {
+    it('stamps executor.model when inputs.executor.model is provided', async () => {
+      const inputs: EnvelopeInputs = {
+        ...baseInputs,
+        executor: { ...baseInputs.executor, model: 'claude-haiku-4-5-20251001' },
+      };
+      const result = await assembleAndSignEnvelope(inputs, deps);
+      expect(result.envelope.executor.model).toBe('claude-haiku-4-5-20251001');
+      expect(() => SignedEnvelopeSchema.parse(result.envelope)).not.toThrow();
+    });
+
+    it('leaves executor.model undefined when inputs.executor.model is absent', async () => {
+      // baseInputs.executor has no model field
+      const result = await assembleAndSignEnvelope(baseInputs, deps);
+      expect(result.envelope.executor.model).toBeUndefined();
+      expect(() => SignedEnvelopeSchema.parse(result.envelope)).not.toThrow();
+    });
+
+    it('does not stamp empty string when model is undefined', async () => {
+      const result = await assembleAndSignEnvelope(baseInputs, deps);
+      expect(result.envelope.executor.model).not.toBe('');
+    });
+  });
 });

--- a/client/test/types/envelope.test.ts
+++ b/client/test/types/envelope.test.ts
@@ -156,4 +156,26 @@ describe('SignedEnvelopeSchema', () => {
   it('accepts a signed envelope', () => {
     expect(() => SignedEnvelopeSchema.parse(baseSigned)).not.toThrow();
   });
+
+  describe('executor.model (jinn-mono-gbut, gh#191)', () => {
+    it('accepts envelope with executor.model set', () => {
+      const env = {
+        ...baseSigned,
+        executor: { ...baseSigned.executor, model: 'claude-haiku-4-5-20251001' },
+      };
+      const parsed = SignedEnvelopeSchema.parse(env);
+      expect(parsed.executor.model).toBe('claude-haiku-4-5-20251001');
+    });
+
+    it('accepts envelope without executor.model (back-compat)', () => {
+      // baseSigned has no model field — must parse cleanly
+      const parsed = SignedEnvelopeSchema.parse(baseSigned);
+      expect(parsed.executor.model).toBeUndefined();
+    });
+
+    it('does not coerce missing executor.model to empty string', () => {
+      const parsed = SignedEnvelopeSchema.parse(baseSigned);
+      expect(parsed.executor.model).not.toBe('');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds optional `model` field to `ExecutorSchema` in `jinn.execution.v1` — pure additive change, no `schemaVersion` bump required; old envelopes without the field pass Zod validation unchanged (back-compat safe).
- Extends `EnvelopeInputs.executor` in `envelope-assembly.ts` with `model?: string`; the existing `{ ...inputs.executor }` spread propagates it automatically.
- In `engine.ts pack()`, sources `executor.model` from `solverNet?.model ?? this.operatorConfig?.claudeModel` — SolverNet-specific model wins, falling back to the daemon-wide default; left `undefined` when neither is set.
- Adds `claudeModel?: string` to `TaskEngineOptions.operatorConfig` and wires `config.claudeModel` into the production `operatorConfig` in `main.ts`.

Closes [#191](https://github.com/Jinn-Network/mono/issues/191).

**Note:** The indexer parser and SPA card are already wired in PR #181 to read `executor.model`. Once this lands and operators restart with the new daemon, the explorer's `composition.byModel` HBars will auto-appear — currently hidden because all envelopes publish `(unknown)`.

## Test plan

- [ ] `yarn typecheck` — zero errors
- [ ] `test/types/envelope.test.ts > SignedEnvelopeSchema > executor.model` — 3 new cases, all green
  - accepts envelope with `executor.model` set
  - accepts envelope without `executor.model` (back-compat)
  - does not coerce missing `executor.model` to empty string
- [ ] `test/harnesses/engine/envelope-assembly.test.ts > executor.model stamping` — 3 new cases, all green
  - stamps `executor.model` when `inputs.executor.model` is provided
  - leaves `executor.model` undefined when absent
  - does not stamp empty string when model is undefined
- [ ] Full `yarn test` — 3217 passing; 3 pre-existing infra failures (anvil fork timeout, transcript watcher timing) unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)