### PR TITLE
growth: composition heuristic as a Refine-time diagnostic

### DIFF
--- a/GROWTH.md
+++ b/GROWTH.md
@@ -100,6 +100,8 @@ The closing structure when an operator is engaged: objective → why important �
 
 Track and analyse the loop itself. Propose diff-shaped amendments to GROWTH.md, skill files, or the loop's structure when accumulated evidence drifts from canon. The skill produces *proposals*, never edits canonical files; Oak applies via PRs (with a spec proposal for canonical changes). Cadence: ad-hoc, suggested every sprint postmortem, surfaced as a Tier B action by `growth-day` when a refine has not run in over thirty days.
 
+**Composition heuristic.** Periodically, as one input to Refine, the operator-set composition is sampled against a small set of diagnostic attributes (founder-proximity, founder economic alignment, financial/professional independence, jurisdiction, crypto exposure, technical savvy, skillset coverage). The attributes are heuristics, not gates: a gapped attribute surfaces a question about what upstream design or recruiting choice produced the gap, not a recruiting filter to apply per candidate. The attribute list and any working thresholds live in [`growth/composition-attributes.md`](growth/composition-attributes.md), not as canonical gates — codifying them as launch-gating numbers would add a governance surface in tension with [`PRINCIPLES.md`](PRINCIPLES.md) *Governance Minimal* and *Permissionless*.
+
 ## 6. What we will not chase
 
 The negative space is doing as much work as the positive plan.

