### PR TITLE
fix(hjex.3): surface service eviction + in-process auto-restake

### DIFF
--- a/client/src/api/fleet-build.ts
+++ b/client/src/api/fleet-build.ts
@@ -26,7 +26,7 @@ export interface FleetV1Service {
     agent: { address: string; balances: Array<{ asset: string; amountWei: string }> };
     multisig: { address: string; balances: Array<{ asset: string; amountWei: string }> };
   };
-  staking: { staked: boolean; evicted: boolean; sinceBlock: number | null };
+  staking: { staked: boolean; evicted: boolean; sinceBlock: number | null; inactivitySeconds: number | null };
   activity: { lastEventAt: string | null; counts: Record<string, number> };
   rewards: { pending: string; asset: 'reward' };
   attention: null | {
@@ -129,8 +129,9 @@ export function assembleFleetV1(raw: GatheredStatusRaw): FleetV1Response {
     },
     staking: {
       staked: isStakedLikeServiceStep(svc.step),
-      evicted: false,
+      evicted: raw.evictedByServiceIndex?.[di] ?? false,
       sinceBlock: null,
+      inactivitySeconds: raw.inactivityByServiceIndex?.[di] ?? null,
     },
     activity: {
       lastEventAt: per?.lastEventAt ?? null,

--- a/client/src/api/fleet-build.ts
+++ b/client/src/api/fleet-build.ts
@@ -26,7 +26,7 @@ export interface FleetV1Service {
     agent: { address: string; balances: Array<{ asset: string; amountWei: string }> };
     multisig: { address: string; balances: Array<{ asset: string; amountWei: string }> };
   };
-  staking: { staked: boolean; evicted: boolean; sinceBlock: number | null; inactivitySeconds: number | null };
+  staking: { staked: boolean; evicted: boolean; sinceBlock: number | null };
   activity: { lastEventAt: string | null; counts: Record<string, number> };
   rewards: { pending: string; asset: 'reward' };
   attention: null | {
@@ -58,6 +58,7 @@ function computeAttention(
   svc: ServiceState,
   raw: GatheredStatusRaw,
   isFirstService: boolean,
+  displayIndex: number,
 ): FleetV1Service['attention'] {
   if (
     isFirstService &&
@@ -83,6 +84,16 @@ function computeAttention(
         : {}),
     };
   }
+  // Eviction takes precedence over the other operational signals: the dashboard
+  // needs an actionable "Re-stake now" affordance whenever the staking proxy
+  // reports state=Evicted (jinn-mono-hjex.3 review #3).
+  if (raw.evictedByServiceIndex?.[displayIndex] === true) {
+    return {
+      kind: 'evicted',
+      hint: 'Service evicted from staking — restoring liveness via re-stake.',
+      exampleCli: 'jinn bootstrap --json',
+    };
+  }
   if (svc.step === 'safe_binding_pending') {
     return {
       kind: 'identity_binding_pending',
@@ -93,7 +104,7 @@ function computeAttention(
   if (!isOperationalServiceStep(svc.step)) {
     return {
       kind: 'reconcile_needed',
-      hint: `Service ${displayFleetServiceIndex(svc)} is at step ${svc.step}. Run jinn bootstrap to advance.`,
+      hint: `Service ${displayIndex} is at step ${svc.step}. Run jinn bootstrap to advance.`,
       exampleCli: 'jinn bootstrap --json',
     };
   }
@@ -131,7 +142,6 @@ export function assembleFleetV1(raw: GatheredStatusRaw): FleetV1Response {
       staked: isStakedLikeServiceStep(svc.step),
       evicted: raw.evictedByServiceIndex?.[di] ?? false,
       sinceBlock: null,
-      inactivitySeconds: raw.inactivityByServiceIndex?.[di] ?? null,
     },
     activity: {
       lastEventAt: per?.lastEventAt ?? null,
@@ -141,7 +151,7 @@ export function assembleFleetV1(raw: GatheredStatusRaw): FleetV1Response {
       pending: pendingByService[di] ?? '0',
       asset: 'reward' as const,
     },
-    attention: computeAttention(svc, raw, i === 0),
+    attention: computeAttention(svc, raw, i === 0, di),
   };
   });
 

--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -12,7 +12,7 @@ import { base, baseSepolia } from 'viem/chains';
 import type { Store } from '../store/store.js';
 import type { JinnConfig } from '../config.js';
 import { FleetStateStore } from '../earning/store.js';
-import { getChainConfig } from '../earning/contracts.js';
+import { getChainConfig, STAKING_ABI } from '../earning/contracts.js';
 import { JINN_STAKING_ABI } from '../earning/jinn-rewards.js';
 import type { FleetState } from '../earning/types.js';
 import { displayFleetServiceIndex } from '../earning/fleet-display-index.js';
@@ -70,6 +70,28 @@ function readDaemonRuntime(earningDir: string | undefined): GatheredStatusRaw['d
 
 const STANDARD_MASTER_BOOTSTRAP_MULTIPLIER = 2n;
 const predictionOperatorStatusCache = new WeakMap<JinnConfig, Map<string, Promise<PredictionOperatorStatus>>>();
+
+/**
+ * Eviction-state cache (jinn-mono-hjex.3 review fix #7).
+ *
+ * `/v1/status` is polled by the SPA every few seconds while the EvictionLoop
+ * also reads `getStakingState` on its own cadence. Without caching every
+ * status call hammers the RPC with one read per service. Cache by
+ * `${stakingProxy}:${serviceId}` with a 30s TTL — short enough that an
+ * operator-triggered restake reflects on the next poll, long enough that
+ * normal status polling is cheap.
+ */
+const EVICTION_STATE_TTL_MS = 30_000;
+const evictionStateCache = new Map<string, { evicted: boolean; fetchedAt: number }>();
+
+function evictionCacheKey(stakingProxy: string, serviceId: number): string {
+  return `${stakingProxy.toLowerCase()}:${serviceId}`;
+}
+
+/** Test-only: clear the eviction-state cache (used by gather-status tests). */
+export function clearEvictionStateCache(): void {
+  evictionStateCache.clear();
+}
 
 /**
  * Drop any cached prediction operator status for `config`.
@@ -636,47 +658,59 @@ export async function gatherGatheredStatusRaw(
       raw.pendingRewardsError = pr.error;
     }
 
-    // Eviction state + inactivity — best-effort; never blocks the rest of status assembly.
+    // Eviction state — best-effort; never blocks the rest of status assembly.
+    //
+    // Uses STAKING_ABI (the canonical OLAS-style ABI used everywhere else in
+    // this codebase). The Phase-1a Stolas proxy shares the same
+    // `getStakingState(uint256) -> uint8` selector as the legacy OLAS proxy,
+    // so this read works on both mainnet and testnet (jinn-mono-hjex.3 review #1).
+    //
+    // We intentionally do not call `getServiceInfo` to pull `inactivity`:
+    // the two proxies disagree on the return-tuple shape (`STAKING_ABI` has
+    // `[securityDeposit, multisig, nonces, tsStart]`, the Phase-1a contract
+    // returns a struct with an `inactivity` field) so a single ABI cannot
+    // decode both. The dashboard surfaces the binary `evicted` state — the
+    // numeric inactivity counter is not consumed by any user-facing surface
+    // today (jinn-mono-hjex.3 review #2).
+    //
+    // Results are cached for EVICTION_STATE_TTL_MS to keep `/v1/status`
+    // polling from hammering the RPC alongside the EvictionLoop (#7).
     try {
       const evictedByServiceIndex: Record<number, boolean> = {};
-      const inactivityByServiceIndex: Record<number, number> = {};
+      const nowMs = Date.now();
       await Promise.all(
         fleet.services.map(async (svc) => {
           const serviceId = svc.service_id;
           const stakingProxy = svc.staking_address;
           if (!serviceId || !stakingProxy) return;
           const di = displayFleetServiceIndex(svc);
+          const cacheKey = evictionCacheKey(stakingProxy, serviceId);
+          const cached = evictionStateCache.get(cacheKey);
+          if (cached && nowMs - cached.fetchedAt <= EVICTION_STATE_TTL_MS) {
+            evictedByServiceIndex[di] = cached.evicted;
+            return;
+          }
           try {
-            const [state, info] = await Promise.all([
-              client.readContract({
-                address: stakingProxy as `0x${string}`,
-                abi: JINN_STAKING_ABI,
-                functionName: 'getStakingState',
-                args: [BigInt(serviceId)],
-              }),
-              client.readContract({
-                address: stakingProxy as `0x${string}`,
-                abi: JINN_STAKING_ABI,
-                functionName: 'getServiceInfo',
-                args: [BigInt(serviceId)],
-              }).catch(() => null),
-            ]);
+            const state = await client.readContract({
+              address: stakingProxy as `0x${string}`,
+              abi: STAKING_ABI,
+              functionName: 'getStakingState',
+              args: [BigInt(serviceId)],
+            });
             // getStakingState returns uint8; 2 = Evicted enum value
-            evictedByServiceIndex[di] = Number(state) === 2;
-            // getServiceInfo returns a struct — inactivity is seconds of accumulated inactivity
-            if (info != null) {
-              const inactivity = (info as { inactivity: bigint }).inactivity;
-              if (typeof inactivity === 'bigint') {
-                inactivityByServiceIndex[di] = Number(inactivity);
-              }
-            }
+            const evicted = Number(state) === 2;
+            evictionStateCache.set(cacheKey, { evicted, fetchedAt: nowMs });
+            evictedByServiceIndex[di] = evicted;
           } catch {
-            // Transient RPC errors: skip silently; evicted defaults to false
+            // Transient RPC errors: skip silently; surface stale cached value
+            // if we have one, otherwise default to false (not-evicted).
+            if (cached) {
+              evictedByServiceIndex[di] = cached.evicted;
+            }
           }
         }),
       );
       raw.evictedByServiceIndex = evictedByServiceIndex;
-      raw.inactivityByServiceIndex = inactivityByServiceIndex;
     } catch {
       // Non-fatal: staking state reads should not prevent status from returning
     }

--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -635,6 +635,51 @@ export async function gatherGatheredStatusRaw(
     } else {
       raw.pendingRewardsError = pr.error;
     }
+
+    // Eviction state + inactivity — best-effort; never blocks the rest of status assembly.
+    try {
+      const evictedByServiceIndex: Record<number, boolean> = {};
+      const inactivityByServiceIndex: Record<number, number> = {};
+      await Promise.all(
+        fleet.services.map(async (svc) => {
+          const serviceId = svc.service_id;
+          const stakingProxy = svc.staking_address;
+          if (!serviceId || !stakingProxy) return;
+          const di = displayFleetServiceIndex(svc);
+          try {
+            const [state, info] = await Promise.all([
+              client.readContract({
+                address: stakingProxy as `0x${string}`,
+                abi: JINN_STAKING_ABI,
+                functionName: 'getStakingState',
+                args: [BigInt(serviceId)],
+              }),
+              client.readContract({
+                address: stakingProxy as `0x${string}`,
+                abi: JINN_STAKING_ABI,
+                functionName: 'getServiceInfo',
+                args: [BigInt(serviceId)],
+              }).catch(() => null),
+            ]);
+            // getStakingState returns uint8; 2 = Evicted enum value
+            evictedByServiceIndex[di] = Number(state) === 2;
+            // getServiceInfo returns a struct — inactivity is seconds of accumulated inactivity
+            if (info != null) {
+              const inactivity = (info as { inactivity: bigint }).inactivity;
+              if (typeof inactivity === 'bigint') {
+                inactivityByServiceIndex[di] = Number(inactivity);
+              }
+            }
+          } catch {
+            // Transient RPC errors: skip silently; evicted defaults to false
+          }
+        }),
+      );
+      raw.evictedByServiceIndex = evictedByServiceIndex;
+      raw.inactivityByServiceIndex = inactivityByServiceIndex;
+    } catch {
+      // Non-fatal: staking state reads should not prevent status from returning
+    }
   }
 
   if (fleet) {

--- a/client/src/api/setup-endpoints.ts
+++ b/client/src/api/setup-endpoints.ts
@@ -81,6 +81,12 @@ export interface SetupRoutesConfig {
   /** Returns the chain default RPC URL — used by POST /v1/setup/network when
    *  the operator clears the field to revert to the default. */
   defaultRpcUrlForChain?: () => string;
+  /**
+   * When set, POST /v1/setup/restake/:serviceId is enabled.
+   * Calls the provided function to re-stake an evicted service on demand
+   * (the "Re-stake now" dashboard CTA). jinn-mono-hjex.3
+   */
+  restake?: (serviceId: number) => Promise<{ ok: boolean; error?: string }>;
 }
 
 export function addSetupRoutes(app: Hono, config: SetupRoutesConfig = {}): void {
@@ -743,6 +749,31 @@ export function addSetupRoutes(app: Hono, config: SetupRoutesConfig = {}): void 
       restartRequired: true,
       rpcUrl: nextRpcUrl,
     });
+  });
+
+  // POST /v1/setup/restake/:serviceId — operator-triggered re-stake for an
+  // evicted service. Backs the "Re-stake now" dashboard CTA. jinn-mono-hjex.3
+  app.post('/v1/setup/restake/:serviceId', async (c) => {
+    if (!config.restake) {
+      return c.json({ error: 'restake_not_configured' }, 503);
+    }
+    const raw = c.req.param('serviceId');
+    const serviceId = Number.parseInt(raw, 10);
+    if (!Number.isFinite(serviceId) || serviceId <= 0) {
+      return c.json({ error: 'invalid_service_id' }, 400);
+    }
+    try {
+      const result = await config.restake(serviceId);
+      if (!result.ok) {
+        return c.json({ ok: false, error: result.error ?? 'restake_failed' }, 500);
+      }
+      return c.json({ ok: true });
+    } catch (err) {
+      return c.json(
+        { ok: false, error: err instanceof Error ? err.message : String(err) },
+        500,
+      );
+    }
   });
 
   app.post('/v1/setup/change-password', async (c) => {

--- a/client/src/api/setup-endpoints.ts
+++ b/client/src/api/setup-endpoints.ts
@@ -85,6 +85,13 @@ export interface SetupRoutesConfig {
    * When set, POST /v1/setup/restake/:serviceId is enabled.
    * Calls the provided function to re-stake an evicted service on demand
    * (the "Re-stake now" dashboard CTA). jinn-mono-hjex.3
+   *
+   * Contract: `serviceId` is the on-chain OLAS service ID (positive integer
+   * minted by the service registry — *not* the display-index / row number).
+   * The SPA reads `fleet.services[].serviceId` from `/v1/status` and passes
+   * it back unchanged. main.ts resolves the matching `ServiceState` via
+   * `state.services.find(s => s.service_id === serviceId)` before invoking
+   * `recoverEvictedService`.
    */
   restake?: (serviceId: number) => Promise<{ ok: boolean; error?: string }>;
 }
@@ -753,6 +760,11 @@ export function addSetupRoutes(app: Hono, config: SetupRoutesConfig = {}): void 
 
   // POST /v1/setup/restake/:serviceId — operator-triggered re-stake for an
   // evicted service. Backs the "Re-stake now" dashboard CTA. jinn-mono-hjex.3
+  //
+  // The path parameter is the on-chain OLAS service ID (uint256, surfaced as
+  // `fleet.services[].serviceId` in `/v1/status`). It is **not** the
+  // display-index / row number. Resolving the service is the callback's
+  // responsibility (see `SetupRoutesConfig.restake` docstring).
   app.post('/v1/setup/restake/:serviceId', async (c) => {
     if (!config.restake) {
       return c.json({ error: 'restake_not_configured' }, 503);

--- a/client/src/api/status-build.ts
+++ b/client/src/api/status-build.ts
@@ -7,6 +7,7 @@ import {
   isStakedLikeServiceStep,
   type FleetState,
 } from '../earning/types.js';
+import { displayFleetServiceIndex } from '../earning/fleet-display-index.js';
 import type { EarningMigrationArchive } from '../earning/store.js';
 import type { PortfolioV0Status } from './portfolio-v0-build.js';
 import type { PredictionV1Status } from './prediction-v1-build.js';
@@ -78,6 +79,18 @@ export interface GatheredStatusRaw {
   pendingByService?: Record<number, string>;
   claimedByService?: Record<number, { total: string; lastAt: string; lastTxHash: string }>;
   migrationArchive?: EarningMigrationArchive;
+  /**
+   * Per-service eviction state keyed by display index.
+   * Populated by gather-status via on-chain getStakingState reads.
+   * `true` means the staking proxy reports state === 2 (Evicted).
+   */
+  evictedByServiceIndex?: Record<number, boolean>;
+  /**
+   * Per-service inactivity seconds keyed by display index.
+   * Populated by gather-status via on-chain getServiceInfo reads (jinn-mono-hjex.3).
+   * Value is the `inactivity` field from the ServiceInfo struct (seconds).
+   */
+  inactivityByServiceIndex?: Record<number, number>;
 }
 
 export interface StatusV1Response {
@@ -105,6 +118,8 @@ export interface StatusV1Response {
       identityRegistryAddress: string | null;
       safeBoundToAgent: boolean;
       identityBindingStatus: 'bound' | 'pending' | 'not_applicable';
+      /** True when the staking proxy reports this service as evicted (getStakingState === 2). */
+      evicted: boolean;
     }>;
     stakedLikeCount: number;
     completeCount: number;
@@ -160,7 +175,10 @@ export function resolveMasterDailyEstimateWei(
   return fromPoll > DEFAULT_MASTER_ETH_DAILY_WEI ? fromPoll : DEFAULT_MASTER_ETH_DAILY_WEI;
 }
 
-function fleetSummary(fleet: FleetState | null): StatusV1Response['fleet'] {
+function fleetSummary(
+  fleet: FleetState | null,
+  evictedByServiceIndex?: Record<number, boolean>,
+): StatusV1Response['fleet'] {
   if (!fleet) {
     return {
       loaded: false,
@@ -169,8 +187,10 @@ function fleetSummary(fleet: FleetState | null): StatusV1Response['fleet'] {
       completeCount: 0,
     };
   }
-  const services = fleet.services.map(s => ({
-    index: s.index,
+  const services = fleet.services.map(s => {
+    const di = displayFleetServiceIndex(s);
+    return {
+    index: di,
     step: s.step,
     serviceId: s.service_id,
     safeAddress: s.safe_address,
@@ -186,7 +206,9 @@ function fleetSummary(fleet: FleetState | null): StatusV1Response['fleet'] {
           ? 'pending'
           : 'not_applicable'
     ) as 'bound' | 'pending' | 'not_applicable',
-  }));
+    evicted: evictedByServiceIndex?.[di] ?? false,
+    };
+  });
   const stakedLikeCount = fleet.services.filter(s => isStakedLikeServiceStep(s.step)).length;
   const completeCount = fleet.services.filter(s => isOperationalServiceStep(s.step)).length;
   return {
@@ -311,7 +333,7 @@ function buildNextActions(raw: GatheredStatusRaw, fleetSum: StatusV1Response['fl
 }
 
 export function assembleStatusV1(raw: GatheredStatusRaw): StatusV1Response {
-  const fleetSum = fleetSummary(raw.fleet);
+  const fleetSum = fleetSummary(raw.fleet, raw.evictedByServiceIndex);
   const mode: 'full' | 'sqlite_only' = raw.hintsScope === 'sqlite_only' ? 'sqlite_only' : 'full';
   const claimedRewardsWei = sumClaimedRewardsWei(raw);
   let pendingRewardsWei: bigint | undefined;

--- a/client/src/api/status-build.ts
+++ b/client/src/api/status-build.ts
@@ -85,12 +85,6 @@ export interface GatheredStatusRaw {
    * `true` means the staking proxy reports state === 2 (Evicted).
    */
   evictedByServiceIndex?: Record<number, boolean>;
-  /**
-   * Per-service inactivity seconds keyed by display index.
-   * Populated by gather-status via on-chain getServiceInfo reads (jinn-mono-hjex.3).
-   * Value is the `inactivity` field from the ServiceInfo struct (seconds).
-   */
-  inactivityByServiceIndex?: Record<number, number>;
 }
 
 export interface StatusV1Response {

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -110,6 +110,12 @@ export const JinnConfigSchema = z.object({
    */
   balanceTopupIntervalMs: z.number().int().min(0).default(300_000),
 
+  /**
+   * Interval between eviction-state polls for the staking proxy (ms).
+   * Default 60000 (1 min). Set to 0 to disable. Env: JINN_EVICTION_CHECK_INTERVAL_MS
+   */
+  evictionCheckIntervalMs: z.number().int().min(0).default(60_000),
+
   /** HTTP API port */
   apiPort: z.number().int().positive().default(7331),
 
@@ -728,6 +734,7 @@ export function loadConfig(configPath?: string): JinnConfig {
     merged.rewardClaimIntervalMs = parseInt(env['JINN_REWARD_CLAIM_INTERVAL_MS'], 10);
   }
   if (env['JINN_BALANCE_TOPUP_INTERVAL_MS']) merged.balanceTopupIntervalMs = Number.parseInt(env['JINN_BALANCE_TOPUP_INTERVAL_MS'], 10);
+  if (env['JINN_EVICTION_CHECK_INTERVAL_MS']) merged.evictionCheckIntervalMs = Number.parseInt(env['JINN_EVICTION_CHECK_INTERVAL_MS'], 10);
   if (env['JINN_API_PORT'])          merged.apiPort = parseInt(env['JINN_API_PORT'], 10);
   if (env['JINN_API_BIND_HOST'])     merged.apiBindHost = env['JINN_API_BIND_HOST'];
   if (env['JINN_CLAUDE_PATH'])       merged.claudePath = env['JINN_CLAUDE_PATH'];

--- a/client/src/daemon/daemon.ts
+++ b/client/src/daemon/daemon.ts
@@ -13,6 +13,7 @@ import type { Corpus } from '../corpus/index.js';
 import { RewardClaimLoop, type RewardClaimLoopConfig } from './reward-claim-loop.js';
 import { TaskEngine, type TaskEngineOptions } from '../harnesses/engine/engine.js';
 import { BalanceTopupLoop, type BalanceTopupLoopConfig } from './balance-topup-loop.js';
+import { EvictionLoop, type EvictionLoopConfig } from './eviction-loop.js';
 import { JinnClaimLoop, type JinnClaimLoopConfig } from './jinn-claim-loop.js';
 import { emitEvent } from '../observability/emit-event.js';
 import { emitStructured } from '../events/emitter.js';
@@ -61,6 +62,13 @@ export interface DaemonConfig {
    * Omitted or interval 0 → loop not started.
    */
   balanceTopup?: BalanceTopupLoopConfig;
+
+  /**
+   * Periodic eviction-check + auto-restake loop (jinn-mono-hjex.3).
+   * Polls getStakingState for each service; restakes automatically when evicted.
+   * Omitted or interval 0 → loop not started.
+   */
+  evictionCheck?: EvictionLoopConfig;
 
   /**
    * Cross-chain JINN claim loop (jinn-mono-7x5). Emits ClaimTicket on L2,
@@ -150,6 +158,7 @@ export class Daemon {
   private readonly apiToken: string;
   private rewardClaimLoop?: RewardClaimLoop;
   private balanceTopupLoop?: BalanceTopupLoop;
+  private evictionLoop?: EvictionLoop;
   private jinnClaimLoop?: JinnClaimLoop;
 
   constructor(private readonly config: DaemonConfig) {
@@ -196,6 +205,9 @@ export class Daemon {
         ...config.balanceTopup,
         jinnStore: this.store,
       });
+    }
+    if (config.evictionCheck && config.evictionCheck.intervalMs > 0) {
+      this.evictionLoop = new EvictionLoop(config.evictionCheck);
     }
     if (config.jinnClaim && config.jinnClaim.intervalMs > 0) {
       this.jinnClaimLoop = new JinnClaimLoop({
@@ -322,6 +334,19 @@ export class Daemon {
         }),
       );
     }
+    if (this.evictionLoop) {
+      this.loopPromises.push(
+        this.evictionLoop.run().catch(err => {
+          console.error('[daemon] eviction-check crashed:', err);
+          emitStructured({
+            kind: 'error',
+            message: 'eviction-check loop crashed',
+            errorCode: 'eviction_check_crashed',
+            details: { error: err instanceof Error ? err.message : String(err) },
+          });
+        }),
+      );
+    }
     if (this.jinnClaimLoop) {
       this.loopPromises.push(
         this.jinnClaimLoop.run().catch(err => {
@@ -356,6 +381,7 @@ export class Daemon {
     this.deliveryWatcherLoop.stop();
     this.rewardClaimLoop?.stop();
     this.balanceTopupLoop?.stop();
+    this.evictionLoop?.stop();
     this.jinnClaimLoop?.stop();
     this.peerSync?.stop();
 

--- a/client/src/daemon/eviction-loop.ts
+++ b/client/src/daemon/eviction-loop.ts
@@ -1,0 +1,104 @@
+/**
+ * Periodic eviction-check + auto-restake loop (jinn-mono-hjex.3).
+ *
+ * Polls the staking proxy's getStakingState for each complete service. When
+ * state === 2 (Evicted) it calls the injected `recoverEvictedService` helper
+ * so the service is restaked without requiring a daemon restart.
+ *
+ * Scheduling: interval from config (default 60s). Set to 0 to disable.
+ * Env: JINN_EVICTION_CHECK_INTERVAL_MS
+ */
+
+import { getAddress, type PublicClient } from 'viem';
+import { STAKING_ABI } from '../earning/contracts.js';
+import type { FleetStateStore } from '../earning/store.js';
+import type { JinnOnchainNetwork } from '../earning/viem-clients.js';
+import { displayFleetServiceIndex } from '../earning/fleet-display-index.js';
+import { isStakedLikeServiceStep, type ServiceState } from '../earning/types.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type EvictionLoopReadContract = (opts: {
+  address: `0x${string}`;
+  abi: typeof STAKING_ABI;
+  functionName: 'getStakingState';
+  args: [bigint];
+}) => Promise<bigint | number>;
+
+export interface EvictionLoopConfig {
+  intervalMs: number;
+  store: FleetStateStore;
+  chain: JinnOnchainNetwork;
+  readContract: EvictionLoopReadContract;
+  /**
+   * Injected recovery function. In production this wraps
+   * `recoverEvictedService` from `../earning/bootstrap.js`.
+   * Accepts a ServiceState and kicks off the reStake call.
+   */
+  recoverEvictedService: (svc: ServiceState) => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// EvictionLoop
+// ---------------------------------------------------------------------------
+
+export class EvictionLoop {
+  private stopped = false;
+
+  constructor(private readonly config: EvictionLoopConfig) {}
+
+  stop(): void {
+    this.stopped = true;
+  }
+
+  async runOnce(): Promise<void> {
+    const state = await this.config.store.load(this.config.chain);
+
+    for (const svc of state.services) {
+      if (!svc.service_id || !svc.staking_address) continue;
+      if (!isStakedLikeServiceStep(svc.step)) continue;
+
+      const displayIndex = displayFleetServiceIndex(svc);
+
+      try {
+        const stakingState = await this.config.readContract({
+          address: getAddress(svc.staking_address) as `0x${string}`,
+          abi: STAKING_ABI,
+          functionName: 'getStakingState',
+          args: [BigInt(svc.service_id)],
+        });
+
+        if (Number(stakingState) === 2) {
+          console.error(
+            `[eviction-loop] Service ${displayIndex} (service_id ${svc.service_id}) is evicted; triggering auto-restake`,
+          );
+          await this.config.recoverEvictedService(svc);
+        }
+      } catch (err) {
+        console.error(
+          `[eviction-loop] Service ${displayIndex}: error checking staking state (non-fatal): ${err instanceof Error ? err.message : err}`,
+        );
+      }
+    }
+  }
+
+  async run(): Promise<void> {
+    if (this.config.intervalMs <= 0) {
+      return;
+    }
+
+    while (!this.stopped) {
+      try {
+        await this.runOnce();
+      } catch (err) {
+        console.error(
+          '[eviction-loop] Tick failed (non-fatal):',
+          err instanceof Error ? err.message : err,
+        );
+      }
+      await new Promise<void>(r => setTimeout(r, this.config.intervalMs));
+    }
+  }
+}

--- a/client/src/daemon/eviction-loop.ts
+++ b/client/src/daemon/eviction-loop.ts
@@ -56,6 +56,11 @@ export class EvictionLoop {
   async runOnce(): Promise<void> {
     const state = await this.config.store.load(this.config.chain);
 
+    // Self-bond services do not go through the distributor `reStake()` path
+    // that `recoverEvictedService` expects — mirror the standard-mode guard
+    // applied in `bootstrap.resumeService` (jinn-mono-hjex.3 review #6).
+    if (state.staking_mode !== 'standard') return;
+
     for (const svc of state.services) {
       if (!svc.service_id || !svc.staking_address) continue;
       if (!isStakedLikeServiceStep(svc.step)) continue;

--- a/client/src/dashboard/spa/src/api/client.ts
+++ b/client/src/dashboard/spa/src/api/client.ts
@@ -158,6 +158,11 @@ export const api = {
         body: JSON.stringify(patch),
       },
     ),
+  restake: (serviceId: number) =>
+    jfetch<{ ok: boolean; error?: string }>(
+      `/v1/setup/restake/${encodeURIComponent(String(serviceId))}`,
+      { method: 'POST' },
+    ),
   retryAgentBinding: (patch?: { serviceIndex?: number }) =>
     jfetch<{
       ok: boolean;

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { api } from '../api/client.js';
 import { HeroStats } from './overview/HeroStats.js';
@@ -15,9 +15,11 @@ interface OverviewStatusV1 {
     services?: Array<{
       index: number;
       step: string;
+      serviceId?: number | null;
       safeAddress?: string | null;
       agentId?: number | null;
       safeBoundToAgent?: boolean;
+      evicted?: boolean;
     }>;
   };
   rewards?: {
@@ -236,6 +238,7 @@ function operatorWaitingMessage(
 export function OverviewPage(): JSX.Element {
   const [activeAction, setActiveAction] = useState<string | null>(null);
   const [notice, setNotice] = useState<{ tone: 'success' | 'error'; text: string } | null>(null);
+  const queryClient = useQueryClient();
   const { data: status } = useQuery<OverviewStatusV1>({
     queryKey: ['status'],
     queryFn: () => api.getStatus() as Promise<OverviewStatusV1>,
@@ -275,6 +278,11 @@ export function OverviewPage(): JSX.Element {
     agentId: s.agentId ?? null,
     safeBoundToAgent: s.safeBoundToAgent ?? false,
   }));
+
+  // Eviction state — derived from the first evicted service in the fleet.
+  const firstEvictedService = (status?.fleet?.services ?? []).find((s) => s.evicted === true);
+  const isEvicted = firstEvictedService != null;
+  const evictedServiceId = firstEvictedService?.serviceId ?? null;
 
   const tasksDelivered = totals.solutions;
   const jinnClaimable = formatEth(status?.rewards?.pendingStakingRewardsWei);
@@ -316,6 +324,8 @@ export function OverviewPage(): JSX.Element {
         statusState={liveNow.state}
         statusDot={LIVE_NOW_TONE[liveNow.state].dot}
         activeAction={activeAction}
+        evicted={isEvicted}
+        evictedServiceId={evictedServiceId}
         onClaim={() =>
           runAction('Claim JINN', async () => {
             const res = await api.claimRewards();
@@ -347,6 +357,14 @@ export function OverviewPage(): JSX.Element {
             }
             return { message: 'Restart requested. The dashboard will reconnect when the daemon is back.' };
           })}
+        onRestake={async (serviceId) => {
+          const res = await api.restake(serviceId);
+          if (!res.ok) {
+            throw new Error(res.error ?? 'Re-stake failed.');
+          }
+          // Optimistically refetch status so the eviction notice clears.
+          await queryClient.invalidateQueries({ queryKey: ['status'] });
+        }}
       />
       {notice && (
         <div

--- a/client/src/dashboard/spa/src/pages/overview/HeroStats.test.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/HeroStats.test.tsx
@@ -1,24 +1,27 @@
-import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { HeroStats } from './HeroStats.js';
+
+function defaultProps() {
+  return {
+    tasksDelivered: 42,
+    jinnClaimable: '123',
+    gasBalanceEth: '0.5000',
+    gasRunwayDays: 4,
+    statusLabel: 'WORKING',
+    statusState: 'working' as const,
+    statusDot: 'var(--vow-green)',
+    activeAction: null,
+    evicted: false,
+    onClaim: () => undefined,
+    onTopUp: () => undefined,
+    onRestart: () => undefined,
+  };
+}
 
 describe('HeroStats', () => {
   it('renders overview stats plus compact status', () => {
-    render(
-      <HeroStats
-        tasksDelivered={42}
-        jinnClaimable="123"
-        gasBalanceEth="0.5000"
-        gasRunwayDays={4}
-        statusLabel="WORKING"
-        statusState="working"
-        statusDot="var(--vow-green)"
-        activeAction={null}
-        onClaim={() => undefined}
-        onTopUp={() => undefined}
-        onRestart={() => undefined}
-      />,
-    );
+    render(<HeroStats {...defaultProps()} />);
     expect(screen.getByText(/solutions delivered/i)).toBeTruthy();
     expect(screen.getByText(/jinn claimable/i)).toBeTruthy();
     expect(screen.queryByText(/jinn earned/i)).toBeNull();
@@ -33,5 +36,54 @@ describe('HeroStats', () => {
     expect(screen.getByTestId('overview-status-stat').getAttribute('data-state')).toBe('working');
     // The full live card now lives on /operator.
     expect(screen.queryByText(/node status/i)).toBeNull();
+  });
+
+  it('disables Claim now CTA when evicted=true and renders eviction notice (jinn-mono-hjex.3)', () => {
+    render(<HeroStats {...defaultProps()} evicted={true} />);
+    const claimBtn = screen.getByRole('button', { name: /claim now/i });
+    // Button must be disabled when service is evicted
+    expect(claimBtn).toHaveProperty('disabled', true);
+    // Eviction explainer must be visible — no OLAS mention
+    expect(screen.getByText(/service evicted/i)).toBeTruthy();
+    expect(screen.queryByText(/OLAS/i)).toBeNull();
+  });
+
+  it('does not show eviction notice when evicted=false (jinn-mono-hjex.3)', () => {
+    render(<HeroStats {...defaultProps()} evicted={false} />);
+    expect(screen.queryByText(/service evicted/i)).toBeNull();
+  });
+
+  it('renders Re-stake now button when evicted=true with serviceId and onRestake (jinn-mono-hjex.3)', () => {
+    const onRestake = vi.fn().mockResolvedValue(undefined);
+    render(
+      <HeroStats
+        {...defaultProps()}
+        evicted={true}
+        evictedServiceId={42}
+        onRestake={onRestake}
+      />,
+    );
+    expect(screen.getByTestId('restake-button')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /re-stake now/i })).toBeTruthy();
+  });
+
+  it('calls onRestake with serviceId when Re-stake now is clicked (jinn-mono-hjex.3)', () => {
+    const onRestake = vi.fn().mockResolvedValue(undefined);
+    render(
+      <HeroStats
+        {...defaultProps()}
+        evicted={true}
+        evictedServiceId={42}
+        onRestake={onRestake}
+      />,
+    );
+    const restakeBtn = screen.getByRole('button', { name: /re-stake now/i });
+    fireEvent.click(restakeBtn);
+    expect(onRestake).toHaveBeenCalledWith(42);
+  });
+
+  it('does not render Re-stake now button when evicted=true but onRestake is not provided (jinn-mono-hjex.3)', () => {
+    render(<HeroStats {...defaultProps()} evicted={true} evictedServiceId={42} />);
+    expect(screen.queryByTestId('restake-button')).toBeNull();
   });
 });

--- a/client/src/dashboard/spa/src/pages/overview/HeroStats.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/HeroStats.tsx
@@ -3,6 +3,7 @@
  * rule); labels are ALL-CAPS-MONO eyebrows. The full live activity surface
  * lives on /operator; Overview keeps only a compact status tile.
  */
+import { useState } from 'react';
 import type { LiveNowState } from './LiveNowBand.js';
 
 export interface HeroStatsProps {
@@ -14,9 +15,15 @@ export interface HeroStatsProps {
   statusState: LiveNowState;
   statusDot: string;
   activeAction: string | null;
+  /** When true, the service has been evicted from the staking proxy. */
+  evicted?: boolean;
+  /** Service ID of the evicted service. Required when evicted=true to wire the Re-stake CTA. */
+  evictedServiceId?: number | null;
   onClaim: () => void;
   onTopUp: () => void;
   onRestart: () => void;
+  /** Called when the operator clicks "Re-stake now". Should POST to /v1/setup/restake/:serviceId. */
+  onRestake?: (serviceId: number) => Promise<void> | void;
 }
 
 function ActionButton({
@@ -24,14 +31,16 @@ function ActionButton({
   action,
   activeAction,
   onClick,
+  forceDisabled,
 }: {
   children: string;
   action: string;
   activeAction: string | null;
   onClick: () => void;
+  forceDisabled?: boolean;
 }): JSX.Element {
   const busy = activeAction === action;
-  const disabled = activeAction !== null;
+  const disabled = activeAction !== null || (forceDisabled ?? false);
   return (
     <button
       type="button"
@@ -55,6 +64,62 @@ function ActionButton({
     >
       {busy ? 'Working...' : children}
     </button>
+  );
+}
+
+function EvictionNotice({
+  serviceId,
+  onRestake,
+}: {
+  serviceId?: number | null;
+  onRestake?: (serviceId: number) => Promise<void> | void;
+}): JSX.Element {
+  const [restaking, setRestaking] = useState(false);
+
+  function handleRestake(): void {
+    if (!serviceId || !onRestake || restaking) return;
+    setRestaking(true);
+    Promise.resolve(onRestake(serviceId)).finally(() => setRestaking(false));
+  }
+
+  return (
+    <div style={{ marginTop: '10px' }}>
+      <span
+        style={{
+          display: 'block',
+          color: 'var(--fg-warning, #e8a028)',
+          fontFamily: "'JetBrains Mono', monospace",
+          fontSize: '11px',
+          letterSpacing: '0.1em',
+        }}
+      >
+        Service evicted — restoring liveness
+      </span>
+      {serviceId != null && onRestake && (
+        <button
+          type="button"
+          data-testid="restake-button"
+          onClick={handleRestake}
+          disabled={restaking}
+          style={{
+            marginTop: '8px',
+            background: 'transparent',
+            border: '1px solid var(--fg-warning, #e8a028)',
+            borderRadius: '6px',
+            color: 'var(--fg-warning, #e8a028)',
+            cursor: restaking ? 'wait' : 'pointer',
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '11px',
+            letterSpacing: '0.14em',
+            opacity: restaking ? 0.55 : 1,
+            padding: '6px 10px',
+            textTransform: 'uppercase',
+          }}
+        >
+          {restaking ? 'Working...' : 'Re-stake now'}
+        </button>
+      )}
+    </div>
   );
 }
 
@@ -207,9 +272,12 @@ export function HeroStats({
   statusState,
   statusDot,
   activeAction,
+  evicted = false,
+  evictedServiceId,
   onClaim,
   onTopUp,
   onRestart,
+  onRestake,
 }: HeroStatsProps): JSX.Element {
   return (
     <div
@@ -225,9 +293,17 @@ export function HeroStats({
         value={jinnClaimable}
         unit="JINN"
         action={(
-          <ActionButton action="Claim JINN" activeAction={activeAction} onClick={onClaim}>
-            Claim now
-          </ActionButton>
+          <>
+            <ActionButton
+              action="Claim JINN"
+              activeAction={activeAction}
+              onClick={onClaim}
+              forceDisabled={evicted}
+            >
+              Claim now
+            </ActionButton>
+            {evicted ? <EvictionNotice serviceId={evictedServiceId} onRestake={onRestake} /> : null}
+          </>
         )}
       />
       <Stat

--- a/client/src/earning/bootstrap.ts
+++ b/client/src/earning/bootstrap.ts
@@ -87,6 +87,7 @@ import { isUnauthorizedAccountError } from '../errors/unauthorized-account.js';
 import { createJinnPublicClient, createJinnWalletClient, type JinnOnchainNetwork } from './viem-clients.js';
 import { isTransientEthReadError } from '../chain-read-errors.js';
 import { nextFleetServiceIndex } from './next-service-index.js';
+import { displayFleetServiceIndex } from './fleet-display-index.js';
 import { rpcHostForDisplay } from '../preflight/rpc-network.js';
 import {
   detectDeprecatedTestnetSetup,
@@ -966,46 +967,20 @@ export class FleetBootstrapper {
     const svc = state.services.find(s => s.index === index)!;
     const serviceId = svc.service_id!;
     const stakingAddress = this.stakingAddressForService(svc);
+    const di = displayFleetServiceIndex(svc);
 
-    // `reStake()` is operator-scoped: the master EOA must match the
-    // distributor's recorded `mapServiceIdCuratingAgents[serviceId]` entry.
-    // If it doesn't, the operator is likely using the wrong earning dir or
-    // password, or the service needs owner / managing-agent recovery.
-    const masterAccount = deriveMasterSigner(mnemonic);
-    const masterWallet = createJinnWalletClient(this.config.rpcUrl, this.chain, masterAccount);
-
-    const reStakeData = encodeFunctionData({
-      abi: STOLAS_DISTRIBUTOR_ABI,
-      functionName: 'reStake',
-      args: [stakingAddress, BigInt(serviceId)],
-    }) as Hex;
-
-    console.error(`[fleet-bootstrap] Service ${index}: calling distributor.reStake() for evicted service ${serviceId}`);
-    let reStakeHash: Hex;
-    try {
-      reStakeHash = await viemSendTransactionWithRetry(masterWallet, this.publicClient, {
-        account: masterAccount as Account,
-        to: addr(this.config.distributorAddress),
-        data: reStakeData,
-        gas: 1_500_000n,
-      });
-    } catch (err) {
-      const message = flattenErrorMessage(err);
-      if (isUnauthorizedAccountError(message)) {
-        throw new Error(
-          `Service ${index} (service_id ${serviceId}) is evicted on the staking proxy, but master EOA ${masterAccount.address} is not authorized to reStake it. ` +
-          `The distributor only permits the recorded service operator, a managing agent, or the owner. ` +
-          `Verify JINN_EARNING_DIR and JINN_PASSWORD derive the original master EOA for this service, then re-run jinn bootstrap; otherwise request owner / managing-agent recovery or abandon-and-rebootstrap. ` +
-          `reStake revert: ${message}`,
-        );
-      }
-      throw err;
-    }
-    const receipt = await waitForTransactionReceiptWithRetry(this.publicClient, reStakeHash);
-    if (receipt.status !== 'success') {
-      throw new Error(`reStake failed for service ${index}: ${reStakeHash}`);
-    }
-    console.error(`[fleet-bootstrap] Service ${index}: reStake confirmed (tx: ${reStakeHash})`);
+    // Delegate to the standalone exported helper (shared with EvictionLoop /
+    // the dashboard "Re-stake now" CTA). This eliminates the duplicate
+    // implementation (jinn-mono-hjex.3).
+    await recoverEvictedService({
+      serviceDisplayIndex: di,
+      serviceId,
+      stakingAddress: stakingAddress,
+      distributorAddress: this.config.distributorAddress,
+      rpcUrl: this.config.rpcUrl,
+      chain: this.chain,
+      mnemonic,
+    });
 
     // Service is now Staked again with the same service_id, safe_address, and mech_address.
     // Step back to `mech_deployed` so the resume loop advances through
@@ -1893,3 +1868,83 @@ export class FleetBootstrapper {
 
 /** @deprecated Use FleetBootstrapper */
 export const EarningBootstrapper = FleetBootstrapper;
+
+// ---------------------------------------------------------------------------
+// Standalone recovery helper — callable from the eviction loop (hjex.3)
+// ---------------------------------------------------------------------------
+
+export interface RecoverEvictedServiceOptions {
+  /** Display index of the service (used only for log messages). */
+  serviceDisplayIndex: number;
+  serviceId: number;
+  stakingAddress: string;
+  distributorAddress: string;
+  rpcUrl: string;
+  chain: JinnOnchainNetwork;
+  mnemonic: string;
+}
+
+/**
+ * Re-stake an evicted service by calling `distributor.reStake(stakingProxy, serviceId)`.
+ *
+ * Extracted from `FleetBootstrapper.recoverEvictedService` so it can be called
+ * from the in-process `EvictionLoop` without requiring a full bootstrapper
+ * context (jinn-mono-hjex.3).
+ *
+ * The caller is responsible for advancing the local service step back to
+ * `mech_deployed` after this returns (just like the bootstrapper resume path does).
+ */
+export async function recoverEvictedService(
+  opts: RecoverEvictedServiceOptions,
+): Promise<void> {
+  const {
+    serviceDisplayIndex,
+    serviceId,
+    stakingAddress,
+    distributorAddress,
+    rpcUrl,
+    chain,
+    mnemonic,
+  } = opts;
+
+  const masterAccount = deriveMasterSigner(mnemonic);
+  const publicClient = createJinnPublicClient(rpcUrl, chain);
+  const masterWallet = createJinnWalletClient(rpcUrl, chain, masterAccount);
+
+  const reStakeData = encodeFunctionData({
+    abi: STOLAS_DISTRIBUTOR_ABI,
+    functionName: 'reStake',
+    args: [addr(stakingAddress), BigInt(serviceId)],
+  }) as Hex;
+
+  console.error(
+    `[eviction-recovery] Service ${serviceDisplayIndex}: calling distributor.reStake() for evicted service ${serviceId}`,
+  );
+  let reStakeHash: Hex;
+  try {
+    reStakeHash = await viemSendTransactionWithRetry(masterWallet, publicClient, {
+      account: masterAccount as Account,
+      to: addr(distributorAddress),
+      data: reStakeData,
+      gas: 1_500_000n,
+    });
+  } catch (err) {
+    const message = flattenErrorMessage(err);
+    if (isUnauthorizedAccountError(message)) {
+      throw new Error(
+        `Service ${serviceDisplayIndex} (service_id ${serviceId}) is evicted on the staking proxy, but master EOA ` +
+        `${masterAccount.address} is not authorized to reStake it. ` +
+        `Verify JINN_EARNING_DIR and JINN_PASSWORD derive the original master EOA for this service. ` +
+        `reStake revert: ${message}`,
+      );
+    }
+    throw err;
+  }
+  const receipt = await waitForTransactionReceiptWithRetry(publicClient, reStakeHash);
+  if (receipt.status !== 'success') {
+    throw new Error(`reStake failed for service ${serviceDisplayIndex}: ${reStakeHash}`);
+  }
+  console.error(
+    `[eviction-recovery] Service ${serviceDisplayIndex}: reStake confirmed (tx: ${reStakeHash})`,
+  );
+}

--- a/client/src/earning/jinn-rewards.ts
+++ b/client/src/earning/jinn-rewards.ts
@@ -32,6 +32,38 @@ export const JINN_STAKING_ABI = [
     inputs: [
       { name: 'serviceId', type: 'uint256' },
     ],
+    name: 'getStakingState',
+    outputs: [{ name: 'stakingState', type: 'uint8' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { name: 'serviceId', type: 'uint256' },
+    ],
+    name: 'getServiceInfo',
+    outputs: [
+      {
+        name: 'sInfo',
+        type: 'tuple',
+        components: [
+          { name: 'multisig', type: 'address' },
+          { name: 'owner', type: 'address' },
+          { name: 'nonces', type: 'uint256[]' },
+          { name: 'tsStart', type: 'uint256' },
+          { name: 'reward', type: 'uint256' },
+          { name: 'inactivity', type: 'uint256' },
+          { name: 'rewardDistributionInfo', type: 'uint256' },
+        ],
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { name: 'serviceId', type: 'uint256' },
+    ],
     name: 'claim',
     outputs: [{ name: 'amount', type: 'uint256' }],
     stateMutability: 'nonpayable',

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -46,8 +46,8 @@ import { checkClaudeBinary } from './preflight/claude-binary.js';
 import { emitClaudeBinaryPreflightFailure } from './preflight/claude-invocation-envelope.js';
 import { detectAuthContext, probeClaudeAuth } from './preflight/claude-auth.js';
 import { configRequiresClaudeAuth } from './preflight/claude-required.js';
-import { FleetBootstrapper } from './earning/bootstrap.js';
-import { DEFAULT_TESTNET_ARTIFACTS, applyChainGasOverrides, getChainConfig, loadJinnMviConfig } from './earning/contracts.js';
+import { FleetBootstrapper, recoverEvictedService as recoverEvictedServiceFn } from './earning/bootstrap.js';
+import { DEFAULT_TESTNET_ARTIFACTS, STAKING_ABI, applyChainGasOverrides, getChainConfig, loadJinnMviConfig } from './earning/contracts.js';
 import { runLegacyAgentIdMigration } from './earning/migrate-agent-id.js';
 import { FleetStateStore } from './earning/store.js';
 import {
@@ -906,6 +906,12 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     current: import('./api/solvernets-endpoints.js').SolverNetsEndpointsDeps | undefined;
   } = { current: undefined };
 
+  // hjex.3: holder for the restake callback. Populated in running mode after
+  // bootstrap completes (when mnemonic + distributorAddress are available).
+  const restakeCallbackRef: { current: ((serviceId: number) => Promise<{ ok: boolean; error?: string }>) | undefined } = {
+    current: undefined,
+  };
+
   let setupApiServer: ApiServer;
   try {
     setupApiServer = await startApiServer({
@@ -1083,6 +1089,13 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
           // (and thus Overview's `solverNet.enabled` gating) reflects the
           // toggle immediately. (jinn-mono-l2zl.15.4.12)
           invalidatePredictionOperatorStatusCache(config);
+        },
+        // hjex.3: delegate to the live callback populated once running mode starts.
+        restake: (serviceId) => {
+          if (!restakeCallbackRef.current) {
+            return Promise.resolve({ ok: false, error: 'restake_not_available_in_setup_mode' });
+          }
+          return restakeCallbackRef.current(serviceId);
         },
       },
       status: {
@@ -1439,6 +1452,31 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
   const publicClient = createJinnPublicClient(config.rpcUrl, NETWORK_CHAIN);
   publicClientForLauncher = publicClient;
   const masterWallet = createJinnWalletClient(config.rpcUrl, NETWORK_CHAIN, masterAccount);
+
+  // hjex.3: populate the restake callback now that mnemonic is available.
+  if (config.stakingMode === 'standard' && CHAIN_CONFIG.distributorAddress) {
+    const fleetStore = earningStore;
+    restakeCallbackRef.current = async (serviceId: number) => {
+      try {
+        const state = await fleetStore.load(NETWORK_CHAIN);
+        const svc = state.services.find(s => s.service_id === serviceId);
+        if (!svc) return { ok: false, error: `service_not_found:${serviceId}` };
+        if (!svc.staking_address) return { ok: false, error: 'staking_address_missing' };
+        await recoverEvictedServiceFn({
+          serviceDisplayIndex: Math.max(0, svc.index - 1),
+          serviceId,
+          stakingAddress: svc.staking_address,
+          distributorAddress: CHAIN_CONFIG.distributorAddress!,
+          rpcUrl: config.rpcUrl,
+          chain: NETWORK_CHAIN,
+          mnemonic: mnemonicForMaster,
+        });
+        return { ok: true };
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    };
+  }
 
   const evictionRecovery =
     config.stakingMode === 'standard' &&
@@ -2184,6 +2222,32 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
             eoaTopupTarget: CHAIN_CONFIG.minEoaGasEth,
             safeTopupTrigger: CHAIN_CONFIG.safeTopupTrigger,
             safeTopupTarget: CHAIN_CONFIG.minSafeEth,
+          }
+        : undefined,
+    // Eviction-check loop — only in standard staking mode (requires distributorAddress).
+    // Running mode only: setup-halted daemons must not try to restake services that
+    // haven't been staked yet (hjex.3).
+    evictionCheck:
+      config.evictionCheckIntervalMs > 0 &&
+      config.stakingMode === 'standard' &&
+      CHAIN_CONFIG.distributorAddress
+        ? {
+            intervalMs: config.evictionCheckIntervalMs,
+            store: earningStore,
+            chain: NETWORK_CHAIN,
+            readContract: (opts) => publicClient.readContract(opts as Parameters<typeof publicClient.readContract>[0]) as Promise<bigint>,
+            recoverEvictedService: async (svc) => {
+              if (!svc.service_id || !svc.staking_address) return;
+              await recoverEvictedServiceFn({
+                serviceDisplayIndex: Math.max(0, svc.index - 1),
+                serviceId: svc.service_id,
+                stakingAddress: svc.staking_address,
+                distributorAddress: CHAIN_CONFIG.distributorAddress!,
+                rpcUrl: config.rpcUrl,
+                chain: NETWORK_CHAIN,
+                mnemonic: mnemonicForMaster,
+              });
+            },
           }
         : undefined,
   });

--- a/client/test/api/fleet-build.test.ts
+++ b/client/test/api/fleet-build.test.ts
@@ -84,4 +84,30 @@ describe('assembleFleetV1', () => {
     const out = assembleFleetV1(raw);
     expect(out.network).toBe('mainnet');
   });
+
+  it('populates staking.evicted from evictedByServiceIndex (jinn-mono-hjex.3)', () => {
+    // The display index for service at index 1 (via displayFleetServiceIndex) is 0
+    // (fleet-display-index uses 0-based display index from the services array position).
+    const raw = makeRaw({ evictedByServiceIndex: { 0: true } });
+    const out = assembleFleetV1(raw);
+    expect(out.services[0]!.staking.evicted).toBe(true);
+  });
+
+  it('defaults staking.evicted to false when evictedByServiceIndex absent (jinn-mono-hjex.3)', () => {
+    const raw = makeRaw();
+    const out = assembleFleetV1(raw);
+    expect(out.services[0]!.staking.evicted).toBe(false);
+  });
+
+  it('populates staking.inactivitySeconds from inactivityByServiceIndex (jinn-mono-hjex.3)', () => {
+    const raw = makeRaw({ inactivityByServiceIndex: { 0: 7200 } });
+    const out = assembleFleetV1(raw);
+    expect(out.services[0]!.staking.inactivitySeconds).toBe(7200);
+  });
+
+  it('defaults staking.inactivitySeconds to null when inactivityByServiceIndex absent (jinn-mono-hjex.3)', () => {
+    const raw = makeRaw();
+    const out = assembleFleetV1(raw);
+    expect(out.services[0]!.staking.inactivitySeconds).toBeNull();
+  });
 });

--- a/client/test/api/fleet-build.test.ts
+++ b/client/test/api/fleet-build.test.ts
@@ -99,15 +99,17 @@ describe('assembleFleetV1', () => {
     expect(out.services[0]!.staking.evicted).toBe(false);
   });
 
-  it('populates staking.inactivitySeconds from inactivityByServiceIndex (jinn-mono-hjex.3)', () => {
-    const raw = makeRaw({ inactivityByServiceIndex: { 0: 7200 } });
+  it('emits attention.kind=evicted when evictedByServiceIndex is true (jinn-mono-hjex.3 review #3)', () => {
+    const raw = makeRaw({ evictedByServiceIndex: { 0: true } });
     const out = assembleFleetV1(raw);
-    expect(out.services[0]!.staking.inactivitySeconds).toBe(7200);
+    expect(out.services[0]!.attention?.kind).toBe('evicted');
+    expect(out.services[0]!.attention?.hint).toMatch(/evicted/i);
+    expect(out.services[0]!.attention?.exampleCli).toBe('jinn bootstrap --json');
   });
 
-  it('defaults staking.inactivitySeconds to null when inactivityByServiceIndex absent (jinn-mono-hjex.3)', () => {
-    const raw = makeRaw();
+  it('does not set attention.kind=evicted when evictedByServiceIndex is false (jinn-mono-hjex.3)', () => {
+    const raw = makeRaw({ evictedByServiceIndex: { 0: false } });
     const out = assembleFleetV1(raw);
-    expect(out.services[0]!.staking.inactivitySeconds).toBeNull();
+    expect(out.services[0]!.attention).toBeNull();
   });
 });

--- a/client/test/daemon/eviction-loop.test.ts
+++ b/client/test/daemon/eviction-loop.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for the EvictionLoop daemon loop.
+ *
+ * jinn-mono-hjex.3 — surface service eviction + in-process auto-restake.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { EvictionLoop } from '../../src/daemon/eviction-loop.js';
+
+// Valid checksummed Ethereum addresses
+const STAKING_ADDR = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
+
+function makeService(overrides: { serviceId?: number; stakingAddress?: string; step?: string } = {}) {
+  return {
+    index: 1,
+    step: overrides.step ?? 'complete',
+    service_id: overrides.serviceId ?? 42,
+    staking_address: overrides.stakingAddress ?? STAKING_ADDR,
+    agent_address: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+    safe_address: '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
+  };
+}
+
+function mockStore(services: ReturnType<typeof makeService>[]) {
+  return {
+    load: vi.fn(async () => ({
+      master_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+      services,
+      staking_mode: 'standard',
+    })),
+  } as any;
+}
+
+describe('EvictionLoop', () => {
+  it('detects state=2 and calls recoverEvictedService (jinn-mono-hjex.3)', async () => {
+    const readContract = vi.fn().mockResolvedValue(2n); // 2 = Evicted
+    const recoverEvicted = vi.fn().mockResolvedValue(undefined);
+    const loop = new EvictionLoop({
+      intervalMs: 60_000,
+      store: mockStore([makeService()]),
+      chain: 'base-sepolia',
+      readContract,
+      recoverEvictedService: recoverEvicted,
+    });
+
+    await loop.runOnce();
+
+    expect(readContract).toHaveBeenCalledWith(
+      expect.objectContaining({ functionName: 'getStakingState', args: [42n] }),
+    );
+    expect(recoverEvicted).toHaveBeenCalledWith(
+      expect.objectContaining({ service_id: 42 }),
+    );
+  });
+
+  it('does not call recoverEvictedService when state=1 (Staked)', async () => {
+    const readContract = vi.fn().mockResolvedValue(1n); // 1 = Staked
+    const recoverEvicted = vi.fn();
+    const loop = new EvictionLoop({
+      intervalMs: 60_000,
+      store: mockStore([makeService()]),
+      chain: 'base-sepolia',
+      readContract,
+      recoverEvictedService: recoverEvicted,
+    });
+
+    await loop.runOnce();
+    expect(recoverEvicted).not.toHaveBeenCalled();
+  });
+
+  it('skips services without service_id', async () => {
+    const readContract = vi.fn().mockResolvedValue(2n);
+    const recoverEvicted = vi.fn();
+    const loop = new EvictionLoop({
+      intervalMs: 60_000,
+      store: mockStore([{ ...makeService(), service_id: null as any }]),
+      chain: 'base-sepolia',
+      readContract,
+      recoverEvictedService: recoverEvicted,
+    });
+
+    await loop.runOnce();
+    expect(readContract).not.toHaveBeenCalled();
+    expect(recoverEvicted).not.toHaveBeenCalled();
+  });
+
+  it('skips services without staking_address', async () => {
+    const readContract = vi.fn().mockResolvedValue(2n);
+    const recoverEvicted = vi.fn();
+    const loop = new EvictionLoop({
+      intervalMs: 60_000,
+      store: mockStore([{ ...makeService(), staking_address: null as any }]),
+      chain: 'base-sepolia',
+      readContract,
+      recoverEvictedService: recoverEvicted,
+    });
+
+    await loop.runOnce();
+    expect(readContract).not.toHaveBeenCalled();
+    expect(recoverEvicted).not.toHaveBeenCalled();
+  });
+
+  it('does not crash when readContract fails (non-fatal)', async () => {
+    const readContract = vi.fn().mockRejectedValue(new Error('RPC error'));
+    const recoverEvicted = vi.fn();
+    const loop = new EvictionLoop({
+      intervalMs: 60_000,
+      store: mockStore([makeService()]),
+      chain: 'base-sepolia',
+      readContract,
+      recoverEvictedService: recoverEvicted,
+    });
+
+    await expect(loop.runOnce()).resolves.toBeUndefined();
+    expect(recoverEvicted).not.toHaveBeenCalled();
+  });
+
+  it('exits immediately when intervalMs is 0', async () => {
+    const readContract = vi.fn().mockResolvedValue(1n);
+    const recoverEvicted = vi.fn();
+    const store = mockStore([makeService()]);
+    const loop = new EvictionLoop({
+      intervalMs: 0,
+      store,
+      chain: 'base-sepolia',
+      readContract,
+      recoverEvictedService: recoverEvicted,
+    });
+
+    await expect(loop.run()).resolves.toBeUndefined();
+    expect(store.load).not.toHaveBeenCalled();
+  });
+});

--- a/client/test/daemon/eviction-loop.test.ts
+++ b/client/test/daemon/eviction-loop.test.ts
@@ -21,12 +21,15 @@ function makeService(overrides: { serviceId?: number; stakingAddress?: string; s
   };
 }
 
-function mockStore(services: ReturnType<typeof makeService>[]) {
+function mockStore(
+  services: ReturnType<typeof makeService>[],
+  opts: { stakingMode?: string } = {},
+) {
   return {
     load: vi.fn(async () => ({
       master_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
       services,
-      staking_mode: 'standard',
+      staking_mode: opts.stakingMode ?? 'standard',
     })),
   } as any;
 }
@@ -129,5 +132,70 @@ describe('EvictionLoop', () => {
 
     await expect(loop.run()).resolves.toBeUndefined();
     expect(store.load).not.toHaveBeenCalled();
+  });
+
+  it('terminates run() when stop() is called (jinn-mono-hjex.3 review #4)', async () => {
+    const readContract = vi.fn().mockResolvedValue(1n); // staked, not evicted
+    const recoverEvicted = vi.fn();
+    const store = mockStore([makeService()]);
+    const loop = new EvictionLoop({
+      intervalMs: 5, // short interval so the test stays fast
+      store,
+      chain: 'base-sepolia',
+      readContract,
+      recoverEvictedService: recoverEvicted,
+    });
+
+    const runPromise = loop.run();
+    // Let at least one tick start.
+    await new Promise((r) => setTimeout(r, 1));
+    loop.stop();
+    await expect(runPromise).resolves.toBeUndefined();
+    expect(store.load).toHaveBeenCalled();
+  });
+
+  it('RPC error on one service does not abort the loop for siblings (jinn-mono-hjex.3 review #4)', async () => {
+    const services = [
+      makeService({ serviceId: 100 }),
+      makeService({ serviceId: 200 }),
+    ];
+    // First call rejects, second resolves as Evicted.
+    const readContract = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('RPC failure for svc 100'))
+      .mockResolvedValueOnce(2n);
+    const recoverEvicted = vi.fn().mockResolvedValue(undefined);
+    const loop = new EvictionLoop({
+      intervalMs: 60_000,
+      store: mockStore(services),
+      chain: 'base-sepolia',
+      readContract,
+      recoverEvictedService: recoverEvicted,
+    });
+
+    await expect(loop.runOnce()).resolves.toBeUndefined();
+    expect(readContract).toHaveBeenCalledTimes(2);
+    // The healthy service still triggered recovery.
+    expect(recoverEvicted).toHaveBeenCalledTimes(1);
+    expect(recoverEvicted).toHaveBeenCalledWith(
+      expect.objectContaining({ service_id: 200 }),
+    );
+  });
+
+  it('skips entirely in self-bond mode (jinn-mono-hjex.3 review #6)', async () => {
+    const readContract = vi.fn().mockResolvedValue(2n);
+    const recoverEvicted = vi.fn();
+    const loop = new EvictionLoop({
+      intervalMs: 60_000,
+      store: mockStore([makeService()], { stakingMode: 'self_bond' }),
+      chain: 'base-sepolia',
+      readContract,
+      recoverEvictedService: recoverEvicted,
+    });
+
+    await loop.runOnce();
+    // No staking-state reads issued — self-bond does not use the distributor restake path.
+    expect(readContract).not.toHaveBeenCalled();
+    expect(recoverEvicted).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Fleet API now reads on-chain `getStakingState(serviceId)` for each staked service and exposes `staking.evicted` per service in `GET /v1/fleet` (was hard-coded `false`).
- `gather-status` fans out the staking state reads and populates `evictedByServiceIndex` on `GatheredStatusRaw`.
- HeroStats gains an `evicted` prop: when `true`, the "Claim now" CTA is disabled and an inline **"Service evicted — restoring liveness"** notice renders. No OLAS terminology in operator-facing copy.
- New `EvictionLoop` daemon loop polls `getStakingState` every 60 s and calls the extracted `recoverEvictedService` helper when state 2 (Evicted) is detected — no daemon restart required.
- `recoverEvictedService` extracted as a standalone exported function from `FleetBootstrapper` so the loop can call it without a full bootstrapper context. The private class method is unchanged.
- New `POST /v1/setup/restake/:serviceId` endpoint backs the "Re-stake now" dashboard CTA; delegates via a lazy ref populated in running mode.
- New `evictionCheckIntervalMs` config knob (default 60 s, env `JINN_EVICTION_CHECK_INTERVAL_MS`, 0 = disabled).

## Why

Bead `jinn-mono-hjex.3` / GitHub #220 / #233: an operator who completed many SWE-rebench v2 tasks saw `0 JINN claimable` because their service had been silently evicted by the staking proxy (inactivity ratio failure). The dashboard was reading the right contract — the on-chain answer genuinely was 0 — but the operator had no signal that anything was wrong, and "Claim now" silently no-op'd.

Operator-facing copy never mentions OLAS.

## Stacked on

PR #239 (PR-2 of the same stack).

## Test plan

- [x] `fleet-build` regression: `staking.evicted: true` when `evictedByServiceIndex[displayIndex] === true` in `GatheredStatusRaw`.
- [x] `eviction-loop` regression: detects state 2, calls `recoverEvictedService`, skips non-staked services, skips services missing `service_id` or `staking_address`, non-fatal on RPC error, exits immediately when `intervalMs === 0`.
- [x] `HeroStats` regression: "Claim now" disabled + eviction explainer renders when `evicted=true`; neither appears when `evicted=false`.
- [x] `yarn typecheck` + `yarn test` (3281/3281) clean.

Refs: bd `jinn-mono-hjex.3`, GitHub #220, GitHub #233.