### PR TITLE
fix: preserve verdict claim metadata on mech delivery retry

### DIFF
--- a/client/src/adapters/mech/adapter.ts
+++ b/client/src/adapters/mech/adapter.ts
@@ -318,19 +318,33 @@ export class MechAdapter implements ExecutionAdapter {
     this.requestKinds.delete(requestId);
   }
 
-  private shouldSkipExpiredRecoveryDelivery(requestId: string): boolean {
+  private recoveryDeliveryExpirySeconds(requestId: string): number | undefined {
     const task = this.originalStates.get(requestId) ?? this.pendingEvaluations.get(requestId);
-    const rawClaimWindowEndTs = task?.claimPolicy?.claimWindowEndTs ?? task?.window?.endTs;
-    if (rawClaimWindowEndTs == null) return false;
+    const claimPolicy = task?.claimPolicy ?? DEFAULT_MECH_CLAIM_POLICY;
+    const normalizeTsToSeconds = (value: number | undefined): number | undefined => {
+      if (value == null) return undefined;
+      return value > 10_000_000_000 ? Math.floor(value / 1000) : value;
+    };
+    const submissionDeadlineSeconds = normalizeTsToSeconds(claimPolicy.submissionDeadlineTs);
+    if (submissionDeadlineSeconds != null) return submissionDeadlineSeconds;
 
-    const claimWindowEndMs = rawClaimWindowEndTs > 10_000_000_000
-      ? rawClaimWindowEndTs
-      : rawClaimWindowEndTs * 1000;
-    if (Date.now() < claimWindowEndMs) return false;
+    const claimWindowEndSeconds = normalizeTsToSeconds(
+      claimPolicy.claimWindowEndTs ?? task?.window?.endTs,
+    );
+    if (claimWindowEndSeconds == null) return undefined;
+    return claimWindowEndSeconds + claimPolicy.claimLeaseTtlSeconds;
+  }
+
+  private shouldSkipExpiredRecoveryDelivery(
+    requestId: string,
+    currentChainTimestampSeconds: number,
+    recoveryExpirySeconds: number,
+  ): boolean {
+    if (currentChainTimestampSeconds <= recoveryExpirySeconds) return false;
 
     console.error(
       `[mech] skipping recovery delivery for ${requestId}: ` +
-      `claim window expired at ${new Date(claimWindowEndMs).toISOString()}`,
+      `submission deadline expired at ${new Date(recoveryExpirySeconds * 1000).toISOString()}`,
     );
     this.clearPendingDeliveryRecoveryState(requestId);
     return true;
@@ -1023,6 +1037,7 @@ export class MechAdapter implements ExecutionAdapter {
           this.deliveryBlockCursor = currentBlock;
 
           const decoded = decodeDeliverLogs(logs);
+          let currentBlockTimestampSeconds: number | undefined;
           for (const { requestId, deliveryDataHex, mechAddress } of decoded) {
             // Two concerns, independent:
             //   (a) Did this Safe DELIVER this? → claim it (counter credit goes to msg.sender)
@@ -1032,7 +1047,24 @@ export class MechAdapter implements ExecutionAdapter {
             const iDelivered = mechAddress.toLowerCase() === this.config.safeAddress.toLowerCase();
             const iCreatedRestoration = this.pendingEvaluations.has(requestId);
             if (!iDelivered && !iCreatedRestoration) continue;
-            if (iCreatedRestoration && this.shouldSkipExpiredRecoveryDelivery(requestId)) continue;
+            if (iCreatedRestoration) {
+              const recoveryExpirySeconds = this.recoveryDeliveryExpirySeconds(requestId);
+              if (recoveryExpirySeconds != null) {
+                if (currentBlockTimestampSeconds == null) {
+                  const currentBlockData = await this.publicClient.getBlock({ blockNumber: currentBlock });
+                  currentBlockTimestampSeconds = Number(currentBlockData.timestamp);
+                }
+                if (
+                  this.shouldSkipExpiredRecoveryDelivery(
+                    requestId,
+                    currentBlockTimestampSeconds,
+                    recoveryExpirySeconds,
+                  )
+                ) {
+                  continue;
+                }
+              }
+            }
 
             // (a) Deliverer-side claim path: if this Safe delivered the request,
             //     claim it first so router counters credit the deliverer.

--- a/client/src/adapters/mech/adapter.ts
+++ b/client/src/adapters/mech/adapter.ts
@@ -1037,8 +1037,9 @@ export class MechAdapter implements ExecutionAdapter {
           this.deliveryBlockCursor = currentBlock;
 
           const decoded = decodeDeliverLogs(logs);
+          const blockTimestampSecondsByNumber = new Map<bigint, number>();
           let currentBlockTimestampSeconds: number | undefined;
-          for (const { requestId, deliveryDataHex, mechAddress } of decoded) {
+          for (const { requestId, deliveryDataHex, mechAddress, blockNumber } of decoded) {
             // Two concerns, independent:
             //   (a) Did this Safe DELIVER this? → claim it (counter credit goes to msg.sender)
             //       The Deliver event's mechAddress is mechServiceMultisig (the Safe that owns
@@ -1050,14 +1051,25 @@ export class MechAdapter implements ExecutionAdapter {
             if (iCreatedRestoration) {
               const recoveryExpirySeconds = this.recoveryDeliveryExpirySeconds(requestId);
               if (recoveryExpirySeconds != null) {
-                if (currentBlockTimestampSeconds == null) {
-                  const currentBlockData = await this.publicClient.getBlock({ blockNumber: currentBlock });
-                  currentBlockTimestampSeconds = Number(currentBlockData.timestamp);
+                let deliveryTimestampSeconds: number | undefined;
+                if (blockNumber != null) {
+                  deliveryTimestampSeconds = blockTimestampSecondsByNumber.get(blockNumber);
+                  if (deliveryTimestampSeconds == null) {
+                    const deliveryBlockData = await this.publicClient.getBlock({ blockNumber });
+                    deliveryTimestampSeconds = Number(deliveryBlockData.timestamp);
+                    blockTimestampSecondsByNumber.set(blockNumber, deliveryTimestampSeconds);
+                  }
+                } else {
+                  if (currentBlockTimestampSeconds == null) {
+                    const currentBlockData = await this.publicClient.getBlock({ blockNumber: currentBlock });
+                    currentBlockTimestampSeconds = Number(currentBlockData.timestamp);
+                  }
+                  deliveryTimestampSeconds = currentBlockTimestampSeconds;
                 }
                 if (
                   this.shouldSkipExpiredRecoveryDelivery(
                     requestId,
-                    currentBlockTimestampSeconds,
+                    deliveryTimestampSeconds,
                     recoveryExpirySeconds,
                   )
                 ) {

--- a/client/src/adapters/mech/adapter.ts
+++ b/client/src/adapters/mech/adapter.ts
@@ -24,7 +24,7 @@ import {
   digestHexToGatewayUrl,
 } from './ipfs.js';
 import { canonicalJson } from '../../harnesses/engine/canonical-json.js';
-import { SignedEnvelopeSchema } from '../../types/envelope.js';
+import { normalizeEnvelopeRole, SignedEnvelopeSchema } from '../../types/envelope.js';
 import {
   submitTask,
   claimTask as claimTaskOnchain,
@@ -44,7 +44,7 @@ import {
   type RouterTaskPolicy,
 } from './contracts.js';
 import { type MechAdapterConfig } from './types.js';
-import { VerdictCode } from './verdict-code.js';
+import { VerdictCode, verdictCodeFromValue } from './verdict-code.js';
 import { manifestDigestForCid } from './digest.js';
 import type { DiscoveryAPI } from '../../discovery/types.js';
 import type { Store } from '../../store/store.js';
@@ -948,9 +948,17 @@ export class MechAdapter implements ExecutionAdapter {
     );
   }
 
-  private async evidenceHashForDelivery(requestId: string, deliveryDataHex: string): Promise<Hex | undefined> {
+  private async deliveryClaimForDelivery(requestId: string, deliveryDataHex: string): Promise<{
+    evidenceHash: Hex | undefined;
+    kind: 'solution' | 'verdict';
+    verdictCode?: VerdictCode;
+  }> {
+    const fallbackKind = this.requestKinds.get(requestId) ?? 'solution';
     if (this.config.routerClaimDeliveryVariant !== 'v2' && this.config.routerClaimDeliveryVariant !== 'v3') {
-      return undefined;
+      return {
+        evidenceHash: undefined,
+        kind: fallbackKind,
+      };
     }
 
     const deliveryDigest = deliveryDataHex.startsWith('0x')
@@ -962,11 +970,6 @@ export class MechAdapter implements ExecutionAdapter {
       envelopeCid,
     );
     const parsed = SignedEnvelopeSchema.parse(rawEnvelope);
-    // Strip signature to recompute the hash over the unsigned body.
-    //
-    // Important: compute over the fetched wire object, not over the parsed
-    // schema result. The schema normalizes some nested objects and may strip
-    // extension metadata that was present when the envelope was signed.
     const rawSigned = rawEnvelope as Record<string, unknown>;
     const { signature: _rawSignature, ...unsignedBody } = rawSigned;
     const signature = parsed.signature;
@@ -977,19 +980,38 @@ export class MechAdapter implements ExecutionAdapter {
         `recomputed hash ${recomputed} !== envelope.signature.hash ${signature.hash}`,
       );
     }
-    return recomputed as Hex;
+
+    const role = normalizeEnvelopeRole(parsed.role);
+    if (role === 'capture') {
+      throw new Error(`unsupported delivery envelope role=capture for requestId ${requestId}`);
+    }
+    const kind = role === 'verdict' ? 'verdict' : 'solution';
+    const payload = rawSigned['payload'];
+    const rawVerdict = payload != null && typeof payload === 'object'
+      ? (payload as Record<string, unknown>)['verdict']
+      : undefined;
+
+    return {
+      evidenceHash: recomputed as Hex,
+      kind,
+      verdictCode: kind === 'verdict' ? verdictCodeFromValue(rawVerdict) : undefined,
+    };
   }
 
   private async ensureDeliveryClaimed(
     requestId: string,
     deliveryDataHex: string,
   ): Promise<'claimed' | 'already-claimed' | 'skipped' | 'retry'> {
-    let evidenceHash: Hex | undefined;
+    let claimOptions: {
+      evidenceHash: Hex | undefined;
+      kind: 'solution' | 'verdict';
+      verdictCode?: VerdictCode;
+    };
     try {
-      evidenceHash = await this.evidenceHashForDelivery(requestId, deliveryDataHex);
+      claimOptions = await this.deliveryClaimForDelivery(requestId, deliveryDataHex);
     } catch (err) {
       console.error(
-        `[mech] evidenceHash derivation failed for ${requestId} — skipping claim, will retry on next loop:`,
+        `[mech] delivery claim metadata derivation failed for ${requestId} — skipping claim, will retry on next loop:`,
         err,
       );
       return 'retry';
@@ -1004,8 +1026,9 @@ export class MechAdapter implements ExecutionAdapter {
         requestId as Hex,
         {
           variant: this.config.routerClaimDeliveryVariant,
-          kind: this.requestKinds.get(requestId) ?? 'solution',
-          evidenceHash,
+          kind: claimOptions.kind,
+          evidenceHash: claimOptions.evidenceHash,
+          verdictCode: claimOptions.verdictCode,
         },
         this.config.evictionRecovery,
       );

--- a/client/src/adapters/mech/adapter.ts
+++ b/client/src/adapters/mech/adapter.ts
@@ -312,6 +312,30 @@ export class MechAdapter implements ExecutionAdapter {
     this.persistPendingEvaluationSolutions();
   }
 
+  private clearPendingDeliveryRecoveryState(requestId: string): void {
+    this.originalStates.delete(requestId);
+    this.pendingEvaluations.delete(requestId);
+    this.requestKinds.delete(requestId);
+  }
+
+  private shouldSkipExpiredRecoveryDelivery(requestId: string): boolean {
+    const task = this.originalStates.get(requestId) ?? this.pendingEvaluations.get(requestId);
+    const rawClaimWindowEndTs = task?.claimPolicy?.claimWindowEndTs ?? task?.window?.endTs;
+    if (rawClaimWindowEndTs == null) return false;
+
+    const claimWindowEndMs = rawClaimWindowEndTs > 10_000_000_000
+      ? rawClaimWindowEndTs
+      : rawClaimWindowEndTs * 1000;
+    if (Date.now() < claimWindowEndMs) return false;
+
+    console.error(
+      `[mech] skipping recovery delivery for ${requestId}: ` +
+      `claim window expired at ${new Date(claimWindowEndMs).toISOString()}`,
+    );
+    this.clearPendingDeliveryRecoveryState(requestId);
+    return true;
+  }
+
   async postTask(state: Task): Promise<PostedTask> {
     const restorationState: Task = {
       ...state,
@@ -1008,6 +1032,7 @@ export class MechAdapter implements ExecutionAdapter {
             const iDelivered = mechAddress.toLowerCase() === this.config.safeAddress.toLowerCase();
             const iCreatedRestoration = this.pendingEvaluations.has(requestId);
             if (!iDelivered && !iCreatedRestoration) continue;
+            if (iCreatedRestoration && this.shouldSkipExpiredRecoveryDelivery(requestId)) continue;
 
             // (a) Deliverer-side claim path: if this Safe delivered the request,
             //     claim it first so router counters credit the deliverer.
@@ -1048,9 +1073,7 @@ export class MechAdapter implements ExecutionAdapter {
               };
 
               // Clean up after yielding
-              this.originalStates.delete(requestId);
-              this.pendingEvaluations.delete(requestId);
-              this.requestKinds.delete(requestId);
+              this.clearPendingDeliveryRecoveryState(requestId);
             } catch (err) {
               console.error(`[mech] Failed to parse delivery ${requestId}:`, err);
             }

--- a/client/src/adapters/mech/contracts.ts
+++ b/client/src/adapters/mech/contracts.ts
@@ -894,6 +894,7 @@ export interface DecodedDeliverEvent {
   requestId: string;
   deliveryDataHex: string;
   mechAddress: string;
+  blockNumber?: bigint;
 }
 
 export function decodeDeliverLogs(logs: Log[]): DecodedDeliverEvent[] {
@@ -917,6 +918,7 @@ export function decodeDeliverLogs(logs: Log[]): DecodedDeliverEvent[] {
           requestId: String(args.requestId),
           deliveryDataHex: String(args.data),
           mechAddress: String(args.mechServiceMultisig),
+          blockNumber: log.blockNumber ?? undefined,
         });
       }
     } catch {

--- a/client/src/adapters/mech/verdict-code.ts
+++ b/client/src/adapters/mech/verdict-code.ts
@@ -18,3 +18,22 @@ export const VerdictCode = {
 } as const;
 
 export type VerdictCode = typeof VerdictCode[keyof typeof VerdictCode];
+
+export function verdictCodeFromValue(raw: unknown): VerdictCode {
+  const normalized = typeof raw === 'string' ? raw.toUpperCase() : raw;
+  switch (normalized) {
+    case 'PASS':
+    case 'SCORED':
+      return VerdictCode.Pass;
+    case 'FAIL':
+    case 'REJECTED':
+      return VerdictCode.Fail;
+    case 'INVALID':
+      return VerdictCode.Invalid;
+    case 'INDETERMINATE':
+    case 'UNRESOLVED':
+      return VerdictCode.Unresolved;
+    default:
+      return VerdictCode.Invalid;
+  }
+}

--- a/client/test/adapters/mech/adapter.test.ts
+++ b/client/test/adapters/mech/adapter.test.ts
@@ -1088,6 +1088,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
         requestId: REQUEST_ID,
         deliveryDataHex: TASK_CID_DIGEST,
         mechAddress: TEST_CONFIG.safeAddress,
+        blockNumber: 101n,
       }]);
       vi.mocked(fetchFromIpfs).mockResolvedValueOnce({ data: 'result' });
 
@@ -1140,6 +1141,82 @@ describe('MechAdapter TaskCoordinator flow', () => {
     }
   });
 
+  it('watchForDeliveries still claims recovery deliveries emitted before expiry even when processed after expiry', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-18T12:30:00.000Z'));
+
+    try {
+      const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+      const { claimDelivery, decodeDeliverLogs } = await import('../../../src/adapters/mech/contracts.js');
+      const { fetchFromIpfs } = await import('../../../src/adapters/mech/ipfs.js');
+      const claimWindowEndTs = Date.parse('2026-05-18T12:00:00.000Z');
+      const submissionDeadlineTs = Date.parse('2026-05-18T12:20:00.000Z');
+      const deliveryBlockNumber = 101n;
+      const scanHeadBlockNumber = 105n;
+      const deliveryBlockTimestampSeconds = Math.floor(Date.parse('2026-05-18T12:10:00.000Z') / 1000);
+      const scanHeadTimestampSeconds = Math.floor(Date.parse('2026-05-18T12:25:00.000Z') / 1000);
+
+      vi.mocked(decodeDeliverLogs).mockReturnValueOnce([{
+        requestId: REQUEST_ID,
+        deliveryDataHex: TASK_CID_DIGEST,
+        mechAddress: TEST_CONFIG.safeAddress,
+        blockNumber: deliveryBlockNumber,
+      }]);
+      vi.mocked(fetchFromIpfs).mockResolvedValueOnce({ data: 'result' });
+
+      const adapter = new MechAdapter({ ...TEST_CONFIG, pollIntervalMs: 1 });
+      await adapter.initialize();
+      (adapter as any).publicClient.getBlockNumber = vi.fn().mockResolvedValue(scanHeadBlockNumber);
+      (adapter as any).publicClient.getBlock = vi.fn(async ({ blockNumber }: { blockNumber: bigint }) => {
+        if (blockNumber === deliveryBlockNumber) {
+          return { timestamp: BigInt(deliveryBlockTimestampSeconds) };
+        }
+        if (blockNumber === scanHeadBlockNumber) {
+          return { timestamp: BigInt(scanHeadTimestampSeconds) };
+        }
+        throw new Error(`unexpected block lookup: ${blockNumber}`);
+      });
+      (adapter as any).publicClient.getLogs = vi.fn().mockResolvedValue([{ data: '0x', topics: [] }]);
+      (adapter as any).deliveryBlockCursor = 100n;
+      const taskWithinDeadlineAtEmit = {
+        id: 'prediction-task-1',
+        description: 'recovery task emitted before expiry',
+        claimPolicy: {
+          mode: 'exclusive',
+          maxClaims: 1,
+          maxClaimsPerOperator: 1,
+          claimLeaseTtlSeconds: 600,
+          claimWindowEndTs,
+          submissionDeadlineTs,
+        },
+      };
+      (adapter as any).pendingEvaluations.set(REQUEST_ID, taskWithinDeadlineAtEmit);
+      (adapter as any).originalStates.set(REQUEST_ID, taskWithinDeadlineAtEmit);
+      (adapter as any).requestKinds.set(REQUEST_ID, 'solution');
+
+      const gen = adapter.watchForDeliveries()[Symbol.asyncIterator]();
+      const { value } = await gen.next();
+
+      expect((adapter as any).publicClient.getBlock).toHaveBeenCalledWith({ blockNumber: deliveryBlockNumber });
+      expect((adapter as any).publicClient.getBlock).not.toHaveBeenCalledWith({ blockNumber: scanHeadBlockNumber });
+      expect(claimDelivery).toHaveBeenCalledOnce();
+      expect(fetchFromIpfs).toHaveBeenCalledOnce();
+      expect(value).toMatchObject({
+        requestId: REQUEST_ID,
+        task: taskWithinDeadlineAtEmit,
+        result: { data: 'result' },
+        deliveryMechAddress: TEST_CONFIG.safeAddress,
+      });
+
+      await adapter.stop();
+      const donePromise = gen.next();
+      await vi.advanceTimersByTimeAsync(5);
+      await expect(donePromise).resolves.toMatchObject({ done: true, value: undefined });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('watchForDeliveries skips recovery deliveries once the submission deadline has passed on chain', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-18T12:05:00.000Z'));
@@ -1156,6 +1233,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
         requestId: REQUEST_ID,
         deliveryDataHex: TASK_CID_DIGEST,
         mechAddress: TEST_CONFIG.safeAddress,
+        blockNumber: 101n,
       }]);
 
       const adapter = new MechAdapter({ ...TEST_CONFIG, pollIntervalMs: 1 });
@@ -1227,6 +1305,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
       requestId: REQUEST_ID,
       deliveryDataHex: TASK_CID_DIGEST,
       mechAddress: '0x9999999999999999999999999999999999999999',
+      blockNumber: 101n,
     }]);
 
     const adapter = new MechAdapter({ ...TEST_CONFIG, routerClaimDeliveryVariant: 'v2' });

--- a/client/test/adapters/mech/adapter.test.ts
+++ b/client/test/adapters/mech/adapter.test.ts
@@ -1072,14 +1072,85 @@ describe('MechAdapter TaskCoordinator flow', () => {
     await adapter.stop();
   });
 
-  it('watchForDeliveries skips expired recovery delivery work once the claim window has ended', async () => {
+  it('watchForDeliveries still claims recovery deliveries while the submission deadline remains open', async () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-05-18T12:00:00.000Z'));
+    vi.setSystemTime(new Date('2026-05-18T12:30:00.000Z'));
 
     try {
       const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
       const { claimDelivery, decodeDeliverLogs } = await import('../../../src/adapters/mech/contracts.js');
       const { fetchFromIpfs } = await import('../../../src/adapters/mech/ipfs.js');
+      const claimWindowEndTs = Date.parse('2026-05-18T12:00:00.000Z');
+      const submissionDeadlineTs = Date.parse('2026-05-18T12:20:00.000Z');
+      const blockTimestampSeconds = Math.floor(Date.parse('2026-05-18T12:10:00.000Z') / 1000);
+
+      vi.mocked(decodeDeliverLogs).mockReturnValueOnce([{
+        requestId: REQUEST_ID,
+        deliveryDataHex: TASK_CID_DIGEST,
+        mechAddress: TEST_CONFIG.safeAddress,
+      }]);
+      vi.mocked(fetchFromIpfs).mockResolvedValueOnce({ data: 'result' });
+
+      const adapter = new MechAdapter({ ...TEST_CONFIG, pollIntervalMs: 1 });
+      await adapter.initialize();
+      (adapter as any).publicClient.getBlockNumber = vi.fn().mockResolvedValue(101n);
+      (adapter as any).publicClient.getBlock = vi.fn().mockResolvedValue({ timestamp: BigInt(blockTimestampSeconds) });
+      (adapter as any).publicClient.getLogs = vi.fn().mockResolvedValue([{ data: '0x', topics: [] }]);
+      (adapter as any).deliveryBlockCursor = 100n;
+      const taskWithinLease = {
+        id: 'prediction-task-1',
+        description: 'recovery task still within submission deadline',
+        claimPolicy: {
+          mode: 'exclusive',
+          maxClaims: 1,
+          maxClaimsPerOperator: 1,
+          claimLeaseTtlSeconds: 600,
+          claimWindowEndTs,
+          submissionDeadlineTs,
+        },
+      };
+      (adapter as any).pendingEvaluations.set(REQUEST_ID, taskWithinLease);
+      (adapter as any).originalStates.set(REQUEST_ID, taskWithinLease);
+      (adapter as any).requestKinds.set(REQUEST_ID, 'solution');
+
+      const gen = adapter.watchForDeliveries()[Symbol.asyncIterator]();
+      const { value } = await gen.next();
+
+      expect((adapter as any).publicClient.getBlock).toHaveBeenCalledWith({ blockNumber: 101n });
+      expect(claimDelivery).toHaveBeenCalledOnce();
+      expect(fetchFromIpfs).toHaveBeenCalledOnce();
+      expect(value).toMatchObject({
+        requestId: REQUEST_ID,
+        task: taskWithinLease,
+        result: { data: 'result' },
+        deliveryMechAddress: TEST_CONFIG.safeAddress,
+      });
+
+      await adapter.stop();
+      const donePromise = gen.next();
+      await vi.advanceTimersByTimeAsync(5);
+      await expect(donePromise).resolves.toMatchObject({ done: true, value: undefined });
+
+      expect((adapter as any).pendingEvaluations.has(REQUEST_ID)).toBe(false);
+      expect((adapter as any).originalStates.has(REQUEST_ID)).toBe(false);
+      expect((adapter as any).requestKinds.has(REQUEST_ID)).toBe(false);
+
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('watchForDeliveries skips recovery deliveries once the submission deadline has passed on chain', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-18T12:05:00.000Z'));
+
+    try {
+      const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+      const { claimDelivery, decodeDeliverLogs } = await import('../../../src/adapters/mech/contracts.js');
+      const { fetchFromIpfs } = await import('../../../src/adapters/mech/ipfs.js');
+      const claimWindowEndTs = Date.parse('2026-05-18T12:00:00.000Z');
+      const submissionDeadlineTs = Date.parse('2026-05-18T12:20:00.000Z');
+      const blockTimestampSeconds = Math.floor(Date.parse('2026-05-18T12:20:01.000Z') / 1000);
 
       vi.mocked(decodeDeliverLogs).mockReturnValueOnce([{
         requestId: REQUEST_ID,
@@ -1090,6 +1161,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
       const adapter = new MechAdapter({ ...TEST_CONFIG, pollIntervalMs: 1 });
       await adapter.initialize();
       (adapter as any).publicClient.getBlockNumber = vi.fn().mockResolvedValue(101n);
+      (adapter as any).publicClient.getBlock = vi.fn().mockResolvedValue({ timestamp: BigInt(blockTimestampSeconds) });
       (adapter as any).publicClient.getLogs = vi.fn().mockResolvedValue([{ data: '0x', topics: [] }]);
       (adapter as any).deliveryBlockCursor = 100n;
       const expiredTask = {
@@ -1100,7 +1172,8 @@ describe('MechAdapter TaskCoordinator flow', () => {
           maxClaims: 1,
           maxClaimsPerOperator: 1,
           claimLeaseTtlSeconds: 600,
-          claimWindowEndTs: Date.now() - 1_000,
+          claimWindowEndTs,
+          submissionDeadlineTs,
         },
       };
       (adapter as any).pendingEvaluations.set(REQUEST_ID, expiredTask);
@@ -1112,6 +1185,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
 
       await vi.advanceTimersByTimeAsync(5);
 
+      expect((adapter as any).publicClient.getBlock).toHaveBeenCalledWith({ blockNumber: 101n });
       expect(claimDelivery).not.toHaveBeenCalled();
       expect(fetchFromIpfs).not.toHaveBeenCalled();
       expect((adapter as any).pendingEvaluations.has(REQUEST_ID)).toBe(false);

--- a/client/test/adapters/mech/adapter.test.ts
+++ b/client/test/adapters/mech/adapter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { MechAdapterConfig } from '../../../src/adapters/mech/types.js';
+import { VerdictCode } from '../../../src/adapters/mech/verdict-code.js';
 import type { SignedTaskV1 } from '../../../src/types/task-document.js';
 import type { DiscoveryAPI, ClaimableTaskCandidate } from '../../../src/discovery/types.js';
 import { DiscoveryUnavailableError } from '../../../src/discovery/types.js';
@@ -112,6 +113,7 @@ vi.mock('../../../src/harnesses/engine/canonical-json.js', () => ({
 
 // MOCK_JUSTIFICATION: envelope schema validation is covered in envelope tests; here we isolate adapter routing logic.
 vi.mock('../../../src/types/envelope.js', () => ({
+  normalizeEnvelopeRole: vi.fn((role: unknown) => role === 'restoration' ? 'solution' : role),
   SignedEnvelopeSchema: {
     parse: vi.fn(),
   },
@@ -1326,6 +1328,67 @@ describe('MechAdapter TaskCoordinator flow', () => {
       TEST_CONFIG.routerAddress,
       REQUEST_ID,
       { variant: 'v2', kind: 'solution', evidenceHash: expectedHash },
+      undefined,
+    );
+    expect(fetchSignedEnvelopeFromIpfs).toHaveBeenCalledWith(TEST_CONFIG.ipfsGatewayUrl, TASK_CID);
+
+    await adapter.stop();
+  });
+
+  it('watchForDeliveries derives verdict claim metadata from the signed verdict envelope on retry', async () => {
+    const { keccak256 } = await import('viem');
+    const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+    const { claimDelivery, decodeDeliverLogs } = await import('../../../src/adapters/mech/contracts.js');
+    const { fetchSignedEnvelopeFromIpfs, fetchFromIpfs } = await import('../../../src/adapters/mech/ipfs.js');
+    const { SignedEnvelopeSchema } = await import('../../../src/types/envelope.js');
+
+    const expectedHash = keccak256(new TextEncoder().encode('{"mocked":"jcs"}'));
+    const fakeEnvelope = {
+      schemaVersion: 'jinn.execution.v1',
+      solverType: 'prediction.v1',
+      role: 'verdict',
+      payload: {
+        verdict: 'REJECTED',
+      },
+      signature: {
+        algo: 'secp256k1',
+        signer: '0xabc',
+        hash: expectedHash,
+        sig: '0xsig',
+      },
+    };
+    vi.mocked(fetchSignedEnvelopeFromIpfs).mockResolvedValueOnce(fakeEnvelope);
+    vi.mocked((SignedEnvelopeSchema as any).parse).mockReturnValue(fakeEnvelope);
+    vi.mocked(fetchFromIpfs).mockResolvedValueOnce({ data: 'verdict' });
+    vi.mocked(decodeDeliverLogs).mockReturnValueOnce([{
+      requestId: REQUEST_ID,
+      deliveryDataHex: TASK_CID_DIGEST,
+      mechAddress: '0x9999999999999999999999999999999999999999',
+    }]);
+
+    const adapter = new MechAdapter({ ...TEST_CONFIG, routerClaimDeliveryVariant: 'v3' });
+    await adapter.initialize();
+    (adapter as any).publicClient.getBlockNumber = vi.fn().mockResolvedValue(101n);
+    (adapter as any).publicClient.getLogs = vi.fn().mockResolvedValue([{ data: '0x', topics: [] }]);
+    (adapter as any).deliveryBlockCursor = 100n;
+    (adapter as any).pendingEvaluations.set(REQUEST_ID, { id: 'prediction-task-1', description: 'test', role: 'evaluation' });
+    (adapter as any).originalStates.set(REQUEST_ID, { id: 'prediction-task-1', description: 'test', role: 'evaluation' });
+
+    const gen = adapter.watchForDeliveries()[Symbol.asyncIterator]();
+    await gen.next();
+
+    expect(claimDelivery).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      TEST_CONFIG.safeAddress,
+      TEST_CONFIG.routerAddress,
+      REQUEST_ID,
+      {
+        variant: 'v3',
+        kind: 'verdict',
+        evidenceHash: expectedHash,
+        verdictCode: VerdictCode.Fail,
+      },
       undefined,
     );
     expect(fetchSignedEnvelopeFromIpfs).toHaveBeenCalledWith(TEST_CONFIG.ipfsGatewayUrl, TASK_CID);

--- a/client/test/adapters/mech/adapter.test.ts
+++ b/client/test/adapters/mech/adapter.test.ts
@@ -1072,6 +1072,61 @@ describe('MechAdapter TaskCoordinator flow', () => {
     await adapter.stop();
   });
 
+  it('watchForDeliveries skips expired recovery delivery work once the claim window has ended', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-18T12:00:00.000Z'));
+
+    try {
+      const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+      const { claimDelivery, decodeDeliverLogs } = await import('../../../src/adapters/mech/contracts.js');
+      const { fetchFromIpfs } = await import('../../../src/adapters/mech/ipfs.js');
+
+      vi.mocked(decodeDeliverLogs).mockReturnValueOnce([{
+        requestId: REQUEST_ID,
+        deliveryDataHex: TASK_CID_DIGEST,
+        mechAddress: TEST_CONFIG.safeAddress,
+      }]);
+
+      const adapter = new MechAdapter({ ...TEST_CONFIG, pollIntervalMs: 1 });
+      await adapter.initialize();
+      (adapter as any).publicClient.getBlockNumber = vi.fn().mockResolvedValue(101n);
+      (adapter as any).publicClient.getLogs = vi.fn().mockResolvedValue([{ data: '0x', topics: [] }]);
+      (adapter as any).deliveryBlockCursor = 100n;
+      const expiredTask = {
+        id: 'prediction-task-1',
+        description: 'expired recovery task',
+        claimPolicy: {
+          mode: 'exclusive',
+          maxClaims: 1,
+          maxClaimsPerOperator: 1,
+          claimLeaseTtlSeconds: 600,
+          claimWindowEndTs: Date.now() - 1_000,
+        },
+      };
+      (adapter as any).pendingEvaluations.set(REQUEST_ID, expiredTask);
+      (adapter as any).originalStates.set(REQUEST_ID, expiredTask);
+      (adapter as any).requestKinds.set(REQUEST_ID, 'solution');
+
+      const gen = adapter.watchForDeliveries()[Symbol.asyncIterator]();
+      const nextPromise = gen.next();
+
+      await vi.advanceTimersByTimeAsync(5);
+
+      expect(claimDelivery).not.toHaveBeenCalled();
+      expect(fetchFromIpfs).not.toHaveBeenCalled();
+      expect((adapter as any).pendingEvaluations.has(REQUEST_ID)).toBe(false);
+      expect((adapter as any).originalStates.has(REQUEST_ID)).toBe(false);
+      expect((adapter as any).requestKinds.has(REQUEST_ID)).toBe(false);
+
+      await adapter.stop();
+      await vi.advanceTimersByTimeAsync(5);
+
+      await expect(nextPromise).resolves.toMatchObject({ done: true, value: undefined });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('V2 claimDelivery derives evidenceHash from the signed execution envelope', async () => {
     const { keccak256 } = await import('viem');
     const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');


### PR DESCRIPTION
## Summary
- derive claim metadata from the signed delivery envelope during retry
- preserve verdict kind and verdictCode when replaying delivery claims
- add Mech adapter coverage for retried verdict deliveries

## Validation
- `PATH=$HOME/.nvm/versions/node/v22.22.2/bin:$PATH yarn --cwd client vitest run test/adapters/mech/adapter.test.ts`