### PR TITLE
fix(k1ng): setAgentWallet retries on returned ok:false (not just thrown errors)

### DIFF
--- a/client/src/earning/bootstrap.ts
+++ b/client/src/earning/bootstrap.ts
@@ -249,6 +249,76 @@ export class FleetBootstrapper {
   }
 
   /**
+   * Run `bindAgentWalletToSafe` with the freshly-deployed-Safe race retry
+   * (jinn-mono-h74p, corrected in jinn-mono-k1ng).
+   *
+   * The race: against a fresh 1/1 Safe on Base Sepolia, the first
+   * setAgentWallet attempt reverts with "Execution reverted for an unknown
+   * reason"; the same Safe + same agentId a few seconds later succeeds.
+   *
+   * The h74p version of the retry only wrapped the call in a try/catch.
+   * In production, `bindAgentWalletToSafe` doesn't throw on revert — it
+   * returns a `{ ok: false, error }` outcome — so the catch never fired
+   * and the retry was dead code. The per-service path "worked" anyway
+   * because it persists `safe_binding_pending` and the next bootstrap
+   * resumes the bind. Stage 1 had no equivalent safety net, so a single
+   * `ok: false` halted bootstrap (the 2026-05-18 canary failure).
+   *
+   * This wrapper:
+   *   - Retries on returned `ok: false` (the way the race actually
+   *     manifests in production).
+   *   - Also retries on thrown exceptions (defense-in-depth in case viem
+   *     error handling changes).
+   *   - Returns the final outcome; callers decide whether to throw, mark
+   *     pending, or proceed.
+   *
+   * Single attempt budget: `safeBindingMaxAttempts` × `safeBindingRetryDelayMs`
+   * (defaults: 3 × 3 s = ~9 s).
+   */
+  private async bindAgentWalletWithRetry(
+    args: Parameters<typeof bindAgentWalletToSafe>[0],
+    label: string,
+  ): Promise<Awaited<ReturnType<typeof bindAgentWalletToSafe>>> {
+    const maxAttempts = Math.max(1, this.safeBindingMaxAttempts);
+    let lastResult: Awaited<ReturnType<typeof bindAgentWalletToSafe>> | undefined;
+    let lastThrowError: unknown;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        lastResult = await bindAgentWalletToSafe(args);
+        if (lastResult.ok) return lastResult;
+        if (attempt < maxAttempts) {
+          console.error(
+            `[fleet-bootstrap] ${label}: setAgentWallet attempt ` +
+              `${attempt}/${maxAttempts} returned ok=false (${lastResult.error.shortMessage}); ` +
+              `retrying in ${this.safeBindingRetryDelayMs}ms...`,
+          );
+          if (this.safeBindingRetryDelayMs > 0) {
+            await sleep(this.safeBindingRetryDelayMs);
+          }
+        }
+      } catch (err) {
+        lastThrowError = err;
+        if (attempt < maxAttempts) {
+          const reason = err instanceof Error ? err.message : String(err);
+          console.error(
+            `[fleet-bootstrap] ${label}: setAgentWallet attempt ` +
+              `${attempt}/${maxAttempts} threw (${reason}); retrying in ` +
+              `${this.safeBindingRetryDelayMs}ms...`,
+          );
+          if (this.safeBindingRetryDelayMs > 0) {
+            await sleep(this.safeBindingRetryDelayMs);
+          }
+        }
+      }
+    }
+    if (lastResult) return lastResult; // final ok:false propagated to caller
+    // Only thrown all the way through — no successful response or returned outcome.
+    throw lastThrowError instanceof Error
+      ? lastThrowError
+      : new Error(String(lastThrowError));
+  }
+
+  /**
    * Conservative daily master gas (wei): max(DEFAULT, rough tx count from poll interval × cost).
    */
   private estimateMasterDailyGasWei(pollIntervalMs?: number): bigint {
@@ -911,22 +981,29 @@ export class FleetBootstrapper {
     });
 
     // Bind the Safe via setAgentWallet (ERC-1271).
+    // Wrapped in the freshly-deployed-Safe retry (jinn-mono-k1ng). The
+    // pre-k1ng single-attempt version halted bootstrap when the documented
+    // race fired on the first attempt — exactly the 2026-05-18 canary's
+    // second-time-around failure mode.
     console.error(
       `[fleet-bootstrap] Stage 1: binding fleet Safe ${fleetSafe} to agentId=${fleetAgentId}`,
     );
