### PR TITLE
fix(n93o): publish evaluation:<cid> MetadataSet on verdict delivery

### DIFF
--- a/client/src/harnesses/engine/engine.ts
+++ b/client/src/harnesses/engine/engine.ts
@@ -1596,73 +1596,76 @@ export class TaskEngine {
     // DELIVERING state by pack()); idempotent on retry (setMetadata is a pure
     // key-value write; re-running with the same payload is safe).
     //
-    // Restoration-only for now. Evaluator setMetadata lands with jinn-mono-2ff.
+    // Both roles publish (jinn-mono-n93o): restoration runs emit
+    // `envelope:<cid>`; evaluation runs emit `evaluation:<cid>`. The indexer's
+    // verdictEnvelopeMeta enrichment branch (ebu7.13) listens for the
+    // `evaluation:` prefix to surface verdicts in the explorer.
     if (this.identityPublisher) {
       const taskRoleRaw = task.taskRole ?? 'restoration';
-      if (taskRoleRaw === 'restoration') {
-        const signatureHash = evidenceHash as `0x${string}` | null | undefined;
-        // v0 tier rule: with an evidenceHash on chain we declare `committed` (tier=1);
-        // higher tiers (`attested`, `proved`) come later when TEE work lands.
-        const tier: ExecutionTier = signatureHash ? 1 : 0;
-        const manifestHashHex = signatureHash ?? ('0x' as `0x${string}`);
+      const metadataKind: 'envelope' | 'evaluation' =
+        taskRoleRaw === 'evaluation' ? 'evaluation' : 'envelope';
+      const signatureHash = evidenceHash as `0x${string}` | null | undefined;
+      // v0 tier rule: with an evidenceHash on chain we declare `committed` (tier=1);
+      // higher tiers (`attested`, `proved`) come later when TEE work lands.
+      const tier: ExecutionTier = signatureHash ? 1 : 0;
+      const manifestHashHex = signatureHash ?? ('0x' as `0x${string}`);
 
-        // Prefer v2 when the harness identity is available — the engine
-        // captures executorMode + executorCodeDigest in pack(). For legacy
-        // rows that completed before payload v2 wiring (or for solver paths
-        // that don't produce a fence digest), executorCodeDigest is null and
-        // we fall back to the v1 encoder so the indexer still sees envelope
-        // metadata, just without harness identity. v1 envelopes are decoded
-        // by the subgraph as mode='train' with empty codeDigest/implName.
-        const harnessImplName = task.implName;
-        const canEmitV2 =
-          !!task.executorMode &&
-          !!task.executorCodeDigest &&
-          !!harnessImplName;
-        try {
-          let pubTxHash: `0x${string}`;
-          if (canEmitV2) {
-            const v2Payload: ExecutionPayloadV2 = {
-              version: 2,
-              tier,
-              manifestHash: manifestHashHex,
-              attestationQuoteCid: '0x',
-              sourceMeasurement:
-                '0x0000000000000000000000000000000000000000000000000000000000000000',
-              codeDigest: codeDigestSha256ToBytes32(task.executorCodeDigest),
-              implName: harnessImplName as string,
-              modeFlag: modeStringToFlag(task.executorMode as 'train' | 'frozen'),
-            };
-            pubTxHash = await this.identityPublisher.publishContentV2({
-              kind: 'envelope',
-              cid: manifestCid,
-              payload: v2Payload,
-            });
-            console.log(
-              `[harness-engine] ${requestId}: setMetadata envelope:${manifestCid} tx=${pubTxHash} (payload v2 mode=${task.executorMode} impl=${harnessImplName})`,
-            );
-          } else {
-            const v1Payload: ExecutionPayload = {
-              version: 1,
-              tier,
-              manifestHash: manifestHashHex,
-              attestationQuoteCid: '0x',
-              sourceMeasurement:
-                '0x0000000000000000000000000000000000000000000000000000000000000000',
-            };
-            pubTxHash = await this.identityPublisher.publishContent({
-              kind: 'envelope',
-              cid: manifestCid,
-              payload: v1Payload,
-            });
-            console.log(
-              `[harness-engine] ${requestId}: setMetadata envelope:${manifestCid} tx=${pubTxHash} (payload v1)`,
-            );
-          }
-        } catch (err) {
-          console.warn(
-            `[harness-engine] ${requestId}: setMetadata envelope publish failed (non-fatal): ${err instanceof Error ? err.message : err}`,
+      // Prefer v2 when the harness identity is available — the engine
+      // captures executorMode + executorCodeDigest in pack(). For legacy
+      // rows that completed before payload v2 wiring (or for solver paths
+      // that don't produce a fence digest), executorCodeDigest is null and
+      // we fall back to the v1 encoder so the indexer still sees envelope
+      // metadata, just without harness identity. v1 envelopes are decoded
+      // by the subgraph as mode='train' with empty codeDigest/implName.
+      const harnessImplName = task.implName;
+      const canEmitV2 =
+        !!task.executorMode &&
+        !!task.executorCodeDigest &&
+        !!harnessImplName;
+      try {
+        let pubTxHash: `0x${string}`;
+        if (canEmitV2) {
+          const v2Payload: ExecutionPayloadV2 = {
+            version: 2,
+            tier,
+            manifestHash: manifestHashHex,
+            attestationQuoteCid: '0x',
+            sourceMeasurement:
+              '0x0000000000000000000000000000000000000000000000000000000000000000',
+            codeDigest: codeDigestSha256ToBytes32(task.executorCodeDigest),
+            implName: harnessImplName as string,
+            modeFlag: modeStringToFlag(task.executorMode as 'train' | 'frozen'),
+          };
+          pubTxHash = await this.identityPublisher.publishContentV2({
+            kind: metadataKind,
+            cid: manifestCid,
+            payload: v2Payload,
+          });
+          console.log(
+            `[harness-engine] ${requestId}: setMetadata ${metadataKind}:${manifestCid} tx=${pubTxHash} (payload v2 mode=${task.executorMode} impl=${harnessImplName})`,
+          );
+        } else {
+          const v1Payload: ExecutionPayload = {
+            version: 1,
+            tier,
+            manifestHash: manifestHashHex,
+            attestationQuoteCid: '0x',
+            sourceMeasurement:
+              '0x0000000000000000000000000000000000000000000000000000000000000000',
+          };
+          pubTxHash = await this.identityPublisher.publishContent({
+            kind: metadataKind,
+            cid: manifestCid,
+            payload: v1Payload,
+          });
+          console.log(
+            `[harness-engine] ${requestId}: setMetadata ${metadataKind}:${manifestCid} tx=${pubTxHash} (payload v1)`,
           );
         }
+      } catch (err) {
+        console.warn(
+          `[harness-engine] ${requestId}: setMetadata ${metadataKind} publish failed (non-fatal): ${err instanceof Error ? err.message : err}`,
+        );
       }
     }
 

--- a/client/test/erc8004/identity-publisher.test.ts
+++ b/client/test/erc8004/identity-publisher.test.ts
@@ -13,8 +13,10 @@ import {
   PayloadValidationError,
   buildMetadataKey,
   encodeExecutionPayload,
+  encodeExecutionPayloadV2,
   validatePayload,
   type ExecutionPayload,
+  type ExecutionPayloadV2,
 } from '../../src/erc8004/identity.js';
 
 // ── Spec test vectors (payload-schema §8) ─────────────────────────────────────
@@ -355,5 +357,74 @@ describe('IdentityPublisher.publishContent', () => {
         payload: VECTOR_A_INPUT,
       }),
     ).rejects.toThrow('rpc unreachable');
+  });
+});
+
+// ── publishContentV2 — kind-prefix calldata ───────────────────────────────────
+
+const V2_VECTOR_INPUT: ExecutionPayloadV2 = {
+  version: 2,
+  tier: 1,
+  manifestHash: '0x1111111111111111111111111111111111111111111111111111111111111111',
+  attestationQuoteCid: '0x',
+  sourceMeasurement: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  codeDigest: ('0x' + 'cd'.repeat(32)) as Hex,
+  implName: 'claude-code-learner',
+  modeFlag: 0,
+};
+
+describe('IdentityPublisher.publishContentV2', () => {
+  const REGISTRY = '0x8004800480048004800480048004800480048004' as `0x${string}`;
+  const AGENT_ID = 42n;
+
+  it('uses "evaluation:" prefix when kind=evaluation (jinn-mono-n93o)', async () => {
+    const { walletClient, publicClient, writeContract, waitForTransactionReceipt } = makeMocks();
+    const publisher = new IdentityPublisher({
+      identityRegistryAddress: REGISTRY,
+      agentId: AGENT_ID,
+      walletClient,
+      publicClient,
+    });
+
+    const cid = 'bafyverdict003';
+    const txHash = await publisher.publishContentV2({
+      kind: 'evaluation',
+      cid,
+      payload: V2_VECTOR_INPUT,
+    });
+
+    expect(txHash).toMatch(/^0x[0-9a-f]{64}$/);
+    expect(writeContract).toHaveBeenCalledTimes(1);
+    expect(waitForTransactionReceipt).toHaveBeenCalledTimes(1);
+
+    const call = writeContract.mock.calls[0]![0] as {
+      address: string;
+      functionName: string;
+      args: [bigint, string, Hex];
+    };
+    expect(call.address).toBe(REGISTRY);
+    expect(call.functionName).toBe('setMetadata');
+    expect(call.args[0]).toBe(AGENT_ID);
+    expect(call.args[1]).toBe(`evaluation:${cid}`);
+    expect(call.args[2]).toBe(encodeExecutionPayloadV2(V2_VECTOR_INPUT));
+  });
+
+  it('uses "envelope:" prefix when kind=envelope (back-compat regression)', async () => {
+    const { walletClient, publicClient, writeContract } = makeMocks();
+    const publisher = new IdentityPublisher({
+      identityRegistryAddress: REGISTRY,
+      agentId: AGENT_ID,
+      walletClient,
+      publicClient,
+    });
+
+    await publisher.publishContentV2({
+      kind: 'envelope',
+      cid: 'bafyenvelope004',
+      payload: V2_VECTOR_INPUT,
+    });
+
+    const call = writeContract.mock.calls[0]![0] as { args: [bigint, string, Hex] };
+    expect(call.args[1]).toBe('envelope:bafyenvelope004');
   });
 });

