### PR TITLE
fix: cut operator log noise so real failures stay visible

### DIFF
--- a/client/src/daemon/daemon.ts
+++ b/client/src/daemon/daemon.ts
@@ -20,6 +20,7 @@ import { StaticConfiguredTaskSource, type TaskSource } from '../tasks/sources.js
 import type { Task } from '../types/index.js';
 import type { HarnessReadinessRegistry } from '../harnesses/readiness-registry.js';
 import { gateClaimByReadiness } from './readiness-gate.js';
+import { SkipLogDeduper } from './skip-log-dedup.js';
 
 const DEFAULT_API_PORT = 7331;
 
@@ -169,6 +170,7 @@ export class Daemon {
   private rewardClaimLoop?: RewardClaimLoop;
   private balanceTopupLoop?: BalanceTopupLoop;
   private jinnClaimLoop?: JinnClaimLoop;
+  private skipLogDeduper = new SkipLogDeduper();
 
   constructor(private readonly config: DaemonConfig) {
     if (config.store) {
@@ -426,9 +428,19 @@ export class Daemon {
       const taskRole = (taskAnnouncement.task.role ?? 'restoration') as 'restoration' | 'evaluation';
       const accept = await engine.canAcceptTask({ solverType, taskRole, task: taskAnnouncement.task });
       if (!accept.ok) {
-        console.log(`[daemon] skipping task ${taskAnnouncement.taskId} — ${accept.reason}`);
+        // Dedupe per (taskId, reason): on a single-slot daemon the engine-watcher
+        // re-observes every pending task each pass, so the original `console.log`
+        // here produced hundreds of identical "another … task is already in flight"
+        // lines per minute. We log once per (taskId, reason) and stay quiet until
+        // the reason for skipping changes (jinn-mono-kzan).
+        if (this.skipLogDeduper.shouldLog(taskAnnouncement.taskId, accept.reason)) {
+          console.log(`[daemon] skipping task ${taskAnnouncement.taskId} — ${accept.reason}`);
+        }
         continue;
       }
+      // Task is acceptable now; reset dedupe state so a future skip (e.g. after
+      // this slot fills again) logs once instead of being silently swallowed.
+      this.skipLogDeduper.forget(taskAnnouncement.taskId);
 
       // Readiness gate: if the task's harness is not ready (e.g. claude unauthenticated),
       // skip this task without blocking other loops. Logs once per ready↔not-ready transition.

--- a/client/src/daemon/skip-log-dedup.ts
+++ b/client/src/daemon/skip-log-dedup.ts
@@ -1,0 +1,47 @@
+/**
+ * Dedupes "[daemon] skipping task X — reason" log lines so the engine-watcher
+ * loop doesn't emit hundreds of identical lines per minute when a single in-flight
+ * slot is occupied. The original loop logged once per `(taskId, reason)` per
+ * pass; this helper collapses repeat lines down to one per `(taskId, reason)`
+ * pair until the reason changes (or the entry is evicted to keep memory bounded).
+ *
+ * See jinn-mono-kzan.
+ */
+export class SkipLogDeduper {
+  private lastReasonByTaskId = new Map<string, string>();
+  private readonly maxEntries: number;
+
+  constructor(maxEntries = 1024) {
+    this.maxEntries = Math.max(1, maxEntries);
+  }
+
+  /**
+   * Returns true when this `(taskId, reason)` pair has not been logged yet
+   * (or the previous reason for this `taskId` was different). Returns false
+   * when the previous skip for this task had the same reason — operators
+   * already saw the line; another copy is noise.
+   */
+  shouldLog(taskId: string, reason: string): boolean {
+    const previous = this.lastReasonByTaskId.get(taskId);
+    if (previous === reason) {
+      // Refresh recency so we don't evict an actively-skipped task.
+      this.lastReasonByTaskId.delete(taskId);
+      this.lastReasonByTaskId.set(taskId, reason);
+      return false;
+    }
+    this.lastReasonByTaskId.set(taskId, reason);
+    if (this.lastReasonByTaskId.size > this.maxEntries) {
+      // Map iteration is insertion-order; evict the oldest entry.
+      const oldestKey = this.lastReasonByTaskId.keys().next().value;
+      if (oldestKey !== undefined) {
+        this.lastReasonByTaskId.delete(oldestKey);
+      }
+    }
+    return true;
+  }
+
+  /** Forget the last-logged reason for `taskId` (e.g. when the task is claimed). */
+  forget(taskId: string): void {
+    this.lastReasonByTaskId.delete(taskId);
+  }
+}

--- a/client/src/erc8004/reputation.ts
+++ b/client/src/erc8004/reputation.ts
@@ -705,11 +705,31 @@ function defaultLog(entry: {
   msg: string;
   data?: unknown;
 }): void {
+  const rendered = formatLogData(entry.data);
+  const line = rendered ? `${entry.msg} ${rendered}` : entry.msg;
   if (entry.level === 'error') {
-    console.error(entry.msg, entry.data ?? '');
+    console.error(line);
   } else if (entry.level === 'warn') {
-    console.warn(entry.msg, entry.data ?? '');
+    console.warn(line);
   } else {
-    console.log(entry.msg, entry.data ?? '');
+    console.log(line);
+  }
+}
+
+/**
+ * Render `data` for stdout. Plain `console.log(msg, obj)` prints `[object Object]`
+ * when stdout is non-TTY (e.g. piped through the operator console), which loses
+ * the structured payload operators actually need (verdict, score, txHash, …).
+ * JSON.stringify with a BigInt-safe replacer keeps the line readable in both
+ * TTY and non-TTY contexts. Exported for unit coverage.
+ */
+export function formatLogData(data: unknown): string {
+  if (data === undefined || data === null) return '';
+  try {
+    return JSON.stringify(data, (_key, value) =>
+      typeof value === 'bigint' ? value.toString() : value,
+    );
+  } catch {
+    return String(data);
   }
 }

--- a/client/src/harnesses/engine/engine.ts
+++ b/client/src/harnesses/engine/engine.ts
@@ -673,6 +673,7 @@ export class TaskEngine {
     }
     if (current.state === TaskRunState.DISCOVERED) {
       this.persistence.transition(task.requestId, TaskRunState.CLAIMED);
+      console.log(`[harness-engine] ${task.requestId} DISCOVERED → CLAIMED`);
     } else {
       console.log(
         `[harness-engine] ${task.requestId}: claim completed but state is already ${current.state}; skipping CLAIMED transition`,
@@ -1969,13 +1970,15 @@ export class TaskEngine {
     task: PersistedTaskRun,
     fn: () => Promise<void>,
   ): Promise<void> {
-    const oldState = task.state;
+    // Each transition method (claim, takePreSnapshot, runImpl, pack, deliver)
+    // logs its own domain-specific line on success (e.g. with manifestCid,
+    // deliveryTx, impl name). We deliberately don't emit a generic
+    // `oldState → newState` line here: doing so produced duplicate
+    // transition lines in the operator log (jinn-mono-kzan). On failure,
+    // the catch below marks the task FAILED and rethrows so the caller can
+    // surface the error.
     try {
       await fn();
-      const updated = this.persistence.getByRequestId(task.requestId);
-      if (updated && updated.state !== oldState) {
-        console.log(`[harness-engine] ${task.requestId} ${oldState} → ${updated.state}`);
-      }
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       this.persistence.markFailed(task.requestId, reason);

--- a/client/test/daemon/skip-log-dedup.test.ts
+++ b/client/test/daemon/skip-log-dedup.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { SkipLogDeduper } from '../../src/daemon/skip-log-dedup.js';
+
+describe('SkipLogDeduper (jinn-mono-kzan)', () => {
+  it('logs the first skip for a (taskId, reason) pair and suppresses repeats', () => {
+    const dedup = new SkipLogDeduper();
+    const reason = 'another swe-rebench-v2.v1/restoration task is already in flight';
+
+    expect(dedup.shouldLog('84', reason)).toBe(true);
+    expect(dedup.shouldLog('84', reason)).toBe(false);
+    expect(dedup.shouldLog('84', reason)).toBe(false);
+  });
+
+  it('re-logs when the reason for the same taskId changes', () => {
+    const dedup = new SkipLogDeduper();
+    expect(dedup.shouldLog('84', 'slot busy')).toBe(true);
+    expect(dedup.shouldLog('84', 'slot busy')).toBe(false);
+    expect(dedup.shouldLog('84', 'harness not ready')).toBe(true);
+    expect(dedup.shouldLog('84', 'harness not ready')).toBe(false);
+  });
+
+  it('treats different taskIds independently', () => {
+    const dedup = new SkipLogDeduper();
+    const reason = 'slot busy';
+    expect(dedup.shouldLog('84', reason)).toBe(true);
+    expect(dedup.shouldLog('85', reason)).toBe(true);
+    expect(dedup.shouldLog('84', reason)).toBe(false);
+    expect(dedup.shouldLog('85', reason)).toBe(false);
+  });
+
+  it('forget() re-arms logging for a taskId', () => {
+    const dedup = new SkipLogDeduper();
+    expect(dedup.shouldLog('84', 'slot busy')).toBe(true);
+    expect(dedup.shouldLog('84', 'slot busy')).toBe(false);
+    dedup.forget('84');
+    expect(dedup.shouldLog('84', 'slot busy')).toBe(true);
+  });
+
+  it('evicts oldest entries when maxEntries is exceeded (FIFO bound)', () => {
+    const dedup = new SkipLogDeduper(2);
+    expect(dedup.shouldLog('1', 'reason')).toBe(true);
+    expect(dedup.shouldLog('2', 'reason')).toBe(true);
+    // '1' and '2' are still tracked; logging them again is a dedup hit.
+    expect(dedup.shouldLog('1', 'reason')).toBe(false);
+    expect(dedup.shouldLog('2', 'reason')).toBe(false);
+    // Inserting a third entry evicts the oldest ('1').
+    expect(dedup.shouldLog('3', 'reason')).toBe(true);
+    // '1' was evicted, so the next skip for '1' logs again.
+    expect(dedup.shouldLog('1', 'reason')).toBe(true);
+  });
+});

--- a/client/test/erc8004/reputation-default-log.test.ts
+++ b/client/test/erc8004/reputation-default-log.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { formatLogData } from '../../src/erc8004/reputation.js';
+
+describe('reputation defaultLog formatting (jinn-mono-kzan)', () => {
+  it('renders a structured payload as inspectable JSON instead of [object Object]', () => {
+    const rendered = formatLogData({
+      harnessAgentId: '42',
+      verdict: 'PASS',
+      score: 100,
+      scoreDecimals: 2,
+      manifestCid: 'bafyabc',
+      txHash: '0xdeadbeef',
+    });
+
+    expect(rendered).not.toBe('[object Object]');
+    expect(rendered).toContain('"harnessAgentId":"42"');
+    expect(rendered).toContain('"verdict":"PASS"');
+    expect(rendered).toContain('"txHash":"0xdeadbeef"');
+  });
+
+  it('serialises BigInt values as decimal strings (BigInt-safe replacer)', () => {
+    const rendered = formatLogData({ harnessAgentId: 42n, score: 100 });
+    expect(rendered).toContain('"harnessAgentId":"42"');
+    expect(rendered).toContain('"score":100');
+  });
+
+  it('returns an empty string for null / undefined data so the message stays bare', () => {
+    expect(formatLogData(undefined)).toBe('');
+    expect(formatLogData(null)).toBe('');
+  });
+
+  it('falls back to String(data) when JSON.stringify throws (e.g. circular refs)', () => {
+    const circular: Record<string, unknown> = {};
+    circular['self'] = circular;
+    const rendered = formatLogData(circular);
+    expect(rendered).toContain('[object Object]');
+  });
+});

--- a/client/test/harnesses/engine/transition-log-dedup.test.ts
+++ b/client/test/harnesses/engine/transition-log-dedup.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Store } from '../../../src/store/store.js';
+import {
+  TaskEngine,
+  NotImplementedError,
+  type TaskEngineOptions,
+} from '../../../src/harnesses/engine/engine.js';
+import {
+  type PersistedTaskRun,
+  type PersistedTaskRunInput,
+  TaskRunPersistence,
+} from '../../../src/harnesses/engine/persistence.js';
+import { TaskRunState } from '../../../src/harnesses/engine/state.js';
+
+function makeOpts(store: Store): TaskEngineOptions {
+  return {
+    store,
+    paths: { workingDirRoot: '/tmp/work', implStateDirRoot: '/tmp/impl' },
+  };
+}
+
+function makeInput(overrides: Partial<PersistedTaskRunInput> = {}): PersistedTaskRunInput {
+  const now = Date.now();
+  return {
+    requestId: 'req-log-001',
+    taskCid: 'bafylog',
+    onchainCreationTx: '0xtx',
+    onchainCreationBlock: 1,
+    solverType: 'portfolio.v0',
+    windowStartTs: now + 60_000,
+    windowEndTs: now + 60_000 + 86_400_000,
+    task: { id: 'req-log-001', description: 't', solverType: 'portfolio.v0', role: 'restoration' },
+    ...overrides,
+  };
+}
+
+class TestEngine extends TaskEngine {
+  runImplFn?: (run: PersistedTaskRun) => Promise<void>;
+
+  override async runImpl(run: PersistedTaskRun): Promise<void> {
+    if (this.runImplFn) return this.runImplFn(run);
+    throw new NotImplementedError('runImpl');
+  }
+
+  get testPersistence(): TaskRunPersistence {
+    return this.persistence;
+  }
+}
+
+describe('transition log dedup (jinn-mono-kzan)', () => {
+  let store: Store;
+  let engine: TestEngine;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    store = new Store(':memory:');
+    engine = new TestEngine(makeOpts(store));
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    store.close();
+  });
+
+  function transitionLines(): string[] {
+    return logSpy.mock.calls
+      .map((args) => String(args[0] ?? ''))
+      .filter((line) => /\[harness-engine\].*→/.test(line));
+  }
+
+  it('emits exactly one transition line per RUNNING → POST_SNAPSHOT (not the duplicate bare line)', async () => {
+    await engine.observe(makeInput());
+    engine.testPersistence.transition('req-log-001', TaskRunState.CLAIMED);
+    engine.testPersistence.transition('req-log-001', TaskRunState.WAITING);
+    engine.testPersistence.transition('req-log-001', TaskRunState.PRE_SNAPSHOT);
+    engine.testPersistence.transition('req-log-001', TaskRunState.RUNNING);
+
+    engine.runImplFn = async (run) => {
+      // Mirror the production runImpl behavior: log a domain-specific line,
+      // then advance state.
+      console.log(`[harness-engine] ${run.requestId} RUNNING → POST_SNAPSHOT via impl=test-impl`);
+      engine.testPersistence.transition(run.requestId, TaskRunState.POST_SNAPSHOT);
+    };
+
+    await engine.process('req-log-001');
+
+    const lines = transitionLines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toBe(
+      '[harness-engine] req-log-001 RUNNING → POST_SNAPSHOT via impl=test-impl',
+    );
+    // The previous generic line `RUNNING → POST_SNAPSHOT` must not be emitted alongside it.
+    expect(lines.some((l) => /RUNNING → POST_SNAPSHOT$/.test(l))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- dedupe repeated transition and reputation log lines
- keep operator logs focused on state changes and actionable failures
- add regression coverage for the log suppression paths

## Validation
- `PATH=$HOME/.nvm/versions/node/v22.22.2/bin:$PATH yarn --cwd client vitest run test/daemon/skip-log-dedup.test.ts test/erc8004/reputation-default-log.test.ts test/harnesses/engine/transition-log-dedup.test.ts`