### PR TITLE
fix(hjex.7): balance-gated 'Fund your wallet' DONE; cold-start multiplier for migration-wiped fleets

### DIFF
--- a/client/src/api/bootstrap-endpoint.ts
+++ b/client/src/api/bootstrap-endpoint.ts
@@ -191,6 +191,11 @@ export function addBootstrapRoutes(app: Hono, config: BootstrapEndpointConfig): 
           eth_required: fundingGate.eth_required,
           eth_balance: fundingGate.eth_balance,
           targetWei: fundingTargetWei(fundingGate),
+          // targetMet is false whenever the funding gate is active: the gate
+          // fires only when master balance < target. Once the gate clears the
+          // daemon advances past awaiting_funding and the funding block is
+          // omitted entirely (allRunning path or currentStep > awaiting_funding).
+          targetMet: false,
         },
       } : {}),
       ...(error ? { error } : {}),

--- a/client/src/dashboard/spa/src/api/types.ts
+++ b/client/src/dashboard/spa/src/api/types.ts
@@ -50,6 +50,15 @@ export interface BootstrapState {
     eth_required?: string;
     eth_balance?: string;
     targetWei?: string;
+    /**
+     * True only when master balance has met or exceeded the bootstrap target
+     * AND `currentStep` has advanced past `awaiting_funding`. Present only
+     * when the funding block is included (i.e. when the gate was recently
+     * active). When the gate clears the funding block is omitted entirely,
+     * so consumers should treat absent funding as "not blocking" and present
+     * funding with targetMet===false as "still blocking".
+     */
+    targetMet?: boolean;
   };
   solverNets?: Record<string, {
     name?: string;

--- a/client/src/dashboard/spa/src/regions/Onboarding.test.tsx
+++ b/client/src/dashboard/spa/src/regions/Onboarding.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * Unit tests for the Onboarding phase state machine.
+ *
+ * Tests for statusFor() — the function that determines whether a phase row
+ * is 'done', 'active', or 'queued'. The key invariant (jinn-mono-hjex.7):
+ *
+ *   Phase 3 ("Fund your wallet") must stay 'active' until the funding gate
+ *   is cleared, even when currentPhase has already advanced to 4. A single
+ *   drip that briefly crossed the threshold must not flip phase 3 to DONE.
+ */
+import { describe, expect, it } from 'vitest';
+import { statusFor } from './Onboarding.js';
+
+describe('statusFor phase machine (jinn-mono-hjex.7)', () => {
+  // ── Baseline: no funding context ─────────────────────────────────────────
+
+  it('marks earlier phases as done when currentPhase advances', () => {
+    expect(statusFor(1, 3)).toBe('done');
+    expect(statusFor(2, 4)).toBe('done');
+  });
+
+  it('marks the current phase as active', () => {
+    expect(statusFor(3, 3)).toBe('active');
+    expect(statusFor(4, 4)).toBe('active');
+  });
+
+  it('marks later phases as queued', () => {
+    expect(statusFor(4, 2)).toBe('queued');
+    expect(statusFor(3, 2)).toBe('queued');
+  });
+
+  // ── Phase 3 funding gate ─────────────────────────────────────────────────
+
+  it('marks phase 3 done when currentPhase > 3 and fundingTargetMet is absent (gate cleared)', () => {
+    // fundingTargetMet === undefined means no funding block in response — gate cleared
+    expect(statusFor(3, 4, undefined)).toBe('done');
+  });
+
+  it('does not mark phase 3 DONE while funding.targetMet is false (jinn-mono-hjex.7)', () => {
+    // Explicit false: gate is still open even though step advanced
+    expect(statusFor(3, 4, false)).toBe('active');
+  });
+
+  it('marks phase 3 DONE when currentPhase > 3 and fundingTargetMet is true', () => {
+    expect(statusFor(3, 4, true)).toBe('done');
+  });
+
+  it('does not apply the funding gate hold to phases other than 3', () => {
+    // Phase 2 done even if fundingTargetMet is false — gate is only for phase 3
+    expect(statusFor(2, 4, false)).toBe('done');
+    // Phase 1 done regardless
+    expect(statusFor(1, 4, false)).toBe('done');
+  });
+
+  it('marks phase 3 active (not queued) when it is the current phase, regardless of funding', () => {
+    expect(statusFor(3, 3, false)).toBe('active');
+    expect(statusFor(3, 3, undefined)).toBe('active');
+  });
+
+  it('phase 4 queued is unaffected by fundingTargetMet', () => {
+    expect(statusFor(4, 3, false)).toBe('queued');
+    expect(statusFor(4, 3, true)).toBe('queued');
+  });
+});

--- a/client/src/dashboard/spa/src/regions/Onboarding.tsx
+++ b/client/src/dashboard/spa/src/regions/Onboarding.tsx
@@ -63,8 +63,19 @@ function bootstrapPhaseFor(step: string): BootstrapPhaseDescriptor {
   return PHASE_FOR_STEP[step] ?? { phase: 2, subState: null };
 }
 
-function statusFor(rowPhase: Phase, currentPhase: Phase): PhaseStatus {
-  if (rowPhase < currentPhase) return 'done';
+/** @internal exported for unit tests */
+export function statusFor(rowPhase: Phase, currentPhase: Phase, fundingTargetMet?: boolean): PhaseStatus {
+  if (rowPhase < currentPhase) {
+    // Phase 3 (Fund your wallet) stays 'active' until the endpoint explicitly
+    // signals that the balance target is met. This prevents a momentary drip
+    // that briefly crossed the threshold from flipping phase 3 to DONE before
+    // the bootstrapper has actually advanced past awaiting_funding on-chain.
+    //
+    // `fundingTargetMet === false` (explicit false from the funding gate) means
+    // the gate is still open; absent funding block means the gate has cleared.
+    if (rowPhase === 3 && fundingTargetMet === false) return 'active';
+    return 'done';
+  }
   if (rowPhase === currentPhase) return 'active';
   return 'queued';
 }
@@ -104,6 +115,8 @@ export function Onboarding(): JSX.Element {
   // claude reports authenticated:true. Phases 2/3/4 are bootstrap-driven.
   const authDone = claudeAuth?.authenticated === true;
   const currentPhase: Phase = !authDone ? 1 : bootstrapPhase;
+  // Explicit false means the funding gate is still open; absent means cleared.
+  const fundingTargetMet = bootstrap.funding?.targetMet;
 
   return (
     <div
@@ -130,7 +143,7 @@ export function Onboarding(): JSX.Element {
 
           <ol className="flex flex-col">
             {([1, 2, 3, 4] as Phase[]).map((p) => {
-              const status = statusFor(p, currentPhase);
+              const status = statusFor(p, currentPhase, fundingTargetMet);
               const showError = bootstrapError && p === currentPhase && p !== 1;
               return (
                 <PhaseRow key={p} phase={p} status={showError ? 'error' : status}>

--- a/client/src/earning/bootstrap.ts
+++ b/client/src/earning/bootstrap.ts
@@ -98,7 +98,63 @@ import type { Account } from 'viem/accounts';
 const addr = (value: string): Address => getAddress(value) as Address;
 
 const SAFE_TOKEN_BOOTSTRAP_MULTIPLIER = 2n;
-const STANDARD_MASTER_BOOTSTRAP_MULTIPLIER = 2n;
+
+/**
+ * 2× cold-start headroom for master ETH target on a fresh bootstrap.
+ *
+ * Gas accounting for a single standard-mode service on first run:
+ *   ~1.3M gas for the Safe deploy + stake + mech (at 2 gwei ≈ 0.0026 ETH)
+ *   + 0.002 ETH Safe seed (sent to the Safe so it can pay mech fees)
+ *   ≈ 0.0046 ETH minimum; 2× gives ≈ 0.009–0.010 ETH — the bootstrap
+ *   `minEoaGasEth` default.
+ *
+ * The multiplier only applies when no service has a persisted `service_id`
+ * on-chain (i.e. the fleet is truly cold — OR migration-wiped, where
+ * services exist in shape but lost their on-chain anchor). Once any service
+ * has committed a `service_id`, the fleet is past the cold-start cliff and
+ * 1× suffices.
+ *
+ * Single source of truth: imported by funding-plan.ts.
+ */
+export const STANDARD_MASTER_BOOTSTRAP_MULTIPLIER = 2n;
+
+/**
+ * Compute the required master ETH gate for the standard staking mode.
+ *
+ * @param services         Persisted service states
+ * @param minEoaGasEth     Configured minimum EOA gas target (wei)
+ * @param standardMultiplier  Cold-start multiplier (defaults to {@link STANDARD_MASTER_BOOTSTRAP_MULTIPLIER})
+ * @param pendingSetupMigration  True when deprecated testnet setup detected
+ * @param targetServices   How many services the fleet is aiming for
+ */
+export function computeRequiredMasterEth({
+  services,
+  minEoaGasEth,
+  standardMultiplier = STANDARD_MASTER_BOOTSTRAP_MULTIPLIER,
+  pendingSetupMigration = false,
+  targetServices = 1,
+}: {
+  services: Array<{ service_id: number | null | undefined; step?: string }>;
+  minEoaGasEth: bigint;
+  standardMultiplier?: bigint;
+  pendingSetupMigration?: boolean;
+  targetServices?: number;
+}): bigint {
+  const completedCount = services.filter(s =>
+    s.step !== undefined && isOperationalServiceStep(s.step),
+  ).length;
+  const standardFleetAlreadyComplete =
+    !pendingSetupMigration && completedCount >= targetServices;
+  if (standardFleetAlreadyComplete) return 0n;
+
+  // "Cold in liability" = no service has an on-chain anchor yet.
+  // This includes:
+  //   1. Fresh fleet (services array is empty)
+  //   2. Migration-wiped fleet (services exist in shape but service_id === null)
+  // Apply the 2× headroom multiplier in both cases.
+  const hasPersistedOnChain = services.some(s => s.service_id != null);
+  return minEoaGasEth * (hasPersistedOnChain ? 1n : standardMultiplier);
+}
 
 /** Conservative default: ~0.001 ETH/day master gas if not configured. */
 const DEFAULT_MASTER_ETH_DAILY_WEI = 1_000_000_000_000_000n;
@@ -279,21 +335,13 @@ export class FleetBootstrapper {
         stakingMode: this.stakingMode,
         currentStakingContract: this.config.stakingContract,
       }).services.length > 0;
-      const completedCountBeforeFunding = state.services.filter(s =>
-        isOperationalServiceStep(s.step),
-      ).length;
-      const standardFleetAlreadyComplete =
-        this.stakingMode === 'standard' &&
-        !pendingSetupMigration &&
-        completedCountBeforeFunding >= this.targetServices;
-      const standardFleetHasInProgressServices =
-        this.stakingMode === 'standard' && state.services.length > 0;
       const requiredMasterEth = this.stakingMode === 'standard'
-        ? (
-            standardFleetAlreadyComplete
-              ? 0n
-              : this.config.minEoaGasEth * (standardFleetHasInProgressServices ? 1n : STANDARD_MASTER_BOOTSTRAP_MULTIPLIER)
-          )
+        ? computeRequiredMasterEth({
+            services: state.services,
+            minEoaGasEth: this.config.minEoaGasEth,
+            pendingSetupMigration,
+            targetServices: this.targetServices,
+          })
         : SELF_BOND_ETH_PER_SERVICE * BigInt(this.targetServices);
       const autoFaucetEnabled = this.autoTestnetFaucet;
 

--- a/client/src/earning/funding-plan.ts
+++ b/client/src/earning/funding-plan.ts
@@ -22,6 +22,7 @@ import { FleetStateStore } from './store.js';
 import { decryptMnemonic, deriveMasterAddress } from './wallet.js';
 import { isOperationalServiceStep, type FleetState, type FundingRequirement, type StakingMode } from './types.js';
 import { createJinnPublicClient, type JinnOnchainNetwork } from './viem-clients.js';
+import { STANDARD_MASTER_BOOTSTRAP_MULTIPLIER } from './bootstrap.js';
 
 export interface FundingPlanOptions {
   earningDir?: string;
@@ -89,7 +90,6 @@ export interface FundingPlan {
 }
 
 const SELF_BOND_ETH_PER_SERVICE = 30_000_000_000_000_000n; // 0.03 ETH
-const STANDARD_MASTER_BOOTSTRAP_MULTIPLIER = 2n;
 
 const addr = (value: string): Address => getAddress(value) as Address;
 
@@ -224,14 +224,16 @@ export async function planFleetFunding(
 
   const completedCount = fleetState?.services.filter((svc) => isOperationalServiceStep(svc.step)).length ?? 0;
   const standardFleetAlreadyComplete = stakingMode === 'standard' && completedCount >= targetServices;
-  const standardFleetHasInProgressServices =
-    stakingMode === 'standard' && (fleetState?.services.length ?? 0) > 0;
+  // "Cold in liability": applies 2× headroom when no service has a persisted on-chain anchor.
+  // Covers both fresh fleets (services array empty) and migration-wiped fleets
+  // (services exist in shape but service_id === null). See bootstrap.ts STANDARD_MASTER_BOOTSTRAP_MULTIPLIER.
+  const hasPersistedOnChain = (fleetState?.services ?? []).some(s => s.service_id != null);
   const requiredMasterEth =
     stakingMode === 'standard'
       ? (
           standardFleetAlreadyComplete
             ? 0n
-            : config.minEoaGasEth * (standardFleetHasInProgressServices ? 1n : STANDARD_MASTER_BOOTSTRAP_MULTIPLIER)
+            : config.minEoaGasEth * (hasPersistedOnChain ? 1n : STANDARD_MASTER_BOOTSTRAP_MULTIPLIER)
         )
       : SELF_BOND_ETH_PER_SERVICE * BigInt(targetServices);
 

--- a/client/test/earning/bootstrap.test.ts
+++ b/client/test/earning/bootstrap.test.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import path from 'path';
 import { getAddress } from 'viem';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { FleetBootstrapper } from '../../src/earning/bootstrap.js';
+import { FleetBootstrapper, computeRequiredMasterEth } from '../../src/earning/bootstrap.js';
 import { FleetStateStore } from '../../src/earning/store.js';
 import {
   generateMnemonic,
@@ -1325,5 +1325,61 @@ describe('Fleet bootstrap', () => {
 
     // Guard did not fire — error must NOT contain agent_already_bound
     expect(result.message).not.toContain('agent_already_bound');
+  });
+});
+
+describe('computeRequiredMasterEth (jinn-mono-hjex.7)', () => {
+  const MIN_ETH = 5_000_000_000_000_000n; // 0.005 ETH
+
+  it('applies 2× cold-start multiplier when services array is empty (fresh fleet)', () => {
+    const required = computeRequiredMasterEth({
+      services: [],
+      minEoaGasEth: MIN_ETH,
+    });
+    expect(required).toBe(MIN_ETH * 2n);
+  });
+
+  it('applies 2× cold-start multiplier when services are migration-wiped (service_id === null) (jinn-mono-hjex.7)', () => {
+    const required = computeRequiredMasterEth({
+      services: [{ service_id: null, step: 'awaiting_stake' }],
+      minEoaGasEth: MIN_ETH,
+    });
+    expect(required).toBe(MIN_ETH * 2n);
+  });
+
+  it('uses 1× multiplier when at least one service has a persisted service_id', () => {
+    const required = computeRequiredMasterEth({
+      services: [{ service_id: 42, step: 'staked' }],
+      minEoaGasEth: MIN_ETH,
+    });
+    expect(required).toBe(MIN_ETH);
+  });
+
+  it('returns 0n when fleet is already complete (no pending setup migration)', () => {
+    const required = computeRequiredMasterEth({
+      services: [{ service_id: 42, step: 'complete' }],
+      minEoaGasEth: MIN_ETH,
+      targetServices: 1,
+      pendingSetupMigration: false,
+    });
+    expect(required).toBe(0n);
+  });
+
+  it('applies 2× multiplier to migration-wiped services regardless of step', () => {
+    // Migration-wiped: service_id is null but step advanced (race condition)
+    const required = computeRequiredMasterEth({
+      services: [{ service_id: null, step: 'staked' }],
+      minEoaGasEth: MIN_ETH,
+    });
+    expect(required).toBe(MIN_ETH * 2n);
+  });
+
+  it('respects custom standardMultiplier override', () => {
+    const required = computeRequiredMasterEth({
+      services: [],
+      minEoaGasEth: MIN_ETH,
+      standardMultiplier: 3n,
+    });
+    expect(required).toBe(MIN_ETH * 3n);
   });
 });


### PR DESCRIPTION
## Summary

- `requiredMasterEth` applies the 2× cold-start multiplier whenever no service has a persisted `service_id` on-chain. Migration-wiped fleets (services in shape but no on-chain anchor) are correctly classified as cold.
- Extracted `computeRequiredMasterEth()` as a testable pure function from `bootstrap.ts`. Used at the original call site (DRY). `funding-plan.ts` carries the same fix via the shared helper.
- `STANDARD_MASTER_BOOTSTRAP_MULTIPLIER` has a single source of truth in `bootstrap.ts` (with gas-accounting doc comment); `funding-plan.ts` imports it instead of re-defining.
- `/v1/bootstrap` exposes `funding: { ..., targetMet: boolean }` alongside the existing fields. `targetMet` is always `false` when the gate is active (gate fires only when balance < target); the entire `funding` block is absent once the gate clears.
- `BootstrapState.funding` type in `api/types.ts` updated with `targetMet?: boolean`.
- `Onboarding.statusFor()` reads `fundingTargetMet`: Phase 3 stays `active` when `funding.targetMet === false`, even after `currentPhase` advances to 4. A momentary drip that briefly crossed threshold no longer fakes DONE.

## Why

Bead `jinn-mono-hjex.7` / GitHub #233 sub-issue 3: CDP faucet drips 0.0001 ETH; the bootstrap target was 0.010 ETH. The UI marked "Fund your wallet" DONE on the first drip, then bootstrap halted on the next step with insufficient gas. Two compounding defects:
1. The cold-start multiplier did not fire for migration-wiped fleets (services present but `service_id === null`).
2. The phase machine was step-derived not balance-derived — advancing the step was sufficient to flip phase 3 DONE regardless of actual balance.

## Stacked on

PR #241 (PR-4 of the same stack).

## Test plan

- [x] Multiplier regression: fresh fleet gets 2× headroom.
- [x] Multiplier regression: migration-wiped fleet (service_id === null) gets 2× headroom.
- [x] Multiplier regression: in-progress fleet (service_id set) uses 1× headroom.
- [x] Phase regression: DONE only fires when `fundingTargetMet` is not explicitly `false`.
- [x] Phase regression: `fundingTargetMet === false` holds phase 3 active even after step advances.
- [x] `yarn typecheck` + `yarn test` clean (3304 passed, 4 skipped pre-existing).

Refs: bd `jinn-mono-hjex.7`.