### PR TITLE
fix(u34i): re-land operator-app polish — Tenderly default RPC, discovery holder, /build design, Hermes catalog

### DIFF
--- a/client/src/api/bootstrap-endpoint.ts
+++ b/client/src/api/bootstrap-endpoint.ts
@@ -116,10 +116,21 @@ export function addBootstrapRoutes(app: Hono, config: BootstrapEndpointConfig): 
       Boolean(parsed.master_address) &&
       fundingGate?.master_address?.toLowerCase() === parsed.master_address?.toLowerCase() &&
       !allRunning;
+    // Three states map to currentStep:
+    //   1. fundingGateActive → 'awaiting_funding' (phase 2 in the panel).
+    //   2. funding cleared, services.length === 0 → 'safe_deployed' (phase 3,
+    //      subState 'Deploying'). This is the "Stage 1 in flight" window —
+    //      the daemon is deploying the fleet Safe, minting agentId, and
+    //      binding via setAgentWallet, none of which creates a service row
+    //      until Stage 2's distributor.stake() lands. Previously this branch
+    //      also returned 'awaiting_funding' which left the panel lying for
+    //      30-60s of post-funding bootstrap work. jinn-mono-u34i UX fix.
+    //   3. services.length > 0 → first service's step (the normal post-
+    //      Stage-2 path).
     const currentStepIdx = fundingGateActive
       ? STEP_INDEX.get('awaiting_funding')!
       : services.length === 0
-      ? (parsed.master_address ? STEP_INDEX.get('awaiting_funding')! : 0)
+      ? (parsed.master_address ? STEP_INDEX.get('safe_deployed')! : 0)
       : Math.min(...services.map((s) => STEP_INDEX.get(s.step) ?? 0));
     const currentStep = STEPS[currentStepIdx];
 

--- a/client/src/api/discovery-endpoint.ts
+++ b/client/src/api/discovery-endpoint.ts
@@ -9,23 +9,44 @@
  *
  * Used by the /build SPA route (hfmf) to render published plug-ins, the
  * local operator's published plug-ins, and per-plug-in score history.
+ *
+ * Accepts two config shapes:
+ *   - `{ discovery: () => DiscoveryAPI }` — direct getter (legacy).
+ *   - `{ getDiscovery: () => DiscoveryAPI | null }` — lazy holder access; returns
+ *     503 subsystem_not_ready until the daemon populates it post-bootstrap.
+ *
+ * The lazy form lets server.ts register the routes eagerly at server-start
+ * (before the daemon has built its DiscoveryAPI), so Hono's matcher includes
+ * the paths and the SPA gets a 503 (not a 404) while waiting for bootstrap to
+ * finish. Same eager-register / late-populate pattern as solverNetsLauncher
+ * and harnessReadinessRegistry. See jinn-mono-u34i.
  */
 import type { Hono } from 'hono';
 import { DiscoveryUnavailableError } from '../discovery/types.js';
 import type { DiscoveryAPI } from '../discovery/types.js';
 
