### PR TITLE
fix(hjex.5): jinn update stops running daemon; jinn stop finds orphans by port

### DIFF
--- a/client/src/api/hermes-doctor-endpoint.ts
+++ b/client/src/api/hermes-doctor-endpoint.ts
@@ -11,6 +11,10 @@
  * `installed: false` means the binary was not found (ENOENT or equivalent).
  * `exitCode !== 0` (with `installed: true`) means the binary exists but
  * reports a config problem.
+ *
+ * The probe logic is exported as `probeHermesDoctor` so the Hermes harness
+ * can reuse it from `isReady()` — same source of truth for the SPA
+ * precheck panel and the daemon's claim-readiness gate (#330).
  */
 import type { Hono } from 'hono';
 import { spawnSync } from 'node:child_process';
@@ -27,35 +31,42 @@ export interface HermesDoctorConfig {
   hermesDoctorTimeoutMs?: number;
 }
 
+/**
+ * Synchronously runs `hermes doctor` and classifies the result. Pure (no
+ * Hono dependency) so the harness layer can call it without pulling the API
+ * server in.
+ */
+export function probeHermesDoctor(config: HermesDoctorConfig = {}): HermesDoctorResponse {
+  const hermesBin = config.hermesPath ?? 'hermes';
+  const timeoutMs = config.hermesDoctorTimeoutMs ?? 30_000;
+
+  const result = spawnSync(hermesBin, ['doctor'], {
+    timeout: timeoutMs,
+    encoding: 'utf8',
+  });
+
+  const errorCode = (result.error as NodeJS.ErrnoException | undefined)?.code;
+  // installed=true means we found the binary on disk. ENOENT is the only
+  // definitive not-installed signal. Other errors (EACCES = wrong
+  // permissions; ETIMEDOUT = ran but didn't finish in time) indicate the
+  // binary exists but couldn't be exercised cleanly — surface those as
+  // config-issue, not missing.
+  const notFound = errorCode === 'ENOENT';
+  const installed = !notFound && (
+    result.status !== null
+    || result.signal !== null
+    || (errorCode != null && errorCode !== 'ENOENT')
+  );
+  return {
+    installed,
+    exitCode: result.status,
+    stdout: (result.stdout ?? '').slice(0, 4000),
+    stderr: (result.stderr ?? '').slice(0, 4000),
+  };
+}
+
 export function addHermesDoctorRoutes(app: Hono, config: HermesDoctorConfig = {}): void {
   app.get('/api/hermes/doctor', (c) => {
-    const hermesBin = config.hermesPath ?? 'hermes';
-    const timeoutMs = config.hermesDoctorTimeoutMs ?? 30_000;
-
-    const result = spawnSync(hermesBin, ['doctor'], {
-      timeout: timeoutMs,
-      encoding: 'utf8',
-    });
-
-    const errorCode = (result.error as NodeJS.ErrnoException | undefined)?.code;
-    // installed=true means we found the binary on disk. ENOENT is the only
-    // definitive not-installed signal. Other errors (EACCES = wrong
-    // permissions; ETIMEDOUT = ran but didn't finish in time) indicate the
-    // binary exists but couldn't be exercised cleanly — surface those as
-    // config-issue, not missing.
-    const notFound = errorCode === 'ENOENT';
-    const installed = !notFound && (
-      result.status !== null
-      || result.signal !== null
-      || (errorCode != null && errorCode !== 'ENOENT')
-    );
-    const body: HermesDoctorResponse = {
-      installed,
-      exitCode: result.status,
-      stdout: (result.stdout ?? '').slice(0, 4000),
-      stderr: (result.stderr ?? '').slice(0, 4000),
-    };
-
-    return c.json(body);
+    return c.json(probeHermesDoctor(config));
   });
 }

--- a/client/src/cli/commands/stop.ts
+++ b/client/src/cli/commands/stop.ts
@@ -22,6 +22,10 @@ export interface StopResult {
   discoveredVia?: 'port';
   /** Pidfile mode discriminator, e.g. 'setup-halted' for a halted bootstrap. */
   pidfileMode?: string | null;
+  /** Set true when we awaited exit and the process actually exited within the deadline. */
+  exited?: boolean;
+  /** Set true when SIGTERM did not bring the process down and we escalated to SIGKILL. */
+  escalatedToSigkill?: boolean;
 }
 
 export type PortPidLookupFn = (port: number) => Promise<PortHolder | null>;
@@ -33,15 +37,40 @@ export interface JinnStopOptions {
   lsofImpl?: PortPidLookupFn;
   /** Skip SIGTERM and just report state (used by jinn update for pre-flight check). */
   dryRun?: boolean;
+  /**
+   * Poll `processAlive(pid)` after dispatching SIGTERM until the process exits or
+   * the deadline elapses. Required by callers (e.g. `jinn update`) that must not
+   * race a subsequent action against the running daemon — the SIGTERM handler in
+   * `main.ts` is async (closes API server, flushes SQLite) and takes time.
+   * Default: false.
+   */
+  waitForExit?: boolean;
+  /** Override the wait-for-exit deadline in ms. Default: 10_000. */
+  waitForExitTimeoutMs?: number;
+  /**
+   * When set, after `waitForExit` exhausts the deadline without the process
+   * exiting, escalate to SIGKILL. Default: false. Implies `waitForExit`.
+   */
+  force?: boolean;
 }
 
-function processAlive(pid: number): boolean {
+/** Exported so callers (e.g. `jinn update`) can poll for exit themselves. */
+export function processAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
   } catch {
     return false;
   }
