### PR TITLE
fix: make bd-mirror --update resolve items directly

### DIFF
--- a/scripts/bd-mirror
+++ b/scripts/bd-mirror
@@ -32,6 +32,9 @@
 # Dependencies: bd, gh (authenticated with `project` scope — `gh auth refresh -s project`), jq.
 #
 # Changelog:
+# - v0.3 (jinn-mono-2cl.22, 2026-05-18): `--update` now resolves the mirrored
+#   issue directly and looks up its Project item via GraphQL instead of scanning
+#   up to 500 Project items client-side.
 # - v0.2 (jinn-mono-2cl.21, 2026-05-12): Sprint field is an Iteration (not a Date) — resolve
 #   @current/@next/<title> to an iteration id and set with --iteration-id. Epic is set to the
 #   human-readable single-select option (mapped from the bead's parent epic via epic_option_for()),
@@ -178,11 +181,51 @@ set_item_fields() {
   gh project item-edit --id "$item_id" --project-id "$PROJECT_NODE_ID" --field-id "$STATUS_FIELD_ID" --single-select-option-id "$STATUS_OPTION_ID" >/dev/null || echo "warning: set Status failed on $item_id" >&2
 }
 
+parse_issue_number_from_ref() {
+  local issue_url="$1"
+  local prefix="https://github.com/$REPO/issues/"
+
+  case "$issue_url" in
+    "$prefix"*)
+      issue_url="${issue_url#$prefix}"
+      issue_url="${issue_url%/}"
+      [[ "$issue_url" =~ ^[0-9]+$ ]] || return 1
+      printf '%s\n' "$issue_url"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+lookup_project_item_for_issue_ref() {
+  local issue_ref="$1"
+  local issue_number
+
+  issue_number="$(parse_issue_number_from_ref "$issue_ref")" || return 1
+  gh api graphql -f query='
+    query($owner:String!,$name:String!,$number:Int!){
+      repository(owner:$owner,name:$name){
+        issue(number:$number){
+          projectItems(first:100){
+            nodes {
+              id
+              project { id }
+            }
+          }
+        }
+      }
+    }' \
+    -F owner="$ORG" -F name="${REPO#*/}" -F number="$issue_number" 2>/dev/null \
+    | jq -r --arg project_id "$PROJECT_NODE_ID" '.data.repository.issue.projectItems.nodes[]? | select(.project.id==$project_id) | .id' \
+    | head -1
+}
+
 # --- idempotency / --update --------------------------------------------------
 if [[ -n "$BD_EXTERNAL_REF" && "$BD_EXTERNAL_REF" == *"$REPO"* ]]; then
   if [[ "$UPDATE_ONLY" -eq 1 ]]; then
     [[ "$DRY_RUN" -eq 1 ]] && { echo "DRY RUN — would re-apply (sprint=${SPRINT_ITER_TITLE:-none} epic=${EPIC_OPTION_NAME:-none} status=$STATUS_NAME) to the item for $BD_EXTERNAL_REF"; exit 0; }
-    ITEM_ID="$(gh project item-list "$PROJECT_NUMBER" --owner "$ORG" --format json --limit 500 2>/dev/null | jq -r --arg u "$BD_EXTERNAL_REF" '.items[]? | select(.content.url==$u) | .id' | head -1)"
+    ITEM_ID="$(lookup_project_item_for_issue_ref "$BD_EXTERNAL_REF" || true)"
     [[ -z "$ITEM_ID" || "$ITEM_ID" == "null" ]] && { echo "error: $BD_ID maps to $BD_EXTERNAL_REF but no matching Project item found." >&2; exit 1; }
     set_item_fields "$ITEM_ID"
     echo "Updated $BD_ID ($BD_EXTERNAL_REF): sprint=${SPRINT_ITER_TITLE:-none} epic=${EPIC_OPTION_NAME:-none} status=$STATUS_NAME"; exit 0

--- a/scripts/test-bd-mirror-direct-lookup.sh
+++ b/scripts/test-bd-mirror-direct-lookup.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/bd-mirror"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+MOCK_BIN="$TMP_DIR/bin"
+mkdir -p "$MOCK_BIN"
+
+cat >"$MOCK_BIN/bd" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$1" == "show" ]]; then
+  cat <<'JSON'
+[{
+  "title": "Direct lookup update path",
+  "description": "keep scope tight",
+  "parent": "",
+  "assignee": "human",
+  "external_ref": "https://github.com/Jinn-Network/mono/issues/236"
+}]
+JSON
+  exit 0
+fi
+
+echo "unexpected bd invocation: $*" >&2
+exit 1
+EOF
+chmod +x "$MOCK_BIN/bd"
+
+cat >"$MOCK_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GH_LOG:?GH_LOG must be set}"
+printf '%s\n' "$*" >>"$GH_LOG"
+
+case "$1 $2" in
+  "project list")
+    cat <<'JSON'
+{"projects":[{"title":"Jinn engineering","number":7,"id":"PVT_project_123"}]}
+JSON
+    ;;
+  "project field-list")
+    cat <<'JSON'
+{"fields":[{"name":"Status","id":"status_field","options":[{"name":"Todo","id":"todo_option"}]}]}
+JSON
+    ;;
+  "api graphql")
+    if [[ "$*" == *'projectItems(first:100)'* ]]; then
+      cat <<'JSON'
+{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"id":"PVTI_item_456","project":{"id":"PVT_project_123"}}]}}}}}
+JSON
+    else
+      echo "unexpected graphql query: $*" >&2
+      exit 1
+    fi
+    ;;
+  "project item-edit")
+    ;;
+  "project item-list")
+    echo "unexpected project item-list invocation" >&2
+    exit 1
+    ;;
+  *)
+    echo "unexpected gh invocation: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$MOCK_BIN/gh"
+
+export PATH="$MOCK_BIN:$PATH"
+export GH_LOG="$TMP_DIR/gh.log"
+
+OUTPUT="$("$SCRIPT_PATH" jinn-mono-2cl.22 none --update --status Todo)"
+
+grep -Fq "Updated jinn-mono-2cl.22 (https://github.com/Jinn-Network/mono/issues/236): sprint=none epic=none status=Todo" <<<"$OUTPUT"
+grep -Fq "api graphql" "$GH_LOG"
+grep -Fq "project item-edit --id PVTI_item_456 --project-id PVT_project_123 --field-id status_field --single-select-option-id todo_option" "$GH_LOG"
+if grep -Fq "project item-list" "$GH_LOG"; then
+  echo "expected direct lookup, but project item-list was invoked" >&2
+  exit 1
+fi
+
+echo "bd-mirror direct lookup test passed"


### PR DESCRIPTION
## Summary
- make `scripts/bd-mirror --update` resolve target items directly
- add targeted shell coverage for direct lookup behavior

## Validation
- `bash scripts/test-bd-mirror-direct-lookup.sh`