-    const bindResult = await bindAgentWalletToSafe({
-      identityRegistryAddress: addr(identityRegistry),
-      agentId: BigInt(fleetAgentId),
-      safeAddress: addr(fleetSafe),
-      agentEoaAccount: agentSigner,
-      agentEoaWalletClient: agentWallet,
-      publicClient: this.publicClient,
-      chainId: this.config.chainId,
-    });
+    const bindResult = await this.bindAgentWalletWithRetry(
+      {
+        identityRegistryAddress: addr(identityRegistry),
+        agentId: BigInt(fleetAgentId),
+        safeAddress: addr(fleetSafe),
+        agentEoaAccount: agentSigner,
+        agentEoaWalletClient: agentWallet,
+        publicClient: this.publicClient,
+        chainId: this.config.chainId,
+      },
+      'Stage 1',
+    );
     if (!bindResult.ok) {
       const bindErr = bindResult.error;
       throw new Error(
-        `Fleet setAgentWallet failed: ${bindErr.shortMessage}` +
+        `Fleet setAgentWallet failed after ${this.safeBindingMaxAttempts} attempts: ${bindErr.shortMessage}` +
           (bindErr.revertReason ? ` (revert: ${bindErr.revertReason})` : ''),
       );
     }
@@ -1653,22 +1730,19 @@ export class FleetBootstrapper {
         step: 'safe_binding_pending',
         error: null,
       });
-      // Combined h74p (retry-on-transient-throw) + hjex.4 (Result-typed
-      // structured errors) policy:
-      //   - bindAgentWalletToSafe now returns a BindAgentWalletOutcome
-      //     (ok=true | ok=false with structured SafeBindingError).
-      //   - A returned Result.ok=false is a deterministic contract revert —
-      //     don't retry; record the structured diagnostic.
-      //   - A *thrown* exception is the freshly-deployed-Safe RPC race
-      //     window h74p targets — retry up to safeBindingMaxAttempts with a
-      //     small delay; if every attempt throws we fall through to a plain
-      //     reason log (no structured fields available).
-      const maxAttempts = Math.max(1, this.safeBindingMaxAttempts);
+      // Unified retry policy (jinn-mono-k1ng — supersedes h74p's throw-only
+      // retry): retry on `ok: false` and on thrown exceptions. The h74p
+      // version only caught throws, but `bindAgentWalletToSafe` returns
+      // `ok: false` for the documented freshly-deployed-Safe revert race —
+      // so the retry was dead code under real RPC. Per-service "worked"
+      // anyway because the next bootstrap resumes from `safe_binding_pending`;
+      // k1ng makes the in-process retry actually do its job so we don't
+      // depend on the operator restarting the daemon.
       let bindResult: Awaited<ReturnType<typeof bindAgentWalletToSafe>> | undefined;
       let lastBindError: unknown;
