### PR TITLE
docs: retire bd as issue substrate (DR-2026-05-18 + agent canon rewrite)

### DIFF
--- a/.claude/skills/eng-day/SKILL.md
+++ b/.claude/skills/eng-day/SKILL.md
@@ -57,6 +57,7 @@ A four-section brief:
 
 - **No active sprint.** Print the fail-loud message:
   > No active sprint declared. Per docs/engineering/handbook.md §Sprint surface, the canonical sprint board is the "Jinn engineering" GitHub Project (v2) on Jinn-Network/mono. Add at least one GitHub Issue to the Project board with `Sprint = <upcoming-monday-date>` to declare a sprint, or take an explicit rest day.
+- **Project number mismatch.** This skill assumes project-number `1` for "Jinn engineering" on `Jinn-Network`. If `gh project item-list 1 --owner Jinn-Network` returns "project not found" or an unrelated board, run `gh project list --owner Jinn-Network --format json | jq '.projects[] | {number,title}'` to discover the actual number and surface it in the brief alongside the "no active sprint" failure — do not silently emit a misleading "no sprint" message when the project number is wrong.
 - **`gh` CLI unauthenticated.** Print the auth instruction (`gh auth login`, with the `project` scope: `gh auth refresh -s project`); do not block on the brief.
 - **Project board not reachable** (network / token issue). Print a one-line note and fall back to the open-Issue queue alone. Continue.
 

--- a/.claude/skills/eng-day/SKILL.md
+++ b/.claude/skills/eng-day/SKILL.md
@@ -1,74 +1,77 @@
 ---
 name: eng-day
-description: Daily aggregator + guidance surface for Jinn engineering work — reads bd ready queue, open PRs, and (once GitHub Project (v2) "Jinn engineering" board exists, per jinn-mono-2cl.9) the current sprint state. Surfaces sprint progress against the upcoming Monday cut, yesterday's shipped, today's top-3 *guidance* actions tagged by work shape (fix / feat / refactor / spike / chore / docs / test), drift flags (canary status, sprint age > 7 days, PRs > 3 days stale, latest vs canary mismatch). Not a dispatcher — does not invoke action skills (brainstorming / writing-plans / executing-plans / systematic-debugging / etc.); Captain invokes those from the brief. Triggers on "eng day", "morning engineering standup", "what should I do today", "daily eng check", "what's pending", "start of day engineering", "let's plan today's work", "engineering check-in", "what's next". Reads bd state via `bd ready` and `bd list`, open PRs via `gh pr list`, and the GitHub Project board state via `gh project item-list` (when 2cl.9 lands). Refuses to produce a top-3 if no active sprint exists in the Project board (fail-loud, references docs/engineering/handbook.md §The shipping machine for the daily-loop shape).
+description: Daily aggregator + guidance surface for Jinn engineering work — reads the open GitHub Issue queue, open PRs, and the "Jinn engineering" GitHub Project (v2) board state for the current sprint. Surfaces sprint progress against the upcoming Monday cut, yesterday's shipped, today's top-3 *guidance* actions tagged by work shape (fix / feat / refactor / spike / chore / docs / test), drift flags (canary status, sprint age > 7 days, PRs > 3 days stale, latest vs canary mismatch). Not a dispatcher — does not invoke action skills (brainstorming / writing-plans / executing-plans / systematic-debugging / etc.); Captain invokes those from the brief. Triggers on "eng day", "morning engineering standup", "what should I do today", "daily eng check", "what's pending", "start of day engineering", "let's plan today's work", "engineering check-in", "what's next". Reads Issue state via `gh issue list`, open PRs via `gh pr list`, and the GitHub Project board state via `gh project item-list`. Refuses to produce a top-3 if no active sprint exists in the Project board (fail-loud, references docs/engineering/handbook.md §The shipping machine for the daily-loop shape). Per DR-2026-05-18 the prior `bd ready` / `bd list` reads are retired — historical `jinn-mono-<id>` lookups still resolve via `bd show <id>` against the in-tree `.beads/` archive.
 ---
 
 # Engineering day
 
-The daily aggregator + guidance surface for Jinn engineering work. Run by Captain at the start of an engineering block. Reads operational state (bd ready, open PRs, Project board); surfaces sprint progress, today's top-3 actions tagged by work shape, drift flags. Not a dispatcher — Captain picks and invokes from the brief.
+The daily aggregator + guidance surface for Jinn engineering work. Run by Captain at the start of an engineering block. Reads operational state (open GitHub Issues, open PRs, the "Jinn engineering" Project board); surfaces sprint progress, today's top-3 actions tagged by work shape, drift flags. Not a dispatcher — Captain picks and invokes from the brief.
 
 Modeled on the `growth-day` skill — same Tier-A discipline, same drift-flag pattern, same fail-loud sprint precondition.
+
+**Substrate note (2026-05-18):** Per DR-2026-05-18, the issue-tracking substrate is GitHub Issues + native sub-issues + the "Jinn engineering" Project (v2). `bd` is retired; the `.beads/` checkout stays in-tree as a read-only archive of historical `jinn-mono-<id>` references but is not part of the live daily-loop state read.
 
 ## Read first
 
 - [`docs/engineering/handbook.md`](../../../docs/engineering/handbook.md) §The shipping machine (daily loop + weekly retrace), §The shapes of work (which shapes exist + their flows), §Sprint surface (GH Project shape).
 - [`CLAUDE.md`](../../../CLAUDE.md) — agent-canonical project guide.
-- bd state: `bd ready`, `bd list --status=in_progress`, `bd list --status=open --priority=P0,P1`.
-- Open PRs: `gh pr list --search 'is:open draft:false' --json number,title,author,createdAt,reviewDecision,mergeable`.
-- GitHub Project board (once `jinn-mono-2cl.9` lands): `gh project item-list <project-number> --owner Jinn-Network --format json` filtered to the current Sprint field value.
+- Open Issues (ready queue): `gh issue list --repo Jinn-Network/mono --state open --json number,title,labels,assignees,createdAt,updatedAt,milestone --limit 200`. Filter to items with no open blocking sub-issue / no `blocked:*` label for "ready."
+- Open PRs: `gh pr list --search 'is:open draft:false' --json number,title,author,createdAt,updatedAt,reviewDecision,mergeable`.
+- GitHub Project board: `gh project item-list <project-number> --owner Jinn-Network --format json`, filtered to the current `Sprint` Iteration value. (Project number: 1 — the "Jinn engineering" board on `Jinn-Network`.)
 
 ## Sprint precondition (fail-loud)
 
-This skill refuses to produce a top-3 unless an active sprint exists. Active sprint = at least one item on the "Jinn engineering" GitHub Project (v2) board with `Sprint = <upcoming-monday-date>`. Until `jinn-mono-2cl.9` creates the Project board, the precondition relaxes to: at least one P0 or P1 bd issue in `bd ready` is recent (created or updated within the last 7 days).
+This skill refuses to produce a top-3 unless an active sprint exists. **Active sprint** = at least one item on the "Jinn engineering" GitHub Project (v2) board with `Sprint = <upcoming-monday-date>`.
 
-No active sprint = no daily plan. Either declare a sprint (mirror at least one bd issue to the Project board with Sprint = upcoming-Monday) or explicitly take a rest day. The fail-loud message quotes `docs/engineering/handbook.md` §Sprint surface for the sprint shape.
+No active sprint = no daily plan. Either declare a sprint (add at least one Issue to the Project board with `Sprint = upcoming-Monday`) or explicitly take a rest day. The fail-loud message quotes `docs/engineering/handbook.md` §Sprint surface for the sprint shape.
 
 ## Output shape
 
 A four-section brief:
 
 1. **Sprint context** — current sprint window (Monday cut date), days elapsed, % closed vs queued, any work in-progress.
-2. **Yesterday shipped** — PRs merged in the last 24h (with shape prefix and author), bd issues closed.
-3. **Today's top-3 guidance** — tagged by work shape, with bd id + one-line context. Order by: blockers first, then by sprint-fit (sprint-target items rank above unrelated ready items), then by priority. Always include the next stale PR (> 3 days idle) if there is one.
+2. **Yesterday shipped** — PRs merged in the last 24h (with shape prefix and author), Issues closed.
+3. **Today's top-3 guidance** — tagged by work shape, with Issue number + one-line context. Order by: blockers first, then by sprint-fit (sprint-target items rank above unrelated ready Issues), then by priority. Always include the next stale PR (> 3 days idle) if there is one.
 4. **Drift flags** — surface only the flags that are active:
    - Canary publish broken on most recent merge.
    - npm `latest` mismatched against expected weekly cut (no Monday Release in the last 8+ days).
    - PR open > 3 days without review activity.
    - Sprint age > 7 days (Monday cut should reset weekly).
