### PR TITLE
chore(waxs.6): GitHub Issue templates — work-unit + epic + config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Engineering handbook
+    url: https://github.com/Jinn-Network/mono/blob/main/docs/engineering/handbook.md
+    about: Cadence, work shapes, AI workflow rules. Read before filing if you're new to the team.
+  - name: DR-2026-05-18 — Issue substrate
+    url: https://github.com/Jinn-Network/mono/blob/main/log/decisions/2026-05-18-bd-vs-gh-substrate.md
+    about: Why we track engineering work as GitHub Issues + sub-issues + Project (v2), not `bd`.
+  - name: GitHub Discussions
+    url: https://github.com/Jinn-Network/mono/discussions
+    about: For RFCs, Q&A, or non-issue conversations. File an Issue only when there's an acceptance-shaped outcome.

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,44 @@
+---
+name: Epic (container)
+about: Multi-work-unit umbrella with sub-issues. Per the engineering handbook §The shapes of work, epics are exempt from the `Run-mode` requirement.
+title: "EPIC: <one-line summary>"
+labels: []
+assignees: []
+---
+
+<!--
+Per DR-2026-05-18, epics are tracked as GitHub Issues with child work-units
+attached via native sub-issues (the "Sub-issues" panel on the Issue page,
+or the `addSubIssue` GraphQL mutation). The umbrella for the bd retirement
+itself is an example: see #261.
+-->
+
+## Context
+
+<!-- What is this epic about? Why now? What problem does the body of work solve? -->
+
+## Scope
+
+<!-- What's in. What's deliberate non-goals. -->
+
+## Children
+
+<!--
+List the work-units that compose this epic. After creating each child Issue,
+attach it to this epic via the Sub-issues panel. The list below is a draft;
+the live tree is the Sub-issues panel.
+-->
+
+- [ ]
+- [ ]
+
+## Acceptance
+
+<!-- The shape of "done" for the epic as a whole. Often a deployment milestone, a published artifact, or a metric. -->
+
+## Reference
+
+<!--
+- Related DRs / specs / runbooks
+- External dependencies (audits, external collaborators)
+-->

--- a/.github/ISSUE_TEMPLATE/work-unit.md
+++ b/.github/ISSUE_TEMPLATE/work-unit.md
@@ -1,0 +1,69 @@
+---
+name: Work unit (default)
+about: Engineering work unit — bug, feature, refactor, spike, chore, docs, test. Default template per the engineering handbook.
+title: "<shape>: <one-line summary>"
+labels: []
+assignees: []
+---
+
+<!--
+Per docs/engineering/handbook.md §The shapes of work + DR-2026-05-18, every
+work-unit Issue declares a shape via the `## Run-mode` section below and via
+a Conventional Commits prefix in the title. Epics (containers) are exempt;
+they use the EPIC template.
+
+Shapes (pick one for `Run-mode`):
+  BUG-FIX / FEATURE / REFACTOR / SPIKE / CHORE / DOCS / TEST / INCIDENT / INTERACTIVE DESIGN
+
+Title prefix examples:
+  fix: SWE typed payload fallback validation
+  feat(uy6v): live verdict-success on Base Sepolia
+  refactor: extract Harness selection from buildHarnesses
+  spike: <can we?> question
+  chore(deps): bump @types/node to 22
+  docs(handbook): clarify §Weekly retrace cadence
+-->
+
+## Run-mode
+
+<!-- Pick ONE: BUG-FIX / FEATURE / REFACTOR / SPIKE / CHORE / DOCS / TEST / INCIDENT / INTERACTIVE DESIGN -->
+
+## Context
+
+<!--
+Problem (not solution): what's wrong / what gap does this close / what need triggers this?
+Include the *why*, not the *how*. Per AI workflow rule 2 (handbook), Issue bodies
+frame problems; solutions live in design sessions or implementation plans.
+-->
+
+## Impact
+
+<!-- Who is affected and how. If unclear, name the user or system that would notice if this is not done. -->
+
+## Acceptance
+
+<!--
+Testable acceptance criteria. Format as a checklist. Per the shape's test
+discipline (handbook §The shapes of work):
+- fix: regression test FIRST
+- feat: TDD per acceptance
+- refactor: TDD + integration tests on migration / contract surfaces
+- chore (deps): integration test if touches a dep
+- spike: output is a finding; not testable as code
+- docs / test: skipped or meta
+-->
+
+- [ ]
+- [ ]
+
+## Out of scope
+
+<!-- Explicit non-goals. Helps reviewers know what NOT to push back on. -->
+
+## Reference
+
+<!--
+- Related Issues / PRs / DRs / specs
+- Parent epic (if any) — open the Issue, then attach via the GitHub Sub-issues UI
+- Archived bd lookups: `bd show <jinn-mono-id>` (pre-DR-2026-05-18 history; gitignored .beads/)
+-->

--- a/.github/ISSUE_TEMPLATE/work-unit.md
+++ b/.github/ISSUE_TEMPLATE/work-unit.md
@@ -10,10 +10,8 @@ assignees: []
 Per docs/engineering/handbook.md §The shapes of work + DR-2026-05-18, every
 work-unit Issue declares a shape via the `## Run-mode` section below and via
 a Conventional Commits prefix in the title. Epics (containers) are exempt;
-they use the EPIC template.
-
-Shapes (pick one for `Run-mode`):
-  BUG-FIX / FEATURE / REFACTOR / SPIKE / CHORE / DOCS / TEST / INCIDENT / INTERACTIVE DESIGN
+they use the EPIC template. The canonical list of shapes + Run-mode values
+lives in the handbook — see the link above.
 
 Title prefix examples:
   fix: SWE typed payload fallback validation


### PR DESCRIPTION
## Summary

Stacks on #269 (waxs.1). Implements waxs.6 from DR-2026-05-18 §Migration plan.

Captures the `Run-mode` + acceptance-criteria body convention (previously a bd convention) so new Issues default to the canonical shape.

### Files

- `.github/ISSUE_TEMPLATE/work-unit.md` — default template with sections Run-mode (one of BUG-FIX/FEATURE/REFACTOR/SPIKE/CHORE/DOCS/TEST/INCIDENT/INTERACTIVE DESIGN), Context, Impact, Acceptance, Out of scope, Reference. Inline guidance points at the handbook shape table.
- `.github/ISSUE_TEMPLATE/epic.md` — umbrella template; epics are exempt from Run-mode per handbook §The shapes of work. Lists sub-issue attachment expectation.
- `.github/ISSUE_TEMPLATE/config.yml` — keeps blank-Issue option enabled; adds contact links for handbook + DR-2026-05-18 + Discussions.

### v0 choices (per DR §Open)

- **Markdown templates, not YAML forms.** Simpler, matches existing conventions. Forms can come later if shape adherence drifts.
- **`Run-mode` is convention-only** (section in the markdown template) — reviewer-enforced, not template-required. Aligns with the handbook's "lightweight refinement mechanism" stance.
- **Single work-unit template covering all shapes.** If shape-specific flows surface friction (per handbook §Iterative refinement), split later.

## Linked Issue

Closes #268. Tracks #261.

## Test plan

`chore` shape. No code change; no test discipline.

Visual check on merge: opening "New Issue" on Jinn-Network/mono should show the **Work unit (default)** and **Epic (container)** templates plus the blank option + three contact links.

## Stacking note

Base is `chore/waxs-retire-bd` (PR #269). After #269 merges, this PR's base rebases onto `next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)