### PR TITLE
chore(waxs.4): disposition report for 34 unmirrored open beads

### DIFF
--- a/log/2026-05-18-waxs.4-unmirrored-beads-sweep.md
+++ b/log/2026-05-18-waxs.4-unmirrored-beads-sweep.md
@@ -1,0 +1,111 @@
+# waxs.4 — Disposition report for 34 unmirrored open beads (2026-05-18)
+
+Per DR-2026-05-18 §Migration plan waxs.4. Tracks #266 under umbrella #261.
+
+## Context
+
+At 2026-05-18 there are 50 open beads. 16 are already mirrored to GitHub Issues (via the now-retired `bd-mirror`). The remaining 34 are *unmirrored* — they have no public surface. The DR retires `bd` as the issue-tracking substrate; this sweep proposes a per-bead disposition for the 34.
+
+**Captain decides each disposition.** This report is the proposal; post-merge the actions execute (close in bd, or `gh issue create` + close in bd). The report is the artifact that pins what was reviewed.
+
+## Headline reading of the corpus
+
+The DR's working assumption was that "most will close in bd as stale or no-longer-relevant." Empirically that does **not** hold for this snapshot — all 34 were created or updated within the last 11 days (2026-05-07 → 2026-05-18). None look stale.
+
+Reading: most should **port to GH Issue** if work continues. Stale-close is the wrong default here; pick-up-on-port is more accurate.
+
+Default proposed disposition: **port to GH Issue** unless flagged otherwise below.
+
+## Open call before executing
+
+Three things Captain should sanity-check on the recommendations below:
+
+1. **`9iq3.1`** (Close Prediction-only bd issues as deferred). This bead's job is *itself* a close-sweep. Recommend: do the sweep it describes in-bd as part of waxs.4 (kill two birds), then close `9iq3.1` itself. Listed below as "execute in-flight."
+2. **`uy6v.5.1`** (Launched SWE dashboard refresh). Labelled `next-release` — likely active sprint work. Recommend: port immediately + add to Sprint.
+3. **`lfge`** (Audit + close out next-only work that didn't reach main). Captain-judgment bead. Recommend: port as a Captain-owned audit task.
+
+## Per-bead disposition
+
+Format: `bd-id` (priority) — title → **Disposition**
+
+### Active epic children — port and re-parent under epic Issues
+
+These are sub-issues of epics already mirrored on GitHub (`uy6v` = #228 area, `vh74` = #259 area, `2cl` = #130 area, `9iq3` = mirrored). Port + use `addSubIssue` to re-parent.
+
+- `jinn-mono-2cl.1` (P1) — CI: auto-canary publish on main merge with full acceptance-gate suite → **Port; parent: existing `2cl` Issue**
+- `jinn-mono-2cl.23` (P2) — Fix changelog mirror under protected main → **Port; parent: existing `2cl` Issue**
+- `jinn-mono-2sro` (P1) — Multi-operator SWE-rebench v2 closed-loop smoke on Base Sepolia canary fleet → **Port; parent: `uy6v` Issue**
+- `jinn-mono-9iq3.1` (P1) — Close Prediction-only bd issues as deferred → **Execute in-flight** (do the close-sweep on the l2zl* tree + 3gr2 beads as part of this PR; then close `9iq3.1` itself with the result captured here)
+- `jinn-mono-9iq3.2` (P1) — Canonical-doc freeze note (SPEC.md / GROWTH.md / CLAUDE.md cite DR-2026-05-11-a) → **Port; parent: `9iq3` Issue**
+- `jinn-mono-srsc` (P1) — SWE-rebench v2 activity visibility in operator app → **Port; parent: `uy6v` Issue**
+- `jinn-mono-uy6v.12` (P1) — Re-verify uy6v.4 install path on clean machine after vh74.2 + vh74.3 land → **Port; parent: `uy6v` Issue**
+- `jinn-mono-uy6v.3` (P1) — Public canary fleet operational on Base Sepolia for ≥ N days → **Port; parent: `uy6v` Issue**
+- `jinn-mono-uy6v.5.1` (P1) — Launched SWE dashboard must reflect fresh generator and task activity during canary runs → **Port + add to current Sprint; parent: `uy6v.5` Issue** (labelled `next-release`)
+- `jinn-mono-vh74.2` (P1) — Daemon-level Claude auth gate is in the wrong layer → **Port; parent: `vh74` Issue**
+- `jinn-mono-vh74.3` (P1) — Stage B: generic HarnessPrecheckPanel + JoinFlow wiring + hermes-doctor migration → **Port; parent: `vh74` Issue**
+- `jinn-mono-vh74.4` (P2) — Thread runtimeMode through HarnessEnv for docker-compose operators → **Port; parent: `vh74` Issue**
+- `jinn-mono-vh74.6` (P2) — Engine canAcceptTask spawns claude auth status live per task announcement → **Port; parent: `vh74` Issue**
+
+### Standalone P1 epics — port as top-level Issues
+
+- `jinn-mono-17k7` (P1) — EPIC: Paid data-market — public artifact endpoints, pricing & acquisition policy → **Port as top-level Issue with the `EPIC:` title prefix preserved**
+
+### Eval-infra cluster (recent, all P2) — port batch with `eval-infra` label
+
+The eval-infra surface had a flurry of bug filings on 2026-05-13/14 and 2026-05-18. Recommend porting the cluster batch so it remains visible.
+
+- `jinn-mono-015m` (P2) — `ensureDeliveryClaimed` retry path omits verdictCode → **Port**
+- `jinn-mono-0t6p` (P2) — Dashboard FAILED vs explorer fails labeling drift → **Port**
+- `jinn-mono-2bf4` (P2) — `ensureDeliveryClaimed` in mech adapter has no verdictCode → **Port** (likely duplicate of `015m` — Captain check, possibly close as dup-of)
+- `jinn-mono-73v5` (P2) — Active notification for stale eval admissions → **Port**
+- `jinn-mono-932d` (P2) — Recovery does `deliverToMarketplace` before checking claim-window open → **Port**
+- `jinn-mono-b940` (P2) — donation-consumption gate is race-prone on busy testnets → **Port**
+- `jinn-mono-bwgl` (P2) — Generalize the admission + substrate-identity primitive to other SolverTypes → **Port**
+- `jinn-mono-c3np` (P2) — SkippableError observability — surface eval-skip rate per SolverNet → **Port**
+- `jinn-mono-e2wt` (P2) — Solution.gating is `Record<string, unknown>` — TypeScript can't enforce verdict on evaluator harnesses → **Port**
+- `jinn-mono-pm7c` (P2) — attd.api-integration: live Hono test for `/builders/:agentId/runs` → **Port**
+- `jinn-mono-rgv5` (P2) — `claimDelivery`: NotDelivered retry backoff is 10x too long → **Port**
+- `jinn-mono-s8yj` (P2) — Reclassify pre-fufn historical verdicts on the explorer → **Port; parent: `ebu7` (network explorer) Issue**
+- `jinn-mono-wlog` (P2) — Watcher claim path lacks verdictCode — verdict claims silently fail → **Port**
+
+### Other P2 work — port as standalone Issues
+
+- `jinn-mono-6jid` (P2) — attd.harness-published-artifact: add `harness` to PublishedArtifact discriminator → **Port**
+- `jinn-mono-iuup` (P2) — Freeze fence should hash the learning subset (memories/, skills/, sessions/), not the whole HERMES_HOME → **Port**
+- `jinn-mono-lfge` (P2) — Audit + close out next-only work that didn't reach main → **Port; assignee: Captain** (audit task)
+- `jinn-mono-ngxc` (P2) — EPIC: Source work-item layer + saturation policy above posted Tasks → **Port as top-level Issue with `EPIC:` prefix**
+- `jinn-mono-p7v9` (P2) — Hermes adapter hardcodes 7331 daemon URL fallback → **Port**
+- `jinn-mono-rvmp` (P2) — Staged-bootstrap refactor + identity_registered Stage 1 capstone step → **Port**
+- `jinn-mono-xhir` (P2) — fix(operator-ux): bootstrap halt copy + handler do not auto-retry → **Port**
+
+## Headline counts
+
+- Total: 34
+- Recommended port: 33
+- Recommended execute-in-flight (close-sweep on Prediction tree): 1 (`9iq3.1`)
+- Recommended stale-close: 0 (none of the 34 are stale by the timestamps)
+
+## Execution mechanics (post-merge)
+
+Each bead in the "Port" list runs through:
+
+```bash
+bd show <id> --json | jq -r '.[0].description'  # capture body
+gh issue create --repo Jinn-Network/mono --title "<title>" --label "engineering,<labels>" --body <body>
+# If parent epic Issue exists, addSubIssue mutation to attach
+bd close <id>  # with a close note: "Ported to GH #<N> per DR-2026-05-18 / waxs.4."
+```
+
+For `9iq3.1`'s in-flight close-sweep:
+
+```bash
+bd list --status=open --json | jq -r '.[] | select(.parent == "jinn-mono-9iq3") | .id'  # find l2zl* + 3gr2
+bd close <each> --reason "Prediction freeze per DR-2026-05-11-a; bd retiring per DR-2026-05-18 / waxs.4."
+bd close jinn-mono-9iq3.1 --reason "Executed in-flight during waxs.4 sweep; tree closed."
+```
+
+## Notes for the merge
+
+- This PR's deliverable is the **report only**. The actual `gh issue create` + `bd close` invocations happen post-merge with Captain steering.
+- After merge, follow-up commits to `chore/waxs.4-disposition-report` or a sibling branch can record the *result* of each port (e.g. `bd-id → #N` mapping) — or it can be captured in PR comments and the bead-close notes.
+- waxs.5 (Dolt freeze) should run **after** this sweep executes, so the freeze captures the final state with closed beads (not in-progress closes).

--- a/log/2026-05-18-waxs.4-unmirrored-beads-sweep.md
+++ b/log/2026-05-18-waxs.4-unmirrored-beads-sweep.md
@@ -104,8 +104,76 @@ bd close <each> --reason "Prediction freeze per DR-2026-05-11-a; bd retiring per
 bd close jinn-mono-9iq3.1 --reason "Executed in-flight during waxs.4 sweep; tree closed."
 ```
 
+## Consolidation pass (2026-05-18 amendment)
+
+The original per-bead disposition above would produce 33 GitHub Issues — too granular for a healthy board. Most beads were filed at bug-report speed and several adjacent beads share a root cause or a single PR-shaped fix.
+
+This pass groups the 33 by "shape of work that lands together" and proposes which port as a single Issue. Captain pushes back on specific cluster merges in this PR's review.
+
+### Cluster A — `verdictCode` missing across claim paths (3 beads → 1 Issue)
+
+- `jinn-mono-015m` — `ensureDeliveryClaimed` retry path omits verdictCode for verdict-kind requests
+- `jinn-mono-2bf4` — `ensureDeliveryClaimed` in mech adapter has no verdictCode (likely the same root cause as 015m — same call site)
+- `jinn-mono-wlog` — Watcher claim path lacks verdictCode; verdict claims silently fail if engine path doesn't win
+
+**Single Issue:** `fix: verdictCode missing across verdict-claim paths (ensureDeliveryClaimed retry, mech adapter, watcher)`. Acceptance covers all three call sites with a regression test that pins the verdictCode shape.
+
+### Cluster B — claim-window correctness in claim / recovery (2 beads → 1 Issue)
+
+- `jinn-mono-932d` — Recovery does `deliverToMarketplace` before checking if claim window is still open (wastes gas)
+- `jinn-mono-rgv5` — `claimDelivery` NotDelivered retry backoff is 10x too long, blows claim window on RPC propagation lag
+
+**Single Issue:** `fix: claim-window correctness — pre-check window before deliverToMarketplace + tune NotDelivered retry backoff`. Both surfaces share the "we acted past the claim window" failure shape.
+
+### Cluster D — TypeScript type tightening on eval surfaces (2 beads → 1 Issue)
+
+- `jinn-mono-6jid` — `attd.harness-published-artifact`: add `harness` to `PublishedArtifact` discriminator
+- `jinn-mono-e2wt` — `Solution.gating` is `Record<string, unknown>` — TypeScript can't enforce verdict on evaluator harnesses
+
+**Single Issue:** `chore(types): tighten eval-surface types — PublishedArtifact discriminator + Solution.gating verdict shape`. Single TS-only PR.
+
+### Cluster E — vh74 harness wiring tail (2 beads → 1 Issue)
+
+- `jinn-mono-vh74.4` — Thread `runtimeMode` through `HarnessEnv` so per-harness `isReady()` probes the right context for docker-compose operators
+- `jinn-mono-vh74.6` — Engine `canAcceptTask` spawns `claude auth status` live per task announcement, redundant with `HarnessReadinessRegistry` cache
+
+**Single Issue:** `refactor(vh74): HarnessReadinessRegistry — thread runtimeMode through HarnessEnv + remove redundant live claude auth probe in canAcceptTask`. Both touch the readiness-registry pathway; landing them in one PR avoids two passes over the same surface.
+
+### Beads that stay independent (24 → 24)
+
+The remaining 24 are genuinely separate work items — different code paths, different acceptance shapes, different review costs. Listed for completeness; each ports to its own Issue.
+
+P1 (10):
+`jinn-mono-17k7` (EPIC: Paid data-market), `jinn-mono-2cl.1`, `jinn-mono-2cl.23`, `jinn-mono-2sro`, `jinn-mono-9iq3.2`, `jinn-mono-srsc`, `jinn-mono-uy6v.3`, `jinn-mono-uy6v.5.1`, `jinn-mono-uy6v.12`, `jinn-mono-vh74.2`, `jinn-mono-vh74.3`.
+
+(That's 11 — 2cl.23 is P2 but kept here as it's an active 2cl child; counted in the P2 bucket below.)
+
+P2 (14):
+`jinn-mono-0t6p`, `jinn-mono-2cl.23`, `jinn-mono-73v5`, `jinn-mono-b940`, `jinn-mono-bwgl`, `jinn-mono-c3np`, `jinn-mono-iuup`, `jinn-mono-lfge`, `jinn-mono-ngxc` (EPIC: Source work-item layer), `jinn-mono-p7v9`, `jinn-mono-pm7c`, `jinn-mono-rvmp`, `jinn-mono-s8yj`, `jinn-mono-xhir`.
+
+### Headline counts after consolidation
+
+| Disposition | Count |
+|---|---|
+| Port as consolidated Issues (4 clusters) | 4 |
+| Port individually (P1) | 10 |
+| Port individually (P2) | 14 |
+| Execute-in-flight close-sweep (`9iq3.1`) | 1 |
+| Total GitHub Issues created | **28** |
+
+Down from 33 separate Issues. 9 source beads collapse into 4 Issues; the rest remain 1:1 because they are independently-shaped work.
+
+### Note on the "Phase A eval-infra hardening" cluster
+
+Four beads (`73v5`, `b940`, `bwgl`, `c3np`) all share the `phase-a, eval-infra` labels. I considered consolidating them under a new `EPIC: Phase A eval-infra hardening` umbrella, but they touch different surfaces (admission UI, race-prone gate, abstraction, observability) and represent independent PR-shaped chunks. **Recommendation:** port individually with a shared `phase-a, eval-infra` label so they're searchable as a cluster on the board without forcing them into an epic that doesn't pre-exist.
+
 ## Notes for the merge
 
 - This PR's deliverable is the **report only**. The actual `gh issue create` + `bd close` invocations happen post-merge with Captain steering.
+- The consolidation pass above proposes 28 Issues for 33 source beads. Captain can adjust specific cluster merges by leaving review comments on this PR; the executor (me or Captain) follows whatever the merged report says.
 - After merge, follow-up commits to `chore/waxs.4-disposition-report` or a sibling branch can record the *result* of each port (e.g. `bd-id → #N` mapping) — or it can be captured in PR comments and the bead-close notes.
 - waxs.5 (Dolt freeze) should run **after** this sweep executes, so the freeze captures the final state with closed beads (not in-progress closes).
+
+## Follow-on (separate Issue)
+
+Captain flagged a related thread: **formalize Issue types + how we write Issues**. That's bigger than this sweep — it covers Issue templates (now in waxs.6), shape-flow per-template guidance, writing-style canon (problem-not-solution, acceptance-as-checklist, etc.), and possibly automated linting on new Issues. Filed as a separate GH Issue under the engineering handbook umbrella; not in waxs.4's scope.

--- a/log/2026-05-18-waxs.4-unmirrored-beads-sweep.md
+++ b/log/2026-05-18-waxs.4-unmirrored-beads-sweep.md
@@ -125,14 +125,14 @@ This pass groups the 33 by "shape of work that lands together" and proposes whic
 
 **Single Issue:** `fix: claim-window correctness — pre-check window before deliverToMarketplace + tune NotDelivered retry backoff`. Both surfaces share the "we acted past the claim window" failure shape.
 
-### Cluster D — TypeScript type tightening on eval surfaces (2 beads → 1 Issue)
+### Cluster C — TypeScript type tightening on eval surfaces (2 beads → 1 Issue)
 
 - `jinn-mono-6jid` — `attd.harness-published-artifact`: add `harness` to `PublishedArtifact` discriminator
 - `jinn-mono-e2wt` — `Solution.gating` is `Record<string, unknown>` — TypeScript can't enforce verdict on evaluator harnesses
 
 **Single Issue:** `chore(types): tighten eval-surface types — PublishedArtifact discriminator + Solution.gating verdict shape`. Single TS-only PR.
 
-### Cluster E — vh74 harness wiring tail (2 beads → 1 Issue)
+### Cluster D — vh74 harness wiring tail (2 beads → 1 Issue)
 
 - `jinn-mono-vh74.4` — Thread `runtimeMode` through `HarnessEnv` so per-harness `isReady()` probes the right context for docker-compose operators
 - `jinn-mono-vh74.6` — Engine `canAcceptTask` spawns `claude auth status` live per task announcement, redundant with `HarnessReadinessRegistry` cache
@@ -144,9 +144,7 @@ This pass groups the 33 by "shape of work that lands together" and proposes whic
 The remaining 24 are genuinely separate work items — different code paths, different acceptance shapes, different review costs. Listed for completeness; each ports to its own Issue.
 
 P1 (10):
-`jinn-mono-17k7` (EPIC: Paid data-market), `jinn-mono-2cl.1`, `jinn-mono-2cl.23`, `jinn-mono-2sro`, `jinn-mono-9iq3.2`, `jinn-mono-srsc`, `jinn-mono-uy6v.3`, `jinn-mono-uy6v.5.1`, `jinn-mono-uy6v.12`, `jinn-mono-vh74.2`, `jinn-mono-vh74.3`.
-
-(That's 11 — 2cl.23 is P2 but kept here as it's an active 2cl child; counted in the P2 bucket below.)
+`jinn-mono-17k7` (EPIC: Paid data-market), `jinn-mono-2cl.1`, `jinn-mono-2sro`, `jinn-mono-9iq3.2`, `jinn-mono-srsc`, `jinn-mono-uy6v.3`, `jinn-mono-uy6v.5.1`, `jinn-mono-uy6v.12`, `jinn-mono-vh74.2`, `jinn-mono-vh74.3`.
 
 P2 (14):
 `jinn-mono-0t6p`, `jinn-mono-2cl.23`, `jinn-mono-73v5`, `jinn-mono-b940`, `jinn-mono-bwgl`, `jinn-mono-c3np`, `jinn-mono-iuup`, `jinn-mono-lfge`, `jinn-mono-ngxc` (EPIC: Source work-item layer), `jinn-mono-p7v9`, `jinn-mono-pm7c`, `jinn-mono-rvmp`, `jinn-mono-s8yj`, `jinn-mono-xhir`.
@@ -159,9 +157,9 @@ P2 (14):
 | Port individually (P1) | 10 |
 | Port individually (P2) | 14 |
 | Execute-in-flight close-sweep (`9iq3.1`) | 1 |
-| Total GitHub Issues created | **28** |
+| Total GitHub Issues created | **29** |
 
-Down from 33 separate Issues. 9 source beads collapse into 4 Issues; the rest remain 1:1 because they are independently-shaped work.
+Down from 33 + 1 (the 9iq3.1 in-flight sweep is one of the 34, not a new addition). 9 source beads collapse into 4 consolidated Issues; the remaining 24 are 1:1.
 
 ### Note on the "Phase A eval-infra hardening" cluster
 

--- a/log/2026-05-18-waxs.4-unmirrored-beads-sweep.md
+++ b/log/2026-05-18-waxs.4-unmirrored-beads-sweep.md
@@ -56,7 +56,7 @@ The eval-infra surface had a flurry of bug filings on 2026-05-13/14 and 2026-05-
 
 - `jinn-mono-015m` (P2) — `ensureDeliveryClaimed` retry path omits verdictCode → **Port**
 - `jinn-mono-0t6p` (P2) — Dashboard FAILED vs explorer fails labeling drift → **Port**
-- `jinn-mono-2bf4` (P2) — `ensureDeliveryClaimed` in mech adapter has no verdictCode → **Port** (likely duplicate of `015m` — Captain check, possibly close as dup-of)
+- `jinn-mono-2bf4` (P2) — `ensureDeliveryClaimed` in mech adapter has no verdictCode → **Duplicate of `015m`** (same call site — both point at `ensureDeliveryClaimed`'s retry path in the mech adapter; absorbed by Cluster A below, no separate Issue)
 - `jinn-mono-73v5` (P2) — Active notification for stale eval admissions → **Port**
 - `jinn-mono-932d` (P2) — Recovery does `deliverToMarketplace` before checking claim-window open → **Port**
 - `jinn-mono-b940` (P2) — donation-consumption gate is race-prone on busy testnets → **Port**
@@ -92,9 +92,16 @@ Each bead in the "Port" list runs through:
 ```bash
 bd show <id> --json | jq -r '.[0].description'  # capture body
 gh issue create --repo Jinn-Network/mono --title "<title>" --label "engineering,<labels>" --body <body>
-# If parent epic Issue exists, addSubIssue mutation to attach
+# Add to the "Jinn engineering" Project (v2) board if sprint-relevant.
+#   PROJECT_NUMBER=1   # "Jinn engineering" on Jinn-Network (verify via `gh project list --owner Jinn-Network`)
+gh project item-add "$PROJECT_NUMBER" --owner Jinn-Network --url "$ISSUE_URL"
+# If parent epic Issue exists, addSubIssue mutation to attach (gh api graphql).
 bd close <id>  # with a close note: "Ported to GH #<N> per DR-2026-05-18 / waxs.4."
 ```
+
+For the three consolidated cluster Issues (A, B, C), the recipe is manual `gh issue create` with a body that names all source beads; the original beads close in bd with the same "Ported to GH #<N>" note pointing at the cluster Issue.
+
+Note: `scripts/bd-mirror` is retired per waxs.2 (lives at `scripts/_archived/bd-mirror`). Using it here would partially work (it handles label auto-creation + Project add + `external_ref` write-back) but couples the port-sweep to retired tooling. The manual recipe above is the post-retirement path.
 
 For `9iq3.1`'s in-flight close-sweep:
 
@@ -125,14 +132,7 @@ This pass groups the 33 by "shape of work that lands together" and proposes whic
 
 **Single Issue:** `fix: claim-window correctness — pre-check window before deliverToMarketplace + tune NotDelivered retry backoff`. Both surfaces share the "we acted past the claim window" failure shape.
 
-### Cluster C — TypeScript type tightening on eval surfaces (2 beads → 1 Issue)
-
-- `jinn-mono-6jid` — `attd.harness-published-artifact`: add `harness` to `PublishedArtifact` discriminator
-- `jinn-mono-e2wt` — `Solution.gating` is `Record<string, unknown>` — TypeScript can't enforce verdict on evaluator harnesses
-
-**Single Issue:** `chore(types): tighten eval-surface types — PublishedArtifact discriminator + Solution.gating verdict shape`. Single TS-only PR.
-
-### Cluster D — vh74 harness wiring tail (2 beads → 1 Issue)
+### Cluster C — vh74 harness wiring tail (2 beads → 1 Issue)
 
 - `jinn-mono-vh74.4` — Thread `runtimeMode` through `HarnessEnv` so per-harness `isReady()` probes the right context for docker-compose operators
 - `jinn-mono-vh74.6` — Engine `canAcceptTask` spawns `claude auth status` live per task announcement, redundant with `HarnessReadinessRegistry` cache
@@ -147,19 +147,28 @@ P1 (10):
 `jinn-mono-17k7` (EPIC: Paid data-market), `jinn-mono-2cl.1`, `jinn-mono-2sro`, `jinn-mono-9iq3.2`, `jinn-mono-srsc`, `jinn-mono-uy6v.3`, `jinn-mono-uy6v.5.1`, `jinn-mono-uy6v.12`, `jinn-mono-vh74.2`, `jinn-mono-vh74.3`.
 
 P2 (14):
-`jinn-mono-0t6p`, `jinn-mono-2cl.23`, `jinn-mono-73v5`, `jinn-mono-b940`, `jinn-mono-bwgl`, `jinn-mono-c3np`, `jinn-mono-iuup`, `jinn-mono-lfge`, `jinn-mono-ngxc` (EPIC: Source work-item layer), `jinn-mono-p7v9`, `jinn-mono-pm7c`, `jinn-mono-rvmp`, `jinn-mono-s8yj`, `jinn-mono-xhir`.
+`jinn-mono-0t6p`, `jinn-mono-2cl.23`, `jinn-mono-6jid`, `jinn-mono-73v5`, `jinn-mono-b940`, `jinn-mono-bwgl`, `jinn-mono-c3np`, `jinn-mono-e2wt`, `jinn-mono-iuup`, `jinn-mono-lfge`, `jinn-mono-ngxc` (EPIC: Source work-item layer), `jinn-mono-p7v9`, `jinn-mono-pm7c`, `jinn-mono-rvmp`, `jinn-mono-s8yj`, `jinn-mono-xhir`.
+
+### Cluster C split (2026-05-18 review pass)
+
+The original consolidation pass bundled `6jid` (PublishedArtifact discriminator) and `e2wt` (Solution.gating verdict shape) into a single "TypeScript type tightening" Issue. PR review surfaced that these are not the same PR shape:
+
+- `6jid` is additive on the discovery/read-path interface (`client/src/discovery/types.ts` + `onchain.ts` + `http.ts`) — a small variant addition to a discriminated union.
+- `e2wt` requires threading a typed verdict shape through the harness-engine boundary; the engine currently casts `gatingClaim as { verdict?: unknown } | null` precisely because `Solution.gating` is loose. Fixing this touches `client/src/harnesses/types.ts`, `engine.ts`, persistence types, and the populating harnesses.
+
+These are independent surfaces and independent acceptance shapes. **Split: `6jid` and `e2wt` now port individually** (both listed in the P2 independent set above).
 
 ### Headline counts after consolidation
 
 | Disposition | Count |
 |---|---|
-| Port as consolidated Issues (4 clusters) | 4 |
+| Port as consolidated Issues (3 clusters) | 3 |
 | Port individually (P1) | 10 |
-| Port individually (P2) | 14 |
-| Execute-in-flight close-sweep (`9iq3.1`) | 1 |
+| Port individually (P2) | 16 |
 | Total GitHub Issues created | **29** |
+| Execute-in-flight bd close-sweep (`9iq3.1`, not a GH Issue) | 1 |
 
-Down from 33 + 1 (the 9iq3.1 in-flight sweep is one of the 34, not a new addition). 9 source beads collapse into 4 consolidated Issues; the remaining 24 are 1:1.
+Down from 34 source beads (33 port candidates + 1 in-flight close-sweep). 7 source beads (3+2+2) collapse into 3 consolidated Issues; the remaining 26 ports are 1:1.
 
 ### Note on the "Phase A eval-infra hardening" cluster
 
@@ -168,7 +177,7 @@ Four beads (`73v5`, `b940`, `bwgl`, `c3np`) all share the `phase-a, eval-infra` 
 ## Notes for the merge
 
 - This PR's deliverable is the **report only**. The actual `gh issue create` + `bd close` invocations happen post-merge with Captain steering.
-- The consolidation pass above proposes 28 Issues for 33 source beads. Captain can adjust specific cluster merges by leaving review comments on this PR; the executor (me or Captain) follows whatever the merged report says.
+- The consolidation pass above proposes 29 GH Issues (3 clusters + 26 individual ports) plus 1 in-flight bd close-sweep, for 34 source beads. Captain can adjust specific cluster merges by leaving review comments on this PR; the executor (me or Captain) follows whatever the merged report says.
 - After merge, follow-up commits to `chore/waxs.4-disposition-report` or a sibling branch can record the *result* of each port (e.g. `bd-id → #N` mapping) — or it can be captured in PR comments and the bead-close notes.
 - waxs.5 (Dolt freeze) should run **after** this sweep executes, so the freeze captures the final state with closed beads (not in-progress closes).
 


### PR DESCRIPTION
## Summary

Stacks on #269 (waxs.1). Implements waxs.4 from DR-2026-05-18 §Migration plan.

**This PR ships the report only.** The actual `gh issue create` + `bd close` invocations happen post-merge with Captain steering. The report is the artifact that pins what was reviewed.

## Headline reading

The DR's working assumption that "most will close in bd as stale" does **not** hold for this snapshot. All 34 unmirrored open beads were created or updated within the last 11 days (2026-05-07 → 2026-05-18). Default recommended disposition is port-to-GH, not stale-close.

Per-bead counts:
- **33 → Port to GH Issue** (most re-parented to existing epic Issues via native sub-issues).
- **1 → Execute-in-flight close-sweep** (`jinn-mono-9iq3.1`: closes the Prediction-only `l2zl*` tree + `3gr2` per DR-2026-05-11-a, then closes itself).
- **0 → Stale-close** (none are stale by timestamps).

Special-attention items flagged for Captain:
- `uy6v.5.1` (next-release label) — port + add to current Sprint.
- `2bf4` likely duplicate of `015m` — Captain checks dup-of close path.
- `lfge` (audit task) — port with Captain as assignee.

## Linked Issue

Closes #266. Tracks #261.

## Test plan

`chore` shape. No code change; no test discipline.

The report is a markdown artifact at `log/2026-05-18-waxs.4-unmirrored-beads-sweep.md`. Reviewer correctness check: open the file, scan the dispositions, push back on any specific bead recommendation.

## Run order

waxs.5 (Dolt freeze) should merge **after** this PR's executions land, so the freeze captures the post-sweep state (closed-or-ported beads, not in-progress closes).

## Stacking note

Base is `chore/waxs-retire-bd` (PR #269). After #269 merges, this PR's base rebases onto `next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)