### PR TITLE
fix(3nc5): Dockerfile build stage copies client/docs/ for /build SPA page

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -33,9 +33,14 @@ RUN corepack enable && cd client && yarn install --immutable
 COPY packages/sdk/tsconfig.json ./packages/sdk/
 COPY packages/sdk/src/ ./packages/sdk/src/
 
-# Copy source and bundled deployment artifacts
+# Copy source and bundled deployment artifacts. `client/docs/` is needed at
+# build time because the /build SPA page (hfmf) embeds `quickstart.md` via a
+# Vite `?raw` import — `client/src/dashboard/spa/src/pages/build/IntroCard.tsx`
+# resolves `../../../../../../docs/build/quickstart.md` relative to itself,
+# which lands at `/app/client/docs/build/quickstart.md` inside the build stage.
 COPY client/src/ ./client/src/
 COPY client/deployments/ ./client/deployments/
+COPY client/docs/ ./client/docs/
 COPY client/plugins/ ./client/plugins/
 COPY client/scripts/ ./client/scripts/
 COPY client/templates/ ./client/templates/


### PR DESCRIPTION
## Summary

**Release blocker for the v0.1.6 Docker testnet acceptance gate.** PR #216 (hfmf) added the /build SPA route with an IntroCard that imports \`docs/build/quickstart.md\` via Vite's \`?raw\` loader. The Dockerfile copies \`client/{src,deployments,plugins,scripts,templates}/\` but not \`client/docs/\`, so the Docker build fails at \`RUN yarn build\`:

\`\`\`
Could not resolve "../../../../../../docs/build/quickstart.md?raw"
from "src/pages/build/IntroCard.tsx"
\`\`\`

That blocks \`yarn setup:testnet-acceptance-operator:docker --bootstrap\` and the v0.1.6 Docker testnet acceptance gate per \`client/RELEASING.md\`.

## Why \`client/docs/\` (not just the build subtree)

Single-file \`COPY client/docs/build/\` works for today's IntroCard import, but a near-term \`?raw\` import of another file (e.g. \`shape-reference.md\`, \`examples.md\`, \`publishing-flow.md\` — all referenced from the same \`/build\` page) would re-introduce the same break. Copying the whole \`client/docs/\` tree (~7 .md files, no binary assets) is cheap and future-proofs the build stage.

Runtime stage is unaffected — \`?raw\` embeds the markdown in the SPA's JS bundle, which is what gets shipped via \`dist/dashboard/\`.

## Test plan

- [x] Locally reproduced: \`yarn setup:testnet-acceptance-operator:docker --bootstrap\` fails at \`yarn build\` inside the Docker build stage with the missing-resolve error
- [ ] After this lands: re-run Docker setup; \`yarn build\` succeeds inside the container; bootstrap proceeds to fund-requirements
- [ ] No change to the runtime image's size budget (markdown ends up in the JS bundle either way)

## Refs

- Originating change: PR #216 \`feat(hfmf): /build SPA route + canonical /docs/build/ tree\`
- Tracking bd: \`jinn-mono-3nc5\` (release prep for v0.1.6)

## Run-mode

BUG-FIX

🤖 Generated with [Claude Code](https://claude.com/claude-code)