-   - bd state has issues marked in-progress with no commits in 5+ days.
+   - Issues marked in-progress (assigned, Project Status = In Progress) with no commits / no PR activity in 5+ days.
 
 ## How to assemble
 
 1. Read state in parallel:
-   - `bd ready`
-   - `bd list --status=in_progress --json id,title,priority,assignee,updated_at`
-   - `gh pr list --search 'is:open draft:false' --json number,title,author,createdAt,updatedAt,reviewDecision,mergeable`
-   - When 2cl.9 lands: `gh project item-list <project-number> --owner Jinn-Network --format json`
+   - `gh issue list --repo Jinn-Network/mono --state open --json number,title,labels,assignees,createdAt,updatedAt`
+   - `gh pr list --search 'is:open draft:false' --repo Jinn-Network/mono --json number,title,author,createdAt,updatedAt,reviewDecision,mergeable`
+   - `gh project item-list <project-number> --owner Jinn-Network --format json` (project-number: 1)
+   - Last Release: `gh release list --repo Jinn-Network/mono --limit 1 --json publishedAt,tagName` (drift baseline for the canary/latest mismatch flag).
 2. Compute drift flags from the joined state.
 3. Build the top-3 by:
-   - Filter `bd ready` to items with `Sprint = <upcoming-monday>` on the Project board (when available); else recent P0/P1 in bd-only.
+   - Filter open Issues to those on the Project board with `Sprint = <upcoming-monday>` (sprint-target); else fall back to recent P0/P1-labelled Issues for an "off-sprint preview."
    - Rank by: stale-PR-review-needed > sprint-blocker > sprint-target ready > non-sprint P0 > non-sprint P1.
-   - Tag each with shape from the bd `Run-mode` field.
+   - Tag each with shape from the Issue body's `## Run-mode` section (or the `shape:*` label if present).
 4. Format the brief; output to terminal; do not dispatch.
 
 ## Failure modes
 
 - **No active sprint.** Print the fail-loud message:
-  > No active sprint declared. Per docs/engineering/handbook.md §Sprint surface, the canonical sprint board is the "Jinn engineering" GitHub Project (v2) on Jinn-Network/mono. Mirror at least one bd issue to the Project board with `Sprint = <upcoming-monday-date>` to declare a sprint, or take an explicit rest day. (Until `jinn-mono-2cl.9` creates the board, the precondition relaxes to: at least one recent P0/P1 in bd ready.)
-- **Project board absent (2cl.9 not landed).** Print a one-line note and fall back to bd-only state. Continue.
-- **gh CLI unauthenticated.** Print the auth instruction (`gh auth login`); do not block on the brief.
+  > No active sprint declared. Per docs/engineering/handbook.md §Sprint surface, the canonical sprint board is the "Jinn engineering" GitHub Project (v2) on Jinn-Network/mono. Add at least one GitHub Issue to the Project board with `Sprint = <upcoming-monday-date>` to declare a sprint, or take an explicit rest day.
+- **`gh` CLI unauthenticated.** Print the auth instruction (`gh auth login`, with the `project` scope: `gh auth refresh -s project`); do not block on the brief.
+- **Project board not reachable** (network / token issue). Print a one-line note and fall back to the open-Issue queue alone. Continue.
 
 ## v0 vs v1
 
 This is the v0 skill. v1 will:
-- Auto-detect Project board number from `gh project list` (currently hardcoded after 2cl.9 lands).
-- Compute the suggested-semver-bump heuristic surface (always-minor; Captain-overrides) and flag if an epic-major bd issue closed in the window.
+
+- Auto-detect Project board number from `gh project list` (currently hardcoded to 1 for the "Jinn engineering" board on `Jinn-Network`).
+- Compute the suggested-semver-bump heuristic surface (always-patch; Captain overrides to minor on epic close) and flag if an epic-major Issue closed in the window.
 - Surface shape-flow refinement candidates (per handbook §Iterative refinement) if friction signals emerge in repeated brief runs.
 
-These v1 improvements come from iterative refinement (handbook §Iterative refinement) — file a bd under `jinn-mono-2cl` if friction observed.
+These v1 improvements come from iterative refinement (handbook §Iterative refinement) — file a GitHub Issue under the engineering handbook umbrella if friction observed.
 
 ## Composition
 
 - Composes with `growth-day` only at the Captain's invocation level (Captain reads both each morning). The two skills do not share state; engineering and growth loops have different rhythms (engineering weekly cut vs growth daily loop).
 - Composes downstream with the action skills it lists but does not invoke (`brainstorming`, `writing-plans`, `executing-plans`, `systematic-debugging`, `dispatching-parallel-agents`, `subagent-driven-development`, `verification-before-completion`, `receiving-code-review`).
-- Composes with the Friday triage cron (`jinn-mono-2cl.11`) which mirrors bd → GitHub Issues + Project board — `eng-day` reads what triage produced.
+- Composes with the Project board's Friday triage flow (handbook §Weekly retrace) — `eng-day` reads what triage produced; the prior `bd-mirror`-coupled Friday cron is retired per DR-2026-05-18.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,9 +10,9 @@ The shape goes in the PR title as a Conventional Commits prefix:
   refactor: extract Harness selection from buildHarnesses
 -->
 
-## Linked bd
+## Linked Issue
 
-<!-- e.g. Closes jinn-mono-XXX -->
+<!-- e.g. Closes #123. Per DR-2026-05-18 the canonical issue substrate is GitHub Issues; the legacy `Closes jinn-mono-<id>` form continues to resolve for archived references but new work links to GH Issue numbers. -->
 
 ## Test plan
 
@@ -24,7 +24,7 @@ How was this verified? Reference the test discipline for the shape:
 - chore (deps): integration test
 - spike: not applicable (output is a finding)
 - docs / test: skipped or meta
-- fix(incident): defer test; file a follow-up bead for the regression test BEFORE closing the incident
+- fix(incident): defer test; file a follow-up Issue for the regression test BEFORE closing the incident
 -->
 
 ## Agent identity (if AI-authored)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ How this team ships — cadence, dist-tags, work-shape taxonomy, AI workflow rul
 
 ### Work shape (declare it before executing)
 
-Seven shapes plus one emergency sub-flow, keyed to Conventional Commits prefixes. Declare the shape in the bd issue's `Run-mode` field; replicate it as the PR title prefix.
+Seven shapes plus one emergency sub-flow, keyed to Conventional Commits prefixes. Declare the shape in the GitHub Issue body's `## Run-mode` section; replicate it as the PR title prefix.
 
 - **`fix`** — bug fix. Regression test first. Skill chain: `systematic-debugging` → `executing-plans` → `verification-before-completion` → `receiving-code-review`.
 - **`feat`** — feature. TDD. Skill chain: (`brainstorming` if ambiguous) → `writing-plans` → `test-driven-development` → `executing-plans` / `dispatching-parallel-agents` → `verification-before-completion` → `receiving-code-review`.
@@ -39,15 +39,15 @@ Seven shapes plus one emergency sub-flow, keyed to Conventional Commits prefixes
 - **`test`** — test-only. Meta test discipline.
 - **`fix(incident)`** — hotfix sub-flow. Relaxed review; post-hoc regression test required as a follow-up bead before closing the incident.
 
-If a bd issue does not fit one of these shapes, it is mis-scoped — split or reshape it. Per-shape SOPs (v0 flows) live in the handbook §The shapes of work; they evolve via iterative refinement (file a bd under `jinn-mono-2cl` when friction surfaces).
+If an Issue does not fit one of these shapes, it is mis-scoped — split or reshape it. Per-shape SOPs (v0 flows) live in the handbook §The shapes of work; they evolve via iterative refinement (file a GitHub Issue under the engineering handbook umbrella when friction surfaces).
 
 ### Eight ratified AI workflow rules
 
-1. **Worktree-for-multi-agent.** Multi-agent or speculative subagent work uses `git worktree add cargo/.tasks/<id>`.
-2. **Beads frame problems, not solutions.** bd body = context + impact + acceptance criteria. Solutions go in design sessions.
-3. **bd-as-SoR, not `MEMORY.md`.** Use `bd remember` / `bd memories`.
+1. **Worktree-for-multi-agent.** Multi-agent or speculative subagent work uses a separate git worktree (current convention: `git worktree add ../jinn-mono_worktrees/<name>`), not the primary checkout.
+2. **Issues frame problems, not solutions.** GitHub Issue body = context + impact + acceptance criteria. Solutions go in design sessions or implementation plans, not the Issue body.
+3. **GitHub Issues are the single SoR for engineering work.** Per DR-2026-05-18, `bd` retires; all new engineering work originates as a GitHub Issue on `Jinn-Network/mono`. Parent/child use native sub-issues; sprint/epic/status live on the "Jinn engineering" Project (v2) board. The `.beads/` checkout stays in-tree as read-only archive of historical `jinn-mono-<id>` references.
 4. **Agent PR review parity.** Codex / Opus / Sonnet / Claude PRs reviewed like human PRs. No agent self-merge. Exception: `fix(incident)` with reviewer justification.