-export interface DiscoveryEndpointConfig {
-  discovery: () => DiscoveryAPI;
-}
+export type DiscoveryEndpointConfig =
+  | { discovery: () => DiscoveryAPI }
+  | { getDiscovery: () => DiscoveryAPI | null };
 
 export function addDiscoveryRoutes(app: Hono, config: DiscoveryEndpointConfig): void {
+  const getDiscovery: () => DiscoveryAPI | null =
+    'getDiscovery' in config ? config.getDiscovery : () => config.discovery();
+
   app.get('/v1/discovery/plugin-publications', async (c) => {
+    const discovery = getDiscovery();
+    if (!discovery) {
+      return c.json(
+        { error: 'subsystem_not_ready', message: 'DiscoveryAPI still initialising' },
+        503,
+      );
+    }
     const solverType = c.req.query('solverType');
     const builderAgentId = c.req.query('builderAgentId');
     const includeRevokedRaw = c.req.query('includeRevoked');
     const includeRevoked = includeRevokedRaw === undefined ? undefined : includeRevokedRaw !== 'false';
     try {
-      const publications = await config.discovery().listPluginPublications({
+      const publications = await discovery.listPluginPublications({
         ...(solverType !== undefined ? { solverType } : {}),
         ...(builderAgentId !== undefined ? { builderAgentId } : {}),
         ...(includeRevoked !== undefined ? { includeRevoked } : {}),
@@ -40,6 +61,13 @@ export function addDiscoveryRoutes(app: Hono, config: DiscoveryEndpointConfig): 
   });
 
   app.get('/v1/discovery/builder-artifacts', async (c) => {
+    const discovery = getDiscovery();
+    if (!discovery) {
+      return c.json(
+        { error: 'subsystem_not_ready', message: 'DiscoveryAPI still initialising' },
+        503,
+      );
+    }
     const builderAgentId = c.req.query('builderAgentId');
     if (!builderAgentId) {
       return c.json({ error: 'builderAgentId is required' }, 400);
@@ -47,7 +75,7 @@ export function addDiscoveryRoutes(app: Hono, config: DiscoveryEndpointConfig): 
     const limitRaw = c.req.query('limit');
     const limit = limitRaw === undefined ? undefined : Number(limitRaw);
     try {
-      const artifacts = await config.discovery().listBuilderArtifacts({
+      const artifacts = await discovery.listBuilderArtifacts({
         builderAgentId,
         ...(limit !== undefined && Number.isFinite(limit) ? { limit } : {}),
       });
@@ -61,12 +89,19 @@ export function addDiscoveryRoutes(app: Hono, config: DiscoveryEndpointConfig): 
   });
 
   app.get('/v1/discovery/plugin-scores', async (c) => {
+    const discovery = getDiscovery();
+    if (!discovery) {
+      return c.json(
+        { error: 'subsystem_not_ready', message: 'DiscoveryAPI still initialising' },
+        503,
+      );
+    }
     const cid = c.req.query('cid');
     if (!cid) return c.json({ error: 'cid is required' }, 400);
     const limitRaw = c.req.query('limit');
     const limit = limitRaw === undefined ? undefined : Number(limitRaw);
     try {
-      const scores = await config.discovery().getPluginScores({
+      const scores = await discovery.getPluginScores({
         pluginCid: cid,
         ...(limit !== undefined && Number.isFinite(limit) ? { limit } : {}),
       });

--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -69,7 +69,6 @@ function readDaemonRuntime(earningDir: string | undefined): GatheredStatusRaw['d
   }
 }
 
-const STANDARD_MASTER_BOOTSTRAP_MULTIPLIER = 2n;
 const predictionOperatorStatusCache = new WeakMap<JinnConfig, Map<string, Promise<PredictionOperatorStatus>>>();
 
 /**
@@ -567,8 +566,14 @@ export async function gatherGatheredStatusRaw(
     minMasterEthWei: (
       !fleet || fleet.fleet_stage === 'none'
         ? stage1MinMasterEth(chainCfg, status?.config?.targetServices ?? 1)
-        : chainCfg.minEoaGasEth *
-          (fleet.services.length > 0 ? 1n : STANDARD_MASTER_BOOTSTRAP_MULTIPLIER)
+        : // Stage 2 master gas budget — minEoaGasEth (stake gas) + per-extra-
+          // service transfers. The historic `× 2` for fresh fleets was wrong:
+          // it double-counted a service-1 transfer that doesn't fire (HD-1
+          // carries Stage 1 leftover). Dropped in jinn-mono-u34i so the
+          // operator-facing 0.020 ETH budget actually clears Stage 2's gate.
+          chainCfg.minEoaGasEth +
+            chainCfg.minEoaGasEth *
+              BigInt(Math.max(0, (status?.config?.targetServices ?? 1) - 1))
     ).toString(),
     master: {
       address: fleet?.master_address ?? null,

--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -555,13 +555,18 @@ export async function gatherGatheredStatusRaw(
     fleet,
     migrationArchive: migrationArchive.entries.length > 0 ? migrationArchive : undefined,
     rpc: { ok: false, error: undefined },
-    // Pre-Stage-1 (fleet state missing or fleet_stage === 'none'): Stage 1
-    // needs STAGE1_AGENT_ETH for the master → agent transfer plus
-    // minEoaGasEth reserved for the master's own gas. Post-Stage-1, keep
-    // the existing 1× / 2× minEoaGasEth heuristic. See jinn-mono-u34i.
+    // Pre-Stage-1 (fleet state missing or fleet_stage === 'none'):
+    // stage1MinMasterEth returns the FULL bootstrap budget — Stage 1 transfer
+    // + Stage 2 reserve + per-extra-service top-ups — so the operator funds
+    // ONCE and the daemon doesn't re-prompt at the Stage 2 gate. See
+    // jinn-mono-u34i (gate-vs-transfer parity) and the one-shot-funding
+    // follow-up.
+    // Post-Stage-1, fall back to the existing 1× / 2× minEoaGasEth heuristic
+    // (the operator already funded Stage 1; this gate only needs to cover
+    // what's left).
     minMasterEthWei: (
       !fleet || fleet.fleet_stage === 'none'
-        ? stage1MinMasterEth(chainCfg)
+        ? stage1MinMasterEth(chainCfg, status?.config?.targetServices ?? 1)
         : chainCfg.minEoaGasEth *
           (fleet.services.length > 0 ? 1n : STANDARD_MASTER_BOOTSTRAP_MULTIPLIER)
     ).toString(),

--- a/client/src/api/server.ts
+++ b/client/src/api/server.ts
@@ -157,12 +157,22 @@ export interface ApiServerConfig {
   /** Operator review API for pending captures. */
   captures?: CapturesRoutesDeps;
   /**
-   * Discovery API instance. When set, mounts GET /v1/discovery/* routes
-   * that proxy DiscoveryAPI methods (listPluginPublications, listBuilderArtifacts,
-   * getPluginScores) so the SPA's /build route can fetch them without direct
-   * GraphQL or RPC access.
+   * Discovery API. Mounts GET /v1/discovery/* routes that proxy DiscoveryAPI
+   * methods (listPluginPublications, listBuilderArtifacts, getPluginScores)
+   * so the SPA's /build route can fetch them without direct GraphQL or RPC
+   * access.
+   *
+   * Accepts either a direct instance or a holder ref (same pattern as
+   * solverNetsLauncher / harnessReadinessRegistry). main.ts uses the holder
+   * shape because the daemon's DiscoveryAPI is constructed post-bootstrap;
+   * routes register eagerly at server start so Hono's matcher includes them
+   * before the first request. Without this, every /v1/discovery/* request
+   * gets a 404 forever, and the /build page renders "Discovery unavailable"
+   * permanently (jinn-mono-u34i field repro).
    */
-  discovery?: DiscoveryAPI;
+  discovery?:
+    | DiscoveryAPI
+    | { holder: { current: DiscoveryAPI | undefined } };
 }
 
 export interface ApiServer {
@@ -385,8 +395,18 @@ export async function startApiServer(config: ApiServerConfig): Promise<ApiServer
   }
 
   if (config.discovery) {
-    const discoveryInstance = config.discovery;
-    addDiscoveryRoutes(app, { discovery: () => discoveryInstance });
+    const disc = config.discovery;
+    if ('holder' in disc) {
+      // Lazy holder shape — register routes eagerly; handler returns 503
+      // subsystem_not_ready until main.ts populates holder.current after
+      // bootstrap. Same pattern as harnessReadinessRegistry.
+      addDiscoveryRoutes(app, {
+        getDiscovery: () => disc.holder.current ?? null,
+      });
+    } else {
+      const discoveryInstance = disc;
+      addDiscoveryRoutes(app, { discovery: () => discoveryInstance });
+    }
   }
 
   if (config.solverNets) {

--- a/client/src/api/setup-endpoints.ts
+++ b/client/src/api/setup-endpoints.ts
@@ -62,6 +62,11 @@ export interface SetupRoutesConfig {
   chain?: JinnOnchainNetwork;
   rpcUrl?: string;
   minEoaGasWei?: string;
+  /**
+   * Pass through from JinnConfig.targetServices so the faucet drip target
+   * scales with multi-service deployments. Defaults to 1 (testnet operators).
+   */
+  targetServices?: number;
   claudePath?: string;
   getClaudePath?: () => string;
   runtimeMode?: 'bare' | 'docker-compose' | 'container';
@@ -182,14 +187,16 @@ export function addSetupRoutes(app: Hono, config: SetupRoutesConfig = {}): void 
     const requestFunding = config.requestFunding ?? requestTestnetFunding;
     const interDripPauseMs = config.interDripPauseMs ?? 1_000;
     // Faucet drip target. Single source of truth: stage1MinMasterEth(chain
-    // config), which is also what FleetBootstrapper.ensureStage1 gates on
-    // (jinn-mono-u34i). The optional `config.minEoaGasWei` override is for
-    // tests that want a custom target. Production callers should NOT pass
-    // it — letting the default win prevents the faucet/gate drift that hit
-    // operators in the 2026-05-18 canary run.
+    // config, targetServices), which is also what FleetBootstrapper.ensureStage1
+    // gates on (jinn-mono-u34i). The faucet drips master ETH until it can
+    // complete the ENTIRE bootstrap — operator gets one drip session, not one
+    // per stage. The optional `config.minEoaGasWei` override is for tests
+    // that want a custom target; production callers should NOT pass it.
+    // `config.targetServices` is also for tests / multi-service deployments;
+    // defaults to 1 (the testnet faucet's audience).
     const targetWei = config.minEoaGasWei
       ? BigInt(config.minEoaGasWei)
-      : stage1MinMasterEth(getChainConfig(chain));
+      : stage1MinMasterEth(getChainConfig(chain), config.targetServices ?? 1);
     const publicClient = config.rpcUrl
       ? createJinnPublicClient(config.rpcUrl, 'base-sepolia')
       : null;

--- a/client/src/api/setup-endpoints.ts
+++ b/client/src/api/setup-endpoints.ts
@@ -724,14 +724,21 @@ export function addSetupRoutes(app: Hono, config: SetupRoutesConfig = {}): void 
       return c.json({ error: 'invalid_body', detail: 'expected JSON body' }, 400);
     }
 
+    // `persistConfigValue` (calling `persistTopLevelConfigValue` in
+    // config.ts) creates the parent dir + file when missing — same pattern
+    // as every other write path in this module. The pre-u34i version 404'd
+    // here on missing config.json, which broke fresh operators (who don't
+    // have config.json yet, since the daemon happily runs with defaults)
+    // from changing their RPC via the panel: the only operator-app affordance
+    // for switching off a rate-limited public RPC. Operator-never-leaves-the-app
+    // principle. See jinn-mono-u34i.
     const cfgPath = config.configPath ?? DEFAULT_CONFIG_PATH;
-    if (!existsSync(cfgPath)) {
-      return c.json({ error: 'config_not_found', path: cfgPath }, 404);
-    }
 
     let nextRpcUrl: string;
     if (body.rpcUrl === null || body.rpcUrl === '') {
-      nextRpcUrl = config.defaultRpcUrlForChain?.() ?? 'https://sepolia.base.org';
+      nextRpcUrl =
+        config.defaultRpcUrlForChain?.() ??
+        'https://base-sepolia.gateway.tenderly.co/75tyLMQuD8EHpXxMwINIKu';
     } else if (typeof body.rpcUrl === 'string') {
       try {
         const parsed = new URL(body.rpcUrl);

--- a/client/src/cli/commands/auth.ts
+++ b/client/src/cli/commands/auth.ts
@@ -44,7 +44,9 @@ function persistRuntimeMode(mode: AuthContext, configPath: string = DEFAULT_CONF
   }
   const network = current['network'] === 'mainnet' ? 'mainnet' : 'testnet';
   if (current['rpcUrl'] === undefined) {
-    current['rpcUrl'] = network === 'testnet' ? 'https://sepolia.base.org' : 'https://mainnet.base.org';
+    current['rpcUrl'] = network === 'testnet'
+      ? 'https://base-sepolia.gateway.tenderly.co/75tyLMQuD8EHpXxMwINIKu'
+      : 'https://mainnet.base.org';
   }
   current['runtimeMode'] = mode;
   mkdirSync(dirname(configPath), { recursive: true, mode: 0o700 });

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -976,10 +976,14 @@ export function loadConfig(configPath?: string): JinnConfig {
     );
   }
 
-  // 4. Resolve rpcUrl default based on network (if not explicitly set)
+  // 4. Resolve rpcUrl default based on network (if not explicitly set).
+  // Testnet default is a Tenderly gateway (free public key) — much higher
+  // rate limits than `https://sepolia.base.org`. See contracts.ts comment +
+  // the panel's "shared RPC" warning in NetworkSection.tsx for the operator-
+  // facing pitch to bring their own key.
   const parsed = result.data;
   const defaultRpcUrl = parsed.network === 'testnet'
-    ? 'https://sepolia.base.org'
+    ? 'https://base-sepolia.gateway.tenderly.co/75tyLMQuD8EHpXxMwINIKu'
     : 'https://mainnet.base.org';
 
   return {

--- a/client/src/dashboard/spa/src/pages/Build.test.tsx
+++ b/client/src/dashboard/spa/src/pages/Build.test.tsx
@@ -62,8 +62,11 @@ describe('BuildPage (hfmf)', () => {
 
   it('renders the my-artifacts panel', async () => {
     render(withQuery(<BuildPage />));
+    // Match the panel's heading specifically; the same phrase appears
+    // inside the quickstart markdown <p> rendered by IntroCard, so a
+    // bare getByText would race against the disabled-state transition.
     await waitFor(() => {
-      expect(screen.getByText(/your published plug-ins/i)).toBeTruthy();
+      expect(screen.getByRole('heading', { name: /your published plug-ins/i })).toBeTruthy();
     });
   });
 

--- a/client/src/dashboard/spa/src/pages/Build.tsx
+++ b/client/src/dashboard/spa/src/pages/Build.tsx
@@ -35,14 +35,55 @@ export function BuildPage(): JSX.Element {
         display: 'flex',
         flexDirection: 'column',
         gap: '24px',
-        padding: '24px',
+        padding: '32px 24px 48px',
         maxWidth: 1100,
         margin: '0 auto',
       }}
     >
+      <header
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '8px',
+          paddingBottom: '8px',
+        }}
+      >
+        {/* Single Gold-as-Hint emphasis on this surface — the page eyebrow.
+            The page-level H1 ("Build a plug-in") is rendered by IntroCard
+            from the quickstart markdown; we don't repeat it here so there
+            is exactly one H1 on the page. */}
+        <span className="j-label" style={{ color: 'var(--accent-gold)' }}>
+          Build · Plug-ins
+        </span>
+        <p
+          className="j-mono"
+          style={{
+            color: 'var(--fg-muted)',
+            fontSize: '14px',
+            lineHeight: 1.7,
+            margin: 0,
+            maxWidth: '64ch',
+          }}
+        >
+          Scaffold a SolverPlugin, publish it to npm and IPFS, watch it appear
+          in the registry under your builder identity. Anchored on the
+          SWE-rebench v2 SolverNet for v0.
+        </p>
+      </header>
+
       <IntroCard />
       <ShapeCatalogue />
-      <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          gap: '16px',
+          paddingTop: '8px',
+          borderTop: '1px solid var(--border)',
+        }}
+      >
+        <span className="j-label">Registry</span>
         <ArtifactTypeFilterChip value={artifactType} onChange={setArtifactType} />
       </div>
       {artifactType === 'plugin' ? (

--- a/client/src/dashboard/spa/src/pages/Operator.tsx
+++ b/client/src/dashboard/spa/src/pages/Operator.tsx
@@ -36,7 +36,9 @@ export function OperatorPage({ onRestartPending = () => undefined }: OperatorPag
 
   const chain = data?.chain ?? 'base-sepolia';
   const rpcUrl = data?.rpcUrl ?? '';
-  const defaultRpcUrl = data?.defaultRpcUrl ?? (chain === 'base' ? 'https://mainnet.base.org' : 'https://sepolia.base.org');
+  const defaultRpcUrl = data?.defaultRpcUrl ?? (chain === 'base'
+    ? 'https://mainnet.base.org'
+    : 'https://base-sepolia.gateway.tenderly.co/75tyLMQuD8EHpXxMwINIKu');
 
   return (
     <div

--- a/client/src/dashboard/spa/src/pages/build/ArtifactTypeFilterChip.tsx
+++ b/client/src/dashboard/spa/src/pages/build/ArtifactTypeFilterChip.tsx
@@ -6,22 +6,37 @@ export interface ArtifactTypeFilterChipProps {
 }
 
 const chipStyle = (active: boolean, disabled: boolean): React.CSSProperties => ({
-  padding: '6px 12px',
-  borderRadius: 'var(--radius-pill, 999px)',
+  padding: '6px 14px',
+  borderRadius: 'var(--radius-pill)',
   border: `1px solid ${active ? 'var(--accent-sky)' : 'var(--border)'}`,
-  background: active ? 'var(--accent-sky-tint, transparent)' : 'transparent',
-  fontFamily: "'JetBrains Mono', monospace",
+  background: 'transparent',
+  fontFamily: 'var(--mono)',
   fontSize: '11px',
+  fontWeight: 500,
   textTransform: 'uppercase',
-  letterSpacing: '0.1em',
-  color: disabled ? 'var(--fg-dim)' : active ? 'var(--fg)' : 'var(--fg-muted)',
+  letterSpacing: '0.14em',
+  color: disabled ? 'var(--fg-dim)' : active ? 'var(--accent-sky)' : 'var(--fg-muted)',
   cursor: disabled ? 'not-allowed' : 'pointer',
+  opacity: disabled ? 0.6 : 1,
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '8px',
 });
+
+const soonStyle: React.CSSProperties = {
+  fontSize: '9px',
+  letterSpacing: '0.14em',
+  color: 'var(--fg-dim)',
+  paddingLeft: '6px',
+  borderLeft: '1px solid var(--border)',
+  marginLeft: '2px',
+};
 
 export function ArtifactTypeFilterChip({ value, onChange }: ArtifactTypeFilterChipProps): JSX.Element {
   return (
     <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
       <button
+        type="button"
         aria-pressed={value === 'plugin' ? 'true' : 'false'}
         style={chipStyle(value === 'plugin', false)}
         onClick={() => {
@@ -31,11 +46,13 @@ export function ArtifactTypeFilterChip({ value, onChange }: ArtifactTypeFilterCh
         Plug-ins
       </button>
       <button
+        type="button"
         disabled
         aria-pressed="false"
         style={chipStyle(false, true)}
       >
-        Harnesses <span style={{ marginLeft: 6, fontSize: 9 }}>coming soon</span>
+        Harnesses
+        <span style={soonStyle}>Coming soon</span>
       </button>
     </div>
   );

--- a/client/src/dashboard/spa/src/pages/build/IntroCard.tsx
+++ b/client/src/dashboard/spa/src/pages/build/IntroCard.tsx
@@ -11,12 +11,39 @@ const QUICKSTART_URL =
 export function IntroCard(): JSX.Element {
   return (
     <PanelCard>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', marginBottom: '20px' }}>
+        <span className="j-label">Quickstart · 60 seconds</span>
+      </div>
       <div className="hfmf-intro-markdown">{renderMarkdownSubset(quickstartMd)}</div>
-      <p style={{ marginTop: '16px' }}>
-        <a href={QUICKSTART_URL} target="_blank" rel="noreferrer">
-          Read the full quickstart on GitHub
+      <div
+        style={{
+          marginTop: '24px',
+          paddingTop: '20px',
+          borderTop: '1px solid var(--border)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: '12px',
+          flexWrap: 'wrap',
+        }}
+      >
+        <span className="j-label">Next</span>
+        <a
+          href={QUICKSTART_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="j-mono"
+          style={{
+            fontSize: '12px',
+            color: 'var(--accent-sky)',
+            textDecoration: 'none',
+            borderBottom: '1px solid var(--border)',
+            paddingBottom: '1px',
+          }}
+        >
+          Read the full quickstart on GitHub →
         </a>
-      </p>
+      </div>
     </PanelCard>
   );
 }

--- a/client/src/dashboard/spa/src/pages/build/MyArtifactsPanel.tsx
+++ b/client/src/dashboard/spa/src/pages/build/MyArtifactsPanel.tsx
@@ -4,19 +4,59 @@ import type { DiscoveryBuilderArtifactsResponse } from '../../api/types.js';
 import { PanelCard } from '../../components/PanelCard.js';
 
 const cellStyle: React.CSSProperties = {
-  padding: '10px 12px',
+  padding: '12px',
   borderBottom: '1px solid var(--border)',
-  fontFamily: "'JetBrains Mono', monospace",
+  fontFamily: 'var(--mono)',
   fontSize: '12px',
+  lineHeight: 1.6,
   color: 'var(--fg)',
 };
+
 const headCellStyle: React.CSSProperties = {
   ...cellStyle,
-  color: 'var(--fg-muted)',
+  color: 'var(--fg-dim)',
   fontWeight: 500,
   textTransform: 'uppercase',
-  letterSpacing: '0.1em',
+  letterSpacing: '0.14em',
+  fontSize: '11px',
+  textAlign: 'left',
+};
+
+const statusChip = (color: string): React.CSSProperties => ({
+  display: 'inline-block',
+  fontFamily: 'var(--mono)',
   fontSize: '10px',
+  fontWeight: 500,
+  textTransform: 'uppercase',
+  letterSpacing: '0.14em',
+  padding: '2px 10px',
+  borderRadius: 'var(--radius-pill)',
+  border: `1px solid ${color}`,
+  color,
+});
+
+function PanelHeader(): JSX.Element {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', marginBottom: '20px' }}>
+      <span className="j-label">Builder</span>
+      <h3
+        className="j-display"
+        style={{ fontSize: '22px', lineHeight: 1.25, color: 'var(--fg)', margin: 0 }}
+      >
+        Your published plug-ins
+      </h3>
+    </div>
+  );
+}
+
+const inlineCode: React.CSSProperties = {
+  fontFamily: 'var(--mono)',
+  fontSize: '12px',
+  color: 'var(--accent-sky)',
+  background: 'var(--bg)',
+  border: '1px solid var(--border)',
+  borderRadius: 'var(--radius-1)',
+  padding: '1px 6px',
 };
 
 export function MyArtifactsPanel({ fleetAgentId }: { fleetAgentId: string | undefined }): JSX.Element {
@@ -30,40 +70,109 @@ export function MyArtifactsPanel({ fleetAgentId }: { fleetAgentId: string | unde
 
   if (!enabled) {
     return (
-      <PanelCard
-        title="Your published plug-ins"
-        style={{ border: '1px dashed var(--border)', background: 'var(--surface-sunken)' }}
-      >
-        <p style={{ color: 'var(--fg-muted)' }}>
-          Complete identity bootstrap to see your published plug-ins. Run{' '}
-          <code>jinn solver-plugins publish</code> on a plug-in and the lazy stage-ensure will provision
-          your builder identity (Stage 1).
-        </p>
+      <PanelCard style={{ background: 'var(--bg-sunken)' }}>
+        <PanelHeader />
+        <div
+          style={{
+            border: '1px dashed var(--border)',
+            borderRadius: 'var(--radius-2)',
+            padding: '24px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '8px',
+          }}
+        >
+          <span className="j-label">Identity pending</span>
+          <p
+            className="j-mono"
+            style={{
+              color: 'var(--fg-muted)',
+              fontSize: '13px',
+              lineHeight: 1.7,
+              margin: 0,
+              maxWidth: '64ch',
+            }}
+          >
+            Complete identity bootstrap to see your published plug-ins. Run{' '}
+            <code style={inlineCode}>jinn solver-plugins publish</code> on a
+            plug-in and the lazy stage-ensure will provision your builder
+            identity (Stage 1).
+          </p>
+        </div>
       </PanelCard>
     );
   }
 
   if (isLoading) {
-    return <section style={{ padding: '24px', color: 'var(--fg-muted)' }}>Loading your plug-ins…</section>;
+    return (
+      <PanelCard>
+        <PanelHeader />
+        <p className="j-mono" style={{ color: 'var(--fg-muted)', fontSize: '13px', margin: 0 }}>
+          Loading your plug-ins…
+        </p>
+      </PanelCard>
+    );
   }
   if (error) {
-    return <section style={{ padding: '24px', color: 'var(--break-red)' }}>Discovery unavailable.</section>;
+    return (
+      <PanelCard>
+        <PanelHeader />
+        <p className="j-mono" style={{ color: 'var(--break-red)', fontSize: '13px', margin: 0 }}>
+          Discovery unavailable.
+        </p>
+      </PanelCard>
+    );
   }
 
   const rows = (data?.artifacts ?? []).filter((a) => a.artifactType === 'plugin');
 
   if (rows.length === 0) {
     return (
-      <PanelCard title="Your published plug-ins">
-        <p style={{ color: 'var(--fg-dim)' }}>You have not published any plug-ins yet.</p>
+      <PanelCard>
+        <PanelHeader />
+        <div
+          style={{
+            border: '1px dashed var(--border)',
+            borderRadius: 'var(--radius-2)',
+            padding: '24px',
+            background: 'var(--bg-sunken)',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '8px',
+          }}
+        >
+          <span className="j-label">Nothing yet</span>
+          <p
+            className="j-mono"
+            style={{
+              color: 'var(--fg-muted)',
+              fontSize: '13px',
+              lineHeight: 1.7,
+              margin: 0,
+              maxWidth: '64ch',
+            }}
+          >
+            You have not published any plug-ins yet. Scaffold one with{' '}
+            <code style={inlineCode}>jinn create plugin</code>, then publish
+            with <code style={inlineCode}>jinn solver-plugins publish</code>.
+            It will appear here under your builder agentId.
+          </p>
+        </div>
       </PanelCard>
     );
   }
 
   return (
-    <PanelCard title="Your published plug-ins">
+    <PanelCard>
+      <PanelHeader />
       <div style={{ overflowX: 'auto' }}>
-        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            borderTop: '1px solid var(--border)',
+          }}
+        >
           <thead>
             <tr>
               <th style={headCellStyle}>Plug-in</th>
@@ -76,10 +185,14 @@ export function MyArtifactsPanel({ fleetAgentId }: { fleetAgentId: string | unde
             {rows.map((r) => (
               <tr key={`${r.builderAgentId}:${r.cid}`}>
                 <td style={cellStyle}>{r.name}</td>
-                <td style={cellStyle}>{r.version}</td>
+                <td style={{ ...cellStyle, color: 'var(--fg-muted)' }}>{r.version}</td>
                 <td style={{ ...cellStyle, color: 'var(--fg-muted)' }}>{r.supports.join(', ')}</td>
                 <td style={cellStyle}>
-                  {r.revoked ? <span style={{ color: 'var(--wane)' }}>revoked</span> : <span style={{ color: 'var(--vow-green)' }}>active</span>}
+                  {r.revoked ? (
+                    <span style={statusChip('var(--wane)')}>Revoked</span>
+                  ) : (
+                    <span style={statusChip('var(--vow-green)')}>Active</span>
+                  )}
                 </td>
               </tr>
             ))}

--- a/client/src/dashboard/spa/src/pages/build/PublishedPluginsPanel.tsx
+++ b/client/src/dashboard/spa/src/pages/build/PublishedPluginsPanel.tsx
@@ -4,24 +4,60 @@ import type { DiscoveryPluginPublicationsResponse, PluginPublicationDto } from '
 import { PanelCard } from '../../components/PanelCard.js';
 
 const cellStyle: React.CSSProperties = {
-  padding: '10px 12px',
+  padding: '12px',
   borderBottom: '1px solid var(--border)',
-  fontFamily: "'JetBrains Mono', monospace",
+  fontFamily: 'var(--mono)',
   fontSize: '12px',
+  lineHeight: 1.6,
   color: 'var(--fg)',
   verticalAlign: 'top',
 };
+
 const headCellStyle: React.CSSProperties = {
   ...cellStyle,
-  color: 'var(--fg-muted)',
+  color: 'var(--fg-dim)',
   fontWeight: 500,
   textTransform: 'uppercase',
-  letterSpacing: '0.1em',
-  fontSize: '10px',
+  letterSpacing: '0.14em',
+  fontSize: '11px',
+  textAlign: 'left',
 };
+
+const statusChip = (color: string): React.CSSProperties => ({
+  display: 'inline-block',
+  fontFamily: 'var(--mono)',
+  fontSize: '10px',
+  fontWeight: 500,
+  textTransform: 'uppercase',
+  letterSpacing: '0.14em',
+  padding: '2px 10px',
+  borderRadius: 'var(--radius-pill)',
+  border: `1px solid ${color}`,
+  color,
+});
 
 function truncate(cid: string): string {
   return cid.length > 14 ? `${cid.slice(0, 8)}…${cid.slice(-4)}` : cid;
+}
+
+/**
+ * Render the panel header — eyebrow + serif title — preserving the
+ * literal phrase "Published plug-ins for <solverType>" so the BuildPage
+ * test's `getByText` matcher still resolves. The eyebrow / title pair
+ * replaces the old <h3> rendered by PanelCard's `title` prop.
+ */
+function PanelHeader({ solverType }: { solverType: string }): JSX.Element {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', marginBottom: '20px' }}>
+      <span className="j-label">Registry</span>
+      <h3
+        className="j-display"
+        style={{ fontSize: '22px', lineHeight: 1.25, color: 'var(--fg)', margin: 0 }}
+      >
+        Published plug-ins for {solverType}
+      </h3>
+    </div>
+  );
 }
 
 export function PublishedPluginsPanel({ solverType }: { solverType: string }): JSX.Element {
@@ -33,15 +69,26 @@ export function PublishedPluginsPanel({ solverType }: { solverType: string }): J
 
   if (isLoading) {
     return (
-      <section style={{ padding: '24px', color: 'var(--fg-muted)' }}>Loading published plug-ins…</section>
+      <PanelCard>
+        <PanelHeader solverType={solverType} />
+        <p className="j-mono" style={{ color: 'var(--fg-muted)', fontSize: '13px', margin: 0 }}>
+          Loading published plug-ins…
+        </p>
+      </PanelCard>
     );
   }
 
   if (error) {
     return (
-      <section style={{ padding: '24px', color: 'var(--break-red)' }}>
-        Discovery unavailable. {(error as Error).message}
-      </section>
+      <PanelCard>
+        <PanelHeader solverType={solverType} />
+        <p
+          className="j-mono"
+          style={{ color: 'var(--break-red)', fontSize: '13px', margin: 0, lineHeight: 1.7 }}
+        >
+          Discovery unavailable. {(error as Error).message}
+        </p>
+      </PanelCard>
     );
   }
 
@@ -49,16 +96,74 @@ export function PublishedPluginsPanel({ solverType }: { solverType: string }): J
 
   if (rows.length === 0) {
     return (
-      <PanelCard title={`Published plug-ins for ${solverType}`}>
-        <p style={{ color: 'var(--fg-dim)' }}>No plug-ins published yet. Be the first.</p>
+      <PanelCard>
+        <PanelHeader solverType={solverType} />
+        <div
+          style={{
+            border: '1px dashed var(--border)',
+            borderRadius: 'var(--radius-2)',
+            padding: '24px',
+            background: 'var(--bg-sunken)',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '8px',
+          }}
+        >
+          <span className="j-label">Empty registry</span>
+          <p
+            className="j-mono"
+            style={{
+              color: 'var(--fg)',
+              fontSize: '13px',
+              lineHeight: 1.7,
+              margin: 0,
+              maxWidth: '64ch',
+            }}
+          >
+            No plug-ins published yet. Be the first.
+          </p>
+          <p
+            className="j-mono"
+            style={{
+              color: 'var(--fg-muted)',
+              fontSize: '13px',
+              lineHeight: 1.7,
+              margin: 0,
+              maxWidth: '64ch',
+            }}
+          >
+            Run{' '}
+            <code
+              style={{
+                fontFamily: 'var(--mono)',
+                fontSize: '12px',
+                color: 'var(--accent-sky)',
+                background: 'var(--bg)',
+                border: '1px solid var(--border)',
+                borderRadius: 'var(--radius-1)',
+                padding: '1px 6px',
+              }}
+            >
+              jinn solver-plugins publish
+            </code>{' '}
+            and your plug-in appears here under your builder agentId.
+          </p>
+        </div>
       </PanelCard>
     );
   }
 
   return (
-    <PanelCard title={`Published plug-ins for ${solverType}`}>
+    <PanelCard>
+      <PanelHeader solverType={solverType} />
       <div style={{ overflowX: 'auto' }}>
-        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            borderTop: '1px solid var(--border)',
+          }}
+        >
           <thead>
             <tr>
               <th style={headCellStyle}>Plug-in</th>
@@ -72,14 +177,16 @@ export function PublishedPluginsPanel({ solverType }: { solverType: string }): J
             {rows.map((r: PluginPublicationDto) => (
               <tr key={`${r.builderAgentId}:${r.cid}`}>
                 <td style={cellStyle}>{r.name}</td>
-                <td style={cellStyle}>{r.version}</td>
+                <td style={{ ...cellStyle, color: 'var(--fg-muted)' }}>{r.version}</td>
                 <td style={{ ...cellStyle, color: 'var(--fg-muted)' }}>{r.builderAgentId}</td>
                 <td style={{ ...cellStyle, color: 'var(--fg-muted)' }}>{truncate(r.cid)}</td>
                 <td style={cellStyle}>
                   {r.revoked ? (
-                    <span style={{ color: 'var(--wane)' }}>revoked{r.revokedReason ? ` — ${r.revokedReason}` : ''}</span>
+                    <span style={statusChip('var(--wane)')}>
+                      Revoked{r.revokedReason ? ` · ${r.revokedReason}` : ''}
+                    </span>
                   ) : (
-                    <span style={{ color: 'var(--vow-green)' }}>active</span>
+                    <span style={statusChip('var(--vow-green)')}>Active</span>
                   )}
                 </td>
               </tr>

--- a/client/src/dashboard/spa/src/pages/build/ShapeCatalogue.tsx
+++ b/client/src/dashboard/spa/src/pages/build/ShapeCatalogue.tsx
@@ -3,67 +3,167 @@ import { PanelCard } from '../../components/PanelCard.js';
 
 const headStyle: React.CSSProperties = {
   textAlign: 'left',
-  padding: '8px 12px',
+  padding: '10px 12px',
   borderBottom: '1px solid var(--border)',
-  fontFamily: "'JetBrains Mono', monospace",
-  fontSize: '10px',
+  fontFamily: 'var(--mono)',
+  fontSize: '11px',
+  fontWeight: 500,
   textTransform: 'uppercase',
-  letterSpacing: '0.1em',
-  color: 'var(--fg-muted)',
+  letterSpacing: '0.14em',
+  color: 'var(--fg-dim)',
 };
 
 const cellStyle: React.CSSProperties = {
-  padding: '10px 12px',
+  padding: '12px',
   borderBottom: '1px solid var(--border)',
+  fontFamily: 'var(--mono)',
   fontSize: '13px',
+  lineHeight: 1.6,
   color: 'var(--fg)',
   verticalAlign: 'top',
 };
 
+const cellMuted: React.CSSProperties = {
+  ...cellStyle,
+  color: 'var(--fg-muted)',
+};
+
+const requiredChip = (required: boolean): React.CSSProperties => ({
+  display: 'inline-block',
+  fontFamily: 'var(--mono)',
+  fontSize: '10px',
+  fontWeight: 500,
+  textTransform: 'uppercase',
+  letterSpacing: '0.14em',
+  padding: '2px 8px',
+  borderRadius: 'var(--radius-1)',
+  border: `1px solid ${required ? 'var(--accent-sky)' : 'var(--border)'}`,
+  color: required ? 'var(--accent-sky)' : 'var(--fg-dim)',
+});
+
 export function ShapeCatalogue(): JSX.Element {
   return (
     <PanelCard>
-      <h2 style={{ marginTop: 0 }}>Plug-in shape</h2>
-      <table style={{ width: '100%', borderCollapse: 'collapse', marginBottom: '24px' }}>
-        <thead>
-          <tr>
-            <th style={headStyle}>Field</th>
-            <th style={headStyle}>Type</th>
-            <th style={headStyle}>Required</th>
-            <th style={headStyle}>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          {PLUGIN_SHAPE_FIELDS.map((f) => (
-            <tr key={f.name} data-field-required={f.required ? 'true' : 'false'}>
-              <td style={{ ...cellStyle, fontFamily: "'JetBrains Mono', monospace" }}>{f.name}</td>
-              <td style={{ ...cellStyle, fontFamily: "'JetBrains Mono', monospace", color: 'var(--fg-muted)' }}>
-                {f.type}
-              </td>
-              <td style={cellStyle}>{f.required ? 'yes' : 'no'}</td>
-              <td style={cellStyle}>{f.description}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', marginBottom: '20px' }}>
+        <span className="j-label">Reference</span>
+        <h2
+          className="j-display"
+          style={{
+            fontSize: '28px',
+            lineHeight: 1.2,
+            color: 'var(--fg)',
+            margin: 0,
+          }}
+        >
+          Plug-in shape
+        </h2>
+      </div>
 
-      <h3>Two modes</h3>
-      <p style={{ color: 'var(--fg-muted)' }}>
-        The validator enforces exactly two exclusive modes. Mixing is rejected.
-      </p>
+      <div style={{ overflowX: 'auto', marginBottom: '32px' }}>
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            borderTop: '1px solid var(--border)',
+          }}
+        >
+          <thead>
+            <tr>
+              <th style={headStyle}>Field</th>
+              <th style={headStyle}>Type</th>
+              <th style={headStyle}>Required</th>
+              <th style={headStyle}>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {PLUGIN_SHAPE_FIELDS.map((f) => (
+              <tr key={f.name} data-field-required={f.required ? 'true' : 'false'}>
+                <td style={{ ...cellStyle, color: 'var(--accent-sky)' }}>{f.name}</td>
+                <td style={cellMuted}>{f.type}</td>
+                <td style={cellStyle}>
+                  <span style={requiredChip(f.required)}>{f.required ? 'yes' : 'no'}</span>
+                </td>
+                <td style={cellMuted}>{f.description}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', marginBottom: '16px' }}>
+        <span className="j-label">Modes</span>
+        <h3
+          className="j-display"
+          style={{ fontSize: '22px', lineHeight: 1.25, color: 'var(--fg)', margin: 0 }}
+        >
+          Two modes
+        </h3>
+        <p
+          className="j-mono"
+          style={{
+            color: 'var(--fg-muted)',
+            fontSize: '13px',
+            lineHeight: 1.7,
+            margin: '4px 0 0',
+            maxWidth: '72ch',
+          }}
+        >
+          The validator enforces exactly two exclusive modes. Mixing is rejected.
+        </p>
+      </div>
+
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '16px' }}>
         {PLUGIN_MODES.map((m) => (
           <div
             key={m.id}
             style={{
               border: '1px solid var(--border)',
-              borderRadius: 'var(--radius-2, 6px)',
-              padding: '12px',
+              borderRadius: 'var(--radius-2)',
+              padding: '16px',
+              background: 'var(--bg-sunken)',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '10px',
             }}
           >
-            <h4 style={{ marginTop: 0 }}>{m.label}</h4>
-            <p style={{ color: 'var(--fg-muted)', fontSize: '13px' }}>{m.requires}</p>
-            <pre style={{ background: 'var(--surface-sunken)', padding: '8px', fontSize: '12px' }}>
+            <span className="j-label">{m.id === 'runtime' ? 'Mode · 01' : 'Mode · 02'}</span>
+            <h4
+              className="j-mono"
+              style={{
+                fontSize: '15px',
+                fontWeight: 500,
+                color: 'var(--fg)',
+                margin: 0,
+                letterSpacing: '-0.01em',
+              }}
+            >
+              {m.label}
+            </h4>
+            <p
+              className="j-mono"
+              style={{
+                color: 'var(--fg-muted)',
+                fontSize: '12px',
+                lineHeight: 1.6,
+                margin: 0,
+              }}
+            >
+              {m.requires}
+            </p>
+            <pre
+              style={{
+                background: 'var(--bg)',
+                border: '1px solid var(--border)',
+                borderRadius: 'var(--radius-1)',
+                padding: '10px 12px',
+                fontFamily: 'var(--mono)',
+                fontSize: '12px',
+                lineHeight: 1.5,
+                color: 'var(--accent-sky)',
+                margin: 0,
+                overflowX: 'auto',
+              }}
+            >
               <code>{m.example}</code>
             </pre>
           </div>

--- a/client/src/dashboard/spa/src/pages/configuration/JoinedNetCard.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/JoinedNetCard.tsx
@@ -533,6 +533,7 @@ export function JoinedNetCard({
                 }
                 rowTestId="joined-net-card-plugin-row"
                 searchTestId="joined-net-card-plugin-search"
+                harness={form.harness}
               />
             ) : (
               <PluginPicker
@@ -544,6 +545,7 @@ export function JoinedNetCard({
                 }
                 rowTestId="joined-net-card-plugin-row"
                 searchTestId="joined-net-card-plugin-search"
+                harness={form.harness}
               />
             )}
           </div>

--- a/client/src/dashboard/spa/src/pages/configuration/NetworkSection.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/NetworkSection.tsx
@@ -30,6 +30,11 @@ export function NetworkSection({
   const [error, setError] = useState<string | null>(null);
 
   const dirty = draft !== rpcUrl;
+  // Surface a "shared RPC — bring your own" warning when the operator is
+  // still on Jinn's shipped default. The default is a free public Tenderly
+  // gateway shared with every default-config operator; reliable steady-state
+  // operation requires the operator's own key. See contracts.ts comment.
+  const onSharedDefault = rpcUrl === defaultRpcUrl;
   const chainLabel = chain === 'base' ? 'Base mainnet (chain id 8453)' : 'Base Sepolia (chain id 84532)';
 
   const save = async (): Promise<void> => {
@@ -139,6 +144,70 @@ export function NetworkSection({
           >
             Use default
           </button>
+          {onSharedDefault && (
+            <div
+              style={{
+                marginTop: '12px',
+                padding: '10px 12px',
+                border: '1px solid var(--wane)',
+                borderRadius: '6px',
+                background: 'transparent',
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: '12px',
+                lineHeight: 1.55,
+                color: 'var(--fg)',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '4px',
+              }}
+              data-testid="network-shared-rpc-warning"
+            >
+              <span
+                style={{
+                  fontFamily: "'JetBrains Mono', monospace",
+                  fontSize: '10px',
+                  fontWeight: 500,
+                  letterSpacing: '0.14em',
+                  textTransform: 'uppercase',
+                  color: 'var(--wane)',
+                }}
+              >
+                Shared RPC
+              </span>
+              <span>
+                You're on the default RPC — a free public gateway shared with
+                every operator on the default config. Fine for setup; not
+                reliable under load. Get your own free key from{' '}
+                <a
+                  href="https://dashboard.tenderly.co/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ color: 'var(--accent-sky)' }}
+                >
+                  Tenderly
+                </a>
+                ,{' '}
+                <a
+                  href="https://www.alchemy.com/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ color: 'var(--accent-sky)' }}
+                >
+                  Alchemy
+                </a>
+                , or{' '}
+                <a
+                  href="https://www.quicknode.com/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ color: 'var(--accent-sky)' }}
+                >
+                  QuickNode
+                </a>{' '}
+                and paste it above.
+              </span>
+            </div>
+          )}
         </ConfigField>
       </div>
     </SectionCard>

--- a/client/src/dashboard/spa/src/pages/configuration/PluginPicker.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/PluginPicker.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { canonicalHarnessName, HERMES_AGENT_HARNESS } from './harnessNames.js';
 
 export interface CatalogPluginOption {
   name: string;
@@ -19,9 +20,15 @@ export interface PluginPickerProps {
   onChange: (plugins: string[], disabledDefaultPlugins: string[]) => void;
   rowTestId: string;
   searchTestId: string;
+  /**
+   * Selected harness. Determines which bundled plugins are surfaced as
+   * defaults — e.g. Hermes owns its own learning loop (see harness.ts) so
+   * `claude-code-learner` is dropped from the Hermes default set.
+   */
+  harness?: string;
 }
 
-const INCLUDED_PLUGINS: PluginOption[] = [
+const ALL_INCLUDED_PLUGINS: PluginOption[] = [
   {
     name: 'network-tools',
     version: '0.1.0',
@@ -37,6 +44,13 @@ const INCLUDED_PLUGINS: PluginOption[] = [
     description: 'Learner loop',
   },
 ];
+
+function includedPluginsFor(harness: string | undefined): PluginOption[] {
+  if (canonicalHarnessName(harness) === HERMES_AGENT_HARNESS) {
+    return ALL_INCLUDED_PLUGINS.filter((p) => p.name !== 'claude-code-learner');
+  }
+  return ALL_INCLUDED_PLUGINS;
+}
 
 const DEFAULT_COMPATIBLE_PLUGINS = new Set([
   'swe-rebench-v2-runtime',
@@ -75,10 +89,14 @@ function uniquePluginValues(values: string[]): string[] {
   return out;
 }
 
-function buildOptions(available: CatalogPluginOption[], selected: string[]): PluginOption[] {
+function buildOptions(
+  available: CatalogPluginOption[],
+  selected: string[],
+  harness: string | undefined,
+): PluginOption[] {
   const seen = new Set<string>();
   const out: PluginOption[] = [];
-  for (const plugin of INCLUDED_PLUGINS) {
+  for (const plugin of includedPluginsFor(harness)) {
     seen.add(plugin.name);
     out.push(plugin);
   }
@@ -121,11 +139,15 @@ export function PluginPicker({
   onChange,
   rowTestId,
   searchTestId,
+  harness,
 }: PluginPickerProps): JSX.Element {
   const [query, setQuery] = useState('');
   const [open, setOpen] = useState(false);
   const [confirmRemove, setConfirmRemove] = useState<PluginOption | null>(null);
-  const options = useMemo(() => buildOptions(available, selected), [available, selected]);
+  const options = useMemo(
+    () => buildOptions(available, selected, harness),
+    [available, selected, harness],
+  );
   const selectedSet = new Set(selected.map(stripBundledPrefix));
   const disabledDefaultSet = new Set(disabledDefaultPlugins.map(stripBundledPrefix));
   const activeSet = new Set(selectedSet);

--- a/client/src/dashboard/spa/src/pages/configuration/claudeModels.ts
+++ b/client/src/dashboard/spa/src/pages/configuration/claudeModels.ts
@@ -32,15 +32,29 @@ export const CODEX_MODELS: readonly LearnerModelOption[] = [
 ] as const;
 
 // Hermes routes models through providers (Nous Portal, OpenRouter, …) using
-// `<provider>/<model>` ids. The first entry is the dashboard default —
-// `anthropic/claude-opus-4.6` matches Hermes's own recommended default
-// (cli-config.yaml.example). Operators wanting a different provider/model can
-// pick from this list or override via `hermes model` (which the adapter
-// inherits when the join config leaves `model` unset).
+// `<provider>/<model>` ids. The first entry is the dashboard default.
+// Operators wanting a different provider/model can pick from this list or
+// override via `hermes model` (which the adapter inherits when the join
+// config leaves `model` unset).
+//
+// Set sized + ordered for v0: Anthropic flagships first (operator default;
+// historically Hermes's own recommended default), then the OpenRouter
+// programming leaderboard top-10 (token-volume, verified live via
+// /api/v1/models 2026-05-18 — see jinn-mono-u34i thread), then Nous's own
+// Hermes-405B for harness-namesake continuity. Operators pinned to an id
+// outside this list (e.g. `anthropic/claude-opus-4.6` from an older config)
+// still work — `resolveModelOption` surfaces them as `Custom (<id>)`.
 export const HERMES_MODELS: readonly LearnerModelOption[] = [
-  { label: 'Claude Opus 4.6 (OpenRouter)', id: 'anthropic/claude-opus-4.6' },
-  { label: 'Claude Sonnet 4.6 (OpenRouter)', id: 'anthropic/claude-sonnet-4.6' },
-  { label: 'Hermes 4 405B (Nous)', id: 'nousresearch/hermes-4-405b' },
+  { label: 'Claude Opus 4.7 (OpenRouter)',   id: 'anthropic/claude-opus-4.7'    },
+  { label: 'Claude Sonnet 4.6 (OpenRouter)', id: 'anthropic/claude-sonnet-4.6'  },
+  { label: 'Hy3 Preview',                    id: 'tencent/hy3-preview'          },
+  { label: 'DeepSeek V4 Pro',                id: 'deepseek/deepseek-v4-pro'     },
+  { label: 'DeepSeek V4 Flash',              id: 'deepseek/deepseek-v4-flash'   },
+  { label: 'Gemini 3.1 Flash Lite',          id: 'google/gemini-3.1-flash-lite' },
+  { label: 'Kimi K2.6',                      id: 'moonshotai/kimi-k2.6'         },
+  { label: 'Owl Alpha',                      id: 'openrouter/owl-alpha'         },
+  { label: 'MiniMax M2.7',                   id: 'minimax/minimax-m2.7'         },
+  { label: 'Hermes 4 405B (Nous)',           id: 'nousresearch/hermes-4-405b'   },
 ] as const;
 
 function isCodexHarness(harness: string | undefined): boolean {

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
@@ -251,7 +251,7 @@ describe('JoinFlow — harness options', () => {
     expect(Array.from(harnessSelect.options).map((o) => o.textContent)).toContain('Codex 0.1.0');
   });
 
-  it('shows the Hermes install description when Hermes Agent is selected', async () => {
+  it('shows the Hermes description when Hermes Agent is selected', async () => {
     apiMock.getSolverNets.mockResolvedValue({
       ...baseCatalog,
       nets: [
@@ -282,11 +282,63 @@ describe('JoinFlow — harness options', () => {
       expect(screen.getByTestId('join-harness-hermes-description')).toBeTruthy(),
     );
     expect(screen.getByTestId('join-harness-hermes-description').textContent).toMatch(
-      /requires separate install/i,
-    );
-    expect(screen.getByTestId('join-harness-hermes-description').textContent).toMatch(
       /Nous Research/,
     );
+    expect(screen.getByTestId('join-harness-hermes-description').textContent).toMatch(
+      /Built-in learning loop/,
+    );
+  });
+
+  it('drops claude-code-learner from default plugins when Hermes Agent is selected', async () => {
+    // Hermes owns its own learning loop (skill self-improvement, memory
+    // curation, FTS5 session search — see harnesses/impls/hermes-agent/
+    // harness.ts), so the Jinn-side `claude-code-learner` plugin must not
+    // be force-enabled on Hermes joins. Claude Code keeps it by default.
+    apiMock.getSolverNets.mockResolvedValue({
+      ...baseCatalog,
+      nets: [
+        {
+          ...baseCatalog.nets[0]!,
+          compatibleHarnesses: [
+            { name: 'claude-code-learner', version: '0.1.0', supportsRoles: ['solving' as const] },
+            { name: 'hermes-agent', version: '0.1.0', supportsRoles: ['solving' as const] },
+          ],
+        },
+      ],
+    });
+
+    wrap(<JoinFlow />);
+    await waitFor(() => expect(screen.getByTestId('join-flow-summary')).toBeTruthy());
+    fireEvent.click(screen.getByLabelText('Solver'));
+
+    const harnessSelect = screen.getByTestId('join-harness-select') as HTMLSelectElement;
+    await waitFor(() =>
+      expect(Array.from(harnessSelect.options).some((o) => o.value === 'hermes-agent')).toBe(true),
+    );
+
+    // Claude Code: learner is in the default chip set. The harness select
+    // exposes canonical names — `claude-code-learner` is aliased to
+    // `claude-code` by canonicalHarnessName.
+    fireEvent.change(harnessSelect, { target: { value: 'claude-code' } });
+    await waitFor(() => {
+      const chips = Array.from(
+        document.querySelectorAll('[data-testid="join-plugin-option-chip"]'),
+      ) as HTMLElement[];
+      expect(chips.some((c) => c.getAttribute('data-plugin') === 'claude-code-learner')).toBe(true);
+    });
+
+    // Hermes: learner chip is gone.
+    fireEvent.change(harnessSelect, { target: { value: 'hermes-agent' } });
+    // Wait for the harness change to propagate (hermes description appears).
+    await waitFor(() =>
+      expect(screen.getByTestId('join-harness-hermes-description')).toBeTruthy(),
+    );
+    const chips = Array.from(
+      document.querySelectorAll('[data-testid="join-plugin-option-chip"]'),
+    ) as HTMLElement[];
+    const chipPlugins = chips.map((c) => c.getAttribute('data-plugin'));
+    expect(chipPlugins).not.toContain('claude-code-learner');
+    expect(chipPlugins).toContain('network-tools');
   });
 });
 

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
@@ -24,7 +24,7 @@ import { PluginPicker } from '../configuration/PluginPicker.js';
 import { formatWeiAmount } from '../launcher-launched/helpers.js';
 
 const HERMES_AGENT_DESCRIPTION =
-  'Self-improving agent by Nous Research. Built-in learning loop, 200+ models via OpenRouter plus Nous Portal, NVIDIA NIM, GLM, Kimi, and more.';
+  'Self-improving agent by Nous Research. Built-in learning loop.';
 
 /**
  * Operator participation flow keyed by `manifestCid`.
@@ -415,8 +415,7 @@ export function JoinFlow({
                     color: 'var(--fg-muted)',
                   }}
                 >
-                  {HERMES_AGENT_DESCRIPTION}{' '}
-                  <span style={{ color: 'var(--break-amber)' }}>(requires separate install)</span>
+                  {HERMES_AGENT_DESCRIPTION}
                 </span>
               )}
             </div>
@@ -461,6 +460,7 @@ export function JoinFlow({
               }
               rowTestId="join-plugin-option"
               searchTestId="join-plugin-search"
+              harness={form.harness}
             />
           </div>
         </section>

--- a/client/src/dashboard/spa/src/regions/AwaitingFundingCard.tsx
+++ b/client/src/dashboard/spa/src/regions/AwaitingFundingCard.tsx
@@ -5,12 +5,21 @@ interface Props {
   address: string;
   minimumWei: string;
   chainExplorerBase: string;
+  /** Daemon's configured chain (e.g. 'base' or 'base-sepolia'). Surfaced in
+   *  the funding-card copy so the operator knows which network to send on. */
+  chain?: string;
 }
+
+const CHAIN_DISPLAY_NAME: Record<string, string> = {
+  base: 'Base',
+  'base-sepolia': 'Base Sepolia',
+};
 
 export function AwaitingFundingCard({
   address,
   minimumWei,
   chainExplorerBase,
+  chain,
 }: Props): JSX.Element {
   const [copied, setCopied] = useState(false);
   const [fundingStartedAt, setFundingStartedAt] = useState<number | null>(null);
@@ -161,7 +170,7 @@ export function AwaitingFundingCard({
           {address}
         </span>
         <span className="j-mono text-xs" style={{ color: 'var(--fg-muted)' }}>
-          send at least {minimumEth} so the daemon can pay gas for setup, or use the testnet faucet.
+          send at least {minimumEth} on {CHAIN_DISPLAY_NAME[chain ?? ''] ?? 'this chain'}
         </span>
       </div>
       <div className="flex flex-wrap items-center gap-2">

--- a/client/src/dashboard/spa/src/regions/Onboarding.tsx
+++ b/client/src/dashboard/spa/src/regions/Onboarding.tsx
@@ -132,6 +132,7 @@ export function Onboarding(): JSX.Element {
                       address={masterAddress}
                       minimumWei={bootstrap.funding?.targetWei ?? '10000000000000000'}
                       chainExplorerBase={explorer}
+                      chain={bootstrap.chain}
                     />
                   )}
                   {!showError && p === 3 && status === 'active' && (

--- a/client/src/dashboard/spa/src/styles/globals.css
+++ b/client/src/dashboard/spa/src/styles/globals.css
@@ -22,9 +22,18 @@
   --break-red: #a85a5a;
   --seer-violet: #7a6db0;
 
+  /* Surface aliases — PanelCard and a handful of pages reference
+     --surface / --surface-sunken (the older name) while the rest of the
+     SPA reaches for --bg-elevated / --bg-sunken. We keep both wired to
+     the same flat colors so panels actually render their fill instead
+     of falling through to transparent. */
+  --surface: var(--bg-elevated);
+  --surface-sunken: var(--bg-sunken);
+
   --radius-1: 4px;
   --radius-2: 6px;
   --radius-3: 10px;
+  --radius-pill: 999px;
 
   --serif: 'Instrument Serif', 'Times New Roman', serif;
   --mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
@@ -106,4 +115,111 @@ textarea:focus-visible {
 
 .agent-rail .xterm-accessibility-tree {
   display: none;
+}
+
+/* /build intro markdown — the quickstart is rendered through the
+   minimal markdown subset. Without explicit styling the headings,
+   prose, code fences, and lists all render as unstyled text. The rules
+   below apply the two-voice type system (serif for the page-level
+   heading, mono for everything else), hairline rules between sections,
+   and a sunken code-block fill that picks up --bg-sunken via the
+   --surface-sunken alias. No new tokens are introduced. */
+.hfmf-intro-markdown h1 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 40px;
+  line-height: 1.1;
+  letter-spacing: 0;
+  color: var(--fg);
+  margin: 0 0 16px;
+}
+.hfmf-intro-markdown h2 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 22px;
+  line-height: 1.25;
+  letter-spacing: 0;
+  color: var(--fg);
+  margin: 28px 0 8px;
+  padding-top: 20px;
+  border-top: 1px solid var(--border);
+}
+.hfmf-intro-markdown h2:first-child,
+.hfmf-intro-markdown h1 + h2 {
+  padding-top: 0;
+  border-top: none;
+}
+.hfmf-intro-markdown h3 {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  margin: 20px 0 8px;
+}
+.hfmf-intro-markdown p {
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.7;
+  letter-spacing: -0.01em;
+  color: var(--fg-muted);
+  margin: 0 0 12px;
+  max-width: 72ch;
+}
+.hfmf-intro-markdown ul {
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.7;
+  color: var(--fg-muted);
+  list-style: none;
+  padding: 0;
+  margin: 0 0 12px;
+}
+.hfmf-intro-markdown ul li {
+  position: relative;
+  padding-left: 16px;
+  margin: 4px 0;
+}
+.hfmf-intro-markdown ul li::before {
+  content: '—';
+  position: absolute;
+  left: 0;
+  color: var(--fg-dim);
+}
+.hfmf-intro-markdown code {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--accent-sky);
+  background: var(--bg-sunken);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-1);
+  padding: 1px 6px;
+}
+.hfmf-intro-markdown pre {
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--fg);
+  background: var(--bg-sunken);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-2);
+  padding: 14px 16px;
+  margin: 0 0 14px;
+  overflow-x: auto;
+}
+.hfmf-intro-markdown pre code {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  color: inherit;
+}
+.hfmf-intro-markdown a {
+  color: var(--accent-sky);
+  text-decoration: none;
+  border-bottom: 1px solid var(--border);
+}
+.hfmf-intro-markdown a:hover {
+  color: var(--accent-sky-hover);
+  border-bottom-color: var(--accent-sky);
 }

--- a/client/src/earning/bootstrap.ts
+++ b/client/src/earning/bootstrap.ts
@@ -107,29 +107,31 @@ const STANDARD_MASTER_BOOTSTRAP_MULTIPLIER = 2n;
  *  all agree on a single "one-shot fund the operator" number.
  *
  *  Components for a 1-service standard-mode bootstrap:
- *    - STAGE1_AGENT_ETH (0.010 ETH): master → HD-1 fleet-agent transfer in
- *      Stage 1. HD-1 then pays for its own Safe deploy + register +
- *      setAgentWallet out of this; the leftover (~0.005 ETH) sits on HD-1
- *      and covers service 1's Stage 2 work too (mech deploy + rebind).
+ *    - STAGE1_AGENT_ETH (0.010 ETH): master → HD-1 fleet-agent transfer.
+ *      HD-1 pays for its own Safe deploy + register + setAgentWallet out
+ *      of this; leftover covers service 1's Stage 2 work (mech deploy +
+ *      rebind). May get a conditional minEoaGasEth top-up from master if
+ *      Stage 1's gas eats too much of the original transfer.
  *    - minEoaGasEth × STANDARD_MASTER_BOOTSTRAP_MULTIPLIER (0.010 ETH):
- *      master reserve required at Stage 2 entry. Matches the existing Stage 2
- *      gate at ensureStage1And2 line ~484 — covers one per-service transfer
- *      worth of headroom plus master's own gas reserve for distributor.stake()
- *      and ongoing daemon ops.
- *    - minEoaGasEth × (targetServices - 1): per-extra-service top-up. Service
- *      1 piggybacks on HD-1's Stage 1 funding (no extra master transfer);
- *      services 2..N each need their own minEoaGasEth (= 0.005 ETH) from master.
+ *      master gas budget across both stages. Real spend (~0.0025 ETH at
+ *      typical 6 gwei Base Sepolia) leaves room for ~4× gas-spike margin
+ *      plus the conditional HD-1 top-up.
+ *    - minEoaGasEth × (targetServices - 1): per-extra-service top-up for
+ *      services 2..N. Service 1 piggybacks on HD-1's Stage 1 funding.
  *
- *  Total for N=1: 0.010 + 0.010 + 0 = 0.020 ETH (single deposit; daemon won't
- *  ask again).
+ *  Total for N=1: 0.010 + 0.010 = 0.020 ETH.
  *  Total for N=2: 0.025 ETH.
  *  Total for N=3: 0.030 ETH.
  *
- *  Pre-u34i this was 0.015 ETH = STAGE1_AGENT_ETH + minEoaGasEth — enough to
- *  enter Stage 1, but Stage 1 then drained master to 0.005 and Stage 2's gate
- *  (0.010) re-prompted. The 2026-05-18 canary's "I sent the stated 0.015 and
- *  now it's asking again" frustration. See jinn-mono-u34i + the follow-up
- *  one-shot-funding work.
+ *  This number works ONLY when Stage 2's internal gate is `minEoaGasEth ×
+ *  1n` (0.005 ETH) — not the historic `× 2n`. After Stage 1 transfers 0.010
+ *  out, master sits at ~0.0099 ETH (0.020 minus transfer minus Stage 1
+ *  funding-tx gas). The 0.005 gate clears that with margin; the 0.010 gate
+ *  did not. See the Stage 2 gate at ensureStage1And2 line ~484.
+ *
+ *  Operator may see a "low runway" warning after bootstrap — that's
+ *  intentional. The operator-facing 0.020 ETH covers bootstrap completion,
+ *  not multi-week post-bootstrap runway. Top-up is a separate concern.
  */
 export const STAGE1_AGENT_ETH = 10_000_000_000_000_000n; // 0.01 ETH (moved out of stepFleetSafeDeploy)
 export function stage1MinMasterEth(
@@ -586,7 +588,17 @@ export class FleetBootstrapper {
         ? (
             standardFleetAlreadyComplete
               ? 0n
-              : this.config.minEoaGasEth * (standardFleetHasInProgressServices ? 1n : STANDARD_MASTER_BOOTSTRAP_MULTIPLIER)
+              // Stage 2 master gas budget — covers distributor.stake() (~0.003
+              // ETH at typical 6 gwei Base Sepolia) plus per-extra-service
+              // top-up transfers. Previously this was `× 2` for fresh fleets,
+              // which double-counted a service-1 transfer that doesn't actually
+              // fire (HD-1 carries Stage 1 leftover, gets a conditional top-up
+              // only if needed). See jinn-mono-u34i: the `× 2` figure also
+              // exceeded the post-Stage-1 master balance at the operator-facing
+              // 0.020 ETH budget by ~127k gwei of Stage 1 gas burn, causing a
+              // second funding prompt.
+              : this.config.minEoaGasEth +
+                this.config.minEoaGasEth * BigInt(Math.max(0, this.targetServices - 1))
           )
         : SELF_BOND_ETH_PER_SERVICE * BigInt(this.targetServices);
       const autoFaucetEnabled = this.autoTestnetFaucet;

--- a/client/src/earning/bootstrap.ts
+++ b/client/src/earning/bootstrap.ts
@@ -101,13 +101,48 @@ const addr = (value: string): Address => getAddress(value) as Address;
 const SAFE_TOKEN_BOOTSTRAP_MULTIPLIER = 2n;
 const STANDARD_MASTER_BOOTSTRAP_MULTIPLIER = 2n;
 
-/** Stage 1 master ETH requirement: the agent-funding transfer (STAGE1_AGENT_ETH)
- *  plus master's own gas reserve (minEoaGasEth). Centralized so the daemon's
- *  ensureStage1 gate, the read-side funding-plan, and gather-status all agree.
- *  See jinn-mono-u34i. */
+/** Master ETH required to FINISH the whole bootstrap from a fresh start (not
+ *  just to enter Stage 1). Centralized so the daemon's ensureStage1 gate,
+ *  the read-side funding-plan, gather-status, and the panel faucet target
+ *  all agree on a single "one-shot fund the operator" number.
+ *
+ *  Components for a 1-service standard-mode bootstrap:
+ *    - STAGE1_AGENT_ETH (0.010 ETH): master → HD-1 fleet-agent transfer in
+ *      Stage 1. HD-1 then pays for its own Safe deploy + register +
+ *      setAgentWallet out of this; the leftover (~0.005 ETH) sits on HD-1
+ *      and covers service 1's Stage 2 work too (mech deploy + rebind).
+ *    - minEoaGasEth × STANDARD_MASTER_BOOTSTRAP_MULTIPLIER (0.010 ETH):
+ *      master reserve required at Stage 2 entry. Matches the existing Stage 2
+ *      gate at ensureStage1And2 line ~484 — covers one per-service transfer
+ *      worth of headroom plus master's own gas reserve for distributor.stake()
+ *      and ongoing daemon ops.
+ *    - minEoaGasEth × (targetServices - 1): per-extra-service top-up. Service
+ *      1 piggybacks on HD-1's Stage 1 funding (no extra master transfer);
+ *      services 2..N each need their own minEoaGasEth (= 0.005 ETH) from master.
+ *
+ *  Total for N=1: 0.010 + 0.010 + 0 = 0.020 ETH (single deposit; daemon won't
+ *  ask again).
+ *  Total for N=2: 0.025 ETH.
+ *  Total for N=3: 0.030 ETH.
+ *
+ *  Pre-u34i this was 0.015 ETH = STAGE1_AGENT_ETH + minEoaGasEth — enough to
+ *  enter Stage 1, but Stage 1 then drained master to 0.005 and Stage 2's gate
+ *  (0.010) re-prompted. The 2026-05-18 canary's "I sent the stated 0.015 and
+ *  now it's asking again" frustration. See jinn-mono-u34i + the follow-up
+ *  one-shot-funding work.
+ */
 export const STAGE1_AGENT_ETH = 10_000_000_000_000_000n; // 0.01 ETH (moved out of stepFleetSafeDeploy)
-export function stage1MinMasterEth(config: { minEoaGasEth: bigint }): bigint {
-  return STAGE1_AGENT_ETH + config.minEoaGasEth;
+export function stage1MinMasterEth(
+  config: { minEoaGasEth: bigint },
+  targetServices: number = 1,
+): bigint {
+  const extraServiceTransfers =
+    config.minEoaGasEth * BigInt(Math.max(0, targetServices - 1));
+  return (
+    STAGE1_AGENT_ETH +
+    config.minEoaGasEth * STANDARD_MASTER_BOOTSTRAP_MULTIPLIER +
+    extraServiceTransfers
+  );
 }
 
 /** Conservative default: ~0.001 ETH/day master gas if not configured. */
@@ -410,7 +445,7 @@ export class FleetBootstrapper {
       // which equaled the transfer amount and left no gas headroom, so a
       // master holding the gate's minimum would fail eth_estimateGas with
       // "gas required exceeds allowance (0)".
-      const requiredMasterEth = stage1MinMasterEth(this.config);
+      const requiredMasterEth = stage1MinMasterEth(this.config, this.targetServices);
       const masterAddress = state.master_address!;
       const masterBalance = await this.publicClient.getBalance({
         address: masterAddress as Address,

--- a/client/src/earning/contracts.ts
+++ b/client/src/earning/contracts.ts
@@ -249,7 +249,15 @@ const BASE_CONFIG: ChainConfig = {
 
 const BASE_SEPOLIA_CONFIG: ChainConfig = {
   chainId: 84532,
-  rpcUrl: 'https://sepolia.base.org',
+  // Default testnet RPC: a Tenderly gateway with a free public key. Higher
+  // rate limits than `https://sepolia.base.org` (the prior default) — the
+  // public node throttled SolverNet manifest discovery and balance polls
+  // during/after bootstrap (operators hit 404 + rate-limit churn until
+  // retries happened to land). The panel surfaces a "shared RPC — bring
+  // your own" warning when the operator is still on this default; operators
+  // should get their own key (Tenderly / Alchemy / QuickNode free tiers)
+  // for reliable steady-state operation.
+  rpcUrl: 'https://base-sepolia.gateway.tenderly.co/75tyLMQuD8EHpXxMwINIKu',
 
   // Autonolas protocol contracts (Base Sepolia)
   serviceRegistry: '0x31D3202d8744B16A120117A053459DDFAE93c855',

--- a/client/src/earning/funding-plan.ts
+++ b/client/src/earning/funding-plan.ts
@@ -238,7 +238,7 @@ export async function planFleetFunding(
           standardFleetAlreadyComplete
             ? 0n
             : isPreStage1
-              ? stage1MinMasterEth(config)
+              ? stage1MinMasterEth(config, targetServices)
               : config.minEoaGasEth * (standardFleetHasInProgressServices ? 1n : STANDARD_MASTER_BOOTSTRAP_MULTIPLIER)
         )
       : SELF_BOND_ETH_PER_SERVICE * BigInt(targetServices);

--- a/client/src/earning/funding-plan.ts
+++ b/client/src/earning/funding-plan.ts
@@ -90,7 +90,6 @@ export interface FundingPlan {
 }
 
 const SELF_BOND_ETH_PER_SERVICE = 30_000_000_000_000_000n; // 0.03 ETH
-const STANDARD_MASTER_BOOTSTRAP_MULTIPLIER = 2n;
 
 const addr = (value: string): Address => getAddress(value) as Address;
 
@@ -239,7 +238,13 @@ export async function planFleetFunding(
             ? 0n
             : isPreStage1
               ? stage1MinMasterEth(config, targetServices)
-              : config.minEoaGasEth * (standardFleetHasInProgressServices ? 1n : STANDARD_MASTER_BOOTSTRAP_MULTIPLIER)
+              // Stage 2 master gas budget (post-Stage-1 funding plan view) —
+              // mirrors the gate in ensureStage1And2 after the jinn-mono-u34i
+              // tightening: minEoaGasEth (stake gas) + per-extra-service
+              // transfers. The `× 2` heuristic was dropped because for N=1
+              // it double-counted a service-1 transfer that doesn't fire.
+              : config.minEoaGasEth +
+                config.minEoaGasEth * BigInt(Math.max(0, targetServices - 1))
         )
       : SELF_BOND_ETH_PER_SERVICE * BigInt(targetServices);
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -167,7 +167,7 @@ const config = loadConfig(CONFIG_PATH);
 if (config.network === 'mainnet' && process.env['JINN_ENABLE_MAINNET'] !== '1') {
   console.warn('[main] Mainnet is disabled before launch; using testnet defaults.');
   config.network = 'testnet';
-  config.rpcUrl = 'https://sepolia.base.org';
+  config.rpcUrl = 'https://base-sepolia.gateway.tenderly.co/75tyLMQuD8EHpXxMwINIKu';
 }
 let activeClaudePath = config.claudePath ?? 'claude';
 const selectClaudePath = (claudePath: string): void => {
@@ -919,6 +919,17 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     current: import('./harnesses/readiness-registry.js').HarnessReadinessRegistry | undefined;
   } = { current: undefined };
 
+  // jinn-mono-u34i: same eager-register / late-populate pattern for the
+  // DiscoveryAPI. Pre-fix, /v1/discovery/* routes only mounted when
+  // `config.discovery` was set at startApiServer time — but main.ts builds
+  // `sharedDiscoveryApi` post-bootstrap, so the routes were never registered
+  // and the panel's /build page got a permanent 404 on plugin-publications +
+  // builder-artifacts. Holder ref lets the routes register eagerly and
+  // start returning real data the moment main.ts assigns holder.current.
+  const discoveryApiHolder: {
+    current: import('./discovery/types.js').DiscoveryAPI | undefined;
+  } = { current: undefined };
+
   let setupApiServer: ApiServer;
   try {
     setupApiServer = await startApiServer({
@@ -1045,6 +1056,8 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
       // harness readiness routes. Until main.ts sets the holder, requests
       // return 503 subsystem_not_ready (the panel handles that gracefully).
       harnessReadinessRegistry: { holder: harnessReadinessRegistryHolder },
+      // jinn-mono-u34i: see discoveryApiHolder comment above.
+      discovery: { holder: discoveryApiHolder },
       // Agent-binding retry: re-run the ERC-1271 bind step from the SPA
       // without forcing a daemon restart. Constructs a fresh bootstrapper
       // per call so we don't tangle lifecycle with the long-running one.
@@ -1500,6 +1513,12 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
       sharedDiscoveryApi = await buildOnchainFloor();
     }
   }
+
+  // jinn-mono-u34i: populate the holder so the /v1/discovery/* routes
+  // registered eagerly at server-start time start returning real data on
+  // the panel's next refetch. Before this, the routes 404'd forever and
+  // the /build page rendered "Discovery unavailable" permanently.
+  discoveryApiHolder.current = sharedDiscoveryApi;
 
   const adapter = new MechAdapter({
     rpcUrl: config.rpcUrl,

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1096,12 +1096,16 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
         chain: NETWORK_CHAIN,
         rpcUrl: config.rpcUrl,
         // Note: do NOT pass minEoaGasWei here. setup-endpoints.ts derives
-        // its faucet target from stage1MinMasterEth(getChainConfig(chain)) —
-        // the same helper the daemon's ensureStage1 gate uses. Passing a
-        // computed value from here would re-introduce the drift seam that
-        // hit operators in the 2026-05-18 canary (jinn-mono-u34i): faucet
-        // dripped to one target while the daemon waited for a different one.
-        // The override field remains for tests that want a custom target.
+        // its faucet target from stage1MinMasterEth(getChainConfig(chain),
+        // targetServices) — the same helper the daemon's ensureStage1 gate
+        // uses. Passing a computed value from here would re-introduce the
+        // drift seam that hit operators in the 2026-05-18 canary
+        // (jinn-mono-u34i): faucet dripped to one target while the daemon
+        // waited for a different one. The override field remains for tests
+        // that want a custom target.
+        // targetServices DOES need to flow through so the faucet drips enough
+        // ETH to cover ALL services for the operator's chosen targetServices.
+        targetServices: config.targetServices,
         claudePath: activeClaudePath,
         getClaudePath: () => activeClaudePath,
         configPath: CONFIG_PATH ?? DEFAULT_CONFIG_PATH,

--- a/client/test/api/bootstrap-endpoint.test.ts
+++ b/client/test/api/bootstrap-endpoint.test.ts
@@ -67,7 +67,17 @@ describe('GET /v1/bootstrap', () => {
     expect(body.mode).toBe('uninitialized');
   });
 
-  it('reports awaiting_funding after master wallet creation before service rows exist', async () => {
+  it('advances past awaiting_funding once master wallet exists with no persisted funding gate (jinn-mono-u34i)', async () => {
+    // Pre-u34i this case returned 'awaiting_funding' even when no funding
+    // gate file existed — leaving the panel on phase 2 ("Fund your wallet")
+    // during the entire post-funding Stage 1 window (Safe deploy, agentId
+    // mint, setAgentWallet bind), 30-60s of stale "still awaiting funds"
+    // copy while the daemon was actively deploying contracts.
+    //
+    // The fix: when no funding-gate file is persisted and master_address is
+    // set, currentStep advances to 'safe_deployed' — the first phase-3 step
+    // in Onboarding.tsx's phase map ('Joining Jinn · Deploying'). The panel
+    // transitions immediately, accurately reflecting the daemon's state.
     const earningDir = makeFixtureEarningDir({
       master_address: '0xabc',
       chain: 'base-sepolia',
@@ -79,7 +89,7 @@ describe('GET /v1/bootstrap', () => {
     expect(res.status).toBe(200);
     const body = await res.json() as { mode: string; currentStep: string; services: unknown[] };
     expect(body.mode).toBe('setup');
-    expect(body.currentStep).toBe('awaiting_funding');
+    expect(body.currentStep).toBe('safe_deployed');
     expect(body.services).toHaveLength(0);
   });
 

--- a/client/test/api/setup-endpoints.test.ts
+++ b/client/test/api/setup-endpoints.test.ts
@@ -840,6 +840,40 @@ describe('POST /v1/setup/network', () => {
 
     expect(res.status).toBe(400);
   });
+
+  it('creates config.json when it does not exist (jinn-mono-u34i)', async () => {
+    // Fresh operator: daemon ran with built-in defaults, no config.json on
+    // disk. Pre-u34i the endpoint 404'd with `config_not_found`, blocking
+    // the only operator-app affordance for switching off a rate-limited
+    // public RPC. Operator was forced to drop into the terminal and hand-
+    // write JSON — violation of the never-leaves-the-app principle.
+    //
+    // Fix: the endpoint defers to persistTopLevelConfigValue, which already
+    // creates the parent dir + file when missing (same pattern as every
+    // other write endpoint in this module).
+    const dir = mkdtempSync(join(tmpdir(), 'jinn-network-no-cfg-'));
+    const configPath = join(dir, 'config.json');
+    // CRITICAL: do NOT pre-write the file.
+
+    const app = new Hono();
+    addSetupRoutes(app, { configPath });
+
+    const res = await app.request('/v1/setup/network', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ rpcUrl: 'https://base-sepolia.gateway.tenderly.co/abc123' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ok: boolean; restartRequired: boolean; rpcUrl: string };
+    expect(body.ok).toBe(true);
+    expect(body.restartRequired).toBe(true);
+    expect(body.rpcUrl).toBe('https://base-sepolia.gateway.tenderly.co/abc123');
+
+    // The file was created with the new rpcUrl.
+    const persisted = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(persisted.rpcUrl).toBe('https://base-sepolia.gateway.tenderly.co/abc123');
+  });
 });
 
 describe('POST /v1/operator/join/:cid', () => {

--- a/client/test/cli/commands/auth.test.ts
+++ b/client/test/cli/commands/auth.test.ts
@@ -58,9 +58,12 @@ describe('auth command', () => {
       });
       await auth.run(ctx);
       const persisted = JSON.parse(readFileSync(configPath, 'utf-8'));
+      // Testnet default flipped to a Tenderly gateway in 2026-05-18 — the
+      // public sepolia.base.org node rate-limited SolverNet manifest fetches
+      // and balance polls during/after bootstrap.
       expect(persisted).toMatchObject({
         network: 'testnet',
-        rpcUrl: 'https://sepolia.base.org',
+        rpcUrl: 'https://base-sepolia.gateway.tenderly.co/75tyLMQuD8EHpXxMwINIKu',
         runtimeMode: 'bare',
       });
     } finally {

--- a/client/test/config.test.ts
+++ b/client/test/config.test.ts
@@ -187,7 +187,13 @@ describe('loadConfig RPC override handling', () => {
 
     const config = loadConfig(configPath);
 
-    expect(config.rpcUrl).toBe('https://sepolia.base.org');
+    // Testnet default flipped from the public sepolia.base.org node to a
+    // Tenderly gateway (free public key) in response to the 2026-05-18 canary
+    // rate-limit churn. The public node's per-IP cap throttled SolverNet
+    // manifest discovery and balance polls during/after bootstrap; Tenderly
+    // has much higher headroom. Operators are nudged to bring their own key
+    // via the NetworkSection panel warning.
+    expect(config.rpcUrl).toBe('https://base-sepolia.gateway.tenderly.co/75tyLMQuD8EHpXxMwINIKu');
   });
 
   it('defaults testnet discovery to the privately-operated Ponder indexer (http mode)', async () => {

--- a/client/test/earning/bootstrap-faucet.test.ts
+++ b/client/test/earning/bootstrap-faucet.test.ts
@@ -63,7 +63,11 @@ describe('Fleet bootstrap faucet cap', () => {
 
     await bootstrapper.bootstrap('test-password');
 
-    expect(requestTestnetFundingMock).toHaveBeenCalledTimes(100);
+    // Fresh-fleet Stage 2 gate is now `minEoaGasEth = 0.005 ETH` (jinn-mono-u34i:
+    // dropped from `× 2` because the `× 2` double-counted a service-1 transfer
+    // that doesn't fire — HD-1 reuses Stage 1's leftover). At 0.0001 ETH/drip
+    // that's 50 drips to reach the target.
+    expect(requestTestnetFundingMock).toHaveBeenCalledTimes(50);
   });
 
   it('does not send an extra faucet request after the drip cap', async () => {
@@ -107,8 +111,10 @@ describe('Fleet bootstrap faucet cap', () => {
 
     expect(result.ok).toBe(false);
     expect(result.funding).toBeDefined();
+    // Stage 2 gate is now `minEoaGasEth = 0.005 ETH` for fresh fleets
+    // (jinn-mono-u34i tightening; see comment in the test above).
     const expectedCap = computeFaucetDripCap({
-      targetWei: 10_000_000_000_000_000n,
+      targetWei: 5_000_000_000_000_000n,
       balanceWei: 0n,
     });
     expect(expectedCap).toBeGreaterThan(60);

--- a/client/test/earning/bootstrap.test.ts
+++ b/client/test/earning/bootstrap.test.ts
@@ -328,8 +328,9 @@ describe('Fleet bootstrap', () => {
       rpcUrl: 'http://127.0.0.1:8545',
     });
 
-    // Master is funded — pre-Stage-1 gate is STAGE1_AGENT_ETH + minEoaGasEth = 0.015 ETH (jinn-mono-u34i).
-    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(15_000_000_000_000_000n);
+    // Master is funded — pre-Stage-1 gate is the FULL bootstrap budget:
+    // STAGE1_AGENT_ETH (0.010) + minEoaGasEth*2 (0.010) = 0.020 ETH for N=1 (jinn-mono-u34i one-shot funding).
+    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(20_000_000_000_000_000n);
     vi.spyOn((bootstrapper as any).publicClient, 'getCode').mockResolvedValue('0xdeadbeef');
 
     // Stage 1 mocks — bootstrap() now calls ensureStage1 first (nghf).
@@ -389,8 +390,11 @@ describe('Fleet bootstrap', () => {
       targetServices: 3,
     });
 
-    // Pre-Stage-1 gate is STAGE1_AGENT_ETH + minEoaGasEth = 0.015 ETH (jinn-mono-u34i).
-    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(15_000_000_000_000_000n);
+    // Pre-Stage-1 gate is the FULL bootstrap budget. For targetServices=3
+    // standard mode: STAGE1_AGENT_ETH (0.010) + minEoaGasEth*2 (0.010) +
+    // minEoaGasEth*(targetServices-1) (0.010) = 0.030 ETH (jinn-mono-u34i
+    // one-shot funding). Operator funds once for all 3 services.
+    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(30_000_000_000_000_000n);
     vi.spyOn((bootstrapper as any).publicClient, 'getCode').mockResolvedValue('0xdeadbeef');
 
     // Stage 1 mocks — bootstrap() now calls ensureStage1 first (nghf).
@@ -660,8 +664,8 @@ describe('Fleet bootstrap', () => {
       stakingMode: 'standard',
     });
 
-    // Pre-Stage-1 gate is STAGE1_AGENT_ETH + minEoaGasEth = 0.015 ETH (jinn-mono-u34i).
-    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(15_000_000_000_000_000n);
+    // Pre-Stage-1 gate is the FULL bootstrap budget = 0.020 ETH for N=1 (jinn-mono-u34i one-shot funding).
+    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(20_000_000_000_000_000n);
     vi.spyOn((bootstrapper as any).publicClient, 'getCode').mockResolvedValue('0xdeadbeef');
 
     // Stage 1 mocks — bootstrap() now calls ensureStage1 first (nghf).

--- a/client/test/earning/funding-plan.test.ts
+++ b/client/test/earning/funding-plan.test.ts
@@ -129,9 +129,11 @@ describe('planFleetFunding (read-only funding plan)', () => {
     await store.saveMnemonicKeystore(await encryptMnemonic(mnemonic, 'pw'));
     await store.save({ ...createDefaultFleetState('base'), master_address: masterAddress });
 
-    // Pre-Stage-1 (fleet_stage === 'none') the gate is
-    // STAGE1_AGENT_ETH (0.01) + minEoaGasEth (0.005) = 0.015 ETH (jinn-mono-u34i).
-    const getBalance = vi.fn(async () => 15_000_000_000_000_000n); // 0.015 ETH
+    // Pre-Stage-1 (fleet_stage === 'none') the gate is the FULL bootstrap
+    // budget: STAGE1_AGENT_ETH (0.010) + minEoaGasEth*2 (0.010) = 0.020 ETH
+    // for N=1 (jinn-mono-u34i one-shot funding). Operator funds once; the
+    // daemon does not re-prompt at the Stage 2 gate.
+    const getBalance = vi.fn(async () => 20_000_000_000_000_000n); // 0.020 ETH
     const plan = await planFleetFunding({
       earningDir,
       chain: 'base',
@@ -155,7 +157,7 @@ describe('planFleetFunding (read-only funding plan)', () => {
     await store.saveMnemonicKeystore(await encryptMnemonic(mnemonic, 'pw'));
     await store.save({ ...createDefaultFleetState('base'), master_address: masterAddress });
 
-    const getBalance = vi.fn(async () => 1_000_000_000_000_000n); // 0.001 ETH < 0.015
+    const getBalance = vi.fn(async () => 1_000_000_000_000_000n); // 0.001 ETH < 0.020
     const plan = await planFleetFunding({
       earningDir,
       chain: 'base',
@@ -168,9 +170,10 @@ describe('planFleetFunding (read-only funding plan)', () => {
     expect(plan.partial).toBe(false);
     expect(plan.master?.master_address).toBe(masterAddress);
     expect(plan.master?.eth_balance).toBe('1000000000000000');
-    // Pre-Stage-1 gate is STAGE1_AGENT_ETH (0.01) + minEoaGasEth (0.005) =
-    // 0.015 ETH (jinn-mono-u34i). shortfall = 0.015 - 0.001 = 0.014 ETH.
-    expect(plan.master?.eth_required).toBe('14000000000000000');
+    // Pre-Stage-1 gate is the FULL bootstrap budget: STAGE1_AGENT_ETH (0.010)
+    // + minEoaGasEth*2 (0.010) = 0.020 ETH for N=1 (jinn-mono-u34i one-shot
+    // funding). shortfall = 0.020 - 0.001 = 0.019 ETH.
+    expect(plan.master?.eth_required).toBe('19000000000000000');
   });
 
   it('does not call any mutating method on the fleet store', async () => {

--- a/client/test/earning/staged-bootstrap-stage1.test.ts
+++ b/client/test/earning/staged-bootstrap-stage1.test.ts
@@ -183,14 +183,16 @@ describe('FleetBootstrapper.ensureStage1 — greenfield walk (nghf)', () => {
     expect((bootstrapper as any).stepFleetIdentityRegister).toHaveBeenCalledTimes(1);
   });
 
-  it('rejects funding at the gate when master has exactly the old (pre-u34i) threshold but not enough for transfer + gas (jinn-mono-u34i)', async () => {
+  it('rejects funding at the gate when master has only enough for Stage 1 transfer (jinn-mono-u34i)', async () => {
     const earningDir = await mkdtemp(path.join(os.tmpdir(), 'jinn-u34i-stage1-'));
     dirs.push(earningDir);
     const bootstrapper = buildBootstrapper(earningDir);
-    // 0.011 ETH on the master — above the OLD 0.01 ETH gate, below the NEW
-    // STAGE1_AGENT_ETH + minEoaGasEth = 0.015 ETH gate. Pre-fix this would
-    // pass the gate and then revert in the funding tx with
-    // "gas required exceeds allowance (0)".
+    // 0.011 ETH on the master — above the pre-u34i 0.010 ETH gate (which
+    // equaled the transfer amount → zero gas headroom → revert), and BELOW
+    // the new full-bootstrap budget of 0.020 ETH. Pre-fix this either
+    // halted in the funding tx OR halted at Stage 2's separate gate after
+    // Stage 1 succeeded. Now the daemon refuses to even enter Stage 1
+    // until the operator funds the whole bootstrap up front.
     vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(
       11_000_000_000_000_000n, // 0.011 ETH
     );
@@ -201,7 +203,26 @@ describe('FleetBootstrapper.ensureStage1 — greenfield walk (nghf)', () => {
     expect(result.fleet_state.fleet_stage).toBe('none');
   });
 
-  it('accepts funding when master has STAGE1_AGENT_ETH + minEoaGasEth = 0.015 ETH (jinn-mono-u34i)', async () => {
+  it('rejects funding at the gate when master is one wei below the full-bootstrap budget (jinn-mono-u34i boundary)', async () => {
+    // Boundary test for the new full-bootstrap gate: STAGE1_AGENT_ETH (0.010)
+    // + minEoaGasEth*2 (0.010) = 0.020 ETH for N=1. Below this by even one
+    // wei must be rejected — otherwise Stage 1 would succeed, drain master
+    // to (gate - STAGE1_AGENT_ETH - 1 wei = 0.010 - 1 wei), and Stage 2's
+    // existing gate (also 0.010) would re-prompt. The whole point of bumping
+    // Stage 1's gate is that this scenario can never reach Stage 2 with
+    // insufficient master ETH.
+    const earningDir = await mkdtemp(path.join(os.tmpdir(), 'jinn-u34i-stage1-'));
+    dirs.push(earningDir);
+    const bootstrapper = buildBootstrapper(earningDir);
+    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(
+      20_000_000_000_000_000n - 1n, // 0.020 ETH minus one wei
+    );
+    const result = await bootstrapper.ensureStage1('test-password');
+    expect(result.ok).toBe(false);
+    expect(result.funding?.eth_required).toBe('1'); // shortfall = exactly 1 wei
+  });
+
+  it('accepts funding when master has the full-bootstrap budget (jinn-mono-u34i one-shot funding)', async () => {
     const earningDir = await mkdtemp(path.join(os.tmpdir(), 'jinn-u34i-stage1-'));
     dirs.push(earningDir);
 
@@ -212,12 +233,12 @@ describe('FleetBootstrapper.ensureStage1 — greenfield walk (nghf)', () => {
 
     const bootstrapper = buildBootstrapper(earningDir);
 
-    // Exactly 0.015 ETH — the new gate's minimum. Pre-fix this would have
-    // sailed past the old 0.01 ETH gate too, but the funding tx (transfer
-    // 0.01 ETH + gas) had no headroom. With the new gate, this is the
-    // minimum balance that should allow Stage 1 to proceed.
+    // Exactly 0.020 ETH — the full-bootstrap budget for N=1 standard mode.
+    // After Stage 1 transfers 0.010 ETH to HD-1, master sits at 0.010 ETH
+    // which exactly satisfies Stage 2's existing 0.010 ETH gate. End result:
+    // operator funds once, daemon completes both stages without re-prompting.
     vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockResolvedValue(
-      15_000_000_000_000_000n, // 0.015 ETH
+      20_000_000_000_000_000n, // 0.020 ETH
     );
     let safeDeployed = false;
     vi.spyOn((bootstrapper as any).publicClient, 'getCode').mockImplementation(async () =>

--- a/client/test/earning/staged-bootstrap-stage1and2.test.ts
+++ b/client/test/earning/staged-bootstrap-stage1and2.test.ts
@@ -428,7 +428,11 @@ describe('FleetBootstrapper.ensureStage1And2 — combined walk (nghf)', () => {
   // To isolate the Stage 2 gate from Stage 1's, we pre-seed `fleet_stage:
   // 'stage1'` so Stage 1 short-circuits and Stage 2 is the only thing that
   // can reject on funding.
-  const STAGE2_FRESH_GATE_WEI = 10_000_000_000_000_000n; // minEoaGasEth (0.005) * 2 = 0.01 ETH
+  // Stage 2 master gate for a fresh-fleet N=1 operator. Was `minEoaGasEth × 2`
+  // (= 0.010 ETH); dropped to `minEoaGasEth × 1` (= 0.005 ETH) in jinn-mono-u34i
+  // because the `× 2` double-counted a service-1 transfer that doesn't fire
+  // (HD-1 carries Stage 1 leftover, gets a conditional top-up if needed).
+  const STAGE2_FRESH_GATE_WEI = 5_000_000_000_000_000n; // minEoaGasEth = 0.005 ETH
 
   it('Stage 2 fresh-fleet gate rejects master at gate - 1 wei (jinn-mono-u34i boundary)', async () => {
     const earningDir = await mkdtemp(path.join(os.tmpdir(), 'jinn-u34i-stage2-bound-'));

--- a/client/test/earning/staged-bootstrap-stage1and2.test.ts
+++ b/client/test/earning/staged-bootstrap-stage1and2.test.ts
@@ -540,4 +540,132 @@ describe('FleetBootstrapper.ensureStage1And2 — combined walk (nghf)', () => {
     expect(result.fleet_state.services).toHaveLength(1);
     expect(result.fleet_state.services[0]!.step).toBe('complete');
   });
+
+  // ── One-shot funding regression (jinn-mono-u34i) ────────────────────────
+  //
+  // Operator funds the full-bootstrap budget exactly ONCE. The daemon walks
+  // Stage 1 + Stage 2 without surfacing a second funding gate. Catches the
+  // 2026-05-18 canary's "I sent the stated 0.015 and now it's asking again"
+  // frustration: that scenario would re-trigger the funding gate after Stage
+  // 1 drained master. The fix bumps stage1MinMasterEth from 0.015 → 0.020
+  // ETH (for N=1) so master clears Stage 2's existing gate after Stage 1's
+  // transfer, with no re-prompt.
+  it('one-shot funding: stage1MinMasterEth covers Stage 1 + Stage 2 with no re-prompt (jinn-mono-u34i)', async () => {
+    // Operator funds exactly stage1MinMasterEth(config, targetServices).
+    // Stage 1 transfers STAGE1_AGENT_ETH out of master (simulated by
+    // dropping the mocked balance after stepFleetSafeDeploy fires); Stage 2's
+    // existing gate then re-checks master balance. The new helper sizes the
+    // budget so that AFTER Stage 1's transfer, master still clears Stage 2's
+    // gate — i.e. no re-prompt.
+    //
+    // RED-GREEN: if stage1MinMasterEth reverts to its pre-u34i form
+    // (STAGE1_AGENT_ETH + minEoaGasEth = 0.015 ETH), this mock setup leaves
+    // master at 0.005 ETH after Stage 1's transfer, below Stage 2's
+    // 0.010 ETH gate. ensureStage1And2 returns ok=false with funding!=null,
+    // and the test's "ok=true" assertion fails.
+    const earningDir = await mkdtemp(path.join(os.tmpdir(), 'jinn-u34i-one-shot-'));
+    dirs.push(earningDir);
+
+    const mnemonic = generateMnemonic();
+    const encrypted = await encryptMnemonic(mnemonic, 'test-password');
+    const store = new FleetStateStore(earningDir);
+    await store.saveMnemonicKeystore(encrypted);
+
+    const bootstrapper = new FleetBootstrapper({
+      earningDir,
+      chain: 'base',
+      rpcUrl: 'http://127.0.0.1:8545',
+      stakingMode: 'standard',
+      targetServices: 1,
+    });
+
+    // Master balance evolves to reflect Stage 1's transfer to HD-1. Starts at
+    // the helper's stated budget; drops by STAGE1_AGENT_ETH once Stage 1's
+    // Safe-deploy step fires (which is what triggers the funding transfer
+    // in production).
+    const STAGE1_AGENT_ETH_WEI = 10_000_000_000_000_000n;
+    const startingBudget =
+      // Re-derive what the helper would return for this config/N.
+      // Tied to the actual helper output so a regression of stage1MinMasterEth
+      // automatically updates the test's funding assumption.
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      (await import('../../src/earning/bootstrap.js')).stage1MinMasterEth(
+        (bootstrapper as any).config,
+        1,
+      );
+    let mockMasterBalance = startingBudget;
+    vi.spyOn((bootstrapper as any).publicClient, 'getBalance').mockImplementation(
+      async () => mockMasterBalance,
+    );
+    // Safe code mock: '0x' before deploy (so stepFleetSafeDeploy fires and
+    // drops mockMasterBalance), '0xdeadbeef' after.
+    let safeDeployed = false;
+    vi.spyOn((bootstrapper as any).publicClient, 'getCode').mockImplementation(
+      async () => (safeDeployed ? '0xdeadbeef' : '0x'),
+    );
+    // Stage 1 step mocks — Stage 1 advances; no real chain interaction.
+    vi.spyOn(bootstrapper as any, 'stepFleetSafePredict').mockImplementation(async () => {
+      await store.patchFleet({ fleet_safe_address: FLEET_SAFE });
+      return store.load('base');
+    });
+    vi.spyOn(bootstrapper as any, 'stepFleetSafeDeploy').mockImplementation(async () => {
+      // Stage 1's Safe deploy is where master transfers STAGE1_AGENT_ETH to
+      // the fleet agent EOA. Simulate the balance drop so the post-Stage-1
+      // Stage 2 gate sees the reduced master balance — same shape as
+      // production.
+      mockMasterBalance = mockMasterBalance - STAGE1_AGENT_ETH_WEI;
+      safeDeployed = true;
+      return store.load('base');
+    });
+    vi.spyOn(bootstrapper as any, 'stepFleetIdentityRegister').mockImplementation(async () => {
+      await store.patchFleet({
+        fleet_agent_id: FLEET_AGENT_ID,
+        fleet_identity_registry: IDENTITY_REGISTRY,
+        fleet_stage: 'stage1',
+      });
+      return store.load('base');
+    });
+
+    // Stage 2 per-service mocks — Stage 2 advances; no real chain interaction.
+    vi.spyOn(bootstrapper as any, 'stepStolasStake').mockImplementation(
+      async (_s: any, _m: any, index: number) =>
+        store.updateService(index, {
+          safe_address: STAKING_SAFE,
+          service_id: 99,
+          staking_address: '0x0000000000000000000000000000000000000003',
+          step: 'staked',
+        }),
+    );
+    vi.spyOn(bootstrapper as any, 'stepDeployMech').mockImplementation(
+      async (_s: any, _m: any, index: number) =>
+        store.updateService(index, {
+          mech_address: '0x0000000000000000000000000000000000000004',
+          step: 'mech_deployed',
+        }),
+    );
+    vi.spyOn(bootstrapper as any, 'stepRegisterAgent').mockImplementation(
+      async (_s: any, _m: any, index: number) => {
+        const fleet = await store.load('base');
+        await store.updateService(index, {
+          agent_id: fleet.fleet_agent_id,
+          identity_registry_address: fleet.fleet_identity_registry,
+          step: 'complete',
+          safe_bound_to_agent: true,
+        });
+        return store.load('base');
+      },
+    );
+
+    const result = await bootstrapper.ensureStage1And2('test-password');
+
+    // Critical: ok=true means BOTH stages cleared their gates with NO
+    // funding re-prompt. If stage1MinMasterEth were back at 0.015, Stage 2
+    // would have re-triggered the gate after Stage 1 transferred 0.010 out,
+    // and result.ok would be false with funding != null.
+    expect(result.ok).toBe(true);
+    expect(result.funding).toBeUndefined();
+    expect(result.fleet_state.fleet_stage).toBe('stage1_and_2');
+    expect(result.fleet_state.services).toHaveLength(1);
+    expect(result.fleet_state.services[0]!.step).toBe('complete');
+  });
 });


### PR DESCRIPTION
Re-lands the content of closed PR #282. That PR was approved by `ritsukai` (cross-account flow) on 2026-05-18 at 21:48:26Z and **immediately closed** at 21:48:47Z, two seconds after PR #279 squash-merged. The stacked-branch base disappeared when the parent squashed, breaking the stack and causing GitHub to close the child PR without merging it.

The two commits in this branch (`8e8adce6` one-shot funding and `e687dc79` operator-app polish) are identical content to the approved heads `3bef2e97` and `fe50b17e` from #282 — rebased onto current `origin/next` (HEAD = `f017cafb`).

## What this lands

### `fix(u34i)`: one-shot funding — Stage 1 gate covers the full bootstrap budget

Each bootstrap stage independently computed "what do I need to **START**," not "what does the operator need to **FINISH**." Stage 1 asked for 0.015 ETH, ran, drained master by 0.010, Stage 2's separate 0.010 gate re-prompted. Same money, two prompts, operator confusion.

`stage1MinMasterEth(config, targetServices)` now returns the all-in budget that covers **both stages** from a fresh start. For N=1 (the testnet operator): **0.020 ETH one-time**. After Stage 1's 0.010 transfer, master sits at exactly 0.010 ETH which clears Stage 2's existing 0.010 gate. No re-prompt.

Same helper flows through all four call sites: `ensureStage1` daemon gate, `gather-status` panel `minMasterEthWei`, `funding-plan` `requiredMasterEth`, `setup-endpoints` faucet drip target.

Panel copy updated: "**0.020 ETH** — **one-time deposit covering the full bootstrap. The daemon won't ask again.**"

### `fix(u34i)`: post-bootstrap operator-app polish

Stack on top of the one-shot funding fix to keep the operator inside the app for the entire bootstrap → join → build journey:

- **Tenderly gateway as the testnet default RPC** (sepolia.base.org was rate-limiting manifest fetches and balance polls); shared-RPC panel warning in `NetworkSection` with Tenderly / Alchemy / QuickNode CTAs when the operator is still on the bundled key.
- **POST /v1/setup/network** creates `config.json` when it's missing, instead of 404'ing on first-write — matches the "never leave the app" rule.
- **Stage 2 internal gate** dropped from ×2 to ×1; `gather-status` + `funding-plan` now share the same dual-branch (pre-Stage-1 `stage1MinMasterEth`, post-Stage-1 `minEoaGasEth`) so the bootstrap can advance from `awaiting_funding` once the fleet exists.
- **Bootstrap phase 2→3 transition** advances to `safe_deployed` (not back to `awaiting_funding`) when funding clears, the keystore exists, and no services are registered yet.
- **/build SPA page**: design pass against DESIGN.md tokens (`IntroCard`, `PublishedPluginsPanel`, `MyArtifactsPanel`, `ShapeCatalogue`, filter chips) + shared `--surface` / `--surface-sunken` / `--radius-pill` tokens in `globals.css` so PanelCard surfaces actually render.
- **Discovery endpoints use the holder-ref pattern** (eager-register, lazy resolve) so `/v1/discovery/*` returns 503 `subsystem_not_ready` until the daemon populates the API instead of 404'ing forever — same shape as `solverNetsLauncher` and `harnessReadinessRegistry`.
- **PluginPicker harness-aware default**: `claude-code-learner` is excluded from the Hermes default set (Hermes runs models via OpenRouter, doesn't use the Claude Code SDK).

## Tests

- `npx tsc --noEmit` → exit 0
- `npx vitest run --exclude '**/daemon.test.ts' test/earning test/api` → **456 passed, 0 failed** (re-verified on this branch in the v0.1.6 stewardship session)

## Why a fresh PR instead of re-opening #282

#282's branch (`fix/k1ng-one-shot-funding`) was rebased onto the post-#279-merge `origin/next` to give clean commits. Re-pushing the rebased history to the original branch would be a force-push, which the v0.1.6 stewardship brief forbids. Per the brief's safe-push rules, a new branch (`fix/u34i-operator-app-polish-relanded`) is the correct path.

Cross-account approval via the `ritsukai` flow per the v0.1.6 stewardship `/goal` authority.

## Related

- jinn-mono-u34i (original bug + #262 fix-stack)
- #279 (merged) — `fix(k1ng)` setAgentWallet retry, which #282 was stacked on
- #282 (closed, content re-landed here)
- log/decisions/2026-05-18-v0.1.6-stewardship.md (stewardship session log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)