### PR TITLE
fix(hjex.6): bootstrap retry endpoint + structured halt envelope + funding auto-resume

### DIFF
--- a/client/src/api/bootstrap-endpoint.ts
+++ b/client/src/api/bootstrap-endpoint.ts
@@ -13,6 +13,7 @@ import type { Hono } from 'hono';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { readBootstrapError } from '../errors/persisted-bootstrap-error.js';
+import { MIGRATIONS_FILE } from '../earning/store.js';
 
 export interface BootstrapEndpointConfig {
   earningDir: string;
@@ -61,6 +62,45 @@ interface FleetStateOnDisk {
   services?: ServiceState[];
   fleet_agent_id?: string | null;
   fleet_safe_address?: string | null;
+}
+
+interface MigrationArchiveEntryOnDisk {
+  retire_status?: string;
+  retire_error?: string | null;
+  retire_tx_hash?: string | null;
+  state_reset_at?: string | null;
+}
+
+interface MigrationArchiveOnDisk {
+  entries?: MigrationArchiveEntryOnDisk[];
+}
+
+/**
+ * Reads the migration archive and returns the most recent retire_error from
+ * any entry whose retire_status is 'failed' and state_reset_at is null
+ * (i.e. the wipe was suppressed because retire failed).
+ */
+function readLatestRetireError(earningDir: string): { retire_error: string; tx_hash: string | null } | null {
+  const archivePath = join(earningDir, MIGRATIONS_FILE);
+  if (!existsSync(archivePath)) return null;
+  let archive: MigrationArchiveOnDisk;
+  try {
+    archive = JSON.parse(readFileSync(archivePath, 'utf-8')) as MigrationArchiveOnDisk;
+  } catch {
+    return null;
+  }
+  const entries = archive.entries ?? [];
+  // Find the most recent failed retire where the wipe did not proceed
+  // (state_reset_at null means the guard preserved local state)
+  const failed = entries.filter(
+    e => e.retire_status === 'failed' && !e.state_reset_at && e.retire_error,
+  );
+  if (failed.length === 0) return null;
+  const latest = failed[failed.length - 1]!;
+  return {
+    retire_error: latest.retire_error!,
+    tx_hash: latest.retire_tx_hash ?? null,
+  };
 }
 
 interface FundingGateOnDisk {
@@ -139,6 +179,11 @@ export function addBootstrapRoutes(app: Hono, config: BootstrapEndpointConfig): 
     // the last persisted step. Cleared at the start of each bootstrap attempt.
     const error = readBootstrapError(config.earningDir);
 
+    // Surface a retire_failed envelope when migration archived a failure but
+    // preserved local state. The BootstrapErrorCard (PR-6) will render it;
+    // for now we just expose the field so the dashboard can act on it.
+    const retireFailed = readLatestRetireError(config.earningDir);
+
     const cfg = config.configReader?.() ?? {};
 
     return c.json({
@@ -164,6 +209,13 @@ export function addBootstrapRoutes(app: Hono, config: BootstrapEndpointConfig): 
         },
       } : {}),
       ...(error ? { error } : {}),
+      ...(retireFailed ? {
+        retire_failed: {
+          retire_error: retireFailed.retire_error,
+          tx_hash: retireFailed.tx_hash,
+          message: 'We could not retire your previous setup. Your service state is preserved; resolve the retire failure before upgrading.',
+        },
+      } : {}),
     });
   });
 }

--- a/client/src/api/bootstrap-endpoint.ts
+++ b/client/src/api/bootstrap-endpoint.ts
@@ -206,6 +206,11 @@ export function addBootstrapRoutes(app: Hono, config: BootstrapEndpointConfig): 
           eth_required: fundingGate.eth_required,
           eth_balance: fundingGate.eth_balance,
           targetWei: fundingTargetWei(fundingGate),
+          // targetMet is false whenever the funding gate is active: the gate
+          // fires only when master balance < target. Once the gate clears the
+          // daemon advances past awaiting_funding and the funding block is
+          // omitted entirely (allRunning path or currentStep > awaiting_funding).
+          targetMet: false,
         },
       } : {}),
       ...(error ? { error } : {}),

--- a/client/src/api/fleet-build.ts
+++ b/client/src/api/fleet-build.ts
@@ -26,7 +26,7 @@ export interface FleetV1Service {
     agent: { address: string; balances: Array<{ asset: string; amountWei: string }> };
     multisig: { address: string; balances: Array<{ asset: string; amountWei: string }> };
   };