--- a/growth/composition-attributes.md
+++ b/growth/composition-attributes.md
@@ -1,0 +1,72 @@
+# Operator-set composition attributes
+
+- **Version:** v0.1 (working notes — not canonical)
+- **Date introduced:** 2026-05-15
+- **Canonical reference:** [`GROWTH.md`](../GROWTH.md) §5 Refine "Composition heuristic"
+- **Origin spec:** [`spec/2026-05-15-growth-composition-heuristic.md`](../spec/2026-05-15-growth-composition-heuristic.md)
+- **Provenance:** GitHub Discussion [#222](https://github.com/Jinn-Network/mono/discussions/222) §C2 / §C5
+
+## What this doc is / is not
+
+This is a working appendix to GROWTH.md §5 Refine's composition heuristic. It carries the **current draft** of attributes and thresholds the audit samples against. It is *not* canonical and edits to this file do *not* require canonical-doc PRs — they require the same operational review any [`growth/`](.) file gets.
+
+This is also explicitly *not* a launch gate, a recruiting filter, or a per-candidate selection criterion. See the *How NOT to use this* section below before doing anything with these numbers.
+
+## Why we sample composition at all
+
+Diversity is one signal of the operator set's structural neutrality. The launch-narrative critiques that have stuck to past fair-launches (Bittensor distribution, Numerai hedge-fund coupling, every founder-cabal narrative) attached because *the operator set at t=0 was visibly downstream of a structural advantage*. Sampling composition against a small attribute set lets Refine catch when that downstream shape is forming in time to push the question back into upstream design — tooling, recruiting loop, cluster strategy, harness accessibility — rather than treat the recruiting loop as the locus of correction.
+
+Per [`PRINCIPLES.md`](../PRINCIPLES.md): the actual launch-legitimacy work lives in *mechanism*. This audit is a diagnostic that runs *alongside* mechanism work and surfaces when mechanism is producing a non-neutral operator set.
+
+## The seven attributes (v0.1)
+
+Six per-operator attributes plus one set-level coverage check.
+
+| # | Attribute | Values | Layer |
+|---|---|---|---|
+| 1 | **Social proximity to Oak/Ritsu** — pre-existing personal relationship, warm intro through Oak/Ritsu, or current/recent compensation from either | Binary (`no proximity` / `proximity`) | Per-operator |
+| 2 | **Founder economic alignment** — how much Oak/Ritsu's positions appreciate if this operator participates | Categorical (`none` / `indirect` / `direct`) | Per-operator |
+| 3 | **Financial / professional independence** — whether the operator is employer-captured in a way that shapes what they can publicly do or say | Categorical (`independent` / `employed-neutral` / `employed-conflicted`) | Per-operator |
+| 4 | **Jurisdiction** — primary residence jurisdiction | Categorical (US / EU / UK / LATAM / E.Asia / S.Asia / Africa / Oceania / hostile-crypto / other) | Per-operator |
+| 5 | **Crypto exposure** — prior public crypto involvement | Categorical (`none` / `single project` / `multi-project`) | Per-operator |
+| 6 | **Technical savvy** — could this operator plausibly have joined if the tools required deep developer skill | Categorical (`high` / `mid` / `low-with-tooling-support`) | Per-operator |
+| 7 | **Capability / skillset class** — primary skill class the operator contributes beyond just running the client | Tag (`engineering` / `design` / `writing` / `research-eval` / `domain-expert` / `coordination`) | Per-operator tag → **set-level coverage** |
+
+## Draft composition targets (v0.1)
+
+All thresholds are working numbers and explicitly contestable. **Do not codify in any canonical doc.**
+
+- **#1 Social proximity:** ≥7/10 `no proximity`
+- **#2 Founder economic alignment:** ≥8/10 `none`; 0/10 `direct`
+- **#3 Financial / professional independence:** ≥6/10 `independent` or `employed-neutral`; 0/10 `employed-conflicted` without an explicit mitigation
+- **#4 Jurisdiction:** ≥3 distinct categories represented
+- **#5 Crypto exposure:** all three categories represented (≥1 of each)
+- **#6 Technical savvy:** ≥2/10 in `low-with-tooling-support`; 0/10 cases where `high` savvy was structurally required to participate
+- **#7 Capability / skillset:** ≥3 distinct skillset classes represented; ≥2 operators contributing non-engineering value
+
+## How to use this
+
+- **`growth-refine` consumes it periodically.** Cadence is operator-discretion within the skill; the canonical commitment is "periodically," not a fixed schedule.
+- **A gapped attribute is a question, not a finding.** *Why* did the operator set produce this gap? Tooling? Recruiting loop bias? Cluster handle too tight? The answer informs upstream design changes — to the loop, to the §3 cluster, to the harness onboarding shape, to the engagement rungs. Not to the recruiting funnel's per-candidate selection.
+- **Audit snapshots live in `growth/.local/composition-audits/YYYY-MM-DD.md`** (working notes, gitignored). Per-audit results are not committed history; if a launch-time disclosure of composition becomes required, the §7 operator-legitimacy methodology spec will own that artefact, not this doc.
+
+## How NOT to use this
+
+- **Not a launch gate.** Composition targets are not numeric gates that "the operator set must hit before mainnet." That's the audit-as-gate failure mode the GROWTH §5 canonical paragraph explicitly refuses.
+- **Not a per-candidate recruiting filter.** Candidates are not screened against attributes before they join. That's the audit-as-recruiting-filter failure mode the canonical paragraph explicitly refuses.
+- **Not a substitute for mechanism work.** Founder economic pre-commitments (Discussion #222 §C7), governance surface minimisation (§C17–C19), distribution-shape mechanism design (§E1–E7) all do more legitimacy work than this audit. If composition audit work is consuming time that should be going to those, the priority has inverted.
+- **Not a substitute for the §7 operator-legitimacy methodology.** That's a separate, on-chain-derivable artefact that counts whether operators exist. This is a diagnostic on the operators that are counted.
+
+## Versioning
+
+This file evolves freely. Significant changes — adding or removing an attribute, materially shifting a threshold — should land via PRs that explain the rationale, but they do not require canonical-doc spec proposals or CODEOWNERS-canonical approval. The canonical commitment in GROWTH.md §5 names the function, not the attribute list.
+
+If this file starts accumulating gate-shaped language ("operators must satisfy," "blocks launch unless," etc.) — that's the signal to revisit the canonical paragraph in GROWTH.md §5, not to ratify the drift.
+
+## Related
+
+- [`GROWTH.md`](../GROWTH.md) §5 Refine — the canonical commitment
+- [`spec/2026-05-15-growth-composition-heuristic.md`](../spec/2026-05-15-growth-composition-heuristic.md) — origin spec
+- [`spec/2026-05-15-growth-principles-alignment.md`](../spec/2026-05-15-growth-principles-alignment.md) — sibling alignment-pass spec; carries §7's operator-legitimacy methodology forward-pointer that this doc is *not* a substitute for
+- [`PRINCIPLES.md`](../PRINCIPLES.md) *Governance Minimal*, *Permissionless*, *Learning Maximised*, *Legible* — the load-bearing principles
+- GitHub Discussion [#222](https://github.com/Jinn-Network/mono/discussions/222) §C2 / §C5 — launch-gating discussion this audit contributes to

--- a/spec/2026-05-15-growth-composition-heuristic.md
+++ b/spec/2026-05-15-growth-composition-heuristic.md
@@ -1,0 +1,92 @@
+- **Date:** 2026-05-15
+- **Author:** Oak (with Claude)
+- **Status:** Proposal
+- **Version:** 0.1
+
+> Provenance: GitHub Discussion [#222](https://github.com/Jinn-Network/mono/discussions/222) §**C2** (which viewpoints must be represented) and §**C5** (diversity maintained over time). Follows [`spec/2026-05-15-growth-principles-alignment.md`](2026-05-15-growth-principles-alignment.md) in the post-PRINCIPLES alignment pass.
+
+## Motivation
+
+Discussion #222 raises group composition as a launch-quality question. Working through the seven candidate attributes against [`PRINCIPLES.md`](../PRINCIPLES.md), the honest read is: composition matters, but as a **diagnostic** signal — not as a launch gate or a per-candidate recruiting filter. The principles-side argument:
+
+- *Governance Minimal* — codifying attribute thresholds as launch-gating numbers adds a governance surface (who interprets edge cases?) rather than reducing one.
+- *Permissionless* — screening each candidate against multiple attributes before they join shifts selection logic toward what the audit values, not what the protocol values.
+- *Learning Maximised* — picking which attributes matter in advance is encoded cleverness about a critique surface we cannot fully predict; the audit must remain mutable as evidence accumulates.
+- *Legible* — most candidate attributes are interpreted, not on-chain. They cannot serve as legible launch claims even if we wanted them to.
+
+The defensible role is **periodic composition sampling during Refine**, treating gaps as questions to push back into upstream design / tooling / recruiting choices — never as recruiting filters or gate failures.
+
+This spec lands the *function* in canon and lets the *detail* (attribute list, draft thresholds) evolve in the working appendix without further canonical PRs.
+
+## What this proposal changes
+
+### §5 Refine — one new paragraph
+
+Append a paragraph to the existing `### Refine — growth-refine` subsection:
+
+> **Composition heuristic.** Periodically, as one input to Refine, the operator-set composition is sampled against a small set of diagnostic attributes (founder-proximity, founder economic alignment, financial/professional independence, jurisdiction, crypto exposure, technical savvy, skillset coverage). The attributes are heuristics, not gates: a gapped attribute surfaces a question about what upstream design or recruiting choice produced the gap, not a recruiting filter to apply per candidate. The attribute list and any working thresholds live in [`growth/`](growth/), not as canonical gates — codifying them as launch-gating numbers would add a governance surface in tension with [`PRINCIPLES.md`](PRINCIPLES.md) *Governance Minimal* and *Permissionless*.
+
+That is the entire canonical change.
+
+### New working-appendix doc — `growth/composition-attributes.md`
+
+Lands in the same PR as a non-canonical working doc. Carries the seven attributes (with the per-operator / set-level split), draft composition targets, the diagnostic-not-gate framing repeated for the reader who lands here directly, and a versioning note explaining that attribute and threshold edits do *not* require canonical-doc PRs — they require the same operational review any `growth/` file gets.
+
+The seven attributes at v0.1:
+
+1. Social proximity to Oak/Ritsu (binary, per-operator)
+2. Founder economic alignment — how much Oak/Ritsu stand to gain from this operator's participation (none / indirect / direct, per-operator)
+3. Financial / professional independence — operator is not employer-captured in a way that shapes what they can publicly do or say (independent / employed-neutral / employed-conflicted, per-operator)
+4. Jurisdiction of primary residence (categorical, per-operator)
+5. Crypto exposure (none / single / multi-project, per-operator)
+6. Technical savvy — could this operator plausibly have joined if the tools required deep developer skill (high / mid / low-with-tooling-support, per-operator)
+7. Capability / skillset class — engineering / design / writing / research-eval / domain-expert / coordination (tag, per-operator → set-level coverage check)
+
+Draft composition targets (working v0.1, all contestable, none canonical):
+
+- **#1** ≥7/10 no pre-existing proximity
+- **#2** ≥8/10 "none"; 0/10 "direct"
+- **#3** ≥6/10 independent or employed-neutral; 0/10 conflicted-and-unmitigated
+- **#4** ≥3 distinct jurisdictions
+- **#5** all three categories represented (≥1 of each)
+- **#6** ≥2/10 low-with-tooling-support; 0/10 high-savvy structurally required
+- **#7** ≥3 distinct skillset classes; ≥2 operators contributing non-engineering value
+
+## What this proposal does *not* change
+
+- §1, §2, §3, §4, §6, §7, §8, §9, §10 — untouched
+- §5 Understand / Teach / Engage — untouched (only the Refine subsection gains one paragraph)
+- The headline metric in §7 — unchanged; composition is explicitly *not* elevated to a supporting metric, because §7 metrics carry targets and the whole point here is no targets in canon
+- The §3 target cluster, bridge model, or rotation trigger — unchanged
+- The seven attributes are *not* canonical claims. They are working v0.1 in `growth/`.
+- No launch gate, no recruiting filter, no per-candidate selection criterion.
+
+## Why not §7 or §3
+
+- **§7 Metrics.** §7 carries metrics *with targets*. Elevating a deliberately-targetless heuristic into §7 would either (a) pollute the section's metric-with-target shape or (b) drift toward acquiring a target over time, which is the slip we are explicitly trying to avoid. The principle-aligned home is §5, where Refine already analyses the loop without target language.
+- **§3 Target recruit.** §3 is about *who we set out to recruit*. Composition is *what we end up with* — a downstream property of the loop, not an input choice. Putting composition under §3 would imply we recruit on the attributes, which is the per-candidate-filter failure mode the spec exists to refuse.
+
+## Risks and limitations
+
+- **Drift into gate-shape over time.** The most obvious failure mode: as composition targets are sampled repeatedly, operational pressure pushes them toward becoming numeric gates. Mitigation: the canonical paragraph explicitly names this failure mode and references the *Governance Minimal* principle; `growth/composition-attributes.md` repeats the framing. If the working doc starts accumulating gate-shaped language, that's the signal to revisit the canonical paragraph, not to ratify the drift.
+
+- **Audit-as-recruiting-filter.** The second failure mode: the daily loop quietly starts screening candidates against attributes before they reach engagement. Mitigation: the canonical paragraph explicitly forbids per-candidate filtering. `growth-refine` is the only function permitted to consume the audit; recruiting-stage skills (`discover-twitter-recruits`, `x-post-builder`, warm-list management) do not reference it.
+
+- **Attribute set ages poorly.** The v0.1 list reflects our current best guess at the critique surface. Bittensor's critique surface looks different from Numerai's looks different from ours. Mitigation: attribute and threshold edits do not require canonical-doc PRs — they happen in `growth/composition-attributes.md` as the loop accumulates evidence. The canonical paragraph names the function, not the list.
+
+- **Priority inversion.** If composition audits start consuming Refine cycles disproportionate to their priority (5–15% of launch-gate work per our current read), they crowd out higher-leverage refine work. Mitigation: the audit is *periodic*, not per-sprint. Cadence is operator-discretion within `growth-refine`; if cadence drifts up, that's a `growth-refine` skill-level conversation, not a canonical one.
+
+## Open questions
+
+- **Cadence.** How often does Refine actually run the audit? The spec deliberately doesn't specify — "periodically" is the canonical commitment, operational cadence lives in `growth-refine` and adapts. Open to redirect if a fixed cadence is preferred upfront.
+
+- **Where does the result live?** Each audit produces a snapshot. Proposed: `growth/.local/composition-audits/YYYY-MM-DD.md` (per-audit, gitignored working notes). Open to a committed-history alternative if the snapshot itself is meant to be legible to outside reviewers (e.g. for launch-time disclosure).
+
+- **Relationship to a future launch-time disclosure.** At mainnet launch, the §7 operator-legitimacy methodology spec (the Change-1 forward pointer from [`spec/2026-05-15-growth-principles-alignment.md`](2026-05-15-growth-principles-alignment.md)) will need to surface an on-chain-derivable operator count. The composition audit is *not* a substitute for that. The relationship: the audit informs whether the operator set the on-chain methodology is counting is also diverse enough for the launch narrative. Two different artefacts, two different purposes.
+
+## Sequencing
+
+1. **This spec lands.** Approval gate per [`spec/2026-04-28-canonical-docs.md`](2026-04-28-canonical-docs.md).
+2. **Same PR ships the GROWTH.md paragraph and the `growth/composition-attributes.md` working doc.**
+3. **First audit happens at a `growth-refine` invocation when Sprint #3 produces a non-trivial pool to sample.** No fixed deadline.
+4. **A short comment on Discussion #222** linking the merged PR as the C2/C5 contribution, with the priority caveat (5–15% of launch-gate work). The Discussion comment is operational, not canonical, and lands after the PR merges.


### PR DESCRIPTION
## Summary

Lands one canonical paragraph in [`GROWTH.md`](../blob/growth-composition-heuristic/GROWTH.md) §5 Refine naming operator-set composition sampling as a periodic Refine input — with explicit framing that the attributes are **heuristics, not gates**, and the attribute list lives in [`growth/composition-attributes.md`](../blob/growth-composition-heuristic/growth/composition-attributes.md) as working notes rather than canon.

Three files:

| File | Status | Purpose |
|---|---|---|
| `GROWTH.md` | Edit (one new paragraph in §5 Refine) | The canonical commitment — function only, not attribute list |
| `spec/2026-05-15-growth-composition-heuristic.md` | New | Proposal doc per canonical-docs flow |
| `growth/composition-attributes.md` | New | Working appendix with v0.1 attribute list, draft thresholds, and use / don't-use guidance |

## What canon learns (and what it deliberately doesn't)

**Canon learns:**

- The *function* — Refine periodically audits composition
- The *failure modes to avoid* — audit-as-gate, audit-as-recruiting-filter
- The pointer to where detail evolves — `growth/composition-attributes.md`

**Canon deliberately does not learn:**

- The seven specific attribute names (could shift as evidence accumulates)
- Any numeric thresholds (would become a governance surface)
- The priority ranking against C7 / C17–C19 / E1–E7 (that's Discussion [#222](https://github.com/Jinn-Network/mono/discussions/222) material, not canon)
- Any launch-gate claim — the whole point is "heuristic, not gate"

## Why §5 Refine, not §7 or §3

- **§7 Metrics** carries metrics *with targets*. Elevating a deliberately-targetless heuristic there would either pollute the section's shape or drift toward acquiring a target.
- **§3 Target recruit** is about *who we set out to recruit*. Composition is *what we end up with* — a downstream property. Putting it in §3 would imply per-candidate attribute filtering.
- **§5 Refine** already analyses the loop and surfaces drift. Composition is one more input.

## Priority context

Per [`PRINCIPLES.md`](../blob/growth-composition-heuristic/PRINCIPLES.md), most launch-legitimacy work is in **mechanism design**, not operator-set curation. Best read: this audit is somewhere between 5–15% of the launch-legitimacy work, not 50%. C7 (founder economic pre-commitments), C17–C19 (governance surface), and E1–E7 (distribution shape) all do more load-bearing work. The audit is a diagnostic running alongside that.

## Stacking

Base: `principles-canonical-doc` (carries PRINCIPLES.md and the seven prior alignment edits). Rebase target after that branch merges: `main`.

## Canonical-doc gate

Per [`spec/2026-04-28-canonical-docs.md`](../blob/growth-composition-heuristic/spec/2026-04-28-canonical-docs.md), GROWTH.md changes require a linked GitHub Discussion + CODEOWNERS approval. **The Discussion that motivates this is [#222](https://github.com/Jinn-Network/mono/discussions/222)** §C2 / §C5 — already open, already the umbrella thread for the alignment pass. A short follow-up comment on #222 linking this PR is sequenced after merge (per the spec's §4).

## Test plan

- [ ] CODEOWNERS approval on `GROWTH.md` + `spec/`
- [ ] Confirm the §5 paragraph reads as diagnostic-only, not gate-shaped
- [ ] Confirm `growth/composition-attributes.md` use / don't-use guidance is unambiguous about per-candidate filter prohibition
- [ ] Confirm the working appendix's "edits don't require canonical PRs" claim is acceptable as a versioning convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)