-      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-        try {
-          bindResult = await bindAgentWalletToSafe({
+      try {
+        bindResult = await this.bindAgentWalletWithRetry(
+          {
             identityRegistryAddress: addr(identityRegistry),
             agentId: BigInt(agentId),
             safeAddress: addr(safeAddress),
@@ -1676,22 +1750,11 @@ export class FleetBootstrapper {
             agentEoaWalletClient: agentWallet,
             publicClient: this.publicClient,
             chainId: this.config.chainId,
-          });
-          break;
-        } catch (err) {
-          lastBindError = err;
-          if (attempt < maxAttempts) {
-            const reason = err instanceof Error ? err.message : String(err);
-            console.error(
-              `[fleet-bootstrap] Service ${index}: setAgentWallet attempt ` +
-              `${attempt}/${maxAttempts} failed (${reason}); retrying in ` +
-              `${this.safeBindingRetryDelayMs}ms...`,
-            );
-            if (this.safeBindingRetryDelayMs > 0) {
-              await sleep(this.safeBindingRetryDelayMs);
-            }
-          }
-        }
+          },
+          `Service ${index}`,
+        );
+      } catch (err) {
+        lastBindError = err;
       }
       if (bindResult?.ok === true) {
         console.error(
@@ -1708,8 +1771,8 @@ export class FleetBootstrapper {
       } else if (bindResult && !bindResult.ok) {
         const bindErr = bindResult.error;
         console.error(
-          `[fleet-bootstrap] Service ${index}: setAgentWallet failed; continuing with ` +
-          `safe_bound_to_agent=false (${bindErr.shortMessage}` +
+          `[fleet-bootstrap] Service ${index}: setAgentWallet failed after retries; ` +
+          `continuing with safe_bound_to_agent=false (${bindErr.shortMessage}` +
           `${bindErr.revertReason ? `, revert: ${bindErr.revertReason}` : ''}).`,
         );
         svc = await this.firstServiceUpdate(index, {
@@ -1723,8 +1786,8 @@ export class FleetBootstrapper {
         const reason =
           lastBindError instanceof Error ? lastBindError.message : String(lastBindError);
         console.error(
-          `[fleet-bootstrap] Service ${index}: setAgentWallet failed after ` +
-          `${maxAttempts} attempts; continuing with safe_bound_to_agent=false (${reason}).`,
+          `[fleet-bootstrap] Service ${index}: setAgentWallet threw on every attempt; ` +
+          `continuing with safe_bound_to_agent=false (${reason}).`,
         );
         svc = await this.firstServiceUpdate(index, {
           safe_bound_to_agent: false,

--- a/client/test/earning/bootstrap.test.ts
+++ b/client/test/earning/bootstrap.test.ts
@@ -1173,6 +1173,90 @@ describe('Fleet bootstrap', () => {
     expect(svc.error).toContain('safe_binding_failed');
   });
 
+  it('agent_registered step retries setAgentWallet on returned ok:false (production race) and succeeds (jinn-mono-k1ng)', async () => {
+    // jinn-mono-k1ng: the existing h74p tests mock `mockRejectedValueOnce(new
+    // Error(...))` — i.e. they assume bindAgentWalletToSafe THROWS on the
+    // race. In production it RETURNS `{ ok: false, error }` (try/catch
+    // internal). The previous retry only caught throws, so it was dead code.
+    // This test mocks the REAL production shape: two transient ok:false
+    // followed by ok:true. The unified bindAgentWalletWithRetry must retry
+    // on returned ok:false (not just thrown exceptions) for the per-service
+    // path to actually heal the race in-process — without relying on the
+    // 'safe_binding_pending' resume-on-next-bootstrap fallback.
+    const earningDir = await mkdtemp(path.join(os.tmpdir(), 'jinn-fleet-'));
+    dirs.push(earningDir);
+
+    const mnemonic = generateMnemonic();
+    const encrypted = await encryptMnemonic(mnemonic, 'test-password');
+    const store = new FleetStateStore(earningDir);
+    await store.saveMnemonicKeystore(encrypted);
+
+    const masterAddr = deriveMasterAddress(mnemonic);
+    const agentAddr = deriveAgentAddress(mnemonic, 1);
+    await store.save({
+      ...createDefaultFleetState('base'),
+      master_address: masterAddr,
+      services: [
+        {
+          index: 1,
+          agent_address: agentAddr,
+          safe_address: '0x2222222222222222222222222222222222222222',
+          service_id: 42,
+          mech_address: '0x3333333333333333333333333333333333333333',
+          staking_address: '0x51c5f4982b9b0b3c0482678f5847ea6228cc8e54',
+          step: 'agent_registered',
+          error: null,
+          agent_id: '777',
+          agent_uri: '',
+          identity_registry_address: '0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
+          agent_registered_tx: '0x' + 'dd'.repeat(32),
+          safe_bound_to_agent: false,
+        },
+      ],
+    });
+
+    const bootstrapper = new FleetBootstrapper({
+      earningDir,
+      chain: 'base',
+      rpcUrl: 'http://127.0.0.1:8545',
+      stakingMode: 'standard',
+      safeBindingRetryDelayMs: 0,
+    });
+
+    const bindingMod = await import('../../src/earning/agent-wallet-binding.js');
+    const transientOkFalse = {
+      ok: false as const,
+      error: {
+        kind: 'safe_binding_failed' as const,
+        message: 'Execution reverted for an unknown reason.',
+        shortMessage: 'Execution reverted for an unknown reason.',
+        revertReason: null,
+      },
+    };
+    const successOutcome = {
+      ok: true as const,
+      txHash: ('0x' + 'ee'.repeat(32)) as `0x${string}`,
+      identityDigest: ('0x' + '11'.repeat(32)) as `0x${string}`,
+      safeMessageHash: ('0x' + '22'.repeat(32)) as `0x${string}`,
+      signature: ('0x' + '33'.repeat(65)) as `0x${string}`,
+      deadline: 9_999_999_999n,
+    };
+    const bindSpy = vi
+      .spyOn(bindingMod, 'bindAgentWalletToSafe')
+      .mockResolvedValueOnce(transientOkFalse)
+      .mockResolvedValueOnce(transientOkFalse)
+      .mockResolvedValueOnce(successOutcome);
+
+    const fleet = await store.load('base');
+    const next = await (bootstrapper as any).resumeServiceStandard(fleet, mnemonic, 1);
+
+    const svc = next.services.find((s: any) => s.index === 1);
+    expect(bindSpy).toHaveBeenCalledTimes(3);
+    expect(svc.safe_bound_to_agent).toBe(true);
+    expect(svc.step).toBe('complete');
+    expect(svc.error).toBe(null);
+  });
+
   it('resume path: complete service with agent_id + safe_bound_to_agent=false runs binding step', async () => {
     // Should-fix #3: legacy operator who minted agent NFT (agent_id set) but
     // never ran the Safe-binding step (safe_bound_to_agent=false). Resuming

--- a/client/test/earning/staged-bootstrap-stage1.test.ts
+++ b/client/test/earning/staged-bootstrap-stage1.test.ts
@@ -295,4 +295,171 @@ describe('FleetBootstrapper.ensureStage1 — greenfield walk (nghf)', () => {
     expect(result.fleet_state.fleet_stage).toBe('stage1');
     expect(olasSpy).not.toHaveBeenCalled();
   });
+
+  // ── Stage 1 setAgentWallet retry (jinn-mono-k1ng) ────────────────────────
+  //
+  // The freshly-deployed-Safe race: against a fresh 1/1 Safe on Base Sepolia,
+  // the first setAgentWallet attempt reverts with "Execution reverted for an
+  // unknown reason"; the same Safe + agentId a few seconds later succeeds.
+  //
+  // CRITICAL: bindAgentWalletToSafe RETURNS `{ ok: false, error }` for this
+  // race — it does NOT throw. The h74p retry only caught throws, so it was
+  // dead code in production. Per-service "worked" via the `safe_binding_pending`
+  // resume safety net; Stage 1 had no such net, so a single `ok: false`
+  // halted bootstrap (the 2026-05-18 canary's second-time-around failure).
+  //
+  // These tests use `mockResolvedValueOnce({ ok: false, ... })` — matching
+  // production behavior — to assert the unified bindAgentWalletWithRetry
+  // helper actually retries. mockRejectedValueOnce (what h74p used) is
+  // documented as the OTHER path the retry handles, but is NOT how the race
+  // actually manifests.
+  it('Stage 1 setAgentWallet retries on ok:false (production race shape) and succeeds (jinn-mono-k1ng)', async () => {
+    const earningDir = await mkdtemp(path.join(os.tmpdir(), 'jinn-k1ng-stage1-bind-'));
+    dirs.push(earningDir);
+
+    const mnemonic = generateMnemonic();
+    const encrypted = await encryptMnemonic(mnemonic, 'test-password');
+    const store = new FleetStateStore(earningDir);
+    await store.saveMnemonicKeystore(encrypted);
+
+    // Pre-seed predicted Safe so stepFleetSafeDeploy can be skipped via mock.
+    await store.patchFleet({ fleet_safe_address: PREDICTED_SAFE });
+
+    const bootstrapper = new FleetBootstrapper({
+      earningDir,
+      chain: 'base',
+      rpcUrl: 'http://127.0.0.1:8545',
+      stakingMode: 'standard',
+      // Fast retry delay so the test doesn't burn seconds.
+      safeBindingRetryDelayMs: 0,
+    });
+
+    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(
+      50_000_000_000_000_000n, // 0.05 ETH — well above any gate
+    );
+    let safeDeployed = false;
+    vi.spyOn((bootstrapper as any).publicClient, 'getCode').mockImplementation(async () =>
+      safeDeployed ? '0xdeadbeef' : '0x',
+    );
+
+    vi.spyOn(bootstrapper as any, 'stepFleetSafeDeploy').mockImplementation(async () => {
+      safeDeployed = true;
+      return store.load('base');
+    });
+
+    // Mock the on-chain register tx so we can drive stepFleetIdentityRegister
+    // all the way to the bind step (which is what we're actually testing).
+    const txMod = await import('../../src/tx-retry.js');
+    vi.spyOn(txMod, 'viemSendTransactionWithRetry').mockResolvedValue(
+      ('0x' + 'aa'.repeat(32)) as `0x${string}`,
+    );
+    vi.spyOn(txMod, 'waitForTransactionReceiptWithRetry').mockResolvedValue({
+      status: 'success',
+      logs: [],
+    } as any);
+    vi.spyOn(bootstrapper as any, 'parseAgentIdFromReceipt').mockReturnValue(FLEET_AGENT_ID);
+
+    // Bind: two transient `ok: false` (the production race), then success.
+    // This is what bindAgentWalletToSafe ACTUALLY returns on Sepolia.
+    const bindingMod = await import('../../src/earning/agent-wallet-binding.js');
+    const bindSpy = vi
+      .spyOn(bindingMod, 'bindAgentWalletToSafe')
+      .mockResolvedValueOnce({
+        ok: false,
+        error: {
+          kind: 'safe_binding_failed',
+          message: 'Execution reverted for an unknown reason.',
+          shortMessage: 'Execution reverted for an unknown reason.',
+          revertReason: null,
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        error: {
+          kind: 'safe_binding_failed',
+          message: 'Execution reverted for an unknown reason.',
+          shortMessage: 'Execution reverted for an unknown reason.',
+          revertReason: null,
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        txHash: ('0x' + 'bb'.repeat(32)) as `0x${string}`,
+        identityDigest: ('0x' + '11'.repeat(32)) as `0x${string}`,
+        safeMessageHash: ('0x' + '22'.repeat(32)) as `0x${string}`,
+        signature: ('0x' + '33'.repeat(65)) as `0x${string}`,
+        deadline: 9_999_999_999n,
+      });
+
+    const result = await bootstrapper.ensureStage1('test-password');
+
+    expect(bindSpy).toHaveBeenCalledTimes(3);
+    expect(result.ok).toBe(true);
+    expect(result.fleet_state.fleet_stage).toBe('stage1');
+    expect(result.fleet_state.fleet_agent_id).toBe(FLEET_AGENT_ID);
+  });
+
+  it('Stage 1 setAgentWallet halts after maxAttempts when ok:false persists (jinn-mono-k1ng)', async () => {
+    const earningDir = await mkdtemp(path.join(os.tmpdir(), 'jinn-k1ng-stage1-bind-'));
+    dirs.push(earningDir);
+
+    const mnemonic = generateMnemonic();
+    const encrypted = await encryptMnemonic(mnemonic, 'test-password');
+    const store = new FleetStateStore(earningDir);
+    await store.saveMnemonicKeystore(encrypted);
+    await store.patchFleet({ fleet_safe_address: PREDICTED_SAFE });
+
+    const bootstrapper = new FleetBootstrapper({
+      earningDir,
+      chain: 'base',
+      rpcUrl: 'http://127.0.0.1:8545',
+      stakingMode: 'standard',
+      safeBindingRetryDelayMs: 0,
+      safeBindingMaxAttempts: 2, // small budget so the test exits fast
+    });
+
+    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(
+      50_000_000_000_000_000n,
+    );
+    let safeDeployed = false;
+    vi.spyOn((bootstrapper as any).publicClient, 'getCode').mockImplementation(async () =>
+      safeDeployed ? '0xdeadbeef' : '0x',
+    );
+    vi.spyOn(bootstrapper as any, 'stepFleetSafeDeploy').mockImplementation(async () => {
+      safeDeployed = true;
+      return store.load('base');
+    });
+    const txMod = await import('../../src/tx-retry.js');
+    vi.spyOn(txMod, 'viemSendTransactionWithRetry').mockResolvedValue(
+      ('0x' + 'aa'.repeat(32)) as `0x${string}`,
+    );
+    vi.spyOn(txMod, 'waitForTransactionReceiptWithRetry').mockResolvedValue({
+      status: 'success',
+      logs: [],
+    } as any);
+    vi.spyOn(bootstrapper as any, 'parseAgentIdFromReceipt').mockReturnValue(FLEET_AGENT_ID);
+
+    // All attempts return ok:false — deterministic revert, no transient.
+    const bindingMod = await import('../../src/earning/agent-wallet-binding.js');
+    const bindSpy = vi.spyOn(bindingMod, 'bindAgentWalletToSafe').mockResolvedValue({
+      ok: false,
+      error: {
+        kind: 'safe_binding_failed',
+        message: 'deterministic revert',
+        shortMessage: 'deterministic revert',
+        revertReason: 'NotAuthorized',
+      },
+    });
+
+    const result = await bootstrapper.ensureStage1('test-password');
+
+    // After maxAttempts (2) all returning ok:false, Stage 1 halts with
+    // a structured error. Bootstrap surfaces the failure with the actual
+    // revert reason (operator can see "NotAuthorized" instead of a generic
+    // OOG-shaped message).
+    expect(bindSpy).toHaveBeenCalledTimes(2);
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('Fleet setAgentWallet failed');
+    expect(result.rawErrorMessage ?? '').toContain('NotAuthorized');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the second-time-around bootstrap failure operators hit after #262 landed: \`Fleet setAgentWallet failed: Execution reverted for an unknown reason\` mid-Stage-1.

bd issue: **jinn-mono-rie5**

## What was actually broken

The freshly-deployed-Safe revert race is documented in this file's h74p comment block (\`bootstrap.ts:118-137\`): against a fresh 1/1 Safe on Base Sepolia, the first \`setAgentWallet\` attempt reverts with \"Execution reverted for an unknown reason\"; the same Safe + agentId a few seconds later succeeds.

**The h74p retry was wired to catch *thrown* exceptions only.** But \`bindAgentWalletToSafe\` doesn't throw on revert — it returns \`{ ok: false, error }\`. The retry's \`try/catch\` never fires in production. Dead code.

- **Per-service path** "worked" anyway because the catch-all marks \`safe_binding_pending\` and the next bootstrap restart resumes from there. The race effectively retried on the next \`jinn run\`, not in-process.
- **Stage 1 path** had no such resume safety net — \`ok: false\` threw and halted bootstrap. The 2026-05-18 canary's second-time-around failure mode.

## Process failures behind this slipping through

The PR for #262 ran an end-to-end on Sepolia. It passed. I declared the fix-stack reliable. The race didn't fire that run (one die roll, came up six). The user re-ran the flow themselves and hit the bug immediately. I was wrong on three counts:

1. **N=1 validation against a documented-flaky code path.** A known race needs N>1 OR deterministic mocks of the failure mode. I had neither.
2. **Audited the bug instance, not the bug class.** I only stared at the bind path that bit me under u34i. Should have grepped every \`bindAgentWalletToSafe\` call site (there are two — fleet and per-service) and verified each has *real* retry coverage.
3. **Trusted false-green tests.** The h74p tests mock with \`mockRejectedValueOnce(new Error(...))\` — testing the throw path that doesn't fire in production. The retry "worked" against the test mock; it never actually retried the real \`ok: false\` race. The PR for those tests was approved with the false-green still passing.

## What this PR changes

- **\`FleetBootstrapper.bindAgentWalletWithRetry()\`** — unified helper that retries on returned \`ok: false\` AND on thrown exceptions. Same budget (3 × 3 s) the previous mechanism advertised.
- **Stage 1** (\`stepFleetIdentityRegister\`) now uses the helper. On persistent \`ok: false\`, throws with the actual revert reason surfaced (operator sees \"NotAuthorized\" etc., not the generic halt message).
- **Per-service** (\`resumeServiceStandard\`) also uses the helper. In-process retry actually retries the race now; no longer depends on the \`safe_binding_pending\` resume-on-next-bootstrap fallback.

## Tests (red-green verified)

- \`staged-bootstrap-stage1.test.ts\`: Stage 1 with two transient \`ok: false\` then \`ok: true\` succeeds; persistent \`ok: false\` halts with the revert reason surfaced.
- \`bootstrap.test.ts\`: per-service with two transient \`ok: false\` then \`ok: true\` succeeds. **This is the mock-parity test that should have existed alongside the h74p tests** — uses \`mockResolvedValueOnce({ ok: false, ... })\` matching production behavior.

Existing h74p tests (\`mockRejectedValueOnce\`) still pass — the helper retries both shapes. The throw path is defense-in-depth; the \`ok: false\` path is the actual production failure mode.

Red-green: reverting each path's call to use a single-attempt \`bindAgentWalletToSafe()\` directly makes the matching test fail with \"expected 3 calls, got 1.\" Restored — both pass.

## Verification

- \`npx tsc --noEmit\` → exit 0
- \`yarn lint:no-late-mount\` → green
- \`npx vitest run --exclude '**/daemon.test.ts'\` → **3550 passed, 0 failed** (daemon.test.ts excluded for port-7331 collision, pre-existing)
- bd issues filed:
  - This: jinn-mono-rie5
  - Class follow-up: jinn-mono-mw7y (Stage 2 in-progress master gate has the same gate==transfer ratio as u34i)
  - Audit follow-up: should add a unit-test convention for mock shapes matching production behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)