### PR TITLE
docs(stewardship): v0.1.6 npm @latest recovery — donation-consumption blocked, marker not written

### DIFF
--- a/log/decisions/2026-05-19-v0.1.6-stewardship.md
+++ b/log/decisions/2026-05-19-v0.1.6-stewardship.md
@@ -452,3 +452,82 @@ verified.
 
 Captain: cut when ready.
 
+---
+
+# v0.1.6 npm @latest recovery — 2026-05-19 (~T+200, post-publish)
+
+Date: 2026-05-19 (~T+200 from session start, ~T+90 from publish)
+Author: opus (release-recovery agent, /goal session)
+Working dir: `/Users/adrianobradley/life's-work/jinn-mono`
+Branch at session start: `next` (= release SHA `92ba5361`)
+
+## Why this session ran
+
+The GitHub Release `v0.1.6 — Hermes Loop` published at `2026-05-19T11:41:59Z` (tag at `92ba53615249d7f0447fafb2eab7be7224e90f16`), but `@jinn-network/client@latest` on npm stayed at `0.1.5`. The release-event `npm Publish` workflow run (https://github.com/Jinn-Network/mono/actions/runs/26094874366) failed at the `Verify stable release evidence marker` step because the Release body was missing the required `<!-- jinn-release-evidence:v1 ... -->` marker.
+
+`Promote main on release` (run 26094874295) and `CHANGELOG mirror` (run 26094874356) also failed on the same release event, for separate workflow bugs (filed below).
+
+The recovery brief asked the agent to run the three release-prep gates against `92ba5361`, generate the marker, re-trigger the publish workflow, and drive npm @latest to `0.1.6`. Stop on any gate failure — do not bypass.
+
+## Gate results
+
+| Gate | Status | Evidence |
+|------|--------|----------|
+| `release-client-prepare` (substance: install + typecheck + 3566 tests + build + pack:smoke) | **PASSED** | `/tmp/v0.1.6-gate-release-client-prepare.log` line "GATE-PREPARE-PASSED" |
+| `app-first-testnet-acceptance` (Docker steady-state mode, fresh ephemeral operator on Base Sepolia) | **PASSED** | `client/acceptance-runs/2026-05-19T12-02-30-879Z-ic04fd/` — `version=0.1.6, commit=92ba5361, reward claim mode=no-pending, ACCEPTANCE_EXIT=0` |
+| `donation-consumption` (live two-operator, strict release mode) | **FAILED — `producer_artifact_timeout`** | `client/acceptance-runs/2026-05-19T12-07-06-034Z-donation-consumption/` |
+
+### Funding for the testnet-acceptance ephemeral operator
+
+The Docker testnet-acceptance setup generated ephemeral master `0xD33590d2Ea062614851668779A6F99bc8129c93a` and paused at "needs ETH to advance bootstrap." Funded with 0.05 ETH from the deployer key per the brief's authorisation:
+
+- Funding tx: `0x40ee13e66112d337aae7691de32fb2837c3f5b5d0f4e9cfc533f9a7825b0a0f8` (block 41711909)
+- Deployer pre-balance: ~0.387 ETH (`0x15e78734481bD31F6e183dad05225505a45ACd07`)
+
+### Why donation-consumption failed
+
+The gate strictly requires the producer daemon (`~/.jinn-client` → port 7332 here) to generate a NEW `swe-rebench-v2_v1_solution` artifact AFTER the gate starts polling. Op A producer's newest such artifact is from `2026-05-18T10:42:13.052Z` — over 24 h old. Op A is also in a `status_gather_failed` state due to a path mismatch in its worktree-vs-install layout (`Phase 1a artifact not found: /Users/adrianobradley/harbor/jinn-mono/cargo/client/deployments/deployment-phase1a-token-baseSepolia-fast.json`); its solver loops appear inactive. The active SWE solver in this environment is Op B at `/tmp/jinn-op-b-2026-05-19/.jinn-client` on port 7333, but Op B is not configured as a donation producer (`operator.donation.enabled` is unset on Op B).
+
+This is the same gap that PR #306's session called out as A5 = YELLOW with the note "`yarn release:donation-consumption` NOT run against the live two-operator topology this session — A5's wiring is verified, full E2E gated on availability of the CLI run." The Captain pre-authorised that scope reduction at cut time. The marker schema, however, does not have a corresponding skip path — `donation-consumption=passed` is required text-exact, and the recovery agent will not fabricate it.
+
+## What this session did NOT do, per the brief
+
+- **Did NOT write the evidence marker** to the v0.1.6 Release body. The brief is explicit: "Don't bypass the evidence marker check by manually crafting `passed=true` values for gates that didn't run." Donation-consumption ran and produced a defined failure (`producer_artifact_timeout`); writing `donation-consumption=passed` would be fabrication.
+- **Did NOT re-trigger the `npm Publish` workflow** (`gh run rerun 26094874366` not executed) since the marker would still be missing. Re-running without the marker is the same path that already failed.
+- **Did NOT push to `main` directly.** The Captain owns that decision — see #307 (holistic-review-at-main gate restoration).
+- **Did NOT modify the donation-consumption script** to skip the freshness check. The script's strictness is intentional.
+
+## Workflow bugs filed for v0.1.7
+
+| Issue | Type | What |
+|-------|------|------|
+| #308 | investigate / `bug, release:blocked` | `Promote main on release` ancestry check fails after shallow tag fetch creates a graft boundary. Locally `git merge-base --is-ancestor origin/main 92ba5361` succeeds; in CI it fails because the `--depth=1` fetch on line 37 of `.github/workflows/promote-main.yml` shallows the tag commit and subsequent `git fetch origin next` does not auto-unshallow. |
+| #309 | investigate / `bug, release:blocked` | `CHANGELOG mirror` workflow successfully commits and pushes the mirror branch (`changelog/mirror-v0.1.6`), then fails at `gh pr create` with `GitHub Actions is not permitted to create or approve pull requests`. Repo-setting (`Allow GitHub Actions to create and approve pull requests`) is OFF, or workflow needs a PAT. The same bug failed v0.1.4 and v0.1.5 too — three orphan mirror branches on origin. |
+| #310 | release-blocker | This recovery session's blocker — donation-consumption gate cannot pass without an actively-solving donation-enabled producer daemon. Captain decision needed on hold/relax-marker/revive-producer. |
+
+Each follow-up is framed "investigate first, then propose" per the established v0.1.7 pattern (#295, #296, #297, #300, #302, #304, #307).
+
+## Final state at session close
+
+- npm `@jinn-network/client@latest` — still `0.1.5`. Stable `0.1.6` was never published.
+- npm `@jinn-network/client@canary` — `0.1.6-canary.4841aa5a` (one commit before the release SHA; canary path for the docs-only PR #306 wasn't separately published because the release event was the first publish trigger after #306, and that workflow failed at the marker).
+- GitHub Release `v0.1.6 — Hermes Loop` — published, marker still missing. Body unchanged by this session.
+- `main` — still at `099d84cf6ae1e1b75856f7fa7736515021c04545`. Behind release SHA by 16 commits. Auto-FF blocked by #308.
+- `next` — at the release SHA `92ba53615249d7f0447fafb2eab7be7224e90f16`. Pushed canaries clean for every commit before the release event.
+
+## Captain decision needed
+
+1. **HOLD npm @latest at 0.1.5 for v0.1.6.** Treat v0.1.6 as a GitHub-Release-only artifact and roll the donation-consumption fix into v0.1.7's Monday cut. Simplest.
+2. **Relax the marker schema** in `.github/workflows/npm-publish.yml` to accept `donation-consumption=skipped` with an inline rationale, while keeping prepare + testnet-acceptance hard-required. Workflow change → counts as a v0.1.7 patch; could be back-ported via hotfix if Captain wants v0.1.6 on npm @latest.
+3. **Revive Op A producer** (or flip Op B to donation-producer mode) long enough to generate fresh donated artifacts, then re-run gate 2 from the recovery agent's evidence directory and let the marker assembly + workflow rerun complete. Multi-hour, requires producer-side activity.
+
+The release-prep evidence the gates DID produce is captured at:
+- `/tmp/v0.1.6-gate-release-client-prepare.log`
+- `client/acceptance-runs/2026-05-19T12-02-30-879Z-ic04fd/` (testnet-acceptance)
+- `client/acceptance-runs/2026-05-19T12-07-06-034Z-donation-consumption/` (the failure)
+
+These can feed directly into the next recovery attempt once donation-consumption's structural blocker is resolved.
+
+## Status
+
+`v0.1.6 npm @latest publish: BLOCKED on #310 (donation-consumption producer-side staleness).` Marker not written. Workflow not re-triggered. `main` not advanced. Two paired workflow bugs filed for v0.1.7 (#308, #309). Captain owns the next step.


### PR DESCRIPTION
## Summary

Recovery session for the partial v0.1.6 release. GitHub Release at `92ba5361` is published; npm `@jinn-network/client@latest` is still `0.1.5` because the release-event `npm Publish` workflow (https://github.com/Jinn-Network/mono/actions/runs/26094874366) failed at the `Verify stable release evidence marker` step.

This PR appends a closing section to `log/decisions/2026-05-19-v0.1.6-stewardship.md` documenting:

- **Two of three release-prep gates passed** against the release commit (`release-client-prepare` substance: 3566 tests + build + pack:smoke; `app-first-testnet-acceptance`: Docker steady-state cycle on Base Sepolia)
- **Third gate failed structurally** — `donation-consumption` got `producer_artifact_timeout` because Op A producer (`~/.jinn-client`, port 7332) has not generated a fresh donated SWE solution artifact since `2026-05-18T10:42` (24h+ stale; Op A is in `status_gather_failed` from a path mismatch and its solver loops appear inactive)
- **Marker NOT written** — the brief forbids fabricating `donation-consumption=passed` for a gate that did not pass

## Workflow bugs filed for v0.1.7

- #308 — `Promote main on release` shallow-fetch ancestry bug (`--depth=1` on tag fetch grafts a shallow boundary that `git fetch origin next` does not auto-unshallow)
- #309 — `CHANGELOG mirror` workflow cannot create PR (`GitHub Actions is not permitted to create or approve pull requests`); same bug failed v0.1.4 and v0.1.5 too
- #310 — this session's release-blocker (donation-consumption structural; Captain decision needed)

## Captain decision needed

1. **HOLD** npm @latest at `0.1.5`. Roll v0.1.6's content into v0.1.7's Monday cut. Simplest.
2. **RELAX MARKER** schema to accept `donation-consumption=skipped` with inline rationale; keep prepare + testnet-acceptance hard-required. Counts as a v0.1.7 workflow patch.
3. **REVIVE PRODUCER** (or flip Op B to donation mode) long enough to generate fresh donated artifacts, then re-run gate 2 from the recovery agent's evidence directory.

## Test plan

- [x] Decision log update preserves prior sections unchanged
- [x] Workflow bug issues #308 and #309 filed before this PR
- [x] Release-blocker issue #310 filed before this PR
- [x] No code changes; docs-only

## Evidence directories (local; not in repo)

- `/tmp/v0.1.6-gate-release-client-prepare.log` — gate 1 (passed)
- `client/acceptance-runs/2026-05-19T12-02-30-879Z-ic04fd/` — gate 3 (passed)
- `client/acceptance-runs/2026-05-19T12-07-06-034Z-donation-consumption/` — gate 2 (failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)