### PR TITLE
fix(hjex.8): /v1/solvernets/registry returns typed errors; SPA classifies failures

### DIFF
--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -102,6 +102,12 @@ export interface StatusGatherConfig {
   /** Full config enables SolverNet/plugin/Harness diagnostics in /v1/status. */
   config?: JinnConfig;
   configPath?: string;
+  /**
+   * Error from SolverNet subsystem init (jinn-mono-hjex.8). Set by main.ts
+   * in the catch block around initSolverNetSubsystem so the operator can
+   * see why /v1/solvernets/* returns 503 via the Overview status page.
+   */
+  solvernetSubsystemError?: string;
 }
 
 function chainKey(network: 'mainnet' | 'testnet'): 'base' | 'base-sepolia' {
@@ -553,6 +559,11 @@ export async function gatherGatheredStatusRaw(
     serviceBalances: {},
     pendingByService: {},
     claimedByService: store.getClaimedRewardsByService(),
+    // jinn-mono-hjex.8: surface subsystem init failure so operators can see
+    // why /v1/solvernets/* returns 503 from the Overview status page.
+    ...(status?.solvernetSubsystemError !== undefined
+      ? { solvernetSubsystemError: status.solvernetSubsystemError }
+      : {}),
   };
 
   if (!status) {

--- a/client/src/api/solvernets-endpoints.ts
+++ b/client/src/api/solvernets-endpoints.ts
@@ -1469,27 +1469,40 @@ export function registerSolverNetsEndpoints(
       statusFilter = ['launched', 'paused'];
     }
 
-    if (c.req.query('refresh') === '1') {
-      // Force a refresh before reading the snapshot. The cache itself
-      // suppresses errors — they land in `lastError` which we surface in
-      // the response, so the SPA can show "couldn't refresh, here's the
-      // last cached snapshot" rather than a blank page.
-      await catalog.refresh();
+    try {
+      if (c.req.query('refresh') === '1') {
+        // Force a refresh before reading the snapshot. The cache itself
+        // suppresses errors — they land in `lastError` which we surface in
+        // the response, so the SPA can show "couldn't refresh, here's the
+        // last cached snapshot" rather than a blank page.
+        await catalog.refresh();
+      }
+
+      const snapshot = catalog.getCatalog();
+      const summaries = snapshot.filter((s) => statusFilter.includes(s.status));
+
+      const lastRefreshedAt = catalog.lastRefreshedAt();
+      const lastError = catalog.lastError();
+      return c.json({
+        summaries,
+        lastRefreshedAt: lastRefreshedAt === null ? null : lastRefreshedAt.toISOString(),
+        lastError:
+          lastError === null
+            ? null
+            : { message: lastError.message, at: lastError.at.toISOString() },
+      });
+    } catch (err) {
+      // jinn-mono-hjex.8: surface catalog read failures as a typed 503 instead
+      // of letting the unhandled rejection bubble to a generic 500. The SPA
+      // error classifier reads the `error` field to produce actionable copy.
+      return c.json(
+        {
+          error: 'registry_unavailable',
+          message: err instanceof Error ? err.message : String(err),
+        },
+        503,
+      );
     }
-
-    const snapshot = catalog.getCatalog();
-    const summaries = snapshot.filter((s) => statusFilter.includes(s.status));
-
-    const lastRefreshedAt = catalog.lastRefreshedAt();
-    const lastError = catalog.lastError();
-    return c.json({
-      summaries,
-      lastRefreshedAt: lastRefreshedAt === null ? null : lastRefreshedAt.toISOString(),
-      lastError:
-        lastError === null
-          ? null
-          : { message: lastError.message, at: lastError.at.toISOString() },
-    });
   });
 
   // GET /v1/solvernets/registry/:cid — fetch a specific manifest from the

--- a/client/src/api/status-build.ts
+++ b/client/src/api/status-build.ts
@@ -91,6 +91,12 @@ export interface GatheredStatusRaw {
    * Value is the `inactivity` field from the ServiceInfo struct (seconds).
    */
   inactivityByServiceIndex?: Record<number, number>;
+  /**
+   * Error message from SolverNet subsystem init, if it failed (jinn-mono-hjex.8).
+   * Set by main.ts in the catch block of initSolverNetSubsystem and surfaced
+   * via /v1/status so the operator can diagnose why /v1/solvernets/* returns 503.
+   */
+  solvernetSubsystemError?: string;
 }
 
 export interface StatusV1Response {
@@ -155,6 +161,14 @@ export interface StatusV1Response {
   predictionV1?: PredictionV1Status;
   /** Generic task-run lifecycle data across all SolverNets. */
   taskRuns?: TaskRunsStatus;
+  /**
+   * Error from SolverNet subsystem init (jinn-mono-hjex.8). Present when
+   * initSolverNetSubsystem threw; absent when the subsystem is healthy or
+   * the daemon is running on mainnet (where the subsystem is not started).
+   * The operator can read this from the SPA Overview page to diagnose why
+   * /v1/solvernets/* routes return 503.
+   */
+  solvernetSubsystemError?: string;
 }
 
 /**
@@ -394,5 +408,8 @@ export function assembleStatusV1(raw: GatheredStatusRaw): StatusV1Response {
     ...(raw.portfolioV0 !== undefined ? { portfolioV0: raw.portfolioV0 } : {}),
     ...(raw.predictionV1 !== undefined ? { predictionV1: raw.predictionV1 } : {}),
     ...(raw.taskRuns !== undefined ? { taskRuns: raw.taskRuns } : {}),
+    ...(raw.solvernetSubsystemError !== undefined
+      ? { solvernetSubsystemError: raw.solvernetSubsystemError }
+      : {}),
   };
 }

--- a/client/src/dashboard/spa/src/pages/operator-catalog/RegistryCatalog.test.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/RegistryCatalog.test.tsx
@@ -340,6 +340,21 @@ describe('RegistryCatalog', () => {
     expect(screen.getByText(/check daemon logs/i)).toBeTruthy();
   });
 
+  it('explains Failed to fetch as daemon unreachable (jinn-mono-hjex.8)', async () => {
+    // Simulates the browser TypeError raised when the daemon is not running —
+    // fetch raises this when the connection is refused at the transport layer.
+    listRegistryMock.mockRejectedValue(
+      Object.assign(new TypeError('Failed to fetch'), {}),
+    );
+
+    render(withProviders(<RegistryCatalog />));
+
+    await waitFor(() =>
+      expect(screen.getByText(/daemon unreachable/i)).toBeTruthy(),
+    );
+    expect(screen.getByText(/jinn run.*still active/i)).toBeTruthy();
+  });
+
   it('surfaces lastRefreshedAt and lastError from the response envelope', async () => {
     listRegistryMock.mockResolvedValue({
       summaries: [],

--- a/client/src/dashboard/spa/src/pages/operator-catalog/RegistryCatalog.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/RegistryCatalog.tsx
@@ -58,6 +58,15 @@ function errorCode(error: unknown): string | null {
 }
 
 function registryErrorCopy(error: unknown): { title: string; detail: string } {
+  // jinn-mono-hjex.8: distinguish four failure modes with actionable copy.
+  // Daemon unreachable is detected by the transport-level TypeError that fetch
+  // raises when the connection is refused (no HTTP response at all).
+  if (error instanceof TypeError && error.message === 'Failed to fetch') {
+    return {
+      title: 'Daemon unreachable.',
+      detail: 'Check that `jinn run` is still active, then retry.',
+    };
+  }
   switch (errorCode(error)) {
     case 'subsystem_not_ready':
       return {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -932,6 +932,27 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
   let retryBootstrapResolve: (() => void) | null = null;
   let retryBootstrapReject: ((err: unknown) => void) | null = null;
 
+  // jinn-mono-hjex.8: mutable status gather config — main.ts populates
+  // `solvernetSubsystemError` in the SolverNet subsystem init catch block so
+  // the operator can see the error from the Overview status page (/v1/status).
+  // The same object is captured by the /v1/status handler closure, so any
+  // mutation is visible on the next request without restarting the server.
+  const setupStatusGatherConfig: import('./api/gather-status.js').StatusGatherConfig = {
+    earningDir: config.earningDir,
+    rpcUrl: config.rpcUrl,
+    network: config.network,
+    pollIntervalMs: config.pollIntervalMs,
+    masterEthDailyEstimateWei: config.masterEthDailyEstimateWei,
+    rewardClaimIntervalMs: config.rewardClaimIntervalMs,
+    testnetL2DeploymentPath: config.testnetL2DeploymentPath,
+    testnetL2TokenDeploymentPath: config.testnetL2TokenDeploymentPath,
+    testnetMechDeploymentPath: config.testnetMechDeploymentPath,
+    testnetStolasDeploymentPath: config.testnetStolasDeploymentPath,
+    engine: config.engine,
+    config,
+    configPath: CONFIG_PATH ?? DEFAULT_CONFIG_PATH,
+  };
+
   let setupApiServer: ApiServer;
   try {
     setupApiServer = await startApiServer({
@@ -1135,21 +1156,7 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
           });
         },
       },
-      status: {
-        earningDir: config.earningDir,
-        rpcUrl: config.rpcUrl,
-        network: config.network,
-        pollIntervalMs: config.pollIntervalMs,
-        masterEthDailyEstimateWei: config.masterEthDailyEstimateWei,
-        rewardClaimIntervalMs: config.rewardClaimIntervalMs,
-        testnetL2DeploymentPath: config.testnetL2DeploymentPath,
-        testnetL2TokenDeploymentPath: config.testnetL2TokenDeploymentPath,
-        testnetMechDeploymentPath: config.testnetMechDeploymentPath,
-        testnetStolasDeploymentPath: config.testnetStolasDeploymentPath,
-        engine: config.engine,
-        config,
-        configPath: CONFIG_PATH ?? DEFAULT_CONFIG_PATH,
-      },
+      status: setupStatusGatherConfig,
       // Launcher mode (Tasks 6 + 7). Deps are resolved lazily because the
       // generator and Safe address are constructed after bootstrap, after
       // this `startApiServer` call. By the time the SPA hits the route,
@@ -2132,9 +2139,13 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
         console.log('[main] SolverNet endpoints deps populated (jinn-mono-hqz0)');
       }
     } catch (err) {
-      console.warn(
-        `[main] SolverNet subsystem init failed; continuing without it: ${err instanceof Error ? err.message : String(err)}`,
+      // jinn-mono-hjex.8: log loudly (error vs. warn) and surface the failure
+      // via /v1/status so operators can diagnose why /v1/solvernets/* returns 503.
+      const errMessage = err instanceof Error ? err.message : String(err);
+      console.error(
+        `[main] SolverNet subsystem init failed; /v1/solvernets/* will return 503: ${errMessage}`,
       );
+      setupStatusGatherConfig.solvernetSubsystemError = errMessage;
     }
   } else {
     console.log(

--- a/client/test/api/solvernets-endpoints.test.ts
+++ b/client/test/api/solvernets-endpoints.test.ts
@@ -2101,6 +2101,29 @@ describe('GET /v1/solvernets/registry (Task 15)', () => {
     expect(body.error).toBe('invalid_query');
   });
 
+  it('returns a typed envelope when getCatalog throws (jinn-mono-hjex.8)', async () => {
+    // Simulate a catalog whose getCatalog() method throws — e.g. IPFS read
+    // failure after the subsystem started successfully. The handler must catch
+    // this and return a typed 503 instead of letting the 500 bubble through.
+    const throwingCatalog: SolverNetCatalogCache = {
+      getCatalog: () => { throw new Error('IPFS unreachable'); },
+      async refresh() {},
+      stop() {},
+      lastRefreshedAt: () => null,
+      lastError: () => null,
+    };
+    const { app } = buildTestApp({ store, catalog: throwingCatalog });
+
+    const res = await app.request('/v1/solvernets/registry', {
+      method: 'GET',
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body.error).toBe('registry_unavailable');
+    expect(body.message).toContain('IPFS');
+  });
+
   it('requires auth', async () => {
     const catalog = makeMockCatalog({});
     const { app } = buildTestApp({ store, catalog });


### PR DESCRIPTION
## Summary

- `/v1/solvernets/registry` handler wraps in try/catch with typed 503 envelope (`{ error: 'registry_unavailable', message }`) when `getCatalog()` or `refresh()` throws internally, instead of bubbling an unhandled 500.
- SolverNet subsystem init failures now log via `console.error` (not `console.warn`) and set `setupStatusGatherConfig.solvernetSubsystemError`; this field is threaded through `GatheredStatusRaw` → `StatusV1Response` so operators can see the init failure from `/v1/status`.
- `RegistryCatalog` SPA distinguishes four failure modes with specific operator-facing copy: daemon unreachable (`Failed to fetch`), subsystem starting (`subsystem_not_ready`), registry source unavailable (`registry_unavailable`), generic fallback. No OLAS terminology.

## Why

Bead `jinn-mono-hjex.8`: the Discover panel showed `Failed to fetch` with no actionable cause; retry produced the same. Transport-level error with no parseable code. Cold-start operators (the v0.1.5 case) hit this and cannot discover any SolverNet.

## Stacked on

PR #244 (PR-7 of the same stack).

## Test plan

- [x] Registry handler regression: thrown error → 503 with typed envelope (`returns a typed envelope when getCatalog throws (jinn-mono-hjex.8)`).
- [x] SPA classification: daemon-unreachable `Failed to fetch` → "Daemon unreachable." copy (`jinn-mono-hjex.8`).
- [x] Existing SPA tests for `subsystem_not_ready` and `registry_unavailable` still pass.
- [x] `yarn typecheck` clean (exit 0).
- [x] `yarn test` clean — 3328 passed, 4 skipped.

Refs: bd `jinn-mono-hjex.8`.