### PR TITLE
fix: use delivery event time for recovery expiry

### DIFF
--- a/client/src/adapters/mech/adapter.ts
+++ b/client/src/adapters/mech/adapter.ts
@@ -318,19 +318,33 @@ export class MechAdapter implements ExecutionAdapter {
     this.requestKinds.delete(requestId);
   }
 
-  private shouldSkipExpiredRecoveryDelivery(requestId: string): boolean {
+  private recoveryDeliveryExpirySeconds(requestId: string): number | undefined {
     const task = this.originalStates.get(requestId) ?? this.pendingEvaluations.get(requestId);
-    const rawClaimWindowEndTs = task?.claimPolicy?.claimWindowEndTs ?? task?.window?.endTs;
-    if (rawClaimWindowEndTs == null) return false;
+    const claimPolicy = task?.claimPolicy ?? DEFAULT_MECH_CLAIM_POLICY;
+    const normalizeTsToSeconds = (value: number | undefined): number | undefined => {
+      if (value == null) return undefined;
+      return value > 10_000_000_000 ? Math.floor(value / 1000) : value;
+    };
+    const submissionDeadlineSeconds = normalizeTsToSeconds(claimPolicy.submissionDeadlineTs);
+    if (submissionDeadlineSeconds != null) return submissionDeadlineSeconds;
 
-    const claimWindowEndMs = rawClaimWindowEndTs > 10_000_000_000
-      ? rawClaimWindowEndTs
-      : rawClaimWindowEndTs * 1000;
-    if (Date.now() < claimWindowEndMs) return false;
+    const claimWindowEndSeconds = normalizeTsToSeconds(
+      claimPolicy.claimWindowEndTs ?? task?.window?.endTs,
+    );
+    if (claimWindowEndSeconds == null) return undefined;
+    return claimWindowEndSeconds + claimPolicy.claimLeaseTtlSeconds;
+  }
+
+  private shouldSkipExpiredRecoveryDelivery(
+    requestId: string,
+    currentChainTimestampSeconds: number,
+    recoveryExpirySeconds: number,
+  ): boolean {
+    if (currentChainTimestampSeconds <= recoveryExpirySeconds) return false;
 
     console.error(
       `[mech] skipping recovery delivery for ${requestId}: ` +
-      `claim window expired at ${new Date(claimWindowEndMs).toISOString()}`,
+      `submission deadline expired at ${new Date(recoveryExpirySeconds * 1000).toISOString()}`,
     );
     this.clearPendingDeliveryRecoveryState(requestId);
     return true;
@@ -1023,6 +1037,7 @@ export class MechAdapter implements ExecutionAdapter {
           this.deliveryBlockCursor = currentBlock;
 
           const decoded = decodeDeliverLogs(logs);
+          let currentBlockTimestampSeconds: number | undefined;
           for (const { requestId, deliveryDataHex, mechAddress } of decoded) {
             // Two concerns, independent:
             //   (a) Did this Safe DELIVER this? → claim it (counter credit goes to msg.sender)
@@ -1032,7 +1047,24 @@ export class MechAdapter implements ExecutionAdapter {
             const iDelivered = mechAddress.toLowerCase() === this.config.safeAddress.toLowerCase();
             const iCreatedRestoration = this.pendingEvaluations.has(requestId);
             if (!iDelivered && !iCreatedRestoration) continue;
-            if (iCreatedRestoration && this.shouldSkipExpiredRecoveryDelivery(requestId)) continue;
+            if (iCreatedRestoration) {
+              const recoveryExpirySeconds = this.recoveryDeliveryExpirySeconds(requestId);
+              if (recoveryExpirySeconds != null) {
+                if (currentBlockTimestampSeconds == null) {
+                  const currentBlockData = await this.publicClient.getBlock({ blockNumber: currentBlock });
+                  currentBlockTimestampSeconds = Number(currentBlockData.timestamp);
+                }
+                if (
+                  this.shouldSkipExpiredRecoveryDelivery(
+                    requestId,
+                    currentBlockTimestampSeconds,
+                    recoveryExpirySeconds,
+                  )
+                ) {
+                  continue;
+                }
+              }
+            }
 
             // (a) Deliverer-side claim path: if this Safe delivered the request,
             //     claim it first so router counters credit the deliverer.

--- a/client/src/adapters/mech/adapter.ts
+++ b/client/src/adapters/mech/adapter.ts
@@ -1037,8 +1037,9 @@ export class MechAdapter implements ExecutionAdapter {
           this.deliveryBlockCursor = currentBlock;
 
           const decoded = decodeDeliverLogs(logs);
+          const blockTimestampSecondsByNumber = new Map<bigint, number>();
           let currentBlockTimestampSeconds: number | undefined;
-          for (const { requestId, deliveryDataHex, mechAddress } of decoded) {
+          for (const { requestId, deliveryDataHex, mechAddress, blockNumber } of decoded) {
             // Two concerns, independent:
             //   (a) Did this Safe DELIVER this? → claim it (counter credit goes to msg.sender)
             //       The Deliver event's mechAddress is mechServiceMultisig (the Safe that owns
@@ -1050,14 +1051,25 @@ export class MechAdapter implements ExecutionAdapter {
             if (iCreatedRestoration) {
               const recoveryExpirySeconds = this.recoveryDeliveryExpirySeconds(requestId);
               if (recoveryExpirySeconds != null) {
-                if (currentBlockTimestampSeconds == null) {
-                  const currentBlockData = await this.publicClient.getBlock({ blockNumber: currentBlock });
-                  currentBlockTimestampSeconds = Number(currentBlockData.timestamp);
+                let deliveryTimestampSeconds: number | undefined;
+                if (blockNumber != null) {
+                  deliveryTimestampSeconds = blockTimestampSecondsByNumber.get(blockNumber);
+                  if (deliveryTimestampSeconds == null) {
+                    const deliveryBlockData = await this.publicClient.getBlock({ blockNumber });
+                    deliveryTimestampSeconds = Number(deliveryBlockData.timestamp);
+                    blockTimestampSecondsByNumber.set(blockNumber, deliveryTimestampSeconds);
+                  }
+                } else {
+                  if (currentBlockTimestampSeconds == null) {
+                    const currentBlockData = await this.publicClient.getBlock({ blockNumber: currentBlock });
+                    currentBlockTimestampSeconds = Number(currentBlockData.timestamp);
+                  }
+                  deliveryTimestampSeconds = currentBlockTimestampSeconds;
                 }
                 if (
                   this.shouldSkipExpiredRecoveryDelivery(
                     requestId,
-                    currentBlockTimestampSeconds,
+                    deliveryTimestampSeconds,
                     recoveryExpirySeconds,
                   )
                 ) {

--- a/client/src/adapters/mech/adapter.ts
+++ b/client/src/adapters/mech/adapter.ts
@@ -312,6 +312,30 @@ export class MechAdapter implements ExecutionAdapter {
     this.persistPendingEvaluationSolutions();
   }
 
+  private clearPendingDeliveryRecoveryState(requestId: string): void {
+    this.originalStates.delete(requestId);
+    this.pendingEvaluations.delete(requestId);
+    this.requestKinds.delete(requestId);
+  }
+
+  private shouldSkipExpiredRecoveryDelivery(requestId: string): boolean {
+    const task = this.originalStates.get(requestId) ?? this.pendingEvaluations.get(requestId);
+    const rawClaimWindowEndTs = task?.claimPolicy?.claimWindowEndTs ?? task?.window?.endTs;
+    if (rawClaimWindowEndTs == null) return false;
+
+    const claimWindowEndMs = rawClaimWindowEndTs > 10_000_000_000
+      ? rawClaimWindowEndTs
+      : rawClaimWindowEndTs * 1000;
+    if (Date.now() < claimWindowEndMs) return false;
+
+    console.error(
+      `[mech] skipping recovery delivery for ${requestId}: ` +
+      `claim window expired at ${new Date(claimWindowEndMs).toISOString()}`,
+    );
+    this.clearPendingDeliveryRecoveryState(requestId);
+    return true;
+  }
+
   async postTask(state: Task): Promise<PostedTask> {
     const restorationState: Task = {
       ...state,
@@ -1008,6 +1032,7 @@ export class MechAdapter implements ExecutionAdapter {
             const iDelivered = mechAddress.toLowerCase() === this.config.safeAddress.toLowerCase();
             const iCreatedRestoration = this.pendingEvaluations.has(requestId);
             if (!iDelivered && !iCreatedRestoration) continue;
+            if (iCreatedRestoration && this.shouldSkipExpiredRecoveryDelivery(requestId)) continue;
 
             // (a) Deliverer-side claim path: if this Safe delivered the request,
             //     claim it first so router counters credit the deliverer.
@@ -1048,9 +1073,7 @@ export class MechAdapter implements ExecutionAdapter {
               };
 
               // Clean up after yielding
-              this.originalStates.delete(requestId);
-              this.pendingEvaluations.delete(requestId);
-              this.requestKinds.delete(requestId);
+              this.clearPendingDeliveryRecoveryState(requestId);
             } catch (err) {
               console.error(`[mech] Failed to parse delivery ${requestId}:`, err);
             }

--- a/client/src/adapters/mech/contracts.ts
+++ b/client/src/adapters/mech/contracts.ts
@@ -894,6 +894,7 @@ export interface DecodedDeliverEvent {
   requestId: string;
   deliveryDataHex: string;
   mechAddress: string;
+  blockNumber?: bigint;
 }
 
 export function decodeDeliverLogs(logs: Log[]): DecodedDeliverEvent[] {
@@ -917,6 +918,7 @@ export function decodeDeliverLogs(logs: Log[]): DecodedDeliverEvent[] {
           requestId: String(args.requestId),
           deliveryDataHex: String(args.data),
           mechAddress: String(args.mechServiceMultisig),
+          blockNumber: log.blockNumber ?? undefined,
         });
       }
     } catch {

--- a/client/test/adapters/mech/adapter.test.ts
+++ b/client/test/adapters/mech/adapter.test.ts
@@ -1088,6 +1088,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
         requestId: REQUEST_ID,
         deliveryDataHex: TASK_CID_DIGEST,
         mechAddress: TEST_CONFIG.safeAddress,
+        blockNumber: 101n,
       }]);
       vi.mocked(fetchFromIpfs).mockResolvedValueOnce({ data: 'result' });
 
@@ -1140,6 +1141,82 @@ describe('MechAdapter TaskCoordinator flow', () => {
     }
   });
 
+  it('watchForDeliveries still claims recovery deliveries emitted before expiry even when processed after expiry', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-18T12:30:00.000Z'));
+
+    try {
+      const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+      const { claimDelivery, decodeDeliverLogs } = await import('../../../src/adapters/mech/contracts.js');
+      const { fetchFromIpfs } = await import('../../../src/adapters/mech/ipfs.js');
+      const claimWindowEndTs = Date.parse('2026-05-18T12:00:00.000Z');
+      const submissionDeadlineTs = Date.parse('2026-05-18T12:20:00.000Z');
+      const deliveryBlockNumber = 101n;
+      const scanHeadBlockNumber = 105n;
+      const deliveryBlockTimestampSeconds = Math.floor(Date.parse('2026-05-18T12:10:00.000Z') / 1000);
+      const scanHeadTimestampSeconds = Math.floor(Date.parse('2026-05-18T12:25:00.000Z') / 1000);
+
+      vi.mocked(decodeDeliverLogs).mockReturnValueOnce([{
+        requestId: REQUEST_ID,
+        deliveryDataHex: TASK_CID_DIGEST,
+        mechAddress: TEST_CONFIG.safeAddress,
+        blockNumber: deliveryBlockNumber,
+      }]);
+      vi.mocked(fetchFromIpfs).mockResolvedValueOnce({ data: 'result' });
+
+      const adapter = new MechAdapter({ ...TEST_CONFIG, pollIntervalMs: 1 });
+      await adapter.initialize();
+      (adapter as any).publicClient.getBlockNumber = vi.fn().mockResolvedValue(scanHeadBlockNumber);
+      (adapter as any).publicClient.getBlock = vi.fn(async ({ blockNumber }: { blockNumber: bigint }) => {
+        if (blockNumber === deliveryBlockNumber) {
+          return { timestamp: BigInt(deliveryBlockTimestampSeconds) };
+        }
+        if (blockNumber === scanHeadBlockNumber) {
+          return { timestamp: BigInt(scanHeadTimestampSeconds) };
+        }
+        throw new Error(`unexpected block lookup: ${blockNumber}`);
+      });
+      (adapter as any).publicClient.getLogs = vi.fn().mockResolvedValue([{ data: '0x', topics: [] }]);
+      (adapter as any).deliveryBlockCursor = 100n;
+      const taskWithinDeadlineAtEmit = {
+        id: 'prediction-task-1',
+        description: 'recovery task emitted before expiry',
+        claimPolicy: {
+          mode: 'exclusive',
+          maxClaims: 1,
+          maxClaimsPerOperator: 1,
+          claimLeaseTtlSeconds: 600,
+          claimWindowEndTs,
+          submissionDeadlineTs,
+        },
+      };
+      (adapter as any).pendingEvaluations.set(REQUEST_ID, taskWithinDeadlineAtEmit);
+      (adapter as any).originalStates.set(REQUEST_ID, taskWithinDeadlineAtEmit);
+      (adapter as any).requestKinds.set(REQUEST_ID, 'solution');
+
+      const gen = adapter.watchForDeliveries()[Symbol.asyncIterator]();
+      const { value } = await gen.next();
+
+      expect((adapter as any).publicClient.getBlock).toHaveBeenCalledWith({ blockNumber: deliveryBlockNumber });
+      expect((adapter as any).publicClient.getBlock).not.toHaveBeenCalledWith({ blockNumber: scanHeadBlockNumber });
+      expect(claimDelivery).toHaveBeenCalledOnce();
+      expect(fetchFromIpfs).toHaveBeenCalledOnce();
+      expect(value).toMatchObject({
+        requestId: REQUEST_ID,
+        task: taskWithinDeadlineAtEmit,
+        result: { data: 'result' },
+        deliveryMechAddress: TEST_CONFIG.safeAddress,
+      });
+
+      await adapter.stop();
+      const donePromise = gen.next();
+      await vi.advanceTimersByTimeAsync(5);
+      await expect(donePromise).resolves.toMatchObject({ done: true, value: undefined });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('watchForDeliveries skips recovery deliveries once the submission deadline has passed on chain', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-18T12:05:00.000Z'));
@@ -1156,6 +1233,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
         requestId: REQUEST_ID,
         deliveryDataHex: TASK_CID_DIGEST,
         mechAddress: TEST_CONFIG.safeAddress,
+        blockNumber: 101n,
       }]);
 
       const adapter = new MechAdapter({ ...TEST_CONFIG, pollIntervalMs: 1 });
@@ -1227,6 +1305,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
       requestId: REQUEST_ID,
       deliveryDataHex: TASK_CID_DIGEST,
       mechAddress: '0x9999999999999999999999999999999999999999',
+      blockNumber: 101n,
     }]);
 
     const adapter = new MechAdapter({ ...TEST_CONFIG, routerClaimDeliveryVariant: 'v2' });

--- a/client/test/adapters/mech/adapter.test.ts
+++ b/client/test/adapters/mech/adapter.test.ts
@@ -1072,14 +1072,85 @@ describe('MechAdapter TaskCoordinator flow', () => {
     await adapter.stop();
   });
 
-  it('watchForDeliveries skips expired recovery delivery work once the claim window has ended', async () => {
+  it('watchForDeliveries still claims recovery deliveries while the submission deadline remains open', async () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-05-18T12:00:00.000Z'));
+    vi.setSystemTime(new Date('2026-05-18T12:30:00.000Z'));
 
     try {
       const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
       const { claimDelivery, decodeDeliverLogs } = await import('../../../src/adapters/mech/contracts.js');
       const { fetchFromIpfs } = await import('../../../src/adapters/mech/ipfs.js');
+      const claimWindowEndTs = Date.parse('2026-05-18T12:00:00.000Z');
+      const submissionDeadlineTs = Date.parse('2026-05-18T12:20:00.000Z');
+      const blockTimestampSeconds = Math.floor(Date.parse('2026-05-18T12:10:00.000Z') / 1000);
+
+      vi.mocked(decodeDeliverLogs).mockReturnValueOnce([{
+        requestId: REQUEST_ID,
+        deliveryDataHex: TASK_CID_DIGEST,
+        mechAddress: TEST_CONFIG.safeAddress,
+      }]);
+      vi.mocked(fetchFromIpfs).mockResolvedValueOnce({ data: 'result' });
+
+      const adapter = new MechAdapter({ ...TEST_CONFIG, pollIntervalMs: 1 });
+      await adapter.initialize();
+      (adapter as any).publicClient.getBlockNumber = vi.fn().mockResolvedValue(101n);
+      (adapter as any).publicClient.getBlock = vi.fn().mockResolvedValue({ timestamp: BigInt(blockTimestampSeconds) });
+      (adapter as any).publicClient.getLogs = vi.fn().mockResolvedValue([{ data: '0x', topics: [] }]);
+      (adapter as any).deliveryBlockCursor = 100n;
+      const taskWithinLease = {
+        id: 'prediction-task-1',
+        description: 'recovery task still within submission deadline',
+        claimPolicy: {
+          mode: 'exclusive',
+          maxClaims: 1,
+          maxClaimsPerOperator: 1,
+          claimLeaseTtlSeconds: 600,
+          claimWindowEndTs,
+          submissionDeadlineTs,
+        },
+      };
+      (adapter as any).pendingEvaluations.set(REQUEST_ID, taskWithinLease);
+      (adapter as any).originalStates.set(REQUEST_ID, taskWithinLease);
+      (adapter as any).requestKinds.set(REQUEST_ID, 'solution');
+
+      const gen = adapter.watchForDeliveries()[Symbol.asyncIterator]();
+      const { value } = await gen.next();
+
+      expect((adapter as any).publicClient.getBlock).toHaveBeenCalledWith({ blockNumber: 101n });
+      expect(claimDelivery).toHaveBeenCalledOnce();
+      expect(fetchFromIpfs).toHaveBeenCalledOnce();
+      expect(value).toMatchObject({
+        requestId: REQUEST_ID,
+        task: taskWithinLease,
+        result: { data: 'result' },
+        deliveryMechAddress: TEST_CONFIG.safeAddress,
+      });
+
+      await adapter.stop();
+      const donePromise = gen.next();
+      await vi.advanceTimersByTimeAsync(5);
+      await expect(donePromise).resolves.toMatchObject({ done: true, value: undefined });
+
+      expect((adapter as any).pendingEvaluations.has(REQUEST_ID)).toBe(false);
+      expect((adapter as any).originalStates.has(REQUEST_ID)).toBe(false);
+      expect((adapter as any).requestKinds.has(REQUEST_ID)).toBe(false);
+
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('watchForDeliveries skips recovery deliveries once the submission deadline has passed on chain', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-18T12:05:00.000Z'));
+
+    try {
+      const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+      const { claimDelivery, decodeDeliverLogs } = await import('../../../src/adapters/mech/contracts.js');
+      const { fetchFromIpfs } = await import('../../../src/adapters/mech/ipfs.js');
+      const claimWindowEndTs = Date.parse('2026-05-18T12:00:00.000Z');
+      const submissionDeadlineTs = Date.parse('2026-05-18T12:20:00.000Z');
+      const blockTimestampSeconds = Math.floor(Date.parse('2026-05-18T12:20:01.000Z') / 1000);
 
       vi.mocked(decodeDeliverLogs).mockReturnValueOnce([{
         requestId: REQUEST_ID,
@@ -1090,6 +1161,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
       const adapter = new MechAdapter({ ...TEST_CONFIG, pollIntervalMs: 1 });
       await adapter.initialize();
       (adapter as any).publicClient.getBlockNumber = vi.fn().mockResolvedValue(101n);
+      (adapter as any).publicClient.getBlock = vi.fn().mockResolvedValue({ timestamp: BigInt(blockTimestampSeconds) });
       (adapter as any).publicClient.getLogs = vi.fn().mockResolvedValue([{ data: '0x', topics: [] }]);
       (adapter as any).deliveryBlockCursor = 100n;
       const expiredTask = {
@@ -1100,7 +1172,8 @@ describe('MechAdapter TaskCoordinator flow', () => {
           maxClaims: 1,
           maxClaimsPerOperator: 1,
           claimLeaseTtlSeconds: 600,
-          claimWindowEndTs: Date.now() - 1_000,
+          claimWindowEndTs,
+          submissionDeadlineTs,
         },
       };
       (adapter as any).pendingEvaluations.set(REQUEST_ID, expiredTask);
@@ -1112,6 +1185,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
 
       await vi.advanceTimersByTimeAsync(5);
 
+      expect((adapter as any).publicClient.getBlock).toHaveBeenCalledWith({ blockNumber: 101n });
       expect(claimDelivery).not.toHaveBeenCalled();
       expect(fetchFromIpfs).not.toHaveBeenCalled();
       expect((adapter as any).pendingEvaluations.has(REQUEST_ID)).toBe(false);

--- a/client/test/adapters/mech/adapter.test.ts
+++ b/client/test/adapters/mech/adapter.test.ts
@@ -1072,6 +1072,61 @@ describe('MechAdapter TaskCoordinator flow', () => {
     await adapter.stop();
   });
 
+  it('watchForDeliveries skips expired recovery delivery work once the claim window has ended', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-18T12:00:00.000Z'));
+
+    try {
+      const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+      const { claimDelivery, decodeDeliverLogs } = await import('../../../src/adapters/mech/contracts.js');
+      const { fetchFromIpfs } = await import('../../../src/adapters/mech/ipfs.js');
+
+      vi.mocked(decodeDeliverLogs).mockReturnValueOnce([{
+        requestId: REQUEST_ID,
+        deliveryDataHex: TASK_CID_DIGEST,
+        mechAddress: TEST_CONFIG.safeAddress,
+      }]);
+
+      const adapter = new MechAdapter({ ...TEST_CONFIG, pollIntervalMs: 1 });
+      await adapter.initialize();
+      (adapter as any).publicClient.getBlockNumber = vi.fn().mockResolvedValue(101n);
+      (adapter as any).publicClient.getLogs = vi.fn().mockResolvedValue([{ data: '0x', topics: [] }]);
+      (adapter as any).deliveryBlockCursor = 100n;
+      const expiredTask = {
+        id: 'prediction-task-1',
+        description: 'expired recovery task',
+        claimPolicy: {
+          mode: 'exclusive',
+          maxClaims: 1,
+          maxClaimsPerOperator: 1,
+          claimLeaseTtlSeconds: 600,
+          claimWindowEndTs: Date.now() - 1_000,
+        },
+      };
+      (adapter as any).pendingEvaluations.set(REQUEST_ID, expiredTask);
+      (adapter as any).originalStates.set(REQUEST_ID, expiredTask);
+      (adapter as any).requestKinds.set(REQUEST_ID, 'solution');
+
+      const gen = adapter.watchForDeliveries()[Symbol.asyncIterator]();
+      const nextPromise = gen.next();
+
+      await vi.advanceTimersByTimeAsync(5);
+
+      expect(claimDelivery).not.toHaveBeenCalled();
+      expect(fetchFromIpfs).not.toHaveBeenCalled();
+      expect((adapter as any).pendingEvaluations.has(REQUEST_ID)).toBe(false);
+      expect((adapter as any).originalStates.has(REQUEST_ID)).toBe(false);
+      expect((adapter as any).requestKinds.has(REQUEST_ID)).toBe(false);
+
+      await adapter.stop();
+      await vi.advanceTimersByTimeAsync(5);
+
+      await expect(nextPromise).resolves.toMatchObject({ done: true, value: undefined });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('V2 claimDelivery derives evidenceHash from the signed execution envelope', async () => {
     const { keccak256 } = await import('viem');
     const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');


### PR DESCRIPTION
## Summary
- skip recovery delivery replay only after the on-chain recovery deadline has actually expired
- key expiry checks off the delivery event block time instead of the later poll time
- cover the recovery window edge cases in Mech adapter tests

## Validation
- `PATH=$HOME/.nvm/versions/node/v22.22.2/bin:$PATH yarn --cwd client vitest run test/adapters/mech/adapter.test.ts`