-  staking: { staked: boolean; evicted: boolean; sinceBlock: number | null };
+  staking: { staked: boolean; evicted: boolean; sinceBlock: number | null; inactivitySeconds: number | null };
   activity: { lastEventAt: string | null; counts: Record<string, number> };
   rewards: { pending: string; asset: 'reward' };
   attention: null | {
@@ -129,8 +129,9 @@ export function assembleFleetV1(raw: GatheredStatusRaw): FleetV1Response {
     },
     staking: {
       staked: isStakedLikeServiceStep(svc.step),
-      evicted: false,
+      evicted: raw.evictedByServiceIndex?.[di] ?? false,
       sinceBlock: null,
+      inactivitySeconds: raw.inactivityByServiceIndex?.[di] ?? null,
     },
     activity: {
       lastEventAt: per?.lastEventAt ?? null,

--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -652,6 +652,51 @@ export async function gatherGatheredStatusRaw(
     } else {
       raw.pendingRewardsError = pr.error;
     }
+
+    // Eviction state + inactivity — best-effort; never blocks the rest of status assembly.
+    try {
+      const evictedByServiceIndex: Record<number, boolean> = {};
+      const inactivityByServiceIndex: Record<number, number> = {};
+      await Promise.all(
+        fleet.services.map(async (svc) => {
+          const serviceId = svc.service_id;
+          const stakingProxy = svc.staking_address;
+          if (!serviceId || !stakingProxy) return;
+          const di = displayFleetServiceIndex(svc);
+          try {
+            const [state, info] = await Promise.all([
+              client.readContract({
+                address: stakingProxy as `0x${string}`,
+                abi: JINN_STAKING_ABI,
+                functionName: 'getStakingState',
+                args: [BigInt(serviceId)],
+              }),
+              client.readContract({
+                address: stakingProxy as `0x${string}`,
+                abi: JINN_STAKING_ABI,
+                functionName: 'getServiceInfo',
+                args: [BigInt(serviceId)],
+              }).catch(() => null),
+            ]);
+            // getStakingState returns uint8; 2 = Evicted enum value
+            evictedByServiceIndex[di] = Number(state) === 2;
+            // getServiceInfo returns a struct — inactivity is seconds of accumulated inactivity
+            if (info != null) {
+              const inactivity = (info as { inactivity: bigint }).inactivity;
+              if (typeof inactivity === 'bigint') {
+                inactivityByServiceIndex[di] = Number(inactivity);
+              }
+            }
+          } catch {
+            // Transient RPC errors: skip silently; evicted defaults to false
+          }
+        }),
+      );
+      raw.evictedByServiceIndex = evictedByServiceIndex;
+      raw.inactivityByServiceIndex = inactivityByServiceIndex;
+    } catch {
+      // Non-fatal: staking state reads should not prevent status from returning
+    }
   }
 
   if (fleet) {

--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -108,6 +108,27 @@ function chainKey(network: 'mainnet' | 'testnet'): 'base' | 'base-sepolia' {
   return network === 'testnet' ? 'base-sepolia' : 'base';
 }
 
+/**
+ * Derive the SolverNet name to use for the prediction operator diagnostic.
+ *
+ * Priority: (1) first legacy `solverNets` entry name, (2) first joined entry's
+ * `name` field, (3) first joined entry's manifestCid, (4) fallback `'prediction'`.
+ *
+ * This replaces the previous hard-coded `'prediction'` string so that operators
+ * who joined a SolverNet via the manifest-keyed flow still get a useful diagnostic
+ * (jinn-mono-hjex.2).
+ */
+function derivePredictionSolverNetName(config: JinnConfig): string {
+  const legacyNames = Object.keys(config.solverNets);
+  if (legacyNames.length > 0) return legacyNames[0]!;
+  const joinedEntries = Object.entries(config.joinedSolverNets ?? {});
+  if (joinedEntries.length > 0) {
+    const [cid, entry] = joinedEntries[0]!;
+    return entry.name ?? cid;
+  }
+  return 'prediction';
+}
+
 function predictionOperatorCacheKey(configPath: string, name: string): string {
   return `${configPath}\0${name}`;
 }
@@ -483,10 +504,11 @@ export async function gatherGatheredStatusRaw(
   let predictionOperatorError: string | undefined;
   if (status?.config) {
     try {
+      const solverNetName = derivePredictionSolverNetName(status.config);
       const raw = await getCachedPredictionOperatorStatus(
         status.config,
         status.configPath ?? '<default>',
-        'prediction',
+        solverNetName,
       );
       predictionOperator = narrowOperatorStatusForApi(raw);
     } catch (error) {

--- a/client/src/api/setup-endpoints.ts
+++ b/client/src/api/setup-endpoints.ts
@@ -88,6 +88,12 @@ export interface SetupRoutesConfig {
   /** Returns the chain default RPC URL — used by POST /v1/setup/network when
    *  the operator clears the field to revert to the default. */
   defaultRpcUrlForChain?: () => string;
+  /**
+   * When set, POST /v1/setup/restake/:serviceId is enabled.
+   * Calls the provided function to re-stake an evicted service on demand
+   * (the "Re-stake now" dashboard CTA). jinn-mono-hjex.3
+   */
+  restake?: (serviceId: number) => Promise<{ ok: boolean; error?: string }>;
 }
 
 export function addSetupRoutes(app: Hono, config: SetupRoutesConfig = {}): void {
@@ -767,6 +773,31 @@ export function addSetupRoutes(app: Hono, config: SetupRoutesConfig = {}): void 
       restartRequired: true,
       rpcUrl: nextRpcUrl,
     });
+  });
+
+  // POST /v1/setup/restake/:serviceId — operator-triggered re-stake for an
+  // evicted service. Backs the "Re-stake now" dashboard CTA. jinn-mono-hjex.3
+  app.post('/v1/setup/restake/:serviceId', async (c) => {
+    if (!config.restake) {
+      return c.json({ error: 'restake_not_configured' }, 503);
+    }
+    const raw = c.req.param('serviceId');
+    const serviceId = Number.parseInt(raw, 10);
+    if (!Number.isFinite(serviceId) || serviceId <= 0) {
+      return c.json({ error: 'invalid_service_id' }, 400);
+    }
+    try {
+      const result = await config.restake(serviceId);
+      if (!result.ok) {
+        return c.json({ ok: false, error: result.error ?? 'restake_failed' }, 500);
+      }
+      return c.json({ ok: true });
+    } catch (err) {
+      return c.json(
+        { ok: false, error: err instanceof Error ? err.message : String(err) },
+        500,
+      );
+    }
   });
 
   app.post('/v1/setup/change-password', async (c) => {

--- a/client/src/api/setup-endpoints.ts
+++ b/client/src/api/setup-endpoints.ts
@@ -43,6 +43,7 @@ import {
   installClaudeCodeLocally,
   type ExecFileAsync,
 } from '../setup/claude-code-install.js';
+import { addSetupRetryEndpoint } from './setup-retry-endpoint.js';
 
 const ChangePasswordSchema = z.object({
   current: z.string().min(1),
@@ -94,6 +95,13 @@ export interface SetupRoutesConfig {
    * (the "Re-stake now" dashboard CTA). jinn-mono-hjex.3
    */
   restake?: (serviceId: number) => Promise<{ ok: boolean; error?: string }>;
+  /**
+   * When set, POST /v1/setup/bootstrap/retry is enabled.
+   * Re-enters the bootstrap state machine in-process — no daemon restart
+   * required. The closure signals main()'s halt-and-resume loop to call
+   * bootstrap() again. jinn-mono-hjex.6
+   */
+  retryBootstrap?: () => Promise<void>;
 }
 
 export function addSetupRoutes(app: Hono, config: SetupRoutesConfig = {}): void {
@@ -774,6 +782,12 @@ export function addSetupRoutes(app: Hono, config: SetupRoutesConfig = {}): void 
       rpcUrl: nextRpcUrl,
     });
   });
+
+  // POST /v1/setup/bootstrap/retry — re-enter the bootstrap state machine
+  // in-process. jinn-mono-hjex.6
+  if (config.retryBootstrap) {
+    addSetupRetryEndpoint(app, { retryBootstrap: config.retryBootstrap });
+  }
 
   // POST /v1/setup/restake/:serviceId — operator-triggered re-stake for an
   // evicted service. Backs the "Re-stake now" dashboard CTA. jinn-mono-hjex.3

--- a/client/src/api/setup-retry-endpoint.ts
+++ b/client/src/api/setup-retry-endpoint.ts
@@ -1,0 +1,50 @@
+/**
+ * POST /v1/setup/bootstrap/retry — jinn-mono-hjex.6
+ *
+ * Re-enters the bootstrap state machine in-process without requiring a daemon
+ * restart. Idempotent: concurrent calls coalesce onto the single in-flight
+ * attempt rather than forking two state machines.
+ */
+import type { Hono } from 'hono';
+
+export interface SetupRetryDeps {
+  /**
+   * Closure that re-runs the bootstrap state machine.
+   * - Resolves when bootstrap completes successfully.
+   * - Rejects with the most-recent error if it fails (non-funding errors
+   *   surface immediately; funding shortfalls are surfaced as rejections once
+   *   the caller gives up).
+   */
+  retryBootstrap: () => Promise<void>;
+}
+
+function serializeError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
+export function addSetupRetryEndpoint(app: Hono, deps: SetupRetryDeps): void {
+  // In-flight promise for idempotency: concurrent POST /retry calls share the
+  // same bootstrap attempt rather than forking two state machines.
+  let inFlight: Promise<void> | null = null;
+
+  app.post('/v1/setup/bootstrap/retry', async (c) => {
+    if (!inFlight) {
+      inFlight = deps.retryBootstrap().finally(() => {
+        inFlight = null;
+      });
+    }
+
+    try {
+      await inFlight;
+      return c.json({ ok: true });
+    } catch (err) {
+      return c.json({ ok: false, error: serializeError(err) }, 500);
+    }
+  });
+}

--- a/client/src/api/status-build.ts
+++ b/client/src/api/status-build.ts
@@ -7,6 +7,7 @@ import {
   isStakedLikeServiceStep,
   type FleetState,
 } from '../earning/types.js';
+import { displayFleetServiceIndex } from '../earning/fleet-display-index.js';
 import type { EarningMigrationArchive } from '../earning/store.js';
 import type { PortfolioV0Status } from './portfolio-v0-build.js';
 import type { PredictionV1Status } from './prediction-v1-build.js';
@@ -78,6 +79,18 @@ export interface GatheredStatusRaw {
   pendingByService?: Record<number, string>;
   claimedByService?: Record<number, { total: string; lastAt: string; lastTxHash: string }>;
   migrationArchive?: EarningMigrationArchive;
+  /**
+   * Per-service eviction state keyed by display index.
+   * Populated by gather-status via on-chain getStakingState reads.
+   * `true` means the staking proxy reports state === 2 (Evicted).
+   */
+  evictedByServiceIndex?: Record<number, boolean>;
+  /**
+   * Per-service inactivity seconds keyed by display index.
+   * Populated by gather-status via on-chain getServiceInfo reads (jinn-mono-hjex.3).
+   * Value is the `inactivity` field from the ServiceInfo struct (seconds).
+   */
+  inactivityByServiceIndex?: Record<number, number>;
 }
 
 export interface StatusV1Response {
@@ -105,6 +118,8 @@ export interface StatusV1Response {
       identityRegistryAddress: string | null;
       safeBoundToAgent: boolean;
       identityBindingStatus: 'bound' | 'pending' | 'not_applicable';
+      /** True when the staking proxy reports this service as evicted (getStakingState === 2). */
+      evicted: boolean;
     }>;
     stakedLikeCount: number;
     completeCount: number;
@@ -160,7 +175,10 @@ export function resolveMasterDailyEstimateWei(
   return fromPoll > DEFAULT_MASTER_ETH_DAILY_WEI ? fromPoll : DEFAULT_MASTER_ETH_DAILY_WEI;
 }
 
-function fleetSummary(fleet: FleetState | null): StatusV1Response['fleet'] {
+function fleetSummary(
+  fleet: FleetState | null,
+  evictedByServiceIndex?: Record<number, boolean>,
+): StatusV1Response['fleet'] {
   if (!fleet) {
     return {
       loaded: false,
@@ -169,8 +187,10 @@ function fleetSummary(fleet: FleetState | null): StatusV1Response['fleet'] {
       completeCount: 0,
     };
   }
-  const services = fleet.services.map(s => ({
-    index: s.index,
+  const services = fleet.services.map(s => {
+    const di = displayFleetServiceIndex(s);
+    return {
+    index: di,
     step: s.step,
     serviceId: s.service_id,
     safeAddress: s.safe_address,
@@ -186,7 +206,9 @@ function fleetSummary(fleet: FleetState | null): StatusV1Response['fleet'] {
           ? 'pending'
           : 'not_applicable'
     ) as 'bound' | 'pending' | 'not_applicable',
-  }));
+    evicted: evictedByServiceIndex?.[di] ?? false,
+    };
+  });
   const stakedLikeCount = fleet.services.filter(s => isStakedLikeServiceStep(s.step)).length;
   const completeCount = fleet.services.filter(s => isOperationalServiceStep(s.step)).length;
   return {
@@ -311,7 +333,7 @@ function buildNextActions(raw: GatheredStatusRaw, fleetSum: StatusV1Response['fl
 }
 
 export function assembleStatusV1(raw: GatheredStatusRaw): StatusV1Response {
-  const fleetSum = fleetSummary(raw.fleet);
+  const fleetSum = fleetSummary(raw.fleet, raw.evictedByServiceIndex);
   const mode: 'full' | 'sqlite_only' = raw.hintsScope === 'sqlite_only' ? 'sqlite_only' : 'full';
   const claimedRewardsWei = sumClaimedRewardsWei(raw);
   let pendingRewardsWei: bigint | undefined;

--- a/client/src/cli/commands/solver-nets.ts
+++ b/client/src/cli/commands/solver-nets.ts
@@ -374,23 +374,38 @@ Output flags:
 
     if (!subverb || subverb === 'list') {
       const loaded = loadConfig(configPath);
+      const legacy = Object.entries(loaded.solverNets).map(([netName, net]) => ({
+        name: netName,
+        source: 'legacy' as const,
+        enabled: net.enabled,
+        solverType: net.solverType,
+        harness: net.harness,
+        pluginCount: net.plugins.length,
+        taskGeneratorEnabled: net.taskGenerator.enabled,
+      }));
+      const joined = Object.entries(loaded.joinedSolverNets ?? {}).map(([cid, net]) => ({
+        name: net.name ?? cid,
+        source: 'joined' as const,
+        manifestCid: cid,
+        enabled: true,
+        solverType: 'prediction.v1',
+        harness: net.harness,
+        pluginCount: (net.plugins ?? []).length,
+        taskGeneratorEnabled: false,
+      }));
       const value = {
         verb: 'solver-nets list',
         configPath,
-        solverNets: Object.entries(loaded.solverNets).map(([netName, net]) => ({
-          name: netName,
-          enabled: net.enabled,
-          solverType: net.solverType,
-          harness: net.harness,
-          pluginCount: net.plugins.length,
-          taskGeneratorEnabled: net.taskGenerator.enabled,
-        })),
+        solverNets: [...legacy, ...joined],
       };
       emit(ctx, value, human, json, (v) => {
         const list = v as typeof value;
         if (list.solverNets.length === 0) return 'No SolverNets configured.';
         return list.solverNets
-          .map((n) => `${n.name}  ${n.enabled ? 'enabled' : 'disabled'}  ${n.solverType}  harness=${n.harness ?? '(default)'}  plugins=${n.pluginCount}  generator=${n.taskGeneratorEnabled ? 'on' : 'off'}`)
+          .map((n) => {
+            const base = `${n.name}  ${n.enabled ? 'enabled' : 'disabled'}  ${n.solverType}  harness=${n.harness ?? '(default)'}  plugins=${n.pluginCount}  generator=${n.taskGeneratorEnabled ? 'on' : 'off'}  source=${n.source}`;
+            return 'manifestCid' in n ? `${base}  cid=${n.manifestCid}` : base;
+          })
           .join('\n');
       });
       return;

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -110,6 +110,12 @@ export const JinnConfigSchema = z.object({
    */
   balanceTopupIntervalMs: z.number().int().min(0).default(300_000),
 
+  /**
+   * Interval between eviction-state polls for the staking proxy (ms).
+   * Default 60000 (1 min). Set to 0 to disable. Env: JINN_EVICTION_CHECK_INTERVAL_MS
+   */
+  evictionCheckIntervalMs: z.number().int().min(0).default(60_000),
+
   /** HTTP API port */
   apiPort: z.number().int().positive().default(7331),
 
@@ -743,6 +749,7 @@ export function loadConfig(configPath?: string): JinnConfig {
     merged.rewardClaimIntervalMs = parseInt(env['JINN_REWARD_CLAIM_INTERVAL_MS'], 10);
   }
   if (env['JINN_BALANCE_TOPUP_INTERVAL_MS']) merged.balanceTopupIntervalMs = Number.parseInt(env['JINN_BALANCE_TOPUP_INTERVAL_MS'], 10);
+  if (env['JINN_EVICTION_CHECK_INTERVAL_MS']) merged.evictionCheckIntervalMs = Number.parseInt(env['JINN_EVICTION_CHECK_INTERVAL_MS'], 10);
   if (env['JINN_API_PORT'])          merged.apiPort = parseInt(env['JINN_API_PORT'], 10);
   if (env['JINN_API_BIND_HOST'])     merged.apiBindHost = env['JINN_API_BIND_HOST'];
   if (env['JINN_CLAUDE_PATH'])       merged.claudePath = env['JINN_CLAUDE_PATH'];

--- a/client/src/daemon/daemon.ts
+++ b/client/src/daemon/daemon.ts
@@ -13,6 +13,7 @@ import type { Corpus } from '../corpus/index.js';
 import { RewardClaimLoop, type RewardClaimLoopConfig } from './reward-claim-loop.js';
 import { TaskEngine, type TaskEngineOptions } from '../harnesses/engine/engine.js';
 import { BalanceTopupLoop, type BalanceTopupLoopConfig } from './balance-topup-loop.js';
+import { EvictionLoop, type EvictionLoopConfig } from './eviction-loop.js';
 import { JinnClaimLoop, type JinnClaimLoopConfig } from './jinn-claim-loop.js';
 import { emitEvent } from '../observability/emit-event.js';
 import { emitStructured } from '../events/emitter.js';
@@ -70,6 +71,13 @@ export interface DaemonConfig {
    * Omitted or interval 0 → loop not started.
    */
   balanceTopup?: BalanceTopupLoopConfig;
+
+  /**
+   * Periodic eviction-check + auto-restake loop (jinn-mono-hjex.3).
+   * Polls getStakingState for each service; restakes automatically when evicted.
+   * Omitted or interval 0 → loop not started.
+   */
+  evictionCheck?: EvictionLoopConfig;
 
   /**
    * Cross-chain JINN claim loop (jinn-mono-7x5). Emits ClaimTicket on L2,
@@ -168,6 +176,7 @@ export class Daemon {
   private readonly apiToken: string;
   private rewardClaimLoop?: RewardClaimLoop;
   private balanceTopupLoop?: BalanceTopupLoop;
+  private evictionLoop?: EvictionLoop;
   private jinnClaimLoop?: JinnClaimLoop;
 
   constructor(private readonly config: DaemonConfig) {
@@ -214,6 +223,9 @@ export class Daemon {
         ...config.balanceTopup,
         jinnStore: this.store,
       });
+    }
+    if (config.evictionCheck && config.evictionCheck.intervalMs > 0) {
+      this.evictionLoop = new EvictionLoop(config.evictionCheck);
     }
     if (config.jinnClaim && config.jinnClaim.intervalMs > 0) {
       this.jinnClaimLoop = new JinnClaimLoop({
@@ -340,6 +352,19 @@ export class Daemon {
         }),
       );
     }
+    if (this.evictionLoop) {
+      this.loopPromises.push(
+        this.evictionLoop.run().catch(err => {
+          console.error('[daemon] eviction-check crashed:', err);
+          emitStructured({
+            kind: 'error',
+            message: 'eviction-check loop crashed',
+            errorCode: 'eviction_check_crashed',
+            details: { error: err instanceof Error ? err.message : String(err) },
+          });
+        }),
+      );
+    }
     if (this.jinnClaimLoop) {
       this.loopPromises.push(
         this.jinnClaimLoop.run().catch(err => {
@@ -374,6 +399,7 @@ export class Daemon {
     this.deliveryWatcherLoop.stop();
     this.rewardClaimLoop?.stop();
     this.balanceTopupLoop?.stop();
+    this.evictionLoop?.stop();
     this.jinnClaimLoop?.stop();
     this.peerSync?.stop();
 

--- a/client/src/daemon/eviction-loop.ts
+++ b/client/src/daemon/eviction-loop.ts
@@ -1,0 +1,104 @@
+/**
+ * Periodic eviction-check + auto-restake loop (jinn-mono-hjex.3).
+ *
+ * Polls the staking proxy's getStakingState for each complete service. When
+ * state === 2 (Evicted) it calls the injected `recoverEvictedService` helper
+ * so the service is restaked without requiring a daemon restart.
+ *
+ * Scheduling: interval from config (default 60s). Set to 0 to disable.
+ * Env: JINN_EVICTION_CHECK_INTERVAL_MS
+ */
+
+import { getAddress, type PublicClient } from 'viem';
+import { STAKING_ABI } from '../earning/contracts.js';
+import type { FleetStateStore } from '../earning/store.js';
+import type { JinnOnchainNetwork } from '../earning/viem-clients.js';
+import { displayFleetServiceIndex } from '../earning/fleet-display-index.js';
+import { isStakedLikeServiceStep, type ServiceState } from '../earning/types.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type EvictionLoopReadContract = (opts: {
+  address: `0x${string}`;
+  abi: typeof STAKING_ABI;
+  functionName: 'getStakingState';
+  args: [bigint];
+}) => Promise<bigint | number>;
+
+export interface EvictionLoopConfig {
+  intervalMs: number;
+  store: FleetStateStore;
+  chain: JinnOnchainNetwork;
+  readContract: EvictionLoopReadContract;
+  /**
+   * Injected recovery function. In production this wraps
+   * `recoverEvictedService` from `../earning/bootstrap.js`.
+   * Accepts a ServiceState and kicks off the reStake call.
+   */
+  recoverEvictedService: (svc: ServiceState) => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// EvictionLoop
+// ---------------------------------------------------------------------------
+
+export class EvictionLoop {
+  private stopped = false;
+
+  constructor(private readonly config: EvictionLoopConfig) {}
+
+  stop(): void {
+    this.stopped = true;
+  }
+
+  async runOnce(): Promise<void> {
+    const state = await this.config.store.load(this.config.chain);
+
+    for (const svc of state.services) {
+      if (!svc.service_id || !svc.staking_address) continue;
+      if (!isStakedLikeServiceStep(svc.step)) continue;
+
+      const displayIndex = displayFleetServiceIndex(svc);
+
+      try {
+        const stakingState = await this.config.readContract({
+          address: getAddress(svc.staking_address) as `0x${string}`,
+          abi: STAKING_ABI,
+          functionName: 'getStakingState',
+          args: [BigInt(svc.service_id)],
+        });
+
+        if (Number(stakingState) === 2) {
+          console.error(
+            `[eviction-loop] Service ${displayIndex} (service_id ${svc.service_id}) is evicted; triggering auto-restake`,
+          );
+          await this.config.recoverEvictedService(svc);
+        }
+      } catch (err) {
+        console.error(
+          `[eviction-loop] Service ${displayIndex}: error checking staking state (non-fatal): ${err instanceof Error ? err.message : err}`,
+        );
+      }
+    }
+  }
+
+  async run(): Promise<void> {
+    if (this.config.intervalMs <= 0) {
+      return;
+    }
+
+    while (!this.stopped) {
+      try {
+        await this.runOnce();
+      } catch (err) {
+        console.error(
+          '[eviction-loop] Tick failed (non-fatal):',
+          err instanceof Error ? err.message : err,
+        );
+      }
+      await new Promise<void>(r => setTimeout(r, this.config.intervalMs));
+    }
+  }
+}

--- a/client/src/dashboard/spa/src/api/client.ts
+++ b/client/src/dashboard/spa/src/api/client.ts
@@ -161,6 +161,11 @@ export const api = {
         body: JSON.stringify(patch),
       },
     ),
+  restake: (serviceId: number) =>
+    jfetch<{ ok: boolean; error?: string }>(
+      `/v1/setup/restake/${encodeURIComponent(String(serviceId))}`,
+      { method: 'POST' },
+    ),
   retryAgentBinding: (patch?: { serviceIndex?: number }) =>
     jfetch<{
       ok: boolean;

--- a/client/src/dashboard/spa/src/api/client.ts
+++ b/client/src/dashboard/spa/src/api/client.ts
@@ -175,6 +175,11 @@ export const api = {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(patch ?? {}),
     }),
+  /** Re-enter the bootstrap state machine in-process. jinn-mono-hjex.6 */
+  retryBootstrap: () =>
+    jfetch<{ ok: boolean; error?: string }>('/v1/setup/bootstrap/retry', {
+      method: 'POST',
+    }),
   updateHarnessMode: (mode: 'train' | 'frozen') =>
     jfetch<{ ok: boolean; restartRequired: boolean; mode: 'train' | 'frozen' }>(
       '/v1/setup/harness',

--- a/client/src/dashboard/spa/src/api/types.ts
+++ b/client/src/dashboard/spa/src/api/types.ts
@@ -52,6 +52,15 @@ export interface BootstrapState {
     eth_required?: string;
     eth_balance?: string;
     targetWei?: string;
+    /**
+     * True only when master balance has met or exceeded the bootstrap target
+     * AND `currentStep` has advanced past `awaiting_funding`. Present only
+     * when the funding block is included (i.e. when the gate was recently
+     * active). When the gate clears the funding block is omitted entirely,
+     * so consumers should treat absent funding as "not blocking" and present
+     * funding with targetMet===false as "still blocking".
+     */
+    targetMet?: boolean;
   };
   solverNets?: Record<string, {
     name?: string;

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { api } from '../api/client.js';
 import { HeroStats } from './overview/HeroStats.js';
@@ -15,9 +15,11 @@ interface OverviewStatusV1 {
     services?: Array<{
       index: number;
       step: string;
+      serviceId?: number | null;
       safeAddress?: string | null;
       agentId?: number | null;
       safeBoundToAgent?: boolean;
+      evicted?: boolean;
     }>;
   };
   rewards?: {
@@ -236,6 +238,7 @@ function operatorWaitingMessage(
 export function OverviewPage(): JSX.Element {
   const [activeAction, setActiveAction] = useState<string | null>(null);
   const [notice, setNotice] = useState<{ tone: 'success' | 'error'; text: string } | null>(null);
+  const queryClient = useQueryClient();
   const { data: status } = useQuery<OverviewStatusV1>({
     queryKey: ['status'],
     queryFn: () => api.getStatus() as Promise<OverviewStatusV1>,
@@ -275,6 +278,11 @@ export function OverviewPage(): JSX.Element {
     agentId: s.agentId ?? null,
     safeBoundToAgent: s.safeBoundToAgent ?? false,
   }));
+
+  // Eviction state — derived from the first evicted service in the fleet.
+  const firstEvictedService = (status?.fleet?.services ?? []).find((s) => s.evicted === true);
+  const isEvicted = firstEvictedService != null;
+  const evictedServiceId = firstEvictedService?.serviceId ?? null;
 
   const tasksDelivered = totals.solutions;
   const jinnClaimable = formatEth(status?.rewards?.pendingStakingRewardsWei);
@@ -316,6 +324,8 @@ export function OverviewPage(): JSX.Element {
         statusState={liveNow.state}
         statusDot={LIVE_NOW_TONE[liveNow.state].dot}
         activeAction={activeAction}
+        evicted={isEvicted}
+        evictedServiceId={evictedServiceId}
         onClaim={() =>
           runAction('Claim JINN', async () => {
             const res = await api.claimRewards();
@@ -347,6 +357,14 @@ export function OverviewPage(): JSX.Element {
             }
             return { message: 'Restart requested. The dashboard will reconnect when the daemon is back.' };
           })}
+        onRestake={async (serviceId) => {
+          const res = await api.restake(serviceId);
+          if (!res.ok) {
+            throw new Error(res.error ?? 'Re-stake failed.');
+          }
+          // Optimistically refetch status so the eviction notice clears.
+          await queryClient.invalidateQueries({ queryKey: ['status'] });
+        }}
       />
       {notice && (
         <div

--- a/client/src/dashboard/spa/src/pages/overview/HeroStats.test.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/HeroStats.test.tsx
@@ -1,24 +1,27 @@
-import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { HeroStats } from './HeroStats.js';
+
+function defaultProps() {
+  return {
+    tasksDelivered: 42,
+    jinnClaimable: '123',
+    gasBalanceEth: '0.5000',
+    gasRunwayDays: 4,
+    statusLabel: 'WORKING',
+    statusState: 'working' as const,
+    statusDot: 'var(--vow-green)',
+    activeAction: null,
+    evicted: false,
+    onClaim: () => undefined,
+    onTopUp: () => undefined,
+    onRestart: () => undefined,
+  };
+}
 
 describe('HeroStats', () => {
   it('renders overview stats plus compact status', () => {
-    render(
-      <HeroStats
-        tasksDelivered={42}
-        jinnClaimable="123"
-        gasBalanceEth="0.5000"
-        gasRunwayDays={4}
-        statusLabel="WORKING"
-        statusState="working"
-        statusDot="var(--vow-green)"
-        activeAction={null}
-        onClaim={() => undefined}
-        onTopUp={() => undefined}
-        onRestart={() => undefined}
-      />,
-    );
+    render(<HeroStats {...defaultProps()} />);
     expect(screen.getByText(/solutions delivered/i)).toBeTruthy();
     expect(screen.getByText(/jinn claimable/i)).toBeTruthy();
     expect(screen.queryByText(/jinn earned/i)).toBeNull();
@@ -33,5 +36,54 @@ describe('HeroStats', () => {
     expect(screen.getByTestId('overview-status-stat').getAttribute('data-state')).toBe('working');
     // The full live card now lives on /operator.
     expect(screen.queryByText(/node status/i)).toBeNull();
+  });
+
+  it('disables Claim now CTA when evicted=true and renders eviction notice (jinn-mono-hjex.3)', () => {
+    render(<HeroStats {...defaultProps()} evicted={true} />);
+    const claimBtn = screen.getByRole('button', { name: /claim now/i });
+    // Button must be disabled when service is evicted
+    expect(claimBtn).toHaveProperty('disabled', true);
+    // Eviction explainer must be visible — no OLAS mention
+    expect(screen.getByText(/service evicted/i)).toBeTruthy();
+    expect(screen.queryByText(/OLAS/i)).toBeNull();
+  });
+
+  it('does not show eviction notice when evicted=false (jinn-mono-hjex.3)', () => {
+    render(<HeroStats {...defaultProps()} evicted={false} />);
+    expect(screen.queryByText(/service evicted/i)).toBeNull();
+  });
+
+  it('renders Re-stake now button when evicted=true with serviceId and onRestake (jinn-mono-hjex.3)', () => {
+    const onRestake = vi.fn().mockResolvedValue(undefined);
+    render(
+      <HeroStats
+        {...defaultProps()}
+        evicted={true}
+        evictedServiceId={42}
+        onRestake={onRestake}
+      />,
+    );
+    expect(screen.getByTestId('restake-button')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /re-stake now/i })).toBeTruthy();
+  });
+
+  it('calls onRestake with serviceId when Re-stake now is clicked (jinn-mono-hjex.3)', () => {
+    const onRestake = vi.fn().mockResolvedValue(undefined);
+    render(
+      <HeroStats
+        {...defaultProps()}
+        evicted={true}
+        evictedServiceId={42}
+        onRestake={onRestake}
+      />,
+    );
+    const restakeBtn = screen.getByRole('button', { name: /re-stake now/i });
+    fireEvent.click(restakeBtn);
+    expect(onRestake).toHaveBeenCalledWith(42);
+  });
+
+  it('does not render Re-stake now button when evicted=true but onRestake is not provided (jinn-mono-hjex.3)', () => {
+    render(<HeroStats {...defaultProps()} evicted={true} evictedServiceId={42} />);
+    expect(screen.queryByTestId('restake-button')).toBeNull();
   });
 });

--- a/client/src/dashboard/spa/src/pages/overview/HeroStats.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/HeroStats.tsx
@@ -3,6 +3,7 @@
  * rule); labels are ALL-CAPS-MONO eyebrows. The full live activity surface
  * lives on /operator; Overview keeps only a compact status tile.
  */
+import { useState } from 'react';
 import type { LiveNowState } from './LiveNowBand.js';
 
 export interface HeroStatsProps {
@@ -14,9 +15,15 @@ export interface HeroStatsProps {
   statusState: LiveNowState;
   statusDot: string;
   activeAction: string | null;
+  /** When true, the service has been evicted from the staking proxy. */
+  evicted?: boolean;
+  /** Service ID of the evicted service. Required when evicted=true to wire the Re-stake CTA. */
+  evictedServiceId?: number | null;
   onClaim: () => void;
   onTopUp: () => void;
   onRestart: () => void;
+  /** Called when the operator clicks "Re-stake now". Should POST to /v1/setup/restake/:serviceId. */
+  onRestake?: (serviceId: number) => Promise<void> | void;
 }
 
 function ActionButton({
@@ -24,14 +31,16 @@ function ActionButton({
   action,
   activeAction,
   onClick,
+  forceDisabled,
 }: {
   children: string;
   action: string;
   activeAction: string | null;
   onClick: () => void;
+  forceDisabled?: boolean;
 }): JSX.Element {
   const busy = activeAction === action;
-  const disabled = activeAction !== null;
+  const disabled = activeAction !== null || (forceDisabled ?? false);
   return (
     <button
       type="button"
@@ -55,6 +64,62 @@ function ActionButton({
     >
       {busy ? 'Working...' : children}
     </button>
+  );
+}
+
+function EvictionNotice({
+  serviceId,
+  onRestake,
+}: {
+  serviceId?: number | null;
+  onRestake?: (serviceId: number) => Promise<void> | void;
+}): JSX.Element {
+  const [restaking, setRestaking] = useState(false);
+
+  function handleRestake(): void {
+    if (!serviceId || !onRestake || restaking) return;
+    setRestaking(true);
+    Promise.resolve(onRestake(serviceId)).finally(() => setRestaking(false));
+  }
+
+  return (
+    <div style={{ marginTop: '10px' }}>
+      <span
+        style={{
+          display: 'block',
+          color: 'var(--fg-warning, #e8a028)',
+          fontFamily: "'JetBrains Mono', monospace",
+          fontSize: '11px',
+          letterSpacing: '0.1em',
+        }}
+      >
+        Service evicted — restoring liveness
+      </span>
+      {serviceId != null && onRestake && (
+        <button
+          type="button"
+          data-testid="restake-button"
+          onClick={handleRestake}
+          disabled={restaking}
+          style={{
+            marginTop: '8px',
+            background: 'transparent',
+            border: '1px solid var(--fg-warning, #e8a028)',
+            borderRadius: '6px',
+            color: 'var(--fg-warning, #e8a028)',
+            cursor: restaking ? 'wait' : 'pointer',
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '11px',
+            letterSpacing: '0.14em',
+            opacity: restaking ? 0.55 : 1,
+            padding: '6px 10px',
+            textTransform: 'uppercase',
+          }}
+        >
+          {restaking ? 'Working...' : 'Re-stake now'}
+        </button>
+      )}
+    </div>
   );
 }
 
@@ -207,9 +272,12 @@ export function HeroStats({
   statusState,
   statusDot,
   activeAction,
+  evicted = false,
+  evictedServiceId,
   onClaim,
   onTopUp,
   onRestart,
+  onRestake,
 }: HeroStatsProps): JSX.Element {
   return (
     <div
@@ -225,9 +293,17 @@ export function HeroStats({
         value={jinnClaimable}
         unit="JINN"
         action={(
-          <ActionButton action="Claim JINN" activeAction={activeAction} onClick={onClaim}>
-            Claim now
-          </ActionButton>
+          <>
+            <ActionButton
+              action="Claim JINN"
+              activeAction={activeAction}
+              onClick={onClaim}
+              forceDisabled={evicted}
+            >
+              Claim now
+            </ActionButton>
+            {evicted ? <EvictionNotice serviceId={evictedServiceId} onRestake={onRestake} /> : null}
+          </>
         )}
       />
       <Stat

--- a/client/src/dashboard/spa/src/regions/Onboarding.test.tsx
+++ b/client/src/dashboard/spa/src/regions/Onboarding.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { Onboarding } from './Onboarding.js';
+import { Onboarding, statusFor } from './Onboarding.js';
 import type { BootstrapState } from '../api/types.js';
 
 // Mock the API client so we control what bootstrap + status data returns.
@@ -40,5 +40,54 @@ describe('Onboarding (3-phase post-vh74.2)', () => {
     render(withQueryClient(<Onboarding />));
     await screen.findByText(/Provisioning your wallet/i);
     expect(screen.queryByText(/Sign in to Claude/i)).toBeNull();
+  });
+});
+
+// statusFor — determines whether a phase row is 'done', 'active', or
+// 'queued'. The funding gate (jinn-mono-hjex.7): Phase 2 ("Fund your wallet")
+// must stay 'active' until the funding gate explicitly clears, even when
+// currentPhase has already advanced to 3. A single drip that briefly crossed
+// the threshold must not flip phase 2 to DONE before the bootstrapper has
+// actually advanced past awaiting_funding on-chain.
+describe('statusFor phase machine', () => {
+  it('marks earlier phases as done when currentPhase advances', () => {
+    expect(statusFor(1, 3)).toBe('done');
+    expect(statusFor(2, 3)).toBe('done');
+    expect(statusFor(1, 2)).toBe('done');
+  });
+
+  it('marks the current phase as active', () => {
+    expect(statusFor(1, 1)).toBe('active');
+    expect(statusFor(2, 2)).toBe('active');
+    expect(statusFor(3, 3)).toBe('active');
+  });
+
+  it('marks later phases as queued', () => {
+    expect(statusFor(3, 2)).toBe('queued');
+    expect(statusFor(3, 1)).toBe('queued');
+    expect(statusFor(2, 1)).toBe('queued');
+  });
+
+  it('keeps Phase 2 active when funding.targetMet is false (hjex.7)', () => {
+    // Explicit false: gate is still open even though step advanced to phase 3.
+    expect(statusFor(2, 3, false)).toBe('active');
+  });
+
+  it('marks Phase 2 done when funding.targetMet is absent (gate cleared)', () => {
+    expect(statusFor(2, 3, undefined)).toBe('done');
+  });
+
+  it('marks Phase 2 done when funding.targetMet is explicitly true', () => {
+    expect(statusFor(2, 3, true)).toBe('done');
+  });
+
+  it('does not apply the funding gate hold to phases other than 2', () => {
+    expect(statusFor(1, 3, false)).toBe('done');
+  });
+
+  it('Phase 2 stays active when it is the current phase, regardless of funding flag', () => {
+    expect(statusFor(2, 2, false)).toBe('active');
+    expect(statusFor(2, 2, undefined)).toBe('active');
+    expect(statusFor(2, 2, true)).toBe('active');
   });
 });

--- a/client/src/dashboard/spa/src/regions/Onboarding.tsx
+++ b/client/src/dashboard/spa/src/regions/Onboarding.tsx
@@ -65,8 +65,22 @@ function bootstrapPhaseFor(step: string): BootstrapPhaseDescriptor {
   return PHASE_FOR_STEP[step] ?? { phase: 1, subState: null };
 }
 
-function statusFor(rowPhase: Phase, currentPhase: Phase): PhaseStatus {
-  if (rowPhase < currentPhase) return 'done';
+/** @internal exported for unit tests */
+export function statusFor(rowPhase: Phase, currentPhase: Phase, fundingTargetMet?: boolean): PhaseStatus {
+  if (rowPhase < currentPhase) {
+    // Phase 2 (Fund your wallet) stays 'active' until the endpoint explicitly
+    // signals that the balance target is met. This prevents a momentary drip
+    // that briefly crossed the threshold from flipping phase 2 to DONE before
+    // the bootstrapper has actually advanced past awaiting_funding on-chain.
+    //
+    // `fundingTargetMet === false` (explicit false from the funding gate) means
+    // the gate is still open; absent funding block means the gate has cleared.
+    // (Numbering note: hjex.7 was authored against the 4-phase shape where
+    // Fund was Phase 3; after vh74.2 collapsed Onboarding to 3 phases, Fund
+    // is now Phase 2.)
+    if (rowPhase === 2 && fundingTargetMet === false) return 'active';
+    return 'done';
+  }
   if (rowPhase === currentPhase) return 'active';
   return 'queued';
 }
@@ -96,7 +110,12 @@ export function Onboarding(): JSX.Element {
   const bootstrapError = bootstrap.error;
   const activeService = bootstrap.services.find((svc) => svc.step === bootstrap.currentStep)
     ?? bootstrap.services[0];
-
+  // hjex.7: explicit `false` means the funding gate is still open; absent
+  // (undefined) means the bootstrapper has cleared funding. The statusFor()
+  // helper keeps Phase 3 (Fund your wallet) 'active' until this clears, so a
+  // momentary drip that briefly crossed the threshold doesn't flip the row
+  // to DONE before the bootstrapper advances past awaiting_funding on-chain.
+  const fundingTargetMet = bootstrap.funding?.targetMet;
   return (
     <div
       className="min-h-screen w-full"
@@ -122,7 +141,7 @@ export function Onboarding(): JSX.Element {
 
           <ol className="flex flex-col">
             {([1, 2, 3] as Phase[]).map((p) => {
-              const status = statusFor(p, currentPhase);
+              const status = statusFor(p, currentPhase, fundingTargetMet);
               const showError = bootstrapError && p === currentPhase;
               return (
                 <PhaseRow key={p} phase={p} status={showError ? 'error' : status}>

--- a/client/src/dashboard/spa/src/regions/Onboarding.tsx
+++ b/client/src/dashboard/spa/src/regions/Onboarding.tsx
@@ -20,7 +20,7 @@
  * phases that genuinely require pre-running-mode completion.
  */
 import { useQuery } from '@tanstack/react-query';
-import type { ReactNode } from 'react';
+import { useState, useCallback, type ReactNode } from 'react';
 import { api } from '../api/client.js';
 import type {
   BootstrapErrorEnvelope,
@@ -145,7 +145,7 @@ export function Onboarding(): JSX.Element {
               const showError = bootstrapError && p === currentPhase;
               return (
                 <PhaseRow key={p} phase={p} status={showError ? 'error' : status}>
-                  {showError && <BootstrapErrorCard envelope={bootstrapError} />}
+                  {showError && <BootstrapErrorCard envelope={bootstrapError} chainExplorerBase={explorer} />}
                   {!showError && p === 2 && status === 'active' && masterAddress && (
                     <AwaitingFundingCard
                       address={masterAddress}
@@ -348,9 +348,34 @@ function ActivePulse(): JSX.Element {
   );
 }
 
-function BootstrapErrorCard({ envelope }: { envelope: BootstrapErrorEnvelope }): JSX.Element {
+function BootstrapErrorCard({ envelope, chainExplorerBase }: { envelope: BootstrapErrorEnvelope; chainExplorerBase: string }): JSX.Element {
   const txHash = extractTxHash(envelope);
   const generatedAt = formatRelativeTime(envelope.generatedAt);
+  const [retryState, setRetryState] = useState<'idle' | 'retrying' | 'success' | 'error'>('idle');
+  const [retryError, setRetryError] = useState<string | null>(null);
+
+  const details = envelope.details as Record<string, unknown> | undefined;
+  const category = typeof details?.['category'] === 'string' ? details['category'] : undefined;
+  const isInsufficientFunds = category === 'insufficient_funds';
+  const fundingAddress = typeof details?.['address'] === 'string' ? details['address'] : null;
+  const requiredWei = typeof details?.['requiredWei'] === 'string' ? details['requiredWei']
+    : typeof details?.['needWei'] === 'string' ? details['needWei'] : null;
+  const haveWei = typeof details?.['haveWei'] === 'string' ? details['haveWei'] : null;
+  const txHashFromDetails = typeof details?.['txHash'] === 'string' ? details['txHash'] : null;
+  const resolvedTxHash = txHashFromDetails ?? txHash;
+
+  const handleRetry = useCallback(async () => {
+    setRetryState('retrying');
+    setRetryError(null);
+    try {
+      await api.retryBootstrap();
+      setRetryState('success');
+    } catch (err) {
+      setRetryState('error');
+      setRetryError(err instanceof Error ? err.message : String(err));
+    }
+  }, []);
+
   return (
     <div
       className="px-5 py-4 flex flex-col gap-3"
@@ -373,15 +398,31 @@ function BootstrapErrorCard({ envelope }: { envelope: BootstrapErrorEnvelope }):
       <p className="j-mono text-xs break-words" style={{ color: 'var(--fg)' }}>
         {envelope.message}
       </p>
-      {envelope.hint && (
+      {isInsufficientFunds && fundingAddress && (
+        <div className="flex flex-col gap-1">
+          <ErrorDetailRow label="Send ETH to">{fundingAddress}</ErrorDetailRow>
+          {requiredWei && (
+            <ErrorDetailRow label="Required">{formatWeiAsEth(requiredWei)}</ErrorDetailRow>
+          )}
+          {haveWei && (
+            <ErrorDetailRow label="Currently have">{formatWeiAsEth(haveWei)}</ErrorDetailRow>
+          )}
+          {requiredWei && haveWei && (
+            <ErrorDetailRow label="Shortfall">
+              {formatWeiAsEth((BigInt(requiredWei) - BigInt(haveWei)).toString())}
+            </ErrorDetailRow>
+          )}
+        </div>
+      )}
+      {!isInsufficientFunds && envelope.hint && (
         <p className="j-mono text-xs" style={{ color: 'var(--fg-muted)' }}>
           <span style={{ color: 'var(--fg-dim)' }}>Fix · </span>
           {envelope.hint}
         </p>
       )}
-      {txHash && (
+      {resolvedTxHash && (
         <a
-          href={`https://sepolia.basescan.org/tx/${txHash}`}
+          href={`${chainExplorerBase}/tx/${resolvedTxHash}`}
           target="_blank"
           rel="noopener noreferrer"
           className="j-mono text-[11px] hover:underline self-start"
@@ -390,13 +431,76 @@ function BootstrapErrorCard({ envelope }: { envelope: BootstrapErrorEnvelope }):
           view failed tx ↗
         </a>
       )}
-      <p className="j-mono text-[11px]" style={{ color: 'var(--fg-dim)' }}>
-        Setup is paused at this step. Once you've addressed the cause, run{' '}
-        <code style={{ color: 'var(--fg-muted)' }}>jinn run</code> again to retry from
-        the persisted state.
-      </p>
+      <div className="flex items-center gap-3 mt-1">
+        <button
+          type="button"
+          onClick={() => { void handleRetry(); }}
+          disabled={retryState === 'retrying'}
+          className="j-label"
+          style={{
+            padding: '5px 12px',
+            borderRadius: 'var(--radius-2)',
+            border: '1px solid var(--break-red)',
+            background: retryState === 'retrying' ? 'rgba(168, 90, 90, 0.15)' : 'transparent',
+            color: retryState === 'retrying' ? 'var(--fg-dim)' : 'var(--break-red)',
+            cursor: retryState === 'retrying' ? 'default' : 'pointer',
+            fontSize: '11px',
+          }}
+        >
+          {retryState === 'retrying' ? 'Retrying…' : retryState === 'success' ? 'Resuming…' : 'Retry'}
+        </button>
+        {retryState === 'success' && (
+          <span className="j-mono text-[11px]" style={{ color: 'var(--fg-muted)' }}>
+            Daemon resumed — waiting for bootstrap to complete
+          </span>
+        )}
+        {retryState === 'error' && retryError && (
+          <span className="j-mono text-[11px]" style={{ color: 'var(--break-red)' }}>
+            {retryError}
+          </span>
+        )}
+      </div>
+      {retryState === 'idle' && (
+        <p className="j-mono text-[11px]" style={{ color: 'var(--fg-dim)' }}>
+          Once you've addressed the cause above, click Retry or{' '}
+          <code style={{ color: 'var(--fg-muted)' }}>jinn run</code> to resume from
+          the persisted state.
+        </p>
+      )}
     </div>
   );
+}
+
+function ErrorDetailRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}): JSX.Element {
+  return (
+    <div className="flex items-baseline gap-2">
+      <span className="j-mono text-[11px] shrink-0" style={{ color: 'var(--fg-dim)', minWidth: '100px' }}>
+        {label}
+      </span>
+      <span className="j-mono text-[11px] break-all" style={{ color: 'var(--fg)' }}>
+        {children}
+      </span>
+    </div>
+  );
+}
+
+function formatWeiAsEth(wei: string): string {
+  try {
+    const n = BigInt(wei);
+    // Show as ETH with up to 6 decimal places
+    const eth = Number(n) / 1e18;
+    if (eth === 0) return '0 ETH';
+    if (eth < 0.000001) return `${n} wei`;
+    return `${eth.toFixed(6).replace(/\.?0+$/, '')} ETH`;
+  } catch {
+    return wei;
+  }
 }
 
 function extractTxHash(envelope: BootstrapErrorEnvelope): string | null {

--- a/client/src/earning/bootstrap.ts
+++ b/client/src/earning/bootstrap.ts
@@ -1387,6 +1387,34 @@ export class FleetBootstrapper {
       }
     }
 
+    // Pre-stake precondition: if migration cleared service_id but kept agent_address,
+    // check the EOA is not already registered on-chain as an agent instance. If it is,
+    // calling stake() again would revert with AgentInstanceRegistered (selector 0x631695bd)
+    // and there is nothing useful the operator can do without rotating the agent EOA.
+    // Fail fast with a typed error instead of letting the contract revert.
+    if (svc.agent_address && svc.service_id === null && this.config.serviceRegistry) {
+      let alreadyBound = false;
+      try {
+        const boundServiceId = (await this.publicClient.readContract({
+          address: getAddress(this.config.serviceRegistry) as Address,
+          abi: SERVICE_REGISTRY_L2_ABI,
+          functionName: 'mapAgentInstances',
+          args: [getAddress(svc.agent_address) as Address],
+        })) as bigint;
+        alreadyBound = boundServiceId > 0n;
+      } catch {
+        // Registry read failure is non-fatal — proceed and let stake() surface
+        // the error if the agent really is bound.
+      }
+      if (alreadyBound) {
+        throw new Error(
+          `agent_already_bound: agent EOA ${svc.agent_address} is already registered as an agent instance on-chain. ` +
+          `The previous setup retirement may have been incomplete. ` +
+          `Contact support or rotate the agent EOA to continue.`,
+        );
+      }
+    }
+
     // Fresh distributor stake() creates a new on-chain service. If state still
     // references an old Safe (e.g. hand-edited JSON), sweep it before replacing.
     if (svc.service_id === null && svc.safe_address && state.master_address) {

--- a/client/src/earning/bootstrap.ts
+++ b/client/src/earning/bootstrap.ts
@@ -100,7 +100,63 @@ import type { Account } from 'viem/accounts';
 const addr = (value: string): Address => getAddress(value) as Address;
 
 const SAFE_TOKEN_BOOTSTRAP_MULTIPLIER = 2n;
-const STANDARD_MASTER_BOOTSTRAP_MULTIPLIER = 2n;
+
+/**
+ * 2× cold-start headroom for master ETH target on a fresh bootstrap.
+ *
+ * Gas accounting for a single standard-mode service on first run:
+ *   ~1.3M gas for the Safe deploy + stake + mech (at 2 gwei ≈ 0.0026 ETH)
+ *   + 0.002 ETH Safe seed (sent to the Safe so it can pay mech fees)
+ *   ≈ 0.0046 ETH minimum; 2× gives ≈ 0.009–0.010 ETH — the bootstrap
+ *   `minEoaGasEth` default.
+ *
+ * The multiplier only applies when no service has a persisted `service_id`
+ * on-chain (i.e. the fleet is truly cold — OR migration-wiped, where
+ * services exist in shape but lost their on-chain anchor). Once any service
+ * has committed a `service_id`, the fleet is past the cold-start cliff and
+ * 1× suffices.
+ *
+ * Single source of truth: imported by funding-plan.ts.
+ */
+export const STANDARD_MASTER_BOOTSTRAP_MULTIPLIER = 2n;
+
+/**
+ * Compute the required master ETH gate for the standard staking mode.
+ *
+ * @param services         Persisted service states
+ * @param minEoaGasEth     Configured minimum EOA gas target (wei)
+ * @param standardMultiplier  Cold-start multiplier (defaults to {@link STANDARD_MASTER_BOOTSTRAP_MULTIPLIER})
+ * @param pendingSetupMigration  True when deprecated testnet setup detected
+ * @param targetServices   How many services the fleet is aiming for
+ */
+export function computeRequiredMasterEth({
+  services,
+  minEoaGasEth,
+  standardMultiplier = STANDARD_MASTER_BOOTSTRAP_MULTIPLIER,
+  pendingSetupMigration = false,
+  targetServices = 1,
+}: {
+  services: Array<{ service_id: number | null | undefined; step?: string }>;
+  minEoaGasEth: bigint;
+  standardMultiplier?: bigint;
+  pendingSetupMigration?: boolean;
+  targetServices?: number;
+}): bigint {
+  const completedCount = services.filter(s =>
+    s.step !== undefined && isOperationalServiceStep(s.step),
+  ).length;
+  const standardFleetAlreadyComplete =
+    !pendingSetupMigration && completedCount >= targetServices;
+  if (standardFleetAlreadyComplete) return 0n;
+
+  // "Cold in liability" = no service has an on-chain anchor yet.
+  // This includes:
+  //   1. Fresh fleet (services array is empty)
+  //   2. Migration-wiped fleet (services exist in shape but service_id === null)
+  // Apply the 2× headroom multiplier in both cases.
+  const hasPersistedOnChain = services.some(s => s.service_id != null);
+  return minEoaGasEth * (hasPersistedOnChain ? 1n : standardMultiplier);
+}
 
 /** Master ETH required to FINISH the whole bootstrap from a fresh start (not
  *  just to enter Stage 1). Centralized so the daemon's ensureStage1 gate,
@@ -576,15 +632,13 @@ export class FleetBootstrapper {
         stakingMode: this.stakingMode,
         currentStakingContract: this.config.stakingContract,
       }).services.length > 0;
-      const completedCountBeforeFunding = state.services.filter(s =>
-        isOperationalServiceStep(s.step),
-      ).length;
       const standardFleetAlreadyComplete =
         this.stakingMode === 'standard' &&
-        !pendingSetupMigration &&
-        completedCountBeforeFunding >= this.targetServices;
-      const standardFleetHasInProgressServices =
-        this.stakingMode === 'standard' && state.services.length > 0;
+        state.services.length >= this.targetServices &&
+        state.services.every(svc =>
+          svc.step !== undefined && isOperationalServiceStep(svc.step),
+        ) &&
+        !pendingSetupMigration;
       const requiredMasterEth = this.stakingMode === 'standard'
         ? (
             standardFleetAlreadyComplete

--- a/client/src/earning/bootstrap.ts
+++ b/client/src/earning/bootstrap.ts
@@ -819,7 +819,7 @@ export class FleetBootstrapper {
         message: `Fleet bootstrap complete. ${state.services.filter(s => isOperationalServiceStep(s.step)).length}/${this.targetServices} services running.`,
       };
     } catch (error) {
-      const { summary, hint, rawMessage } = formatBootstrapOperatorMessage(error);
+      const { summary, hint, rawMessage, category } = formatBootstrapOperatorMessage(error);
       const userMessage = hint !== undefined ? `${summary}\nHint: ${hint}` : summary;
       if (this.debug) {
         console.error(`[fleet-bootstrap] Bootstrap failed:`, error);
@@ -833,11 +833,21 @@ export class FleetBootstrapper {
           console.error(`[fleet-bootstrap] raw: ${rawMessage.split('\n')[0]}`);
         }
       }
+      // Extract a tx hash embedded in the error message by the on-chain revert
+      // paths (format: "...tx failed for service N: 0x<hash>" or
+      // "...tx reverted: 0x<hash>"). Surfaced in the fatal envelope so the SPA
+      // can render a block-explorer link. jinn-mono-hjex reviewer fix.
+      const txHashMatch = /(0x[a-fA-F0-9]{64})/.exec(rawMessage);
+      const txHash = txHashMatch ? txHashMatch[1] : null;
       return {
         ok: false,
         fleet_state: state,
         message: userMessage,
         rawErrorMessage: rawMessage,
+        // Preserve the structured category so the error envelope in main.ts
+        // can surface it in `details.category` for SPA consumers. jinn-mono-hjex.6
+        ...(category !== undefined ? { errorCategory: category } : {}),
+        ...(txHash !== null ? { txHash } : {}),
       };
     }
   }

--- a/client/src/earning/bootstrap.ts
+++ b/client/src/earning/bootstrap.ts
@@ -89,6 +89,7 @@ import { isUnauthorizedAccountError } from '../errors/unauthorized-account.js';
 import { createJinnPublicClient, createJinnWalletClient, type JinnOnchainNetwork } from './viem-clients.js';
 import { isTransientEthReadError } from '../chain-read-errors.js';
 import { nextFleetServiceIndex } from './next-service-index.js';
+import { displayFleetServiceIndex } from './fleet-display-index.js';
 import { rpcHostForDisplay } from '../preflight/rpc-network.js';
 import {
   detectDeprecatedTestnetSetup,
@@ -1470,46 +1471,20 @@ export class FleetBootstrapper {
     const svc = state.services.find(s => s.index === index)!;
     const serviceId = svc.service_id!;
     const stakingAddress = this.stakingAddressForService(svc);
+    const di = displayFleetServiceIndex(svc);
 
-    // `reStake()` is operator-scoped: the master EOA must match the
-    // distributor's recorded `mapServiceIdCuratingAgents[serviceId]` entry.
-    // If it doesn't, the operator is likely using the wrong earning dir or
-    // password, or the service needs owner / managing-agent recovery.
-    const masterAccount = deriveMasterSigner(mnemonic);
-    const masterWallet = createJinnWalletClient(this.config.rpcUrl, this.chain, masterAccount);
-
-    const reStakeData = encodeFunctionData({
-      abi: STOLAS_DISTRIBUTOR_ABI,
-      functionName: 'reStake',
-      args: [stakingAddress, BigInt(serviceId)],
-    }) as Hex;
-
-    console.error(`[fleet-bootstrap] Service ${index}: calling distributor.reStake() for evicted service ${serviceId}`);
-    let reStakeHash: Hex;
-    try {
-      reStakeHash = await viemSendTransactionWithRetry(masterWallet, this.publicClient, {
-        account: masterAccount as Account,
-        to: addr(this.config.distributorAddress),
-        data: reStakeData,
-        gas: 1_500_000n,
-      });
-    } catch (err) {
-      const message = flattenErrorMessage(err);
-      if (isUnauthorizedAccountError(message)) {
-        throw new Error(
-          `Service ${index} (service_id ${serviceId}) is evicted on the staking proxy, but master EOA ${masterAccount.address} is not authorized to reStake it. ` +
-          `The distributor only permits the recorded service operator, a managing agent, or the owner. ` +
-          `Verify JINN_EARNING_DIR and JINN_PASSWORD derive the original master EOA for this service, then re-run jinn bootstrap; otherwise request owner / managing-agent recovery or abandon-and-rebootstrap. ` +
-          `reStake revert: ${message}`,
-        );
-      }
-      throw err;
-    }
-    const receipt = await waitForTransactionReceiptWithRetry(this.publicClient, reStakeHash);
-    if (receipt.status !== 'success') {
-      throw new Error(`reStake failed for service ${index}: ${reStakeHash}`);
-    }
-    console.error(`[fleet-bootstrap] Service ${index}: reStake confirmed (tx: ${reStakeHash})`);
+    // Delegate to the standalone exported helper (shared with EvictionLoop /
+    // the dashboard "Re-stake now" CTA). This eliminates the duplicate
+    // implementation (jinn-mono-hjex.3).
+    await recoverEvictedService({
+      serviceDisplayIndex: di,
+      serviceId,
+      stakingAddress: stakingAddress,
+      distributorAddress: this.config.distributorAddress,
+      rpcUrl: this.config.rpcUrl,
+      chain: this.chain,
+      mnemonic,
+    });
 
     // Service is now Staked again with the same service_id, safe_address, and mech_address.
     // Step back to `mech_deployed` so the resume loop advances through
@@ -2448,3 +2423,83 @@ export class FleetBootstrapper {
 
 /** @deprecated Use FleetBootstrapper */
 export const EarningBootstrapper = FleetBootstrapper;
+
+// ---------------------------------------------------------------------------
+// Standalone recovery helper — callable from the eviction loop (hjex.3)
+// ---------------------------------------------------------------------------
+
+export interface RecoverEvictedServiceOptions {
+  /** Display index of the service (used only for log messages). */
+  serviceDisplayIndex: number;
+  serviceId: number;
+  stakingAddress: string;
+  distributorAddress: string;
+  rpcUrl: string;
+  chain: JinnOnchainNetwork;
+  mnemonic: string;
+}
+
+/**
+ * Re-stake an evicted service by calling `distributor.reStake(stakingProxy, serviceId)`.
+ *
+ * Extracted from `FleetBootstrapper.recoverEvictedService` so it can be called
+ * from the in-process `EvictionLoop` without requiring a full bootstrapper
+ * context (jinn-mono-hjex.3).
+ *
+ * The caller is responsible for advancing the local service step back to
+ * `mech_deployed` after this returns (just like the bootstrapper resume path does).
+ */
+export async function recoverEvictedService(
+  opts: RecoverEvictedServiceOptions,
+): Promise<void> {
+  const {
+    serviceDisplayIndex,
+    serviceId,
+    stakingAddress,
+    distributorAddress,
+    rpcUrl,
+    chain,
+    mnemonic,
+  } = opts;
+
+  const masterAccount = deriveMasterSigner(mnemonic);
+  const publicClient = createJinnPublicClient(rpcUrl, chain);
+  const masterWallet = createJinnWalletClient(rpcUrl, chain, masterAccount);
+
+  const reStakeData = encodeFunctionData({
+    abi: STOLAS_DISTRIBUTOR_ABI,
+    functionName: 'reStake',
+    args: [addr(stakingAddress), BigInt(serviceId)],
+  }) as Hex;
+
+  console.error(
+    `[eviction-recovery] Service ${serviceDisplayIndex}: calling distributor.reStake() for evicted service ${serviceId}`,
+  );
+  let reStakeHash: Hex;
+  try {
+    reStakeHash = await viemSendTransactionWithRetry(masterWallet, publicClient, {
+      account: masterAccount as Account,
+      to: addr(distributorAddress),
+      data: reStakeData,
+      gas: 1_500_000n,
+    });
+  } catch (err) {
+    const message = flattenErrorMessage(err);
+    if (isUnauthorizedAccountError(message)) {
+      throw new Error(
+        `Service ${serviceDisplayIndex} (service_id ${serviceId}) is evicted on the staking proxy, but master EOA ` +
+        `${masterAccount.address} is not authorized to reStake it. ` +
+        `Verify JINN_EARNING_DIR and JINN_PASSWORD derive the original master EOA for this service. ` +
+        `reStake revert: ${message}`,
+      );
+    }
+    throw err;
+  }
+  const receipt = await waitForTransactionReceiptWithRetry(publicClient, reStakeHash);
+  if (receipt.status !== 'success') {
+    throw new Error(`reStake failed for service ${serviceDisplayIndex}: ${reStakeHash}`);
+  }
+  console.error(
+    `[eviction-recovery] Service ${serviceDisplayIndex}: reStake confirmed (tx: ${reStakeHash})`,
+  );
+}

--- a/client/src/earning/contracts.ts
+++ b/client/src/earning/contracts.ts
@@ -541,6 +541,13 @@ export const SERVICE_REGISTRY_L2_ABI = [
     type: 'function',
   },
   {
+    inputs: [{ name: 'agentInstance', type: 'address' }],
+    name: 'mapAgentInstances',
+    outputs: [{ name: 'serviceId', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
     inputs: [
       { name: 'serviceId', type: 'uint256' },
       { name: 'agentInstances', type: 'address[]' },

--- a/client/src/earning/funding-plan.ts
+++ b/client/src/earning/funding-plan.ts
@@ -23,6 +23,7 @@ import { stage1MinMasterEth } from './bootstrap.js';
 import { decryptMnemonic, deriveMasterAddress } from './wallet.js';
 import { isOperationalServiceStep, type FleetState, type FundingRequirement, type StakingMode } from './types.js';
 import { createJinnPublicClient, type JinnOnchainNetwork } from './viem-clients.js';
+import { STANDARD_MASTER_BOOTSTRAP_MULTIPLIER } from './bootstrap.js';
 
 export interface FundingPlanOptions {
   earningDir?: string;

--- a/client/src/earning/jinn-rewards.ts
+++ b/client/src/earning/jinn-rewards.ts
@@ -32,6 +32,38 @@ export const JINN_STAKING_ABI = [
     inputs: [
       { name: 'serviceId', type: 'uint256' },
     ],
+    name: 'getStakingState',
+    outputs: [{ name: 'stakingState', type: 'uint8' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { name: 'serviceId', type: 'uint256' },
+    ],
+    name: 'getServiceInfo',
+    outputs: [
+      {
+        name: 'sInfo',
+        type: 'tuple',
+        components: [
+          { name: 'multisig', type: 'address' },
+          { name: 'owner', type: 'address' },
+          { name: 'nonces', type: 'uint256[]' },
+          { name: 'tsStart', type: 'uint256' },
+          { name: 'reward', type: 'uint256' },
+          { name: 'inactivity', type: 'uint256' },
+          { name: 'rewardDistributionInfo', type: 'uint256' },
+        ],
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { name: 'serviceId', type: 'uint256' },
+    ],
     name: 'claim',
     outputs: [{ name: 'amount', type: 'uint256' }],
     stateMutability: 'nonpayable',

--- a/client/src/earning/testnet-setup-migration.ts
+++ b/client/src/earning/testnet-setup-migration.ts
@@ -28,10 +28,23 @@ export interface TestnetSetupMigrationPlan {
   services: ServiceState[];
 }
 
+export interface TestnetSetupMigrationRetireFailedEnvelope {
+  kind: 'retire_failed';
+  retire_error: string | null;
+  tx_hash: string | null;
+  message: string;
+}
+
 export interface TestnetSetupMigrationResult {
   state: FleetState;
   migratedCount: number;
   archivePaths: string[];
+  /**
+   * Set when at least one service's retire failed and the wipe was suppressed.
+   * The migration archived the failure but left local state intact.
+   * Callers should surface this to the operator.
+   */
+  retireFailedEnvelope?: TestnetSetupMigrationRetireFailedEnvelope;
 }
 
 export interface TestnetSetupMigrationParams {
@@ -251,6 +264,7 @@ export async function migrateDeprecatedTestnetSetup(
   let nextState = params.state;
   const archivePaths = new Set<string>();
   let migratedCount = 0;
+  let retireFailedEnvelope: TestnetSetupMigrationRetireFailedEnvelope | undefined;
 
   for (const svc of plan.services) {
     const id = migrationId(svc);
@@ -287,9 +301,23 @@ export async function migrateDeprecatedTestnetSetup(
         ...retire,
       });
       if (retire.retire_status === 'failed') {
+        // Retire failed — do NOT wipe local state. The operator's service is
+        // still running on-chain against the old setup. Preserve all fields so
+        // they can continue operating. Surface the error via the envelope so
+        // callers (bootstrap, /v1/bootstrap) can show an actionable message.
         console.error(
-          'Previous Jinn setup could not be fully retired automatically; it was archived for recovery. Continuing upgrade...',
+          'Previous Jinn setup could not be fully retired automatically; it was archived for recovery. Local state is preserved — resolve the retire failure before upgrading.',
         );
+        retireFailedEnvelope = {
+          kind: 'retire_failed',
+          retire_error: retire.retire_error ?? null,
+          tx_hash: retire.retire_tx_hash ?? null,
+          message: 'We could not retire your previous setup. Your service state is preserved; resolve the retire failure before upgrading.',
+        };
+        // Count as a migration attempt even though state was not wiped, so
+        // callers know we ran the migration path.
+        migratedCount += 1;
+        continue;
       }
     }
 
@@ -319,5 +347,6 @@ export async function migrateDeprecatedTestnetSetup(
     state: nextState,
     migratedCount,
     archivePaths: [...archivePaths],
+    ...(retireFailedEnvelope ? { retireFailedEnvelope } : {}),
   };
 }

--- a/client/src/earning/types.ts
+++ b/client/src/earning/types.ts
@@ -204,4 +204,19 @@ export interface FleetBootstrapResult {
   rawErrorMessage?: string;
   funding?: FundingRequirement;
   self_bond_funding?: SelfBondFundingRequirement;
+  /**
+   * Structured category for operator-error cases where the error type is
+   * known but comes from an exception (rather than the early-return funding
+   * gate above). Currently used to propagate `'insufficient_funds'` so the
+   * error envelope in main.ts can surface a structured `category` field
+   * instead of a prose disjunction. jinn-mono-hjex.6
+   */
+  errorCategory?: 'insufficient_funds' | 'gas_too_low' | 'nonce_conflict';
+  /**
+   * Transaction hash of the failed on-chain tx, when available.
+   * Extracted from the thrown error message in the bootstrap catch path.
+   * Surfaced in the fatal envelope `details.txHash` so the SPA can render
+   * a block-explorer link. jinn-mono-hjex reviewer fix.
+   */
+  txHash?: string | null;
 }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -567,11 +567,17 @@ async function bootstrap(): Promise<{
         hint: 'Fund the listed address and re-run this command.',
         exampleCli: 'jinn fund-requirements --json',
         details: {
-          role: 'master',
+          // jinn-mono-hjex.6: structured envelope so SPA can render the
+          // specific address + amount instead of a prose disjunction.
+          category: 'insufficient_funds',
+          step: 'awaiting_funding',
           address: result.funding.master_address,
+          requiredWei: result.funding.eth_required,
+          haveWei: result.funding.eth_balance,
+          // Legacy aliases kept for any external consumers that read these.
+          role: 'master',
           asset: 'native',
           needWei: result.funding.eth_required,
-          haveWei: result.funding.eth_balance,
         },
       });
     }
@@ -590,11 +596,17 @@ async function bootstrap(): Promise<{
       hint: 'Bootstrap failed before the fleet reached a runnable state.',
       details: {
         cause: result.message,
+        // jinn-mono-hjex.6: propagate structured category from the bootstrapper
+        // so the SPA can render category-specific UI (e.g. funding shortfall).
+        ...(result.errorCategory !== undefined ? { category: result.errorCategory } : {}),
         // Preserve the raw underlying error so a misclassified summary can
         // be diagnosed without re-running with JINN_DEBUG. See jinn-mono-jz9f.
         ...(result.rawErrorMessage && result.rawErrorMessage !== result.message
           ? { rawErrorMessage: result.rawErrorMessage }
           : {}),
+        // jinn-mono-hjex reviewer fix: propagate tx hash so the SPA can render
+        // a block-explorer link for failed on-chain revert transactions.
+        ...(result.txHash != null ? { txHash: result.txHash } : {}),
       },
     });
   }
@@ -936,6 +948,14 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     current: undefined,
   };
 
+  // hjex.6: retry signal for the bootstrap halt-and-resume loop.
+  // When a SetupBootstrapHalted is caught (fatal non-funding error or funding
+  // timeout), main() waits on this promise instead of returning, so the setup
+  // API stays alive and the operator can click Retry in the SPA.
+  // The retry endpoint resolves this promise to trigger a re-run.
+  let retryBootstrapResolve: (() => void) | null = null;
+  let retryBootstrapReject: ((err: unknown) => void) | null = null;
+
   let setupApiServer: ApiServer;
   try {
     setupApiServer = await startApiServer({
@@ -1145,6 +1165,23 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
             return Promise.resolve({ ok: false, error: 'restake_not_available_in_setup_mode' });
           }
           return restakeCallbackRef.current(serviceId);
+        },
+        // hjex.6: re-trigger the bootstrap state machine from the SPA Retry button.
+        // Resolves the halt-and-resume promise; main() will loop back and call
+        // bootstrap() again. Rejects if the daemon is not currently halted.
+        retryBootstrap: () => {
+          return new Promise<void>((resolve, reject) => {
+            if (!retryBootstrapResolve) {
+              reject(new Error('daemon_not_halted'));
+              return;
+            }
+            const prevResolve = retryBootstrapResolve;
+            // The resolve will unblock the main loop's await. When bootstrap
+            // completes (success or new halt), the caller receives the result
+            // via the /v1/bootstrap polling endpoint.
+            prevResolve();
+            resolve();
+          });
         },
       },
       status: {
@@ -1374,29 +1411,95 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     setupController.refresh({ keystoreExists: true, allComplete: false });
   }
 
+  // hjex.6: halt-and-resume loop for bootstrap retries.
+  // When failBootstrap() throws SetupBootstrapHalted, we wait for the operator
+  // to click Retry in the SPA (which resolves retryBootstrapResolve) rather
+  // than returning and exiting. On each retry, we loop back and call bootstrap()
+  // again. bootstrap() is idempotent — completed steps are no-ops.
   let bootstrapResult;
-  try {
-    bootstrapResult = await bootstrap();
-  } catch (err) {
-    if (err instanceof SetupBootstrapHalted) {
-      return {
-        schemaVersion: 1,
-        generatedAt: new Date().toISOString(),
-        kind: 'setup_halted',
-        pid: process.pid,
-        network: config.network,
-        phase: config.network === 'testnet' ? 'phase-1b' : 'phase-0',
-        apiPort: setupApiServer.port,
-        dashboardUrl: `http://127.0.0.1:${setupApiServer.port}`,
-        error: err.envelope,
-      };
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      bootstrapResult = await bootstrap();
+      break; // success — exit the retry loop
+    } catch (err) {
+      if (err instanceof SetupBootstrapHalted) {
+        // Install the retry signal so the endpoint can unblock us.
+        const retrySignal = new Promise<void>((resolve, reject) => {
+          retryBootstrapResolve = resolve;
+          retryBootstrapReject = reject;
+        });
+        console.log('[main] Bootstrap halted. Waiting for retry signal from the dashboard...');
+
+        // hjex.6: Auto-resume funding poller.
+        // When the halt is a funding shortfall, poll the master EOA balance
+        // every JINN_FUNDING_POLL_INTERVAL_MS (default 15s). When the balance
+        // meets or exceeds the required amount, auto-signal the retry loop.
+        // Only runs while the halt signal is pending; stops on any signal.
+        let fundingPollHandle: ReturnType<typeof setTimeout> | null = null;
+        const isHaltedOnFunding = err.envelope.code === 'funding_required';
+        const haltDetails = err.envelope.details as Record<string, unknown> | undefined;
+        const haltAddress = typeof haltDetails?.['address'] === 'string'
+          ? haltDetails['address'] as `0x${string}`
+          : null;
+        const haltRequired = typeof haltDetails?.['requiredWei'] === 'string'
+          ? BigInt(haltDetails['requiredWei'])
+          : typeof haltDetails?.['needWei'] === 'string'
+            ? BigInt(haltDetails['needWei'])
+            : null;
+        const fundingPollIntervalMs = (() => {
+          const raw = process.env['JINN_FUNDING_POLL_INTERVAL_MS'];
+          if (!raw) return 15_000;
+          const n = Number.parseInt(raw, 10);
+          return Number.isFinite(n) && n > 0 ? n : 15_000;
+        })();
+        if (isHaltedOnFunding && haltAddress && haltRequired !== null) {
+          const publicClient = createJinnPublicClient(config.rpcUrl, NETWORK_CHAIN);
+          const schedulePoll = (): void => {
+            fundingPollHandle = setTimeout(async () => {
+              // Guard: if the signal was already fired, stop polling.
+              if (!retryBootstrapResolve) return;
+              try {
+                const balance = await publicClient.getBalance({ address: haltAddress });
+                if (balance >= haltRequired) {
+                  console.log(
+                    `[main] Funding shortfall cleared (have ${balance}, required ${haltRequired}). ` +
+                    `Auto-resuming bootstrap...`,
+                  );
+                  retryBootstrapResolve?.();
+                  return; // don't schedule the next poll
+                }
+              } catch (pollErr) {
+                // Balance read failed — not fatal, just skip this tick.
+                const msg = pollErr instanceof Error ? pollErr.message : String(pollErr);
+                console.log(`[main] Funding poller balance read failed (will retry): ${msg}`);
+              }
+              schedulePoll(); // reschedule
+            }, fundingPollIntervalMs);
+          };
+          schedulePoll();
+        }
+
+        try {
+          await retrySignal;
+        } finally {
+          retryBootstrapResolve = null;
+          retryBootstrapReject = null;
+          if (fundingPollHandle !== null) {
+            clearTimeout(fundingPollHandle);
+            fundingPollHandle = null;
+          }
+        }
+        console.log('[main] Retry triggered — re-running bootstrap...');
+        continue; // loop back to the bootstrap() call
+      }
+      // If bootstrap throws an unexpected error (vs. SetupBootstrapHalted),
+      // tear down the API we just started so we don't leave a dangling listener.
+      await setupApiServer.close().catch(() => undefined);
+      await closeCaptureReceiver();
+      sharedStore.close();
+      throw err;
     }
-    // If bootstrap throws (vs. emitEnvelope-exits), tear down the API we
-    // just started so we don't leave a dangling listener on the port.
-    await setupApiServer.close().catch(() => undefined);
-    await closeCaptureReceiver();
-    sharedStore.close();
-    throw err;
   }
 
   // Bootstrap completed — flip the controller into 'running' so any waiters

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -46,8 +46,8 @@ import {
 import { emitStructured } from './events/emitter.js';
 import { checkClaudeBinary } from './preflight/claude-binary.js';
 import { emitClaudeBinaryPreflightFailure } from './preflight/claude-invocation-envelope.js';
-import { FleetBootstrapper } from './earning/bootstrap.js';
-import { DEFAULT_TESTNET_ARTIFACTS, applyChainGasOverrides, getChainConfig, loadJinnMviConfig } from './earning/contracts.js';
+import { FleetBootstrapper, recoverEvictedService as recoverEvictedServiceFn } from './earning/bootstrap.js';
+import { DEFAULT_TESTNET_ARTIFACTS, STAKING_ABI, applyChainGasOverrides, getChainConfig, loadJinnMviConfig } from './earning/contracts.js';
 import { runLegacyAgentIdMigration } from './earning/migrate-agent-id.js';
 import { FleetStateStore } from './earning/store.js';
 import {
@@ -930,6 +930,12 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     current: import('./discovery/types.js').DiscoveryAPI | undefined;
   } = { current: undefined };
 
+  // hjex.3: holder for the restake callback. Populated in running mode after
+  // bootstrap completes (when mnemonic + distributorAddress are available).
+  const restakeCallbackRef: { current: ((serviceId: number) => Promise<{ ok: boolean; error?: string }>) | undefined } = {
+    current: undefined,
+  };
+
   let setupApiServer: ApiServer;
   try {
     setupApiServer = await startApiServer({
@@ -1132,6 +1138,13 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
           // (and thus Overview's `solverNet.enabled` gating) reflects the
           // toggle immediately. (jinn-mono-l2zl.15.4.12)
           invalidatePredictionOperatorStatusCache(config);
+        },
+        // hjex.3: delegate to the live callback populated once running mode starts.
+        restake: (serviceId) => {
+          if (!restakeCallbackRef.current) {
+            return Promise.resolve({ ok: false, error: 'restake_not_available_in_setup_mode' });
+          }
+          return restakeCallbackRef.current(serviceId);
         },
       },
       status: {
@@ -1458,6 +1471,31 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
   const publicClient = createJinnPublicClient(config.rpcUrl, NETWORK_CHAIN);
   publicClientForLauncher = publicClient;
   const masterWallet = createJinnWalletClient(config.rpcUrl, NETWORK_CHAIN, masterAccount);
+
+  // hjex.3: populate the restake callback now that mnemonic is available.
+  if (config.stakingMode === 'standard' && CHAIN_CONFIG.distributorAddress) {
+    const fleetStore = earningStore;
+    restakeCallbackRef.current = async (serviceId: number) => {
+      try {
+        const state = await fleetStore.load(NETWORK_CHAIN);
+        const svc = state.services.find(s => s.service_id === serviceId);
+        if (!svc) return { ok: false, error: `service_not_found:${serviceId}` };
+        if (!svc.staking_address) return { ok: false, error: 'staking_address_missing' };
+        await recoverEvictedServiceFn({
+          serviceDisplayIndex: Math.max(0, svc.index - 1),
+          serviceId,
+          stakingAddress: svc.staking_address,
+          distributorAddress: CHAIN_CONFIG.distributorAddress!,
+          rpcUrl: config.rpcUrl,
+          chain: NETWORK_CHAIN,
+          mnemonic: mnemonicForMaster,
+        });
+        return { ok: true };
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    };
+  }
 
   const evictionRecovery =
     config.stakingMode === 'standard' &&
@@ -2245,6 +2283,32 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
             eoaTopupTarget: CHAIN_CONFIG.minEoaGasEth,
             safeTopupTrigger: CHAIN_CONFIG.safeTopupTrigger,
             safeTopupTarget: CHAIN_CONFIG.minSafeEth,
+          }
+        : undefined,
+    // Eviction-check loop — only in standard staking mode (requires distributorAddress).
+    // Running mode only: setup-halted daemons must not try to restake services that
+    // haven't been staked yet (hjex.3).
+    evictionCheck:
+      config.evictionCheckIntervalMs > 0 &&
+      config.stakingMode === 'standard' &&
+      CHAIN_CONFIG.distributorAddress
+        ? {
+            intervalMs: config.evictionCheckIntervalMs,
+            store: earningStore,
+            chain: NETWORK_CHAIN,
+            readContract: (opts) => publicClient.readContract(opts as Parameters<typeof publicClient.readContract>[0]) as Promise<bigint>,
+            recoverEvictedService: async (svc) => {
+              if (!svc.service_id || !svc.staking_address) return;
+              await recoverEvictedServiceFn({
+                serviceDisplayIndex: Math.max(0, svc.index - 1),
+                serviceId: svc.service_id,
+                stakingAddress: svc.staking_address,
+                distributorAddress: CHAIN_CONFIG.distributorAddress!,
+                rpcUrl: config.rpcUrl,
+                chain: NETWORK_CHAIN,
+                mnemonic: mnemonicForMaster,
+              });
+            },
           }
         : undefined,
   });

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -101,6 +101,7 @@ import { GeneratedTaskSource, StaticConfiguredTaskSource } from './tasks/sources
 import { checkRpcNetwork, logRpcLocalDevToStderr, rpcNetworkFailureHint } from './preflight/rpc-network.js';
 import { apiPortFailureMessage, checkApiPortAvailable } from './preflight/api-port.js';
 import { openBrowser } from './cli/open-browser.js';
+import { keepSetupUiOnBootstrapError } from './setup/halt-mode.js';
 import type { ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace-base';
 
 if (process.env['JINN_LOAD_DEV_ENV'] === '1' || process.env['NODE_ENV'] === 'development') {
@@ -729,8 +730,9 @@ class SetupBootstrapHalted extends Error {
   }
 }
 
-const keepSetupUiOnBootstrapError = (): boolean =>
-  process.env['JINN_NO_UI'] !== '1' && process.env['JINN_NO_DAEMON'] !== '1';
+// hjex.6: gate for the halt-and-resume loop. Lives in ./setup/halt-mode.ts
+// so it can be unit-tested without dragging main.ts's top-level side
+// effects (password resolution, config load) into the test.
 
 // ── Main ────────────────────────────────────────────────────────────────────
 

--- a/client/src/operator-errors.ts
+++ b/client/src/operator-errors.ts
@@ -125,11 +125,18 @@ export function formatBootstrapOperatorMessage(error: unknown): OperatorErrorPar
   // pay for even 1 wei of gas. That's an insufficient-balance error, not an
   // OOG. Must come before the broader OOG matcher below so it doesn't fall
   // through. See jinn-mono-u34i.
+  //
+  // jinn-mono-hjex.6 review: this branch is semantically the same shortfall
+  // as the explicit "insufficient funds for gas" branch below (zero spendable
+  // balance vs gas), so it must classify as `insufficient_funds` — NOT
+  // `gas_too_low` — so the SPA renders the funding-shortfall UI (send ETH to
+  // address X) instead of a misleading "re-run, the daemon will retry gas".
   if (lower.includes('gas required exceeds allowance (0)')) {
     return {
       summary: 'Not enough ETH on the paying account to cover gas (and value, if any).',
       hint: 'Send ETH to the master wallet, agent EOA, or Safe depending on which step failed.',
       rawMessage: msg,
+      category: 'insufficient_funds',
     };
   }
 

--- a/client/src/operator-errors.ts
+++ b/client/src/operator-errors.ts
@@ -56,6 +56,13 @@ export interface OperatorErrorParts {
    * untouched message to diagnose. Always populated.
    */
   rawMessage: string;
+  /**
+   * Structured category for the error type when it can be determined with
+   * confidence. Absent for unclassified errors. Consumers can use this to
+   * render structured UI (e.g. "insufficient_funds" → show address + amount)
+   * rather than relying on prose parsing. jinn-mono-hjex.6
+   */
+  category?: 'insufficient_funds' | 'gas_too_low' | 'nonce_conflict';
 }
 
 /**
@@ -109,6 +116,7 @@ export function formatBootstrapOperatorMessage(error: unknown): OperatorErrorPar
       summary: 'A transaction with the same nonce is already pending, and the new gas price is too low.',
       hint: 'Wait for confirmation, cancel/replace with a higher maxFeePerGas, or clear the stuck nonce.',
       rawMessage: msg,
+      category: 'nonce_conflict',
     };
   }
 
@@ -140,6 +148,7 @@ export function formatBootstrapOperatorMessage(error: unknown): OperatorErrorPar
         'Transaction ran out of gas — the Safe wrapper or inner contract call needed more gas than the supplied limit.',
       hint: 'Re-run; the daemon estimates gas dynamically and a transient RPC failure may have forced a fallback. If it persists, the gas requirement of the underlying step has likely drifted past the safe-adapter fallback floor.',
       rawMessage: msg,
+      category: 'gas_too_low',
     };
   }
 
@@ -155,8 +164,11 @@ export function formatBootstrapOperatorMessage(error: unknown): OperatorErrorPar
   ) {
     return {
       summary: 'Not enough ETH on the paying account to cover gas (and value, if any).',
-      hint: 'Send ETH to the master wallet, agent EOA, or Safe depending on which step failed.',
+      // The structured envelope (jinn-mono-hjex.6) surfaces the specific address
+      // and amounts; this hint is the fallback for non-SPA consumers.
+      hint: 'Check the bootstrap error details for the specific address and required amount.',
       rawMessage: msg,
+      category: 'insufficient_funds',
     };
   }
 

--- a/client/src/setup/halt-mode.ts
+++ b/client/src/setup/halt-mode.ts
@@ -1,0 +1,16 @@
+/**
+ * Halt-and-resume gate (jinn-mono-hjex.6).
+ *
+ * When bootstrap fails after the setup API has come up, we want the dashboard
+ * to stay alive so the operator can click Retry from `BootstrapErrorCard`
+ * (see `main.ts` halt-and-resume loop). That mode is only safe when there is
+ * actually a human (or watcher) on the other side; in CI / agent-driven flows
+ * driven with `JINN_NO_UI=1` or `JINN_NO_DAEMON=1` no Retry click is coming,
+ * so a halt must surface as a fatal exit immediately rather than suspending
+ * in the retry loop forever.
+ *
+ * This predicate is the single source of truth for that gate.
+ */
+export function keepSetupUiOnBootstrapError(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env['JINN_NO_UI'] !== '1' && env['JINN_NO_DAEMON'] !== '1';
+}

--- a/client/src/solver-nets/prediction-operator-ux.ts
+++ b/client/src/solver-nets/prediction-operator-ux.ts
@@ -19,6 +19,8 @@ import { PredictionV1TaskSchema, type PredictionV1Task } from '../types/predicti
 import type { SolverPluginEntry } from '../plugins/types.js';
 import {
   loadSolverNets as defaultLoadSolverNets,
+  rolesFromJoinedConfig,
+  type JoinedSolverNetConfig,
   type LoadedSolverNet,
   type SolverNetConfig,
   type SolverNetOperatorRole,
@@ -214,6 +216,28 @@ function missingSolverNetStatus(
   };
 }
 
+/**
+ * Build a synthetic SolverNetConfig from the first entry in joinedSolverNets.
+ * This lets the diagnostic loop run unchanged when an operator has joined a
+ * SolverNet via the manifest-keyed flow but has no legacy solverNets[name] entry.
+ */
+function synthesizeFromJoined(
+  joinedSolverNets: Record<string, JoinedSolverNetConfig>,
+  solverType = 'prediction.v1',
+): SolverNetConfig {
+  const first = Object.values(joinedSolverNets)[0];
+  const roles = rolesFromJoinedConfig(first);
+  return {
+    enabled: true,
+    solverType,
+    roles: roles.length > 0 ? roles : ['solving'],
+    harness: first.harness ?? '',
+    model: first.model,
+    plugins: (first.plugins ?? []) as SolverNetConfig['plugins'],
+    taskGenerator: { enabled: false },
+  };
+}
+
 export async function buildPredictionOperatorStatus({
   config,
   configPath,
@@ -223,8 +247,12 @@ export async function buildPredictionOperatorStatus({
   loadSolverNets = defaultLoadSolverNets,
   daemonRunning = false,
 }: BuildPredictionOperatorStatusOptions): Promise<PredictionOperatorStatus> {
-  const net = config.solverNets[name];
-  if (!net) return missingSolverNetStatus(configPath, name, daemonRunning);
+  const legacy = config.solverNets[name];
+  const hasJoined = Object.keys(config.joinedSolverNets ?? {}).length > 0;
+  if (!legacy && !hasJoined) {
+    return missingSolverNetStatus(configPath, name, daemonRunning);
+  }
+  const net: SolverNetConfig = legacy ?? synthesizeFromJoined(config.joinedSolverNets!, 'prediction.v1');
 
   const diagnostics: PredictionOperatorDiagnostic[] = [];
   let loadedNet: LoadedSolverNet | undefined;

--- a/client/src/solver-nets/registry.ts
+++ b/client/src/solver-nets/registry.ts
@@ -66,7 +66,7 @@ function rolesFromConfig(net: SolverNetConfig): SolverNetOperatorRole[] {
   return ['solving'];
 }
 
-function rolesFromJoinedConfig(net: JoinedSolverNetConfig): SolverNetOperatorRole[] {
+export function rolesFromJoinedConfig(net: JoinedSolverNetConfig): SolverNetOperatorRole[] {
   const roles: SolverNetOperatorRole[] = [];
   for (const role of net.roles) {
     if (role === 'solver') roles.push('solving');

--- a/client/test/api/fleet-build.test.ts
+++ b/client/test/api/fleet-build.test.ts
@@ -84,4 +84,30 @@ describe('assembleFleetV1', () => {
     const out = assembleFleetV1(raw);
     expect(out.network).toBe('mainnet');
   });
+
+  it('populates staking.evicted from evictedByServiceIndex (jinn-mono-hjex.3)', () => {
+    // The display index for service at index 1 (via displayFleetServiceIndex) is 0
+    // (fleet-display-index uses 0-based display index from the services array position).
+    const raw = makeRaw({ evictedByServiceIndex: { 0: true } });
+    const out = assembleFleetV1(raw);
+    expect(out.services[0]!.staking.evicted).toBe(true);
+  });
+
+  it('defaults staking.evicted to false when evictedByServiceIndex absent (jinn-mono-hjex.3)', () => {
+    const raw = makeRaw();
+    const out = assembleFleetV1(raw);
+    expect(out.services[0]!.staking.evicted).toBe(false);
+  });
+
+  it('populates staking.inactivitySeconds from inactivityByServiceIndex (jinn-mono-hjex.3)', () => {
+    const raw = makeRaw({ inactivityByServiceIndex: { 0: 7200 } });
+    const out = assembleFleetV1(raw);
+    expect(out.services[0]!.staking.inactivitySeconds).toBe(7200);
+  });
+
+  it('defaults staking.inactivitySeconds to null when inactivityByServiceIndex absent (jinn-mono-hjex.3)', () => {
+    const raw = makeRaw();
+    const out = assembleFleetV1(raw);
+    expect(out.services[0]!.staking.inactivitySeconds).toBeNull();
+  });
 });

--- a/client/test/api/gather-status.test.ts
+++ b/client/test/api/gather-status.test.ts
@@ -310,6 +310,61 @@ describe('gatherStatusForApi', () => {
     });
   });
 
+  it('derives SolverNet name from joinedSolverNets when solverNets is empty (jinn-mono-hjex.2)', async () => {
+    mockStatusRpc();
+    const buildPredictionOperatorStatus = vi.fn(async (): Promise<PredictionOperatorStatus> => ({
+      kind: 'prediction.v1.operatorStatus',
+      ok: true,
+      configPath: '/tmp/config.json',
+      solverNet: {
+        name: 'SWE-rebench v2',
+        enabled: true,
+        solverType: 'prediction.v1',
+        roles: ['solving'],
+        harness: 'claude-code',
+        taskGeneratorEnabled: false,
+      },
+      runtimePlugins: [],
+      diagnostics: [],
+      nextAction: { description: 'Run', cli: 'jinn run' },
+    }));
+    vi.doMock('../../src/solver-nets/prediction-operator-ux.js', () => ({
+      buildPredictionOperatorStatus,
+    }));
+    const { gatherStatusForApi } = await import('../../src/api/gather-status.js');
+    const config = {
+      solverNets: {},
+      joinedSolverNets: {
+        'bafkreichdzxtjav3rh5boyybgx6wolh7boqedxix4vvw44slfppwppshpi': {
+          manifestCid: 'bafkreichdzxtjav3rh5boyybgx6wolh7boqedxix4vvw44slfppwppshpi',
+          name: 'SWE-rebench v2',
+          roles: ['solver'],
+          harness: 'claude-code',
+          plugins: [],
+          disabledDefaultPlugins: [],
+        },
+      },
+    } as unknown as JinnConfig;
+
+    await withTempStore(async (store) => {
+      await gatherStatusForApi(store, {
+        earningDir: mkdtempSync(join(tmpdir(), 'jinn-status-test-')),
+        rpcUrl: 'http://127.0.0.1:0',
+        network: 'testnet' as const,
+        pollIntervalMs: 5000,
+        rewardClaimIntervalMs: 0,
+        config,
+        configPath: '/tmp/config.json',
+      });
+    });
+
+    // gather-status must have called buildPredictionOperatorStatus with the name
+    // from the joined entry ('SWE-rebench v2'), not the hard-coded 'prediction'.
+    expect(buildPredictionOperatorStatus).toHaveBeenCalledTimes(1);
+    const [callArgs] = buildPredictionOperatorStatus.mock.calls;
+    expect((callArgs as [{ name?: string }])[0].name).toBe('SWE-rebench v2');
+  });
+
   it("omits 'launching' from operator.solverNet.roles on the unavailable path", async () => {
     mockStatusRpc();
     const buildPredictionOperatorStatus = vi.fn(async () => {

--- a/client/test/api/setup-retry-endpoint.test.ts
+++ b/client/test/api/setup-retry-endpoint.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for POST /v1/setup/bootstrap/retry — jinn-mono-hjex.6
+ *
+ * The endpoint re-enters the bootstrap state machine in-process so the
+ * operator doesn't need to restart the daemon after a funding shortfall clears.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { Hono } from 'hono';
+import { addSetupRetryEndpoint } from '../../src/api/setup-retry-endpoint.js';
+
+describe('POST /v1/setup/bootstrap/retry', () => {
+  it('calls retryBootstrap and returns ok:true on success', async () => {
+    const retryBootstrap = vi.fn().mockResolvedValue(undefined);
+    const app = new Hono();
+    addSetupRetryEndpoint(app, { retryBootstrap });
+
+    const res = await app.request('/v1/setup/bootstrap/retry', { method: 'POST' });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ok: boolean };
+    expect(body.ok).toBe(true);
+    expect(retryBootstrap).toHaveBeenCalledOnce();
+  });
+
+  it('returns ok:false with 500 when retryBootstrap throws', async () => {
+    const retryBootstrap = vi.fn().mockRejectedValue(new Error('bootstrap exploded'));
+    const app = new Hono();
+    addSetupRetryEndpoint(app, { retryBootstrap });
+
+    const res = await app.request('/v1/setup/bootstrap/retry', { method: 'POST' });
+    expect(res.status).toBe(500);
+    const body = await res.json() as { ok: boolean; error?: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/bootstrap exploded/);
+  });
+
+  it('is idempotent — concurrent calls do not fork two state machines', async () => {
+    let inFlight = 0;
+    let maxConcurrent = 0;
+
+    const retryBootstrap = vi.fn().mockImplementation(async () => {
+      inFlight++;
+      maxConcurrent = Math.max(maxConcurrent, inFlight);
+      await new Promise((r) => setTimeout(r, 20));
+      inFlight--;
+    });
+
+    const app = new Hono();
+    addSetupRetryEndpoint(app, { retryBootstrap });
+
+    // Fire two requests concurrently
+    const [r1, r2] = await Promise.all([
+      app.request('/v1/setup/bootstrap/retry', { method: 'POST' }),
+      app.request('/v1/setup/bootstrap/retry', { method: 'POST' }),
+    ]);
+
+    // Both must succeed
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+
+    // retryBootstrap must never have been executing concurrently
+    expect(maxConcurrent).toBe(1);
+  });
+
+  it('releases the idempotency lock after a failure so subsequent retries can proceed', async () => {
+    let callCount = 0;
+    const retryBootstrap = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) throw new Error('transient failure');
+      // second call succeeds
+    });
+
+    const app = new Hono();
+    addSetupRetryEndpoint(app, { retryBootstrap });
+
+    // First call: fails
+    const r1 = await app.request('/v1/setup/bootstrap/retry', { method: 'POST' });
+    expect(r1.status).toBe(500);
+
+    // Second call: should proceed (lock must have been released)
+    const r2 = await app.request('/v1/setup/bootstrap/retry', { method: 'POST' });
+    expect(r2.status).toBe(200);
+    expect(retryBootstrap).toHaveBeenCalledTimes(2);
+  });
+});

--- a/client/test/cli/commands/solver-nets.test.ts
+++ b/client/test/cli/commands/solver-nets.test.ts
@@ -680,4 +680,87 @@ describe('solver-nets command', () => {
       expect(raw).toContain('prediction.v1');
     });
   });
+
+  describe('solver-nets list — joinedSolverNets enumeration (jinn-mono-hjex.2)', () => {
+    it('enumerates legacy solverNets entries with source: legacy', async () => {
+      const configPath = tempConfig(predictionConfig());
+      const result = await runSolverNets(['list', '--config', configPath]);
+
+      expect(result.exits).toEqual([]);
+      const nets = result.envelope['solverNets'] as Array<Record<string, unknown>>;
+      expect(nets.length).toBeGreaterThan(0);
+      const legacyEntry = nets.find((n) => n['name'] === 'prediction');
+      expect(legacyEntry).toBeDefined();
+      expect(legacyEntry?.['source']).toBe('legacy');
+    });
+
+    it('enumerates joinedSolverNets entries with source: joined', async () => {
+      const configPath = tempConfig({
+        solverNets: {},
+        joinedSolverNets: {
+          'bafkreichdzxtjav3rh5boyybgx6wolh7boqedxix4vvw44slfppwppshpi': {
+            manifestCid: 'bafkreichdzxtjav3rh5boyybgx6wolh7boqedxix4vvw44slfppwppshpi',
+            name: 'SWE-rebench v2',
+            roles: ['solver', 'evaluator'],
+            harness: 'claude-code',
+            plugins: [],
+          },
+        },
+      });
+      const result = await runSolverNets(['list', '--config', configPath]);
+
+      expect(result.exits).toEqual([]);
+      const nets = result.envelope['solverNets'] as Array<Record<string, unknown>>;
+      expect(nets.length).toBe(1);
+      expect(nets[0]?.['source']).toBe('joined');
+      expect(nets[0]?.['name']).toBe('SWE-rebench v2');
+      expect(nets[0]?.['manifestCid']).toBe('bafkreichdzxtjav3rh5boyybgx6wolh7boqedxix4vvw44slfppwppshpi');
+    });
+
+    it('returns both legacy and joined entries when both are present', async () => {
+      const configPath = tempConfig({
+        ...predictionConfig(),
+        joinedSolverNets: {
+          'bafkreichdzxtjav3rh5boyybgx6wolh7boqedxix4vvw44slfppwppshpi': {
+            manifestCid: 'bafkreichdzxtjav3rh5boyybgx6wolh7boqedxix4vvw44slfppwppshpi',
+            name: 'SWE-rebench v2',
+            roles: ['solver'],
+            harness: 'claude-code',
+            plugins: [],
+          },
+        },
+      });
+      const result = await runSolverNets(['list', '--config', configPath]);
+
+      expect(result.exits).toEqual([]);
+      const nets = result.envelope['solverNets'] as Array<Record<string, unknown>>;
+      expect(nets.length).toBe(2);
+      const sources = nets.map((n) => n['source']);
+      expect(sources).toContain('legacy');
+      expect(sources).toContain('joined');
+    });
+
+    it('solver-nets list --human includes joined SolverNet name in output', async () => {
+      const configPath = tempConfig({
+        solverNets: {},
+        joinedSolverNets: {
+          'bafkreichdzxtjav3rh5boyybgx6wolh7boqedxix4vvw44slfppwppshpi': {
+            manifestCid: 'bafkreichdzxtjav3rh5boyybgx6wolh7boqedxix4vvw44slfppwppshpi',
+            name: 'SWE-rebench v2',
+            roles: ['solver'],
+            harness: 'claude-code',
+            plugins: [],
+          },
+        },
+      });
+      const made = makeCommandCtx({ argv: ['list', '--human', '--config', configPath] });
+      await solverNetsCommand.run(made.ctx);
+      const raw = made.writes.join('');
+
+      expect(made.exits).toEqual([]);
+      expect(raw.trim().startsWith('{')).toBe(false);
+      expect(raw).toContain('SWE-rebench v2');
+      expect(raw).toContain('joined');
+    });
+  });
 });

--- a/client/test/daemon/eviction-loop.test.ts
+++ b/client/test/daemon/eviction-loop.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for the EvictionLoop daemon loop.
+ *
+ * jinn-mono-hjex.3 — surface service eviction + in-process auto-restake.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { EvictionLoop } from '../../src/daemon/eviction-loop.js';
+
+// Valid checksummed Ethereum addresses
+const STAKING_ADDR = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
+
+function makeService(overrides: { serviceId?: number; stakingAddress?: string; step?: string } = {}) {
+  return {
+    index: 1,
+    step: overrides.step ?? 'complete',
+    service_id: overrides.serviceId ?? 42,
+    staking_address: overrides.stakingAddress ?? STAKING_ADDR,
+    agent_address: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+    safe_address: '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
+  };
+}
+
+function mockStore(services: ReturnType<typeof makeService>[]) {
+  return {
+    load: vi.fn(async () => ({
+      master_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+      services,
+      staking_mode: 'standard',
+    })),
+  } as any;
+}
+
+describe('EvictionLoop', () => {
+  it('detects state=2 and calls recoverEvictedService (jinn-mono-hjex.3)', async () => {
+    const readContract = vi.fn().mockResolvedValue(2n); // 2 = Evicted
+    const recoverEvicted = vi.fn().mockResolvedValue(undefined);
+    const loop = new EvictionLoop({
+      intervalMs: 60_000,
+      store: mockStore([makeService()]),
+      chain: 'base-sepolia',
+      readContract,
+      recoverEvictedService: recoverEvicted,
+    });
+
+    await loop.runOnce();
+
+    expect(readContract).toHaveBeenCalledWith(
+      expect.objectContaining({ functionName: 'getStakingState', args: [42n] }),
+    );
+    expect(recoverEvicted).toHaveBeenCalledWith(
+      expect.objectContaining({ service_id: 42 }),
+    );
+  });
+
+  it('does not call recoverEvictedService when state=1 (Staked)', async () => {
+    const readContract = vi.fn().mockResolvedValue(1n); // 1 = Staked
+    const recoverEvicted = vi.fn();
+    const loop = new EvictionLoop({
+      intervalMs: 60_000,
+      store: mockStore([makeService()]),
+      chain: 'base-sepolia',
+      readContract,
+      recoverEvictedService: recoverEvicted,
+    });
+
+    await loop.runOnce();
+    expect(recoverEvicted).not.toHaveBeenCalled();
+  });
+
+  it('skips services without service_id', async () => {
+    const readContract = vi.fn().mockResolvedValue(2n);
+    const recoverEvicted = vi.fn();
+    const loop = new EvictionLoop({
+      intervalMs: 60_000,
+      store: mockStore([{ ...makeService(), service_id: null as any }]),
+      chain: 'base-sepolia',
+      readContract,
+      recoverEvictedService: recoverEvicted,
+    });
+
+    await loop.runOnce();
+    expect(readContract).not.toHaveBeenCalled();
+    expect(recoverEvicted).not.toHaveBeenCalled();
+  });
+
+  it('skips services without staking_address', async () => {
+    const readContract = vi.fn().mockResolvedValue(2n);
+    const recoverEvicted = vi.fn();
+    const loop = new EvictionLoop({
+      intervalMs: 60_000,
+      store: mockStore([{ ...makeService(), staking_address: null as any }]),
+      chain: 'base-sepolia',
+      readContract,
+      recoverEvictedService: recoverEvicted,
+    });
+
+    await loop.runOnce();
+    expect(readContract).not.toHaveBeenCalled();
+    expect(recoverEvicted).not.toHaveBeenCalled();
+  });
+
+  it('does not crash when readContract fails (non-fatal)', async () => {
+    const readContract = vi.fn().mockRejectedValue(new Error('RPC error'));
+    const recoverEvicted = vi.fn();
+    const loop = new EvictionLoop({
+      intervalMs: 60_000,
+      store: mockStore([makeService()]),
+      chain: 'base-sepolia',
+      readContract,
+      recoverEvictedService: recoverEvicted,
+    });
+
+    await expect(loop.runOnce()).resolves.toBeUndefined();
+    expect(recoverEvicted).not.toHaveBeenCalled();
+  });
+
+  it('exits immediately when intervalMs is 0', async () => {
+    const readContract = vi.fn().mockResolvedValue(1n);
+    const recoverEvicted = vi.fn();
+    const store = mockStore([makeService()]);
+    const loop = new EvictionLoop({
+      intervalMs: 0,
+      store,
+      chain: 'base-sepolia',
+      readContract,
+      recoverEvictedService: recoverEvicted,
+    });
+
+    await expect(loop.run()).resolves.toBeUndefined();
+    expect(store.load).not.toHaveBeenCalled();
+  });
+});

--- a/client/test/earning/bootstrap.test.ts
+++ b/client/test/earning/bootstrap.test.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import path from 'path';
 import { getAddress } from 'viem';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { FleetBootstrapper } from '../../src/earning/bootstrap.js';
+import { FleetBootstrapper, computeRequiredMasterEth } from '../../src/earning/bootstrap.js';
 import { FleetStateStore } from '../../src/earning/store.js';
 import {
   generateMnemonic,
@@ -1595,5 +1595,61 @@ describe('Fleet bootstrap', () => {
 
     // Guard did not fire — error must NOT contain agent_already_bound
     expect(result.message).not.toContain('agent_already_bound');
+  });
+});
+
+describe('computeRequiredMasterEth (jinn-mono-hjex.7)', () => {
+  const MIN_ETH = 5_000_000_000_000_000n; // 0.005 ETH
+
+  it('applies 2× cold-start multiplier when services array is empty (fresh fleet)', () => {
+    const required = computeRequiredMasterEth({
+      services: [],
+      minEoaGasEth: MIN_ETH,
+    });
+    expect(required).toBe(MIN_ETH * 2n);
+  });
+
+  it('applies 2× cold-start multiplier when services are migration-wiped (service_id === null) (jinn-mono-hjex.7)', () => {
+    const required = computeRequiredMasterEth({
+      services: [{ service_id: null, step: 'awaiting_stake' }],
+      minEoaGasEth: MIN_ETH,
+    });
+    expect(required).toBe(MIN_ETH * 2n);
+  });
+
+  it('uses 1× multiplier when at least one service has a persisted service_id', () => {
+    const required = computeRequiredMasterEth({
+      services: [{ service_id: 42, step: 'staked' }],
+      minEoaGasEth: MIN_ETH,
+    });
+    expect(required).toBe(MIN_ETH);
+  });
+
+  it('returns 0n when fleet is already complete (no pending setup migration)', () => {
+    const required = computeRequiredMasterEth({
+      services: [{ service_id: 42, step: 'complete' }],
+      minEoaGasEth: MIN_ETH,
+      targetServices: 1,
+      pendingSetupMigration: false,
+    });
+    expect(required).toBe(0n);
+  });
+
+  it('applies 2× multiplier to migration-wiped services regardless of step', () => {
+    // Migration-wiped: service_id is null but step advanced (race condition)
+    const required = computeRequiredMasterEth({
+      services: [{ service_id: null, step: 'staked' }],
+      minEoaGasEth: MIN_ETH,
+    });
+    expect(required).toBe(MIN_ETH * 2n);
+  });
+
+  it('respects custom standardMultiplier override', () => {
+    const required = computeRequiredMasterEth({
+      services: [],
+      minEoaGasEth: MIN_ETH,
+      standardMultiplier: 3n,
+    });
+    expect(required).toBe(MIN_ETH * 3n);
   });
 });

--- a/client/test/earning/bootstrap.test.ts
+++ b/client/test/earning/bootstrap.test.ts
@@ -1653,3 +1653,132 @@ describe('computeRequiredMasterEth (jinn-mono-hjex.7)', () => {
     expect(required).toBe(MIN_ETH * 3n);
   });
 });
+
+describe('structured error envelope (jinn-mono-hjex.6)', () => {
+  const dirs: string[] = [];
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it('returns errorCategory: insufficient_funds when bootstrap fails with an EVM insufficient-funds error', async () => {
+    const earningDir = await mkdtemp(path.join(os.tmpdir(), 'jinn-fleet-hjex6-'));
+    dirs.push(earningDir);
+
+    // Enough ETH to pass the funding gate, so we get into Phase 2 and hit the exception.
+    const sufficientBalance = 100_000_000_000_000_000n; // 0.1 ETH
+
+    const bootstrapper = new FleetBootstrapper({
+      earningDir,
+      chain: 'base',
+      rpcUrl: 'http://127.0.0.1:8545',
+      stakingMode: 'standard',
+    });
+
+    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(sufficientBalance);
+    // Simulate an EVM "insufficient funds for gas" revert during service creation.
+    vi.spyOn(bootstrapper as any, 'bootstrapService').mockRejectedValue(
+      new Error('insufficient funds for gas * price + value: have 0 want 1000000000000000'),
+    );
+
+    const result = await bootstrapper.bootstrap('test-password');
+
+    expect(result.ok).toBe(false);
+    expect(result.errorCategory).toBe('insufficient_funds');
+    // The funding gate must NOT be set — this is an exception, not an early-return.
+    expect(result.funding).toBeUndefined();
+  });
+
+  it('returns errorCategory: gas_too_low when bootstrap fails with an out-of-gas error', async () => {
+    const earningDir = await mkdtemp(path.join(os.tmpdir(), 'jinn-fleet-hjex6-oog-'));
+    dirs.push(earningDir);
+
+    const bootstrapper = new FleetBootstrapper({
+      earningDir,
+      chain: 'base',
+      rpcUrl: 'http://127.0.0.1:8545',
+      stakingMode: 'standard',
+    });
+
+    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(100_000_000_000_000_000n);
+    vi.spyOn(bootstrapper as any, 'bootstrapService').mockRejectedValue(
+      new Error('execution reverted: out of gas while creating contract'),
+    );
+
+    const result = await bootstrapper.bootstrap('test-password');
+
+    expect(result.ok).toBe(false);
+    expect(result.errorCategory).toBe('gas_too_low');
+  });
+
+  it('does not set errorCategory for unclassified errors', async () => {
+    const earningDir = await mkdtemp(path.join(os.tmpdir(), 'jinn-fleet-hjex6-unclassified-'));
+    dirs.push(earningDir);
+
+    const bootstrapper = new FleetBootstrapper({
+      earningDir,
+      chain: 'base',
+      rpcUrl: 'http://127.0.0.1:8545',
+      stakingMode: 'standard',
+    });
+
+    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(100_000_000_000_000_000n);
+    vi.spyOn(bootstrapper as any, 'bootstrapService').mockRejectedValue(
+      new Error('some completely unrecognized blockchain error'),
+    );
+
+    const result = await bootstrapper.bootstrap('test-password');
+
+    expect(result.ok).toBe(false);
+    expect(result.errorCategory).toBeUndefined();
+  });
+
+  it('surfaces txHash in result when a contract-revert path embeds it in the error message', async () => {
+    const earningDir = await mkdtemp(path.join(os.tmpdir(), 'jinn-fleet-hjex6-txhash-'));
+    dirs.push(earningDir);
+
+    const expectedTxHash = '0x' + 'ab'.repeat(32);
+
+    const bootstrapper = new FleetBootstrapper({
+      earningDir,
+      chain: 'base',
+      rpcUrl: 'http://127.0.0.1:8545',
+      stakingMode: 'standard',
+    });
+
+    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(100_000_000_000_000_000n);
+    // Simulate an on-chain revert that embeds the tx hash in the message,
+    // matching the pattern thrown by stepStakeService / stepSelfBond* paths.
+    vi.spyOn(bootstrapper as any, 'bootstrapService').mockRejectedValue(
+      new Error(`stOLAS stake() tx failed for service 1: ${expectedTxHash}`),
+    );
+
+    const result = await bootstrapper.bootstrap('test-password');
+
+    expect(result.ok).toBe(false);
+    expect(result.txHash).toBe(expectedTxHash);
+  });
+
+  it('does not set txHash when the error message has no embedded tx hash', async () => {
+    const earningDir = await mkdtemp(path.join(os.tmpdir(), 'jinn-fleet-hjex6-notxhash-'));
+    dirs.push(earningDir);
+
+    const bootstrapper = new FleetBootstrapper({
+      earningDir,
+      chain: 'base',
+      rpcUrl: 'http://127.0.0.1:8545',
+      stakingMode: 'standard',
+    });
+
+    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(100_000_000_000_000_000n);
+    vi.spyOn(bootstrapper as any, 'bootstrapService').mockRejectedValue(
+      new Error('RPC connection refused'),
+    );
+
+    const result = await bootstrapper.bootstrap('test-password');
+
+    expect(result.ok).toBe(false);
+    expect(result.txHash).toBeUndefined();
+  });
+});

--- a/client/test/earning/bootstrap.test.ts
+++ b/client/test/earning/bootstrap.test.ts
@@ -1501,8 +1501,11 @@ describe('Fleet bootstrap', () => {
       autoTestnetFaucet: false,
     });
 
-    // Master is funded
-    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(10_000_000_000_000_000n);
+    // Master is funded. Must be >= stage1MinMasterEth (0.020 ETH for N=1 on
+    // base-sepolia post-u34i one-shot-funding); otherwise ensureStage1 returns
+    // the funding-shortfall result before stepStolasStake's
+    // agent_already_bound guard can fire.
+    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(50_000_000_000_000_000n);
 
     // mapAgentInstances returns 47n — agent EOA is already bound on-chain (service 47 from the dogfood case)
     vi.spyOn((bootstrapper as any).publicClient, 'readContract').mockImplementation(
@@ -1521,6 +1524,16 @@ describe('Fleet bootstrap', () => {
       registryMultisig: null,
       safeDeployed: false,
     });
+
+    // ensureStage1 now does Safe-predict + Safe-deploy + identity-register
+    // before Phase 2 runs (post jinn-mono-u34i refactor). The test only
+    // exercises the agent_already_bound guard in stepStolasStake; bypass
+    // Stage 1 with a stub state that pretends fleet identity already exists.
+    vi.spyOn(bootstrapper as any, 'ensureStage1').mockImplementation(async () => ({
+      ok: true,
+      fleet_state: await (bootstrapper as any).store.load('base-sepolia'),
+      message: 'stage1 stubbed for hjex.1 regression',
+    }));
 
     const result = await bootstrapper.bootstrap('test-password');
 
@@ -1662,12 +1675,48 @@ describe('structured error envelope (jinn-mono-hjex.6)', () => {
     await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
   });
 
+  /**
+   * Helper: install mocks that satisfy ensureStage1 + the post-Stage-1
+   * `getBalance` re-check, so the test's `bootstrapService` mock is the
+   * first thing that can throw inside `ensureStage1And2`.
+   *
+   * After the u34i/wkbw rebase ensureStage1 calls getCode() + ensureStage1
+   * runs a real flow that the unit-level tests can't satisfy without a
+   * network. Stubbing ensureStage1 to a clean ok-result is the smallest
+   * fixture that keeps the post-rebase `category`/`txHash` assertions
+   * meaningful.
+   */
+  function stubEnsureStage1AndBalance(bootstrapper: FleetBootstrapper): void {
+    // Empty services so ensureStage1And2's "create new" loop calls
+    // bootstrapService for service 1 — that's the test's mock target.
+    const stubState = {
+      master_address: '0x000000000000000000000000000000000000dEaD',
+      fleet_stage: 'stage1' as const,
+      services: [] as any[],
+    };
+    vi.spyOn(bootstrapper as any, 'ensureStage1').mockResolvedValue({
+      ok: true,
+      fleet_state: stubState,
+      message: 'stage1 stubbed',
+    });
+    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(
+      100_000_000_000_000_000n,
+    );
+    // Phase 2 calls loadExistingMnemonic → decryptMnemonic. Bypass with a
+    // canonical test mnemonic; the test never spends from it.
+    vi.spyOn(bootstrapper as any, 'loadExistingMnemonic').mockResolvedValue(
+      'test test test test test test test test test test test junk',
+    );
+    // Skip the reconcile branch; it would otherwise read chain state.
+    vi.spyOn(bootstrapper as any, 'reconcileFleetWithChain').mockImplementation(
+      async (state: any) => state,
+    );
+    vi.spyOn((bootstrapper as any).store, 'patchFleet').mockImplementation(async () => stubState);
+  }
+
   it('returns errorCategory: insufficient_funds when bootstrap fails with an EVM insufficient-funds error', async () => {
     const earningDir = await mkdtemp(path.join(os.tmpdir(), 'jinn-fleet-hjex6-'));
     dirs.push(earningDir);
-
-    // Enough ETH to pass the funding gate, so we get into Phase 2 and hit the exception.
-    const sufficientBalance = 100_000_000_000_000_000n; // 0.1 ETH
 
     const bootstrapper = new FleetBootstrapper({
       earningDir,
@@ -1675,8 +1724,8 @@ describe('structured error envelope (jinn-mono-hjex.6)', () => {
       rpcUrl: 'http://127.0.0.1:8545',
       stakingMode: 'standard',
     });
+    stubEnsureStage1AndBalance(bootstrapper);
 
-    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(sufficientBalance);
     // Simulate an EVM "insufficient funds for gas" revert during service creation.
     vi.spyOn(bootstrapper as any, 'bootstrapService').mockRejectedValue(
       new Error('insufficient funds for gas * price + value: have 0 want 1000000000000000'),
@@ -1700,8 +1749,8 @@ describe('structured error envelope (jinn-mono-hjex.6)', () => {
       rpcUrl: 'http://127.0.0.1:8545',
       stakingMode: 'standard',
     });
+    stubEnsureStage1AndBalance(bootstrapper);
 
-    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(100_000_000_000_000_000n);
     vi.spyOn(bootstrapper as any, 'bootstrapService').mockRejectedValue(
       new Error('execution reverted: out of gas while creating contract'),
     );
@@ -1722,8 +1771,8 @@ describe('structured error envelope (jinn-mono-hjex.6)', () => {
       rpcUrl: 'http://127.0.0.1:8545',
       stakingMode: 'standard',
     });
+    stubEnsureStage1AndBalance(bootstrapper);
 
-    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(100_000_000_000_000_000n);
     vi.spyOn(bootstrapper as any, 'bootstrapService').mockRejectedValue(
       new Error('some completely unrecognized blockchain error'),
     );
@@ -1746,8 +1795,8 @@ describe('structured error envelope (jinn-mono-hjex.6)', () => {
       rpcUrl: 'http://127.0.0.1:8545',
       stakingMode: 'standard',
     });
+    stubEnsureStage1AndBalance(bootstrapper);
 
-    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(100_000_000_000_000_000n);
     // Simulate an on-chain revert that embeds the tx hash in the message,
     // matching the pattern thrown by stepStakeService / stepSelfBond* paths.
     vi.spyOn(bootstrapper as any, 'bootstrapService').mockRejectedValue(
@@ -1770,8 +1819,8 @@ describe('structured error envelope (jinn-mono-hjex.6)', () => {
       rpcUrl: 'http://127.0.0.1:8545',
       stakingMode: 'standard',
     });
+    stubEnsureStage1AndBalance(bootstrapper);
 
-    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(100_000_000_000_000_000n);
     vi.spyOn(bootstrapper as any, 'bootstrapService').mockRejectedValue(
       new Error('RPC connection refused'),
     );

--- a/client/test/earning/bootstrap.test.ts
+++ b/client/test/earning/bootstrap.test.ts
@@ -1454,4 +1454,146 @@ describe('Fleet bootstrap', () => {
     const svc = next.services.find((s: any) => s.index === 1);
     expect(svc.safe_bound_to_agent).toBe(true);
   });
+
+  it('refuses to stake when agent_address is already registered on-chain (jinn-mono-hjex.1)', async () => {
+    // Simulates the scenario after a failed migration: service_id was cleared
+    // but agent_address kept. mapAgentInstances returns non-zero on-chain,
+    // so calling stake() would revert with AgentInstanceRegistered (0x631695bd).
+    // stepStolasStake must detect this and fail fast with a typed error.
+    const earningDir = await mkdtemp(path.join(os.tmpdir(), 'jinn-fleet-'));
+    dirs.push(earningDir);
+
+    const mnemonic = generateMnemonic();
+    const encrypted = await encryptMnemonic(mnemonic, 'test-password');
+    const store = new FleetStateStore(earningDir);
+    await store.saveMnemonicKeystore(encrypted);
+
+    const masterAddr = deriveMasterAddress(mnemonic);
+    const agentAddr = deriveAgentAddress(mnemonic, 1);
+    // State after a failed migration: service_id null but agent_address present
+    await store.save({
+      ...createDefaultFleetState('base-sepolia'),
+      master_address: masterAddr,
+      services: [
+        {
+          index: 1,
+          agent_address: agentAddr,
+          safe_address: null,
+          service_id: null,
+          mech_address: null,
+          staking_address: null,
+          step: 'awaiting_stake',
+          error: null,
+          agent_id: null,
+          agent_uri: null,
+          identity_registry_address: null,
+          agent_registered_tx: null,
+          safe_bound_to_agent: false,
+        },
+      ],
+    });
+
+    const bootstrapper = new FleetBootstrapper({
+      earningDir,
+      chain: 'base-sepolia',
+      rpcUrl: 'http://127.0.0.1:8545',
+      stakingMode: 'standard',
+      autoTestnetFaucet: false,
+    });
+
+    // Master is funded
+    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(10_000_000_000_000_000n);
+
+    // mapAgentInstances returns 47n — agent EOA is already bound on-chain (service 47 from the dogfood case)
+    vi.spyOn((bootstrapper as any).publicClient, 'readContract').mockImplementation(
+      async ({ functionName }: { functionName: string }) => {
+        if (functionName === 'mapAgentInstances') return 47n;
+        // Other readContract calls (e.g., staking state checks) return safe defaults
+        return 0n;
+      },
+    );
+
+    // reconcileFleetWithChain uses gatherChainSignals — stub it so we get to stepStolasStake
+    vi.spyOn(bootstrapper as any, 'gatherChainSignals').mockResolvedValue({
+      stakingState: null,
+      stakingMultisig: null,
+      registryState: null,
+      registryMultisig: null,
+      safeDeployed: false,
+    });
+
+    const result = await bootstrapper.bootstrap('test-password');
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('agent_already_bound');
+    expect(result.message).toContain(agentAddr);
+  });
+
+  it('does NOT trip the agent_already_bound guard when mapAgentInstances returns 0n (unregistered)', async () => {
+    // Simulates a clean state after migration: service_id null, agent_address present,
+    // but the agent EOA is NOT registered on-chain (mapAgentInstances returns 0n).
+    // stepStolasStake should proceed past the precondition without throwing.
+    const earningDir = await mkdtemp(path.join(os.tmpdir(), 'jinn-fleet-'));
+    dirs.push(earningDir);
+
+    const mnemonic = generateMnemonic();
+    const encrypted = await encryptMnemonic(mnemonic, 'test-password');
+    const store = new FleetStateStore(earningDir);
+    await store.saveMnemonicKeystore(encrypted);
+
+    const masterAddr = deriveMasterAddress(mnemonic);
+    const agentAddr = deriveAgentAddress(mnemonic, 1);
+    await store.save({
+      ...createDefaultFleetState('base-sepolia'),
+      master_address: masterAddr,
+      services: [
+        {
+          index: 1,
+          agent_address: agentAddr,
+          safe_address: null,
+          service_id: null,
+          mech_address: null,
+          staking_address: null,
+          step: 'awaiting_stake',
+          error: null,
+          agent_id: null,
+          agent_uri: null,
+          identity_registry_address: null,
+          agent_registered_tx: null,
+          safe_bound_to_agent: false,
+        },
+      ],
+    });
+
+    const bootstrapper = new FleetBootstrapper({
+      earningDir,
+      chain: 'base-sepolia',
+      rpcUrl: 'http://127.0.0.1:8545',
+      stakingMode: 'standard',
+      autoTestnetFaucet: false,
+    });
+
+    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(10_000_000_000_000_000n);
+
+    // mapAgentInstances returns 0n — agent EOA is NOT registered on-chain
+    vi.spyOn((bootstrapper as any).publicClient, 'readContract').mockImplementation(
+      async ({ functionName }: { functionName: string }) => {
+        if (functionName === 'mapAgentInstances') return 0n;
+        return 0n;
+      },
+    );
+
+    vi.spyOn(bootstrapper as any, 'gatherChainSignals').mockResolvedValue({
+      stakingState: null,
+      stakingMultisig: null,
+      registryState: null,
+      registryMultisig: null,
+      safeDeployed: false,
+    });
+
+    const result = await bootstrapper.bootstrap('test-password');
+
+    // Guard did not fire — error must NOT contain agent_already_bound
+    expect(result.message).not.toContain('agent_already_bound');
+  });
 });

--- a/client/test/earning/testnet-setup-migration.test.ts
+++ b/client/test/earning/testnet-setup-migration.test.ts
@@ -118,20 +118,62 @@ describe('automatic testnet setup migration', () => {
     expect(entry.state_reset_at).toBeTruthy();
   });
 
-  it('continues to the new setup when old setup retirement fails', async () => {
+  it('preserves local state when old setup retirement fails (jinn-mono-hjex.1)', async () => {
     const { earningDir, store, result, sendTransaction } = await runMigration({
       sendThrows: new Error('retire rejected'),
     });
     dirs.push(earningDir);
 
     expect(sendTransaction).toHaveBeenCalledTimes(1);
-    expect(result.state.services[0]!.step).toBe('awaiting_stake');
-    expect(result.state.services[0]!.agent_id).toBe('123');
 
+    // State must be preserved — wipe is guarded on retire success
+    const svc = result.state.services[0]!;
+    expect(svc.service_id).toBe(42);
+    expect(svc.safe_address).toBe('0x3333333333333333333333333333333333333333');
+    expect(svc.mech_address).toBe('0x4444444444444444444444444444444444444444');
+    expect(svc.staking_address).toBe(DEPRECATED_BASE_SEPOLIA_STAKING_PROXY);
+    expect(svc.step).toBe('complete');
+    expect(svc.agent_id).toBe('123');
+
+    // Archive records the failure
     const archive = await store.loadMigrationArchive();
     expect(archive.entries).toHaveLength(1);
     expect(archive.entries[0]!.retire_status).toBe('failed');
     expect(archive.entries[0]!.retire_error).toContain('retire rejected');
+
+    // Envelope is surfaced in the result
+    expect(result.retireFailedEnvelope).toBeDefined();
+    expect(result.retireFailedEnvelope!.kind).toBe('retire_failed');
+    expect(result.retireFailedEnvelope!.retire_error).toContain('retire rejected');
+  });
+
+  it('does not mutate local state when retire_status === "failed" (jinn-mono-hjex.1)', async () => {
+    const initial = legacyState();
+
+    // Run migration where retire throws with the specific InsufficientStake message
+    const { earningDir, store, result } = await runMigration({
+      state: initial,
+      sendThrows: new Error('distributor.unstakeAndWithdraw reverted with InsufficientStake'),
+    });
+    dirs.push(earningDir);
+
+    // All runtime fields preserved
+    const svc = result.state.services[0]!;
+    expect(svc.service_id).toBe(42);
+    expect(svc.safe_address).toBe('0x3333333333333333333333333333333333333333');
+    expect(svc.mech_address).toBe('0x4444444444444444444444444444444444444444');
+    expect(svc.staking_address).toBe(DEPRECATED_BASE_SEPOLIA_STAKING_PROXY);
+    expect(svc.step).toBe('complete');
+
+    // Envelope present with correct fields
+    expect(result.retireFailedEnvelope).toBeDefined();
+    expect(result.retireFailedEnvelope!.kind).toBe('retire_failed');
+    expect(result.retireFailedEnvelope!.retire_error).toContain('InsufficientStake');
+
+    // Archive records the failure, state_reset_at is null
+    const archive = await store.loadMigrationArchive();
+    expect(archive.entries[0]!.retire_status).toBe('failed');
+    expect(archive.entries[0]!.state_reset_at).toBeNull();
   });
 
   it('records the retirement tx hash when receipt waiting fails after broadcast', async () => {

--- a/client/test/operator-errors.test.ts
+++ b/client/test/operator-errors.test.ts
@@ -27,6 +27,8 @@ describe('formatBootstrapOperatorMessage', () => {
     expect(r.summary).toMatch(/ETH|eth/i);
     expect(r.hint).toBeDefined();
     expect(r.rawMessage).toBe('insufficient funds for gas * price + value');
+    // jinn-mono-hjex.6: category must be set so SPA can render structured display.
+    expect(r.category).toBe('insufficient_funds');
   });
 
   it('maps out-of-gas as a gas-supply problem, not a funding problem (jinn-mono-jz9f)', () => {
@@ -39,6 +41,8 @@ describe('formatBootstrapOperatorMessage', () => {
     expect(r.summary.toLowerCase()).not.toContain('not enough eth');
     expect(r.summary.toLowerCase()).not.toContain('paying account');
     expect(r.hint).toBeDefined();
+    // jinn-mono-hjex.6: category must be gas_too_low, not insufficient_funds.
+    expect(r.category).toBe('gas_too_low');
   });
 
   it('maps `gas required exceeds allowance (0)` as insufficient funds, not OOG (jinn-mono-u34i)', () => {

--- a/client/test/operator-errors.test.ts
+++ b/client/test/operator-errors.test.ts
@@ -45,7 +45,7 @@ describe('formatBootstrapOperatorMessage', () => {
     expect(r.category).toBe('gas_too_low');
   });
 
-  it('maps `gas required exceeds allowance (0)` as insufficient funds, not OOG (jinn-mono-u34i)', () => {
+  it('maps `gas required exceeds allowance (0)` as insufficient funds, not OOG (jinn-mono-u34i / hjex.6 review)', () => {
     const r = formatBootstrapOperatorMessage(
       new Error('Execution reverted with reason: gas required exceeds allowance (0).'),
     );
@@ -55,6 +55,10 @@ describe('formatBootstrapOperatorMessage', () => {
     expect(r.summary.toLowerCase()).not.toContain('ran out of gas');
     expect(r.hint).toBeDefined();
     expect(r.hint!.toLowerCase()).toContain('send eth');
+    // jinn-mono-hjex.6 review: this branch must classify as insufficient_funds
+    // (zero spendable balance) so the SPA renders the funding-shortfall UI,
+    // not the gas-retry UI.
+    expect(r.category).toBe('insufficient_funds');
   });
 
   it('keeps `gas required exceeds allowance (50000)` as OOG (true gas-limit shortfall)', () => {

--- a/client/test/setup/halt-mode.test.ts
+++ b/client/test/setup/halt-mode.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Tests for the halt-and-resume gate (jinn-mono-hjex.6).
+ *
+ * `keepSetupUiOnBootstrapError()` is the predicate that decides whether
+ * `failBootstrap()` in main.ts throws `SetupBootstrapHalted` (entering the
+ * retry loop) vs calls `emitEnvelope()` (which exits). Headless modes
+ * (JINN_NO_UI=1 / JINN_NO_DAEMON=1) MUST exit; interactive mode MUST halt
+ * so the SPA can offer Retry.
+ *
+ * Also documents the inflight-promise coalescing pattern referenced by
+ * fix #4 in PR #243 review (the endpoint-level test for coalescing lives
+ * in client/test/api/setup-retry-endpoint.test.ts).
+ */
+import { describe, it, expect } from 'vitest';
+import { keepSetupUiOnBootstrapError } from '../../src/setup/halt-mode.js';
+
+describe('keepSetupUiOnBootstrapError', () => {
+  it('returns true for an interactive env (neither flag set)', () => {
+    expect(keepSetupUiOnBootstrapError({})).toBe(true);
+  });
+
+  it('returns false when JINN_NO_UI=1 (operator runs headless)', () => {
+    expect(keepSetupUiOnBootstrapError({ JINN_NO_UI: '1' })).toBe(false);
+  });
+
+  it('returns false when JINN_NO_DAEMON=1 (CI / agent-driven one-shot)', () => {
+    expect(keepSetupUiOnBootstrapError({ JINN_NO_DAEMON: '1' })).toBe(false);
+  });
+
+  it('returns false when both flags are set', () => {
+    expect(
+      keepSetupUiOnBootstrapError({ JINN_NO_UI: '1', JINN_NO_DAEMON: '1' }),
+    ).toBe(false);
+  });
+
+  it('treats values other than exactly "1" as interactive (matches main.ts strict check)', () => {
+    expect(keepSetupUiOnBootstrapError({ JINN_NO_UI: 'true' })).toBe(true);
+    expect(keepSetupUiOnBootstrapError({ JINN_NO_UI: '0' })).toBe(true);
+    expect(keepSetupUiOnBootstrapError({ JINN_NO_DAEMON: 'yes' })).toBe(true);
+  });
+
+  it('defaults to reading process.env when no arg is supplied', () => {
+    // Smoke test — the no-arg overload exists and returns a boolean.
+    expect(typeof keepSetupUiOnBootstrapError()).toBe('boolean');
+  });
+});

--- a/client/test/solver-nets/prediction-operator-ux.test.ts
+++ b/client/test/solver-nets/prediction-operator-ux.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { buildPredictionOperatorStatus } from '../../src/solver-nets/prediction-operator-ux.js';
+import type { JinnConfig } from '../../src/config.js';
+
+// Minimal stub deps: no harnesses needed for the missing-solvernet path.
+const minimalDeps = {
+  loadSolverNets: async () => ({ get: () => undefined }),
+  loadExternalImpl: async () => ({ kind: 'error' as const, reason: 'not configured' }),
+  buildHarnesses: () => [] as never[],
+};
+
+/** A minimal JinnConfig-shaped stub that satisfies the diagnostic loop. */
+function minimalConfig(overrides: Partial<JinnConfig> = {}): JinnConfig {
+  return {
+    solverNets: {},
+    joinedSolverNets: undefined,
+    engine: {
+      workingDirRoot: '/tmp',
+      implStateDirRoot: '/tmp',
+    },
+    harnesses: undefined,
+    trustedImplSigners: [],
+    ...overrides,
+  } as unknown as JinnConfig;
+}
+
+describe('buildPredictionOperatorStatus — joinedSolverNets awareness (jinn-mono-hjex.2)', () => {
+  it('emits prediction_solvernet_missing when both solverNets and joinedSolverNets are empty', async () => {
+    const status = await buildPredictionOperatorStatus({
+      config: minimalConfig({ solverNets: {}, joinedSolverNets: undefined }),
+      configPath: '/tmp/config.json',
+      daemonRunning: true,
+      ...minimalDeps,
+    });
+
+    const codes = status.diagnostics.map((d) => d.code);
+    expect(codes).toContain('prediction_solvernet_missing');
+  });
+
+  it('does not emit prediction_solvernet_missing when joinedSolverNets has an entry (jinn-mono-hjex.2)', async () => {
+    const status = await buildPredictionOperatorStatus({
+      config: minimalConfig({
+        solverNets: {},
+        joinedSolverNets: {
+          'bafkreichdzxtjav3rh5boyybgx6wolh7boqedxix4vvw44slfppwppshpi': {
+            manifestCid: 'bafkreichdzxtjav3rh5boyybgx6wolh7boqedxix4vvw44slfppwppshpi',
+            name: 'SWE-rebench v2',
+            roles: ['solver', 'evaluator'],
+            harness: 'claude-code',
+            plugins: [],
+          },
+        },
+      }),
+      configPath: '/tmp/config.json',
+      daemonRunning: true,
+      ...minimalDeps,
+    });
+
+    const codes = status.diagnostics.map((d) => d.code);
+    expect(codes).not.toContain('prediction_solvernet_missing');
+  });
+
+  it('still runs harness diagnostics against a synthesized net from joinedSolverNets', async () => {
+    const status = await buildPredictionOperatorStatus({
+      config: minimalConfig({
+        solverNets: {},
+        joinedSolverNets: {
+          'bafkreichdzxtjav3rh5boyybgx6wolh7boqedxix4vvw44slfppwppshpi': {
+            manifestCid: 'bafkreichdzxtjav3rh5boyybgx6wolh7boqedxix4vvw44slfppwppshpi',
+            name: 'SWE-rebench v2',
+            roles: ['solver'],
+            harness: 'claude-code',
+            plugins: [],
+          },
+        },
+      }),
+      configPath: '/tmp/config.json',
+      daemonRunning: true,
+      ...minimalDeps,
+    });
+
+    // The net is synthesized as enabled — the diagnostic loop continues past the
+    // missing-solvernet guard. We won't see prediction_solvernet_missing.
+    const codes = status.diagnostics.map((d) => d.code);
+    expect(codes).not.toContain('prediction_solvernet_missing');
+    // With an empty harness list the synthesized net will hit prediction_harness_unknown
+    // (or prediction_harness_missing if harness is not found) — either way
+    // the loop ran, which is what we're proving.
+    expect(status.kind).toBe('prediction.v1.operatorStatus');
+  });
+});


### PR DESCRIPTION
## Summary

- New `POST /v1/setup/bootstrap/retry` endpoint re-enters the bootstrap state machine in-process — no daemon restart required. Uses a halt-and-resume loop in `main()`: when `SetupBootstrapHalted` is caught, the process waits for a retry signal rather than returning.
- `BootstrapErrorCard` exposes a Retry button + a structured shortfall display (specific address + required/have/shortfall amounts) instead of the static prose "Send ETH to the master wallet, agent EOA, or Safe depending on which step failed."
- Setup-mode runtime polls master balance every 15s (`JINN_FUNDING_POLL_INTERVAL_MS`); when the shortfall clears, the bootstrap auto-resumes.
- `operator-errors.ts` returns a structured `category` field (`insufficient_funds`, `gas_too_low`, `nonce_conflict`) propagated through `bootstrap.ts → main.ts → error envelope details → SPA`.

## Why

Bead `jinn-mono-hjex.6` / GitHub #233 sub-issues 6 + 15: after a funding shortfall halted bootstrap, the dashboard sat for 37 minutes with no actionable affordance — no Retry button, no balance auto-detect, "Send ETH to the master wallet, agent EOA, or Safe depending on which step failed" as the operator-facing hint despite the daemon knowing exactly which address was short.

## Architecture notes

- `main()` now contains a retry loop around the `bootstrap()` call. On `SetupBootstrapHalted`, it installs a Promise resolver (`retryBootstrapResolve`) that the retry endpoint fires.
- The retry endpoint is idempotent: concurrent POSTs coalesce onto the same in-flight attempt (single `inFlight` Promise per `addSetupRetryEndpoint` closure) so two rapid clicks don't fork two state machines.
- Auto-resume poller only runs when `envelope.code === 'funding_required'` — non-funding halts do not poll.
- The lock releases on failure so a subsequent retry attempt can proceed.

## Stacked on

PR #242 (PR-5 / `fix/hjex7-funding-gate`).

## Test plan

- [x] Structured envelope: `result.errorCategory === 'insufficient_funds'` on EVM insufficient-funds exception
- [x] Structured envelope: `result.errorCategory === 'gas_too_low'` on out-of-gas exception
- [x] `errorCategory` absent for unclassified errors
- [x] `operator-errors.ts` returns `category: 'insufficient_funds'` for viem phrasing
- [x] `operator-errors.ts` returns `category: 'gas_too_low'` for OOG (not `insufficient_funds`)
- [x] Retry endpoint: `ok: true` on success
- [x] Retry endpoint: `ok: false` + 500 on retryBootstrap failure
- [x] Retry endpoint idempotency: concurrent calls coalesce (maxConcurrent === 1)
- [x] Lock releases after failure so subsequent retry proceeds
- [x] `yarn typecheck` + `yarn test` clean (3311 passed)

Refs: bd `jinn-mono-hjex.6`.