-5. _(Deferred — supervised-diff for the self-modifying learner. Mechanism open; see `jinn-mono-8qbc`.)_
+5. _(Deferred — supervised-diff for the self-modifying learner. Mechanism open.)_
 6. **Integration tests > mocks for migration / contract surfaces.**
 7. **TDD for new features, regression test for fixes.**
 8. **Auto-canary on push to `next`; Monday-only named stable cut promotes `main`.** Cadence policy.
@@ -63,7 +63,9 @@ If a bd issue does not fit one of these shapes, it is mis-scoped — split or re
 
 ### Daily entry point
 
-`eng-day` skill (in `cargo/.claude/skills/eng-day/`) is the canonical daily brief. Fallback when the GitHub Project board doesn't exist yet: `bd ready` + `gh pr list --search 'is:open draft:false'`.
+`eng-day` skill (in `.claude/skills/eng-day/`) is the canonical daily brief. Fallback: `gh issue list --search 'is:open no:assignee'` + `gh pr list --search 'is:open draft:false'`.
+
+**Operator-local cleanup (one-time, per DR-2026-05-18):** if your `.claude/settings.json` has a `bd prime` SessionStart or PreCompact hook (the legacy beads workflow primer), remove it. `.claude/settings.json` is gitignored, so this cleanup is per-operator. The hook is no longer recommended; CLAUDE.md auto-load covers session start.
 
 ## Repository Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ How this team ships — cadence, dist-tags, work-shape taxonomy, AI workflow rul
 
 ### Work shape (declare it before executing)
 
