### PR TITLE
codeowners: drop @ritsuKai2000 (secondary account) from canon ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
 # Canonical docs — require canon-owner review.
 # See spec/2026-04-28-canonical-docs.md for policy.
-/SPEC.md       @oaksprout @ritsukai @ritsuKai2000
-/THESIS.md     @oaksprout @ritsukai @ritsuKai2000
-/BRAND.md      @oaksprout @ritsukai @ritsuKai2000
-/GROWTH.md     @oaksprout @ritsukai @ritsuKai2000
-/GLOSSARY.md   @oaksprout @ritsukai @ritsuKai2000
-/CLAUDE.md     @oaksprout @ritsukai @ritsuKai2000
-/README.md     @oaksprout @ritsukai @ritsuKai2000
+/SPEC.md       @oaksprout @ritsukai
+/THESIS.md     @oaksprout @ritsukai
+/BRAND.md      @oaksprout @ritsukai
+/GROWTH.md     @oaksprout @ritsukai
+/GLOSSARY.md   @oaksprout @ritsukai
+/CLAUDE.md     @oaksprout @ritsukai
+/README.md     @oaksprout @ritsukai


### PR DESCRIPTION
## Summary

- CODEOWNERS currently lists three canon stewards: `@oaksprout`, `@ritsukai`, `@ritsuKai2000`.
- `@ritsukai` and `@ritsuKai2000` are both Ritsu (commit history: 719 vs 65 commits in the last 3 months; both authored under `ritsu.kai2000@gmail.com` / `ritsu@jinn.network`).
- Drops `@ritsuKai2000` so the listed stewards (2 accounts) match the actual humans (2 stewards).

## Why this matters

Two accounts for one human is a real governance issue, not a cosmetic one:

- **Legible** (just-landed principle): the public CODEOWNERS file is the claim of who governs canon; that claim is currently mis-stating the steward count.
- **Governance Minimal** (just-landed principle): every extra steward account is a capture surface. An extra one controlled by a single human is strictly net-negative.
- **Future all-CODEOWNERS enforcement**: if we ever raise the bar to "all listed owners must approve" (option 2 from discussion in [#230](https://github.com/Jinn-Network/mono/pull/230)), 2 of the 3 "approvals" coming from one human defeats the point.

## Interaction with [#230](https://github.com/Jinn-Network/mono/pull/230)

[#230](https://github.com/Jinn-Network/mono/pull/230) adds `/PRINCIPLES.md @oaksprout @ritsukai @ritsuKai2000` (mirroring the existing pattern). Merge order:

- **If this PR lands first**: #230 needs a one-line rebase to drop `@ritsuKai2000` from its new entry.
- **If #230 lands first**: this PR needs to additionally drop `@ritsuKai2000` from the new `/PRINCIPLES.md` line — also a one-line rebase.

Either way the conflict is trivial. No coupling concerns.

## Provenance

Discussion: https://github.com/Jinn-Network/mono/discussions/222 (raised under the principles re-establishment thread; spotted while reviewing #230).

## Test plan

- [ ] Confirm `@ritsukai` is Ritsu's primary account (it has 719 vs 65 commits — but Ritsu's call).
- [ ] CODEOWNERS still resolves to two distinct humans for all canonical-doc paths.
- [ ] After merge, ensure any GitHub Team subscriptions or notification routing relying on `@ritsuKai2000` are migrated to `@ritsukai`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)