### PR TITLE
fix(hjex.9): gate Settings error banner on data === undefined

### DIFF
--- a/client/src/dashboard/spa/src/pages/configuration/SolverNetsSection.test.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/SolverNetsSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, render, screen, act, waitFor } from '@testing-library/react';
 import { Router } from 'wouter';
 import { memoryLocation } from 'wouter/memory-location';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -147,6 +147,54 @@ describe('SolverNetsSection', () => {
     expect(cards.find((c) => c.getAttribute('data-manifest-cid') === 'bafybeiaaa')).toBeTruthy();
     expect(cards.find((c) => c.getAttribute('data-manifest-cid') === 'bafybeibbb')).toBeTruthy();
     expect(screen.getByText('Other Net')).toBeTruthy();
+  });
+
+  it('does not paint "Failed to load" banner when data is present from a prior success (jinn-mono-hjex.9)', async () => {
+    // First render: succeed so react-query caches data.
+    vi.mocked(api.operator.listJoined).mockResolvedValue({
+      joinedSolverNets: {
+        bafybeiswe: {
+          manifestCid: 'bafybeiswe',
+          name: 'SWE-rebench v2',
+          roles: ['solver'],
+          harness: 'claude-code-learner',
+          plugins: [],
+          model: 'claude-haiku-4-5-20251001',
+        },
+      },
+    });
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: 0 } } });
+    const { hook } = memoryLocation({ path: '/operator' });
+    render(
+      <QueryClientProvider client={qc}>
+        <Router hook={hook}>
+          <SolverNetsSection />
+        </Router>
+      </QueryClientProvider>,
+    );
+    // Wait for the initial successful fetch to render the card.
+    await waitFor(() => expect(screen.getByText('SWE-rebench v2')).toBeTruthy());
+
+    // Now make refetch fail (simulates a failed background poll).
+    vi.mocked(api.operator.listJoined).mockRejectedValue(new Error('network error'));
+
+    // Force a refetch by invalidating the cache — this is what the 30s interval does.
+    // refetchQueries resolves even when the query fails; query state transitions to
+    // isError=true while retaining the previous data.
+    await act(async () => {
+      await qc.refetchQueries({ queryKey: ['operator', 'joined'] });
+    });
+
+    // The stale card data is still visible (react-query keeps previous data).
+    await waitFor(() => expect(screen.getByText('SWE-rebench v2')).toBeTruthy());
+
+    // The fatal red banner must NOT appear alongside stale-but-valid data.
+    expect(screen.queryByText(/Failed to load joined SolverNets/i)).toBeNull();
+
+    // A low-severity stale indicator must appear instead.
+    // (RegistryCatalog inside SolverNetsSection also uses the ['operator','joined']
+    // query, so two stale indicators may appear — one per consumer. Use getAllByTitle.)
+    await waitFor(() => expect(screen.getAllByTitle(/last refresh failed/i).length).toBeGreaterThan(0));
   });
 
   it('auto-expands the joined card whose cid matches joinedHashFragment', async () => {

--- a/client/src/dashboard/spa/src/pages/configuration/SolverNetsSection.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/SolverNetsSection.tsx
@@ -115,7 +115,7 @@ export function SolverNetsSection({
               >
                 Joined · {joinedEntries.length}
               </span>
-              {joinedQuery.isError && (
+              {joinedQuery.isError && joinedQuery.data === undefined && (
                 <span
                   role="alert"
                   style={{
@@ -125,6 +125,18 @@ export function SolverNetsSection({
                   }}
                 >
                   Failed to load joined SolverNets.
+                </span>
+              )}
+              {joinedQuery.isError && joinedQuery.data !== undefined && (
+                <span
+                  title="Last refresh failed"
+                  style={{
+                    fontFamily: "'JetBrains Mono', monospace",
+                    fontSize: '11px',
+                    color: 'var(--wane)',
+                  }}
+                >
+                  &#x26A0; stale
                 </span>
               )}
             </div>

--- a/client/src/dashboard/spa/src/pages/operator-catalog/RegistryCatalog.test.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/RegistryCatalog.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Router } from 'wouter';
 import { memoryLocation } from 'wouter/memory-location';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -409,6 +409,40 @@ describe('RegistryCatalog', () => {
 
     // A low-severity stale indicator must appear instead.
     await waitFor(() => expect(screen.getByTitle(/last refresh failed/i)).toBeTruthy());
+  });
+
+  it('retry refetches BOTH registry and joined queries when joined-list fatal arm fires (jinn-mono-hjex.9)', async () => {
+    // Registry query succeeds; joined-list query has never succeeded. This is
+    // the second fatal arm — `joinedQuery.isError && joinedQuery.data === undefined`.
+    // The Retry button must refetch BOTH queries, not just `refetch` (registry),
+    // otherwise the user is stuck because the failing query (joined-list) is
+    // never re-triggered.
+    listRegistryMock.mockResolvedValue({
+      summaries: [],
+      lastRefreshedAt: '2026-05-05T01:00:00Z',
+      lastError: null,
+    });
+    listJoinedMock.mockRejectedValue(new Error('joined list network error'));
+
+    render(withProviders(<RegistryCatalog />));
+
+    // Fatal panel renders because joined-list has no data.
+    await waitFor(() =>
+      expect(screen.getByTestId('registry-catalog-error')).toBeTruthy(),
+    );
+    expect(screen.getByText(/joined list network error/i)).toBeTruthy();
+
+    // Baseline: each query was called once on mount.
+    expect(listRegistryMock).toHaveBeenCalledTimes(1);
+    expect(listJoinedMock).toHaveBeenCalledTimes(1);
+
+    // Click Retry; both queries must refetch.
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('registry-catalog-retry'));
+    });
+
+    await waitFor(() => expect(listJoinedMock).toHaveBeenCalledTimes(2));
+    expect(listRegistryMock).toHaveBeenCalledTimes(2);
   });
 
   it('surfaces lastRefreshedAt and lastError from the response envelope', async () => {

--- a/client/src/dashboard/spa/src/pages/operator-catalog/RegistryCatalog.test.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/RegistryCatalog.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { Router } from 'wouter';
 import { memoryLocation } from 'wouter/memory-location';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -353,6 +353,62 @@ describe('RegistryCatalog', () => {
       expect(screen.getByText(/daemon unreachable/i)).toBeTruthy(),
     );
     expect(screen.getByText(/jinn run.*still active/i)).toBeTruthy();
+  });
+
+  it('does not replace catalog with error panel when a refetch fails over stale data (jinn-mono-hjex.9)', async () => {
+    // First fetch succeeds — react-query caches the registry data.
+    listRegistryMock.mockResolvedValue({
+      summaries: [
+        {
+          manifestCid: 'bafybeiswe',
+          solverNetId: 'agent5474_swe-rebench-v2-v1_aaaaaaaa',
+          name: 'SWE-rebench v2',
+          network: 'base-sepolia',
+          launcherAgentId: '5474',
+          launcherSafeAddress: '0xE64bAfABCDEF0123456789abcdef0123456789B5CF',
+          status: 'launched',
+          statusUpdatedAt: '2026-05-05T00:00:00Z',
+          contractId: 'swe-rebench-v2',
+          contractVersion: 'v1',
+          solutionPriceWei: '10000000000',
+          verdictPriceWei: '5000000000',
+          openRoles: ['solver', 'evaluator'],
+          anchorBlock: 1,
+        },
+      ],
+      lastRefreshedAt: '2026-05-05T01:00:00Z',
+      lastError: null,
+    });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: 0 } } });
+    const { hook } = memoryLocation({ path: '/operator' });
+    render(
+      <QueryClientProvider client={qc}>
+        <Router hook={hook}>
+          <RegistryCatalog refetchIntervalMs={0} />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    // Wait for initial successful render.
+    await waitFor(() => expect(screen.getByText('SWE-rebench v2')).toBeTruthy());
+
+    // Simulate failed background refetch.
+    listRegistryMock.mockRejectedValue(new Error('network error'));
+    await act(async () => {
+      // refetchQueries resolves even when the query fails — the query state
+      // transitions to isError=true while retaining the previous data.
+      await qc.refetchQueries({ queryKey: ['solvernets', 'registry'] });
+    });
+
+    // Stale card data is still visible.
+    await waitFor(() => expect(screen.getByText('SWE-rebench v2')).toBeTruthy());
+
+    // The fatal error panel must NOT replace the catalog.
+    expect(screen.queryByTestId('registry-catalog-error')).toBeNull();
+
+    // A low-severity stale indicator must appear instead.
+    await waitFor(() => expect(screen.getByTitle(/last refresh failed/i)).toBeTruthy());
   });
 
   it('surfaces lastRefreshedAt and lastError from the response envelope', async () => {

--- a/client/src/dashboard/spa/src/pages/operator-catalog/RegistryCatalog.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/RegistryCatalog.tsx
@@ -376,6 +376,7 @@ export function RegistryCatalog({
           type="button"
           onClick={() => {
             void refetch();
+            if (joinedQuery.isError) void joinedQuery.refetch();
           }}
           data-testid="registry-catalog-retry"
           style={{

--- a/client/src/dashboard/spa/src/pages/operator-catalog/RegistryCatalog.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/RegistryCatalog.tsx
@@ -334,7 +334,13 @@ export function RegistryCatalog({
     );
   }
 
-  if (isError || joinedQuery.isError) {
+  // Fatal: show the full error panel only when no data has ever loaded.
+  // When data is present from a prior successful fetch, fall through and render
+  // the stale catalog with a low-severity indicator instead.
+  const showFatalError = (isError && data === undefined) || (joinedQuery.isError && joinedQuery.data === undefined);
+  const showStaleIndicator = (isError && data !== undefined) || (joinedQuery.isError && joinedQuery.data !== undefined);
+
+  if (showFatalError) {
     const visibleError = isError ? error : joinedQuery.error;
     const copy = registryErrorCopy(visibleError);
     return (
@@ -415,6 +421,15 @@ export function RegistryCatalog({
           {summaries.length} discoverable · last refreshed{' '}
           {lastRefreshed ?? 'never'}
         </span>
+        {showStaleIndicator && !lastError && (
+          <span
+            data-testid="registry-catalog-warn"
+            title="Last refresh failed"
+            style={{ color: 'var(--wane)' }}
+          >
+            &#x26A0; stale
+          </span>
+        )}
         {lastError && (
           <span
             data-testid="registry-catalog-warn"


### PR DESCRIPTION
## Summary

- Fatal "Failed to load" error banner only renders when `data === undefined && isError` — react-query's stale-after-failed-refetch state no longer paints the banner alongside cached data.
- A low-severity "Last refresh failed" indicator appears alongside stale data when a background refetch fails.
- Applied to `SolverNetsSection` and `RegistryCatalog` which share the `['operator', 'joined']` query key.

## Why

Bead `jinn-mono-hjex.9` / GitHub #233 sub-issue 11: Settings page showed the joined SWE-rebench v2 card AND a red "Failed to load joined SolverNets" banner simultaneously. react-query retains `data` on successful initial fetch + sets `isError` on a failed refetch — both branches were rendering.

## Implementation

- `SolverNetsSection.tsx`: The inline error span is now gated on `joinedQuery.isError && joinedQuery.data === undefined`. A new `⚠ stale` span with `title="Last refresh failed"` renders when `isError && data !== undefined`.
- `RegistryCatalog.tsx`: The full error panel early-return is now gated on `showFatalError = (isError && data === undefined) || (joinedQuery.isError && joinedQuery.data === undefined)`. A `showStaleIndicator` flag controls a low-severity indicator in the normal render path.

## Stacked on

PR #245 (PR-8 of the same stack).

## Test plan

- [x] SolverNetsSection regression (jinn-mono-hjex.9): prior-success data + failed refetch → no fatal banner, stale indicator instead.
- [x] RegistryCatalog regression (jinn-mono-hjex.9): prior-success data + failed refetch → no error panel replacement, stale indicator instead.
- [x] No test-only props added to production code — test uses `QueryClient.refetchQueries` with mocked rejection.
- [x] `yarn typecheck` (tsc --noEmit) clean.
- [x] `yarn test` — 3330 passed, 4 skipped.

Refs: bd `jinn-mono-hjex.9`.