-Seven shapes plus one emergency sub-flow, keyed to Conventional Commits prefixes. Declare the shape in the GitHub Issue body's `## Run-mode` section; replicate it as the PR title prefix.
+Seven shapes plus one emergency sub-flow plus one meta-shape (`INTERACTIVE DESIGN`, for design-only sessions whose output is a spec or DR, not implementation), keyed to Conventional Commits prefixes. Declare the shape in the GitHub Issue body's `## Run-mode` section; replicate it as the PR title prefix.
 
 - **`fix`** — bug fix. Regression test first. Skill chain: `systematic-debugging` → `executing-plans` → `verification-before-completion` → `receiving-code-review`.
 - **`feat`** — feature. TDD. Skill chain: (`brainstorming` if ambiguous) → `writing-plans` → `test-driven-development` → `executing-plans` / `dispatching-parallel-agents` → `verification-before-completion` → `receiving-code-review`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Seven shapes plus one emergency sub-flow plus one meta-shape (`INTERACTIVE DESIG
 - **`chore`** — deps, CI, dev tooling. Integration tests if touches a dep.
 - **`docs`** — documentation. Canonical-doc changes need Discussion + CODEOWNERS approval.
 - **`test`** — test-only. Meta test discipline.
-- **`fix(incident)`** — hotfix sub-flow. Relaxed review; post-hoc regression test required as a follow-up bead before closing the incident.
+- **`fix(incident)`** — hotfix sub-flow. Relaxed review; post-hoc regression test required as a follow-up Issue before closing the incident.
 
 If an Issue does not fit one of these shapes, it is mis-scoped — split or reshape it. Per-shape SOPs (v0 flows) live in the handbook §The shapes of work; they evolve via iterative refinement (file a GitHub Issue under the engineering handbook umbrella when friction surfaces).
 

--- a/docs/engineering/handbook.md
+++ b/docs/engineering/handbook.md
@@ -67,7 +67,7 @@ The Project board's Sprint view resets to the new Monday; shipped items move to 
 
 ## The shapes of work
 
-The handbook recognises seven shapes plus one emergency sub-flow. Each shape declares a **disposition** — when it applies, what discipline its container demands, what ceremony fits. The shape is declared in the GitHub Issue body's `## Run-mode` section and replicated in the PR title prefix (Conventional Commits). If an Issue does not fit one of these shapes, it is mis-scoped — split it or reshape it.
+The handbook recognises seven shapes plus one emergency sub-flow, plus one meta-shape (`INTERACTIVE DESIGN`) used when the Issue's job is to *produce a design doc* (spec or DR) rather than ship implementation. Each shape declares a **disposition** — when it applies, what discipline its container demands, what ceremony fits. The shape is declared in the GitHub Issue body's `## Run-mode` section and replicated in the PR title prefix (Conventional Commits). If an Issue does not fit one of these shapes, it is mis-scoped — split it or reshape it.
 
 The taxonomy is keyed to Conventional Commits prefixes so it composes with existing tooling: PR title → Release section grouping → CHANGELOG entry.
 

--- a/docs/engineering/handbook.md
+++ b/docs/engineering/handbook.md
@@ -6,9 +6,11 @@ The handbook is **Jinn-flavored**, not generic. Per [`BRAND.md`](../../BRAND.md)
 
 Canonical references:
 - Design that ratified this handbook: [`docs/superpowers/specs/2026-05-11-engineering-handbook-codesign.md`](../superpowers/specs/2026-05-11-engineering-handbook-codesign.md)
-- DR-2026-05-11-b — Engineering substrate decision: [`log/decisions/2026-05-11-engineering-substrate.md`](../../log/decisions/2026-05-11-engineering-substrate.md)
+- DR-2026-05-18 — Issue tracking substrate (retire `bd`, single-track on GitHub): [`log/decisions/2026-05-18-bd-vs-gh-substrate.md`](../../log/decisions/2026-05-18-bd-vs-gh-substrate.md)
+- DR-2026-05-11-b — Engineering substrate (superseded for the internal-SoR claim by DR-2026-05-18; sprint-surface claim survives): [`log/decisions/2026-05-11-engineering-substrate.md`](../../log/decisions/2026-05-11-engineering-substrate.md)
 - DR-2026-05-11-a — Prediction freeze: [`log/decisions/2026-05-11-freeze-prediction-solvernet.md`](../../log/decisions/2026-05-11-freeze-prediction-solvernet.md)
-- Umbrella bd: `jinn-mono-2cl`
+
+**Note on `bd` retirement (2026-05-18):** Per DR-2026-05-18, `bd` is retired as the issue-tracking substrate. GitHub Issues + native sub-issues + the "Jinn engineering" Project (v2) are the single source of truth for engineering work going forward. The `.beads/` checkout stays in-tree as a read-only archive so historical `jinn-mono-<id>` references continue to resolve. Sections below reflect the new substrate; the prior `bd ↔ GitHub Issue mirror` from DR-2026-05-11-b is retired.
 
 ## Cadence
 
@@ -16,7 +18,7 @@ Two-train release model:
 
 - **`next` is the integration branch.** Every PR targets `next`. Every push to `next` that touches `client/**` publishes `<package.version>-canary.<sha8>` to npm under the `canary` dist-tag within minutes (`cargo/.github/workflows/npm-publish.yml`). Operators on `npm install -g @jinn-network/client@canary` receive the rolling build.
 - **`main` is the released-train head.** It is advanced only by `cargo/.github/workflows/promote-main.yml`, which fast-forwards main to the v<semver> tag on `release: published`. `main` HEAD therefore always reflects what is currently in npm `@latest`.
-- **Weekly named Build Notes cut every Monday.** A Monday cron creates a GitHub Release **draft** at 09:00 UTC against `next` HEAD. Captain reviews (Hermes-style: build-name + highlights + known-issues + auto-aggregated PRs/closed-bd/stats), then publishes. Publish triggers (a) npm `latest`, (b) `promote-main.yml` to fast-forward main, (c) CHANGELOG auto-mirror. Default `npm install -g @jinn-network/client` gets the weekly named stable build.
+- **Weekly named Build Notes cut every Monday.** A Monday cron creates a GitHub Release **draft** at 09:00 UTC against `next` HEAD. Captain reviews (Hermes-style: build-name + highlights + known-issues + auto-aggregated PRs and closed Issues), then publishes. Publish triggers (a) npm `latest`, (b) `promote-main.yml` to fast-forward main, (c) CHANGELOG auto-mirror. Default `npm install -g @jinn-network/client` gets the weekly named stable build.
 
 Tag format on Monday cuts: dual — `v2026.MM.DD` (the human-readable build identifier) and `vX.Y.Z` (the semver for npm). Pre-v1 weekly Build Notes cuts usually patch (`v0.1.3 → v0.1.4`). A Monday cut where an epic or significant capability lands can bump the minor (`v0.1.x → v0.2.0`). **v1.0.0 is reserved for far-future graduation** (mainnet / exit-testnet / Phase 2), explicitly not `jinn-mono-uy6v`.
 
@@ -35,7 +37,7 @@ There is no `@next` dist-tag. The branch named `next` exists; the dist-tag does 
 
 ### Daily loop
 
-In `cargo/`:
+At the repo root:
 
 ```
 claude
@@ -43,17 +45,17 @@ claude
 
 then:
 
-1. **Orient.** Invoke `eng-day` skill (or fallback: `bd ready` + `gh pr list --search 'is:open draft:false'`). Brief reports sprint progress, yesterday's shipped, today's top-3 guidance, drift flags.
-2. **Pick one piece of work** — a bd issue, a stale PR, or a design conversation. Run `bd show <id>` to read the work.
-3. **Execute according to shape** — the bd issue's `Run-mode` field declares the shape; the shape determines the skill chain, test discipline, design ceremony, and stacking policy (see §The shapes of work below).
-4. **Open PR(s).** PR title format: `<shape>(<optional scope>): <one-line summary>` (Conventional Commits). Template in `cargo/.github/PULL_REQUEST_TEMPLATE.md` prompts for problem-not-solution body, test plan, agent identity, Co-Authored-By trailer.
+1. **Orient.** Invoke `eng-day` skill (or fallback: `gh issue list --search 'is:open' --json number,title,labels,assignees` + `gh pr list --search 'is:open draft:false'`). Brief reports sprint progress, yesterday's shipped, today's top-3 guidance, drift flags.
+2. **Pick one piece of work** — a GitHub Issue, a stale PR, or a design conversation. Run `gh issue view <N>` to read the work.
+3. **Execute according to shape** — the Issue body's `## Run-mode` section declares the shape; the shape determines the skill chain, test discipline, design ceremony, and stacking policy (see §The shapes of work below).
+4. **Open PR(s).** PR title format: `<shape>(<optional scope>): <one-line summary>` (Conventional Commits). The PR template (`.github/PULL_REQUEST_TEMPLATE.md`) prompts for problem-not-solution body, test plan, agent identity, Co-Authored-By trailer.
 5. **Review.** Human eyes on every PR (rule 4). No agent self-merge. Exception: `fix(incident)` allows reviewer relaxation with documented justification.
 6. **Merge to `next` → auto-canary.** `npm-publish.yml` fires on push to `next`, publishes `<v>-canary.<sha>` under `canary`. `main` advances only on the Monday cut's release publish (or via the hotfix sub-flow).
-7. **Close bd.** `bd close <id>`. The mirrored GitHub Issue (if any) auto-closes via PR linking.
+7. **Close the Issue.** PR body's `Closes #<N>` auto-closes the Issue on merge; otherwise `gh issue close <N>`.
 
 ### Weekly retrace
 
-**Friday afternoon — triage.** The Friday triage workflow (`cargo/.github/workflows/friday-triage.yml`, currently `workflow_dispatch` only until cron is enabled) reads the bd ready queue, picks top-N priority bd issues (P0 + capped P1), invokes `cargo/scripts/bd-mirror` for each to open a public GitHub Issue with sprint label + Project board entry. Captain reviews on Friday and **rejects** anything that doesn't belong (close Issue, remove sprint label). Captain adds Issues by exception only. Default flow is *reject, not select*.
+**Friday afternoon — triage.** Captain walks the open GitHub Issue queue, picks candidates for the upcoming Monday sprint, and adds them to the "Jinn engineering" Project (v2) board with the upcoming-Monday Iteration value on the `Sprint` field. The pre-DR-2026-05-18 Friday triage cron + `scripts/bd-mirror` helper are retired. If a labeling pass surfaces value (e.g. flagging top-priority unsprinted Issues), the cron may be reintroduced as a label-only pass over open Issues — file a follow-up Issue if so. Default flow stays *select, not auto-promote*.
 
 **Monday morning — cut.** The Monday cron (`cargo/.github/workflows/release-notes-scaffold.yml`, currently `workflow_dispatch` only) creates a GitHub Release **draft** at 09:00 UTC. Captain edits build-name + highlights + known-issues, clicks Publish. Publish triggers:
 
@@ -65,7 +67,7 @@ The Project board's Sprint view resets to the new Monday; shipped items move to 
 
 ## The shapes of work
 
-The handbook recognises seven shapes plus one emergency sub-flow. Each shape declares a **disposition** — when it applies, what discipline its container demands, what ceremony fits. The shape is declared in the bd issue's `Run-mode` field and replicated in the PR title prefix (Conventional Commits). If a bd issue does not fit one of these shapes, it is mis-scoped — split it or reshape it.
+The handbook recognises seven shapes plus one emergency sub-flow. Each shape declares a **disposition** — when it applies, what discipline its container demands, what ceremony fits. The shape is declared in the GitHub Issue body's `## Run-mode` section and replicated in the PR title prefix (Conventional Commits). If an Issue does not fit one of these shapes, it is mis-scoped — split it or reshape it.
 
 The taxonomy is keyed to Conventional Commits prefixes so it composes with existing tooling: PR title → Release section grouping → CHANGELOG entry.
 
@@ -74,7 +76,7 @@ The taxonomy is keyed to Conventional Commits prefixes so it composes with exist
 | Shape | Trigger | v0 skill chain | Test discipline | Design upfront | Stacking | Observed pitfall (2026-05-11) |
 |---|---|---|---|---|---|---|
 | **`fix`** — Bug fix | Failing test, user report, canary alert | `systematic-debugging` → `executing-plans` → `verification-before-completion` → `receiving-code-review` | Regression test **first** (rule 7) | Skipped — escalate to `refactor` if bug reveals architectural problem | Skipped — single PR | Proposing a fix before reproducing |
-| **`feat`** — Feature | bd issue with acceptance criteria; user request; spec need | (`brainstorming` if scope ambiguous) → `writing-plans` → `test-driven-development` → `executing-plans` or `dispatching-parallel-agents` → `verification-before-completion` → `receiving-code-review` | TDD (rule 7) | Required if scope ambiguous; optional if acceptance concrete | Allowed/encouraged for multi-task | Skipping TDD and discovering at PR time the design doesn't support testing |
+| **`feat`** — Feature | Issue with acceptance criteria; user request; spec need | (`brainstorming` if scope ambiguous) → `writing-plans` → `test-driven-development` → `executing-plans` or `dispatching-parallel-agents` → `verification-before-completion` → `receiving-code-review` | TDD (rule 7) | Required if scope ambiguous; optional if acceptance concrete | Allowed/encouraged for multi-task | Skipping TDD and discovering at PR time the design doesn't support testing |
 | **`refactor`** — Architecture / migration | Scaling problem, velocity drag, migration to a new pattern | `brainstorming` (**required**) → `writing-plans` → `test-driven-development` → `subagent-driven-development` → `executing-plans` → `verification-before-completion` → `receiving-code-review` | TDD + integration tests on migration / contract surfaces (rules 6 + 7) | **Required** — DR for big, spec for medium | **Required** — strangler-fig preferred; each layer ships independently | Big-bang refactor as one giant PR — reviewers reject |
 | **`spike`** — Research / exploration | Open "can we?" question; tech evaluation | `brainstorming` → exploratory work in a worktree → write finding as spec or DR | Skipped — output is a finding | The output IS the design | Skipped — spike code does not merge | Letting spike code drift back into a feature PR; not writing the finding |
 | **`chore`** — Deps, CI, dev tooling | Dependabot, CI tweak, dev-pain | `executing-plans` → `verification-before-completion` → `receiving-code-review` | Integration tests required if touches a dep (rule 6) | Skipped | Skipped | Batching dep upgrade with feature work |
@@ -83,33 +85,33 @@ The taxonomy is keyed to Conventional Commits prefixes so it composes with exist
 
 **Emergency sub-flow of `fix`:**
 
-`fix(incident)` — used when canary is broken, production is incident-mode, or a security disclosure lands. SOP: acknowledge in the incident thread; diagnose (revert is the default); ship the smallest possible patch with **relaxed review** (one reviewer, justification noted in PR body); the post-hoc regression test and proper-fix are **required follow-up beads** filed before the incident is closed. Rule 4 (review parity) explicitly allows relaxation here; rule 7 (regression test) defers but does not waive.
+`fix(incident)` — used when canary is broken, production is incident-mode, or a security disclosure lands. SOP: acknowledge in the incident thread; diagnose (revert is the default); ship the smallest possible patch with **relaxed review** (one reviewer, justification noted in PR body); the post-hoc regression test and proper-fix are **required follow-up Issues** filed before the incident is closed. Rule 4 (review parity) explicitly allows relaxation here; rule 7 (regression test) defers but does not waive.
 
-**`Run-mode` values** used in bd issue bodies: `BUG-FIX` / `FEATURE` / `REFACTOR` / `SPIKE` / `CHORE` / `DOCS` / `TEST` / `INCIDENT` / `INTERACTIVE DESIGN`. The `INTERACTIVE DESIGN` value is the meta-shape used when the bd issue's job is to *produce a design doc* — its skill chain is `brainstorming` → spec → DR(s) → bd restructure, with no implementation in the same session.
+**`Run-mode` values** used in Issue bodies: `BUG-FIX` / `FEATURE` / `REFACTOR` / `SPIKE` / `CHORE` / `DOCS` / `TEST` / `INCIDENT` / `INTERACTIVE DESIGN`. The `INTERACTIVE DESIGN` value is the meta-shape used when the Issue's job is to *produce a design doc* — its skill chain is `brainstorming` → spec → DR(s) → Issue restructure, with no implementation in the same session.
 
-**Every bd issue declares a `Run-mode`.** Add a `## Run-mode` section to the bd body at create-time. Epics (containers) are exempt; only work-unit beads need it. The `eng-day` daily-brief skill reads `Run-mode` to apply the right skill chain when surfacing a task. If you create a bd without `Run-mode`, a reviewer will infer one from the title and `type` field — `bd update --append-notes` adds the section retroactively, but declaring it up front is cheaper. Captain may amend a previously-declared `Run-mode` if the shape changes (e.g. a `feat` that reveals a deeper architectural problem becomes a `refactor`).
+**Every work-unit Issue declares a `Run-mode`.** Add a `## Run-mode` section to the Issue body at create-time. Epics (containers) are exempt; only work-unit Issues need it. The `eng-day` daily-brief skill reads `Run-mode` to apply the right skill chain when surfacing a task. If you create an Issue without `Run-mode`, a reviewer will infer one from the title and labels — `gh issue edit <N> --body-file -` adds the section retroactively, but declaring it up front is cheaper. Captain may amend a previously-declared `Run-mode` if the shape changes (e.g. a `feat` that reveals a deeper architectural problem becomes a `refactor`).
 
 ### Iterative refinement of shape flows
 
 The shape taxonomy above is the stable surface. The per-shape skill chains are v0 defaults — they will be wrong in places we haven't shipped enough work to know yet.
 
-Friction observed in a shape's flow → bd issue under `jinn-mono-2cl` → refinement, via one of three paths:
+Friction observed in a shape's flow → file a GitHub Issue under the engineering handbook umbrella → refinement, via one of three paths:
 
-1. **Author a new shape-specific skill.** If friction recurs and no existing skill covers it. New skill lands in `cargo/.claude/skills/` (in-repo, AI agents pick up via Claude Code skill loading); the shape's v0 skill chain in this handbook updates to invoke it.
+1. **Author a new shape-specific skill.** If friction recurs and no existing skill covers it. New skill lands in `.claude/skills/` (in-repo, AI agents pick up via Claude Code skill loading); the shape's v0 skill chain in this handbook updates to invoke it.
 2. **Amend an existing skill.** If friction is in how an existing skill (e.g., `superpowers:systematic-debugging`) fits the shape's context. The amendment is itself a `docs` change in the relevant skill's repo.
 3. **Revise the handbook.** If the friction is taxonomic (e.g., `chore` should split into `chore(deps)` vs `chore(ci)`). `docs`-shape change against this file.
 
-For v0 the refinement mechanism is intentionally lightweight: file a bd under `jinn-mono-2cl` tagged with the shape it concerns, body describing the friction and the proposed refinement. No structured retro skill, no per-PR friction form, no end-of-sprint shape ceremony — until usage demonstrates a more disciplined mechanism would pay off.
+For v0 the refinement mechanism is intentionally lightweight: file an Issue under the engineering handbook umbrella tagged with the shape it concerns, body describing the friction and the proposed refinement. No structured retro skill, no per-PR friction form, no end-of-sprint shape ceremony — until usage demonstrates a more disciplined mechanism would pay off.
 
 ## AI workflow rules
 
-The eight rules below land in this handbook + [`cargo/CLAUDE.md`](../../CLAUDE.md) immediately. Rule 5 is a placeholder pending `jinn-mono-8qbc` (the self-modifying learner design).
+The eight rules below land in this handbook + [`CLAUDE.md`](../../CLAUDE.md) immediately. Rule 5 is a placeholder pending the self-modifying learner design.
 
-1. **Worktree-for-multi-agent.** Multi-agent or speculative subagent work uses `git worktree add cargo/.tasks/<id>`, not the primary checkout.
-2. **Beads frame problems, not solutions.** bd issue bodies = context + impact + needs-design-session or testable acceptance criteria. Solutions live in design sessions (`INTERACTIVE DESIGN` shape) or implementation plans, not in the bd body.
-3. **bd-as-SoR, not `MEMORY.md`.** Memory fragments across accounts and worktrees. Use `bd remember "..."` and `bd memories <keyword>` for persistent knowledge.
+1. **Worktree-for-multi-agent.** Multi-agent or speculative subagent work uses a separate git worktree (current convention: `git worktree add ../jinn-mono_worktrees/<name>`), not the primary checkout.
+2. **Issues frame problems, not solutions.** GitHub Issue bodies = context + impact + needs-design-session or testable acceptance criteria. Solutions live in design sessions (`INTERACTIVE DESIGN` shape) or implementation plans, not in the Issue body.
+3. **GitHub Issues are the single SoR for engineering work.** Per DR-2026-05-18, `bd` retires; all new engineering work originates as a GitHub Issue on `Jinn-Network/mono`. Parent/child use native sub-issues; `Sprint`/`Epic`/`Status` live on the "Jinn engineering" Project (v2). The `.beads/` checkout stays in-tree as a read-only archive so historical `jinn-mono-<id>` references continue to resolve via `bd show <id>`.
 4. **Agent PR review parity.** Codex / Opus / Sonnet / Claude PRs go through the same review gate as human PRs. No agent self-merge. Exception: `fix(incident)` allows reviewer relaxation with documented justification.
-5. **(Deferred — open)** Supervised-diff for the self-modifying learner. Phase A.5+ learner ships proposed changes as PRs against the repo; designated reviewer approves before merge. Concrete mechanism is open until `jinn-mono-8qbc` closes. **Status: open — see `jinn-mono-8qbc`.**
+5. **(Deferred — open)** Supervised-diff for the self-modifying learner. Phase A.5+ learner ships proposed changes as PRs against the repo; designated reviewer approves before merge. Concrete mechanism is open. **Status: open.**
 6. **Integration tests > mocks for migration / contract surfaces.** Mock policy stays for the unit-test pyramid; migration tests must hit a real database or a forked chain (per `superpowers:test-driven-development`'s position on the test pyramid).
 7. **TDD for new features, regression test for fixes.** Per `superpowers:test-driven-development`. TDD on `feat` / `refactor`; regression-first on `fix`; deferred-not-waived on `fix(incident)`.
 8. **Auto-canary on every push to `next`; Monday-only named stable cut promotes `main`.** Cadence policy from §Cadence above. Hotfix sub-flow may bypass `next`; back-merge is mandatory.
@@ -119,30 +121,31 @@ Rule-to-shape wiring is in §The shapes of work; the mapping is the load-bearing
 
 ## Sprint surface — GitHub Project (v2)
 
-Per DR-2026-05-11-b, the canonical sprint board is a GitHub Project (v2) on `Jinn-Network/mono` named **Jinn engineering**.
+The canonical sprint board is a GitHub Project (v2) on `Jinn-Network/mono` named **Jinn engineering** (established by DR-2026-05-11-b; its sprint-surface claim survives DR-2026-05-18's retirement of `bd`).
 
 - **Status columns**: Todo / In Progress / In Review / Done.
 - **Sprint field** (Iteration): keyed to the current Monday week.
-- **Epic field** (single select): human option names such as `Engineering handbook`, `Discovery API`, and `v1 public testnet`; option descriptions carry the internal `jinn-mono-<id>` mapping.
+- **Epic field** (single select): human option names such as `Engineering handbook`, `Discovery API`, and `v1 public testnet`. (Option descriptions no longer carry the legacy `jinn-mono-<id>` mapping, which served the retired mirror.)
+- **Parent/child**: native GitHub sub-issues (`addSubIssue` mutation / native UI). Epics are Issues with sub-issues attached.
 - **Default view**: current sprint Status board.
 - **Roadmap view**: grouped by Epic in Now / Next / Later.
 
-**bd ↔ GitHub Issue boundary**: bd is the internal SoR. When (and only when) a bd issue is pulled into the upcoming sprint, the `cargo/scripts/bd-mirror` helper opens a public GitHub Issue with a curated subset of the bd body and adds it to the Project board with the current Sprint iteration. The Issue body ends with `Internal tracking: jinn-mono-<bd-id>` so the boundary is legible to external readers. Backlog stays in bd-only.
+**Workflow**: All new engineering work originates as a GitHub Issue. To put work into a sprint, add the Issue to the "Jinn engineering" Project board and set the `Sprint` Iteration to the upcoming Monday. PR merges that include `Closes #<N>` auto-close the Issue; Project automation moves it to Done.
 
-The Friday triage cron (currently manual via `workflow_dispatch`) auto-mirrors top-N priority bd issues for the upcoming sprint. Captain reviews and **rejects** anything that doesn't belong. Default flow is reject, not select.
+Backlog Issues live un-sprinted on the Project board (or off-board entirely until Captain reviews). Captain's Friday triage walks the open queue and pulls candidates onto the upcoming-Monday Iteration — see §Weekly retrace above. The pre-DR-2026-05-18 `bd-mirror` helper and Friday triage cron are retired.
 
 ## Building in public — substrate
 
-Per the umbrella `jinn-mono-2cl` and DR-2026-05-11-b:
+Per the engineering handbook umbrella and DR-2026-05-18 (retire `bd`, single-track on GitHub):
 
 - **GitHub Projects (v2)** — public sprint board (this handbook §Sprint surface above).
-- **Public GitHub Issues** — the sprint-scoped mirrored Issues are the externally-visible "what we're working on right now" surface.
+- **Public GitHub Issues** — the single source of truth for engineering work. Externally visible at create-time; the public surface and the working surface are the same surface (per DR-2026-05-18).
 - **GitHub Releases + auto-generated notes** — the devlog. Monday cuts. Released artifacts: `v2026.MM.DD` + `vX.Y.Z` dual tags.
-- **CHANGELOG.md** — `cargo/client/CHANGELOG.md` auto-mirrored from Release body on publish via `cargo/.github/workflows/changelog-mirror.yml`. npm-tarball-shipped.
-- **Repo-as-docs** — `cargo/docs/` (engineering, runbooks, specs, decisions). GitHub Pages-ready.
+- **CHANGELOG.md** — `client/CHANGELOG.md` auto-mirrored from Release body on publish via `.github/workflows/changelog-mirror.yml`. npm-tarball-shipped.
+- **Repo-as-docs** — `docs/` (engineering, runbooks, specs, decisions). GitHub Pages-ready.
 - **GitHub Discussions** — RFCs / Q&A / governance prep through Phase 2.
 
-What we do **not** do (yet): GitHub Wiki (drifts), Discourse forum (premature — Discussions cover it), Discord/Telegram as engineering substrate (community engagement, not engineering), public bd mirror beyond sprint-scope (bd is internal by design).
+What we do **not** do (yet): GitHub Wiki (drifts), Discourse forum (premature — Discussions cover it), Discord/Telegram as engineering substrate (community engagement, not engineering).
 
 ## Stacked PRs
 
@@ -162,6 +165,6 @@ Tooling: `gh-stack` (GitHub-native CLI extension, April 2026) is the canonical r
 
 ## Open
 
-- **Rule 5 concrete mechanism.** Waits on `jinn-mono-8qbc` (self-modifying learner design).
-- **Cron enablement for 2cl.2 + 2cl.11.** Both shipped with `workflow_dispatch` only; cron schedules commented out. Promote after first manual run validates.
-- **GitHub Project (v2) board creation.** Tracked as `jinn-mono-2cl.9`. External irreversible org-write; Captain does manually.
+- **Rule 5 concrete mechanism.** Waits on the self-modifying learner design.
+- **Friday triage cron form (post DR-2026-05-18).** The pre-retirement Friday triage cron + `bd-mirror` workflow retire under DR-2026-05-18. If a label-only pass over open Issues turns out to add value, file a follow-up GitHub Issue under the engineering handbook umbrella.
+- **GitHub Project (v2) board** is live ("Jinn engineering"). No open work here; documented for context.

--- a/legacy/jinn-cli-agents-reference/AGENTS.md
+++ b/legacy/jinn-cli-agents-reference/AGENTS.md
@@ -1,12 +1,17 @@
 ---
-title: Agent Instructions
-purpose: entry-point
+title: Agent Instructions (legacy reference)
+purpose: historical-reference
 last_verified: 2026-02-01
+status: archived (2026-05-18) — see note below
 ---
 
-# Agent Instructions
+# Agent Instructions (legacy reference)
 
-> Single entry point for AI agents working on Jinn.
+> **Status — archived reference (2026-05-18+).** This file is the historical entry point from the `jinn-gemini` subtree, retained under `legacy/jinn-cli-agents-reference/` for OLAS / staking / tokenomics / Phase 1 contract context. The canonical canon for live Jinn engineering work is at the repo root: [`CLAUDE.md`](../../CLAUDE.md), [`docs/engineering/handbook.md`](../../docs/engineering/handbook.md), [`SPEC.md`](../../SPEC.md), and the other root-level canonical docs.
+>
+> **Issue tracking:** per [DR-2026-05-18](../../log/decisions/2026-05-18-bd-vs-gh-substrate.md), engineering work is tracked on GitHub Issues + the "Jinn engineering" Project (v2), **not** `bd`. The `bd` / "beads" references below are historical and should not be followed for new work. Treat the workflow advice in this file as a 2026-Q1 snapshot, not active canon.
+
+> Original framing follows.
 
 ---
 

--- a/log/decisions/2026-05-11-engineering-substrate.md
+++ b/log/decisions/2026-05-11-engineering-substrate.md
@@ -3,7 +3,7 @@ id: DR-2026-05-11-b
 title: Engineering substrate — bd as internal SoR; GitHub Projects (v2) as the public sprint surface; sprint-scoped bd→GH-Issue mirror
 date: 2026-05-11
 verb: Choose
-status: proposed
+status: superseded (by DR-2026-05-18 for the internal-SoR claim; the sprint-surface claim — GitHub Project (v2) as the canonical sprint board — survives)
 authors: opus (proposed), oak (Captain attached)
 spec: docs/superpowers/specs/2026-05-11-engineering-handbook-codesign.md (this design)
 supersedes-context-from: (none — establishes substrate)

--- a/log/decisions/2026-05-18-bd-vs-gh-substrate.md
+++ b/log/decisions/2026-05-18-bd-vs-gh-substrate.md
@@ -1,0 +1,122 @@
+---
+id: DR-2026-05-18
+title: Issue tracking substrate — retire bd, single-track on GitHub Issues
+date: 2026-05-18
+verb: Choose
+status: ratified
+authors: opus (proposed), oak (Captain ratified 2026-05-18)
+spec: jinn-mono-waxs (spike)
+supersedes-context-from: DR-2026-05-11-b (bd-as-SoR with sprint-scoped mirror)
+---
+
+## Context
+
+DR-2026-05-11-b ratified a dual-substrate model one month ago: `bd` (Dolt-backed, local-first) as internal source of truth, mirrored one-way to public GitHub Issues + the "Jinn engineering" Project (v2) at sprint-pull time via the `scripts/bd-mirror` helper. The decision rested on three load-bearing claims:
+
+1. **bd's privacy is load-bearing** — exploratory `needs-design-session` framing and captain-internal notes would either self-censor or leak if all bd were public.
+2. **GitHub Projects already won on visibility** — splitting roles uses each tool's strength.
+3. **Sprint-scoped mirror is cheap and reversible** — a ~30-line bridge with low reversibility cost.
+
+A month of operation under this model produces three observations that re-open the trade.
+
+**Mirror drift is structural, not incidental.** Empirical state on 2026-05-18: 50 open bd issues, 16 mirrored to GitHub (32%), 34 unmirrored (68%). The "sprint-scoped" framing means two-thirds of in-flight work has no public surface. Beyond coverage: closes do not propagate (six bd-closed beads stayed open on GitHub at the v0.1.5 cut on 2026-05-13, manually closed via `gh issue close`); labels, sprint fields, body edits, and dependency edges do not sync after creation. The `bd-mirror` script accumulated mechanical friction (Sprint field GraphQL workaround, label auto-creation, agent-label fallback chain producing `agent:merge-plan@example.invalid`) that is symptomatic of the dual-system path being unmaintained beyond release pressure.
+
+**The original privacy rationale does not hold in practice.** Captain reports the exploratory-leak concern is empirically not a problem on the mirrored beads to date, and the upside of public-by-default — *intentionality discipline at issue-create-time + open surface for community contribution* — outweighs the cost of losing the curated public boundary.
+
+**The GitHub technical gap closed.** Sub-issues are now a first-class GraphQL surface on this repo (`subIssuesSummary`, `addSubIssue` mutation, native UI). The original "bd has parent/child epics, GH doesn't" argument from DR-2026-05-11-b no longer holds. Iteration fields (sprint), single-select fields (epic, status), and saved views were already strong enough; sub-issues closes the last semantic gap.
+
+This decision retires bd as the issue-tracking substrate and collapses to GitHub-native, single-track.
+
+## Decision
+
+**Retire `bd` as the issue-tracking substrate. GitHub Issues + sub-issues + the "Jinn engineering" Project (v2) become the single source of truth for engineering issue tracking. The Dolt remote freezes as a read-only archive. No bulk migration of the existing open bead corpus.**
+
+Concretely:
+
+- **All new issues originate as GitHub Issues** on `Jinn-Network/mono`. No new beads created from 2026-05-18 forward.
+- **Parent/child epic relations** use native GitHub sub-issues (`addSubIssue` mutation, native UI). The `epic:<short>` label convention retires.
+- **Dependency / "blocks" edges** use GitHub's tracked-by / tasklist semantics where needed; first-class "blocked-by" remains a small expressivity loss documented as Open below.
+- **Run-mode / shape** lives in a `## Run-mode` section in the Issue body (the existing convention) plus a `shape:<fix|feat|refactor|spike|chore|docs|test>` label set on the Issue at create-time.
+- **Priority** lives on a `priority:<P0..P4>` label (existing convention on the mirrored Issues stays).
+- **Sprint** stays on the Project v2 Iteration field (unchanged from DR-2026-05-11-b).
+- **Epic** stays on the Project v2 single-select field (unchanged from DR-2026-05-11-b). Option descriptions stop carrying the bd id mapping.
+- **Status** stays on Issue open/closed + the Project Status column (Todo / In Progress / In Review / Done) (unchanged).
+- **"Ready queue"** = the Project's default view filtered by `Status=Todo` ∧ `no open tracked-by relationship`, surfaced by the `eng-day` skill which already queries via `gh project item-list` + `gh issue list`.
+- **Issue templates** capture the Run-mode section + acceptance-criteria body shape so the *bd issue body convention* survives as a *GitHub Issue body convention*.
+- **No bulk migration.** The 34 unmirrored open beads stay in bd-archive. If an agent picks one up, it gets a one-off `gh issue create` at pickup time and the bd issue closes. Most will close in bd as stale or no-longer-relevant during the agent canon rewrite (waxs.4 below).
+- **Dolt remote freezes** as `bd-archive-2026-05-18`. The `.beads/` checkout stays in-tree as historical context. `bd` CLI stays installed for read-only lookups; the auto-export git hook decommissions so new bd writes do not pollute git state.
+- **The `bd remember` / `bd memories` agent-memory primitive is out of scope** per the bead's explicit clause. We don't actively use it. If a replacement memory substrate is needed it lands as a separate spike.
+
+## Rationale
+
+Three reasons, in order of weight:
+
+- **Drift is the steady state, not an exception.** 68% of open work invisible externally, mirror script printing "manual fix needed" on every Sprint write, six close-propagation failures in a single release cut. The dual-system path is unmaintained beyond release pressure; deferring the spike defers nothing but compounded cost. The original DR-2026-05-11-b claim "sprint-scoped mirror is cheap and reversible" is true in isolation; what is not cheap is the *labels / sprint / body / dep-edge / close* drift that accumulates between mirror invocations.
+- **Public-by-default is a feature, not a cost.** Captain assessment: tracking issues in public makes us more intentional about what we file, and opens the surface to community contribution at the time the issue exists, not after Captain hand-publishes. The DR-2026-05-11-b "privacy is load-bearing" claim was a hypothesis; a month of mirrored use shows it was not the real constraint. This is consistent with the headless-brand posture in [`BRAND.md`](../../BRAND.md): the public surface *is* the engineering substrate.
+- **The technical floor moved.** GitHub's 2025 sub-issues rollout closes the parent/child gap that was the strongest non-privacy argument for bd in DR-2026-05-11-b. Iteration + single-select fields were already strong enough. The remaining bd advantages — sub-second CLI latency, local-first, Dolt history — are real but small; the `eng-day` daily-brief skill already absorbs the per-day GH-query cost, and historical bd state continues to read fine through the archived `.beads/` checkout.
+
+## Alternatives considered and rejected
+
+- **Reaffirm DR-2026-05-11-b (status quo with the sprint-scoped mirror).** Rejected: 68% drift is not "occasional close-propagation gap"; it is the default state. The privacy argument that justified the dual-system is empirically not load-bearing.
+- **Drop the mirror but keep bd internal-only.** Stop the Friday cron + retire `bd-mirror`; bd stays as the team CLI; GH Issues exist only when Captain hand-publishes. Cheaper and more reversible than full retire. Rejected because it addresses drift without addressing the *dual-system maintenance tax* that the bead names as the load-bearing concern. The dual-system cost compounds with every new bead regardless of mirror state. Also forfeits the intentionality + community-fixable upside of public-by-default.
+- **Two-way sync (bd ↔ GH).** Rejected: dependency, body, status, label, and assignee drift are all real-time concerns; even a healthy bidirectional sync is more code than it produces value over single-track. Pure yak shave.
+- **Bulk-mirror the 34 unmirrored open beads as part of retirement.** Rejected per Captain direction. Stale beads die in bd-archive; live work either gets picked up and `gh issue create`'d at that moment, or it was never going to ship. Bulk-mirror would re-publish exploratory framing without intentionality review — exactly the "low-fidelity content erodes the public surface" cost the original DR was guarding against.
+- **Migrate to Linear / GitLab / Jira / etc.** Rejected: the `jinn-mono-2cl` umbrella commits to building-in-public on GitHub-native substrate (Issues, Discussions, Releases, Projects). Substrate-shopping is out of scope.
+
+## Consequences
+
+- **DR-2026-05-11-b is partially superseded.** The internal-SoR claim retires. The "GitHub Project (v2) is the canonical sprint surface" claim survives unchanged; bd→GH-mirror sections retire in favor of native GitHub Issue create.
+- **The agent canon rewrites.** Highest-blast-radius surfaces:
+  - `CLAUDE.md` references bd across the Daily entry point + Engineering handbook recap + Repository Structure. Rewrite.
+  - [`docs/engineering/handbook.md`](../../docs/engineering/handbook.md) §Daily loop, §Weekly retrace, §Sprint surface, §Eight ratified AI workflow rules (rule 3 specifically) rewrite.
+  - `.claude/skills/eng-day/SKILL.md` carries 16 bd references; rewrite to read from `gh issue list` / `gh project item-list` directly.
+  - **Operator-local SessionStart / PreCompact hooks.** `.claude/settings.json` is gitignored (per the `.claude/*` ignore rule, with `.claude/skills/` excepted), so the `bd prime` hook many operators currently have configured cannot be removed via a tracked PR. The canon explicitly tells operators to remove `bd prime` from their local `.claude/settings.json`; cleanup is per-operator.
+- **AI workflow rule 3 rewrites.** "bd-as-SoR, not `MEMORY.md`" → "GitHub Issues as single SoR" (the rule's name and intent change). The original rule's *don't-fragment-memory* sub-argument is orthogonal and out of scope.
+- **Tooling delta:**
+  - `scripts/bd-mirror` retires; relocate to `scripts/_archived/bd-mirror` for git history; do not delete.
+  - `.github/workflows/friday-triage.yml` retires its mirror call. The Friday triage *idea* (Captain reviews candidate Issues for the upcoming Sprint) can survive as a labeling pass over open Issues — file as a follow-up bead/Issue if Captain wants the affordance.
+  - `.github/workflows/release-notes-scaffold.yml` already reads closed PRs and aggregates per-Conventional-Commits prefix; verify it does not have a `bd close` read path that needs swapping.
+  - `.github/workflows/changelog-mirror.yml` already reads the GitHub Release body; no bd coupling expected — verify.
+- **No CI gate.** Nothing currently blocks merges on bd state; nothing needs adding or removing on the gate side.
+- **External references continue to resolve.** PR descriptions, DRs, spec docs cite `jinn-mono-<id>` strings (e.g., `Closes jinn-mono-uy6v.5.1`). The `.beads/` checkout stays in-tree so `bd show <id>` reads the archived state for as long as historical lookup remains useful.
+- **CLI ergonomic regression for agents.** `bd ready` (~ms local) → `gh search issues` / `gh issue list` (HTTP). The `eng-day` skill caches per-day; per-action `gh issue view <N>` calls multiply per session. Acceptable cost.
+- **Public-draft pollution risk.** Without the mirror's curation gate, exploratory framing lands public at create-time. Captain assessment: this is the intent, not a cost — see Rationale. No special `draft:` label is mandated; if friction surfaces, file a follow-up.
+
+## Migration plan
+
+No bulk migration. Implementation children file beneath `jinn-mono-waxs` as GitHub Issues (not new beads):
+
+1. **waxs.1 — Rewrite agent canon (highest priority).**
+   - Rewrite `CLAUDE.md` Daily entry point + cross-cutting bd references.
+   - Rewrite `docs/engineering/handbook.md` §Daily loop, §Weekly retrace, §Sprint surface, AI workflow rule 3.
+   - Rewrite `.claude/skills/eng-day/SKILL.md` to drop bd reads.
+   - Document the operator-local cleanup step (`bd prime` SessionStart + PreCompact hooks in `.claude/settings.json` are gitignored; each operator removes them locally).
+2. **waxs.2 — Retire `scripts/bd-mirror` + friday-triage workflow.** Move script to `scripts/_archived/`. Update or retire the friday-triage workflow.
+3. **waxs.3 — Verify release-notes-scaffold + changelog-mirror workflows are bd-free.** Sweep for any remaining `bd ` reads.
+4. **waxs.4 — Close-or-port sweep of the 34 unmirrored open beads.** One pass: each bead either closes in bd (stale, no-longer-relevant, subsumed) or becomes a fresh `gh issue create` if Captain or an agent intends to pick it up.
+5. **waxs.5 — Freeze the Dolt remote as archive.** Tag remote head `bd-archive-2026-05-18`. Disable the bd auto-export git hook to prevent further commits to `.beads/`. Add a one-line note in the repo README or handbook pointing at this DR for the rationale.
+6. **waxs.6 — Issue templates.** Add Issue templates capturing the `## Run-mode` section + acceptance-criteria body shape so the convention survives.
+
+Children file as GitHub Issues, parented to a top-level "Retire bd, single-track on GitHub" tracking Issue (created at DR-ratification time). The bead `jinn-mono-waxs` itself closes when the children land.
+
+## Risk assessment
+
+- **Historical reference resolution.** PR bodies, DRs, and specs cite `jinn-mono-<id>` strings; some external readers cannot resolve these. Mitigation: keep `.beads/` in-tree as the archive; reference DR-2026-05-18 from the handbook + README so external readers know `jinn-mono-<id>` strings index into the archived corpus.
+- **Memory primitive loss.** `bd remember` / `bd memories` go cold. Confirmed unused per the bead and Captain. If agent-memory substrate becomes needed, file a separate spike. Risk: low.
+- **Per-action CLI latency for agents.** `gh issue view <N>` HTTP cost on every `bd show <id>` equivalent. Mitigation: skills cache per-session where appropriate; daily brief absorbs the orientation cost. Risk: tolerable.
+- **One currently-blocked bead** (`jinn-mono-vh74.2` per current state). The bd `blocked` state has no first-class GH equivalent; carries via label `blocked:true` or a `blocks-on:` tracked-by tasklist row if the bead ports to GH per waxs.4. Risk: small expressivity loss documented as Open below.
+- **Tooling fan-out missed in the sweep.** Other workflows or scripts may read `bd` state that the sweep doesn't surface. Mitigation: waxs.3 explicitly enumerates the workflow sweep; any miss surfaces as a workflow error post-Dolt-freeze and gets patched in-flight.
+- **External contributors and the new-issue surface.** Once `bd` retires, every external contributor lands on GitHub Issues without indirection. Existing Issue templates need to be reviewed for clarity (not a regression, but worth a pass).
+
+## Open
+
+- **First-class `blocked-by` semantic on GitHub.** Tracked-by and tasklists cover most uses but no clean "this Issue is blocked by this other Issue, do not surface in ready queue" primitive exists. Label convention `blocked:true` is fine for v0; revisit if friction surfaces.
+- **Friday triage replacement.** DR-2026-05-11-b's friday-triage cron mirrored top-N priority beads into public Issues for the upcoming sprint. Under this DR there are no beads to mirror; if Captain wants a "candidate Issues for sprint" surface, the cron retargets to label open Issues with `sprint:candidate` for review. Decide at waxs.2 implementation time.
+- **Dolt-archive longevity.** The `.beads/` checkout in-tree carries some size; at some future date it may be worth migrating to a tag-only branch or a separate `mono-archive` repo. Not urgent.
+- **Issue template strictness.** Whether the `## Run-mode` section is template-required vs convention-only is a waxs.6 implementation decision.
+
+## Status
+
+Proposed by opus 2026-05-18 as the spike output for `jinn-mono-waxs`. Captain oak's input (bd privacy not load-bearing; intentionality + community-fixability of public-by-default; no bulk migration) was incorporated, and the DR was ratified by Captain oak on 2026-05-18. Implementation tracked under the umbrella GitHub Issue created at ratification; children waxs.1–.6 land as sub-issues of that umbrella.
+
+Note on `.claude/settings.json`: the `bd prime` SessionStart + PreCompact hooks are operator-local (gitignored under `.claude/*`), so they cannot be removed via a tracked PR. Operators clean up their own settings; the canon (CLAUDE.md, handbook) documents that the hooks are no longer recommended.


### PR DESCRIPTION
## Summary

Ratifies [DR-2026-05-18](log/decisions/2026-05-18-bd-vs-gh-substrate.md): GitHub Issues + native sub-issues + the "Jinn engineering" Project (v2) become the single source of truth for engineering issue tracking. `bd` retires; the `.beads/` checkout stays in-tree as a read-only archive so historical `jinn-mono-<id>` references continue to resolve via `bd show <id>`. DR-2026-05-11-b's internal-SoR claim retires; its sprint-surface claim survives.

This PR delivers **waxs.1 — Rewrite agent canon (the load-bearing unblocker)** plus the DR itself. Implementation children waxs.2–.6 are filed as sub-issues of the tracking umbrella.

**Empirical baseline** that drove the DR: 50 open bd issues, 16 mirrored to GH (32%), 34 unmirrored (68%) — two-thirds of in-flight work invisible externally under the DR-2026-05-11-b mirror model.

## Linked Issue

Closes #263 (waxs.1). Tracks #261 (umbrella).

## What changed

- `log/decisions/2026-05-18-bd-vs-gh-substrate.md` — new DR, ratified 2026-05-18.
- `CLAUDE.md` — Daily entry point + Eight AI workflow rules. Rules 1 (worktree path), 2 (Issues frame problems), 3 (GitHub Issues as single SoR).
- `docs/engineering/handbook.md` — Canonical references + retirement note; §Cadence Build Notes aggregation; §Daily loop steps 1/2/3/7; §Weekly retrace Friday triage; §The shapes of work (Run-mode values + Iterative refinement); AI workflow rules 1-3; §Sprint surface; §Building in public; §Open.
- `.claude/skills/eng-day/SKILL.md` — full rewrite to drop all bd reads; reads GH Issue queue, PR queue, and Project board state directly.
- `.github/PULL_REQUEST_TEMPLATE.md` — "Linked bd" → "Linked Issue"; rule-7 follow-up "bead" → "Issue".

## Test plan

`docs` shape — no test discipline beyond visual review. Verified via:

- `grep -n "bd ready\|bd close\|bd create\|bd-as-SoR\|cargo/scripts/bd-mirror" CLAUDE.md docs/engineering/handbook.md .claude/skills/eng-day/SKILL.md` returns only intentional references (history, archive-read context, operator-cleanup note).
- New file: `log/decisions/2026-05-18-bd-vs-gh-substrate.md` (DR-2026-05-18, status: ratified).

## Agent identity (if AI-authored)

Authored by Claude Opus 4.7 (1M context) under Captain oak's direction. Captain ratified the DR mid-conversation; this PR implements waxs.1 from the DR's migration plan.

### Canonical-doc changes

This PR touches multiple canonical-status docs (`CLAUDE.md`, `docs/engineering/handbook.md`). Per the handbook's canonical-doc ceremony:

- [x] CODEOWNERS approval — Captain oak ratified DR-2026-05-18 in chat on 2026-05-18, which is the authoritative approval for this implementation. The ratification appears in the DR's §Status section.
- [x] Reviewed downstream docs — the swept surfaces (CLAUDE.md, handbook, eng-day skill, PR template) are the load-bearing references; sweep verified above.
- [ ] Linked GitHub Discussion — not opened; DR-2026-05-18 itself + the umbrella tracking issue (#261) carry the design discussion in public.

### Prediction-freeze guardrail

N/A — does not touch Prediction surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)