### PR TITLE
fix: scope failed counters to the joined SolverNet

### DIFF
--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -240,6 +240,8 @@ function predictionV1Unavailable(
       solutions: 0,
       verdicts: 0,
       failed: 0,
+      settledFailed: 0,
+      localErrors: 0,
     },
     latest: {
       taskAt: null,

--- a/client/src/api/portfolio-v0-build.ts
+++ b/client/src/api/portfolio-v0-build.ts
@@ -79,7 +79,17 @@ export interface PortfolioV0Status {
   totals: {
     /** Tasks that reached terminal success and delivered their result. */
     delivered: number;
+    /**
+     * Sum of `settledFailed` and `localErrors`. Retained for callers that
+     * still want a single failure count; new surfaces should prefer the
+     * split fields to distinguish on-chain settled fails from local
+     * engine errors.
+     */
     failed: number;
+    /** FAILED runs whose delivery tx landed on-chain (settled failure). */
+    settledFailed: number;
+    /** FAILED runs that never reached the marketplace (local engine error). */
+    localErrors: number;
     active: number;
   };
   /** Tasks currently being processed (not in a terminal state). */
@@ -153,9 +163,13 @@ export function gatherPortfolioV0Status(
     (a, b) => b.stateUpdatedAt - a.stateUpdatedAt,
   );
   const recentVerdicts = allTerminal.slice(0, RECENT_VERDICTS_LIMIT).map(toVerdict);
+  const settledFailed = failed.filter((task) => task.deliveryTxHash !== null);
+  const localErrors = failed.filter((task) => task.deliveryTxHash === null);
   const totals = {
     delivered: complete.length,
     failed: failed.length,
+    settledFailed: settledFailed.length,
+    localErrors: localErrors.length,
     active: inFlight.length,
   };
 

--- a/client/src/api/portfolio-v0-build.ts
+++ b/client/src/api/portfolio-v0-build.ts
@@ -153,12 +153,18 @@ export function gatherPortfolioV0Status(
 ): PortfolioV0Status {
   const persistence = new TaskRunPersistence(store.db);
 
-  // In-flight: all non-terminal task runs
-  const inFlight = persistence.getInFlight().map(toInFlightTask);
+  // portfolio.v0 is a solver-specific status payload — filter task_runs by
+  // `solverType === 'portfolio.v0'` so other SolverNets' runs don't leak
+  // into these counters (jinn-mono-0t6p). Pre-migration rows without a
+  // `solverType` value are excluded; today the persistence layer always
+  // threads the solver type at observe() time.
+  const inFlight = persistence.getInFlight().filter(isPortfolioV0Run);
+  const complete = persistence.getByState('COMPLETE').filter(isPortfolioV0Run);
+  const failed = persistence.getByState('FAILED').filter(isPortfolioV0Run);
+
+  const inFlightSummaries = inFlight.map(toInFlightTask);
 
   // Recent verdicts: last N COMPLETE + FAILED task runs combined, newest first
-  const complete = persistence.getByState('COMPLETE');
-  const failed = persistence.getByState('FAILED');
   const allTerminal = [...complete, ...failed].sort(
     (a, b) => b.stateUpdatedAt - a.stateUpdatedAt,
   );
@@ -194,7 +200,17 @@ export function gatherPortfolioV0Status(
 
   const recentClaudeOutcomes = gatherRecentClaudeOutcomes(workingDirRoot);
 
-  return { totals, inFlight, recentVerdicts, recentSnapshots, recentClaudeOutcomes };
+  return {
+    totals,
+    inFlight: inFlightSummaries,
+    recentVerdicts,
+    recentSnapshots,
+    recentClaudeOutcomes,
+  };
+}
+
+function isPortfolioV0Run(run: PersistedTaskRun): boolean {
+  return run.solverType === 'portfolio.v0';
 }
 
 /**

--- a/client/src/api/portfolio-v0-build.ts
+++ b/client/src/api/portfolio-v0-build.ts
@@ -15,6 +15,7 @@ import { join } from 'node:path';
 import type { Store } from '../store/store.js';
 import { TaskRunPersistence } from '../harnesses/engine/persistence.js';
 import type { PersistedTaskRun } from '../harnesses/engine/persistence.js';
+import { taskRunRoutingKey } from './task-run-routing.js';
 
 /** Default per-task engine work root; kept in sync with `config.engine.workingDirRoot`. */
 export const DEFAULT_ENGINE_WORKING_DIR_ROOT = join(homedir(), '.jinn-client', 'engine', 'work');
@@ -154,10 +155,10 @@ export function gatherPortfolioV0Status(
   const persistence = new TaskRunPersistence(store.db);
 
   // portfolio.v0 is a solver-specific status payload — filter task_runs by
-  // `solverType === 'portfolio.v0'` so other SolverNets' runs don't leak
-  // into these counters (jinn-mono-0t6p). Pre-migration rows without a
-  // `solverType` value are excluded; today the persistence layer always
-  // threads the solver type at observe() time.
+  // the daemon's internal routing key so other SolverNets' runs don't leak
+  // into these counters (jinn-mono-0t6p) while historical rows can still be
+  // classified from canonical `contractId` / `contractVersion` or the legacy
+  // `task_payload.solverType` alias.
   const inFlight = persistence.getInFlight().filter(isPortfolioV0Run);
   const complete = persistence.getByState('COMPLETE').filter(isPortfolioV0Run);
   const failed = persistence.getByState('FAILED').filter(isPortfolioV0Run);
@@ -210,7 +211,7 @@ export function gatherPortfolioV0Status(
 }
 
 function isPortfolioV0Run(run: PersistedTaskRun): boolean {
-  return run.solverType === 'portfolio.v0';
+  return taskRunRoutingKey(run) === 'portfolio.v0';
 }
 
 /**

--- a/client/src/api/prediction-v1-build.ts
+++ b/client/src/api/prediction-v1-build.ts
@@ -9,6 +9,7 @@
 import type { Store } from '../store/store.js';
 import { TaskRunPersistence, type PersistedTaskRun } from '../harnesses/engine/persistence.js';
 import type { PredictionOperatorStatus } from '../solver-nets/prediction-operator-ux.js';
+import { taskRunRoutingKey } from './task-run-routing.js';
 
 /**
  * Operator-mode visible roles. The launcher is configured per-net but is
@@ -124,7 +125,7 @@ export function gatherPredictionV1Status(
 }
 
 function isPredictionV1Run(run: PersistedTaskRun): boolean {
-  return run.solverType === 'prediction.v1';
+  return taskRunRoutingKey(run) === 'prediction.v1';
 }
 
 function taskIdentity(run: PersistedTaskRun): string {

--- a/client/src/api/prediction-v1-build.ts
+++ b/client/src/api/prediction-v1-build.ts
@@ -55,7 +55,16 @@ export interface PredictionV1Status {
     activeTaskRuns: number;
     solutions: number;
     verdicts: number;
+    /**
+     * Sum of `settledFailed` and `localErrors`. Retained for callers that
+     * still want the rolled-up count; new surfaces should prefer the split
+     * fields to align with the public explorer.
+     */
     failed: number;
+    /** FAILED runs whose delivery tx landed on-chain (settled failure). */
+    settledFailed: number;
+    /** FAILED runs that never reached the marketplace (local engine error). */
+    localErrors: number;
   };
   latest: {
     taskAt: number | null;
@@ -88,6 +97,8 @@ export function gatherPredictionV1Status(
   const verdicts = complete
     .filter((run) => run.taskRole === 'evaluation')
     .sort((a, b) => b.stateUpdatedAt - a.stateUpdatedAt);
+  const settledFailed = failed.filter((run) => run.deliveryTxHash !== null);
+  const localErrors = failed.filter((run) => run.deliveryTxHash === null);
 
   return {
     operator: options.operator ?? null,
@@ -98,6 +109,8 @@ export function gatherPredictionV1Status(
       solutions: solutions.length,
       verdicts: verdicts.length,
       failed: failed.length,
+      settledFailed: settledFailed.length,
+      localErrors: localErrors.length,
     },
     latest: {
       taskAt: latestAt(allRuns),

--- a/client/src/api/task-run-routing.ts
+++ b/client/src/api/task-run-routing.ts
@@ -1,0 +1,13 @@
+import type { PersistedTaskRun } from '../harnesses/engine/persistence.js';
+
+/**
+ * Mirrors the daemon's internal routing-key compatibility logic so status
+ * builders can keep classifying legacy task_runs rows during the
+ * `solverType` -> `contractId`/`contractVersion` migration.
+ */
+export function taskRunRoutingKey(run: PersistedTaskRun): string | undefined {
+  if (run.task?.contractId && run.task?.contractVersion) {
+    return `${run.task.contractId}.${run.task.contractVersion}`;
+  }
+  return run.solverType ?? run.task?.solverType ?? undefined;
+}

--- a/client/src/api/task-runs-build.ts
+++ b/client/src/api/task-runs-build.ts
@@ -26,7 +26,27 @@ export interface TaskRunsStatus {
     completed: number;
     solutions: number;
     verdicts: number;
+    /**
+     * Sum of `settledFailed` and `localErrors`. Retained for callers that
+     * still want the rolled-up count, but operator surfaces should prefer
+     * the split fields so the on-chain vs. local distinction is visible.
+     */
     failed: number;
+    /**
+     * FAILED task runs whose `delivery_tx_hash` landed on-chain before the
+     * run terminated — the marketplace recorded the delivery and a
+     * downstream step (claimDelivery, on-chain verdict) marked it as a
+     * settled failure. This is the count that should align with the public
+     * explorer's per-operator fail count.
+     */
+    settledFailed: number;
+    /**
+     * FAILED task runs with no on-chain delivery tx — the run never reached
+     * the marketplace (SkippableError, claim-time rejects, runner crashes,
+     * recovery aborts). Operator-only debugging signal; not visible on
+     * the public explorer.
+     */
+    localErrors: number;
   };
   inFlight: TaskRunSummary[];
   recentTasks: TaskRunSummary[];
@@ -41,6 +61,8 @@ export function gatherTaskRunsStatus(store: Store): TaskRunsStatus {
   const allRecent = [...allRuns].sort((a, b) => b.stateUpdatedAt - a.stateUpdatedAt);
   const solutions = complete.filter((run) => run.taskRole !== 'evaluation');
   const verdicts = complete.filter((run) => run.taskRole === 'evaluation');
+  const settledFailed = failed.filter((run) => run.deliveryTxHash !== null);
+  const localErrors = failed.filter((run) => run.deliveryTxHash === null);
 
   return {
     totals: {
@@ -50,6 +72,8 @@ export function gatherTaskRunsStatus(store: Store): TaskRunsStatus {
       solutions: solutions.length,
       verdicts: verdicts.length,
       failed: failed.length,
+      settledFailed: settledFailed.length,
+      localErrors: localErrors.length,
     },
     inFlight: [...inFlight]
       .sort((a, b) => b.stateUpdatedAt - a.stateUpdatedAt)

--- a/client/src/dashboard/spa/src/pages/Overview.test.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.test.tsx
@@ -213,6 +213,84 @@ describe('OverviewPage empty-state gating', () => {
     expect(change?.getAttribute('href')).toBe('/operator#solvernets');
   });
 
+  it('prefers SolverNet-scoped prediction totals for the manifest-keyed joined prediction path (jinn-mono-0t6p)', async () => {
+    // Spec §12 / canonical shape: the operator joined prediction via
+    // `joinedSolverNets[<manifestCid>]` and bound the prediction harness.
+    // The joined entry's `name` is operator-chosen ("Prediction Markets"),
+    // its `configId` is the manifestCid (NOT 'prediction'), and the
+    // legacy `predictionV1.operator.solverNet.enabled` is false because the
+    // user no longer maintains a `solverNets.prediction` short-name entry.
+    // The fix must still route this case to the scoped predictionV1.totals.
+    getStatusMock.mockResolvedValue({
+      taskRuns: {
+        totals: {
+          observedTasks: 201,
+          activeTaskRuns: 50,
+          completed: 100,
+          solutions: 41,
+          verdicts: 62,
+          failed: 81,
+          settledFailed: 61,
+          localErrors: 23,
+        },
+        inFlight: [],
+        recentTasks: [],
+      },
+      predictionV1: {
+        operator: {
+          ok: true,
+          // The daemon's prediction operator block is cold for this user —
+          // their config has no legacy `solverNets.prediction`. The scoped
+          // payload must still be preferred via the harness signal.
+          solverNet: { name: 'prediction', enabled: false },
+          diagnostics: [],
+        },
+        totals: {
+          observedTasks: 22,
+          activeTaskRuns: 5,
+          solutions: 8,
+          verdicts: 7,
+          failed: 18,
+          settledFailed: 12,
+          localErrors: 6,
+        },
+      },
+      fleet: { services: [] },
+    });
+    getBootstrapMock.mockResolvedValue({
+      joinedSolverNets: {
+        bafybeipredmanifest: {
+          name: 'Prediction Markets',
+          manifestCid: 'bafybeipredmanifest',
+          roles: ['solver'],
+          harness: 'prediction-v1-baseline',
+        },
+      },
+    });
+    render(withProviders(<OverviewPage />));
+
+    const networkTitle = await screen.findByText(
+      /network · prediction markets/i,
+    );
+    const network = networkTitle.closest('section');
+    expect(network).not.toBeNull();
+    const card = network as HTMLElement;
+    // Scoped predictionV1 totals surface — not the global rollup.
+    expect(within(card).getByText('22')).toBeTruthy();
+    expect(within(card).getByText('5')).toBeTruthy();
+    expect(within(card).getByText('8')).toBeTruthy();
+    expect(within(card).getByText('7')).toBeTruthy();
+    expect(within(card).getByText('12')).toBeTruthy();
+    expect(within(card).getByText('6')).toBeTruthy();
+    // Global counts that don't belong to prediction must not appear here.
+    expect(within(card).queryByText('201')).toBeNull();
+    expect(within(card).queryByText('50')).toBeNull();
+    expect(within(card).queryByText('41')).toBeNull();
+    expect(within(card).queryByText('62')).toBeNull();
+    expect(within(card).queryByText('61')).toBeNull();
+    expect(within(card).queryByText('23')).toBeNull();
+  });
+
   it('prefers SolverNet-scoped prediction totals when the joined net is prediction (jinn-mono-0t6p)', async () => {
     // The operator's local SQLite carries historical FAILED rows from
     // legacy solvernets in addition to prediction.v1. The NetworkCard

--- a/client/src/dashboard/spa/src/pages/Overview.test.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.test.tsx
@@ -213,6 +213,69 @@ describe('OverviewPage empty-state gating', () => {
     expect(change?.getAttribute('href')).toBe('/operator#solvernets');
   });
 
+  it('prefers SolverNet-scoped prediction totals when the joined net is prediction (jinn-mono-0t6p)', async () => {
+    // The operator's local SQLite carries historical FAILED rows from
+    // legacy solvernets in addition to prediction.v1. The NetworkCard
+    // must show the scoped numbers so the operator sees the same fail
+    // count as the public explorer.
+    getStatusMock.mockResolvedValue({
+      taskRuns: {
+        totals: {
+          observedTasks: 201,
+          activeTaskRuns: 50,
+          completed: 100,
+          solutions: 41,
+          verdicts: 62,
+          failed: 81,
+          settledFailed: 61,
+          localErrors: 23,
+        },
+        inFlight: [],
+        recentTasks: [],
+      },
+      predictionV1: {
+        operator: {
+          ok: true,
+          solverNet: { name: 'prediction', enabled: true },
+          diagnostics: [],
+        },
+        totals: {
+          observedTasks: 22,
+          activeTaskRuns: 5,
+          solutions: 8,
+          verdicts: 7,
+          failed: 18,
+          settledFailed: 12,
+          localErrors: 6,
+        },
+      },
+      fleet: { services: [] },
+    });
+    getBootstrapMock.mockResolvedValue({
+      solverNets: { prediction: { enabled: true, roles: ['solving'] } },
+    });
+    render(withProviders(<OverviewPage />));
+
+    const networkTitle = await screen.findByText(/network · prediction/i);
+    const network = networkTitle.closest('section');
+    expect(network).not.toBeNull();
+    const card = network as HTMLElement;
+    // Scoped values surface in the card.
+    expect(within(card).getByText('22')).toBeTruthy();
+    expect(within(card).getByText('5')).toBeTruthy();
+    expect(within(card).getByText('8')).toBeTruthy();
+    expect(within(card).getByText('7')).toBeTruthy();
+    expect(within(card).getByText('12')).toBeTruthy();
+    expect(within(card).getByText('6')).toBeTruthy();
+    // Global counts that don't belong to prediction must not appear here.
+    expect(within(card).queryByText('201')).toBeNull();
+    expect(within(card).queryByText('50')).toBeNull();
+    expect(within(card).queryByText('41')).toBeNull();
+    expect(within(card).queryByText('62')).toBeNull();
+    expect(within(card).queryByText('61')).toBeNull();
+    expect(within(card).queryByText('23')).toBeNull();
+  });
+
   it('uses generic task-run totals before stale prediction counters', async () => {
     getStatusMock.mockResolvedValue({
       taskRuns: {

--- a/client/src/dashboard/spa/src/pages/Overview.test.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.test.tsx
@@ -34,6 +34,7 @@ vi.mock('../api/client.js', () => ({
 
 // Import after the mock so the page picks up the mocked client.
 const { OverviewPage } = await import('./Overview.js');
+const { detectJoinedSolverNet, operatorWaitingMessage } = await import('./overview/joined-solver-net.js');
 
 beforeEach(() => {
   getStatusMock.mockReset();
@@ -119,6 +120,40 @@ describe('OverviewPage empty-state gating', () => {
     );
     expect(screen.queryByText(/pick a solvernet to participate in/i)).toBeNull();
     expect(screen.getByText(/waiting for tasks/i)).toBeTruthy();
+  });
+
+  it('routes manifest-keyed joined prediction nets to the prediction waiting copy', () => {
+    const joined = detectJoinedSolverNet(
+      {
+        bafybeipredmanifest: {
+          name: 'Prediction Markets',
+          manifestCid: 'bafybeipredmanifest',
+          roles: ['solver'],
+          harness: 'prediction-v1-baseline',
+        },
+      },
+      undefined,
+      false,
+      undefined,
+    );
+
+    expect(joined).toMatchObject({
+      name: 'Prediction Markets',
+      configId: 'bafybeipredmanifest',
+      scopedStatusKey: 'predictionV1',
+    });
+    expect(
+      operatorWaitingMessage(
+        joined,
+        {
+          observedTasks: 0,
+          activeTaskRuns: 0,
+          completed: 0,
+          failed: 0,
+        },
+        'Waiting for Tasks. SolverNet active, Harness loaded; no incoming Tasks since startup.',
+      ),
+    ).toMatch(/waiting for tasks/i);
   });
 
   it('shows the OperatorCard from operator roles even when legacy enabled is false', async () => {
@@ -244,6 +279,7 @@ describe('OverviewPage empty-state gating', () => {
           // payload must still be preferred via the harness signal.
           solverNet: { name: 'prediction', enabled: false },
           diagnostics: [],
+          nextAction: { description: 'Waiting for Tasks.' },
         },
         totals: {
           observedTasks: 22,

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -44,6 +44,8 @@ interface OverviewStatusV1 {
       solutions?: number;
       verdicts?: number;
       failed?: number;
+      settledFailed?: number;
+      localErrors?: number;
     };
     inFlight?: Array<{ state: string; taskRole: 'restoration' | 'evaluation' | null; stateUpdatedAt: number }>;
     recentTasks?: Array<{ state: string; taskRole: 'restoration' | 'evaluation' | null; stateUpdatedAt: number }>;
@@ -69,7 +71,15 @@ interface OverviewStatusV1 {
       };
     };
     operatorError?: string;
-    totals?: { observedTasks?: number; activeTaskRuns?: number; solutions?: number; verdicts?: number; failed?: number };
+    totals?: {
+      observedTasks?: number;
+      activeTaskRuns?: number;
+      solutions?: number;
+      verdicts?: number;
+      failed?: number;
+      settledFailed?: number;
+      localErrors?: number;
+    };
     recentTasks?: Array<{ state: string; taskRole: 'restoration' | 'evaluation' | null; stateUpdatedAt: number }>;
   };
 }
@@ -262,12 +272,25 @@ export function OverviewPage(): JSX.Element {
   );
   const taskRunTotals = status?.taskRuns?.totals;
   const predictionTotals = status?.predictionV1?.totals;
+  // Split per jinn-mono-0t6p: `settledFailed` aligns with the public
+  // explorer's per-operator fail count (delivery landed on-chain, run
+  // ended FAILED), `localErrors` is the operator-only debugging signal
+  // for runs that never reached the marketplace. Falls back to the
+  // legacy `failed` rollup when an older daemon hasn't shipped the
+  // split yet.
+  const totalFailed = taskRunTotals?.failed ?? predictionTotals?.failed ?? 0;
+  const settledFailed =
+    taskRunTotals?.settledFailed ?? predictionTotals?.settledFailed;
+  const localErrors = taskRunTotals?.localErrors ?? predictionTotals?.localErrors;
   const totals = {
     tasks: taskRunTotals?.observedTasks ?? predictionTotals?.observedTasks ?? 0,
     active: taskRunTotals?.activeTaskRuns ?? predictionTotals?.activeTaskRuns ?? 0,
     solutions: taskRunTotals?.solutions ?? predictionTotals?.solutions ?? 0,
     verdicts: taskRunTotals?.verdicts ?? predictionTotals?.verdicts ?? 0,
-    failed: taskRunTotals?.failed ?? predictionTotals?.failed ?? 0,
+    settledFailed: settledFailed ?? 0,
+    // Old daemons only ship `failed`; surface it under `localErrors` so the
+    // operator's debugging signal isn't lost during the rollout window.
+    localErrors: localErrors ?? (settledFailed === undefined ? totalFailed : 0),
   };
   const services: ServiceIdentity[] = (status?.fleet?.services ?? []).map((s) => ({
     index: s.index,

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -272,25 +272,36 @@ export function OverviewPage(): JSX.Element {
   );
   const taskRunTotals = status?.taskRuns?.totals;
   const predictionTotals = status?.predictionV1?.totals;
-  // Split per jinn-mono-0t6p: `settledFailed` aligns with the public
-  // explorer's per-operator fail count (delivery landed on-chain, run
-  // ended FAILED), `localErrors` is the operator-only debugging signal
-  // for runs that never reached the marketplace. Falls back to the
-  // legacy `failed` rollup when an older daemon hasn't shipped the
-  // split yet.
-  const totalFailed = taskRunTotals?.failed ?? predictionTotals?.failed ?? 0;
+  // Per jinn-mono-0t6p: the NetworkCard's counters must be scoped to the
+  // joined SolverNet. `predictionV1.totals` is filtered by
+  // `solverType === 'prediction.v1'` in the build layer, while
+  // `taskRuns.totals` is global across every solver type the operator's
+  // SQLite has ever observed. When the joined net is `prediction`, prefer
+  // the scoped payload so historical FAILED rows from other SolverNets
+  // don't leak into this card's settledFailed / localErrors tiles. For any
+  // other joined net we fall back to taskRunTotals (no scoped payload
+  // exists for those solver types today — captured as a follow-up risk).
+  const preferPredictionTotals =
+    joined?.configId === 'prediction' && predictionTotals !== undefined;
+  const primaryTotals = preferPredictionTotals ? predictionTotals : taskRunTotals;
+  const fallbackTotals = preferPredictionTotals ? taskRunTotals : predictionTotals;
+  // Old daemons only ship `failed`; surface it under `localErrors` so the
+  // operator's debugging signal isn't lost during the rollout window —
+  // anything that reaches `localErrors` here pre-dates the on-chain split.
+  const legacyFailedFallback =
+    primaryTotals?.failed ?? fallbackTotals?.failed ?? 0;
   const settledFailed =
-    taskRunTotals?.settledFailed ?? predictionTotals?.settledFailed;
-  const localErrors = taskRunTotals?.localErrors ?? predictionTotals?.localErrors;
+    primaryTotals?.settledFailed ?? fallbackTotals?.settledFailed;
+  const localErrors =
+    primaryTotals?.localErrors ?? fallbackTotals?.localErrors;
   const totals = {
-    tasks: taskRunTotals?.observedTasks ?? predictionTotals?.observedTasks ?? 0,
-    active: taskRunTotals?.activeTaskRuns ?? predictionTotals?.activeTaskRuns ?? 0,
-    solutions: taskRunTotals?.solutions ?? predictionTotals?.solutions ?? 0,
-    verdicts: taskRunTotals?.verdicts ?? predictionTotals?.verdicts ?? 0,
+    tasks: primaryTotals?.observedTasks ?? fallbackTotals?.observedTasks ?? 0,
+    active: primaryTotals?.activeTaskRuns ?? fallbackTotals?.activeTaskRuns ?? 0,
+    solutions: primaryTotals?.solutions ?? fallbackTotals?.solutions ?? 0,
+    verdicts: primaryTotals?.verdicts ?? fallbackTotals?.verdicts ?? 0,
     settledFailed: settledFailed ?? 0,
-    // Old daemons only ship `failed`; surface it under `localErrors` so the
-    // operator's debugging signal isn't lost during the rollout window.
-    localErrors: localErrors ?? (settledFailed === undefined ? totalFailed : 0),
+    localErrors:
+      localErrors ?? (settledFailed === undefined ? legacyFailedFallback : 0),
   };
   const services: ServiceIdentity[] = (status?.fleet?.services ?? []).map((s) => ({
     index: s.index,

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -5,10 +5,15 @@ import { HeroStats } from './overview/HeroStats.js';
 import { AlertBand } from './overview/AlertBand.js';
 import { deriveLiveNow, LIVE_NOW_STATE_LABEL, LIVE_NOW_TONE } from './overview/LiveNowBand.js';
 import { NetworkCard } from './overview/NetworkCard.js';
-import { OperatorCard, type OperatorCardRole } from './overview/OperatorCard.js';
+import { OperatorCard } from './overview/OperatorCard.js';
 import { IdentityCard, type ServiceIdentity } from './overview/IdentityCard.js';
 import { AdvancedDetails } from './overview/AdvancedDetails.js';
 import { HarnessStatusPanel } from './overview/HarnessStatusPanel.js';
+import {
+  detectJoinedSolverNet,
+  operatorWaitingMessage,
+  type BootstrapWithSolverNets,
+} from './overview/joined-solver-net.js';
 
 interface OverviewStatusV1 {
   fleet?: {
@@ -84,178 +89,6 @@ interface OverviewStatusV1 {
   };
 }
 
-type OverviewTaskRunTotals = NonNullable<OverviewStatusV1['taskRuns']>['totals'];
-
-/**
- * The operator's joined SolverNets per spec §12. Tasks 21/22 finish the
- * migration from the legacy short-name-keyed `solverNets` shape to the
- * `manifestCid`-keyed shape; until then, OperatorCard accepts both.
- *
- * New shape:    { '<manifestCid>': { name, manifestCid, roles: ['solver'|'evaluator'], harness?, ... } }
- * Legacy shape: { '<shortName>':   { enabled: boolean, roles?: ['solving'|'evaluating'], ... } }
- */
-interface BootstrapWithSolverNets {
-  solverNets?: Record<
-    string,
-    {
-      name?: string;
-      manifestCid?: string;
-      enabled?: boolean;
-      roles?: string[];
-      solverType?: string;
-      harness?: string;
-    }
-  >;
-  joinedSolverNets?: Record<
-    string,
-    {
-      name?: string;
-      manifestCid?: string;
-      roles?: string[];
-      /**
-       * Harness name bound to this joined entry. Used to discriminate which
-       * underlying solverType the joined SolverNet runs: e.g.
-       * `prediction-v1-baseline` ⇒ `prediction.v1`. The bootstrap endpoint
-       * pass-throughs the operator's config record.
-       */
-      harness?: string;
-      /** Optional explicit solverType override; honoured when present. */
-      solverType?: string;
-    }
-  >;
-}
-
-interface JoinedSolverNet {
-  /** Display name for the OperatorCard. */
-  name: string;
-  /** Manifest CID / config key used for deep-linking into the joined config. */
-  configId?: string;
-  /** Roles narrowed to OperatorCard's `solving` / `evaluating` vocabulary. */
-  roles: OperatorCardRole[];
-  /**
-   * Best-effort discriminator for the underlying solver type. Derived from
-   * the join entry (legacy short-name → 'prediction.v1'; manifest-keyed
-   * `harness === 'prediction-v1-baseline'` → 'prediction.v1'). Used by the
-   * Overview wiring to decide whether the SolverNet-scoped
-   * `predictionV1.totals` payload applies to this joined net.
-   */
-  solverType?: string;
-}
-
-/**
- * Map a join entry's `harness` name to the canonical solverType the harness
- * supports. Currently only the prediction harness is registered here — other
- * solver types have no dedicated scoped status payload to route to, so
- * widening this table prematurely would have no consumer.
- */
-function solverTypeForHarness(harness: string | undefined): string | undefined {
-  if (harness === 'prediction-v1-baseline') return 'prediction.v1';
-  return undefined;
-}
-
-/**
- * Detect whether the operator has joined any SolverNet. Returns the first
- * joined entry projected into OperatorCard's prop shape. The explicit
- * `joinedSolverNets` config block wins over the legacy `solverNets` map. The new
- * manifestCid-keyed shape (any entry with non-empty `roles`) wins over the
- * legacy `enabled` flag; both are accepted during the Tasks 21/22 migration
- * (spec §12). The predictionV1 status payload is a final-fallback signal
- * for daemons that haven't been restarted since this migration landed.
- */
-function detectJoinedSolverNet(
-  joinedSolverNets: BootstrapWithSolverNets['joinedSolverNets'] | undefined,
-  bootstrapSolverNets: BootstrapWithSolverNets['solverNets'] | undefined,
-  predictionEnabled: boolean,
-  predictionRoles: string[] | undefined,
-): JoinedSolverNet | null {
-  if (joinedSolverNets) {
-    for (const [key, entry] of Object.entries(joinedSolverNets)) {
-      if (!entry || typeof entry !== 'object') continue;
-      const rawRoles = Array.isArray(entry.roles) ? entry.roles : [];
-      if (rawRoles.length === 0) continue;
-      const roles = mapRolesToOperatorVocab(rawRoles);
-      // Manifest-keyed entries don't carry a top-level solverType today, so
-      // we lean on the bound `harness` name to identify the underlying
-      // solver. An explicit `solverType` field on the entry wins when present.
-      const solverType = entry.solverType ?? solverTypeForHarness(entry.harness);
-      return {
-        name: entry.name ?? entry.manifestCid ?? key,
-        configId: entry.manifestCid ?? key,
-        roles: roles.length > 0 ? roles : ['solving'],
-        ...(solverType ? { solverType } : {}),
-      };
-    }
-  }
-
-  if (bootstrapSolverNets) {
-    // Pass 1: new shape — entries keyed by manifestCid (heuristic: starts
-    // with 'baf' / 'Qm', or has a `manifestCid` field) with non-empty roles.
-    for (const [key, entry] of Object.entries(bootstrapSolverNets)) {
-      if (!entry || typeof entry !== 'object') continue;
-      const looksLikeCid =
-        entry.manifestCid !== undefined ||
-        key.startsWith('baf') ||
-        key.startsWith('Qm');
-      if (!looksLikeCid) continue;
-      const rawRoles = Array.isArray(entry.roles) ? entry.roles : [];
-      if (rawRoles.length === 0) continue;
-      const roles = mapRolesToOperatorVocab(rawRoles);
-      const solverType = entry.solverType ?? solverTypeForHarness(entry.harness);
-      return {
-        name: entry.name ?? key,
-        configId: entry.manifestCid ?? key,
-        roles: roles.length > 0 ? roles : ['solving'],
-        ...(solverType ? { solverType } : {}),
-      };
-    }
-    // Pass 2: legacy short-name shape — enabled entries or operator-visible roles.
-    for (const [key, entry] of Object.entries(bootstrapSolverNets)) {
-      if (!entry || typeof entry !== 'object') continue;
-      const rawRoles = Array.isArray(entry.roles) ? entry.roles : [];
-      const roles = mapRolesToOperatorVocab(rawRoles);
-      if (entry.enabled !== true && roles.length === 0) continue;
-      // Legacy short-name 'prediction' maps to solverType prediction.v1;
-      // honour an explicit field or harness signal first so non-prediction
-      // legacy entries (if they ever surface) don't get mislabelled.
-      const solverType =
-        entry.solverType ??
-        solverTypeForHarness(entry.harness) ??
-        (key === 'prediction' ? 'prediction.v1' : undefined);
-      return {
-        name: entry.name ?? key,
-        configId: entry.manifestCid ?? key,
-        roles: roles.length > 0 ? roles : ['solving'],
-        ...(solverType ? { solverType } : {}),
-      };
-    }
-  }
-
-  // Pass 3: predictionV1 status payload as a last-resort signal. The daemon
-  // surfaces this for back-compat with the pre-spec-§12 single-net world.
-  const mappedPredictionRoles = mapRolesToOperatorVocab(predictionRoles ?? []);
-  if (predictionEnabled || mappedPredictionRoles.length > 0) {
-    return {
-      name: 'prediction',
-      configId: 'prediction',
-      roles: mappedPredictionRoles.length > 0 ? mappedPredictionRoles : ['solving'],
-      solverType: 'prediction.v1',
-    };
-  }
-  return null;
-}
-
-function mapRolesToOperatorVocab(roles: string[]): OperatorCardRole[] {
-  const mapped: OperatorCardRole[] = [];
-  for (const r of roles) {
-    if (r === 'solving' || r === 'solver') {
-      if (!mapped.includes('solving')) mapped.push('solving');
-    } else if (r === 'evaluating' || r === 'evaluator') {
-      if (!mapped.includes('evaluating')) mapped.push('evaluating');
-    }
-  }
-  return mapped;
-}
-
 function formatEth(wei?: string): string {
   if (!wei || !/^\d+$/.test(wei)) return '—';
   try {
@@ -265,28 +98,6 @@ function formatEth(wei?: string): string {
   } catch {
     return '—';
   }
-}
-
-function operatorWaitingMessage(
-  joined: JoinedSolverNet | null,
-  taskRunTotals: OverviewTaskRunTotals,
-  predictionDescription: string | undefined,
-): string | undefined {
-  const hasGenericRuns =
-    (taskRunTotals?.observedTasks ?? 0) > 0 ||
-    (taskRunTotals?.activeTaskRuns ?? 0) > 0 ||
-    (taskRunTotals?.completed ?? 0) > 0 ||
-    (taskRunTotals?.failed ?? 0) > 0;
-  if (hasGenericRuns) {
-    if ((taskRunTotals?.activeTaskRuns ?? 0) > 0) {
-      return 'Working on current run.';
-    }
-    return 'Waiting for the next available run.';
-  }
-  if (joined?.configId === 'prediction') {
-    return predictionDescription;
-  }
-  return undefined;
 }
 
 export function OverviewPage(): JSX.Element {
@@ -319,18 +130,18 @@ export function OverviewPage(): JSX.Element {
   const taskRunTotals = status?.taskRuns?.totals;
   const predictionTotals = status?.predictionV1?.totals;
   // Per jinn-mono-0t6p: the NetworkCard's counters must be scoped to the
-  // joined SolverNet. `predictionV1.totals` is filtered by
-  // `solverType === 'prediction.v1'` in the build layer, while
+  // joined SolverNet. `predictionV1.totals` is filtered to prediction task
+  // runs in the build layer, while
   // `taskRuns.totals` is global across every solver type the operator's
-  // SQLite has ever observed. The discriminator is the joined net's
-  // resolved `solverType` (see `detectJoinedSolverNet`): both the legacy
-  // short-name `solverNets.prediction` path AND the manifest-keyed
-  // `joinedSolverNets[<cid>]` path resolve to `'prediction.v1'` via the
-  // bound harness, so users on either shape get scoped counters. For any
-  // other joined net we fall back to taskRunTotals (no scoped payload
-  // exists for those solver types today — captured as a follow-up risk).
+  // SQLite has ever observed. The discriminator is the joined net's scoped
+  // status key (see `detectJoinedSolverNet`): both the legacy short-name
+  // `solverNets.prediction` path AND the manifest-keyed
+  // `joinedSolverNets[<cid>]` path route to `predictionV1` via the bound
+  // harness, so users on either shape get scoped counters. For any other
+  // joined net we fall back to taskRunTotals (no scoped payload exists for
+  // those SolverNets today — captured as a follow-up risk).
   const preferPredictionTotals =
-    joined?.solverType === 'prediction.v1' && predictionTotals !== undefined;
+    joined?.scopedStatusKey === 'predictionV1' && predictionTotals !== undefined;
   const primaryTotals = preferPredictionTotals ? predictionTotals : taskRunTotals;
   const fallbackTotals = preferPredictionTotals ? taskRunTotals : predictionTotals;
   // Old daemons only ship `failed`; surface it under `localErrors` so the

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -102,6 +102,8 @@ interface BootstrapWithSolverNets {
       manifestCid?: string;
       enabled?: boolean;
       roles?: string[];
+      solverType?: string;
+      harness?: string;
     }
   >;
   joinedSolverNets?: Record<
@@ -110,6 +112,15 @@ interface BootstrapWithSolverNets {
       name?: string;
       manifestCid?: string;
       roles?: string[];
+      /**
+       * Harness name bound to this joined entry. Used to discriminate which
+       * underlying solverType the joined SolverNet runs: e.g.
+       * `prediction-v1-baseline` ⇒ `prediction.v1`. The bootstrap endpoint
+       * pass-throughs the operator's config record.
+       */
+      harness?: string;
+      /** Optional explicit solverType override; honoured when present. */
+      solverType?: string;
     }
   >;
 }
@@ -121,6 +132,25 @@ interface JoinedSolverNet {
   configId?: string;
   /** Roles narrowed to OperatorCard's `solving` / `evaluating` vocabulary. */
   roles: OperatorCardRole[];
+  /**
+   * Best-effort discriminator for the underlying solver type. Derived from
+   * the join entry (legacy short-name → 'prediction.v1'; manifest-keyed
+   * `harness === 'prediction-v1-baseline'` → 'prediction.v1'). Used by the
+   * Overview wiring to decide whether the SolverNet-scoped
+   * `predictionV1.totals` payload applies to this joined net.
+   */
+  solverType?: string;
+}
+
+/**
+ * Map a join entry's `harness` name to the canonical solverType the harness
+ * supports. Currently only the prediction harness is registered here — other
+ * solver types have no dedicated scoped status payload to route to, so
+ * widening this table prematurely would have no consumer.
+ */
+function solverTypeForHarness(harness: string | undefined): string | undefined {
+  if (harness === 'prediction-v1-baseline') return 'prediction.v1';
+  return undefined;
 }
 
 /**
@@ -144,10 +174,15 @@ function detectJoinedSolverNet(
       const rawRoles = Array.isArray(entry.roles) ? entry.roles : [];
       if (rawRoles.length === 0) continue;
       const roles = mapRolesToOperatorVocab(rawRoles);
+      // Manifest-keyed entries don't carry a top-level solverType today, so
+      // we lean on the bound `harness` name to identify the underlying
+      // solver. An explicit `solverType` field on the entry wins when present.
+      const solverType = entry.solverType ?? solverTypeForHarness(entry.harness);
       return {
         name: entry.name ?? entry.manifestCid ?? key,
         configId: entry.manifestCid ?? key,
         roles: roles.length > 0 ? roles : ['solving'],
+        ...(solverType ? { solverType } : {}),
       };
     }
   }
@@ -165,10 +200,12 @@ function detectJoinedSolverNet(
       const rawRoles = Array.isArray(entry.roles) ? entry.roles : [];
       if (rawRoles.length === 0) continue;
       const roles = mapRolesToOperatorVocab(rawRoles);
+      const solverType = entry.solverType ?? solverTypeForHarness(entry.harness);
       return {
         name: entry.name ?? key,
         configId: entry.manifestCid ?? key,
         roles: roles.length > 0 ? roles : ['solving'],
+        ...(solverType ? { solverType } : {}),
       };
     }
     // Pass 2: legacy short-name shape — enabled entries or operator-visible roles.
@@ -177,10 +214,18 @@ function detectJoinedSolverNet(
       const rawRoles = Array.isArray(entry.roles) ? entry.roles : [];
       const roles = mapRolesToOperatorVocab(rawRoles);
       if (entry.enabled !== true && roles.length === 0) continue;
+      // Legacy short-name 'prediction' maps to solverType prediction.v1;
+      // honour an explicit field or harness signal first so non-prediction
+      // legacy entries (if they ever surface) don't get mislabelled.
+      const solverType =
+        entry.solverType ??
+        solverTypeForHarness(entry.harness) ??
+        (key === 'prediction' ? 'prediction.v1' : undefined);
       return {
         name: entry.name ?? key,
         configId: entry.manifestCid ?? key,
         roles: roles.length > 0 ? roles : ['solving'],
+        ...(solverType ? { solverType } : {}),
       };
     }
   }
@@ -193,6 +238,7 @@ function detectJoinedSolverNet(
       name: 'prediction',
       configId: 'prediction',
       roles: mappedPredictionRoles.length > 0 ? mappedPredictionRoles : ['solving'],
+      solverType: 'prediction.v1',
     };
   }
   return null;
@@ -276,13 +322,15 @@ export function OverviewPage(): JSX.Element {
   // joined SolverNet. `predictionV1.totals` is filtered by
   // `solverType === 'prediction.v1'` in the build layer, while
   // `taskRuns.totals` is global across every solver type the operator's
-  // SQLite has ever observed. When the joined net is `prediction`, prefer
-  // the scoped payload so historical FAILED rows from other SolverNets
-  // don't leak into this card's settledFailed / localErrors tiles. For any
+  // SQLite has ever observed. The discriminator is the joined net's
+  // resolved `solverType` (see `detectJoinedSolverNet`): both the legacy
+  // short-name `solverNets.prediction` path AND the manifest-keyed
+  // `joinedSolverNets[<cid>]` path resolve to `'prediction.v1'` via the
+  // bound harness, so users on either shape get scoped counters. For any
   // other joined net we fall back to taskRunTotals (no scoped payload
   // exists for those solver types today — captured as a follow-up risk).
   const preferPredictionTotals =
-    joined?.configId === 'prediction' && predictionTotals !== undefined;
+    joined?.solverType === 'prediction.v1' && predictionTotals !== undefined;
   const primaryTotals = preferPredictionTotals ? predictionTotals : taskRunTotals;
   const fallbackTotals = preferPredictionTotals ? taskRunTotals : predictionTotals;
   // Old daemons only ship `failed`; surface it under `localErrors` so the

--- a/client/src/dashboard/spa/src/pages/overview/NetworkCard.test.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/NetworkCard.test.tsx
@@ -7,7 +7,7 @@ describe('NetworkCard', () => {
     render(
       <NetworkCard
         name="prediction"
-        totals={{ tasks: 12, active: 3, solutions: 9, verdicts: 8, failed: 1 }}
+        totals={{ tasks: 12, active: 3, solutions: 9, verdicts: 8, settledFailed: 1, localErrors: 2 }}
       />,
     );
     expect(screen.getByText(/network · prediction/i)).toBeTruthy();
@@ -15,8 +15,35 @@ describe('NetworkCard', () => {
     expect(screen.getByText('3')).toBeTruthy();
     expect(screen.getByText('9')).toBeTruthy();
     expect(screen.getByText('8')).toBeTruthy();
-    expect(screen.getByText('1')).toBeTruthy();
     expect(screen.queryByText(/role/i)).toBeNull();
     expect(screen.queryByText(/view/i)).toBeNull();
+  });
+
+  it('surfaces on-chain settled failures and local engine errors as separate stats', () => {
+    render(
+      <NetworkCard
+        name="prediction"
+        totals={{ tasks: 30, active: 0, solutions: 12, verdicts: 8, settledFailed: 3, localErrors: 7 }}
+      />,
+    );
+    // Both labels render, replacing the prior single "failed" stat.
+    expect(screen.getByText(/settled fail/i)).toBeTruthy();
+    expect(screen.getByText(/local err/i)).toBeTruthy();
+    expect(screen.queryByText(/^failed$/i)).toBeNull();
+    // Each count surfaces under its dedicated label, distinguishable when
+    // the two values differ.
+    expect(screen.getByText('3')).toBeTruthy();
+    expect(screen.getByText('7')).toBeTruthy();
+  });
+
+  it('renders zero counts without the warn tone', () => {
+    render(
+      <NetworkCard
+        name="prediction"
+        totals={{ tasks: 5, active: 1, solutions: 4, verdicts: 0, settledFailed: 0, localErrors: 0 }}
+      />,
+    );
+    // Both failure stats render as zero — no warn tone needed.
+    expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(3);
   });
 });

--- a/client/src/dashboard/spa/src/pages/overview/NetworkCard.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/NetworkCard.tsx
@@ -3,10 +3,27 @@
  * on the network. Renders even when this operator is not participating.
  * No role, no state pill, no CTA — those belong on OperatorCard. This card
  * is the surface that could one day be lifted into a public explorer page.
+ *
+ * The single "failed" count was split per jinn-mono-0t6p: operator
+ * dashboards conflated on-chain settled failures (delivery landed but the
+ * marketplace/verdict marked it Fail) with local engine errors (the run
+ * never reached the marketplace — SkippableError, claim-time rejects,
+ * runner crashes). The two are different metrics and surfacing them
+ * separately keeps operator counters aligned with the public explorer's
+ * fail count while still exposing the operator's local debugging signal.
  */
 export interface NetworkCardProps {
   name: string;
-  totals: { tasks: number; active: number; solutions: number; verdicts: number; failed: number };
+  totals: {
+    tasks: number;
+    active: number;
+    solutions: number;
+    verdicts: number;
+    /** On-chain settled failures: delivery tx landed and the run terminated FAILED. */
+    settledFailed: number;
+    /** Local engine errors: FAILED runs that never reached the marketplace. */
+    localErrors: number;
+  };
 }
 
 function Stat({ label, value, tone }: { label: string; value: number; tone?: 'warn' }): JSX.Element {
@@ -74,7 +91,16 @@ export function NetworkCard({ name, totals }: NetworkCardProps): JSX.Element {
         <Stat label="active" value={totals.active} />
         <Stat label="solutions" value={totals.solutions} />
         <Stat label="verdicts" value={totals.verdicts} />
-        <Stat label="failed" value={totals.failed} tone={totals.failed > 0 ? 'warn' : undefined} />
+        <Stat
+          label="settled fail"
+          value={totals.settledFailed}
+          tone={totals.settledFailed > 0 ? 'warn' : undefined}
+        />
+        <Stat
+          label="local err"
+          value={totals.localErrors}
+          tone={totals.localErrors > 0 ? 'warn' : undefined}
+        />
       </div>
     </section>
   );

--- a/client/src/dashboard/spa/src/pages/overview/joined-solver-net.ts
+++ b/client/src/dashboard/spa/src/pages/overview/joined-solver-net.ts
@@ -1,0 +1,183 @@
+import type { OperatorCardRole } from './OperatorCard.js';
+
+/**
+ * The operator's joined SolverNets per spec §12. Tasks 21/22 finish the
+ * migration from the legacy short-name-keyed `solverNets` shape to the
+ * `manifestCid`-keyed shape; until then, Overview accepts both.
+ *
+ * New shape:    { '<manifestCid>': { name, manifestCid, roles: ['solver'|'evaluator'], harness?, ... } }
+ * Legacy shape: { '<shortName>':   { enabled: boolean, roles?: ['solving'|'evaluating'], ... } }
+ */
+export interface BootstrapWithSolverNets {
+  solverNets?: Record<
+    string,
+    {
+      name?: string;
+      manifestCid?: string;
+      enabled?: boolean;
+      roles?: string[];
+      harness?: string;
+    }
+  >;
+  joinedSolverNets?: Record<
+    string,
+    {
+      name?: string;
+      manifestCid?: string;
+      roles?: string[];
+      /**
+       * Harness name bound to this joined entry. Used to route the card to a
+       * dedicated SolverNet-scoped status payload when one exists, e.g.
+       * `prediction-v1-baseline` ⇒ `predictionV1.totals`.
+       */
+      harness?: string;
+    }
+  >;
+}
+
+export type ScopedStatusKey = 'predictionV1';
+
+export interface JoinedSolverNet {
+  /** Display name for the OperatorCard. */
+  name: string;
+  /** Manifest CID / config key used for deep-linking into the joined config. */
+  configId?: string;
+  /** Roles narrowed to OperatorCard's `solving` / `evaluating` vocabulary. */
+  roles: OperatorCardRole[];
+  /**
+   * UI-internal routing key for SolverNet-scoped status payloads. Derived from
+   * the join entry's harness or the legacy short-name bootstrap path without
+   * re-exposing `solverType` in the SPA model.
+   */
+  scopedStatusKey?: ScopedStatusKey;
+}
+
+export interface WaitingMessageTaskRunTotals {
+  observedTasks?: number;
+  activeTaskRuns?: number;
+  completed?: number;
+  failed?: number;
+}
+
+/**
+ * Map a join entry's `harness` name to the dedicated SolverNet-scoped status
+ * payload that Overview can consume. Currently only the prediction harness is
+ * registered here — other SolverNets have no scoped payload yet.
+ */
+function scopedStatusKeyForHarness(harness: string | undefined): ScopedStatusKey | undefined {
+  if (harness === 'prediction-v1-baseline') return 'predictionV1';
+  return undefined;
+}
+
+function mapRolesToOperatorVocab(roles: string[]): OperatorCardRole[] {
+  const mapped: OperatorCardRole[] = [];
+  for (const r of roles) {
+    if (r === 'solving' || r === 'solver') {
+      if (!mapped.includes('solving')) mapped.push('solving');
+    } else if (r === 'evaluating' || r === 'evaluator') {
+      if (!mapped.includes('evaluating')) mapped.push('evaluating');
+    }
+  }
+  return mapped;
+}
+
+/**
+ * Detect whether the operator has joined any SolverNet. Returns the first
+ * joined entry projected into OperatorCard's prop shape. The explicit
+ * `joinedSolverNets` config block wins over the legacy `solverNets` map. The new
+ * manifestCid-keyed shape (any entry with non-empty `roles`) wins over the
+ * legacy `enabled` flag; both are accepted during the Tasks 21/22 migration
+ * (spec §12). The predictionV1 status payload is a final-fallback signal
+ * for daemons that haven't been restarted since this migration landed.
+ */
+export function detectJoinedSolverNet(
+  joinedSolverNets: BootstrapWithSolverNets['joinedSolverNets'] | undefined,
+  bootstrapSolverNets: BootstrapWithSolverNets['solverNets'] | undefined,
+  predictionEnabled: boolean,
+  predictionRoles: string[] | undefined,
+): JoinedSolverNet | null {
+  if (joinedSolverNets) {
+    for (const [key, entry] of Object.entries(joinedSolverNets)) {
+      if (!entry || typeof entry !== 'object') continue;
+      const rawRoles = Array.isArray(entry.roles) ? entry.roles : [];
+      if (rawRoles.length === 0) continue;
+      const roles = mapRolesToOperatorVocab(rawRoles);
+      const scopedStatusKey = scopedStatusKeyForHarness(entry.harness);
+      return {
+        name: entry.name ?? entry.manifestCid ?? key,
+        configId: entry.manifestCid ?? key,
+        roles: roles.length > 0 ? roles : ['solving'],
+        ...(scopedStatusKey ? { scopedStatusKey } : {}),
+      };
+    }
+  }
+
+  if (bootstrapSolverNets) {
+    for (const [key, entry] of Object.entries(bootstrapSolverNets)) {
+      if (!entry || typeof entry !== 'object') continue;
+      const looksLikeCid =
+        entry.manifestCid !== undefined ||
+        key.startsWith('baf') ||
+        key.startsWith('Qm');
+      if (!looksLikeCid) continue;
+      const rawRoles = Array.isArray(entry.roles) ? entry.roles : [];
+      if (rawRoles.length === 0) continue;
+      const roles = mapRolesToOperatorVocab(rawRoles);
+      const scopedStatusKey = scopedStatusKeyForHarness(entry.harness);
+      return {
+        name: entry.name ?? key,
+        configId: entry.manifestCid ?? key,
+        roles: roles.length > 0 ? roles : ['solving'],
+        ...(scopedStatusKey ? { scopedStatusKey } : {}),
+      };
+    }
+    for (const [key, entry] of Object.entries(bootstrapSolverNets)) {
+      if (!entry || typeof entry !== 'object') continue;
+      const rawRoles = Array.isArray(entry.roles) ? entry.roles : [];
+      const roles = mapRolesToOperatorVocab(rawRoles);
+      if (entry.enabled !== true && roles.length === 0) continue;
+      const scopedStatusKey =
+        scopedStatusKeyForHarness(entry.harness) ??
+        (key === 'prediction' ? 'predictionV1' : undefined);
+      return {
+        name: entry.name ?? key,
+        configId: entry.manifestCid ?? key,
+        roles: roles.length > 0 ? roles : ['solving'],
+        ...(scopedStatusKey ? { scopedStatusKey } : {}),
+      };
+    }
+  }
+
+  const mappedPredictionRoles = mapRolesToOperatorVocab(predictionRoles ?? []);
+  if (predictionEnabled || mappedPredictionRoles.length > 0) {
+    return {
+      name: 'prediction',
+      configId: 'prediction',
+      roles: mappedPredictionRoles.length > 0 ? mappedPredictionRoles : ['solving'],
+      scopedStatusKey: 'predictionV1',
+    };
+  }
+  return null;
+}
+
+export function operatorWaitingMessage(
+  joined: JoinedSolverNet | null,
+  taskRunTotals: WaitingMessageTaskRunTotals | undefined,
+  predictionDescription: string | undefined,
+): string | undefined {
+  const hasGenericRuns =
+    (taskRunTotals?.observedTasks ?? 0) > 0 ||
+    (taskRunTotals?.activeTaskRuns ?? 0) > 0 ||
+    (taskRunTotals?.completed ?? 0) > 0 ||
+    (taskRunTotals?.failed ?? 0) > 0;
+  if (hasGenericRuns) {
+    if ((taskRunTotals?.activeTaskRuns ?? 0) > 0) {
+      return 'Working on current run.';
+    }
+    return 'Waiting for the next available run.';
+  }
+  if (joined?.scopedStatusKey === 'predictionV1') {
+    return predictionDescription;
+  }
+  return undefined;
+}

--- a/client/test/api/gather-status.test.ts
+++ b/client/test/api/gather-status.test.ts
@@ -71,6 +71,8 @@ describe('gatherStatusForApi', () => {
         solutions: 0,
         verdicts: 0,
         failed: 0,
+        settledFailed: 0,
+        localErrors: 0,
       });
     });
   });

--- a/client/test/api/portfolio-v0-build.test.ts
+++ b/client/test/api/portfolio-v0-build.test.ts
@@ -61,6 +61,24 @@ describe('gatherPortfolioV0Status', () => {
     });
   });
 
+  it('splits FAILED runs into settled fails and local errors via delivery_tx_hash', async () => {
+    await withTempStore(async (store) => {
+      const persistence = new TaskRunPersistence(store.db);
+      seedIntent(persistence, 'req-local-error');
+      seedIntent(persistence, 'req-settled-fail');
+      persistence.markFailed('req-local-error', 'SkippableError');
+      persistence.markFailed('req-settled-fail', 'claimDelivery reverted');
+      store.db
+        .prepare('UPDATE task_runs SET delivery_tx_hash = ? WHERE request_id = ?')
+        .run('0xdeadbeef', 'req-settled-fail');
+
+      const result = gatherPortfolioV0Status(store);
+      expect(result.totals.failed).toBe(2);
+      expect(result.totals.settledFailed).toBe(1);
+      expect(result.totals.localErrors).toBe(1);
+    });
+  });
+
   it('includes solverType and implName in in-flight summaries', async () => {
     await withTempStore(async (store) => {
       const persistence = new TaskRunPersistence(store.db);

--- a/client/test/api/portfolio-v0-build.test.ts
+++ b/client/test/api/portfolio-v0-build.test.ts
@@ -79,6 +79,65 @@ describe('gatherPortfolioV0Status', () => {
     });
   });
 
+  it('scopes totals and lists to solverType=portfolio.v0 — other solvers do not leak', async () => {
+    await withTempStore(async (store) => {
+      const persistence = new TaskRunPersistence(store.db);
+      // portfolio.v0 — should be counted.
+      seedIntent(persistence, 'pv0-failed');
+      persistence.markFailed('pv0-failed', 'portfolio failure');
+      seedIntent(persistence, 'pv0-delivered');
+      store.db.prepare(`UPDATE task_runs SET state = 'COMPLETE' WHERE request_id = ?`).run('pv0-delivered');
+      seedIntent(persistence, 'pv0-running');
+      store.db.prepare(`UPDATE task_runs SET state = 'RUNNING' WHERE request_id = ?`).run('pv0-running');
+
+      // Foreign solverType — must NOT leak into portfolio.v0 counters.
+      persistence.insertDiscovered({
+        requestId: 'pred-failed',
+        taskCid: 'bafy-pred-failed',
+        onchainCreationTx: '0xpred',
+        onchainCreationBlock: 1,
+        solverType: 'prediction.v1',
+        windowStartTs: 1_000,
+        windowEndTs: 2_000,
+        task: { id: 'pred-failed', description: 'prediction task', solverType: 'prediction.v1' },
+      });
+      persistence.markFailed('pred-failed', 'prediction failure');
+      store.db
+        .prepare('UPDATE task_runs SET delivery_tx_hash = ? WHERE request_id = ?')
+        .run('0xpredfail', 'pred-failed');
+
+      persistence.insertDiscovered({
+        requestId: 'swe-failed',
+        taskCid: 'bafy-swe-failed',
+        onchainCreationTx: '0xswe',
+        onchainCreationBlock: 1,
+        solverType: 'swe-rebench-v2.v1',
+        windowStartTs: 1_000,
+        windowEndTs: 2_000,
+        task: { id: 'swe-failed', description: 'swe task', solverType: 'swe-rebench-v2.v1' },
+      });
+      persistence.markFailed('swe-failed', 'swe failure');
+
+      const result = gatherPortfolioV0Status(store);
+
+      // Only portfolio.v0 rows are counted.
+      expect(result.totals.delivered).toBe(1);
+      expect(result.totals.failed).toBe(1);
+      expect(result.totals.settledFailed).toBe(0);
+      expect(result.totals.localErrors).toBe(1);
+      expect(result.totals.active).toBe(1);
+
+      // Foreign-solver requestIds must not appear in the surfaced lists.
+      const inFlightIds = result.inFlight.map((row) => row.requestId);
+      const verdictIds = result.recentVerdicts.map((row) => row.requestId);
+      expect(inFlightIds).toContain('pv0-running');
+      expect(inFlightIds).not.toContain('swe-failed');
+      expect(verdictIds).toContain('pv0-failed');
+      expect(verdictIds).not.toContain('pred-failed');
+      expect(verdictIds).not.toContain('swe-failed');
+    });
+  });
+
   it('includes solverType and implName in in-flight summaries', async () => {
     await withTempStore(async (store) => {
       const persistence = new TaskRunPersistence(store.db);

--- a/client/test/api/portfolio-v0-build.test.ts
+++ b/client/test/api/portfolio-v0-build.test.ts
@@ -138,6 +138,50 @@ describe('gatherPortfolioV0Status', () => {
     });
   });
 
+  it('keeps portfolio rows when solver_type is missing but task_payload still identifies the net', async () => {
+    await withTempStore(async (store) => {
+      const persistence = new TaskRunPersistence(store.db);
+      seedIntent(persistence, 'canonical-pv0');
+      store.db.prepare(
+        `UPDATE task_runs
+         SET solver_type = NULL,
+             task_payload = ?
+         WHERE request_id = ?`,
+      ).run(
+        JSON.stringify({
+          id: 'canonical-pv0',
+          description: 'test',
+          contractId: 'portfolio',
+          contractVersion: 'v0',
+        }),
+        'canonical-pv0',
+      );
+
+      seedIntent(persistence, 'legacy-pv0');
+      persistence.markFailed('legacy-pv0', 'legacy failure');
+      store.db.prepare(
+        `UPDATE task_runs
+         SET solver_type = NULL,
+             task_payload = ?
+         WHERE request_id = ?`,
+      ).run(
+        JSON.stringify({
+          id: 'legacy-pv0',
+          description: 'test',
+          solverType: 'portfolio.v0',
+        }),
+        'legacy-pv0',
+      );
+
+      const result = gatherPortfolioV0Status(store);
+
+      expect(result.totals.active).toBe(1);
+      expect(result.totals.failed).toBe(1);
+      expect(result.inFlight.map((row) => row.requestId)).toContain('canonical-pv0');
+      expect(result.recentVerdicts.map((row) => row.requestId)).toContain('legacy-pv0');
+    });
+  });
+
   it('includes solverType and implName in in-flight summaries', async () => {
     await withTempStore(async (store) => {
       const persistence = new TaskRunPersistence(store.db);

--- a/client/test/api/prediction-v1-build.test.ts
+++ b/client/test/api/prediction-v1-build.test.ts
@@ -71,6 +71,8 @@ describe('gatherPredictionV1Status', () => {
         solutions: 0,
         verdicts: 0,
         failed: 0,
+        settledFailed: 0,
+        localErrors: 0,
       });
       expect(result.recentTasks).toEqual([]);
     });
@@ -138,6 +140,8 @@ describe('gatherPredictionV1Status', () => {
         solutions: 1,
         verdicts: 1,
         failed: 1,
+        settledFailed: 0,
+        localErrors: 1,
       });
       expect(result.latest).toEqual({
         taskAt: 40,
@@ -159,6 +163,35 @@ describe('gatherPredictionV1Status', () => {
         requestId: 'verdict-a',
         taskRole: 'evaluation',
       });
+    });
+  });
+
+  it('splits FAILED prediction runs into settled fails and local errors via delivery_tx_hash', async () => {
+    await withTempStore(async (store) => {
+      const persistence = new TaskRunPersistence(store.db);
+      // Local engine error: no delivery tx ever landed.
+      seedPredictionRun(store, persistence, {
+        requestId: 'local-error',
+        taskId: 'task-local',
+        state: 'FAILED',
+        stateUpdatedAt: 100,
+      });
+      // Settled failure: delivery tx landed on-chain before the run failed.
+      seedPredictionRun(store, persistence, {
+        requestId: 'settled-fail',
+        taskId: 'task-settled',
+        state: 'FAILED',
+        stateUpdatedAt: 200,
+      });
+      store.db
+        .prepare(`UPDATE task_runs SET delivery_tx_hash = ? WHERE request_id = ?`)
+        .run('0xdeadbeef', 'settled-fail');
+
+      const result = gatherPredictionV1Status(store);
+
+      expect(result.totals.failed).toBe(2);
+      expect(result.totals.settledFailed).toBe(1);
+      expect(result.totals.localErrors).toBe(1);
     });
   });
 });

--- a/client/test/api/prediction-v1-build.test.ts
+++ b/client/test/api/prediction-v1-build.test.ts
@@ -194,4 +194,59 @@ describe('gatherPredictionV1Status', () => {
       expect(result.totals.localErrors).toBe(1);
     });
   });
+
+  it('keeps prediction rows when solver_type is missing but task_payload still identifies the net', async () => {
+    await withTempStore(async (store) => {
+      const persistence = new TaskRunPersistence(store.db);
+      seedPredictionRun(store, persistence, {
+        requestId: 'canonical-prediction',
+        taskId: 'prediction-canonical-task',
+      });
+      store.db.prepare(
+        `UPDATE task_runs
+         SET solver_type = NULL,
+             task_payload = ?
+         WHERE request_id = ?`,
+      ).run(
+        JSON.stringify({
+          id: 'prediction-canonical-task',
+          description: 'prediction test task',
+          contractId: 'prediction',
+          contractVersion: 'v1',
+          role: 'restoration',
+        }),
+        'canonical-prediction',
+      );
+
+      seedPredictionRun(store, persistence, {
+        requestId: 'legacy-prediction',
+        taskId: 'prediction-legacy-task',
+        state: 'FAILED',
+        stateUpdatedAt: 25,
+      });
+      store.db.prepare(
+        `UPDATE task_runs
+         SET solver_type = NULL,
+             task_payload = ?
+         WHERE request_id = ?`,
+      ).run(
+        JSON.stringify({
+          id: 'prediction-legacy-task',
+          description: 'prediction test task',
+          solverType: 'prediction.v1',
+          role: 'restoration',
+        }),
+        'legacy-prediction',
+      );
+
+      const result = gatherPredictionV1Status(store);
+
+      expect(result.totals.observedTasks).toBe(2);
+      expect(result.totals.activeTaskRuns).toBe(1);
+      expect(result.totals.failed).toBe(1);
+      expect(result.recentTasks.map((task) => task.requestId)).toEqual(
+        expect.arrayContaining(['canonical-prediction', 'legacy-prediction']),
+      );
+    });
+  });
 });

--- a/client/test/api/task-runs-build.test.ts
+++ b/client/test/api/task-runs-build.test.ts
@@ -46,7 +46,61 @@ describe('gatherTaskRunsStatus', () => {
         solutions: 1,
         verdicts: 1,
         failed: 1,
+        settledFailed: 0,
+        localErrors: 1,
       });
+    });
+  });
+
+  it('splits FAILED runs into on-chain settled failures and local engine errors', async () => {
+    await withTempStore(async (store) => {
+      const persistence = new TaskRunPersistence(store.db);
+      // local error: failed before reaching the marketplace (no delivery tx).
+      insertTask(persistence, {
+        requestId: 'local-error',
+        taskId: 'task-local',
+        taskRole: 'restoration',
+      });
+      // settled failure: delivery tx landed on-chain but the run terminated FAILED.
+      insertTask(persistence, {
+        requestId: 'settled-fail',
+        taskId: 'task-settled',
+        taskRole: 'restoration',
+      });
+      // settled failure for an evaluation run — same split logic applies.
+      insertTask(persistence, {
+        requestId: 'settled-fail-eval',
+        taskId: 'task-settled-eval',
+        taskRole: 'evaluation',
+      });
+
+      store.db
+        .prepare(
+          `UPDATE task_runs
+             SET state = 'FAILED', state_updated_at = ?, failure_reason = ?
+             WHERE request_id = ?`,
+        )
+        .run(1_100, 'SkippableError', 'local-error');
+      store.db
+        .prepare(
+          `UPDATE task_runs
+             SET state = 'FAILED', state_updated_at = ?, failure_reason = ?, delivery_tx_hash = ?
+             WHERE request_id = ?`,
+        )
+        .run(1_200, 'claimDelivery reverted', '0xdeadbeef', 'settled-fail');
+      store.db
+        .prepare(
+          `UPDATE task_runs
+             SET state = 'FAILED', state_updated_at = ?, failure_reason = ?, delivery_tx_hash = ?
+             WHERE request_id = ?`,
+        )
+        .run(1_300, 'verdict rejected', '0xfeedface', 'settled-fail-eval');
+
+      const status = gatherTaskRunsStatus(store);
+
+      expect(status.totals.failed).toBe(3);
+      expect(status.totals.settledFailed).toBe(2);
+      expect(status.totals.localErrors).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## Summary
- split FAILED totals into settled on-chain failures vs local engine errors
- scope joined prediction cards to the SolverNet-specific counters instead of the global rollup
- cover both the legacy short-name and manifest-keyed joined prediction paths

## Validation
- `PATH=$HOME/.nvm/versions/node/v22.22.2/bin:$PATH yarn --cwd client vitest run test/api/gather-status.test.ts test/api/portfolio-v0-build.test.ts test/api/prediction-v1-build.test.ts test/api/task-runs-build.test.ts src/dashboard/spa/src/pages/Overview.test.tsx src/dashboard/spa/src/pages/overview/NetworkCard.test.tsx`