--- a/client/test/harnesses/engine/engine-identity-publisher.test.ts
+++ b/client/test/harnesses/engine/engine-identity-publisher.test.ts
@@ -394,6 +394,71 @@ describe('Engine IdentityPublisher wiring (PR#37 review2 must-fix #2)', () => {
     expect(publishContentV2Mock).not.toHaveBeenCalled();
   });
 
+  // ── jinn-mono-n93o: evaluation role publishes `evaluation:<cid>` ────────────
+
+  it('deliver() publishes evaluation:<cid> when taskRole=evaluation (jinn-mono-n93o)', async () => {
+    const publishContentMock = vi.fn().mockResolvedValue('0xpubtxhash' as Hex);
+    const publishContentV2Mock = vi.fn().mockResolvedValue('0xpubtxhashv2' as Hex);
+    const mockPublisher = {
+      publishContent: publishContentMock,
+      publishContentV2: publishContentV2Mock,
+    } as unknown as IdentityPublisher;
+
+    const engine = new TestEngine(makeOpts(store, tmp, mockPublisher));
+    const requestId = 'req-deliver-eval-pub';
+
+    // Seed an evaluation-role intent in DELIVERING with the v2 fields populated
+    // so we exercise the same payload-v2 path restoration uses; the only
+    // difference under test is the metadataKey prefix.
+    const now = Date.now() - 1000;
+    const input = makeIntentInput(requestId);
+    input.taskRole = 'evaluation';
+    await engine.observe(input);
+    const p = engine.testPersistence;
+    p.transition(requestId, TaskRunState.CLAIMED, { implName: 'claude-code-learner' });
+    p.transition(requestId, TaskRunState.WAITING);
+    p.transition(requestId, TaskRunState.PRE_SNAPSHOT, {
+      workingDir: '/tmp/wd',
+      implStateDir: '/tmp/impl',
+      preSnapshotCapturedAt: now,
+      preSnapshotPayload: { capturedAt: now, hlTime: 0 },
+    });
+    p.transition(requestId, TaskRunState.RUNNING);
+    p.transition(requestId, TaskRunState.POST_SNAPSHOT, {
+      postSnapshotCapturedAt: now,
+      postSnapshotPayload: { capturedAt: now, hlTime: 0 },
+      fillsPayload: [],
+      gatingClaim: {},
+    });
+    const v2CodeDigestSha256 = `sha256:${'cd'.repeat(32)}`;
+    p.transition(requestId, TaskRunState.PACKAGING, {
+      manifestCid: PACK_MANIFEST_CID,
+      artifactCids: {},
+      evidenceHash: PACK_EVIDENCE_HASH,
+      executorMode: 'frozen',
+      executorCodeDigest: v2CodeDigestSha256,
+    });
+    p.transition(requestId, TaskRunState.DELIVERING);
+
+    await engine.process(requestId);
+
+    const intent = engine.testPersistence.getByRequestId(requestId)!;
+    expect(intent.state).toBe(TaskRunState.COMPLETE);
+
+    // v2 path was used — v1 mock untouched.
+    expect(publishContentV2Mock).toHaveBeenCalledTimes(1);
+    expect(publishContentMock).not.toHaveBeenCalled();
+    const arg = publishContentV2Mock.mock.calls[0]![0] as {
+      kind: string;
+      cid: string;
+      payload: { version: number; manifestHash: Hex };
+    };
+    expect(arg.kind).toBe('evaluation');
+    expect(arg.cid).toBe(PACK_MANIFEST_CID);
+    expect(arg.payload.version).toBe(2);
+    expect(arg.payload.manifestHash).toBe(PACK_EVIDENCE_HASH);
+  });
+
   it('setMetadata is idempotent on retry — publishContent called with same evidenceHash on repeated deliver()', async () => {
     // setMetadata (publishContent on IdentityRegistry) is a pure key-value write;
     // calling it a second time with the same payload is safe. This test seeds two


### PR DESCRIPTION
Closes #198.

Closes `jinn-mono-n93o`.

The daemon's TaskEngine `setMetadata` block fired only for restoration role, leaving the evaluator's verdict envelope CID anchored only as the `claimDelivery` `evidenceHash` and unreachable to the indexer's `verdictEnvelopeMeta` enrichment branch (ebu7.13).

## Live coverage today

- Attempts: 122/184 enriched (66%, daemon already publishes `envelope:<cid>` correctly).
- Verdicts: **0/107 enriched (0%)** — daemon never publishes `evaluation:<cid>`.

Post-deploy, freshly-claimed verdicts should enrich at parity with attempts (~66%+) — the verdictEnvelopeMeta branch is already deployed and listening. Backfill of the existing 107 verdicts is out of scope for this PR; this fix stops the bleed on new ones.

## What changed

Lift the `taskRoleRaw === 'restoration'` gate and parametrize the metadataKey kind. Restoration runs continue to emit `envelope:<cid>`; evaluation runs now emit `evaluation:<cid>`. V2 payload shape (`manifestHash` + tier + harness identity) is identical for both kinds — the only difference is the key prefix.

Net change is ~19 semantic lines in `engine.ts` (the larger diff stat is indentation reflow from removing the `if` wrapper) plus two new tests.

## Files touched

- `client/src/harnesses/engine/engine.ts` — drop role gate, derive `metadataKind` from `taskRoleRaw`, thread through both v2 and v1 publish paths + three log lines + catch warn. Refresh the stale `jinn-mono-2ff` comment (that bd was about `giveFeedback`, not `setMetadata`) to reference `jinn-mono-n93o`.
- `client/test/erc8004/identity-publisher.test.ts` — new test asserting `publishContentV2({ kind: 'evaluation', ... })` writes `evaluation:<cid>` as the metadataKey, plus an `envelope:` back-compat regression.
- `client/test/harnesses/engine/engine-identity-publisher.test.ts` — new integration case driving the TaskEngine through an evaluator task (`taskRole='evaluation'`) and asserting `publishContentV2` was called once with `kind: 'evaluation'`.

## What was not changed

Per the spec for this fix: no changes to `IdentityPublisher`, encoders, `ContentKind` union (`evaluation` was already in it), indexer, SPA, or new config/env flags. The catch still swallows publish failures (non-fatal) without widening.

## Verification

- `yarn typecheck` — 0 errors.
- `yarn test` — 3216 passed, 4 skipped (399 files), including the new `evaluation`-role cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