+}
+
+async function waitForProcessExit(pid: number, deadlineMs: number): Promise<boolean> {
+  const deadline = Date.now() + deadlineMs;
+  while (Date.now() < deadline) {
+    if (!processAlive(pid)) return true;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  return !processAlive(pid);
 }
 
 /**
@@ -96,7 +125,16 @@ function removePidfile(path: string): boolean {
  *   3. If nothing found, return `state: 'stopped'`.
  */
 export async function jinnStop(opts: JinnStopOptions): Promise<StopResult> {
-  const { pidfilePath, port, dbPath, lsofImpl = defaultPortPidLookup, dryRun = false } = opts;
+  const {
+    pidfilePath,
+    port,
+    dbPath,
+    lsofImpl = defaultPortPidLookup,
+    dryRun = false,
+    force = false,
+    waitForExit = force,
+    waitForExitTimeoutMs = 10_000,
+  } = opts;
   const now = () => new Date().toISOString();
 
   // ── Path A: pidfile exists ────────────────────────────────────────────────
@@ -105,6 +143,8 @@ export async function jinnStop(opts: JinnStopOptions): Promise<StopResult> {
     let killed = false;
     let stalePidfileCleaned = false;
     let pidfileRemoved = false;
+    let exited = false;
+    let escalatedToSigkill = false;
 
     if (pid !== null && processAlive(pid)) {
       if (!dryRun) {
@@ -117,6 +157,24 @@ export async function jinnStop(opts: JinnStopOptions): Promise<StopResult> {
           pidfileRemoved = removePidfile(pidfilePath);
           markShutdownClean(dbPath);
         }
+
+        // Wait for the SIGTERM handler to actually run — main.ts shuts the
+        // API server, flushes SQLite, then exits, which on a loaded node can
+        // take a few seconds. Callers that swap the binary (jinn update) MUST
+        // await exit, otherwise they race the running daemon.
+        if (killed && waitForExit) {
+          exited = await waitForProcessExit(pid, waitForExitTimeoutMs);
+          if (!exited && force) {
+            try {
+              process.kill(pid, 'SIGKILL');
+              escalatedToSigkill = true;
+              exited = await waitForProcessExit(pid, 2_000);
+            } catch {
+              /* process exited between SIGTERM and SIGKILL */
+              exited = !processAlive(pid);
+            }
+          }
+        }
       }
     } else {
       // PID is null or process is gone — stale pidfile.
@@ -128,13 +186,15 @@ export async function jinnStop(opts: JinnStopOptions): Promise<StopResult> {
     return {
       schemaVersion: 1,
       generatedAt: now(),
-      state: killed || (pid !== null && processAlive(pid)) ? 'stopping' : 'stopped',
+      state: killed && !exited ? 'stopping' : pid !== null && processAlive(pid) ? 'stopping' : 'stopped',
       pid,
       killed,
       pidfilePath,
       pidfileRemoved,
       stalePidfileCleaned,
       pidfileMode,
+      ...(killed && waitForExit ? { exited } : {}),
+      ...(escalatedToSigkill ? { escalatedToSigkill: true } : {}),
     };
   }
 
@@ -149,6 +209,8 @@ export async function jinnStop(opts: JinnStopOptions): Promise<StopResult> {
 
     if (holder !== null) {
       let killed = false;
+      let exited = false;
+      let escalatedToSigkill = false;
       if (!dryRun) {
         try {
           process.kill(holder.pid, 'SIGTERM');
@@ -156,18 +218,33 @@ export async function jinnStop(opts: JinnStopOptions): Promise<StopResult> {
         } catch {
           /* process gone by the time we tried to kill it */
         }
+
+        if (killed && waitForExit) {
+          exited = await waitForProcessExit(holder.pid, waitForExitTimeoutMs);
+          if (!exited && force) {
+            try {
+              process.kill(holder.pid, 'SIGKILL');
+              escalatedToSigkill = true;
+              exited = await waitForProcessExit(holder.pid, 2_000);
+            } catch {
+              exited = !processAlive(holder.pid);
+            }
+          }
+        }
       }
       markShutdownClean(dbPath);
       return {
         schemaVersion: 1,
         generatedAt: now(),
-        state: killed || processAlive(holder.pid) ? 'stopping' : 'stopped',
+        state: killed && !exited ? 'stopping' : processAlive(holder.pid) ? 'stopping' : 'stopped',
         pid: holder.pid,
         killed,
         pidfilePath,
         pidfileRemoved: false,
         stalePidfileCleaned: false,
         discoveredVia: 'port',
+        ...(killed && waitForExit ? { exited } : {}),
+        ...(escalatedToSigkill ? { escalatedToSigkill: true } : {}),
       };
     }
   }
@@ -194,6 +271,7 @@ async function run(ctx: CommandContext): Promise<void> {
       options: {
         json: { type: 'boolean', default: false },
         human: { type: 'boolean', default: false },
+        force: { type: 'boolean', default: false },
         config: { type: 'string' },
       },
       allowPositionals: false,
@@ -237,10 +315,13 @@ async function run(ctx: CommandContext): Promise<void> {
   const apiPort = config?.apiPort ?? 7331;
   const pidPath = join(earningDir, 'daemon.pid');
 
+  const force = Boolean(parsed.values.force);
   const result = await jinnStop({
     pidfilePath: pidPath,
     port: apiPort,
     dbPath,
+    force,
+    waitForExit: force,
   });
 
   emitResult(
@@ -248,11 +329,17 @@ async function run(ctx: CommandContext): Promise<void> {
     (v) => {
       const value = v as StopResult;
       if (value.discoveredVia === 'port') {
+        if (value.escalatedToSigkill) {
+          return `Discovered daemon on port ${apiPort} (PID ${value.pid}); SIGTERM did not resolve, escalated to SIGKILL.`;
+        }
         return value.killed
           ? `Discovered daemon on port ${apiPort} (PID ${value.pid}); sent SIGTERM.`
           : value.pid !== null
             ? `Daemon PID ${value.pid} was already gone (found via port ${apiPort}); cleaned stale state.`
             : `Daemon is already stopped.`;
+      }
+      if (value.escalatedToSigkill) {
+        return `SIGTERM did not bring down daemon pid ${value.pid}; escalated to SIGKILL.`;
       }
       if (value.killed) {
         return `Sent SIGTERM to daemon pid ${value.pid}.`;
@@ -275,16 +362,21 @@ async function run(ctx: CommandContext): Promise<void> {
 const command: CommandModule = {
   name: 'stop',
   summary: 'Signal a running jinn daemon to shut down gracefully',
-  helpText: `Usage: jinn stop [--human]
+  helpText: `Usage: jinn stop [--human] [--force]
 
 Reads the daemon pid from <earningDir>/daemon.pid and sends SIGTERM.
 If the pidfile is missing, falls back to port-based discovery (lsof / ss).
 Idempotent: if the daemon is already stopped, returns state=stopped and
 killed=false with exit 0. Stale pidfiles are removed.
 
+With --force, waits up to 10s for graceful exit after SIGTERM and then
+escalates to SIGKILL if the daemon is still alive. Use this to recover
+when a previous shutdown got stuck (e.g. EADDRINUSE on relaunch).
+
 Examples:
   jinn stop
   jinn stop --human
+  jinn stop --force
 `,
   run,
 };

--- a/client/src/cli/commands/stop.ts
+++ b/client/src/cli/commands/stop.ts
@@ -6,8 +6,10 @@ import { emitResult } from '../output.js';
 import { emitEnvelope } from '../../errors/envelope.js';
 import { loadConfig } from '../../config.js';
 import { Store } from '../../store/store.js';
+import type { PortHolder } from '../../preflight/port-pid.js';
+import { defaultPortPidLookup } from '../../preflight/port-pid.js';
 
-interface StopResult {
+export interface StopResult {
   schemaVersion: 1;
   generatedAt: string;
   state: 'stopped' | 'stopping';
@@ -16,6 +18,21 @@ interface StopResult {
   pidfilePath: string;
   pidfileRemoved: boolean;
   stalePidfileCleaned: boolean;
+  /** Set when we found the daemon via port discovery (no pidfile). */
+  discoveredVia?: 'port';
+  /** Pidfile mode discriminator, e.g. 'setup-halted' for a halted bootstrap. */
+  pidfileMode?: string | null;
+}
+
+export type PortPidLookupFn = (port: number) => Promise<PortHolder | null>;
+
+export interface JinnStopOptions {
+  pidfilePath: string;
+  port?: number;
+  dbPath?: string;
+  lsofImpl?: PortPidLookupFn;
+  /** Skip SIGTERM and just report state (used by jinn update for pre-flight check). */
+  dryRun?: boolean;
 }
 
 function processAlive(pid: number): boolean {
@@ -25,6 +42,29 @@ function processAlive(pid: number): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Parse a pidfile that may be either:
+ *   - A plain integer string: "12345\n"   (running mode)
+ *   - A JSON object: {"pid":12345,"mode":"setup-halted"}  (halted setup mode)
+ *
+ * Returns `{ pid, mode }` or `{ pid: null, mode: null }` on parse failure.
+ */
+function parsePidfile(raw: string): { pid: number | null; mode: string | null } {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith('{')) {
+    try {
+      const obj = JSON.parse(trimmed) as { pid?: unknown; mode?: unknown };
+      const pid = typeof obj.pid === 'number' && Number.isFinite(obj.pid) ? obj.pid : null;
+      const mode = typeof obj.mode === 'string' ? obj.mode : null;
+      return { pid, mode };
+    } catch {
+      return { pid: null, mode: null };
+    }
+  }
+  const n = parseInt(trimmed, 10);
+  return { pid: Number.isFinite(n) ? n : null, mode: null };
 }
 
 function markShutdownClean(dbPath: string | undefined): void {
@@ -44,6 +84,106 @@ function removePidfile(path: string): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Core stop logic, exposed for programmatic use (e.g. `jinn update`).
+ *
+ * Resolution order:
+ *   1. Read pidfile at `pidfilePath` — use if present and valid.
+ *   2. If pidfile absent/stale and `port` is provided, call `lsofImpl` to
+ *      find the holder by port. Sets `discoveredVia: 'port'` on the result.
+ *   3. If nothing found, return `state: 'stopped'`.
+ */
+export async function jinnStop(opts: JinnStopOptions): Promise<StopResult> {
+  const { pidfilePath, port, dbPath, lsofImpl = defaultPortPidLookup, dryRun = false } = opts;
+  const now = () => new Date().toISOString();
+
+  // ── Path A: pidfile exists ────────────────────────────────────────────────
+  if (existsSync(pidfilePath)) {
+    const { pid, mode: pidfileMode } = parsePidfile(readFileSync(pidfilePath, 'utf-8'));
+    let killed = false;
+    let stalePidfileCleaned = false;
+    let pidfileRemoved = false;
+
+    if (pid !== null && processAlive(pid)) {
+      if (!dryRun) {
+        try {
+          process.kill(pid, 'SIGTERM');
+          killed = true;
+        } catch {
+          // Race: process exited between our check and kill — treat as stale.
+          stalePidfileCleaned = true;
+          pidfileRemoved = removePidfile(pidfilePath);
+          markShutdownClean(dbPath);
+        }
+      }
+    } else {
+      // PID is null or process is gone — stale pidfile.
+      stalePidfileCleaned = true;
+      pidfileRemoved = removePidfile(pidfilePath);
+      markShutdownClean(dbPath);
+    }
+
+    return {
+      schemaVersion: 1,
+      generatedAt: now(),
+      state: killed || (pid !== null && processAlive(pid)) ? 'stopping' : 'stopped',
+      pid,
+      killed,
+      pidfilePath,
+      pidfileRemoved,
+      stalePidfileCleaned,
+      pidfileMode,
+    };
+  }
+
+  // ── Path B: no pidfile — try port discovery ───────────────────────────────
+  if (port !== undefined) {
+    let holder: PortHolder | null = null;
+    try {
+      holder = await lsofImpl(port);
+    } catch {
+      /* lsof unavailable — fall through to "already stopped" */
+    }
+
+    if (holder !== null) {
+      let killed = false;
+      if (!dryRun) {
+        try {
+          process.kill(holder.pid, 'SIGTERM');
+          killed = true;
+        } catch {
+          /* process gone by the time we tried to kill it */
+        }
+      }
+      markShutdownClean(dbPath);
+      return {
+        schemaVersion: 1,
+        generatedAt: now(),
+        state: killed || processAlive(holder.pid) ? 'stopping' : 'stopped',
+        pid: holder.pid,
+        killed,
+        pidfilePath,
+        pidfileRemoved: false,
+        stalePidfileCleaned: false,
+        discoveredVia: 'port',
+      };
+    }
+  }
+
+  // ── Path C: nothing found ─────────────────────────────────────────────────
+  markShutdownClean(dbPath);
+  return {
+    schemaVersion: 1,
+    generatedAt: now(),
+    state: 'stopped',
+    pid: null,
+    killed: false,
+    pidfilePath,
+    pidfileRemoved: false,
+    stalePidfileCleaned: false,
+  };
 }
 
 async function run(ctx: CommandContext): Promise<void> {
@@ -94,65 +234,33 @@ async function run(ctx: CommandContext): Promise<void> {
     config?.earningDir ??
     join(process.env['HOME'] ?? '.', '.jinn-client', 'earning');
   const dbPath = ctx.env['JINN_DB_PATH'] ?? config?.dbPath;
+  const apiPort = config?.apiPort ?? 7331;
   const pidPath = join(earningDir, 'daemon.pid');
 
-  if (!existsSync(pidPath)) {
-    markShutdownClean(dbPath);
-    emitResult(
-      {
-        schemaVersion: 1,
-        generatedAt: new Date().toISOString(),
-        state: 'stopped',
-        pid: null,
-        killed: false,
-        pidfilePath: pidPath,
-        pidfileRemoved: false,
-        stalePidfileCleaned: false,
-      } satisfies StopResult,
-      () => 'Daemon is already stopped.',
-      {
-        json: Boolean(parsed.values.json),
-        human: Boolean(parsed.values.human),
-        writer: ctx.writer,
-        stdoutIsTty: ctx.stdoutIsTty,
-        noColor: Boolean(ctx.env['NO_COLOR']),
-      },
-    );
-    return;
-  }
-
-  const parsedPid = parseInt(readFileSync(pidPath, 'utf-8').trim(), 10);
-  const pid = Number.isFinite(parsedPid) ? parsedPid : null;
-  let killed = false;
-  let stalePidfileCleaned = false;
-  let pidfileRemoved = false;
-  try {
-    if (pid === null) throw new Error('invalid pidfile');
-    process.kill(pid, 'SIGTERM');
-    killed = true;
-  } catch {
-    // Process already gone; clean the stale pidfile and persisted running bit.
-    stalePidfileCleaned = true;
-    pidfileRemoved = removePidfile(pidPath);
-    markShutdownClean(dbPath);
-  }
+  const result = await jinnStop({
+    pidfilePath: pidPath,
+    port: apiPort,
+    dbPath,
+  });
 
   emitResult(
-    {
-      schemaVersion: 1,
-      generatedAt: new Date().toISOString(),
-      state: killed || (pid !== null && processAlive(pid)) ? 'stopping' : 'stopped',
-      pid,
-      killed,
-      pidfilePath: pidPath,
-      pidfileRemoved,
-      stalePidfileCleaned,
-    },
+    result,
     (v) => {
       const value = v as StopResult;
-      return value.killed
-        ? `Sent SIGTERM to daemon pid ${value.pid}.`
-        : `Daemon pid ${value.pid} was already gone; cleaned stale state.`;
+      if (value.discoveredVia === 'port') {
+        return value.killed
+          ? `Discovered daemon on port ${apiPort} (PID ${value.pid}); sent SIGTERM.`
+          : value.pid !== null
+            ? `Daemon PID ${value.pid} was already gone (found via port ${apiPort}); cleaned stale state.`
+            : `Daemon is already stopped.`;
+      }
+      if (value.killed) {
+        return `Sent SIGTERM to daemon pid ${value.pid}.`;
+      }
+      if (value.pid !== null) {
+        return `Daemon pid ${value.pid} was already gone; cleaned stale state.`;
+      }
+      return 'Daemon is already stopped.';
     },
     {
       json: Boolean(parsed.values.json),
@@ -170,6 +278,7 @@ const command: CommandModule = {
   helpText: `Usage: jinn stop [--human]
 
 Reads the daemon pid from <earningDir>/daemon.pid and sends SIGTERM.
+If the pidfile is missing, falls back to port-based discovery (lsof / ss).
 Idempotent: if the daemon is already stopped, returns state=stopped and
 killed=false with exit 0. Stale pidfiles are removed.
 

--- a/client/src/cli/commands/update.ts
+++ b/client/src/cli/commands/update.ts
@@ -402,13 +402,31 @@ Examples:
 
         console.error('[update] Checking for running daemon...');
         try {
-          const stopResult = await deps.jinnStopFn({ pidfilePath, port: apiPort, dbPath });
+          // waitForExit + force: SIGTERM alone is not enough — the daemon's
+          // signal handler (main.ts) closes the API server and flushes
+          // SQLite asynchronously and can take seconds, so we must await
+          // the process actually exiting before swapping the binary. If
+          // it does not exit within the deadline, escalate to SIGKILL so
+          // npm install never races a still-running daemon.
+          const stopResult = await deps.jinnStopFn({
+            pidfilePath,
+            port: apiPort,
+            dbPath,
+            waitForExit: true,
+            force: true,
+          });
           if (stopResult.state === 'stopping' || stopResult.killed) {
-            console.error(`[update] Daemon (PID ${stopResult.pid}) signalled to stop.`);
+            const via = stopResult.discoveredVia === 'port' ? ` (discovered via port ${apiPort})` : '';
+            const exitNote = stopResult.escalatedToSigkill
+              ? '; SIGTERM did not resolve, escalated to SIGKILL'
+              : stopResult.exited
+                ? '; exited cleanly'
+                : '';
+            console.error(`[update] Daemon (PID ${stopResult.pid}) signalled to stop${exitNote}.`);
             steps.push({
               step: 'stop-daemon',
               status: 'ok',
-              detail: `Sent SIGTERM to daemon PID ${stopResult.pid}${stopResult.discoveredVia === 'port' ? ` (discovered via port ${apiPort})` : ''}.`,
+              detail: `Sent SIGTERM to daemon PID ${stopResult.pid}${via}${exitNote}.`,
             });
           } else if (stopResult.pid !== null && stopResult.stalePidfileCleaned) {
             steps.push({

--- a/client/src/cli/commands/update.ts
+++ b/client/src/cli/commands/update.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'node:child_process';
 import { copyFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { parseArgs } from 'node:util';
 import type { CommandContext, CommandModule } from '../command.js';
 import { COMMON_FLAGS } from '../command.js';
@@ -14,6 +15,8 @@ import { FleetStateStore } from '../../earning/store.js';
 import type { FleetState, ServiceState } from '../../earning/types.js';
 import { Store } from '../../store/store.js';
 import integrationsCommand from './integrations.js';
+import { jinnStop } from './stop.js';
+import type { JinnStopOptions, StopResult } from './stop.js';
 
 class StringWriter {
   private chunks: string[] = [];
@@ -60,6 +63,8 @@ export interface UpdateDeps {
   getConfigPathFromArgs: typeof defaultGetConfigPathFromArgs;
   fleetStateStoreFactory: (earningDir: string) => Pick<FleetStateStore, 'dir' | 'hasStateFile' | 'tryLoadExisting' | 'save'>;
   storeFactory: (dbPath: string) => Pick<Store, 'close'>;
+  /** Injectable for tests; defaults to the real jinnStop. */
+  jinnStopFn: (opts: JinnStopOptions) => Promise<StopResult>;
 }
 
 const PRODUCTION_DEPS: UpdateDeps = {
@@ -68,6 +73,7 @@ const PRODUCTION_DEPS: UpdateDeps = {
   getConfigPathFromArgs: defaultGetConfigPathFromArgs,
   fleetStateStoreFactory: (earningDir) => new FleetStateStore(earningDir),
   storeFactory: (dbPath) => new Store(dbPath),
+  jinnStopFn: jinnStop,
 };
 
 type UpdateStepStatus = 'ok' | 'error' | 'skipped' | 'warning' | 'state-integrity';
@@ -374,6 +380,82 @@ Examples:
       const skipPlugins = parsed.values['skip-plugins'] as boolean;
 
       const steps: UpdateStep[] = [];
+
+      // ── Step 0: Stop the running daemon (if any) before swapping the binary ──
+      if (!skipNpm) {
+        let stopConfig;
+        try {
+          const configPath =
+            deps.getConfigPathFromArgs(ctx.argv ?? []) ??
+            (typeof process !== 'undefined' ? deps.getConfigPathFromArgs(process.argv.slice(2)) : undefined);
+          stopConfig = deps.loadConfig(configPath);
+        } catch {
+          /* config unavailable — use defaults */
+        }
+        const earningDir =
+          ctx.env['JINN_EARNING_DIR'] ??
+          stopConfig?.earningDir ??
+          join(process.env['HOME'] ?? '.', '.jinn-client', 'earning');
+        const dbPath = ctx.env['JINN_DB_PATH'] ?? stopConfig?.dbPath;
+        const apiPort = stopConfig?.apiPort ?? 7331;
+        const pidfilePath = join(earningDir, 'daemon.pid');
+
+        console.error('[update] Checking for running daemon...');
+        try {
+          const stopResult = await deps.jinnStopFn({ pidfilePath, port: apiPort, dbPath });
+          if (stopResult.state === 'stopping' || stopResult.killed) {
+            console.error(`[update] Daemon (PID ${stopResult.pid}) signalled to stop.`);
+            steps.push({
+              step: 'stop-daemon',
+              status: 'ok',
+              detail: `Sent SIGTERM to daemon PID ${stopResult.pid}${stopResult.discoveredVia === 'port' ? ` (discovered via port ${apiPort})` : ''}.`,
+            });
+          } else if (stopResult.pid !== null && stopResult.stalePidfileCleaned) {
+            steps.push({
+              step: 'stop-daemon',
+              status: 'ok',
+              detail: `Daemon PID ${stopResult.pid} was already gone; cleaned stale state.`,
+            });
+          } else {
+            // Nothing running — proceed without warning.
+            steps.push({ step: 'stop-daemon', status: 'skipped', detail: 'No running daemon found.' });
+          }
+        } catch (err) {
+          // If we can't stop the daemon, refuse to swap the binary to avoid EADDRINUSE on re-launch.
+          const message = err instanceof Error ? err.message : String(err);
+          steps.push({
+            step: 'stop-daemon',
+            status: 'error',
+            detail: `Could not stop running daemon: ${message}. Aborting update to avoid port conflict.`,
+          });
+          console.error(`[update] Could not stop daemon, aborting: ${message}`);
+          const allOk = false;
+          emitResult(
+            {
+              schemaVersion: 1,
+              generatedAt: new Date().toISOString(),
+              verb: 'update',
+              ok: allOk,
+              steps,
+            },
+            (v) => {
+              const value = v as { ok: boolean; steps: UpdateStep[] };
+              const lines = value.steps.map(
+                (s) => `  ${s.step.padEnd(20)} ${s.status}: ${s.detail}`,
+              );
+              return `Update ${value.ok ? 'complete' : 'completed with errors'}:\n${lines.join('\n')}`;
+            },
+            {
+              json: Boolean(parsed.values.json),
+              human: Boolean(parsed.values.human),
+              writer: ctx.writer,
+              stdoutIsTty: ctx.stdoutIsTty,
+              noColor: Boolean(ctx.env['NO_COLOR']),
+            },
+          );
+          return;
+        }
+      }
 
       // ── Step 1: Update the npm package ──
       if (!skipNpm) {

--- a/client/src/dashboard/spa/src/pages/configuration/CostEstimatePanel.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/CostEstimatePanel.tsx
@@ -1,0 +1,206 @@
+/**
+ * Shared cost-estimate surface used by `JoinFlow` (operator catalog) and
+ * `JoinedNetCard` (Settings). Reads the harness/model billing model from
+ * `client/src/harnesses/cost-estimates.ts`.
+ *
+ * Issue #331 (P0 tier). The component:
+ *   - Renders nothing for subscription harnesses (Claude Code, Codex) —
+ *     callers see `decision.showEstimate === false` and the parent omits
+ *     this panel. We still render a tiny "Included in subscription"
+ *     reassurance row when `mode='inline'` so the operator gets explicit
+ *     confirmation instead of an absent UI.
+ *   - For paid-API-key harnesses, surfaces the per-task USD estimate and
+ *     the heuristic that produced it.
+ *   - When the estimate trips the configured high-cost threshold the
+ *     confirmation gate ("I understand — I have a budget for this") must
+ *     be rendered by the caller; this component exposes `data-cost-*`
+ *     attributes so tests can assert the gate condition.
+ */
+
+import type { JSX } from 'react';
+import {
+  decideCostSurface,
+  DEFAULT_HIGH_COST_THRESHOLD_USD,
+  formatUsd,
+  type CostSurfaceDecision,
+} from '../../../../../harnesses/cost-estimates.js';
+
+export interface CostEstimatePanelProps {
+  harness: string | undefined;
+  modelId: string | undefined;
+  /** Override the gate threshold. Defaults to $1/task. */
+  thresholdUsd?: number;
+  /**
+   * `'card'` (default) renders the panel inside its own card-style
+   * container suitable for the JoinFlow's stacked layout. `'inline'`
+   * renders a compact two-line variant for the JoinedNetCard edit form.
+   */
+  variant?: 'card' | 'inline';
+  /** testid prefix — defaults to `cost-estimate`. */
+  testIdPrefix?: string;
+}
+
+export function useCostSurfaceDecision(
+  harness: string | undefined,
+  modelId: string | undefined,
+  thresholdUsd: number = DEFAULT_HIGH_COST_THRESHOLD_USD,
+): CostSurfaceDecision {
+  return decideCostSurface(harness, modelId, thresholdUsd);
+}
+
+export function CostEstimatePanel({
+  harness,
+  modelId,
+  thresholdUsd = DEFAULT_HIGH_COST_THRESHOLD_USD,
+  variant = 'card',
+  testIdPrefix = 'cost-estimate',
+}: CostEstimatePanelProps): JSX.Element | null {
+  const decision = decideCostSurface(harness, modelId, thresholdUsd);
+
+  if (!decision.showEstimate) {
+    // Subscription harness — render the explicit reassurance row so the
+    // operator gets confirmation that there is no per-task API cost.
+    return (
+      <div
+        data-testid={`${testIdPrefix}-subscription`}
+        data-cost-mode="subscription"
+        style={variant === 'card' ? subscriptionCardStyle : subscriptionInlineStyle}
+      >
+        <span style={iconStyle} aria-hidden="true">
+          ◆
+        </span>
+        <span style={subscriptionTextStyle}>
+          {decision.suppressedReason ?? 'Included in subscription, no per-task API cost.'}
+        </span>
+      </div>
+    );
+  }
+
+  const estimate = decision.estimate;
+  const usd = estimate?.usd ?? null;
+  const isHighCost = decision.requiresConfirmation;
+
+  return (
+    <div
+      data-testid={`${testIdPrefix}-panel`}
+      data-cost-mode="paid-api"
+      data-cost-usd={usd !== null ? usd.toFixed(4) : 'unknown'}
+      data-cost-high-cost={isHighCost ? 'true' : 'false'}
+      style={variant === 'card' ? paidCardStyle(isHighCost) : paidInlineStyle(isHighCost)}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: '12px' }}>
+        <span style={labelStyle}>Estimated cost per task</span>
+        <span
+          data-testid={`${testIdPrefix}-amount`}
+          style={{
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: variant === 'card' ? '18px' : '14px',
+            fontWeight: 500,
+            color: isHighCost ? 'var(--break-red)' : 'var(--fg)',
+          }}
+        >
+          {usd !== null ? `~${formatUsd(usd)}` : 'unavailable'}
+        </span>
+      </div>
+      {estimate && (
+        <span
+          data-testid={`${testIdPrefix}-heuristic`}
+          style={{
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '11px',
+            color: 'var(--fg-muted)',
+          }}
+        >
+          Heuristic: ~{(estimate.typicalInputTokens / 1000).toFixed(0)}k input + ~
+          {(estimate.typicalOutputTokens / 1000).toFixed(0)}k output @ ${estimate.entry.inputPer1kTokens.toFixed(4)}
+          /1k in, ${estimate.entry.outputPer1kTokens.toFixed(4)}/1k out (provider: {estimate.entry.provider}).
+          Real usage will vary.
+        </span>
+      )}
+      {usd === null && (
+        <span
+          data-testid={`${testIdPrefix}-unknown`}
+          style={{
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '11px',
+            color: 'var(--fg-muted)',
+          }}
+        >
+          No pricing entry for this model id — confirm rates with your provider before joining.
+        </span>
+      )}
+      {isHighCost && (
+        <span
+          data-testid={`${testIdPrefix}-warning`}
+          style={{
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '11px',
+            color: 'var(--break-red)',
+          }}
+        >
+          This model is above ${thresholdUsd.toFixed(2)}/task. You will be asked to confirm before joining.
+        </span>
+      )}
+    </div>
+  );
+}
+
+const labelStyle: React.CSSProperties = {
+  fontFamily: "'JetBrains Mono', monospace",
+  fontSize: '11px',
+  fontWeight: 500,
+  letterSpacing: '0.14em',
+  textTransform: 'uppercase',
+  color: 'var(--fg-muted)',
+};
+
+const iconStyle: React.CSSProperties = {
+  color: 'var(--accent-sky)',
+  fontSize: '12px',
+};
+
+const subscriptionTextStyle: React.CSSProperties = {
+  fontFamily: "'JetBrains Mono', monospace",
+  fontSize: '12px',
+  color: 'var(--fg-muted)',
+};
+
+const subscriptionCardStyle: React.CSSProperties = {
+  background: 'var(--bg-elevated)',
+  border: '1px solid var(--border)',
+  borderRadius: 'var(--radius-2)',
+  padding: '10px 14px',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '10px',
+};
+
+const subscriptionInlineStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+  padding: '6px 0',
+};
+
+function paidCardStyle(highCost: boolean): React.CSSProperties {
+  return {
+    background: 'var(--bg-elevated)',
+    border: `1px solid ${highCost ? 'var(--break-red)' : 'var(--border)'}`,
+    borderRadius: 'var(--radius-2)',
+    padding: '14px 16px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+  };
+}
+
+function paidInlineStyle(highCost: boolean): React.CSSProperties {
+  return {
+    border: `1px solid ${highCost ? 'var(--break-red)' : 'var(--border)'}`,
+    borderRadius: 'var(--radius-2)',
+    padding: '8px 10px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '4px',
+  };
+}

--- a/client/src/dashboard/spa/src/pages/configuration/JoinedNetCard.test.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/JoinedNetCard.test.tsx
@@ -418,3 +418,79 @@ describe('<JoinedNetCard />', () => {
     expect(onRestart).not.toHaveBeenCalled();
   });
 });
+
+describe('<JoinedNetCard /> — cost surfacing + confirmation gate (Issue #331 P0)', () => {
+  const HERMES_CATALOG: SolverNetCatalogEntry = {
+    name: 'Prediction Markets',
+    description: 'Predict things',
+    state: 'live',
+    contract: { id: 'prediction', version: 'v1' },
+    supportedRoles: ['solving', 'evaluating'],
+    compatibleHarnesses: [
+      { name: 'claude-code-learner', version: '0.1.0', supportsRoles: ['solving'] },
+      { name: 'hermes-agent', version: '0.1.0', supportsRoles: ['solving'] },
+    ],
+    compatiblePlugins: [],
+  };
+
+  it('renders the subscription reassurance row for Claude Code (no false-positive gate)', () => {
+    wrap(<JoinedNetCard joined={ENTRY} catalogEntry={HERMES_CATALOG} defaultExpanded />);
+    expect(screen.getByTestId('joined-net-card-cost-subscription')).toBeTruthy();
+    expect(screen.getByTestId('joined-net-card-cost-subscription').textContent).toMatch(
+      /subscription/i,
+    );
+    expect(screen.queryByTestId('joined-net-card-cost-confirmation')).toBeNull();
+    expect(screen.queryByTestId('joined-net-card-cost-panel')).toBeNull();
+  });
+
+  it('shows the cost panel + confirmation when the operator switches to Hermes + Opus 4.7', async () => {
+    vi.mocked(api.operator.join).mockResolvedValue({
+      ok: true,
+      restartRequired: true,
+      manifestCid: 'bafybeiaaa',
+      config: { manifestCid: 'bafybeiaaa', roles: ['solver', 'evaluator'] },
+    });
+    wrap(<JoinedNetCard joined={ENTRY} catalogEntry={HERMES_CATALOG} defaultExpanded />);
+
+    fireEvent.change(screen.getByTestId('joined-net-card-harness-select'), {
+      target: { value: 'hermes-agent' },
+    });
+
+    // Hermes default model is anthropic/claude-opus-4.7 (Opus 4.7 via
+    // OpenRouter), well above the $1/task gate.
+    await waitFor(() =>
+      expect(screen.getByTestId('joined-net-card-cost-panel')).toBeTruthy(),
+    );
+    expect(screen.getByTestId('joined-net-card-cost-panel').getAttribute('data-cost-high-cost')).toBe(
+      'true',
+    );
+    expect(screen.getByTestId('joined-net-card-cost-amount').textContent).toMatch(/\$2\.25/);
+    expect(screen.getByTestId('joined-net-card-cost-confirmation')).toBeTruthy();
+
+    // Save disabled until acknowledged.
+    const save = screen.getByTestId('joined-net-card-save') as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+
+    fireEvent.click(
+      screen.getByTestId('joined-net-card-cost-confirmation-checkbox'),
+    );
+    await waitFor(() => expect(save.disabled).toBe(false));
+
+    fireEvent.click(save);
+    await waitFor(() => expect(api.operator.join).toHaveBeenCalled());
+  });
+
+  it('does NOT show the confirmation gate when the model stays under $1/task', () => {
+    const sonnetEntry: JoinedNetEntry = {
+      ...ENTRY,
+      harness: 'hermes-agent',
+      model: 'deepseek/deepseek-v4-flash',
+    };
+    wrap(<JoinedNetCard joined={sonnetEntry} catalogEntry={HERMES_CATALOG} defaultExpanded />);
+    expect(screen.getByTestId('joined-net-card-cost-panel')).toBeTruthy();
+    expect(screen.getByTestId('joined-net-card-cost-panel').getAttribute('data-cost-high-cost')).toBe(
+      'false',
+    );
+    expect(screen.queryByTestId('joined-net-card-cost-confirmation')).toBeNull();
+  });
+});

--- a/client/src/dashboard/spa/src/pages/configuration/JoinedNetCard.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/JoinedNetCard.tsx
@@ -18,6 +18,7 @@ import {
   harnessOptionLabel,
 } from './harnessNames.js';
 import { PluginPicker } from './PluginPicker.js';
+import { CostEstimatePanel, useCostSurfaceDecision } from './CostEstimatePanel.js';
 
 /**
  * Per-SolverNet edit card on /operator → SolverNets → Joined.
@@ -206,6 +207,15 @@ export function JoinedNetCard({
       if (res.restartRequired) onRestartPending?.();
     },
   });
+
+  const [highCostAcknowledged, setHighCostAcknowledged] = useState(false);
+  const isSolver = joined.roles.includes('solver');
+  const costDecision = useCostSurfaceDecision(
+    isSolver ? form.harness : undefined,
+    isSolver ? form.model : undefined,
+  );
+  const requiresCostConfirmation = isSolver && costDecision.requiresConfirmation;
+  const costGateBlocked = requiresCostConfirmation && !highCostAcknowledged;
 
   const [confirmingLeave, setConfirmingLeave] = useState(false);
   const leaveMutation = useMutation({
@@ -450,6 +460,7 @@ export function JoinedNetCard({
                   harness,
                   model: defaultModelForHarness(harness),
                 }));
+                setHighCostAcknowledged(false);
               }}
               style={{
                 ...selectStyle,
@@ -556,7 +567,10 @@ export function JoinedNetCard({
               aria-label="Model"
               data-testid="joined-net-card-model-select"
               value={form.model}
-              onChange={(e) => setForm({ ...form, model: e.target.value })}
+              onChange={(e) => {
+                setForm({ ...form, model: e.target.value });
+                setHighCostAcknowledged(false);
+              }}
               style={selectStyle}
             >
               {modelOptions.map((m) => (
@@ -577,6 +591,48 @@ export function JoinedNetCard({
               })()}
             </select>
           </div>
+
+          {isSolver && (
+            <CostEstimatePanel
+              harness={form.harness}
+              modelId={form.model}
+              variant="inline"
+              testIdPrefix="joined-net-card-cost"
+            />
+          )}
+
+          {requiresCostConfirmation && (
+            <label
+              data-testid="joined-net-card-cost-confirmation"
+              data-cost-confirmation-checked={highCostAcknowledged ? 'true' : 'false'}
+              style={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: '8px',
+                padding: '10px 12px',
+                border: '1px solid var(--break-red)',
+                borderRadius: 'var(--radius-2)',
+                background: 'var(--bg)',
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: '12px',
+                color: 'var(--fg)',
+                cursor: 'pointer',
+              }}
+            >
+              <input
+                type="checkbox"
+                data-testid="joined-net-card-cost-confirmation-checkbox"
+                checked={highCostAcknowledged}
+                onChange={(e) => setHighCostAcknowledged(e.target.checked)}
+                style={{ accentColor: 'var(--break-red)', marginTop: '2px', width: '14px', height: '14px' }}
+                aria-label="I understand the per-task cost and have a budget for this"
+              />
+              <span>
+                I understand — I have a budget for this. The selected model is estimated above $1/task on
+                my own provider key.
+              </span>
+            </label>
+          )}
 
           {saveMutation.isError && (
             <span
@@ -614,9 +670,9 @@ export function JoinedNetCard({
               <button
                 type="button"
                 data-testid="joined-net-card-save"
-                disabled={!dirty || saveMutation.isPending}
+                disabled={!dirty || saveMutation.isPending || costGateBlocked}
                 onClick={() => saveMutation.mutate()}
-                style={primaryButtonStyle(dirty && !saveMutation.isPending)}
+                style={primaryButtonStyle(dirty && !saveMutation.isPending && !costGateBlocked)}
               >
                 {saveMutation.isPending ? 'Saving…' : 'Save'}
               </button>

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
@@ -675,6 +675,14 @@ describe('JoinFlow — Hermes Agent precheck panel', () => {
     // Select hermes-agent.
     fireEvent.change(harnessSelect, { target: { value: 'hermes-agent' } });
     await waitFor(() => expect(harnessSelect.value).toBe('hermes-agent'));
+
+    // Hermes default is Opus 4.7 — above the $1/task cost gate (Issue
+    // #331). Acknowledge it so the submit button isn't gated; these
+    // tests are exercising the precheck path, not the cost gate.
+    await waitFor(() =>
+      expect(screen.getByTestId('join-flow-cost-confirmation')).toBeTruthy(),
+    );
+    fireEvent.click(screen.getByTestId('join-flow-cost-confirmation-checkbox'));
   }
 
   it('shows the not-installed panel when hermesDoctor returns installed:false', async () => {
@@ -786,6 +794,9 @@ describe('JoinFlow — Hermes Agent precheck panel', () => {
     expect(screen.getByTestId('join-flow-solver-fields')).toBeTruthy();
   });
 
+  // Cost-protection P0 tests live in the following describe block, then the
+  // remaining Hermes precheck cases continue below.
+
   it('shows the network-error panel when hermesDoctor rejects (does NOT fall through to install)', async () => {
     apiMock.hermesDoctor.mockRejectedValue(new Error('Network error: failed to fetch /api/hermes/doctor'));
 
@@ -800,5 +811,132 @@ describe('JoinFlow — Hermes Agent precheck panel', () => {
     // reinstall a Hermes that is already there when the daemon is just down).
     expect(screen.queryByTestId('hermes-precheck-not-installed')).toBeNull();
     expect(apiMock.operatorJoin).not.toHaveBeenCalled();
+  });
+});
+
+describe('JoinFlow — cost surfacing + confirmation gate (Issue #331 P0)', () => {
+  /**
+   * Catalog with Hermes + Claude Code, both compatible. The default solver
+   * harness is the first compatible — Claude Code — so the cost surface
+   * for that path renders the subscription reassurance. Switching to
+   * Hermes + Opus 4.7 puts us in the high-cost band; switching to
+   * Hermes + DeepSeek V4 Flash stays under the $1 threshold.
+   */
+  const mixedHarnessCatalog = {
+    ...baseCatalog,
+    nets: [
+      {
+        ...baseCatalog.nets[0]!,
+        compatibleHarnesses: [
+          { name: 'claude-code-learner', version: '0.1.0', supportsRoles: ['solving' as const] },
+          { name: 'hermes-agent', version: '0.1.0', supportsRoles: ['solving' as const] },
+        ],
+      },
+    ],
+  };
+
+  async function setupSolverWithMixedHarnesses(): Promise<HTMLSelectElement> {
+    apiMock.getSolverNets.mockResolvedValue(mixedHarnessCatalog);
+    wrap(<JoinFlow />);
+    await waitFor(() => expect(screen.getByTestId('join-flow-summary')).toBeTruthy());
+    fireEvent.click(screen.getByLabelText('Solver'));
+    const harnessSelect = screen.getByTestId('join-harness-select') as HTMLSelectElement;
+    await waitFor(() =>
+      expect(Array.from(harnessSelect.options).some((o) => o.value === 'hermes-agent')).toBe(true),
+    );
+    return harnessSelect;
+  }
+
+  it('renders the subscription reassurance row and NO confirmation gate for Claude Code', async () => {
+    const harnessSelect = await setupSolverWithMixedHarnesses();
+    fireEvent.change(harnessSelect, { target: { value: 'claude-code' } });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('join-flow-cost-subscription')).toBeTruthy(),
+    );
+    expect(screen.getByTestId('join-flow-cost-subscription').textContent).toMatch(
+      /subscription/i,
+    );
+    // No confirmation gate, no high-cost panel.
+    expect(screen.queryByTestId('join-flow-cost-confirmation')).toBeNull();
+    expect(screen.queryByTestId('join-flow-cost-panel')).toBeNull();
+
+    // The submit button should remain enabled once a role is picked.
+    const submit = screen.getByTestId('join-flow-submit') as HTMLButtonElement;
+    expect(submit.disabled).toBe(false);
+  });
+
+  it('shows the cost panel and the $1/task warning for Hermes + Opus 4.7', async () => {
+    const harnessSelect = await setupSolverWithMixedHarnesses();
+    fireEvent.change(harnessSelect, { target: { value: 'hermes-agent' } });
+
+    // Hermes default is anthropic/claude-opus-4.7 — above the $1/task gate.
+    await waitFor(() => expect(screen.getByTestId('join-flow-cost-panel')).toBeTruthy());
+    const panel = screen.getByTestId('join-flow-cost-panel');
+    expect(panel.getAttribute('data-cost-high-cost')).toBe('true');
+    expect(panel.getAttribute('data-cost-mode')).toBe('paid-api');
+    expect(screen.getByTestId('join-flow-cost-amount').textContent).toMatch(/\$2\.25/);
+    expect(screen.getByTestId('join-flow-cost-warning')).toBeTruthy();
+    expect(screen.getByTestId('join-flow-cost-confirmation')).toBeTruthy();
+  });
+
+  it('disables the Save & Join button until the high-cost confirmation is checked', async () => {
+    const harnessSelect = await setupSolverWithMixedHarnesses();
+    fireEvent.change(harnessSelect, { target: { value: 'hermes-agent' } });
+
+    await waitFor(() => expect(screen.getByTestId('join-flow-cost-confirmation')).toBeTruthy());
+    const submit = screen.getByTestId('join-flow-submit') as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+
+    const checkbox = screen.getByTestId(
+      'join-flow-cost-confirmation-checkbox',
+    ) as HTMLInputElement;
+    fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(true);
+
+    await waitFor(() => expect(submit.disabled).toBe(false));
+  });
+
+  it('does NOT show the confirmation gate for Hermes + DeepSeek V4 Flash (sub-$1 model)', async () => {
+    const harnessSelect = await setupSolverWithMixedHarnesses();
+    fireEvent.change(harnessSelect, { target: { value: 'hermes-agent' } });
+
+    // Switch to a low-cost model.
+    await waitFor(() => expect(screen.getByTestId('join-model-select')).toBeTruthy());
+    const modelSelect = screen.getByTestId('join-model-select') as HTMLSelectElement;
+    fireEvent.change(modelSelect, { target: { value: 'deepseek/deepseek-v4-flash' } });
+
+    // Panel still shows, but the warning + confirmation are gone.
+    await waitFor(() => expect(screen.getByTestId('join-flow-cost-panel')).toBeTruthy());
+    expect(screen.getByTestId('join-flow-cost-panel').getAttribute('data-cost-high-cost')).toBe('false');
+    expect(screen.queryByTestId('join-flow-cost-warning')).toBeNull();
+    expect(screen.queryByTestId('join-flow-cost-confirmation')).toBeNull();
+
+    // And the submit button is enabled (no gate).
+    const submit = screen.getByTestId('join-flow-submit') as HTMLButtonElement;
+    expect(submit.disabled).toBe(false);
+  });
+
+  it('resets the confirmation when the model is swapped back to a low-cost model', async () => {
+    const harnessSelect = await setupSolverWithMixedHarnesses();
+    fireEvent.change(harnessSelect, { target: { value: 'hermes-agent' } });
+
+    // Acknowledge Opus 4.7.
+    await waitFor(() => expect(screen.getByTestId('join-flow-cost-confirmation')).toBeTruthy());
+    fireEvent.click(screen.getByTestId('join-flow-cost-confirmation-checkbox'));
+
+    // Switch to a cheap model — confirmation goes away.
+    const modelSelect = screen.getByTestId('join-model-select') as HTMLSelectElement;
+    fireEvent.change(modelSelect, { target: { value: 'deepseek/deepseek-v4-flash' } });
+    await waitFor(() => expect(screen.queryByTestId('join-flow-cost-confirmation')).toBeNull());
+
+    // Switch back to Opus — confirmation reappears and the prior tick must
+    // NOT have persisted (operator must re-confirm).
+    fireEvent.change(modelSelect, { target: { value: 'anthropic/claude-opus-4.7' } });
+    await waitFor(() => expect(screen.getByTestId('join-flow-cost-confirmation')).toBeTruthy());
+    const checkbox = screen.getByTestId('join-flow-cost-confirmation-checkbox') as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+    const submit = screen.getByTestId('join-flow-submit') as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
   });
 });

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
@@ -289,6 +289,56 @@ describe('JoinFlow — harness options', () => {
     );
   });
 
+  it('selecting Claude Code in the dropdown sticks even when the catalog default is Hermes (issue #329)', async () => {
+    // Issue #329 regression. Production SWE-rebench v2 catalog
+    // (`client/src/main.ts`) lists Hermes first; selecting Claude Code from
+    // the dropdown silently reverted to Hermes on every render because a
+    // render-time `setForm` was bouncing form.harness back to the catalog
+    // default whenever it equalled the seed `claude-code`. Cover the full
+    // sequence: catalog default Hermes -> operator picks Claude Code -> value
+    // sticks across re-renders -> submit carries claude-code.
+    apiMock.getSolverNets.mockResolvedValue({
+      ...baseCatalog,
+      nets: [
+        {
+          ...baseCatalog.nets[0]!,
+          compatibleHarnesses: [
+            { name: 'hermes-agent', version: '0.1.0', supportsRoles: ['solving' as const] },
+            { name: 'claude-code-learner', version: '0.1.0', supportsRoles: ['solving' as const] },
+            { name: 'codex-code-learner', version: '0.1.0', supportsRoles: ['solving' as const] },
+          ],
+        },
+      ],
+    });
+
+    wrap(<JoinFlow />);
+    await waitFor(() => expect(screen.getByTestId('join-flow-summary')).toBeTruthy());
+    fireEvent.click(screen.getByLabelText('Solver'));
+
+    const harnessSelect = screen.getByTestId('join-harness-select') as HTMLSelectElement;
+    // Catalog-arrival effect picks Hermes as the seed.
+    await waitFor(() => expect(harnessSelect.value).toBe('hermes-agent'));
+
+    // Operator selects Claude Code.
+    fireEvent.change(harnessSelect, { target: { value: 'claude-code' } });
+
+    // The pick must stick — not silently revert to Hermes on re-render.
+    await waitFor(() => expect(harnessSelect.value).toBe('claude-code'));
+    // Force several re-renders (toggle Evaluator on and off) to exercise the
+    // catalog-arrival effect's dependency tracking — Claude Code must remain.
+    fireEvent.click(screen.getByLabelText('Evaluator'));
+    fireEvent.click(screen.getByLabelText('Evaluator'));
+    expect(harnessSelect.value).toBe('claude-code');
+
+    // Submit carries the operator's choice.
+    fireEvent.click(screen.getByTestId('join-flow-submit'));
+    await waitFor(() => expect(apiMock.operatorJoin).toHaveBeenCalled());
+    expect(apiMock.operatorJoin).toHaveBeenCalledWith(
+      'bafybeiaaa',
+      expect.objectContaining({ harness: 'claude-code', roles: ['solver'] }),
+    );
+  });
+
   it('drops claude-code-learner from default plugins when Hermes Agent is selected', async () => {
     // Hermes owns its own learning loop (skill self-improvement, memory
     // curation, FTS5 session search — see harnesses/impls/hermes-agent/

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { HermesPrecheckPanel } from './HermesPrecheckPanel.js';
 import { useLocation, useParams } from 'wouter';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -127,25 +127,33 @@ export function JoinFlow({
   });
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [showHermesPrecheck, setShowHermesPrecheck] = useState(false);
+  // Tracks whether the operator has explicitly picked a harness in this
+  // session. Once true, the catalog-arrival effect below MUST NOT stomp
+  // their choice — that was the cause of issue #329, where SWE-rebench v2
+  // (whose catalog default is Hermes) re-overrode every Claude Code click.
+  const operatorPickedHarness = useRef(false);
 
   // The catalog loads independently of the manifest — when it arrives, if
-  // the operator hasn't picked a harness yet (`form.harness` still equal to
-  // the seed default) and the catalog's first compatible option differs,
-  // shift to that. This is render-time-safe because we only call setForm
-  // when the values are unequal — React queues the re-render and bails out
-  // from infinite loops automatically.
+  // the operator hasn't picked a harness yet, shift the seed default to the
+  // catalog's first compatible option. Once-per-catalog-load via useEffect
+  // (NOT a render-time setState) so subsequent dropdown selections don't
+  // get reverted on every re-render.
   const catalogPreferredHarness = solverCompatibleHarnesses[0]?.name;
-  if (
-    catalogPreferredHarness &&
-    form.harness === DEFAULT_HARNESS &&
-    catalogPreferredHarness !== DEFAULT_HARNESS
-  ) {
-    setForm({
-      ...form,
+  useEffect(() => {
+    if (operatorPickedHarness.current) return;
+    if (!catalogPreferredHarness) return;
+    if (catalogPreferredHarness === form.harness) return;
+    setForm((prev) => ({
+      ...prev,
       harness: catalogPreferredHarness,
       model: defaultModelForHarness(catalogPreferredHarness),
-    });
-  }
+    }));
+    // form.harness intentionally omitted: we only react to the catalog
+    // value changing (initial load / contract switch). Including form.harness
+    // would re-fire this effect after the operator picks something and
+    // bounce them back to the catalog default.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [catalogPreferredHarness]);
   const modelOptions = modelOptionsForHarness(form.harness);
 
   const submitMutation = useMutation({
@@ -389,6 +397,10 @@ export function JoinFlow({
                 value={form.harness}
                 onChange={(e) => {
                   const harness = e.target.value;
+                  // Mark the choice as operator-driven so the catalog-arrival
+                  // effect above doesn't bounce them back to the catalog
+                  // default on the next render (issue #329).
+                  operatorPickedHarness.current = true;
                   setForm({
                     ...form,
                     harness,

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
@@ -21,6 +21,7 @@ import {
   harnessOptionLabel,
 } from '../configuration/harnessNames.js';
 import { PluginPicker } from '../configuration/PluginPicker.js';
+import { CostEstimatePanel, useCostSurfaceDecision } from '../configuration/CostEstimatePanel.js';
 import { formatWeiAmount } from '../launcher-launched/helpers.js';
 
 const HERMES_AGENT_DESCRIPTION =
@@ -132,6 +133,7 @@ export function JoinFlow({
   // their choice — that was the cause of issue #329, where SWE-rebench v2
   // (whose catalog default is Hermes) re-overrode every Claude Code click.
   const operatorPickedHarness = useRef(false);
+  const [highCostAcknowledged, setHighCostAcknowledged] = useState(false);
 
   // The catalog loads independently of the manifest — when it arrives, if
   // the operator hasn't picked a harness yet, shift the seed default to the
@@ -235,7 +237,19 @@ export function JoinFlow({
 
   const showSolverFields = form.roles.includes('solver');
   const showEvaluatorInfo = form.roles.includes('evaluator');
-  const canSubmit = form.roles.length > 0 && !submitMutation.isPending;
+
+  // Cost-protection surface (Issue #331). Only consulted when the solver
+  // role is selected — the evaluator role binds to a manifest-supplied
+  // implementation and bypasses operator harness choice entirely.
+  const costDecision = useCostSurfaceDecision(
+    showSolverFields ? form.harness : undefined,
+    showSolverFields ? form.model : undefined,
+  );
+  const requiresCostConfirmation = showSolverFields && costDecision.requiresConfirmation;
+  const costGateBlocked = requiresCostConfirmation && !highCostAcknowledged;
+
+  const canSubmit =
+    form.roles.length > 0 && !submitMutation.isPending && !costGateBlocked;
 
   return (
     <main data-testid="join-flow" data-manifest-cid={cid} style={pageStyle}>
@@ -406,6 +420,7 @@ export function JoinFlow({
                     harness,
                     model: defaultModelForHarness(harness),
                   });
+                  setHighCostAcknowledged(false);
                 }}
                 style={selectStyle}
               >
@@ -438,7 +453,10 @@ export function JoinFlow({
                 aria-label="Model"
                 data-testid="join-model-select"
                 value={form.model}
-                onChange={(e) => setForm({ ...form, model: e.target.value })}
+                onChange={(e) => {
+                  setForm({ ...form, model: e.target.value });
+                  setHighCostAcknowledged(false);
+                }}
                 style={selectStyle}
               >
                 {modelOptions.map((m) => (
@@ -460,6 +478,45 @@ export function JoinFlow({
               </select>
             </div>
           </div>
+
+          <CostEstimatePanel
+            harness={form.harness}
+            modelId={form.model}
+            testIdPrefix="join-flow-cost"
+          />
+
+          {requiresCostConfirmation && (
+            <label
+              data-testid="join-flow-cost-confirmation"
+              data-cost-confirmation-checked={highCostAcknowledged ? 'true' : 'false'}
+              style={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: '10px',
+                padding: '12px 14px',
+                border: '1px solid var(--break-red)',
+                borderRadius: 'var(--radius-2)',
+                background: 'var(--bg)',
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: '12px',
+                color: 'var(--fg)',
+                cursor: 'pointer',
+              }}
+            >
+              <input
+                type="checkbox"
+                data-testid="join-flow-cost-confirmation-checkbox"
+                checked={highCostAcknowledged}
+                onChange={(e) => setHighCostAcknowledged(e.target.checked)}
+                style={{ accentColor: 'var(--break-red)', marginTop: '2px', width: '14px', height: '14px' }}
+                aria-label="I understand the per-task cost and have a budget for this"
+              />
+              <span>
+                I understand — I have a budget for this. The selected model is estimated at more than $1
+                per task; I am responsible for the API spend on my own provider key.
+              </span>
+            </label>
+          )}
 
           <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
             <span style={fieldLabelStyle}>Plugins</span>

--- a/client/src/harnesses/cost-estimates.ts
+++ b/client/src/harnesses/cost-estimates.ts
@@ -1,0 +1,360 @@
+/**
+ * Per-task cost estimates for paid-API-key harnesses.
+ *
+ * Background — Issue #331 (Run-mode `feat`, P0 tier under release-feedback
+ * umbrella #328). The operator dashboard surfaces a harness/model selection
+ * at SolverNet-join time and again in Settings. Operators routing a paid
+ * API key (Anthropic, OpenAI, OpenRouter, Nous Portal) through the Hermes
+ * harness — or a "raw API key" Claude Code variant if we ever add one —
+ * have **no UI nudge** at join-time about per-task cost. The v0.1.6 dogfood
+ * surfaced the concrete worry: a first-run operator could pick Opus 4.7 +
+ * SWE-rebench v2 and burn $100s/hr before they figure out what Jinn does.
+ *
+ * This module captures the heuristic the SPA uses to render that estimate
+ * and to gate the Save & Join action when the estimate exceeds a
+ * configurable per-task threshold (default $1).
+ *
+ * Heuristic shape per the spec:
+ *   per-1k-token rate × typical task length, by model id.
+ *
+ * Subscription harnesses (Claude Code, Codex) are flagged via
+ * `subscriptionPath: true` on the harness; in that case the surface shows
+ * "Included in subscription, no per-task API cost" and **does not** trigger
+ * the confirmation gate, regardless of the model selected.
+ *
+ * To add a new model: append an entry to `MODEL_COST_TABLE`. The id is the
+ * exact `model` string persisted to `joinedSolverNets[<cid>].model`. To
+ * shape a new harness: append to `HARNESS_BILLING`. Keep the units
+ * consistent: token counts in tokens, rates in USD-per-1k-tokens.
+ *
+ * Units note: Anthropic + OpenAI publish prices per million tokens; we
+ * convert to per-1k-tokens here so the multiplication reads as
+ * `(tokens / 1000) * pricePer1k`. Avoids floating-point surprises when the
+ * dashboard renders cents.
+ *
+ * Pricing references captured at the time of this commit (see PR body):
+ *   - Anthropic Claude Opus 4.7: $15/M input, $75/M output (≈ $0.015 / 1k
+ *     input, $0.075 / 1k output). Typical SWE-rebench v2 task estimated at
+ *     ~50k input + 20k output → ~$2.25/task. Anthropic public pricing.
+ *   - Anthropic Claude Sonnet 4.6: $3/M input, $15/M output.
+ *   - OpenAI GPT-5.4: $1.25/M input, $10/M output (OpenAI public pricing).
+ *   - OpenAI GPT-5.4 Mini: $0.25/M input, $2/M output.
+ *
+ * These are heuristics. Provider-API reconciliation (actual usage) is
+ * deferred to the P1 follow-up tracked in #331.
+ */
+
+import {
+  CLAUDE_CODE_HARNESS,
+  CODEX_HARNESS,
+  HERMES_AGENT_HARNESS,
+  canonicalHarnessName,
+} from './names.js';
+
+export type Provider = 'anthropic' | 'openai' | 'openrouter' | 'nous' | 'other';
+
+export interface ModelCostEntry {
+  /** Upstream API provider that owns the billing relationship. */
+  provider: Provider;
+  /** USD per 1k input tokens. */
+  inputPer1kTokens: number;
+  /** USD per 1k output tokens. */
+  outputPer1kTokens: number;
+  /** Typical input-token consumption for a single task. Heuristic. */
+  typicalInputTokens: number;
+  /** Typical output-token consumption for a single task. Heuristic. */
+  typicalOutputTokens: number;
+  /**
+   * `true` when this model id is only ever reached via a subscription path
+   * (e.g. a future "Claude Code subscription" pinned model). The default
+   * gate logic prefers the harness-level flag — this exists so an
+   * individual model entry can override it on a per-id basis.
+   */
+  subscriptionPath?: boolean;
+}
+
+/**
+ * Per-model cost entries. Keyed by the exact `model` id persisted to
+ * `joinedSolverNets[<cid>].model`. The dashboard model dropdown in
+ * `claudeModels.ts` is the source of truth for which ids appear here.
+ */
+export const MODEL_COST_TABLE: Readonly<Record<string, ModelCostEntry>> = {
+  // ---------- Anthropic family (direct + via OpenRouter) ----------
+  'claude-opus-4-7': {
+    provider: 'anthropic',
+    inputPer1kTokens: 0.015,
+    outputPer1kTokens: 0.075,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'claude-sonnet-4-6': {
+    provider: 'anthropic',
+    inputPer1kTokens: 0.003,
+    outputPer1kTokens: 0.015,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'claude-haiku-4-5-20251001': {
+    provider: 'anthropic',
+    inputPer1kTokens: 0.001,
+    outputPer1kTokens: 0.005,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  // OpenRouter routing of the same families (Hermes harness uses these).
+  'anthropic/claude-opus-4.7': {
+    provider: 'openrouter',
+    inputPer1kTokens: 0.015,
+    outputPer1kTokens: 0.075,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'anthropic/claude-sonnet-4.6': {
+    provider: 'openrouter',
+    inputPer1kTokens: 0.003,
+    outputPer1kTokens: 0.015,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+
+  // ---------- OpenAI family ----------
+  'gpt-5.4': {
+    provider: 'openai',
+    inputPer1kTokens: 0.00125,
+    outputPer1kTokens: 0.01,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'gpt-5.4-mini': {
+    provider: 'openai',
+    inputPer1kTokens: 0.00025,
+    outputPer1kTokens: 0.002,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'gpt-5.5': {
+    provider: 'openai',
+    // Newer flagship; public pricing not confirmed at heuristic-capture
+    // time, so use Opus-4.7-class rates as a conservative upper bound
+    // until we get a verified figure.
+    inputPer1kTokens: 0.015,
+    outputPer1kTokens: 0.06,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'gpt-5.3-codex': {
+    provider: 'openai',
+    inputPer1kTokens: 0.00125,
+    outputPer1kTokens: 0.01,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'gpt-5.3-codex-spark': {
+    provider: 'openai',
+    inputPer1kTokens: 0.00125,
+    outputPer1kTokens: 0.01,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+
+  // ---------- OpenRouter long-tail (Hermes) ----------
+  // These rates are coarse — OpenRouter's effective price depends on the
+  // route picked. We pick the published list-price upper bound so the
+  // estimate biases toward over-warning rather than under-warning.
+  'tencent/hy3-preview': {
+    provider: 'openrouter',
+    inputPer1kTokens: 0.003,
+    outputPer1kTokens: 0.015,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'deepseek/deepseek-v4-pro': {
+    provider: 'openrouter',
+    inputPer1kTokens: 0.0014,
+    outputPer1kTokens: 0.0028,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'deepseek/deepseek-v4-flash': {
+    provider: 'openrouter',
+    inputPer1kTokens: 0.0001,
+    outputPer1kTokens: 0.0004,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'google/gemini-3.1-flash-lite': {
+    provider: 'openrouter',
+    inputPer1kTokens: 0.0001,
+    outputPer1kTokens: 0.0004,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'moonshotai/kimi-k2.6': {
+    provider: 'openrouter',
+    inputPer1kTokens: 0.0006,
+    outputPer1kTokens: 0.0025,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'openrouter/owl-alpha': {
+    provider: 'openrouter',
+    inputPer1kTokens: 0.002,
+    outputPer1kTokens: 0.008,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'minimax/minimax-m2.7': {
+    provider: 'openrouter',
+    inputPer1kTokens: 0.0008,
+    outputPer1kTokens: 0.0032,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'nousresearch/hermes-4-405b': {
+    provider: 'nous',
+    inputPer1kTokens: 0.0009,
+    outputPer1kTokens: 0.0009,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+};
+
+/**
+ * Harness-level billing classification.
+ *
+ * `subscriptionPath: true` means the harness shells out to a
+ * subscription-billed CLI (Claude Code, Codex) and the operator does NOT
+ * incur per-task API charges — the cost surface is suppressed entirely
+ * and the confirmation gate is never triggered.
+ *
+ * `subscriptionPath: false` means the harness routes to a paid API key
+ * (Hermes via OpenRouter / Anthropic API / Nous Portal). The cost surface
+ * is shown and the gate fires above the configured threshold.
+ */
+export const HARNESS_BILLING: Readonly<Record<string, { subscriptionPath: boolean }>> = {
+  [CLAUDE_CODE_HARNESS]: { subscriptionPath: true },
+  [CODEX_HARNESS]: { subscriptionPath: true },
+  [HERMES_AGENT_HARNESS]: { subscriptionPath: false },
+};
+
+/** Default per-task USD threshold above which the confirmation gate fires. */
+export const DEFAULT_HIGH_COST_THRESHOLD_USD = 1;
+
+export interface CostEstimate {
+  /** Estimated per-task cost in USD. */
+  usd: number;
+  /** Computed input cost in USD. */
+  inputUsd: number;
+  /** Computed output cost in USD. */
+  outputUsd: number;
+  /** Heuristic typical input tokens used. */
+  typicalInputTokens: number;
+  /** Heuristic typical output tokens used. */
+  typicalOutputTokens: number;
+  /** Underlying entry consulted. */
+  entry: ModelCostEntry;
+}
+
+/**
+ * Compute the per-task cost estimate for a given model id. Returns `null`
+ * when the id has no entry in `MODEL_COST_TABLE` — callers should treat
+ * that as "unknown, don't surface a number" rather than rendering $0.
+ */
+export function estimateModelCost(modelId: string): CostEstimate | null {
+  const entry = MODEL_COST_TABLE[modelId];
+  if (!entry) return null;
+  const inputUsd = (entry.typicalInputTokens / 1000) * entry.inputPer1kTokens;
+  const outputUsd = (entry.typicalOutputTokens / 1000) * entry.outputPer1kTokens;
+  return {
+    usd: inputUsd + outputUsd,
+    inputUsd,
+    outputUsd,
+    typicalInputTokens: entry.typicalInputTokens,
+    typicalOutputTokens: entry.typicalOutputTokens,
+    entry,
+  };
+}
+
+/**
+ * `true` when the harness routes through a paid API key. Subscription
+ * harnesses (Claude Code, Codex) return `false`; unknown harnesses
+ * conservatively return `true` so a misnamed harness doesn't silently
+ * skip the cost surface.
+ */
+export function harnessUsesPaidApiKey(harness: string | undefined): boolean {
+  if (!harness) return false;
+  const canonical = canonicalHarnessName(harness);
+  const billing = HARNESS_BILLING[canonical];
+  if (!billing) return true;
+  return !billing.subscriptionPath;
+}
+
+export interface CostSurfaceDecision {
+  /** Whether to show a numeric cost-per-task estimate at all. */
+  showEstimate: boolean;
+  /** Resolved estimate (may be `null` even when `showEstimate` is true if the model id is unknown). */
+  estimate: CostEstimate | null;
+  /** Whether the Save & Join action requires the high-cost confirmation. */
+  requiresConfirmation: boolean;
+  /**
+   * Human-readable reason the surface is suppressed when `showEstimate`
+   * is false — e.g. "Included in subscription, no per-task API cost".
+   * `null` when the surface is shown.
+   */
+  suppressedReason: string | null;
+}
+
+/**
+ * Decide what the cost surface should render for a given harness + model
+ * combination, plus whether the confirmation gate fires.
+ *
+ * Defaults:
+ *   - threshold: $1 / task (see DEFAULT_HIGH_COST_THRESHOLD_USD).
+ *   - subscription harness → suppress surface + skip gate.
+ *   - unknown model on a paid harness → show estimate slot (caller may
+ *     render "estimate unavailable") but DO NOT trigger the gate.
+ */
+export function decideCostSurface(
+  harness: string | undefined,
+  modelId: string | undefined,
+  thresholdUsd: number = DEFAULT_HIGH_COST_THRESHOLD_USD,
+): CostSurfaceDecision {
+  if (!harnessUsesPaidApiKey(harness)) {
+    return {
+      showEstimate: false,
+      estimate: null,
+      requiresConfirmation: false,
+      suppressedReason: 'Included in subscription, no per-task API cost.',
+    };
+  }
+  const estimate = modelId ? estimateModelCost(modelId) : null;
+  const modelOverridesSubscription =
+    estimate?.entry.subscriptionPath === true;
+  if (modelOverridesSubscription) {
+    return {
+      showEstimate: false,
+      estimate: null,
+      requiresConfirmation: false,
+      suppressedReason: 'Included in subscription, no per-task API cost.',
+    };
+  }
+  return {
+    showEstimate: true,
+    estimate,
+    requiresConfirmation: estimate !== null && estimate.usd > thresholdUsd,
+    suppressedReason: null,
+  };
+}
+
+/**
+ * Format a USD amount for compact display in the dashboard. Picks the
+ * smallest fraction count that still distinguishes the value from $0.
+ */
+export function formatUsd(amount: number): string {
+  if (!Number.isFinite(amount)) return '—';
+  if (amount === 0) return '$0';
+  if (amount < 0.01) return `<$0.01`;
+  if (amount < 1) return `$${amount.toFixed(2)}`;
+  if (amount < 10) return `$${amount.toFixed(2)}`;
+  return `$${amount.toFixed(2)}`;
+}

--- a/client/src/harnesses/impls/hermes-agent/harness.ts
+++ b/client/src/harnesses/impls/hermes-agent/harness.ts
@@ -1,12 +1,17 @@
 // client/src/harnesses/impls/hermes-agent/harness.ts
-import type { Harness, HarnessContext, Solution } from '../../types.js';
+import type { Harness, HarnessContext, ReadyStatus, Solution } from '../../types.js';
 import { HERMES_AGENT_HARNESS } from '../../names.js';
 import type { HermesHarnessAdapter } from './adapter.js';
 import { harvestOutput } from '../learner/harvest.js';
+import { probeHermesDoctor } from '../../../api/hermes-doctor-endpoint.js';
 
 export interface HermesHarnessConfig {
   adapter: HermesHarnessAdapter;
   version?: string;
+  /** Hermes binary path used by `isReady()`. Defaults to `hermes` (PATH lookup). */
+  hermesPath?: string;
+  /** Timeout for the `hermes doctor` probe. Defaults to 30s. */
+  hermesDoctorTimeoutMs?: number;
 }
 
 /**
@@ -26,10 +31,59 @@ export class HermesHarness implements Harness {
   readonly version: string;
   readonly freezeStateHashIgnore = ['auth', 'auth.json', 'bin/tirith', '.env', 'config.yaml'] as const;
   private readonly adapter: HermesHarnessAdapter;
+  private readonly hermesPath: string | undefined;
+  private readonly hermesDoctorTimeoutMs: number | undefined;
 
   constructor(config: HermesHarnessConfig) {
     this.adapter = config.adapter;
     this.version = config.version ?? '0.1.0';
+    this.hermesPath = config.hermesPath;
+    this.hermesDoctorTimeoutMs = config.hermesDoctorTimeoutMs;
+  }
+
+  /**
+   * Readiness probe — shells out to `hermes doctor` via the shared
+   * `probeHermesDoctor` helper (same logic the SPA precheck endpoint
+   * uses). Reports:
+   *   - `installed: false` → binary not on PATH → ready=false with install
+   *     nextStep so the operator sees an actionable message instead of
+   *     N/N failed claims (#330).
+   *   - `exitCode !== 0` → binary exists but `hermes doctor` reports a
+   *     configuration problem (e.g. provider not signed in) → ready=false
+   *     with a nextStep that points at the SPA precheck panel.
+   *   - `exitCode === 0` → ready=true.
+   */
+  async isReady(_ctx?: { solverType: string; role?: 'restoration' | 'evaluation' }): Promise<ReadyStatus> {
+    const config: { hermesPath?: string; hermesDoctorTimeoutMs?: number } = {};
+    if (this.hermesPath !== undefined) config.hermesPath = this.hermesPath;
+    if (this.hermesDoctorTimeoutMs !== undefined) config.hermesDoctorTimeoutMs = this.hermesDoctorTimeoutMs;
+    const result = probeHermesDoctor(config);
+    if (!result.installed) {
+      return {
+        ready: false,
+        reason: 'hermes binary not installed',
+        nextStep: {
+          description:
+            'Install the Hermes agent runner — see the Hermes precheck panel in the operator dashboard for the install command.',
+          url: '/api/hermes/doctor',
+        },
+      };
+    }
+    if (result.exitCode !== 0) {
+      const stderr = result.stderr.trim();
+      const stdout = result.stdout.trim();
+      const detail = stderr.length > 0 ? stderr : stdout;
+      return {
+        ready: false,
+        reason: `hermes doctor exit ${result.exitCode}${detail ? `: ${detail}` : ''}`,
+        nextStep: {
+          description:
+            'Run `hermes doctor` locally to surface the configuration problem, or open the Hermes precheck panel in the operator dashboard to sign in / select a provider.',
+          url: '/api/hermes/doctor',
+        },
+      };
+    }
+    return { ready: true };
   }
 
   supports(spec: { solverType: string; role?: 'restoration' | 'evaluation' }): boolean {

--- a/client/src/harnesses/impls/index.ts
+++ b/client/src/harnesses/impls/index.ts
@@ -104,6 +104,8 @@ export interface HarnessEnv {
   hermesModel?: string;
   /** Hermes provider (e.g. 'anthropic'). */
   hermesProvider?: string;
+  /** Timeout (ms) for the `hermes doctor` probe in HermesHarness.isReady. */
+  hermesDoctorTimeoutMs?: number;
 }
 
 /**
@@ -258,7 +260,11 @@ export function buildHarnesses(env: HarnessEnv): Harness[] {
     storePath: env.storePath,
     corpusEnv: env.corpusEnv ?? {},
   });
-  out.push(new HermesHarness({ adapter: hermesAdapter }));
+  out.push(new HermesHarness({
+    adapter: hermesAdapter,
+    ...(env.hermesPath !== undefined ? { hermesPath: env.hermesPath } : {}),
+    ...(env.hermesDoctorTimeoutMs !== undefined ? { hermesDoctorTimeoutMs: env.hermesDoctorTimeoutMs } : {}),
+  }));
 
   if (env.disabledNames && env.disabledNames.length > 0) {
     const disabled = canonicalHarnessNameSet(env.disabledNames);

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -38,6 +38,7 @@ import { readModeState } from './harnesses/mode-state.js';
 import { attachAgentWs, updateAgentClaudePath } from './agent/agent-ws.js';
 import { createSetupModeController } from './setup-mode.js';
 import { formatBootstrapOperatorMessage } from './operator-errors.js';
+import { requestDaemonRestart } from './restart-daemon.js';
 import { buildEnvelope, emitEnvelope, type ErrorCode, type ErrorEnvelope } from './errors/envelope.js';
 import {
   clearBootstrapError,
@@ -944,10 +945,12 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
         hermesDoctorTimeoutMs: config.hermesDoctorTimeoutMs,
       },
       admin: {
-        onRestartRequested: () => {
-          console.log('[main] Restart requested via operator MCP. Exiting...');
-          process.exit(0);
-        },
+        // jinn-mono #289: in interactive mode (the dashboard SPA case),
+        // spawn a detached replacement before exiting so the panel reconnects
+        // to a live daemon instead of seeing a 502 + terminal prompt. In
+        // headless mode (`JINN_NO_UI=1`), exit without respawning so the
+        // supervisor / systemd / docker entrypoint decides what to do.
+        onRestartRequested: () => requestDaemonRestart(),
       },
       harnessStatus: {
         getStatus: async () => {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1697,6 +1697,7 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     hermesPath: config.hermesPath,
     hermesModel: config.hermesModel,
     hermesProvider: config.hermesProvider,
+    hermesDoctorTimeoutMs: config.hermesDoctorTimeoutMs,
   })) {
     implRegistry.register(impl);
   }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1436,6 +1436,30 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
         });
         console.log('[main] Bootstrap halted. Waiting for retry signal from the dashboard...');
 
+        // hjex.5: Write a setup-halted pidfile so `jinn stop` can find this
+        // process even though it has not entered full running mode yet.
+        // The `mode` discriminator prevents `jinn run` from killing a
+        // halted-but-recoverable process before the operator has a chance to
+        // fund the wallet and click Retry.
+        const setupHaltedPidPath = join(config.earningDir, 'daemon.pid');
+        try {
+          mkdirSync(config.earningDir, { recursive: true, mode: 0o700 });
+          writeFileSyncMain(
+            setupHaltedPidPath,
+            JSON.stringify({ pid: process.pid, mode: 'setup-halted' }) + '\n',
+            'utf-8',
+          );
+          // Remove on process exit so a clean restart doesn't see a stale pidfile.
+          process.once('exit', () => {
+            try { unlinkSync(setupHaltedPidPath); } catch { /* ignore */ }
+          });
+        } catch (pidErr) {
+          console.warn(
+            `[main] Could not write setup-halted pidfile at ${setupHaltedPidPath}: ` +
+              (pidErr instanceof Error ? pidErr.message : String(pidErr)),
+          );
+        }
+
         // hjex.6: Auto-resume funding poller.
         // When the halt is a funding shortfall, poll the master EOA balance
         // every JINN_FUNDING_POLL_INTERVAL_MS (default 15s). When the balance

--- a/client/src/preflight/api-port.ts
+++ b/client/src/preflight/api-port.ts
@@ -1,4 +1,6 @@
 import { createServer } from 'node:net';
+import type { PortHolder } from './port-pid.js';
+import { defaultPortPidLookup, formatUptime } from './port-pid.js';
 
 export interface ApiPortPreflightOk {
   ok: true;
@@ -10,11 +12,18 @@ export interface ApiPortPreflightFail {
   port: number;
   code?: string;
   message: string;
+  /** Set when code === 'EADDRINUSE' and we could determine the holder. */
+  holder?: PortHolder;
 }
 
 export type ApiPortPreflightResult = ApiPortPreflightOk | ApiPortPreflightFail;
 
-export async function checkApiPortAvailable(port: number): Promise<ApiPortPreflightResult> {
+export type PortPidLookup = (port: number) => Promise<PortHolder | null>;
+
+export async function checkApiPortAvailable(
+  port: number,
+  portPidLookup: PortPidLookup = defaultPortPidLookup,
+): Promise<ApiPortPreflightResult> {
   return new Promise((resolve) => {
     const server = createServer();
     let settled = false;
@@ -27,12 +36,32 @@ export async function checkApiPortAvailable(port: number): Promise<ApiPortPrefli
     };
 
     server.once('error', (error: NodeJS.ErrnoException) => {
-      finish({
-        ok: false,
-        port,
-        code: error.code,
-        message: error.message,
-      });
+      if (error.code === 'EADDRINUSE') {
+        // Enrich with port-to-PID info asynchronously, then resolve.
+        portPidLookup(port).then((holder) => {
+          finish({
+            ok: false,
+            port,
+            code: error.code,
+            message: error.message,
+            ...(holder !== null ? { holder } : {}),
+          });
+        }).catch(() => {
+          finish({
+            ok: false,
+            port,
+            code: error.code,
+            message: error.message,
+          });
+        });
+      } else {
+        finish({
+          ok: false,
+          port,
+          code: error.code,
+          message: error.message,
+        });
+      }
     });
 
     server.listen({ port, host: '0.0.0.0', exclusive: true }, () => {
@@ -43,7 +72,18 @@ export async function checkApiPortAvailable(port: number): Promise<ApiPortPrefli
 
 export function apiPortFailureMessage(result: ApiPortPreflightFail): string {
   if (result.code === 'EADDRINUSE') {
-    return `Port ${result.port} is already in use. Stop the other daemon or set JINN_API_PORT / apiPort to another port.`;
+    if (result.holder) {
+      const { pid, command, uptimeSeconds } = result.holder;
+      const uptimePart = uptimeSeconds !== null ? `, started ${formatUptime(uptimeSeconds)} ago` : '';
+      return (
+        `Port ${result.port} is held by PID ${pid} (${command}${uptimePart}). ` +
+        `Run \`jinn stop --force\` to recover.`
+      );
+    }
+    return (
+      `Port ${result.port} is already in use. ` +
+      `Run \`jinn stop\` or set JINN_API_PORT / apiPort to another port.`
+    );
   }
   return `Port ${result.port} is not available: ${result.message}`;
 }

--- a/client/src/preflight/port-pid.ts
+++ b/client/src/preflight/port-pid.ts
@@ -1,0 +1,219 @@
+/**
+ * port-pid.ts — port-to-PID resolution
+ *
+ * Abstracts the OS-level call behind a small helper so callers (jinn stop,
+ * api-port preflight) can inject a mock in tests. Production uses lsof on
+ * macOS/Linux (when available) and falls back to `ss -lntp` on Linux. If
+ * neither tool is found or parsing fails, returns null gracefully — callers
+ * must handle a null result without crashing.
+ */
+
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+export interface PortHolder {
+  pid: number;
+  command: string;
+  uptimeSeconds: number | null;
+}
+
+/**
+ * Default implementation: calls lsof (or ss on Linux as fallback) to find
+ * the process holding `port`. Returns null when the tool is unavailable,
+ * yields no output, or parsing fails.
+ */
+export async function defaultPortPidLookup(port: number): Promise<PortHolder | null> {
+  // Try lsof first (macOS + most Linux distros with lsof installed)
+  const lsofResult = tryLsof(port);
+  if (lsofResult !== null) return lsofResult;
+
+  // Fallback: ss -lntp (Linux iproute2)
+  const ssResult = trySs(port);
+  if (ssResult !== null) return ssResult;
+
+  return null;
+}
+
+function tryLsof(port: number): PortHolder | null {
+  try {
+    const out = execSync(`lsof -i :${port} -n -P -F pcu`, {
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return parseLsofOutput(out, port);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse lsof -F pcu output. The -F flag gives field output:
+ *   p<pid>\nc<command>\nu<user>\n...
+ * We look for lines with 'p' (pid) and 'c' (command).
+ */
+function parseLsofOutput(out: string, _port: number): PortHolder | null {
+  if (!out.trim()) return null;
+  const lines = out.split('\n');
+  let pid: number | null = null;
+  let command: string | null = null;
+  for (const line of lines) {
+    if (line.startsWith('p')) {
+      const n = parseInt(line.slice(1), 10);
+      if (Number.isFinite(n)) pid = n;
+    } else if (line.startsWith('c')) {
+      command = line.slice(1).trim();
+    }
+    if (pid !== null && command !== null) break;
+  }
+  if (pid === null || command === null) {
+    // Fallback: try plain text output (lsof without -F)
+    return parseLsofPlainOutput(out);
+  }
+  return {
+    pid,
+    command,
+    uptimeSeconds: tryGetProcessUptimeSeconds(pid),
+  };
+}
+
+/**
+ * Parse plain lsof output (without -F) as a fallback. Looks for lines
+ * where the NAME column contains :<port>.
+ */
+function parseLsofPlainOutput(out: string): PortHolder | null {
+  const lines = out.split('\n').filter(Boolean);
+  // Skip the header line (COMMAND PID USER ...)
+  for (const line of lines.slice(1)) {
+    const cols = line.trim().split(/\s+/);
+    // COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME
+    if (cols.length >= 9) {
+      const cmdCol = cols[0];
+      const pidCol = parseInt(cols[1] ?? '', 10);
+      if (Number.isFinite(pidCol) && cmdCol) {
+        return {
+          pid: pidCol,
+          command: cmdCol,
+          uptimeSeconds: tryGetProcessUptimeSeconds(pidCol),
+        };
+      }
+    }
+  }
+  return null;
+}
+
+function trySs(port: number): PortHolder | null {
+  try {
+    // ss -lntp 'sport = :PORT' — lists listening TCP sockets on that port
+    const out = execSync(`ss -lntp "sport = :${port}"`, {
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return parseSsOutput(out);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse ss -lntp output. Lines look like:
+ *   LISTEN  0  128  0.0.0.0:7331  0.0.0.0:*  users:(("node",pid=12345,fd=20))
+ */
+function parseSsOutput(out: string): PortHolder | null {
+  const lines = out.split('\n').filter(Boolean);
+  for (const line of lines) {
+    const m = line.match(/users:\(\("([^"]+)",pid=(\d+)/);
+    if (m) {
+      const command = m[1] as string;
+      const pid = parseInt(m[2] as string, 10);
+      if (Number.isFinite(pid)) {
+        return {
+          pid,
+          command,
+          uptimeSeconds: tryGetProcessUptimeSeconds(pid),
+        };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Attempt to determine how long a process has been running by reading
+ * /proc/<pid>/stat (Linux) or using ps on macOS. Returns null if unavailable.
+ */
+function tryGetProcessUptimeSeconds(pid: number): number | null {
+  // Linux: /proc/<pid>/stat has start time in clock ticks from boot
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, 'utf-8');
+    const uptimeRaw = readFileSync('/proc/uptime', 'utf-8');
+    const uptimeStr = uptimeRaw.split(' ')[0];
+    const uptimeSecs = uptimeStr ? parseFloat(uptimeStr) : null;
+    const fields = stat.split(' ');
+    // Field 22 (index 21) is starttime in clock ticks
+    const startTicks = parseInt(fields[21] ?? '0', 10);
+    const clkTck = 100; // sysconf(_SC_CLK_TCK) — almost always 100 on Linux
+    if (Number.isFinite(startTicks) && uptimeSecs !== null) {
+      const startSecs = startTicks / clkTck;
+      const elapsed = uptimeSecs - startSecs;
+      return Math.max(0, Math.round(elapsed));
+    }
+  } catch {
+    /* not Linux or permission denied */
+  }
+
+  // macOS: ps -o etime= -p <pid>
+  try {
+    const out = execSync(`ps -o etime= -p ${pid}`, {
+      encoding: 'utf-8',
+      timeout: 3000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    return parseEtime(out);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse ps etime format: [[DD-]HH:]MM:SS
+ */
+export function parseEtime(etime: string): number | null {
+  const t = etime.trim();
+  // Format: [[DD-]HH:]MM:SS
+  const parts = t.split(':');
+  if (parts.length === 2) {
+    // MM:SS
+    const mm = parseInt(parts[0] ?? '0', 10);
+    const ss = parseInt(parts[1] ?? '0', 10);
+    if (Number.isFinite(mm) && Number.isFinite(ss)) return mm * 60 + ss;
+  } else if (parts.length === 3) {
+    // HH:MM:SS or DD-HH:MM:SS
+    const hhPart = parts[0] ?? '0';
+    const mm = parseInt(parts[1] ?? '0', 10);
+    const ss = parseInt(parts[2] ?? '0', 10);
+    if (hhPart.includes('-')) {
+      const [ddStr, hhStr] = hhPart.split('-');
+      const dd = parseInt(ddStr ?? '0', 10);
+      const hh = parseInt(hhStr ?? '0', 10);
+      if ([dd, hh, mm, ss].every(Number.isFinite)) {
+        return dd * 86400 + hh * 3600 + mm * 60 + ss;
+      }
+    } else {
+      const hh = parseInt(hhPart, 10);
+      if ([hh, mm, ss].every(Number.isFinite)) return hh * 3600 + mm * 60 + ss;
+    }
+  }
+  return null;
+}
+
+/** Format uptimeSeconds into a human-readable string like "1d4h" or "2h3m". */
+export function formatUptime(seconds: number): string {
+  const d = Math.floor(seconds / 86400);
+  const h = Math.floor((seconds % 86400) / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (d > 0) return `${d}d${h}h`;
+  if (h > 0) return `${h}h${m}m`;
+  return `${m}m`;
+}

--- a/client/src/preflight/port-pid.ts
+++ b/client/src/preflight/port-pid.ts
@@ -41,7 +41,7 @@ function tryLsof(port: number): PortHolder | null {
       timeout: 5000,
       stdio: ['ignore', 'pipe', 'ignore'],
     });
-    return parseLsofOutput(out, port);
+    return parseLsofOutput(out);
   } catch {
     return null;
   }
@@ -51,8 +51,9 @@ function tryLsof(port: number): PortHolder | null {
  * Parse lsof -F pcu output. The -F flag gives field output:
  *   p<pid>\nc<command>\nu<user>\n...
  * We look for lines with 'p' (pid) and 'c' (command).
+ * Exported for unit testing.
  */
-function parseLsofOutput(out: string, _port: number): PortHolder | null {
+export function parseLsofOutput(out: string): PortHolder | null {
   if (!out.trim()) return null;
   const lines = out.split('\n');
   let pid: number | null = null;
@@ -67,39 +68,13 @@ function parseLsofOutput(out: string, _port: number): PortHolder | null {
     if (pid !== null && command !== null) break;
   }
   if (pid === null || command === null) {
-    // Fallback: try plain text output (lsof without -F)
-    return parseLsofPlainOutput(out);
+    return null;
   }
   return {
     pid,
     command,
     uptimeSeconds: tryGetProcessUptimeSeconds(pid),
   };
-}
-
-/**
- * Parse plain lsof output (without -F) as a fallback. Looks for lines
- * where the NAME column contains :<port>.
- */
-function parseLsofPlainOutput(out: string): PortHolder | null {
-  const lines = out.split('\n').filter(Boolean);
-  // Skip the header line (COMMAND PID USER ...)
-  for (const line of lines.slice(1)) {
-    const cols = line.trim().split(/\s+/);
-    // COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME
-    if (cols.length >= 9) {
-      const cmdCol = cols[0];
-      const pidCol = parseInt(cols[1] ?? '', 10);
-      if (Number.isFinite(pidCol) && cmdCol) {
-        return {
-          pid: pidCol,
-          command: cmdCol,
-          uptimeSeconds: tryGetProcessUptimeSeconds(pidCol),
-        };
-      }
-    }
-  }
-  return null;
 }
 
 function trySs(port: number): PortHolder | null {
@@ -119,8 +94,9 @@ function trySs(port: number): PortHolder | null {
 /**
  * Parse ss -lntp output. Lines look like:
  *   LISTEN  0  128  0.0.0.0:7331  0.0.0.0:*  users:(("node",pid=12345,fd=20))
+ * Exported for unit testing.
  */
-function parseSsOutput(out: string): PortHolder | null {
+export function parseSsOutput(out: string): PortHolder | null {
   const lines = out.split('\n').filter(Boolean);
   for (const line of lines) {
     const m = line.match(/users:\(\("([^"]+)",pid=(\d+)/);

--- a/client/src/restart-daemon.ts
+++ b/client/src/restart-daemon.ts
@@ -1,0 +1,120 @@
+/**
+ * In-process respawn helper for operator-triggered daemon restarts.
+ *
+ * Issue #289: clicking "Restart node" in the operator panel previously called
+ * `process.exit(0)`, which killed the daemon and stranded the operator outside
+ * the app (the panel went 502, the terminal got a shell prompt). Every
+ * restart-required config change funnelled through the same handler:
+ *
+ *   - POST /v1/setup/network              — RPC URL change
+ *   - POST /v1/setup/change-password      — keystore password rotation
+ *   - POST /v1/setup/solvernets/:name     — SolverNet enable/disable
+ *   - POST /v1/operator/join/:cid         — SolverNet join
+ *
+ * The fix is the smallest thing that makes the button mean what it says:
+ * before the parent exits, spawn a detached copy of the current process,
+ * inheriting argv (sans node binary), env, and stdio. The child takes over
+ * the port; the panel reconnects within a couple of seconds.
+ *
+ * Headless gate: `JINN_NO_UI=1` (already the established headless flag in
+ * main.ts) skips the respawn — operators running `jinn run --no-ui` from a
+ * supervisor / systemd unit / docker entrypoint want the supervisor to
+ * decide whether to restart, not the daemon.
+ *
+ * The helper is split out from main.ts so it's unit-testable without
+ * touching the entry-point bootstrap path.
+ */
+
+import { spawn, type SpawnOptions } from 'node:child_process';
+
+/**
+ * Options for `requestDaemonRestart`. All optional in production; the helper
+ * defaults to `process` / `node:child_process`. Tests inject doubles.
+ */
+export interface RequestDaemonRestartOptions {
+  /** Defaults to `process.env`. */
+  env?: NodeJS.ProcessEnv;
+  /** Defaults to `process.argv` (`[node, scriptPath, ...args]`). */
+  argv?: readonly string[];
+  /** Defaults to `process.execPath` (the node binary). */
+  execPath?: string;
+  /**
+   * Defaults to `node:child_process.spawn`. Injected for tests so we can
+   * assert what was spawned without actually forking node.
+   */
+  spawnFn?: typeof spawn;
+  /** Defaults to `(code) => process.exit(code)`. Injected for tests. */
+  exitFn?: (code: number) => void;
+  /** Defaults to `console.log`. Injected for tests to capture output. */
+  log?: (message: string) => void;
+  /**
+   * Delay (ms) between spawning the child and exiting the parent. Gives the
+   * child a moment to bind the API port before the parent vacates it.
+   * Defaults to 250ms per the issue body. Tests can pass 0 for synchrony.
+   */
+  exitDelayMs?: number;
+}
+
+/**
+ * Pure predicate: true when the current env is headless and respawn should
+ * be skipped. Exposed so callers and tests can share the same check.
+ */
+export function isHeadless(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env['JINN_NO_UI'] === '1';
+}
+
+/**
+ * Handle an operator-triggered restart request.
+ *
+ * - In **interactive** mode (default), spawn a detached child that re-runs
+ *   the current node invocation, then exit after a short delay so the child
+ *   can bind the API port.
+ * - In **headless** mode (`JINN_NO_UI=1`), exit without respawning. The
+ *   supervisor is responsible for relaunching the daemon if it wants to.
+ *
+ * Returns the action taken (for tests). Production callers ignore the return.
+ */
+export function requestDaemonRestart(
+  opts: RequestDaemonRestartOptions = {},
+): 'respawned' | 'headless-exit' {
+  const env = opts.env ?? process.env;
+  const argv = opts.argv ?? process.argv;
+  const execPath = opts.execPath ?? process.execPath;
+  const spawnFn = opts.spawnFn ?? spawn;
+  const exitFn = opts.exitFn ?? ((code: number) => process.exit(code));
+  const log = opts.log ?? ((message: string) => console.log(message));
+  const exitDelayMs = opts.exitDelayMs ?? 250;
+
+  if (isHeadless(env)) {
+    log(
+      '[main] Restart requested via operator MCP, but JINN_NO_UI=1 — exiting without respawn (let the supervisor decide).',
+    );
+    exitFn(0);
+    return 'headless-exit';
+  }
+
+  log('[main] Restart requested via operator MCP. Spawning replacement and exiting...');
+
+  // argv[0] is the node binary; argv[1..] are the script + flags. The child
+  // re-runs the same script with the same flags, under the same node binary.
+  const childArgs = argv.slice(1);
+  const spawnOptions: SpawnOptions = {
+    detached: true,
+    stdio: 'inherit',
+    env,
+  };
+  const child = spawnFn(execPath, childArgs, spawnOptions);
+  // Detach so the parent can exit without taking the child with it.
+  child.unref();
+
+  // Give the child a moment to bind the API port before we vacate it.
+  // The 250ms default matches the issue body's empirical measurement; tests
+  // pass 0 for synchrony.
+  if (exitDelayMs <= 0) {
+    exitFn(0);
+  } else {
+    setTimeout(() => exitFn(0), exitDelayMs);
+  }
+
+  return 'respawned';
+}

--- a/client/test/cli/commands/stop.test.ts
+++ b/client/test/cli/commands/stop.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { mkdtempSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import stop from '../../../src/cli/commands/stop.js';
+import { jinnStop } from '../../../src/cli/commands/stop.js';
 import { makeCommandCtx } from '@test/cli.js';
 import { Store } from '../../../src/store/store.js';
 
@@ -71,5 +72,76 @@ describe('stop command', () => {
     const parsed = JSON.parse(writes[writes.length - 1]);
     expect(parsed.code).toBe('invalid_invocation');
     expect(exits).toEqual([11]);
+  });
+
+  // ── jinn-mono-hjex.5: port-based discovery ───────────────────────────────
+
+  it('discovers daemon by port when pidfile is missing (jinn-mono-hjex.5)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'jinn-stop-hjex5-'));
+    const pidfilePath = join(dir, 'daemon.pid');
+    // Ensure no pidfile exists.
+    expect(existsSync(pidfilePath)).toBe(false);
+
+    const fakeLsof = vi.fn().mockResolvedValue({ pid: 19958, command: 'node', uptimeSeconds: 104400 });
+    const result = await jinnStop({ pidfilePath, port: 7331, lsofImpl: fakeLsof, dryRun: true });
+
+    expect(result.schemaVersion).toBe(1);
+    // dryRun=true so killed stays false; PID was found via port
+    expect(result.pid).toBe(19958);
+    expect(result.discoveredVia).toBe('port');
+    expect(fakeLsof).toHaveBeenCalledWith(7331);
+  });
+
+  it('returns state=stopped and no discoveredVia when lsof finds nothing (jinn-mono-hjex.5)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'jinn-stop-hjex5-'));
+    const pidfilePath = join(dir, 'daemon.pid');
+
+    const fakeLsof = vi.fn().mockResolvedValue(null);
+    const result = await jinnStop({ pidfilePath, port: 7331, lsofImpl: fakeLsof });
+
+    expect(result.state).toBe('stopped');
+    expect(result.pid).toBeNull();
+    expect(result.discoveredVia).toBeUndefined();
+  });
+
+  it('gracefully handles lsof unavailable (jinn-mono-hjex.5)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'jinn-stop-hjex5-'));
+    const pidfilePath = join(dir, 'daemon.pid');
+
+    const fakeLsof = vi.fn().mockRejectedValue(new Error('lsof not found'));
+    const result = await jinnStop({ pidfilePath, port: 7331, lsofImpl: fakeLsof });
+
+    // Should not crash; falls through to "already stopped"
+    expect(result.state).toBe('stopped');
+    expect(result.pid).toBeNull();
+  });
+
+  it('parses setup-halted JSON pidfile and surfaces pidfileMode (jinn-mono-hjex.5)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'jinn-stop-hjex5-'));
+    const pidfilePath = join(dir, 'daemon.pid');
+    // Write a JSON pidfile as main.ts does when halted
+    writeFileSync(pidfilePath, JSON.stringify({ pid: 99999, mode: 'setup-halted' }) + '\n');
+
+    const result = await jinnStop({ pidfilePath, port: 7331 });
+
+    expect(result.pid).toBe(99999);
+    expect(result.pidfileMode).toBe('setup-halted');
+    // PID 99999 doesn't exist so it should be cleaned up as stale
+    expect(result.stalePidfileCleaned).toBe(true);
+  });
+
+  it('does not fall back to port discovery when pidfile exists (jinn-mono-hjex.5)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'jinn-stop-hjex5-'));
+    const pidfilePath = join(dir, 'daemon.pid');
+    // Write a stale pidfile — process 99999 doesn't exist
+    writeFileSync(pidfilePath, '99999\n');
+
+    const fakeLsof = vi.fn().mockResolvedValue({ pid: 12345, command: 'node', uptimeSeconds: 100 });
+    const result = await jinnStop({ pidfilePath, port: 7331, lsofImpl: fakeLsof });
+
+    // Should use pidfile path, NOT port discovery
+    expect(result.pid).toBe(99999);
+    expect(result.discoveredVia).toBeUndefined();
+    expect(fakeLsof).not.toHaveBeenCalled();
   });
 });

--- a/client/test/cli/commands/update.test.ts
+++ b/client/test/cli/commands/update.test.ts
@@ -12,6 +12,7 @@ import type { FleetState, ServiceState } from '@/earning/types.js';
 import { DEFAULT_TESTNET_ARTIFACTS, getChainConfig } from '@/earning/contracts.js';
 import { resolveTaskNativeReadiness } from '@/cli/task-native-readiness.js';
 import { Store } from '@/store/store.js';
+import type { StopResult } from '@/cli/commands/stop.js';
 
 // MOCK_JUSTIFICATION: node:child_process is a leaf Node built-in; execSync is a syscall and cannot be DI'd without a shim module we don't own.
 vi.mock('node:child_process', async (importOriginal) => {
@@ -36,12 +37,39 @@ describe('update command', () => {
     return dir;
   }
 
+  function makeStoppedResult(pid: number | null = null): StopResult {
+    return {
+      schemaVersion: 1,
+      generatedAt: new Date().toISOString(),
+      state: 'stopped',
+      pid,
+      killed: false,
+      pidfilePath: '/tmp/daemon.pid',
+      pidfileRemoved: false,
+      stalePidfileCleaned: false,
+    };
+  }
+
+  function makeKilledResult(pid: number): StopResult {
+    return {
+      schemaVersion: 1,
+      generatedAt: new Date().toISOString(),
+      state: 'stopping',
+      pid,
+      killed: true,
+      pidfilePath: '/tmp/daemon.pid',
+      pidfileRemoved: false,
+      stalePidfileCleaned: false,
+    };
+  }
+
   function makeUpdateCommand(
     earningDir: string,
     integrationsRun = vi.fn(async () => {}),
     opts: {
       dbPath?: string;
       storeFactory?: (dbPath: string) => Pick<Store, 'close'>;
+      jinnStopFn?: () => Promise<StopResult>;
     } = {},
   ) {
     return createUpdateCommand({
@@ -53,6 +81,7 @@ describe('update command', () => {
       },
       fleetStateStoreFactory: (dir) => new FleetStateStore(dir),
       storeFactory: opts.storeFactory ?? (() => ({ close: () => {} })),
+      jinnStopFn: opts.jinnStopFn ?? vi.fn().mockResolvedValue(makeStoppedResult()),
     });
   }
 
@@ -466,5 +495,94 @@ describe('update command', () => {
     expect(earningStep).toMatchObject({ status: 'skipped' });
     expect(earningStep?.detail).toContain('not bootstrapped');
     expect(await new FleetStateStore(earningDir).tryLoadExisting()).toBeNull();
+  });
+
+  // ── jinn-mono-hjex.5: stop daemon before npm update ───────────────────────
+
+  it('stops a running daemon before swapping the binary (jinn-mono-hjex.5)', async () => {
+    const earningDir = await makeEarningDir();
+    const stopMock = vi.fn().mockResolvedValue(makeKilledResult(19958));
+    const execSyncMock = (await import('node:child_process')).execSync as ReturnType<typeof vi.fn>;
+
+    const cmd = makeUpdateCommand(earningDir, vi.fn(async () => {}), {
+      jinnStopFn: stopMock,
+    });
+    const { envelopes } = await runCommand(cmd, { argv: ['--json', '--skip-plugins'] });
+
+    // stop must be called before execSync (npm update)
+    expect(stopMock).toHaveBeenCalled();
+    const stopCallOrder = stopMock.mock.invocationCallOrder[0];
+    const execCallOrder = execSyncMock.mock.invocationCallOrder[0];
+    // stopMock called first (lower invocation call order index)
+    if (execCallOrder !== undefined && stopCallOrder !== undefined) {
+      expect(stopCallOrder).toBeLessThan(execCallOrder);
+    }
+
+    const payload = envelopes[envelopes.length - 1] as {
+      ok: boolean;
+      steps: Array<{ step: string; status: string; detail: string }>;
+    };
+    const stopStep = payload.steps.find((step) => step.step === 'stop-daemon');
+    expect(stopStep).toBeDefined();
+    expect(stopStep?.status).toBe('ok');
+    expect(stopStep?.detail).toContain('19958');
+  });
+
+  it('reports no daemon to stop when jinnStop returns already-stopped (jinn-mono-hjex.5)', async () => {
+    const earningDir = await makeEarningDir();
+    const stopMock = vi.fn().mockResolvedValue(makeStoppedResult());
+
+    const cmd = makeUpdateCommand(earningDir, vi.fn(async () => {}), {
+      jinnStopFn: stopMock,
+    });
+    const { envelopes } = await runCommand(cmd, { argv: ['--json', '--skip-plugins'] });
+    const payload = envelopes[envelopes.length - 1] as {
+      ok: boolean;
+      steps: Array<{ step: string; status: string; detail: string }>;
+    };
+
+    const stopStep = payload.steps.find((step) => step.step === 'stop-daemon');
+    expect(stopStep).toBeDefined();
+    expect(stopStep?.status).toBe('skipped');
+    expect(stopStep?.detail).toContain('No running daemon');
+  });
+
+  it('aborts update if daemon stop fails (jinn-mono-hjex.5)', async () => {
+    const earningDir = await makeEarningDir();
+    const stopMock = vi.fn().mockRejectedValue(new Error('permission denied'));
+
+    const cmd = makeUpdateCommand(earningDir, vi.fn(async () => {}), {
+      jinnStopFn: stopMock,
+    });
+    const { envelopes } = await runCommand(cmd, { argv: ['--json', '--skip-plugins'] });
+    const payload = envelopes[envelopes.length - 1] as {
+      ok: boolean;
+      steps: Array<{ step: string; status: string; detail: string }>;
+    };
+
+    expect(payload.ok).toBe(false);
+    const stopStep = payload.steps.find((step) => step.step === 'stop-daemon');
+    expect(stopStep?.status).toBe('error');
+    expect(stopStep?.detail).toContain('permission denied');
+    // npm-update step should NOT appear because we aborted early
+    expect(payload.steps.find((step) => step.step === 'npm-update')).toBeUndefined();
+  });
+
+  it('skip-npm bypasses the stop-daemon step (jinn-mono-hjex.5)', async () => {
+    const earningDir = await makeEarningDir();
+    const stopMock = vi.fn().mockResolvedValue(makeStoppedResult());
+
+    const cmd = makeUpdateCommand(earningDir, vi.fn(async () => {}), {
+      jinnStopFn: stopMock,
+    });
+    const { envelopes } = await runCommand(cmd, { argv: ['--json', '--skip-npm', '--skip-plugins'] });
+    const payload = envelopes[envelopes.length - 1] as {
+      ok: boolean;
+      steps: Array<{ step: string; status: string; detail: string }>;
+    };
+
+    // With --skip-npm there is no binary swap, so stop is not needed
+    expect(stopMock).not.toHaveBeenCalled();
+    expect(payload.steps.find((step) => step.step === 'stop-daemon')).toBeUndefined();
   });
 });

--- a/client/test/cli/commands/update.test.ts
+++ b/client/test/cli/commands/update.test.ts
@@ -513,10 +513,12 @@ describe('update command', () => {
     expect(stopMock).toHaveBeenCalled();
     const stopCallOrder = stopMock.mock.invocationCallOrder[0];
     const execCallOrder = execSyncMock.mock.invocationCallOrder[0];
+    // Fail loudly rather than passing vacuously if either side wasn't recorded
+    // (e.g. npm-update step regression that skips execSync, or stop wired wrong).
+    expect(stopCallOrder).toBeDefined();
+    expect(execCallOrder).toBeDefined();
     // stopMock called first (lower invocation call order index)
-    if (execCallOrder !== undefined && stopCallOrder !== undefined) {
-      expect(stopCallOrder).toBeLessThan(execCallOrder);
-    }
+    expect(stopCallOrder).toBeLessThan(execCallOrder as number);
 
     const payload = envelopes[envelopes.length - 1] as {
       ok: boolean;

--- a/client/test/daemon/claim-readiness-gate.test.ts
+++ b/client/test/daemon/claim-readiness-gate.test.ts
@@ -1,0 +1,172 @@
+// client/test/daemon/claim-readiness-gate.test.ts
+//
+// Regression for #330: the daemon must not claim tasks against a SolverNet
+// whose harness reports not-ready. Pre-fix on v0.1.6, a fresh operator who
+// joined SWE-rebench v2 without installing/authing Hermes burned 26 failed
+// claims in minutes — every claim landed because the gate was wired but
+// `HermesHarness` had no `isReady()` so the registry treated it as
+// always-ready.
+//
+// The test spins up a real `Daemon` against a `LocalAdapter`, posts a task
+// whose `solverNetManifestCid` matches a joined entry, and verifies the
+// claim path observes a not-ready harness and skips. The reverse path
+// (registry transitions to ready → claims resume) is also covered.
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Daemon, type DaemonConfig } from '../../src/daemon/daemon.js';
+import { LocalAdapter } from '../../src/adapters/local/adapter.js';
+import { SimpleRunner } from '../../src/runner/simple.js';
+import { HarnessRegistry } from '../../src/harnesses/engine/registry.js';
+import {
+  _resetReadinessGateMemoForTests,
+} from '../../src/daemon/readiness-gate.js';
+import type { HarnessReadinessRegistry } from '../../src/harnesses/readiness-registry.js';
+
+function minimalEngineConfig(): DaemonConfig['restorationEngine'] {
+  const root = mkdtempSync(join(tmpdir(), 'jinn-daemon-readiness-test-'));
+  const implRegistry = new HarnessRegistry({ default: 'legacy-claude' });
+  return {
+    implRegistry,
+    paths: {
+      workingDirRoot: join(root, 'work'),
+      implStateDirRoot: join(root, 'impl-state'),
+    },
+  };
+}
+
+/** Fake registry that returns whatever the controllable callback says. */
+function controlledRegistry(getReady: () => { ready: boolean; reason?: string }) {
+  return {
+    isReadyForClaim: vi.fn(() => getReady()),
+    getSnapshot: vi.fn(() => ({ lastRefreshedAt: '', harnesses: [] })),
+    refreshNow: vi.fn(async () => {}),
+    start: vi.fn(),
+    stop: vi.fn(),
+  } as unknown as HarnessReadinessRegistry;
+}
+
+beforeEach(() => {
+  _resetReadinessGateMemoForTests();
+});
+
+describe('Daemon — claim readiness gate (#330)', () => {
+  it('does NOT call adapter.claimTask when registry reports the harness not ready', async () => {
+    const adapter = new LocalAdapter();
+    const claimSpy = vi.spyOn(adapter, 'claimTask');
+
+    const registry = controlledRegistry(() => ({
+      ready: false,
+      reason: 'hermes binary not installed',
+    }));
+
+    const daemon = new Daemon({
+      adapter,
+      runner: new SimpleRunner(async (d) => `done: ${d}`),
+      taskSources: [],
+      dbPath: ':memory:',
+      restorationEngine: minimalEngineConfig(),
+      harnessReadinessRegistry: registry,
+    });
+    await daemon.start();
+
+    // Post a task carrying a manifestCid so the gate path activates.
+    await adapter.postTask({
+      id: 'task-not-ready',
+      description: 'should be skipped',
+      solverNetManifestCid: 'bafkrei.fake-cid',
+    });
+
+    // Give the engine-watcher loop a few ticks to observe the announcement.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(registry.isReadyForClaim).toHaveBeenCalledWith('bafkrei.fake-cid');
+    expect(claimSpy).not.toHaveBeenCalled();
+
+    await daemon.stop();
+  });
+
+  it('claims when registry transitions from not-ready to ready', async () => {
+    const adapter = new LocalAdapter();
+    const claimSpy = vi.spyOn(adapter, 'claimTask');
+
+    // Flip from not-ready to ready between announcements.
+    let ready = false;
+    const registry = controlledRegistry(() =>
+      ready
+        ? { ready: true }
+        : { ready: false, reason: 'hermes binary not installed' },
+    );
+
+    const daemon = new Daemon({
+      adapter,
+      runner: new SimpleRunner(async (d) => `done: ${d}`),
+      taskSources: [],
+      dbPath: ':memory:',
+      restorationEngine: minimalEngineConfig(),
+      harnessReadinessRegistry: registry,
+    });
+    await daemon.start();
+
+    // Round 1 — not ready, no claim.
+    await adapter.postTask({
+      id: 'task-skip-1',
+      description: 'first task — gate not ready',
+      solverNetManifestCid: 'bafkrei.fake-cid',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(claimSpy).not.toHaveBeenCalled();
+
+    // Round 2 — flip to ready, post a fresh task, expect a claim.
+    ready = true;
+    await adapter.postTask({
+      id: 'task-claim-2',
+      description: 'second task — gate ready',
+      solverNetManifestCid: 'bafkrei.fake-cid',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(claimSpy).toHaveBeenCalled();
+    const args = claimSpy.mock.calls[0]!;
+    expect(args[0]).toBe('2');  // LocalAdapter assigns sequential string ids
+
+    await daemon.stop();
+  });
+
+  it('surfaces the not-ready reason via a warn log on first transition', async () => {
+    const adapter = new LocalAdapter();
+
+    const registry = controlledRegistry(() => ({
+      ready: false,
+      reason: 'hermes doctor exit 1: provider not configured',
+    }));
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const daemon = new Daemon({
+      adapter,
+      runner: new SimpleRunner(async (d) => `done: ${d}`),
+      taskSources: [],
+      dbPath: ':memory:',
+      restorationEngine: minimalEngineConfig(),
+      harnessReadinessRegistry: registry,
+    });
+    await daemon.start();
+
+    await adapter.postTask({
+      id: 'task-log',
+      description: 'gate skip with operator-visible reason',
+      solverNetManifestCid: 'bafkrei.fake-cid',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const matched = warnSpy.mock.calls.some((call) => {
+      const msg = String(call[0] ?? '');
+      return msg.includes('hermes doctor exit 1') && msg.includes('skipping');
+    });
+    expect(matched).toBe(true);
+
+    warnSpy.mockRestore();
+    await daemon.stop();
+  });
+});

--- a/client/test/harnesses/cost-estimates.test.ts
+++ b/client/test/harnesses/cost-estimates.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Unit tests for `client/src/harnesses/cost-estimates.ts`.
+ *
+ * Acceptance criteria pulled from Issue #331 (cost protection P0):
+ *   - MODEL_COST_TABLE lookup returns the heuristic per-task estimate.
+ *   - decideCostSurface suppresses the cost surface for subscription
+ *     harnesses (Claude Code, Codex).
+ *   - decideCostSurface requires the confirmation gate when estimate
+ *     exceeds the default $1/task threshold (e.g. Opus 4.7).
+ *   - decideCostSurface does NOT require the gate below threshold or for
+ *     subscription harnesses (no false-positive gate fire).
+ *   - Heuristic value for Opus 4.7 on SWE-rebench-v2 typical task lands
+ *     near $2.25 (the figure called out in the issue body).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_HIGH_COST_THRESHOLD_USD,
+  MODEL_COST_TABLE,
+  decideCostSurface,
+  estimateModelCost,
+  formatUsd,
+  harnessUsesPaidApiKey,
+} from '../../src/harnesses/cost-estimates.js';
+
+describe('MODEL_COST_TABLE', () => {
+  it('covers the canonical Anthropic, OpenAI, and OpenRouter ids the dashboard exposes', () => {
+    // Spot-check the ids that ship in client/src/dashboard/spa/src/pages/
+    // configuration/claudeModels.ts — at minimum the operator default
+    // (Haiku), the warning-tier (Opus 4.7), the OpenRouter route of the
+    // same Opus family that Hermes lists, and the GPT-5.4 family.
+    expect(MODEL_COST_TABLE['claude-haiku-4-5-20251001']).toBeDefined();
+    expect(MODEL_COST_TABLE['claude-sonnet-4-6']).toBeDefined();
+    expect(MODEL_COST_TABLE['claude-opus-4-7']).toBeDefined();
+    expect(MODEL_COST_TABLE['anthropic/claude-opus-4.7']).toBeDefined();
+    expect(MODEL_COST_TABLE['gpt-5.4']).toBeDefined();
+    expect(MODEL_COST_TABLE['gpt-5.4-mini']).toBeDefined();
+  });
+
+  it('keeps the Opus 4.7 entry shape conservative — $0.015/1k input, $0.075/1k output', () => {
+    const opus = MODEL_COST_TABLE['claude-opus-4-7']!;
+    expect(opus.provider).toBe('anthropic');
+    expect(opus.inputPer1kTokens).toBeCloseTo(0.015, 5);
+    expect(opus.outputPer1kTokens).toBeCloseTo(0.075, 5);
+  });
+});
+
+describe('estimateModelCost', () => {
+  it('returns null for unknown model ids (callers render "estimate unavailable")', () => {
+    expect(estimateModelCost('not-a-real-model-id')).toBeNull();
+  });
+
+  it('matches the Issue #331 heuristic: Opus 4.7 ≈ $2.25/task at 50k input + 20k output', () => {
+    const estimate = estimateModelCost('claude-opus-4-7');
+    expect(estimate).not.toBeNull();
+    // 50k input × $0.015/1k + 20k output × $0.075/1k = $0.75 + $1.50 = $2.25
+    expect(estimate!.usd).toBeCloseTo(2.25, 5);
+    expect(estimate!.inputUsd).toBeCloseTo(0.75, 5);
+    expect(estimate!.outputUsd).toBeCloseTo(1.5, 5);
+  });
+
+  it('produces a sub-$1 estimate for Haiku — does not trigger the high-cost band', () => {
+    const estimate = estimateModelCost('claude-haiku-4-5-20251001');
+    expect(estimate).not.toBeNull();
+    expect(estimate!.usd).toBeLessThan(DEFAULT_HIGH_COST_THRESHOLD_USD);
+  });
+
+  it('produces a sub-$1 estimate for GPT-5.4 Mini', () => {
+    const estimate = estimateModelCost('gpt-5.4-mini');
+    expect(estimate).not.toBeNull();
+    expect(estimate!.usd).toBeLessThan(DEFAULT_HIGH_COST_THRESHOLD_USD);
+  });
+});
+
+describe('harnessUsesPaidApiKey', () => {
+  it('returns false for subscription harnesses (Claude Code, Codex)', () => {
+    expect(harnessUsesPaidApiKey('claude-code')).toBe(false);
+    expect(harnessUsesPaidApiKey('codex')).toBe(false);
+  });
+
+  it('returns true for Hermes (paid raw API key path)', () => {
+    expect(harnessUsesPaidApiKey('hermes-agent')).toBe(true);
+  });
+
+  it('canonicalises learner-prefixed harness names before classification', () => {
+    // `claude-code-learner` aliases to `claude-code` in canonicalHarnessName.
+    expect(harnessUsesPaidApiKey('claude-code-learner')).toBe(false);
+    expect(harnessUsesPaidApiKey('codex-code-learner')).toBe(false);
+  });
+
+  it('treats unknown harnesses conservatively as paid (so we never silently hide a cost surface)', () => {
+    expect(harnessUsesPaidApiKey('some-future-harness')).toBe(true);
+  });
+
+  it('returns false for an undefined harness (nothing to show)', () => {
+    expect(harnessUsesPaidApiKey(undefined)).toBe(false);
+  });
+});
+
+describe('decideCostSurface — subscription harnesses', () => {
+  it('suppresses the estimate for Claude Code regardless of model', () => {
+    const decision = decideCostSurface('claude-code', 'claude-opus-4-7');
+    expect(decision.showEstimate).toBe(false);
+    expect(decision.requiresConfirmation).toBe(false);
+    expect(decision.suppressedReason).toMatch(/subscription/i);
+  });
+
+  it('suppresses the estimate for Codex regardless of model', () => {
+    const decision = decideCostSurface('codex', 'gpt-5.5');
+    expect(decision.showEstimate).toBe(false);
+    expect(decision.requiresConfirmation).toBe(false);
+    expect(decision.suppressedReason).toMatch(/subscription/i);
+  });
+
+  it('does NOT trigger the confirmation gate for Claude Code + Opus 4.7 (false-positive guard)', () => {
+    // This is the explicit non-false-positive test called out in the
+    // PR scope: subscription harnesses must never demand the budget
+    // confirmation, even when paired with what would otherwise be a
+    // high-cost API-priced model.
+    const decision = decideCostSurface('claude-code', 'claude-opus-4-7');
+    expect(decision.requiresConfirmation).toBe(false);
+  });
+});
+
+describe('decideCostSurface — paid-API-key harnesses', () => {
+  it('shows the estimate and triggers the gate for Hermes + Opus 4.7 ($2.25 > $1)', () => {
+    const decision = decideCostSurface('hermes-agent', 'anthropic/claude-opus-4.7');
+    expect(decision.showEstimate).toBe(true);
+    expect(decision.estimate).not.toBeNull();
+    expect(decision.estimate!.usd).toBeGreaterThan(DEFAULT_HIGH_COST_THRESHOLD_USD);
+    expect(decision.requiresConfirmation).toBe(true);
+  });
+
+  it('shows the estimate but does NOT trigger the gate for Hermes + DeepSeek V4 Flash (well under $1)', () => {
+    const decision = decideCostSurface('hermes-agent', 'deepseek/deepseek-v4-flash');
+    expect(decision.showEstimate).toBe(true);
+    expect(decision.estimate).not.toBeNull();
+    expect(decision.estimate!.usd).toBeLessThan(DEFAULT_HIGH_COST_THRESHOLD_USD);
+    expect(decision.requiresConfirmation).toBe(false);
+  });
+
+  it('shows the estimate slot but does NOT trigger the gate when the model is unknown', () => {
+    // Unknown model — caller will render "estimate unavailable" rather
+    // than a number. We deliberately don't gate, to avoid blocking joins
+    // on operator-pinned custom ids we haven't priced yet.
+    const decision = decideCostSurface('hermes-agent', 'unknown-vendor/custom-finetune');
+    expect(decision.showEstimate).toBe(true);
+    expect(decision.estimate).toBeNull();
+    expect(decision.requiresConfirmation).toBe(false);
+  });
+
+  it('honours a caller-supplied threshold', () => {
+    // Bump the threshold so even Opus 4.7 no longer trips the gate.
+    const decision = decideCostSurface('hermes-agent', 'anthropic/claude-opus-4.7', 10);
+    expect(decision.showEstimate).toBe(true);
+    expect(decision.requiresConfirmation).toBe(false);
+  });
+});
+
+describe('formatUsd', () => {
+  it('renders <$0.01 for tiny values', () => {
+    expect(formatUsd(0.0001)).toBe('<$0.01');
+  });
+
+  it('renders cents for sub-$1 values', () => {
+    expect(formatUsd(0.43)).toBe('$0.43');
+  });
+
+  it('renders two decimals for typical task costs', () => {
+    expect(formatUsd(2.25)).toBe('$2.25');
+  });
+
+  it('handles zero cleanly', () => {
+    expect(formatUsd(0)).toBe('$0');
+  });
+
+  it('handles non-finite values without crashing', () => {
+    expect(formatUsd(Number.NaN)).toBe('—');
+  });
+});

--- a/client/test/harnesses/impls/hermes-agent/is-ready.test.ts
+++ b/client/test/harnesses/impls/hermes-agent/is-ready.test.ts
@@ -1,0 +1,62 @@
+// client/test/harnesses/impls/hermes-agent/is-ready.test.ts
+//
+// Regression coverage for #330: HermesHarness must expose isReady() so the
+// readiness registry can prevent the claim loop from claiming tasks against
+// an uninstalled / mis-configured hermes binary. Pre-fix HermesHarness had
+// no isReady; the registry treated it as always-ready and rvx's fresh
+// install burned 26 failed claims in minutes.
+import { describe, expect, it, vi } from 'vitest';
+import { HermesHarness } from '../../../../src/harnesses/impls/hermes-agent/harness.js';
+import { probeHermesDoctor } from '../../../../src/api/hermes-doctor-endpoint.js';
+
+vi.mock('../../../../src/api/hermes-doctor-endpoint.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../src/api/hermes-doctor-endpoint.js')>();
+  return {
+    ...actual,
+    probeHermesDoctor: vi.fn(),
+  };
+});
+
+const fakeAdapter = { name: 'hermes-agent', runTask: vi.fn() };
+
+describe('HermesHarness.isReady', () => {
+  it('returns ready=true when probeHermesDoctor reports installed and exit 0', async () => {
+    vi.mocked(probeHermesDoctor).mockReturnValue({
+      installed: true,
+      exitCode: 0,
+      stdout: 'ok',
+      stderr: '',
+    });
+    const h = new HermesHarness({ adapter: fakeAdapter as any });
+    const result = await h.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+    expect(result.ready).toBe(true);
+  });
+
+  it('returns ready=false with install nextStep when hermes binary missing', async () => {
+    vi.mocked(probeHermesDoctor).mockReturnValue({
+      installed: false,
+      exitCode: null,
+      stdout: '',
+      stderr: '',
+    });
+    const h = new HermesHarness({ adapter: fakeAdapter as any });
+    const result = await h.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+    expect(result.ready).toBe(false);
+    expect(result.reason).toMatch(/not installed/i);
+    expect(result.nextStep?.description).toMatch(/install/i);
+  });
+
+  it('returns ready=false with config nextStep when hermes doctor exit != 0', async () => {
+    vi.mocked(probeHermesDoctor).mockReturnValue({
+      installed: true,
+      exitCode: 1,
+      stdout: '',
+      stderr: 'no provider configured',
+    });
+    const h = new HermesHarness({ adapter: fakeAdapter as any });
+    const result = await h.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+    expect(result.ready).toBe(false);
+    expect(result.reason).toMatch(/doctor/i);
+    expect(result.nextStep?.description).toMatch(/sign in|configure|hermes/i);
+  });
+});

--- a/client/test/main/restart-daemon-respawn.test.ts
+++ b/client/test/main/restart-daemon-respawn.test.ts
@@ -1,0 +1,160 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+import { isHeadless, requestDaemonRestart } from '../../src/restart-daemon.js';
+
+/**
+ * Regression test for #289 — `'Restart node' button kills the daemon`.
+ *
+ * Before this fix, the operator-MCP restart handler in main.ts called
+ * `process.exit(0)` directly. That stranded the operator: the panel went
+ * 502-on-localhost, the terminal returned to a shell prompt, and the only
+ * path back was a manual `jinn run` re-invocation.
+ *
+ * The fix replaces the bare exit with an in-process respawn: spawn a
+ * detached copy of the current process inheriting argv + env, then exit
+ * after a short delay so the child can bind the API port.
+ *
+ * Test surface:
+ *  - In interactive mode (default), respawn IS invoked, child inherits
+ *    argv[1..] and env, child is detached + unref'd, parent exits 0.
+ *  - In headless mode (`JINN_NO_UI=1`), respawn is NOT invoked — the
+ *    supervisor decides whether to restart.
+ *  - Source-textual: main.ts no longer contains the bare-exit pattern in
+ *    `onRestartRequested`. Catches future-regression-via-revert.
+ */
+
+function makeFakeChild() {
+  return {
+    unref: vi.fn(),
+  };
+}
+
+describe('#289 — operator-triggered restart respawn', () => {
+  describe('isHeadless predicate', () => {
+    it('returns true when JINN_NO_UI=1', () => {
+      expect(isHeadless({ JINN_NO_UI: '1' })).toBe(true);
+    });
+
+    it('returns false when JINN_NO_UI is unset', () => {
+      expect(isHeadless({})).toBe(false);
+    });
+
+    it('returns false when JINN_NO_UI is any other value', () => {
+      expect(isHeadless({ JINN_NO_UI: '0' })).toBe(false);
+      expect(isHeadless({ JINN_NO_UI: 'true' })).toBe(false);
+    });
+  });
+
+  describe('interactive mode (default)', () => {
+    it('spawns a detached replacement with the same argv[1..] and env, then exits 0', () => {
+      const fakeChild = makeFakeChild();
+      const spawnFn = vi.fn(() => fakeChild as never);
+      const exitFn = vi.fn();
+      const log = vi.fn();
+
+      const env = { HOME: '/tmp/test-home', JINN_PASSWORD: 'secret' };
+      const argv = ['/usr/bin/node', '/opt/jinn/dist/main.js', 'run', '--config', '/tmp/c.json'];
+
+      const result = requestDaemonRestart({
+        env,
+        argv,
+        execPath: '/usr/bin/node',
+        spawnFn: spawnFn as unknown as typeof import('node:child_process').spawn,
+        exitFn,
+        log,
+        exitDelayMs: 0,
+      });
+
+      expect(result).toBe('respawned');
+
+      // Spawn was called exactly once, with the node binary + argv[1..].
+      expect(spawnFn).toHaveBeenCalledTimes(1);
+      const [execPathArg, argsArg, optionsArg] = spawnFn.mock.calls[0]!;
+      expect(execPathArg).toBe('/usr/bin/node');
+      expect(argsArg).toEqual(['/opt/jinn/dist/main.js', 'run', '--config', '/tmp/c.json']);
+
+      // Spawned detached + stdio inherit + env passed through.
+      expect(optionsArg).toMatchObject({
+        detached: true,
+        stdio: 'inherit',
+        env,
+      });
+
+      // Child was unref'd so the parent's exit doesn't take it down.
+      expect(fakeChild.unref).toHaveBeenCalledTimes(1);
+
+      // Parent exited 0.
+      expect(exitFn).toHaveBeenCalledWith(0);
+    });
+
+    it('logs that it is respawning', () => {
+      const log = vi.fn();
+      requestDaemonRestart({
+        env: {},
+        argv: ['/usr/bin/node', '/main.js'],
+        execPath: '/usr/bin/node',
+        spawnFn: vi.fn(() => makeFakeChild() as never) as unknown as typeof import('node:child_process').spawn,
+        exitFn: vi.fn(),
+        log,
+        exitDelayMs: 0,
+      });
+      const joined = log.mock.calls.map((c) => c[0]).join('\n');
+      expect(joined).toMatch(/Restart requested/i);
+      expect(joined).toMatch(/[Ss]pawning|[Rr]espawn/);
+    });
+  });
+
+  describe('headless mode (JINN_NO_UI=1)', () => {
+    it('does NOT spawn a replacement; exits 0', () => {
+      const spawnFn = vi.fn();
+      const exitFn = vi.fn();
+      const log = vi.fn();
+
+      const result = requestDaemonRestart({
+        env: { JINN_NO_UI: '1' },
+        argv: ['/usr/bin/node', '/main.js', 'run'],
+        execPath: '/usr/bin/node',
+        spawnFn: spawnFn as unknown as typeof import('node:child_process').spawn,
+        exitFn,
+        log,
+        exitDelayMs: 0,
+      });
+
+      expect(result).toBe('headless-exit');
+      expect(spawnFn).not.toHaveBeenCalled();
+      expect(exitFn).toHaveBeenCalledWith(0);
+
+      // The log should make it obvious why we exited without respawning,
+      // so an operator inspecting logs after a supervisor doesn't restart
+      // the daemon understands what happened.
+      const joined = log.mock.calls.map((c) => c[0]).join('\n');
+      expect(joined).toMatch(/JINN_NO_UI/);
+    });
+  });
+
+  describe('main.ts wiring', () => {
+    const MAIN_PATH = join(__dirname, '../../src/main.ts');
+
+    it('no longer contains the bare process.exit(0) in onRestartRequested', () => {
+      const source = readFileSync(MAIN_PATH, 'utf8');
+      // The exact pre-fix shape: an arrow function whose body is just the log
+      // line + `process.exit(0)`. We assert the source no longer matches the
+      // bare-exit pattern under onRestartRequested.
+      const onRestartIdx = source.indexOf('onRestartRequested');
+      expect(onRestartIdx).toBeGreaterThan(-1);
+      const handlerWindow = source.slice(onRestartIdx, onRestartIdx + 500);
+      expect(handlerWindow).not.toMatch(/process\.exit\(\s*0\s*\)/);
+    });
+
+    it('routes onRestartRequested through requestDaemonRestart', () => {
+      const source = readFileSync(MAIN_PATH, 'utf8');
+      expect(source).toMatch(/from\s+['"]\.\/restart-daemon\.js['"]/);
+      // Handler body invokes requestDaemonRestart.
+      const onRestartIdx = source.indexOf('onRestartRequested');
+      const handlerWindow = source.slice(onRestartIdx, onRestartIdx + 500);
+      expect(handlerWindow).toMatch(/requestDaemonRestart\s*\(/);
+    });
+  });
+});

--- a/client/test/preflight/api-port.test.ts
+++ b/client/test/preflight/api-port.test.ts
@@ -1,5 +1,5 @@
 import { createServer } from 'node:net';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { apiPortFailureMessage, checkApiPortAvailable } from '../../src/preflight/api-port.js';
 
 describe('api port preflight', () => {
@@ -13,6 +13,96 @@ describe('api port preflight', () => {
       expect(result).toMatchObject({ ok: false, port: addr.port, code: 'EADDRINUSE' });
       if (!result.ok) {
         expect(apiPortFailureMessage(result)).toContain(String(addr.port));
+      }
+    } finally {
+      await new Promise<void>((resolve) => holder.close(() => resolve()));
+    }
+  });
+
+  // ── jinn-mono-hjex.5: EADDRINUSE error envelope names the PID ─────────────
+
+  it('includes holder PID in EADDRINUSE failure message when portPidLookup returns a holder (jinn-mono-hjex.5)', async () => {
+    const holder = createServer();
+    await new Promise<void>((resolve) => holder.listen(0, '0.0.0.0', () => resolve()));
+    const addr = holder.address();
+    if (!addr || typeof addr === 'string') throw new Error('missing address');
+
+    const fakeHolder = { pid: 19958, command: 'jinn run', uptimeSeconds: 104400 };
+    const fakeLookup = vi.fn().mockResolvedValue(fakeHolder);
+
+    try {
+      const result = await checkApiPortAvailable(addr.port, fakeLookup);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.holder).toEqual(fakeHolder);
+        const msg = apiPortFailureMessage(result);
+        expect(msg).toContain('19958');
+        expect(msg).toContain('jinn run');
+        expect(msg).toContain('jinn stop --force');
+      }
+    } finally {
+      await new Promise<void>((resolve) => holder.close(() => resolve()));
+    }
+  });
+
+  it('falls back to generic message when portPidLookup returns null (jinn-mono-hjex.5)', async () => {
+    const holder = createServer();
+    await new Promise<void>((resolve) => holder.listen(0, '0.0.0.0', () => resolve()));
+    const addr = holder.address();
+    if (!addr || typeof addr === 'string') throw new Error('missing address');
+
+    const fakeLookup = vi.fn().mockResolvedValue(null);
+
+    try {
+      const result = await checkApiPortAvailable(addr.port, fakeLookup);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.holder).toBeUndefined();
+        const msg = apiPortFailureMessage(result);
+        expect(msg).toContain(String(addr.port));
+        expect(msg).toContain('jinn stop');
+      }
+    } finally {
+      await new Promise<void>((resolve) => holder.close(() => resolve()));
+    }
+  });
+
+  it('falls back to generic message when portPidLookup rejects (jinn-mono-hjex.5)', async () => {
+    const holder = createServer();
+    await new Promise<void>((resolve) => holder.listen(0, '0.0.0.0', () => resolve()));
+    const addr = holder.address();
+    if (!addr || typeof addr === 'string') throw new Error('missing address');
+
+    const fakeLookup = vi.fn().mockRejectedValue(new Error('lsof not found'));
+
+    try {
+      const result = await checkApiPortAvailable(addr.port, fakeLookup);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.holder).toBeUndefined();
+        const msg = apiPortFailureMessage(result);
+        expect(msg).toContain(String(addr.port));
+      }
+    } finally {
+      await new Promise<void>((resolve) => holder.close(() => resolve()));
+    }
+  });
+
+  it('includes uptime in the PID failure message when uptimeSeconds is known (jinn-mono-hjex.5)', async () => {
+    const holder = createServer();
+    await new Promise<void>((resolve) => holder.listen(0, '0.0.0.0', () => resolve()));
+    const addr = holder.address();
+    if (!addr || typeof addr === 'string') throw new Error('missing address');
+
+    // 1d4h = 24*3600 + 4*3600 = 100800 seconds
+    const fakeHolder = { pid: 42, command: 'node', uptimeSeconds: 100800 };
+    const fakeLookup = vi.fn().mockResolvedValue(fakeHolder);
+
+    try {
+      const result = await checkApiPortAvailable(addr.port, fakeLookup);
+      if (!result.ok) {
+        const msg = apiPortFailureMessage(result);
+        expect(msg).toContain('1d4h');
       }
     } finally {
       await new Promise<void>((resolve) => holder.close(() => resolve()));

--- a/client/test/preflight/port-pid.test.ts
+++ b/client/test/preflight/port-pid.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatUptime,
+  parseEtime,
+  parseLsofOutput,
+  parseSsOutput,
+} from '../../src/preflight/port-pid.js';
+
+describe('port-pid parsers (jinn-mono-hjex.5)', () => {
+  describe('parseEtime', () => {
+    it('parses MM:SS', () => {
+      expect(parseEtime('02:30')).toBe(150); // 2m30s
+      expect(parseEtime('00:00')).toBe(0);
+      expect(parseEtime('59:59')).toBe(59 * 60 + 59);
+    });
+
+    it('parses HH:MM:SS', () => {
+      expect(parseEtime('01:00:00')).toBe(3600);
+      expect(parseEtime('02:03:04')).toBe(2 * 3600 + 3 * 60 + 4);
+    });
+
+    it('parses DD-HH:MM:SS', () => {
+      // 1d4h: 24*3600 + 4*3600 = 100800
+      expect(parseEtime('01-04:00:00')).toBe(100800);
+      // 0 days, 5h, 6m, 7s
+      expect(parseEtime('00-05:06:07')).toBe(5 * 3600 + 6 * 60 + 7);
+    });
+
+    it('tolerates leading/trailing whitespace', () => {
+      expect(parseEtime('   02:30   ')).toBe(150);
+    });
+
+    it('returns null on garbage', () => {
+      expect(parseEtime('not-a-time')).toBe(null);
+      expect(parseEtime('1:2:3:4')).toBe(null);
+      expect(parseEtime('')).toBe(null);
+    });
+  });
+
+  describe('parseLsofOutput', () => {
+    it('parses a known -F pcu fixture (single holder)', () => {
+      // lsof -F pcu output: one block per process; fields prefixed by
+      // 'p' (pid), 'c' (command), 'u' (uid). A blank line separates blocks.
+      const fixture = ['p19958', 'cnode', 'u501', ''].join('\n');
+      const result = parseLsofOutput(fixture);
+      expect(result).not.toBeNull();
+      expect(result!.pid).toBe(19958);
+      expect(result!.command).toBe('node');
+      // uptimeSeconds may be null (no /proc, ps unavailable, or PID gone) —
+      // we don't pin it.
+    });
+
+    it('parses output with trailing whitespace in command', () => {
+      const fixture = ['p42', 'cjinn run\t', 'u501'].join('\n');
+      const result = parseLsofOutput(fixture);
+      expect(result).not.toBeNull();
+      expect(result!.pid).toBe(42);
+      expect(result!.command).toBe('jinn run');
+    });
+
+    it('returns null on empty output', () => {
+      expect(parseLsofOutput('')).toBeNull();
+      expect(parseLsofOutput('   \n  ')).toBeNull();
+    });
+
+    it('returns null when -F output lacks p+c pair', () => {
+      // 'u' field but no 'p' or 'c' — incomplete record.
+      expect(parseLsofOutput('u501\n')).toBeNull();
+      // 'p' alone — no command.
+      expect(parseLsofOutput('p12345\nu501\n')).toBeNull();
+    });
+
+    it('returns null on non-numeric PID', () => {
+      expect(parseLsofOutput('pnotanumber\ncnode\n')).toBeNull();
+    });
+  });
+
+  describe('parseSsOutput', () => {
+    it('parses a known ss -lntp fixture', () => {
+      // First line is the header from ss, second line is the entry.
+      const fixture = [
+        'State    Recv-Q   Send-Q   Local Address:Port   Peer Address:Port   Process',
+        'LISTEN   0        128      0.0.0.0:7331         0.0.0.0:*           users:(("node",pid=12345,fd=20))',
+      ].join('\n');
+      const result = parseSsOutput(fixture);
+      expect(result).not.toBeNull();
+      expect(result!.pid).toBe(12345);
+      expect(result!.command).toBe('node');
+    });
+
+    it('parses a holder with a multi-word command name', () => {
+      const fixture =
+        'LISTEN 0 128 0.0.0.0:7331 0.0.0.0:* users:(("jinn-client",pid=42,fd=20))';
+      const result = parseSsOutput(fixture);
+      expect(result).not.toBeNull();
+      expect(result!.pid).toBe(42);
+      expect(result!.command).toBe('jinn-client');
+    });
+
+    it('returns null when no users:() block is present', () => {
+      const fixture = 'LISTEN 0 128 0.0.0.0:7331 0.0.0.0:*';
+      expect(parseSsOutput(fixture)).toBeNull();
+    });
+
+    it('returns null on empty output', () => {
+      expect(parseSsOutput('')).toBeNull();
+    });
+  });
+
+  describe('formatUptime round-trip', () => {
+    it('round-trips with parseEtime for MM:SS', () => {
+      // 12 minutes
+      expect(formatUptime(parseEtime('12:34')!)).toBe('12m');
+    });
+
+    it('round-trips with parseEtime for HH:MM:SS', () => {
+      // 2h3m
+      expect(formatUptime(parseEtime('02:03:04')!)).toBe('2h3m');
+    });
+
+    it('round-trips with parseEtime for DD-HH:MM:SS', () => {
+      // 1d4h
+      expect(formatUptime(parseEtime('01-04:00:00')!)).toBe('1d4h');
+    });
+
+    it('drops sub-minute granularity', () => {
+      expect(formatUptime(30)).toBe('0m');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `jinn stop` discovers daemons by port (lsof / ss -lntp) when the pidfile is missing — operators no longer need manual lsof forensics after an unexpected crash or upgrade.
- `jinn update` stops the running daemon before swapping the binary, so `jinn run` after an upgrade does not hit `EADDRINUSE`.
- `EADDRINUSE` preflight error names the holder PID + uptime ("Port 7331 is held by PID 19958 (jinn run, started 1d4h ago). Run `jinn stop --force` to recover.").
- Setup-mode halt path now writes a JSON pidfile (`{"pid":…,"mode":"setup-halted"}`) so `jinn stop` can find and clean it up during the funding-await window.
- Pidfile parser handles both the legacy plain-integer format and the new JSON format.

## Why

Bead `jinn-mono-hjex.5` / GitHub #233 sub-issue 1: operator upgraded v0.1.3-canary → v0.1.5 while their daemon was running. `jinn run` hit `EADDRINUSE`. `jinn stop` returned "already stopped" because the pidfile was missing. Operator had to drop to terminal forensics.

## New file

`client/src/preflight/port-pid.ts` — cross-platform port-to-PID helper abstracted behind an injectable interface. Uses `lsof -i :PORT -n -P` on macOS/Linux (with `-F` field output for reliable parsing), falls back to `ss -lntp` on Linux when lsof is unavailable. Returns `null` gracefully when neither tool is present.

## Stacked on

PR #243 (PR-6 of the same stack, branch `fix/hjex6-halt-retry`).

## Test plan

- [x] `jinn stop` regression: discovers by port when pidfile missing (5 new tests).
- [x] `jinn stop` regression: gracefully no-ops when lsof throws.
- [x] `jinn stop` regression: parses setup-halted JSON pidfile, surfaces `pidfileMode`.
- [x] `jinn update` regression: calls jinnStop before npm update.
- [x] `jinn update` regression: aborts if daemon stop fails (no binary swap).
- [x] `jinn update` regression: skip-npm bypasses stop-daemon step entirely.
- [x] `api-port` preflight regression: EADDRINUSE envelope names PID + uptime.
- [x] `api-port` preflight regression: falls back to generic message when lookup returns null or throws.
- [x] `yarn typecheck` + `yarn test` (3326 pass, 4 skipped).

Refs: bd `jinn-mono-hjex.5`.