### PR TITLE
docs(release-readiness): design spec for substrate + release-prep + release-readiness

### DIFF
--- a/docs/superpowers/plans/2026-05-19-release-readiness-skill-plan.md
+++ b/docs/superpowers/plans/2026-05-19-release-readiness-skill-plan.md
@@ -1,0 +1,1654 @@
+# release-readiness skill + Tier 3 implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the meta-skill that audits canon, triages gaps, drives blocking-gap closure, invokes release-prep + Tier 3, and emits the handoff doc that humans use to decide ship/defer/block. Plus the Tier 3 scenario itself (real Base Sepolia, real Hermes, real verdict) — the only required gate for a named cut. This plan ends the brainstorm-to-execution loop: when Plan E lands, the full release-readiness flow is callable.
+
+**Architecture:** The skill is a thin coordinator implemented as the `.claude/skills/release-readiness/SKILL.md` definition plus a small TypeScript scaffolding script that the skill's instructions point at. The skill dispatches a single audit subagent (judgmental + canon pass combined) plus a triage subagent, then optionally fans out closure subagents per blocking gap, then invokes the `release-prep` skill (Plan C/D) and the Tier 3 callable, then dispatches a handoff-doc-drafting subagent. Main agent stays a thin coordinator. The Tier 3 scenario is a separate callable at `client/test/release/tier-3/T3.1-producer-evaluator-real.ts` — same shape as Tier 2 scenarios but no Anvil fork (real Base Sepolia) and a real Hermes call (small budget cap).
+
+**Tech Stack:** Markdown for the skill + reference docs. TypeScript for Tier 3 callable + run-tier-3 orchestrator (mirrors Plan D's `run-tier-2.ts` shape). Reuses Plan A's substrate (this time the gold copy, no workspace), Plan B's multi-op-daemon, Plan C's scenario-types, Plan D's tier-2-helpers (one-off adaptation for gold-direct vs workspace-copy).
+
+**Dependencies:**
+- **Plan A** — substrate scripts. Tier 3 uses the gold substrate directly (no workspace copy — Tier 3 mutations are append-only on-chain).
+- **Plan B** — multi-op-daemon, handshake-url.
+- **Plan C** — scenario-types (ScenarioVerdict, classifyFailure), release-prep skill must exist.
+- **Plan D** — release-prep with Tier 2 populated, tier-2-helpers as a structural model for tier-3 setup. The release-readiness skill invokes release-prep; Plan D fills in release-prep's Tier 2 surface.
+
+---
+
+## File structure
+
+**New source files:**
+
+| Path | Responsibility |
+|---|---|
+| `client/test/release/tier-3/T3.1-producer-evaluator-real.ts` | T3.1 callable: real Base Sepolia, real Hermes, real verdict |
+| `client/test/release/tier-3/tier-3-helpers.ts` | `setupTier3Scenario()` — gold-substrate-direct daemon spawn with daily-driver mutex check |
+| `client/scripts/release/run-tier-3.ts` | Tier 3 orchestrator (single-scenario for now; expandable) |
+| `client/scripts/release/release-readiness.ts` | Thin TS scaffolding for the skill: audit summary aggregator, handoff doc writer, log/decisions appender |
+
+**New skill files:**
+
+| Path | Responsibility |
+|---|---|
+| `.claude/skills/release-readiness/SKILL.md` | Skill definition: phases, subagent dispatch, input contract |
+| `.claude/skills/release-readiness/references/static-checklist.md` | C1-C11 detailed shape + which run in main vs subagent |
+| `.claude/skills/release-readiness/references/canon-audit-prompts.md` | Prompt templates for the judgmental audit subagent |
+| `.claude/skills/release-readiness/references/triage-taxonomy.md` | BLOCKING / DEFERRABLE / ALREADY-MET rules |
+| `.claude/skills/release-readiness/references/handoff-doc-template.md` | The output artifact's full template |
+| `.claude/skills/release-readiness/references/tier-3-scenario.md` | Detailed contract for T3.1 |
+| `.claude/skills/release-readiness/references/autonomous-vs-invoked.md` | Mode differences |
+
+**Modified files:**
+
+| Path | Change |
+|---|---|
+| `client/package.json` | Add `release:tier-3`, `release-readiness` yarn scripts |
+| `client/scripts/release/README.md` | Document Tier 3 + the release-readiness scaffolding |
+
+**No CI workflow changes.** release-readiness is human-invoked (and future cron). It doesn't wire into `npm-publish.yml`.
+
+---
+
+## Task 1: Tier 3 setup helper
+
+**Files:**
+- Create: `client/test/release/tier-3/tier-3-helpers.ts`
+- Test: `client/test/release/tier-3/tier-3-helpers.test.ts`
+
+Tier 3 runs against the gold substrate directly (no workspace copy). Mutations are append-only on-chain (post task, deliver solution, post verdict — no state corruption). Plan A's substrate has the gold operators at `~/jinn-dev/operators/op-{a,b}/` already.
+
+**Critical difference from Tier 2:** Tier 3 must check that the daily-driver daemons (the user's `~/.jinn-client/` and `~/jinn-canary-test/...`) are NOT running before spawning gold-substrate daemons. They share on-chain identity. Tier 3 SIGTERMs them in human-invoked mode and refuses to run in autonomous mode if they're present.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// client/test/release/tier-3/tier-3-helpers.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { setupTier3Scenario, type Tier3Handle, isDailyDriverRunning } from './tier-3-helpers';
+
+describe('isDailyDriverRunning', () => {
+  it('returns false when nothing is on the daily-driver ports', async () => {
+    const running = await isDailyDriverRunning({ ports: [60001, 60002] });
+    expect(running).toBe(false);
+  });
+
+  it('returns true when something is on a daily-driver port', async () => {
+    const net = await import('node:net');
+    const srv = net.createServer();
+    await new Promise<void>((resolve) => srv.listen(60003, resolve));
+    try {
+      const running = await isDailyDriverRunning({ ports: [60003] });
+      expect(running).toBe(true);
+    } finally {
+      await new Promise<void>((resolve) => srv.close(() => resolve()));
+    }
+  });
+});
+
+describe('setupTier3Scenario', () => {
+  it('refuses to run when daily driver is up and mode is autonomous', async () => {
+    const net = await import('node:net');
+    const srv = net.createServer();
+    await new Promise<void>((resolve) => srv.listen(60004, resolve));
+    try {
+      await expect(
+        setupTier3Scenario({
+          scenarioId: 'T3.X-test',
+          mode: 'autonomous',
+          dailyDriverPorts: [60004],
+        }),
+      ).rejects.toThrow(/daily driver/i);
+    } finally {
+      await new Promise<void>((resolve) => srv.close(() => resolve()));
+    }
+  });
+
+  it('uses gold paths directly (no workspace copy)', async () => {
+    // Skip if substrate not present
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const os = await import('node:os');
+    const goldOpA = path.join(os.homedir(), 'jinn-dev', 'operators', 'op-a');
+    try { await fs.access(goldOpA); } catch { return; }
+
+    // We don't actually want to spawn daemons in this unit test (that would
+    // require mutex'ing the real daily driver). Just assert that the helper's
+    // resolveGoldPath function returns the gold dir.
+    const { resolveGoldDaemonHome } = await import('./tier-3-helpers');
+    const home = resolveGoldDaemonHome('op-a');
+    expect(home).toBe(goldOpA);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd client && yarn vitest run test/release/tier-3/tier-3-helpers.test.ts`
+Expected: FAIL with module-not-found.
+
+- [ ] **Step 3: Implement the helper**
+
+```typescript
+// client/test/release/tier-3/tier-3-helpers.ts
+import * as net from 'node:net';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { spawnMultiOpDaemons, type MultiOpHandle } from '../../helpers/multi-op-daemon';
+import { goldPath } from '../../../scripts/release/substrate-paths';
+
+const DAILY_DRIVER_PORTS = [7331, 7332];     // ~/.jinn-client and ~/jinn-canary-test default ports
+
+export function resolveGoldDaemonHome(opName: string): string {
+  return goldPath(opName);
+}
+
+export interface IsDailyDriverOptions {
+  ports?: number[];
+}
+
+export async function isDailyDriverRunning(opts: IsDailyDriverOptions = {}): Promise<boolean> {
+  const ports = opts.ports ?? DAILY_DRIVER_PORTS;
+  for (const port of ports) {
+    const inUse = await isPortInUse(port);
+    if (inUse) return true;
+  }
+  return false;
+}
+
+async function isPortInUse(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const tester = net.createServer();
+    tester.once('error', (err: NodeJS.ErrnoException) => {
+      resolve(err.code === 'EADDRINUSE');
+    });
+    tester.once('listening', () => {
+      tester.close(() => resolve(false));
+    });
+    tester.listen(port, '127.0.0.1');
+  });
+}
+
+export interface Tier3SetupOptions {
+  scenarioId: string;
+  mode: 'human-invoked' | 'autonomous';
+  portBase?: number;                  // daemons get portBase, portBase+1
+  dailyDriverPorts?: number[];        // override the default mutex check
+  extraEnv?: NodeJS.ProcessEnv;
+}
+
+export interface Tier3Handle {
+  daemons: MultiOpHandle;
+  teardown: () => Promise<void>;
+}
+
+export async function setupTier3Scenario(opts: Tier3SetupOptions): Promise<Tier3Handle> {
+  // 1. Daily-driver mutex check
+  const dailyUp = await isDailyDriverRunning({ ports: opts.dailyDriverPorts });
+  if (dailyUp) {
+    if (opts.mode === 'autonomous') {
+      throw new Error(
+        'daily driver appears to be running on one of the substrate-shared ports. ' +
+        'Autonomous mode refuses to SIGTERM it. Re-run in human-invoked mode or stop the daily driver first.',
+      );
+    }
+    // human-invoked mode: instruct caller to stop daily driver first.
+    // We don't auto-SIGTERM because that requires the caller's process to have permission
+    // over the daily-driver process; instead surface explicitly and let release-readiness
+    // handle the SIGTERM via its own daemon-mutex Phase 5 logic.
+    throw new Error(
+      'daily driver is running on a substrate-shared port. ' +
+      'In human-invoked mode, release-readiness should SIGTERM it before invoking Tier 3.',
+    );
+  }
+
+  // 2. Spawn daemons against gold paths (no workspace copy)
+  const portBase = opts.portBase ?? 7350;
+  let daemons: MultiOpHandle;
+  try {
+    daemons = await spawnMultiOpDaemons({
+      ops: [
+        { name: 'op-a', home: resolveGoldDaemonHome('op-a'), apiPort: portBase },
+        { name: 'op-b', home: resolveGoldDaemonHome('op-b'), apiPort: portBase + 1 },
+      ],
+      extraEnv: opts.extraEnv,
+      readyTimeoutMs: 60000,           // real chain warm-up may be slower than fork
+    });
+  } catch (err) {
+    throw new Error(`Tier 3 daemon spawn failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  let torn = false;
+  return {
+    daemons,
+    teardown: async () => {
+      if (torn) return;
+      torn = true;
+      await daemons.teardown();
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd client && yarn vitest run test/release/tier-3/tier-3-helpers.test.ts`
+Expected: 3 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/test/release/tier-3/tier-3-helpers.ts client/test/release/tier-3/tier-3-helpers.test.ts
+git commit -m "test(release): add Tier 3 setup helper with daily-driver mutex check"
+```
+
+---
+
+## Task 2: T3.1 — producer-evaluator real-testnet
+
+**Files:**
+- Create: `client/test/release/tier-3/T3.1-producer-evaluator-real.ts` (callable only)
+- Create: `client/test/release/tier-3/T3.1-producer-evaluator-real.test.ts` (Vitest wrapper)
+
+**What this scenario does:** Per the contract: op-a posts a small SWE-rebench v2 task on real Base Sepolia, claims, solves via real Hermes (real OpenRouter API call, ~$0.05-$0.10 cost), delivers. op-b claims verdict request, runs real evaluator Docker image, posts verdict. Assert `verdictCode === KNOWN_EXPECTED_VERDICT`.
+
+**Key differences from T2.2 (Tier 2):**
+- Real chain, not Anvil fork — txs cost real test ETH (tiny amounts)
+- Real Hermes harness, not stubbed — real API spend
+- Cost cap enforced
+- Wall-clock budget 10 min (vs 5 min for T2.2)
+
+- [ ] **Step 1: Write the callable**
+
+```typescript
+// client/test/release/tier-3/T3.1-producer-evaluator-real.ts
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { setupTier3Scenario, type Tier3Handle } from './tier-3-helpers';
+import { classifyFailure, type ScenarioVerdict, type ScenarioOptions } from '../../../scripts/release/scenario-types';
+import {
+  KNOWN_INSTANCE_ID,
+  KNOWN_REPO,
+  KNOWN_COMMIT,
+  KNOWN_EXPECTED_VERDICT,
+} from '../tier-2/fixtures/known-instance';
+
+const COST_CAP_USD = 0.25;
+const WALL_CLOCK_BUDGET_MS = 10 * 60 * 1000;
+
+interface ScenarioOptionsT3 extends ScenarioOptions {
+  mode?: 'human-invoked' | 'autonomous';
+  hermesModel?: string;
+}
+
+async function waitFor<T>(
+  fn: () => Promise<T | null>,
+  opts: { timeoutMs: number; intervalMs?: number; label?: string },
+): Promise<T> {
+  const interval = opts.intervalMs ?? 5000;
+  const deadline = Date.now() + opts.timeoutMs;
+  while (Date.now() < deadline) {
+    const result = await fn();
+    if (result !== null) return result;
+    await new Promise((r) => setTimeout(r, interval));
+  }
+  throw new Error(`waitFor${opts.label ? ` (${opts.label})` : ''} timed out after ${opts.timeoutMs}ms`);
+}
+
+export async function runT31ProducerEvaluatorReal(opts: ScenarioOptionsT3): Promise<ScenarioVerdict> {
+  const started = Date.now();
+  const evidenceLines: string[] = [];
+  const log = (msg: string) => evidenceLines.push(`[${new Date().toISOString()}] ${msg}`);
+
+  let handle: Tier3Handle | null = null;
+  const hermesModel = opts.hermesModel ?? 'deepseek/deepseek-v4-flash';
+
+  try {
+    log(`1. setup Tier 3 scenario (mode=${opts.mode ?? 'human-invoked'}, model=${hermesModel})`);
+    handle = await setupTier3Scenario({
+      scenarioId: 'T3.1',
+      mode: opts.mode ?? 'human-invoked',
+      portBase: 7360,
+      extraEnv: {
+        JINN_HERMES_MODEL: hermesModel,
+        JINN_TIER3_COST_CAP_USD: COST_CAP_USD.toString(),
+      },
+    });
+    log('   daemons up against real Base Sepolia');
+
+    const opAPort = handle.daemons.daemons['op-a'].apiPort;
+    const opBPort = handle.daemons.daemons['op-b'].apiPort;
+
+    log(`2. op-a posts task instance=${KNOWN_INSTANCE_ID}`);
+    const postRes = await fetch(`http://127.0.0.1:${opAPort}/v1/tasks`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        solverType: 'swe-rebench-v2.v1',
+        spec: { instanceId: KNOWN_INSTANCE_ID, repo: KNOWN_REPO, commit: KNOWN_COMMIT },
+      }),
+    });
+    if (!postRes.ok) throw new Error(`/v1/tasks returned ${postRes.status}: ${await postRes.text()}`);
+    const posted = await postRes.json() as { taskId: string; requestId: string };
+    log(`   taskId=${posted.taskId}, requestId=${posted.requestId}`);
+
+    log('3. wait for op-a to claim, solve via real Hermes, deliver');
+    const delivered = await waitFor(async () => {
+      const r = await fetch(`http://127.0.0.1:${opAPort}/v1/tasks/${posted.taskId}`);
+      if (!r.ok) return null;
+      const body = await r.json() as { state?: string; deliveryTxHash?: string; cost?: { usd?: number } };
+      return body.state === 'DELIVERED' ? body : null;
+    }, { timeoutMs: 8 * 60 * 1000, intervalMs: 5000, label: 'op-a-delivery' });
+    log(`   deliveryTx=${delivered.deliveryTxHash}`);
+    if (delivered.cost?.usd !== undefined) {
+      log(`   cost so far: $${delivered.cost.usd.toFixed(4)}`);
+      if (delivered.cost.usd > COST_CAP_USD) {
+        throw new Error(`cost cap exceeded: spent $${delivered.cost.usd.toFixed(4)}, cap $${COST_CAP_USD}`);
+      }
+    }
+
+    log('4. wait for op-b to claim verdict request, run evaluator, post verdict');
+    const verdict = await waitFor(async () => {
+      const r = await fetch(`http://127.0.0.1:${opBPort}/v1/verdicts?taskId=${posted.taskId}`);
+      if (!r.ok) return null;
+      const body = await r.json() as { verdicts?: Array<{ verdictCode: number; verdictTxHash?: string; solutionCid?: string; verdictCid?: string }> };
+      return body.verdicts && body.verdicts.length > 0 ? body.verdicts[0] : null;
+    }, { timeoutMs: 5 * 60 * 1000, intervalMs: 5000, label: 'op-b-verdict' });
+    log(`   verdictCode=${verdict.verdictCode}, verdictTx=${verdict.verdictTxHash}`);
+    log(`   solutionCid=${verdict.solutionCid}, verdictCid=${verdict.verdictCid}`);
+
+    log('5. assert verdict matches expected');
+    if (verdict.verdictCode !== KNOWN_EXPECTED_VERDICT) {
+      throw new Error(`expected verdictCode=${KNOWN_EXPECTED_VERDICT}, got ${verdict.verdictCode}`);
+    }
+    log('   PASS — verdict matches');
+
+    await fs.writeFile(opts.evidencePath, evidenceLines.join('\n'));
+    return {
+      scenarioId: 'T3.1',
+      verdict: 'pass',
+      wallClockMs: Date.now() - started,
+      evidencePath: opts.evidencePath,
+      failClass: null,
+      failNotes: null,
+    };
+  } catch (err) {
+    log(`FAILED: ${err instanceof Error ? err.message : String(err)}`);
+    await fs.writeFile(opts.evidencePath, evidenceLines.join('\n'));
+    return {
+      scenarioId: 'T3.1',
+      verdict: 'fail',
+      wallClockMs: Date.now() - started,
+      evidencePath: opts.evidencePath,
+      failClass: classifyFailure(err),
+      failNotes: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    if (handle) { try { await handle.teardown(); } catch {} }
+  }
+}
+```
+
+- [ ] **Step 2: Write the Vitest wrapper**
+
+```typescript
+// client/test/release/tier-3/T3.1-producer-evaluator-real.test.ts
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { runT31ProducerEvaluatorReal } from './T3.1-producer-evaluator-real';
+
+describe('T3.1 producer-evaluator-real', () => {
+  // Gated: this test spends real testnet ETH + real OpenRouter $. Only runs when
+  // explicitly opted in via JINN_T31_REAL=1.
+  const enabled = process.env['JINN_T31_REAL'] === '1';
+
+  it.skipIf(!enabled)('returns pass verdict against real Base Sepolia + real Hermes', async () => {
+    const evidenceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'T3.1-evidence-'));
+    const evidencePath = path.join(evidenceDir, 'T3.1.log');
+    try {
+      const verdict = await runT31ProducerEvaluatorReal({
+        evidencePath,
+        mode: 'human-invoked',
+        wallClockBudgetMs: 10 * 60 * 1000,
+      });
+      expect(['pass', 'fail']).toContain(verdict.verdict);
+      if (verdict.verdict === 'fail') {
+        console.error('T3.1 fail:', verdict.failNotes);
+      }
+    } finally {
+      await fs.rm(evidenceDir, { recursive: true, force: true });
+    }
+  }, 12 * 60 * 1000);
+
+  it('callable shape matches ScenarioVerdict', () => {
+    // Static type check at compile time; this test just asserts the export exists.
+    expect(typeof runT31ProducerEvaluatorReal).toBe('function');
+  });
+});
+```
+
+- [ ] **Step 3: Run the wrapper without the gate (function shape only)**
+
+Run: `cd client && yarn vitest run test/release/tier-3/T3.1-producer-evaluator-real.test.ts`
+Expected: 1 passing (callable shape), 1 skipped (real-network gate not opted in).
+
+To run the real-network test:
+```bash
+cd client && JINN_T31_REAL=1 yarn vitest run test/release/tier-3/T3.1-producer-evaluator-real.test.ts
+```
+
+(This will cost ~$0.10 in real OpenRouter spend + tiny test ETH.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/test/release/tier-3/T3.1-producer-evaluator-real.ts client/test/release/tier-3/T3.1-producer-evaluator-real.test.ts
+git commit -m "feat(release): add T3.1 producer-evaluator real-testnet scenario"
+```
+
+---
+
+## Task 3: run-tier-3.ts orchestrator
+
+**Files:**
+- Create: `client/scripts/release/run-tier-3.ts`
+
+Single-scenario orchestrator for now (T3.1 only). Structure matches `run-tier-2.ts` for consistency.
+
+- [ ] **Step 1: Implement**
+
+```typescript
+// client/scripts/release/run-tier-3.ts
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { runT31ProducerEvaluatorReal } from '../../test/release/tier-3/T3.1-producer-evaluator-real';
+import { type ScenarioVerdict, ScenarioVerdictSchema } from './scenario-types';
+
+interface RunOptions {
+  outputDir?: string;
+  candidateVersion?: string;
+  mode?: 'human-invoked' | 'autonomous';
+  hermesModel?: string;
+}
+
+export async function runTier3(opts: RunOptions = {}): Promise<{ verdicts: ScenarioVerdict[]; allPassed: boolean }> {
+  const outputDir = opts.outputDir ?? path.join(
+    process.cwd(),
+    'tier-3-evidence',
+    new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19),
+  );
+  await fs.mkdir(outputDir, { recursive: true });
+
+  const verdict = await runT31ProducerEvaluatorReal({
+    evidencePath: path.join(outputDir, 'T3.1.log'),
+    mode: opts.mode ?? 'human-invoked',
+    hermesModel: opts.hermesModel,
+    wallClockBudgetMs: 10 * 60 * 1000,
+  });
+
+  ScenarioVerdictSchema.parse(verdict);
+  const verdicts = [verdict];
+  const allPassed = verdict.verdict === 'pass';
+
+  const summary = {
+    candidateVersion: opts.candidateVersion ?? 'unknown',
+    timestamp: new Date().toISOString(),
+    mode: opts.mode ?? 'human-invoked',
+    verdicts,
+    allPassed,
+  };
+  await fs.writeFile(path.join(outputDir, 'summary.json'), JSON.stringify(summary, null, 2));
+
+  const markerLines = [
+    '<!-- jinn-release-evidence:v1',
+    `release-candidate=${opts.candidateVersion ?? 'unknown'}`,
+    `tier-3-t3-1=${verdict.verdict === 'pass' ? 'passed' : `failed:${verdict.failClass}`}`,
+    `tier-3-overall=${allPassed ? 'passed' : 'failed'}`,
+    '-->',
+  ];
+  await fs.writeFile(path.join(outputDir, 'marker.txt'), markerLines.join('\n') + '\n');
+
+  return { verdicts, allPassed };
+}
+
+async function cliMain(): Promise<void> {
+  const candidateVersion = process.argv[2];
+  const mode = (process.argv[3] as 'human-invoked' | 'autonomous' | undefined) ?? 'human-invoked';
+  const { verdicts, allPassed } = await runTier3({ candidateVersion, mode });
+  console.log(JSON.stringify({ verdicts, allPassed }, null, 2));
+  const hasRealBug = verdicts.some((v) => v.verdict === 'fail' && v.failClass === 'real-bug');
+  process.exit(hasRealBug ? 1 : 0);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  cliMain().catch((err) => {
+    console.error('run-tier-3 crashed:', err);
+    process.exit(2);
+  });
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add client/scripts/release/run-tier-3.ts
+git commit -m "feat(release): add run-tier-3 orchestrator"
+```
+
+---
+
+## Task 4: release-readiness scaffolding
+
+**Files:**
+- Create: `client/scripts/release/release-readiness.ts`
+- Test: `client/scripts/release/release-readiness.test.ts`
+
+The release-readiness skill's SKILL.md is the primary deliverable, but it needs a thin TS scaffolding for:
+- Aggregating audit findings + triage + verdicts into the handoff doc
+- Writing the handoff doc to `docs/release/<version>/handoff.md`
+- Appending the one-line audit-trail entry to `log/decisions/release-readiness-runs.md`
+- Emitting the final marker block
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// client/scripts/release/release-readiness.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  writeHandoffDoc,
+  appendAuditTrailEntry,
+  type HandoffDocInput,
+  type ReadinessRecommendation,
+} from './release-readiness';
+
+describe('release-readiness scaffolding', () => {
+  let tmpRoot: string;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'release-readiness-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('writeHandoffDoc produces a structured markdown file', async () => {
+    const input: HandoffDocInput = {
+      candidateVersion: 'v0.1.7',
+      branchSha: 'abc123def4567890abc123def4567890abc123de',
+      lastReleasedSha: '579541cd7fefe305289a51b0ac5da19587e00ad2',
+      mode: 'human-invoked',
+      runId: '2026-05-26T11-30-00-a4f3',
+      recommendation: 'SHIP',
+      recommendationReasoning: 'All blocking gaps closed; Tier 3 passed.',
+      diffSummary: { prsInWindow: 14, locAdded: 2847, locRemoved: 442, surfacesTouched: ['bootstrap', 'dashboard'] },
+      gaps: [
+        { id: 'GAP-1', source: 'C1', classification: 'BLOCKING', status: 'CLOSED', notes: 'PR #321 merged' },
+        { id: 'GAP-2', source: 'canon:SPEC.md', classification: 'DEFERRABLE', status: 'FILED', ghIssue: '#322', milestone: 'v0.1.8' },
+      ],
+      releasePrepVerdicts: [
+        { scenarioId: 'T1.1', verdict: 'pass', wallClockMs: 87234, evidencePath: '', failClass: null, failNotes: null },
+      ],
+      tier3Verdict: { scenarioId: 'T3.1', verdict: 'pass', wallClockMs: 278000, evidencePath: '', failClass: null, failNotes: null },
+      tier3Evidence: {
+        scenario: 'op-a solves sympy__sympy-27510, op-b evaluates',
+        hermesModel: 'deepseek/deepseek-v4-flash',
+        verdictCode: 1,
+        deliveryTxHash: '0xa1b2',
+        verdictTxHash: '0xc3d4',
+        costUsd: 0.07,
+      },
+      walkThrough: ['Fresh operator bootstrap completes panel-driven', 'Network view solve-rate hero renders'],
+      openQuestions: ['Q1: spec drift in unused section — acceptable?'],
+    };
+
+    const outPath = path.join(tmpRoot, 'docs', 'release', 'v0.1.7', 'handoff.md');
+    await writeHandoffDoc(outPath, input);
+    const content = await fs.readFile(outPath, 'utf-8');
+    expect(content).toContain('# Release-readiness handoff — v0.1.7');
+    expect(content).toContain('## Recommendation: SHIP');
+    expect(content).toContain('GAP-1');
+    expect(content).toContain('verdictCode=1');
+    expect(content).toContain('release-readiness-recommendation=SHIP');
+  });
+
+  it('appendAuditTrailEntry adds a one-line entry to log/decisions/', async () => {
+    const trailPath = path.join(tmpRoot, 'log', 'decisions', 'release-readiness-runs.md');
+    await appendAuditTrailEntry(trailPath, {
+      timestamp: '2026-05-26T11:30:00Z',
+      candidateVersion: 'v0.1.7',
+      mode: 'human-invoked',
+      recommendation: 'SHIP' as ReadinessRecommendation,
+      handoffPath: 'docs/release/v0.1.7/handoff.md',
+    });
+    const content = await fs.readFile(trailPath, 'utf-8');
+    expect(content).toContain('2026-05-26T11:30:00Z | v0.1.7 | human-invoked | recommendation=SHIP | handoff=docs/release/v0.1.7/handoff.md');
+  });
+
+  it('appendAuditTrailEntry creates the file if missing', async () => {
+    const trailPath = path.join(tmpRoot, 'log', 'decisions', 'release-readiness-runs.md');
+    await appendAuditTrailEntry(trailPath, {
+      timestamp: '2026-05-26T12:00:00Z',
+      candidateVersion: 'v0.1.7',
+      mode: 'autonomous',
+      recommendation: 'DEFER' as ReadinessRecommendation,
+      handoffPath: 'docs/release/v0.1.7/handoff.md',
+    });
+    const content = await fs.readFile(trailPath, 'utf-8');
+    expect(content.split('\n').length).toBeGreaterThanOrEqual(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd client && yarn vitest run scripts/release/release-readiness.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the scaffolding**
+
+```typescript
+// client/scripts/release/release-readiness.ts
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type { ScenarioVerdict } from './scenario-types';
+
+export type ReadinessRecommendation = 'SHIP' | 'DEFER' | 'BLOCK';
+
+export interface Gap {
+  id: string;
+  source: string;                       // e.g. "C1" or "canon:PRINCIPLES.md"
+  classification: 'BLOCKING' | 'DEFERRABLE' | 'ALREADY-MET';
+  status: 'OPEN' | 'CLOSED' | 'FILED' | 'ESCALATED' | 'EVIDENCE-LINKED';
+  notes: string;
+  ghIssue?: string;                     // e.g. "#322"
+  milestone?: string;                   // e.g. "v0.1.8"
+}
+
+export interface HandoffDocInput {
+  candidateVersion: string;
+  branchSha: string;
+  lastReleasedSha: string;
+  mode: 'human-invoked' | 'autonomous';
+  runId: string;
+  recommendation: ReadinessRecommendation;
+  recommendationReasoning: string;
+  diffSummary: {
+    prsInWindow: number;
+    locAdded: number;
+    locRemoved: number;
+    surfacesTouched: string[];
+  };
+  gaps: Gap[];
+  releasePrepVerdicts: ScenarioVerdict[];
+  tier3Verdict: ScenarioVerdict | null;
+  tier3Evidence: {
+    scenario: string;
+    hermesModel: string;
+    verdictCode: number;
+    deliveryTxHash: string;
+    verdictTxHash: string;
+    costUsd: number;
+  } | null;
+  walkThrough: string[];
+  openQuestions: string[];
+  independentEvidence?: string;
+}
+
+export async function writeHandoffDoc(outPath: string, input: HandoffDocInput): Promise<void> {
+  await fs.mkdir(path.dirname(outPath), { recursive: true });
+  const lines: string[] = [];
+  const push = (line = '') => lines.push(line);
+
+  push(`# Release-readiness handoff — ${input.candidateVersion}`);
+  push(`Generated: ${new Date().toISOString()}`);
+  push(`Branch SHA: ${input.branchSha}`);
+  push(`Mode: ${input.mode}`);
+  push(`Audited against last released: ${input.lastReleasedSha}`);
+  push(`Run-id: ${input.runId}`);
+  push();
+  push(`## Recommendation: ${input.recommendation}`);
+  push();
+  push(input.recommendationReasoning);
+  push();
+  push(`## Diff under audit`);
+  push(`- PRs in window: ${input.diffSummary.prsInWindow}`);
+  push(`- LOC: +${input.diffSummary.locAdded} / -${input.diffSummary.locRemoved}`);
+  push(`- Surfaces touched: ${input.diffSummary.surfacesTouched.join(', ')}`);
+  push();
+  push(`## Gap log`);
+  push();
+  const blocking = input.gaps.filter((g) => g.classification === 'BLOCKING');
+  const deferrable = input.gaps.filter((g) => g.classification === 'DEFERRABLE');
+  const alreadyMet = input.gaps.filter((g) => g.classification === 'ALREADY-MET');
+  push(`### Blocking (${blocking.length})`);
+  for (const g of blocking) {
+    push(`- **${g.id}** [${g.source}] ${g.status}: ${g.notes}`);
+  }
+  push();
+  push(`### Deferrable (${deferrable.length})`);
+  for (const g of deferrable) {
+    const tag = g.ghIssue ? ` (${g.ghIssue}${g.milestone ? `, milestone ${g.milestone}` : ''})` : '';
+    push(`- **${g.id}** [${g.source}]${tag}: ${g.notes}`);
+  }
+  push();
+  push(`### Already met (${alreadyMet.length})`);
+  for (const g of alreadyMet) {
+    push(`- **${g.id}** [${g.source}]: ${g.notes}`);
+  }
+  push();
+  push(`## release-prep evidence`);
+  for (const v of input.releasePrepVerdicts) {
+    push(`- ${v.scenarioId}: ${v.verdict}${v.failClass ? ` (${v.failClass})` : ''} (${v.wallClockMs}ms)`);
+  }
+  push();
+  if (input.tier3Verdict && input.tier3Evidence) {
+    push(`## Tier 3 evidence (load-bearing)`);
+    push(`- Scenario: ${input.tier3Evidence.scenario}`);
+    push(`- Hermes model: ${input.tier3Evidence.hermesModel}`);
+    push(`- Verdict: ${input.tier3Verdict.verdict} (verdictCode=${input.tier3Evidence.verdictCode})`);
+    push(`- Tx: deliver ${input.tier3Evidence.deliveryTxHash}, verdict ${input.tier3Evidence.verdictTxHash}`);
+    push(`- Cost: $${input.tier3Evidence.costUsd.toFixed(2)}`);
+    push(`- Wall-clock: ${input.tier3Verdict.wallClockMs}ms`);
+    push();
+  } else {
+    push(`## Tier 3 evidence`);
+    push(`SKIPPED (mode=${input.mode}; Tier 3 only runs in human-invoked mode with explicit consent).`);
+    push();
+  }
+  push(`## Walk-through script for human pass`);
+  for (const item of input.walkThrough) {
+    push(`- [ ] ${item}`);
+  }
+  push();
+  push(`## Open questions for human`);
+  for (const q of input.openQuestions) {
+    push(`- ${q}`);
+  }
+  push();
+  if (input.independentEvidence) {
+    push(`## Independent evidence`);
+    push(input.independentEvidence);
+    push();
+  }
+  push(`## Marker block (final)`);
+  push(`<!-- jinn-release-evidence:v1`);
+  push(`release-tag=${input.candidateVersion}`);
+  push(`release-commit=${input.branchSha}`);
+  for (const v of input.releasePrepVerdicts) {
+    const key = `${v.scenarioId.toLowerCase().replace(/\./g, '-').replace(/^t/, 'tier-')}`;
+    push(`${key}=${v.verdict === 'pass' ? 'passed' : `failed:${v.failClass}`}`);
+  }
+  if (input.tier3Verdict) {
+    push(`tier-3-t3-1=${input.tier3Verdict.verdict === 'pass' ? 'passed' : `failed:${input.tier3Verdict.failClass}`}`);
+  } else {
+    push(`tier-3-t3-1=skipped:${input.mode === 'autonomous' ? 'autonomous-mode' : 'human-skipped'}`);
+  }
+  push(`release-readiness-recommendation=${input.recommendation}`);
+  push(`release-readiness-handoff=docs/release/${input.candidateVersion}/handoff.md`);
+  push(`release-readiness-run=${input.runId}`);
+  push(`-->`);
+
+  await fs.writeFile(outPath, lines.join('\n') + '\n');
+}
+
+export interface AuditTrailEntry {
+  timestamp: string;
+  candidateVersion: string;
+  mode: 'human-invoked' | 'autonomous';
+  recommendation: ReadinessRecommendation;
+  handoffPath: string;
+}
+
+export async function appendAuditTrailEntry(trailPath: string, entry: AuditTrailEntry): Promise<void> {
+  await fs.mkdir(path.dirname(trailPath), { recursive: true });
+  const line = `${entry.timestamp} | ${entry.candidateVersion} | ${entry.mode} | recommendation=${entry.recommendation} | handoff=${entry.handoffPath}\n`;
+  try {
+    await fs.access(trailPath);
+    await fs.appendFile(trailPath, line);
+  } catch {
+    const header = '# release-readiness audit trail\n\nOne line per release-readiness run. Format: `timestamp | version | mode | recommendation=<X> | handoff=<path>`.\n\n';
+    await fs.writeFile(trailPath, header + line);
+  }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd client && yarn vitest run scripts/release/release-readiness.test.ts`
+Expected: 3 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/scripts/release/release-readiness.ts client/scripts/release/release-readiness.test.ts
+git commit -m "feat(release): add release-readiness scaffolding — handoff writer + audit trail"
+```
+
+---
+
+## Task 5: release-readiness SKILL.md
+
+**Files:**
+- Create: `.claude/skills/release-readiness/SKILL.md`
+
+This is the canonical skill definition. The main agent reads this when the skill is invoked.
+
+- [ ] **Step 1: Write SKILL.md**
+
+```markdown
+# release-readiness
+
+Meta-skill. Audits a candidate release against canon, triages identified gaps, drives blocking-gap closure, invokes release-prep + Tier 3 for evidence, and emits a structured handoff doc that humans use to decide ship/defer/block. **Advisory, never blocking** — the skill produces a recommendation; humans (and future automation) make the final call.
+
+Spec: `docs/superpowers/specs/2026-05-19-release-readiness-and-substrate-design.md` §4.
+
+## When to use
+
+- Manually invoked when a candidate version is in view (Friday evening / Saturday for a Monday cut).
+- (Future) auto-triggered by a weekend GitHub Actions cron — separate follow-up.
+- Never invoked as a subagent of release-prep; the dependency is the other way.
+
+## Input contract
+
+```typescript
+interface ReleaseReadinessInput {
+  candidateVersion: string;              // "v0.1.7"
+  branchSha: string;                     // candidate SHA (usually next HEAD)
+  lastReleasedSha?: string;              // diff anchor; defaults to v<prev> tag
+  mode: "human-invoked" | "autonomous";
+  outputDir?: string;                    // default: docs/release/<candidateVersion>/
+  forceShip?: boolean;                   // emergency override, logged
+}
+```
+
+## Subagent-first design
+
+Main agent is a thin coordinator. Anything that requires loading non-trivial context (canon doc, PR diff, daemon logs) runs as a subagent. Main only sees structured verdicts.
+
+| Operation | Where |
+|---|---|
+| Phase 1 setup (git diff, gh issue queries, substrate-verify) | main |
+| Phase 2 mechanical checks (C2, C5, C6, C9 — grep/AST) | main |
+| Phase 2 judgmental + canon pass (C1, C3, C4, C7, C8, C10, C11) | **1 subagent** |
+| Phase 3 triage (classify all gaps) | **1 subagent** |
+| Phase 4 closure (fix + PR) | **1 subagent per gap** |
+| Phase 4 PR review per closure | **1 subagent per PR** |
+| Phase 5 release-prep invocation | **release-prep skill** |
+| Phase 5 Tier 3 scenario | **1 subagent invoking run-tier-3** |
+| Phase 6 handoff doc drafting | **1 subagent** |
+| Phase 6 SHIP/DEFER/BLOCK decision | main |
+| Phase 7 terminal notification | main |
+
+Per-run subagent count: ~6-9 fixed + N closure subagents (usually 0-3).
+
+## Seven-phase process
+
+```
+Phase 1: Setup
+  ├─ git diff lastReleasedSha..branchSha → resolve diff
+  ├─ load canon: PRINCIPLES.md, SPEC.md, BRAND.md, GROWTH.md, GLOSSARY.md
+  ├─ load operational memory from ~/.claude/projects/<project>/memory/
+  ├─ gh issue list --label release-blocker
+  └─ substrate-verify op-a op-b
+
+Phase 2: Audit
+  ├─ main: mechanical checks (C2/C5/C6/C9 grep + AST)
+  ├─ dispatch judgmental audit subagent with full diff + all canon + check items
+  │   See references/canon-audit-prompts.md for the prompt template.
+  └─ collect findings list
+
+Phase 3: Triage
+  ├─ dispatch triage subagent with all findings
+  │   See references/triage-taxonomy.md for the classification rules.
+  ├─ subagent classifies BLOCKING / DEFERRABLE / ALREADY-MET
+  ├─ for DEFERRABLE: subagent emits gh issue create shell with labels/milestone
+  └─ for BLOCKING: queue for Phase 4
+
+Phase 4: Closure (skip if no BLOCKING)
+  ├─ for each BLOCKING gap, dispatch closure subagent in parallel
+  ├─ subagent: investigate, fix on a worktree branch, push, file PR
+  ├─ for each returned PR, dispatch PR-review subagent
+  ├─ main: cross-account merge via dual-account flow if approved
+  └─ 3 failed close attempts on same gap → BLOCKING-ESCALATED (recommendation → DEFER)
+
+Phase 5: Validate
+  ├─ Skill release-prep --branchSha=<sha> --candidateVersion=<v>
+  │   reads back: marker block + per-scenario verdicts
+  ├─ if mode === human-invoked:
+  │     SIGTERM daily-driver daemons (ports 7331, 7332)
+  │     tsx scripts/release/run-tier-3.ts <candidateVersion> human-invoked
+  │     restart daily-driver daemons after
+  │   else (autonomous):
+  │     SKIP Tier 3 if daily-driver running; otherwise still SKIP
+  │     (autonomous can't safely manage daemon mutex)
+  └─ aggregate release-prep + Tier 3 verdicts
+
+Phase 6: Synthesize
+  ├─ dispatch handoff-doc-drafting subagent with all inputs
+  ├─ subagent returns: structured doc draft
+  ├─ main: determine recommendation
+  │     SHIP   if all BLOCKING closed AND Tier 3 passed
+  │     DEFER  if BLOCKING escalated OR Tier 3 failed AND independent evidence weak
+  │            OR mode=autonomous AND Tier 3 skipped (INSUFFICIENT-EVIDENCE)
+  │     BLOCK  if Tier 3 produced a clear regression vs last release
+  ├─ writeHandoffDoc(...) — see scripts/release/release-readiness.ts
+  └─ appendAuditTrailEntry(...) — log/decisions/release-readiness-runs.md
+
+Phase 7: Terminal
+  ├─ human-invoked: emit "handoff at <path>; recommendation: <X>"
+  └─ autonomous: gh issue create --label release-ready --title "release-readiness completed for <v>" --body "review at <path>"
+```
+
+## Reference docs
+
+- [`references/static-checklist.md`](references/static-checklist.md) — C1-C11 detailed shape
+- [`references/canon-audit-prompts.md`](references/canon-audit-prompts.md) — subagent prompt templates
+- [`references/triage-taxonomy.md`](references/triage-taxonomy.md) — classification rules
+- [`references/handoff-doc-template.md`](references/handoff-doc-template.md) — output shape
+- [`references/tier-3-scenario.md`](references/tier-3-scenario.md) — T3.1 contract
+- [`references/autonomous-vs-invoked.md`](references/autonomous-vs-invoked.md) — mode differences
+
+## Invocation
+
+```bash
+# Human-invoked (full flow including Tier 3 with real-network spend)
+Skill release-readiness --candidateVersion v0.1.7 --mode human-invoked
+
+# Autonomous (audit + closure + release-prep; Tier 3 SKIPPED)
+Skill release-readiness --candidateVersion v0.1.7 --mode autonomous
+
+# Emergency override (logs forceShip in handoff)
+Skill release-readiness --candidateVersion v0.1.7 --mode human-invoked --forceShip
+```
+
+## What this skill deliberately does NOT do
+
+- **Publish the release.** Always advisory.
+- **Modify canon docs unilaterally.** Audit findings → GH issue, never silent rewrite.
+- **Re-run release-prep gates when they already ran against this SHA.**
+- **Kill operator daemons in autonomous mode.** Mutual exclusion is human-supervised.
+- **Run Tier 3 in autonomous mode.** Cost/risk requires explicit consent.
+- **Use bd.** All issue tracking via `gh issue`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/skills/release-readiness/SKILL.md
+git commit -m "docs(release-readiness): add SKILL.md"
+```
+
+---
+
+## Task 6: static-checklist.md reference
+
+**Files:**
+- Create: `.claude/skills/release-readiness/references/static-checklist.md`
+
+- [ ] **Step 1: Write the doc**
+
+```markdown
+# Static checklist (C1-C11)
+
+Mechanical checks that fire deterministically against the diff. Each item is either grep/AST-based (runs in main) or judgmental (dispatched to the judgmental audit subagent).
+
+## C1 — operator-app-principle
+
+**Triggers when:** diff touches `client/src/dashboard/` or operator-facing copy.
+
+**Where:** judgmental subagent.
+
+**The principle (from memory `operator-app-principle-oak-reiterated-2026-05-18`):** after the first `jinn run`, the operator should never have to leave the app. Any new error message instructing CLI re-runs is a violation.
+
+**Subagent looks for:** new strings in the diff matching `(rerun|run again|jinn run)` in user-facing text, especially in panel components.
+
+## C2 — bootstrap-phase change
+
+**Triggers when:** diff touches `client/src/earning/bootstrap.ts` or phase definitions.
+
+**Where:** main (grep).
+
+**Why:** u34i / h74p / k1ng / 3nc5 all regressed bootstrap; high regression risk.
+
+## C3 — per-harness readiness
+
+**Triggers when:** new harness implementation added, or readiness flow changed.
+
+**Where:** judgmental subagent.
+
+**Subagent looks for:** any new file in `client/src/harnesses/impls/` that lacks an `isReady()` implementation; or changes to `client/src/api/server.ts` `/v1/harnesses/*` routes.
+
+## C4 — eval admission / verdict recheck
+
+**Triggers when:** diff touches eval admission or substrate hashing (`client/src/eval/admission/`, `client/src/eval/substrate-hash/`).
+
+**Where:** judgmental subagent.
+
+**Subagent looks for:** changes that could weaken the verdict-time recheck (e.g. removed assertions, conditional skips of the hash check).
+
+## C5 — task admission filter
+
+**Triggers when:** diff touches floor logic, DiscoveryAPI filter, or claim eligibility.
+
+**Where:** main (grep for known floor constants + filter call sites).
+
+**Why:** #300 ghost-task class — floor drift introduces silent non-claimability or worse, silent re-emergence.
+
+## C6 — canon doc movement
+
+**Triggers when:** any line of PRINCIPLES.md / SPEC.md / BRAND.md / GROWTH.md / GLOSSARY.md changes.
+
+**Where:** main (grep).
+
+**Action:** flag as concern. Canonical-docs policy requires Discussion + CODEOWNERS approval; the audit subagent verifies this was followed.
+
+## C7 — memory invariant violation
+
+**Triggers when:** any diff that contradicts a stored memory file.
+
+**Where:** judgmental subagent.
+
+**Subagent reads:** all memory files under `~/.claude/projects/<project>/memory/`. For each memory whose body describes an invariant or rule, checks the diff for direct violation.
+
+## C8 — wiring-seam coverage
+
+**Triggers when:** any value computed in 2+ modules without a single-source-of-truth helper.
+
+**Where:** judgmental subagent (AST + reasoning).
+
+**Why:** u34i lesson — module-isolated unit tests miss cross-module invariant drift.
+
+## C9 — release-evidence marker schema
+
+**Triggers when:** diff touches `.github/workflows/npm-publish.yml` marker check.
+
+**Where:** main (grep).
+
+**Action:** validate any new marker keys against `client/scripts/release/release-readiness.ts` schema. If the schema isn't updated to match, flag.
+
+## C10 — spec freshness
+
+**Triggers when:** a spec under `spec/` referenced by code no longer matches the code.
+
+**Where:** judgmental subagent.
+
+**Subagent reads:** each referenced spec + the code section that references it. Reports drift.
+
+## C11 — skill currency
+
+**Triggers when:** diff touches operator-facing UI, CLI verbs, public skill-relevant surfaces.
+
+**Where:** judgmental subagent.
+
+**Subagent reads:** every `.claude/skills/*/SKILL.md` and the diff. Reports:
+- Skills that make false claims about changed surfaces (BLOCKING)
+- Skills that don't yet cover new surfaces but existing surfaces are still accurate (DEFERRABLE)
+
+This is the recursion that keeps the system honest. Every release sweeps the skills.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/skills/release-readiness/references/static-checklist.md
+git commit -m "docs(release-readiness): add static-checklist C1-C11 reference"
+```
+
+---
+
+## Task 7: canon-audit-prompts.md reference
+
+**Files:**
+- Create: `.claude/skills/release-readiness/references/canon-audit-prompts.md`
+
+- [ ] **Step 1: Write the doc**
+
+```markdown
+# Canon audit prompts
+
+Prompt templates for the judgmental audit subagent (Phase 2) and the triage subagent (Phase 3).
+
+## Judgmental audit subagent prompt
+
+The subagent runs once per release-readiness invocation. It receives:
+- Full diff from `git log lastReleasedSha..branchSha`
+- All five canon docs (PRINCIPLES.md, SPEC.md, BRAND.md, GROWTH.md, GLOSSARY.md)
+- All operational memory files
+- All skill SKILL.md files (under `.claude/skills/`)
+- List of judgmental check items (C1, C3, C4, C7, C8, C10, C11) with descriptions
+
+```
+You're auditing a candidate release branch against canon and operational memory.
+
+Inputs you have access to:
+- Diff: {DIFF_TEXT}
+- Canon docs: {CANON_DOCS_INLINED}
+- Operational memories: {MEMORY_FILES}
+- Skill files: {SKILL_FILES}
+- Judgmental check items: {CHECK_ITEMS}
+
+For EACH check item, walk the diff and identify findings.
+
+Then, for EACH canon doc, do an open-ended pass: does anything in the diff
+contradict, undermine, or skirt a principle in this doc?
+
+For EACH skill file, ask: does anything in the diff make this skill's
+instructions wrong or incomplete?
+
+Return a single unified structured report as JSON:
+
+[
+  {
+    "id": "GAP-1",
+    "source": "C1" | "C7" | "canon:PRINCIPLES.md" | "skill:testing-jinn-app/SKILL.md" | ...,
+    "description": "...",
+    "severity": "high" | "medium" | "low",
+    "rationale": "specific cite from both the diff and the source",
+    "references": [{"file": "path", "line": N, "snippet": "..."}, ...],
+    "crossCuttingWith": ["GAP-N", ...]
+  },
+  ...
+]
+
+Be specific. "Vibes off" is not a finding. Cite both sides — the diff content
+that triggers the concern AND the canon/memory/skill section it violates.
+
+If two findings share a root cause, list both in `crossCuttingWith`.
+```
+
+## Triage subagent prompt
+
+The triage subagent runs once after the audit. It receives:
+- The full findings list from the audit subagent
+- PRINCIPLES.md (re-loaded for context)
+- The current candidate version and recent release history (so it knows what "next release" target is)
+- The triage taxonomy rules
+
+```
+You're triaging audit findings for release {CANDIDATE_VERSION}.
+
+Findings: {FINDINGS_JSON}
+
+Rules: {TRIAGE_TAXONOMY_TEXT}
+
+For each finding, classify:
+  BLOCKING   — close before recommend SHIP
+  DEFERRABLE — file GH issue with milestone, ship anyway
+  ALREADY-MET — link to evidence (existing test, spec section, etc.)
+
+For each:
+- BLOCKING: leave as-is; will be passed to closure subagents.
+- DEFERRABLE: emit a `gh issue create` shell with:
+    - Title: short, action-oriented
+    - Body: includes the rationale + references from the finding
+    - Labels: "release-blocker" if escalating from DEFERRABLE to near-blocking;
+              "skill-drift" if C11 source; relevant area label otherwise
+    - Milestone: next release version
+- ALREADY-MET: link to the evidence (file path / test name / spec section).
+
+Cross-cutting:
+- If multiple findings share a root cause, indicate so in the classifications.
+- If a deferrable cluster is large enough that the next-release surface is
+  going to drift further, escalate one of them to BLOCKING with a note.
+
+Return JSON:
+
+[
+  {
+    "gapId": "GAP-1",
+    "classification": "BLOCKING" | "DEFERRABLE" | "ALREADY-MET",
+    "rationale": "...",
+    "ghIssueDraft": null | {
+      "title": "...",
+      "body": "...",
+      "labels": ["..."],
+      "milestone": "v0.1.8"
+    },
+    "evidenceLinks": [{"path": "...", "summary": "..."}, ...]
+  },
+  ...
+]
+```
+
+## Handoff-doc-drafting subagent prompt
+
+```
+You're drafting a release-readiness handoff doc.
+
+Inputs:
+- audit findings: {AUDIT_FINDINGS}
+- triage classifications: {TRIAGE_CLASSIFICATIONS}
+- closure outcomes: {CLOSURE_OUTCOMES}
+- release-prep verdicts: {RELEASE_PREP_VERDICTS}
+- Tier 3 verdict + evidence: {TIER_3_RESULT}
+- diff summary: {DIFF_SUMMARY}
+
+Use the template at references/handoff-doc-template.md to produce a fully
+populated draft. The MAIN agent will read your draft, make the SHIP/DEFER/BLOCK
+recommendation, and write the final file.
+
+Produce a markdown draft. Don't make the SHIP/DEFER/BLOCK decision yourself —
+populate everything else.
+```
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/skills/release-readiness/references/canon-audit-prompts.md
+git commit -m "docs(release-readiness): add canon-audit-prompts reference"
+```
+
+---
+
+## Task 8: Remaining reference docs
+
+**Files:**
+- Create: `.claude/skills/release-readiness/references/triage-taxonomy.md`
+- Create: `.claude/skills/release-readiness/references/handoff-doc-template.md`
+- Create: `.claude/skills/release-readiness/references/tier-3-scenario.md`
+- Create: `.claude/skills/release-readiness/references/autonomous-vs-invoked.md`
+
+These are reference docs that mirror sections from the spec §4. The content is largely already specified in the spec; this task just transcribes into the right place.
+
+- [ ] **Step 1: triage-taxonomy.md**
+
+Save:
+
+```markdown
+# Triage taxonomy
+
+Classification rules used by the triage subagent. The taxonomy is from spec §4.
+
+## BLOCKING
+
+Close before recommend SHIP. Includes:
+- Direct PRINCIPLES.md violation **introduced by this branch** (not pre-existing).
+- operator-app-principle violation in new UI copy.
+- Canon doc moved without ratification path (Discussion + CODEOWNERS approval).
+- Bootstrap / auth / eval substrate regression.
+- Wiring-seam drift introduced (multiple modules computing same value, no helper).
+- Tier 3 scenario regression vs last release.
+- Skill makes false claims about changed surface (operator hits a wall).
+
+## DEFERRABLE
+
+File GH issue with milestone, ship anyway, note in release notes. Includes:
+- Spec-drift in unreferenced area.
+- Pre-existing open issue.
+- Quality-of-life concerns that don't break a documented invariant.
+- Tier 1/2 flake-class failures (release-prep marked `flake-infra`).
+- Skill doesn't yet cover new surface but existing surface is still accurate.
+- Anything previously triaged as "next release" pattern.
+
+## ALREADY-MET
+
+Concern is addressed; link to evidence. Includes:
+- Static checklist item that passed without finding.
+- Open-ended concern that's covered by an existing test.
+- Concern explicitly resolved by a commit in this window.
+
+## Edge cases
+
+- **BLOCKING that can't be closed (after 3 attempts):** mark BLOCKING-ESCALATED. Gap stays BLOCKING; recommendation shifts to DEFER (not BLOCK — defer means "not ready this cycle," block means "broken in a way that needs hotfix-level attention").
+- **Cross-cutting clusters:** multiple deferrable findings with the same root cause should escalate one to BLOCKING with a note about the cluster.
+- **Pre-existing vs introduced:** the audit only flags issues *introduced by this branch*. Pre-existing issues that the diff happens to touch don't escalate; they stay DEFERRABLE.
+```
+
+- [ ] **Step 2: handoff-doc-template.md**
+
+Save:
+
+```markdown
+# Handoff doc template
+
+The shape of `docs/release/<candidateVersion>/handoff.md`. Generated by `writeHandoffDoc()` in `client/scripts/release/release-readiness.ts`.
+
+```markdown
+# Release-readiness handoff — <version>
+Generated: <ISO timestamp>
+Branch SHA: <sha>
+Mode: human-invoked | autonomous
+Audited against last released: <prev-sha>
+Run-id: <run-id>
+
+## Recommendation: SHIP | DEFER | BLOCK
+
+<one sentence + reasoning>
+
+## Diff under audit
+- PRs in window: N
+- LOC: +X / -Y
+- Surfaces touched: <list>
+
+## Gap log
+
+### Blocking (N)
+- **GAP-1** [source]: ...
+
+### Deferrable (N)
+- **GAP-2** [source] (gh issue #N, milestone v0.1.8): ...
+
+### Already met (N)
+- **GAP-3** [source]: covered by <evidence>
+
+## release-prep evidence
+- T1.1: pass (87s)
+- T1.2: pass (22s)
+- ...
+
+## Tier 3 evidence (load-bearing)
+- Scenario: op-a solves ..., op-b evaluates
+- Hermes model: ...
+- Verdict: pass (verdictCode=1)
+- Tx: deliver 0x..., verdict 0x...
+- Cost: $0.07
+- Wall-clock: 4m 38s
+
+## Walk-through script for human pass
+- [ ] check 1
+- [ ] check 2
+
+## Open questions for human
+- Q1: ...
+
+## Independent evidence
+<any out-of-band signal>
+
+## Marker block (final)
+<!-- jinn-release-evidence:v1
+release-tag=...
+...
+-->
+```
+```
+
+- [ ] **Step 3: tier-3-scenario.md**
+
+Save:
+
+```markdown
+# Tier 3 scenario — producer-evaluator real-testnet
+
+The single Tier 3 scenario. Run from release-readiness Phase 5 in human-invoked mode only.
+
+**Implementation:** `client/test/release/tier-3/T3.1-producer-evaluator-real.ts`
+
+**Orchestrator:** `client/scripts/release/run-tier-3.ts`
+
+## Pre-conditions
+
+- Daily-driver daemons SIGTERM'd (ports 7331, 7332 free). release-readiness Phase 5 manages this.
+- substrate-topup verified: op-a + op-b have ≥ 0.002 ETH on Base Sepolia; OLAS bond current.
+- OpenRouter API key available (env `OPENROUTER_API_KEY` or daemon config).
+- `JINN_T31_REAL=1` environment variable to acknowledge real-network spend.
+
+## Execution flow
+
+1. Spawn op-a daemon: `HOME=~/jinn-dev/operators/op-a node dist/bin/jinn.js run --no-ui` (port 7360)
+2. Spawn op-b daemon: `HOME=~/jinn-dev/operators/op-b ...` (port 7361)
+3. op-a posts a small SWE-rebench v2 task (instance from fixtures/known-instance.ts)
+4. op-a claims, solves via real Hermes (real OpenRouter API call, ~$0.05-$0.10)
+5. op-a delivers
+6. op-b claims verdict request
+7. op-b runs real evaluator Docker image, scores
+8. op-b posts verdict
+9. Assert `verdictCode === KNOWN_EXPECTED_VERDICT`
+
+## Budgets
+
+- Wall-clock: 10 min hard
+- Cost: $0.25 cap (API + tiny gas)
+
+## Failure modes
+
+| Failure | Class | Result |
+|---|---|---|
+| Daily driver running | n/a | abort with explicit instruction |
+| Daemon spawn fails | real-bug | BLOCK with daemon stderr |
+| Task post fails | real-bug | BLOCK |
+| Solve times out (>8 min) | flake-timing first; real-bug on retry | retry once |
+| Verdict mismatches expected | real-bug | REAL REGRESSION → recommendation = BLOCK |
+| API budget exceeded | n/a | abort partial; surface cost analysis |
+
+## Output
+
+- `tier-3-evidence/<timestamp>/T3.1.log` — phase markers + tx hashes + CIDs
+- `tier-3-evidence/<timestamp>/summary.json` — structured verdict
+- `tier-3-evidence/<timestamp>/marker.txt` — release-evidence marker
+
+## Why this is load-bearing
+
+T3.1 was the manual A3 verification that carried the v0.1.6 ship decision (the gates flaked four ways; A3 said `verdictCode=1`; we shipped). Codifying it makes that evidence pattern reproducible.
+```
+
+- [ ] **Step 4: autonomous-vs-invoked.md**
+
+Save:
+
+```markdown
+# Autonomous vs human-invoked
+
+The two modes differ in what they're allowed to do.
+
+## human-invoked
+
+- Daily-driver daemons SIGTERM'd before Tier 3, restarted after.
+- Tier 3 runs (real network + real Hermes spend).
+- Cost budget permissive (one run per week).
+- Phase 7: emits "handoff ready at <path>, see you in a new session". Session ends.
+- Human reads handoff doc in a fresh session, drives the walk-through script, makes ship/no-ship decision.
+
+## autonomous
+
+- Daily-driver daemons NOT touched.
+- Tier 3 SKIPPED entirely (autonomous can't safely manage daemon mutex).
+- If Tier 3 skipped, recommendation defaults to INSUFFICIENT-EVIDENCE-FOR-SHIP; needs human-invoked re-run.
+- Cost budget tighter.
+- Phase 7: `gh issue create --label release-ready --title "release-readiness completed for <v>"`. Session ends. Issue sits in queue.
+
+## When to use which
+
+- **Autonomous:** weekend run for Monday cut. Audit + closure happen overnight; the human picks up Monday morning and runs Tier 3 themselves before deciding.
+- **Human-invoked:** any time a human wants the full flow including Tier 3. Required for the final pre-publish run.
+
+## Future cron
+
+Captured as follow-up GH issue: "Wire release-readiness autonomous-mode to a Friday 23:00 UTC GitHub Actions schedule." When wired:
+- Cron triggers a workflow that checks out `next`, runs the skill against HEAD with `--mode autonomous`.
+- Workflow posts the handoff doc as a comment on the existing Monday-draft GH Release.
+- Captain reads on Monday, optionally runs human-invoked for Tier 3, publishes if SHIP.
+```
+
+- [ ] **Step 5: Commit all four reference docs**
+
+```bash
+git add .claude/skills/release-readiness/references/triage-taxonomy.md \
+        .claude/skills/release-readiness/references/handoff-doc-template.md \
+        .claude/skills/release-readiness/references/tier-3-scenario.md \
+        .claude/skills/release-readiness/references/autonomous-vs-invoked.md
+git commit -m "docs(release-readiness): add triage-taxonomy, handoff-doc-template, tier-3-scenario, autonomous-vs-invoked references"
+```
+
+---
+
+## Task 9: yarn scripts + README
+
+**Files:**
+- Modify: `client/package.json`
+- Modify: `client/scripts/release/README.md`
+
+- [ ] **Step 1: Add yarn scripts**
+
+In `client/package.json`'s `scripts` object, add:
+
+```json
+{
+  "scripts": {
+    "release:tier-3": "tsx scripts/release/run-tier-3.ts",
+    "release:tier-3:T3.1": "JINN_T31_REAL=1 vitest run test/release/tier-3/T3.1-producer-evaluator-real.test.ts"
+  }
+}
+```
+
+- [ ] **Step 2: Update README**
+
+In `client/scripts/release/README.md`, add a new section after "Tier 1 orchestrator":
+
+```markdown
+## Tier 3 orchestrator
+
+`run-tier-3.ts` runs the single Tier 3 scenario (T3.1 producer-evaluator-real) against the real Base Sepolia testnet. **This spends real test ETH + real OpenRouter API budget (~$0.10).** Only run when intentional.
+
+```bash
+yarn release:tier-3 <candidate-version>
+```
+
+Output goes to `tier-3-evidence/<timestamp>/`.
+
+Per-scenario standalone (gated on `JINN_T31_REAL=1`):
+
+```bash
+yarn release:tier-3:T3.1
+```
+
+## release-readiness skill
+
+The audit + triage + closure + handoff meta-skill. Invoked from a Claude Code session:
+
+```bash
+# Skill release-readiness --candidateVersion v0.1.7 --mode human-invoked
+```
+
+See `.claude/skills/release-readiness/SKILL.md` for the full skill contract.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/package.json client/scripts/release/README.md
+git commit -m "chore(release): wire yarn scripts + README for Tier 3 + release-readiness"
+```
+
+---
+
+## Task 10: End-to-end smoke
+
+**Files:**
+- None modified. Verification gate.
+
+- [ ] **Step 1: Verify all prerequisites are present**
+
+Run:
+```bash
+cd client
+
+# Substrate (Plan A)
+yarn substrate:verify op-a --skip-on-chain
+yarn substrate:verify op-b --skip-on-chain
+
+# Helpers (Plan B)
+ls test/helpers/multi-op-daemon.ts test/helpers/handshake-url.ts
+
+# Tier 1 (Plan C)
+ls scripts/release/scenario-types.ts scripts/release/run-tier-1.ts
+ls .claude/skills/release-prep/SKILL.md
+
+# Tier 2 (Plan D, if landed)
+ls scripts/release/run-tier-2.ts 2>/dev/null || echo "Plan D not landed yet"
+
+# Tier 3 + release-readiness (this plan)
+ls scripts/release/run-tier-3.ts scripts/release/release-readiness.ts
+ls .claude/skills/release-readiness/SKILL.md
+ls .claude/skills/release-readiness/references/
+```
+
+Expected: every check passes, OR the missing item is a known cross-plan gap.
+
+- [ ] **Step 2: Smoke the Tier 3 scaffolding (no real-network spend)**
+
+Run: `cd client && yarn vitest run scripts/release/release-readiness.test.ts test/release/tier-3/`
+Expected: scaffolding tests pass; T3.1 callable-shape test passes; real-network T3.1 test skips (gate off).
+
+- [ ] **Step 3: Smoke the Tier 3 orchestrator (without running the scenario)**
+
+Run: `cd client && tsx scripts/release/run-tier-3.ts v0.1.7-smoke autonomous 2>&1 | head -30`
+Expected: orchestrator runs Tier 3 with the daily-driver mutex check. Because we're in autonomous mode and either daily drivers are up OR substrate isn't healthy, it should abort with a clear message rather than spending real budget.
+
+- [ ] **Step 4: If you want to run T3.1 for real**
+
+This is THE moment to test the load-bearing scenario. Cost ~$0.10. Run:
+
+```bash
+cd client
+# Make sure daily-driver daemons are stopped (ports 7331, 7332)
+JINN_T31_REAL=1 yarn release:tier-3 v0.1.7-smoke human-invoked
+```
+
+Expected: ~5-10 min run, produces tier-3-evidence/, exits 0 if pass.
+
+- [ ] **Step 5: No commit unless gaps were found**
+
+Verification gate. If everything resolves, the brainstorm-to-execution loop is complete.
+
+---
+
+## Self-review
+
+### Spec coverage
+
+| Spec requirement | Covered by | Status |
+|---|---|---|
+| §4 release-readiness skill | Tasks 5-8 | ✓ |
+| §4 7-phase process | Task 5 (SKILL.md) | ✓ |
+| §4 subagent-first design | Tasks 5, 7 | ✓ |
+| §4 static checklist C1-C11 | Task 6 | ✓ |
+| §4 triage taxonomy | Task 8 | ✓ |
+| §4 handoff doc shape | Task 4 (scaffolding) + Task 8 (template) | ✓ |
+| §4 Tier 3 scenario | Tasks 1, 2 | ✓ |
+| §4 autonomous vs human-invoked | Task 8 | ✓ |
+| §6 T3.1 scenario | Task 2 | ✓ |
+| Marker schema extension | Task 4 (writeHandoffDoc emits new keys) | ✓ |
+| Audit trail | Task 4 (appendAuditTrailEntry) | ✓ |
+
+### Placeholder scan
+
+- Task 2 (T3.1): wall-clock budget hard-coded to 10 min; reuses Plan D's fixture. No placeholder; just env-gated for cost protection.
+- Task 5 (SKILL.md): subagent dispatch table mirrors what's in the spec. No placeholder.
+- All other tasks have complete content.
+
+### Type consistency
+
+- `ScenarioVerdict` consistent with Plan C's definition. T3.1 returns it; orchestrator parses it.
+- `Gap`, `HandoffDocInput`, `ReadinessRecommendation` types defined in Task 4 used in Task 5 SKILL.md.
+- `setupTier3Scenario` signature consistent across Tasks 1, 2.
+
+### Cross-plan contract check
+
+This plan consumes from:
+- Plan A: substrate gold copy at `~/jinn-dev/operators/` (Tier 3 uses directly).
+- Plan B: multi-op-daemon (Task 1 uses `spawnMultiOpDaemons`).
+- Plan C: scenario-types (ScenarioVerdict, classifyFailure). release-prep skill (release-readiness Phase 5 invokes via `Skill release-prep`).
+- Plan D: tier-2-scenarios infrastructure as the model for `setupTier3Scenario`. Plan D's `release-prep` updates (Tier 2 populated) are required for release-readiness Phase 5 to get full evidence.
+
+This plan completes the brainstorm-to-execution loop. No downstream plan depends on it.
+
+### Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-19-release-readiness-skill-plan.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven (recommended)** — Dispatch a fresh subagent per task. 10 tasks; the most documentation-heavy plan (5 reference docs). Subagent flow's review pass catches transcription errors.
+
+2. **Inline Execution** — Execute tasks in this session.
+
+Plan E depends on A + B + C + D. To dispatch in background, the worktree must be stacked on all four. Since Plan D's branch already includes A+B+C via merges, Plan E's branch can be stacked on Plan D's branch directly.
+
+Which approach?

--- a/docs/superpowers/plans/2026-05-19-substrate-foundation-plan.md
+++ b/docs/superpowers/plans/2026-05-19-substrate-foundation-plan.md
@@ -1,0 +1,1992 @@
+# Substrate foundation implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Codify the test-operator substrate lifecycle as four production TypeScript scripts (`substrate-adopt`, `substrate-copy`, `substrate-verify`, `substrate-topup`) plus a workspace reaper. Each ships with unit + integration tests and a yarn-script entry point. The gold substrate already exists on disk (adopted manually 2026-05-19 during the spec brainstorm); this plan replaces the manual adoption with idempotent reproducible scripts.
+
+**Architecture:** Single shared types module (Zod schemas) feeds five focused scripts that each export a callable function plus a CLI main. Tests live alongside under `client/test/release/substrate/` and use Vitest with `tmp` dirs for filesystem isolation and an Anvil fork helper for on-chain reads (matches the existing `client/scripts/staking-validate.ts` test pattern).
+
+**Tech Stack:** TypeScript, Zod for schema validation (matches `client/src/earning/types.ts`), viem for on-chain reads (matches `client/src/earning/contracts.ts`), node:fs/promises for filesystem, Vitest for tests, Anvil fork for integration tests.
+
+---
+
+## File structure
+
+**Source files (all new under `client/scripts/release/`):**
+
+| Path | Responsibility |
+|---|---|
+| `client/scripts/release/types.ts` | Zod schemas: `ManifestSchema`, `VerifyResult`, `TopupResult` |
+| `client/scripts/release/substrate-paths.ts` | Path helpers: `goldPath()`, `workspacePath()`, `workspacesRoot()` |
+| `client/scripts/release/substrate-adopt.ts` | Adopt: copy from existing operator dir → gold dir, write manifest |
+| `client/scripts/release/substrate-copy.ts` | Per-run workspace copy from gold, port rewriting |
+| `client/scripts/release/substrate-verify.ts` | Manifest validation + on-chain identity check |
+| `client/scripts/release/substrate-topup.ts` | Balance check + low-balance gap surfacing (no auto-drip) |
+| `client/scripts/release/substrate-reap.ts` | Workspace garbage collection (>7 days) |
+| `client/scripts/release/README.md` | Usage documentation |
+
+**Test files (all new under `client/test/release/substrate/`):**
+
+| Path | Covers |
+|---|---|
+| `client/test/release/substrate/types.test.ts` | Manifest schema parse/validate |
+| `client/test/release/substrate/substrate-paths.test.ts` | Path resolution |
+| `client/test/release/substrate/adopt.test.ts` | Adopt + verify cycle on fixtures |
+| `client/test/release/substrate/copy.test.ts` | Workspace creation + port rewriting |
+| `client/test/release/substrate/verify.test.ts` | Manifest validation + on-chain (Anvil fork) |
+| `client/test/release/substrate/topup.test.ts` | Balance check report (Anvil fork) |
+| `client/test/release/substrate/reap.test.ts` | Workspace age-based pruning |
+| `client/test/release/substrate/fixtures/op-a-fixture/.jinn-client/*` | Minimal valid operator state |
+| `client/test/release/substrate/fixtures/op-b-fixture/.jinn-client/*` | Second fixture operator |
+| `client/test/release/substrate/helpers/anvil-fork.ts` | Anvil fork helper for integration tests |
+| `client/test/release/substrate/helpers/tmp-substrate.ts` | tmp-dir substrate helper for isolation |
+
+**Modified files:**
+
+| Path | Change |
+|---|---|
+| `client/package.json` | Add yarn scripts: `substrate:adopt`, `substrate:copy`, `substrate:verify`, `substrate:topup`, `substrate:reap` |
+
+---
+
+## Task 1: Manifest schema and shared types
+
+**Files:**
+- Create: `client/scripts/release/types.ts`
+- Test: `client/test/release/substrate/types.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// client/test/release/substrate/types.test.ts
+import { describe, it, expect } from 'vitest';
+import { ManifestSchema, type Manifest } from '../../../scripts/release/types';
+
+describe('ManifestSchema', () => {
+  const validManifest = {
+    substrateVersion: '1',
+    createdAt: '2026-05-19T14:47:19Z',
+    adoptedFrom: '~/.jinn-client/',
+    name: 'op-a',
+    shape: 'current' as const,
+    role: 'launcher' as const,
+    network: 'base-sepolia' as const,
+    operator: {
+      masterAddress: '0xE64bAf0073a71b0Cb2C0558bB16f24b45E1FB5CF',
+      fleetAgentId: '5474',
+      fleetSafeAddress: '0x0e767E28C6889CcD0DfB88E631a3702D56Ce24FC',
+      fleetStage: 'stage1_and_2',
+      serviceId: 46,
+      serviceStep: 'complete',
+      agentEoa: '0x63192d38350b796856cF002caC25c377D9A0DB5A',
+      safeAddress: '0x0e767E28C6889CcD0DfB88E631a3702D56Ce24FC',
+      mechAddress: '0x9c415369D0597e4867F419d256BD61D16a8C47b5',
+      stakingAddress: '0x24e34E5037956a5Feca1AAAfaA30297084C228B8',
+      identityRegistry: '0x8004A818BFB912233c491871b3d84c89A494BD9e',
+    },
+    config: {
+      apiPort: 7332,
+      rpcUrl: 'https://base-sepolia.gateway.tenderly.co/abc',
+      joinedSolverNets: ['bafkrei123'],
+    },
+  };
+
+  it('parses a valid manifest', () => {
+    const parsed = ManifestSchema.parse(validManifest);
+    expect(parsed.name).toBe('op-a');
+    expect(parsed.operator.fleetAgentId).toBe('5474');
+  });
+
+  it('rejects missing required field', () => {
+    const invalid = { ...validManifest, name: undefined };
+    expect(() => ManifestSchema.parse(invalid)).toThrow();
+  });
+
+  it('rejects invalid network value', () => {
+    const invalid = { ...validManifest, network: 'mainnet-pro' };
+    expect(() => ManifestSchema.parse(invalid)).toThrow();
+  });
+
+  it('accepts pre-fleet shape with null fleet fields', () => {
+    const preFleet: Manifest = {
+      ...validManifest,
+      name: 'op-c-legacy',
+      shape: 'pre-fleet',
+      role: 'legacy-backup',
+      operator: {
+        ...validManifest.operator,
+        fleetAgentId: null,
+        fleetSafeAddress: null,
+        fleetStage: null,
+      },
+    };
+    expect(() => ManifestSchema.parse(preFleet)).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client && yarn vitest run test/release/substrate/types.test.ts`
+Expected: FAIL with `Cannot find module '../../../scripts/release/types'`
+
+- [ ] **Step 3: Write the schema and types**
+
+```typescript
+// client/scripts/release/types.ts
+import { z } from 'zod';
+
+const AddressSchema = z.string().regex(/^0x[a-fA-F0-9]{40}$/, 'must be a 0x-prefixed 20-byte hex address');
+
+const ShapeSchema = z.enum(['current', 'pre-fleet']);
+const RoleSchema = z.enum(['launcher', 'participant', 'legacy-backup']);
+const NetworkSchema = z.enum(['base-sepolia', 'base']);
+
+const OperatorSchema = z.object({
+  masterAddress: AddressSchema,
+  fleetAgentId: z.string().nullable(),
+  fleetSafeAddress: AddressSchema.nullable(),
+  fleetStage: z.string().nullable(),
+  serviceId: z.number().int().positive(),
+  serviceStep: z.string(),
+  agentEoa: AddressSchema,
+  safeAddress: AddressSchema,
+  mechAddress: AddressSchema,
+  stakingAddress: AddressSchema,
+  identityRegistry: AddressSchema,
+});
+
+const ConfigSchema = z.object({
+  apiPort: z.number().int().positive(),
+  rpcUrl: z.string().url(),
+  joinedSolverNets: z.array(z.string()),
+});
+
+export const ManifestSchema = z.object({
+  substrateVersion: z.literal('1'),
+  createdAt: z.string().datetime(),
+  adoptedFrom: z.string(),
+  name: z.string(),
+  shape: ShapeSchema,
+  role: RoleSchema,
+  network: NetworkSchema,
+  operator: OperatorSchema,
+  config: ConfigSchema,
+});
+
+export type Manifest = z.infer<typeof ManifestSchema>;
+
+export interface VerifyResult {
+  opName: string;
+  ok: boolean;
+  failures: string[];           // each entry describes one failed check
+  warnings: string[];           // each entry describes a non-blocking concern
+  onChain: {
+    boundSafeAddress: string | null;
+    ethBalanceWei: bigint;
+    olasBalanceWei: bigint | null;
+  } | null;                     // null if on-chain check was skipped
+}
+
+export interface TopupResult {
+  opName: string;
+  needs: { resource: 'ETH' | 'USDC'; have: bigint; want: bigint }[];
+  ok: boolean;                  // true if all balances above their topup-trigger threshold
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd client && yarn vitest run test/release/substrate/types.test.ts`
+Expected: PASS, 4 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/scripts/release/types.ts client/test/release/substrate/types.test.ts
+git commit -m "feat(substrate): add manifest schema and shared types"
+```
+
+---
+
+## Task 2: Path resolution helpers
+
+**Files:**
+- Create: `client/scripts/release/substrate-paths.ts`
+- Test: `client/test/release/substrate/substrate-paths.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// client/test/release/substrate/substrate-paths.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as os from 'node:os';
+import {
+  goldPath,
+  workspacePath,
+  workspacesRoot,
+  defaultSubstrateRoot,
+} from '../../../scripts/release/substrate-paths';
+
+describe('substrate-paths', () => {
+  const originalEnv = { ...process.env };
+  beforeEach(() => { process.env = { ...originalEnv }; });
+  afterEach(() => { process.env = originalEnv; });
+
+  it('defaultSubstrateRoot resolves to ~/jinn-dev under HOME', () => {
+    process.env.HOME = '/Users/test';
+    expect(defaultSubstrateRoot()).toBe('/Users/test/jinn-dev');
+  });
+
+  it('goldPath composes correctly', () => {
+    process.env.HOME = '/Users/test';
+    expect(goldPath('op-a')).toBe('/Users/test/jinn-dev/operators/op-a');
+    expect(goldPath('op-b')).toBe('/Users/test/jinn-dev/operators/op-b');
+  });
+
+  it('workspacePath composes correctly', () => {
+    process.env.HOME = '/Users/test';
+    expect(workspacePath('run-123', 'op-a')).toBe('/Users/test/jinn-dev/workspaces/run-123/op-a');
+  });
+
+  it('workspacesRoot returns the workspaces dir', () => {
+    process.env.HOME = '/Users/test';
+    expect(workspacesRoot()).toBe('/Users/test/jinn-dev/workspaces');
+  });
+
+  it('accepts a custom substrateRoot override', () => {
+    expect(goldPath('op-a', '/custom/root')).toBe('/custom/root/operators/op-a');
+    expect(workspacePath('run-1', 'op-a', '/custom/root')).toBe('/custom/root/workspaces/run-1/op-a');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client && yarn vitest run test/release/substrate/substrate-paths.test.ts`
+Expected: FAIL with `Cannot find module '../../../scripts/release/substrate-paths'`
+
+- [ ] **Step 3: Write the helpers**
+
+```typescript
+// client/scripts/release/substrate-paths.ts
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+export function defaultSubstrateRoot(): string {
+  return path.join(os.homedir(), 'jinn-dev');
+}
+
+export function goldPath(opName: string, substrateRoot: string = defaultSubstrateRoot()): string {
+  return path.join(substrateRoot, 'operators', opName);
+}
+
+export function workspacesRoot(substrateRoot: string = defaultSubstrateRoot()): string {
+  return path.join(substrateRoot, 'workspaces');
+}
+
+export function workspacePath(runId: string, opName: string, substrateRoot: string = defaultSubstrateRoot()): string {
+  return path.join(workspacesRoot(substrateRoot), runId, opName);
+}
+
+export function generateRunId(): string {
+  const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  const rand = Math.random().toString(36).slice(2, 6);
+  return `${ts}-${rand}`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd client && yarn vitest run test/release/substrate/substrate-paths.test.ts`
+Expected: PASS, 5 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/scripts/release/substrate-paths.ts client/test/release/substrate/substrate-paths.test.ts
+git commit -m "feat(substrate): add path resolution helpers"
+```
+
+---
+
+## Task 3: Fixture operators for tests
+
+**Files:**
+- Create: `client/test/release/substrate/fixtures/op-a-fixture/.jinn-client/config.json`
+- Create: `client/test/release/substrate/fixtures/op-a-fixture/.jinn-client/keystore-password`
+- Create: `client/test/release/substrate/fixtures/op-a-fixture/.jinn-client/earning/earning_state.json`
+- Create: `client/test/release/substrate/fixtures/op-a-fixture/.jinn-client/earning/master_keystore.json`
+- Create: `client/test/release/substrate/fixtures/op-b-fixture/.jinn-client/...` (same shape, different identity)
+- Create: `client/test/release/substrate/fixtures/README.md`
+
+- [ ] **Step 1: Create the op-a-fixture config.json**
+
+```bash
+mkdir -p client/test/release/substrate/fixtures/op-a-fixture/.jinn-client/earning
+```
+
+```json
+{
+  "network": "testnet",
+  "rpcUrl": "https://base-sepolia.example/fixture-key",
+  "apiPort": 7332,
+  "joinedSolverNets": {
+    "bafkrei-fixture-cid": {
+      "name": "fixture-swe-rebench",
+      "manifestCid": "bafkrei-fixture-cid",
+      "roles": ["solving"],
+      "harness": "claude-code-learner",
+      "plugins": [],
+      "model": "claude-haiku-4-5-20251001"
+    }
+  }
+}
+```
+
+Save as `client/test/release/substrate/fixtures/op-a-fixture/.jinn-client/config.json`.
+
+- [ ] **Step 2: Create op-a-fixture earning_state.json**
+
+```json
+{
+  "master_address": "0x1111111111111111111111111111111111111111",
+  "chain": "base-sepolia",
+  "staking_mode": "standard",
+  "services": [
+    {
+      "index": 1,
+      "agent_address": "0x2222222222222222222222222222222222222222",
+      "safe_address": "0x3333333333333333333333333333333333333333",
+      "service_id": 9999,
+      "mech_address": "0x4444444444444444444444444444444444444444",
+      "staking_address": "0x5555555555555555555555555555555555555555",
+      "step": "complete",
+      "error": null,
+      "agent_id": "99001",
+      "agent_uri": "",
+      "identity_registry_address": "0x6666666666666666666666666666666666666666",
+      "agent_registered_tx": "0xfixture",
+      "safe_bound_to_agent": true,
+      "error_revert_reason": null,
+      "error_short_message": null
+    }
+  ],
+  "updated_at": "2026-05-01T00:00:00.000Z",
+  "fleet_agent_id": "99001",
+  "fleet_safe_address": "0x3333333333333333333333333333333333333333",
+  "fleet_identity_registry": "0x6666666666666666666666666666666666666666",
+  "fleet_stage": "stage1_and_2"
+}
+```
+
+Save as `client/test/release/substrate/fixtures/op-a-fixture/.jinn-client/earning/earning_state.json`.
+
+- [ ] **Step 3: Create op-a-fixture keystore + password**
+
+```json
+{ "version": 3, "id": "fixture-id", "address": "1111111111111111111111111111111111111111", "crypto": {"cipher": "aes-128-ctr", "ciphertext": "deadbeef", "cipherparams": {"iv": "00000000000000000000000000000000"}, "kdf": "scrypt", "kdfparams": {"dklen": 32, "n": 1024, "p": 1, "r": 8, "salt": "00"}, "mac": "00"} }
+```
+
+Save as `client/test/release/substrate/fixtures/op-a-fixture/.jinn-client/earning/master_keystore.json`.
+
+```
+fixture-password-not-real
+```
+
+Save as `client/test/release/substrate/fixtures/op-a-fixture/.jinn-client/keystore-password` (chmod 600 not needed for fixture but acceptable).
+
+- [ ] **Step 4: Repeat for op-b-fixture with different addresses and apiPort 7333**
+
+Create the same four files under `client/test/release/substrate/fixtures/op-b-fixture/.jinn-client/` with:
+- `master_address`: `0x7777777777777777777777777777777777777777`
+- `agent_id`: `99002`
+- All other addresses bumped to `0xAAAA...`, `0xBBBB...`, etc.
+- `apiPort`: 7333
+
+- [ ] **Step 5: Add README explaining fixtures**
+
+```markdown
+# Substrate test fixtures
+
+These are *not real* operator state. All addresses are placeholders (0x1111...,
+0x2222...). They exist purely for unit tests of substrate-adopt, substrate-copy,
+and substrate-verify. The on-chain identity referenced here does not exist on
+any real chain; tests that exercise on-chain reads must use the Anvil fork
+helper (`helpers/anvil-fork.ts`) to seed deterministic state.
+
+Two fixtures:
+- `op-a-fixture/` — launcher role, agentId 99001
+- `op-b-fixture/` — participant role, agentId 99002
+```
+
+Save as `client/test/release/substrate/fixtures/README.md`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/test/release/substrate/fixtures/
+git commit -m "test(substrate): add fixture operators for unit tests"
+```
+
+---
+
+## Task 4: substrate-verify — manifest validation
+
+**Files:**
+- Create: `client/scripts/release/substrate-verify.ts`
+- Test: `client/test/release/substrate/verify.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// client/test/release/substrate/verify.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { verifySubstrate } from '../../../scripts/release/substrate-verify';
+import type { Manifest } from '../../../scripts/release/types';
+
+describe('substrate-verify (manifest only)', () => {
+  let tmpRoot: string;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'substrate-verify-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  const validManifest: Manifest = {
+    substrateVersion: '1',
+    createdAt: '2026-05-19T14:47:19Z',
+    adoptedFrom: '~/.jinn-client/',
+    name: 'op-a',
+    shape: 'current',
+    role: 'launcher',
+    network: 'base-sepolia',
+    operator: {
+      masterAddress: '0xE64bAf0073a71b0Cb2C0558bB16f24b45E1FB5CF',
+      fleetAgentId: '5474',
+      fleetSafeAddress: '0x0e767E28C6889CcD0DfB88E631a3702D56Ce24FC',
+      fleetStage: 'stage1_and_2',
+      serviceId: 46,
+      serviceStep: 'complete',
+      agentEoa: '0x63192d38350b796856cF002caC25c377D9A0DB5A',
+      safeAddress: '0x0e767E28C6889CcD0DfB88E631a3702D56Ce24FC',
+      mechAddress: '0x9c415369D0597e4867F419d256BD61D16a8C47b5',
+      stakingAddress: '0x24e34E5037956a5Feca1AAAfaA30297084C228B8',
+      identityRegistry: '0x8004A818BFB912233c491871b3d84c89A494BD9e',
+    },
+    config: {
+      apiPort: 7332,
+      rpcUrl: 'https://base-sepolia.example/x',
+      joinedSolverNets: ['bafkrei1'],
+    },
+  };
+
+  async function seedOp(name: string, manifest: Manifest | null): Promise<void> {
+    const opDir = path.join(tmpRoot, 'operators', name);
+    await fs.mkdir(opDir, { recursive: true });
+    if (manifest !== null) {
+      await fs.writeFile(path.join(opDir, 'manifest.json'), JSON.stringify(manifest));
+    }
+  }
+
+  it('reports ok when manifest is valid and skipOnChain=true', async () => {
+    await seedOp('op-a', validManifest);
+    const result = await verifySubstrate('op-a', { substrateRoot: tmpRoot, skipOnChain: true });
+    expect(result.ok).toBe(true);
+    expect(result.failures).toEqual([]);
+  });
+
+  it('reports failure when manifest is missing', async () => {
+    await seedOp('op-a', null);
+    const result = await verifySubstrate('op-a', { substrateRoot: tmpRoot, skipOnChain: true });
+    expect(result.ok).toBe(false);
+    expect(result.failures.some((f) => f.includes('manifest.json'))).toBe(true);
+  });
+
+  it('reports failure when manifest fails schema validation', async () => {
+    await fs.mkdir(path.join(tmpRoot, 'operators', 'op-a'), { recursive: true });
+    await fs.writeFile(path.join(tmpRoot, 'operators', 'op-a', 'manifest.json'), '{"substrateVersion": "1"}');
+    const result = await verifySubstrate('op-a', { substrateRoot: tmpRoot, skipOnChain: true });
+    expect(result.ok).toBe(false);
+    expect(result.failures.some((f) => f.toLowerCase().includes('schema'))).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client && yarn vitest run test/release/substrate/verify.test.ts`
+Expected: FAIL with `Cannot find module '../../../scripts/release/substrate-verify'`
+
+- [ ] **Step 3: Write the substrate-verify manifest-only implementation**
+
+```typescript
+// client/scripts/release/substrate-verify.ts
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { ManifestSchema, type Manifest, type VerifyResult } from './types';
+import { goldPath } from './substrate-paths';
+
+export interface VerifyOptions {
+  substrateRoot?: string;
+  skipOnChain?: boolean;
+}
+
+export async function verifySubstrate(opName: string, opts: VerifyOptions = {}): Promise<VerifyResult> {
+  const failures: string[] = [];
+  const warnings: string[] = [];
+
+  const opDir = goldPath(opName, opts.substrateRoot);
+  const manifestPath = path.join(opDir, 'manifest.json');
+
+  // 1. Manifest exists
+  let manifestRaw: string;
+  try {
+    manifestRaw = await fs.readFile(manifestPath, 'utf-8');
+  } catch (err) {
+    failures.push(`manifest.json not found at ${manifestPath}`);
+    return { opName, ok: false, failures, warnings, onChain: null };
+  }
+
+  // 2. Manifest parses
+  let manifestJson: unknown;
+  try {
+    manifestJson = JSON.parse(manifestRaw);
+  } catch (err) {
+    failures.push(`manifest.json is not valid JSON: ${(err as Error).message}`);
+    return { opName, ok: false, failures, warnings, onChain: null };
+  }
+
+  // 3. Manifest validates against schema
+  const parseResult = ManifestSchema.safeParse(manifestJson);
+  if (!parseResult.success) {
+    failures.push(`manifest.json failed schema validation: ${parseResult.error.message}`);
+    return { opName, ok: false, failures, warnings, onChain: null };
+  }
+  const manifest: Manifest = parseResult.data;
+
+  // 4. Name in manifest matches the op being verified
+  if (manifest.name !== opName) {
+    failures.push(`manifest.name=${manifest.name} does not match expected opName=${opName}`);
+  }
+
+  // 5. Sanity: gold dir contains .jinn-client structure
+  const jinnClientDir = path.join(opDir, '.jinn-client');
+  try {
+    await fs.access(jinnClientDir);
+  } catch {
+    failures.push(`gold operator missing .jinn-client/ directory at ${jinnClientDir}`);
+  }
+
+  // 6. On-chain check (skip for now if requested)
+  if (opts.skipOnChain) {
+    return { opName, ok: failures.length === 0, failures, warnings, onChain: null };
+  }
+
+  // On-chain check implementation lands in Task 5
+  warnings.push('on-chain check not yet implemented; skipping');
+  return { opName, ok: failures.length === 0, failures, warnings, onChain: null };
+}
+
+async function cliMain(): Promise<void> {
+  const opName = process.argv[2];
+  if (!opName) {
+    console.error('usage: substrate-verify <op-name> [--skip-on-chain]');
+    process.exit(2);
+  }
+  const skipOnChain = process.argv.includes('--skip-on-chain');
+  const result = await verifySubstrate(opName, { skipOnChain });
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(result.ok ? 0 : 1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  cliMain().catch((err) => {
+    console.error(err);
+    process.exit(2);
+  });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd client && yarn vitest run test/release/substrate/verify.test.ts`
+Expected: PASS, 3 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/scripts/release/substrate-verify.ts client/test/release/substrate/verify.test.ts
+git commit -m "feat(substrate): add manifest-validating substrate-verify"
+```
+
+---
+
+## Task 5: substrate-verify — on-chain identity check
+
+**Files:**
+- Modify: `client/scripts/release/substrate-verify.ts`
+- Modify: `client/test/release/substrate/verify.test.ts` (add on-chain tests)
+- Create: `client/test/release/substrate/helpers/anvil-fork.ts`
+
+- [ ] **Step 1: Write the Anvil fork helper**
+
+```typescript
+// client/test/release/substrate/helpers/anvil-fork.ts
+import { spawn, type ChildProcess } from 'node:child_process';
+import * as net from 'node:net';
+
+export interface AnvilForkHandle {
+  rpcUrl: string;
+  port: number;
+  stop: () => Promise<void>;
+}
+
+async function pickFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.unref();
+    srv.on('error', reject);
+    srv.listen(0, () => {
+      const port = (srv.address() as net.AddressInfo).port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitForRpc(rpcUrl: string, timeoutMs = 10000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(rpcUrl, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'eth_blockNumber', params: [] }),
+      });
+      if (res.ok) return;
+    } catch {
+      // not yet
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`anvil at ${rpcUrl} did not become reachable within ${timeoutMs}ms`);
+}
+
+export async function spawnAnvilFork(opts: { forkUrl?: string; forkBlock?: number } = {}): Promise<AnvilForkHandle> {
+  const port = await pickFreePort();
+  const args = ['--port', port.toString(), '--silent'];
+  if (opts.forkUrl) {
+    args.push('--fork-url', opts.forkUrl);
+    if (opts.forkBlock !== undefined) {
+      args.push('--fork-block-number', opts.forkBlock.toString());
+    }
+  }
+  const child: ChildProcess = spawn('anvil', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+  const rpcUrl = `http://127.0.0.1:${port}`;
+  try {
+    await waitForRpc(rpcUrl);
+  } catch (err) {
+    child.kill('SIGTERM');
+    throw err;
+  }
+  return {
+    rpcUrl,
+    port,
+    stop: async () => {
+      child.kill('SIGTERM');
+      await new Promise((r) => setTimeout(r, 100));
+      if (!child.killed) child.kill('SIGKILL');
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Add a failing on-chain test**
+
+Append to `client/test/release/substrate/verify.test.ts`:
+
+```typescript
+import { spawnAnvilFork, type AnvilForkHandle } from './helpers/anvil-fork';
+import { createTestClient, createWalletClient, http, parseEther, type Address } from 'viem';
+import { baseSepolia } from 'viem/chains';
+import { privateKeyToAccount } from 'viem/accounts';
+
+describe('substrate-verify (on-chain check)', () => {
+  let tmpRoot: string;
+  let anvil: AnvilForkHandle;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'substrate-verify-onchain-'));
+    anvil = await spawnAnvilFork();
+  });
+
+  afterEach(async () => {
+    await anvil.stop();
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('reports failure when master EOA has zero ETH balance', async () => {
+    const opDir = path.join(tmpRoot, 'operators', 'op-a');
+    await fs.mkdir(path.join(opDir, '.jinn-client'), { recursive: true });
+    const manifest: Manifest = {
+      substrateVersion: '1',
+      createdAt: '2026-05-19T14:47:19Z',
+      adoptedFrom: '~/.jinn-client/',
+      name: 'op-a',
+      shape: 'current',
+      role: 'launcher',
+      network: 'base-sepolia',
+      operator: {
+        masterAddress: '0x1234567890123456789012345678901234567890',
+        fleetAgentId: '5474',
+        fleetSafeAddress: '0x0e767E28C6889CcD0DfB88E631a3702D56Ce24FC',
+        fleetStage: 'stage1_and_2',
+        serviceId: 46,
+        serviceStep: 'complete',
+        agentEoa: '0x63192d38350b796856cF002caC25c377D9A0DB5A',
+        safeAddress: '0x0e767E28C6889CcD0DfB88E631a3702D56Ce24FC',
+        mechAddress: '0x9c415369D0597e4867F419d256BD61D16a8C47b5',
+        stakingAddress: '0x24e34E5037956a5Feca1AAAfaA30297084C228B8',
+        identityRegistry: '0x8004A818BFB912233c491871b3d84c89A494BD9e',
+      },
+      config: { apiPort: 7332, rpcUrl: anvil.rpcUrl, joinedSolverNets: [] },
+    };
+    await fs.writeFile(path.join(opDir, 'manifest.json'), JSON.stringify(manifest));
+
+    const result = await verifySubstrate('op-a', { substrateRoot: tmpRoot, skipOnChain: false });
+
+    expect(result.onChain).not.toBeNull();
+    expect(result.onChain!.ethBalanceWei).toBe(0n);
+    expect(result.failures.some((f) => f.toLowerCase().includes('eth balance'))).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 3: Run to verify the new test fails**
+
+Run: `cd client && yarn vitest run test/release/substrate/verify.test.ts`
+Expected: 3 prior tests PASS; new on-chain test FAILS because on-chain check isn't implemented yet.
+
+- [ ] **Step 4: Implement the on-chain check**
+
+Replace the on-chain stub in `client/scripts/release/substrate-verify.ts` with:
+
+```typescript
+// Add at top of substrate-verify.ts
+import { createPublicClient, http, parseAbi, type Address } from 'viem';
+import { baseSepolia } from 'viem/chains';
+
+const MIN_MASTER_ETH_WEI = 2_000_000_000_000_000n;   // 0.002 ETH
+const IDENTITY_REGISTRY_ABI = parseAbi([
+  'function getAgentWallet(uint256 agentId) view returns (address)',
+]);
+const OLAS_TOKEN_ADDRESS_BASE_SEPOLIA: Address = '0x54330d28ca3357F294334BDC454a032e7f353416';
+const OLAS_TOKEN_ABI = parseAbi([
+  'function balanceOf(address account) view returns (uint256)',
+]);
+
+// Replace the warnings.push('on-chain check not yet implemented...') block with:
+const client = createPublicClient({ chain: baseSepolia, transport: http(manifest.config.rpcUrl) });
+const onChain = {
+  boundSafeAddress: null as string | null,
+  ethBalanceWei: 0n,
+  olasBalanceWei: null as bigint | null,
+};
+
+// Master ETH balance
+try {
+  onChain.ethBalanceWei = await client.getBalance({ address: manifest.operator.masterAddress as Address });
+  if (onChain.ethBalanceWei < MIN_MASTER_ETH_WEI) {
+    failures.push(`master ETH balance ${onChain.ethBalanceWei} below minimum ${MIN_MASTER_ETH_WEI}`);
+  }
+} catch (err) {
+  failures.push(`failed to read master ETH balance: ${(err as Error).message}`);
+}
+
+// AgentId binding (skip if pre-fleet shape)
+if (manifest.shape === 'current' && manifest.operator.fleetAgentId !== null && manifest.operator.fleetSafeAddress !== null) {
+  try {
+    const bound = await client.readContract({
+      address: manifest.operator.identityRegistry as Address,
+      abi: IDENTITY_REGISTRY_ABI,
+      functionName: 'getAgentWallet',
+      args: [BigInt(manifest.operator.fleetAgentId)],
+    });
+    onChain.boundSafeAddress = bound;
+    if (bound.toLowerCase() !== manifest.operator.fleetSafeAddress.toLowerCase()) {
+      failures.push(`identityRegistry.getAgentWallet(${manifest.operator.fleetAgentId})=${bound} does not match manifest.fleetSafeAddress=${manifest.operator.fleetSafeAddress}`);
+    }
+  } catch (err) {
+    failures.push(`failed to read identityRegistry.getAgentWallet: ${(err as Error).message}`);
+  }
+}
+
+// OLAS balance on Safe (informational; staked balance is locked so we just check)
+try {
+  onChain.olasBalanceWei = await client.readContract({
+    address: OLAS_TOKEN_ADDRESS_BASE_SEPOLIA,
+    abi: OLAS_TOKEN_ABI,
+    functionName: 'balanceOf',
+    args: [manifest.operator.safeAddress as Address],
+  });
+} catch {
+  // Non-blocking; legacy ops or future schema may not have OLAS readable
+}
+
+return { opName, ok: failures.length === 0, failures, warnings, onChain };
+```
+
+- [ ] **Step 5: Run all verify tests**
+
+Run: `cd client && yarn vitest run test/release/substrate/verify.test.ts`
+Expected: 4 tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/scripts/release/substrate-verify.ts client/test/release/substrate/verify.test.ts client/test/release/substrate/helpers/anvil-fork.ts
+git commit -m "feat(substrate): add on-chain identity verification to substrate-verify"
+```
+
+---
+
+## Task 6: substrate-adopt — single operator copy + manifest write
+
+**Files:**
+- Create: `client/scripts/release/substrate-adopt.ts`
+- Test: `client/test/release/substrate/adopt.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// client/test/release/substrate/adopt.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { adoptOperator } from '../../../scripts/release/substrate-adopt';
+
+describe('substrate-adopt', () => {
+  let tmpRoot: string;
+  const fixtureDir = path.resolve(__dirname, 'fixtures', 'op-a-fixture', '.jinn-client');
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'substrate-adopt-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('copies a source operator dir into gold with the expected layout', async () => {
+    await adoptOperator({
+      sourceDir: fixtureDir,
+      opName: 'op-a',
+      role: 'launcher',
+      shape: 'current',
+      apiPort: 7332,
+      substrateRoot: tmpRoot,
+    });
+
+    const goldOp = path.join(tmpRoot, 'operators', 'op-a');
+    await expect(fs.access(path.join(goldOp, 'manifest.json'))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(goldOp, '.jinn-client', 'config.json'))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(goldOp, '.jinn-client', 'earning', 'earning_state.json'))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(goldOp, '.jinn-client', 'keystore-password'))).resolves.toBeUndefined();
+  });
+
+  it('writes a manifest matching the source operator state', async () => {
+    await adoptOperator({
+      sourceDir: fixtureDir,
+      opName: 'op-a',
+      role: 'launcher',
+      shape: 'current',
+      apiPort: 7332,
+      substrateRoot: tmpRoot,
+    });
+
+    const manifestRaw = await fs.readFile(path.join(tmpRoot, 'operators', 'op-a', 'manifest.json'), 'utf-8');
+    const manifest = JSON.parse(manifestRaw);
+    expect(manifest.name).toBe('op-a');
+    expect(manifest.shape).toBe('current');
+    expect(manifest.role).toBe('launcher');
+    expect(manifest.network).toBe('base-sepolia');
+    expect(manifest.operator.masterAddress).toBe('0x1111111111111111111111111111111111111111');
+    expect(manifest.operator.fleetAgentId).toBe('99001');
+    expect(manifest.config.apiPort).toBe(7332);
+  });
+
+  it('rewrites apiPort in the copied config.json', async () => {
+    await adoptOperator({
+      sourceDir: fixtureDir,
+      opName: 'op-a',
+      role: 'launcher',
+      shape: 'current',
+      apiPort: 7340,
+      substrateRoot: tmpRoot,
+    });
+
+    const cfgRaw = await fs.readFile(path.join(tmpRoot, 'operators', 'op-a', '.jinn-client', 'config.json'), 'utf-8');
+    const cfg = JSON.parse(cfgRaw);
+    expect(cfg.apiPort).toBe(7340);
+  });
+
+  it('excludes engine/, logs, and backups from the copy', async () => {
+    // seed the source dir with some junk to make sure it's excluded
+    const dirtySource = await fs.mkdtemp(path.join(os.tmpdir(), 'dirty-source-'));
+    await fs.cp(fixtureDir, path.join(dirtySource, '.jinn-client'), { recursive: true });
+    await fs.mkdir(path.join(dirtySource, '.jinn-client', 'engine', 'work'), { recursive: true });
+    await fs.writeFile(path.join(dirtySource, '.jinn-client', 'engine', 'work', 'fake-task.json'), '{}');
+    await fs.writeFile(path.join(dirtySource, '.jinn-client', 'daemon-20260101.log'), 'old');
+    await fs.writeFile(path.join(dirtySource, '.jinn-client', 'jinn.db.bak-20260101'), 'backup');
+
+    await adoptOperator({
+      sourceDir: path.join(dirtySource, '.jinn-client'),
+      opName: 'op-a',
+      role: 'launcher',
+      shape: 'current',
+      apiPort: 7332,
+      substrateRoot: tmpRoot,
+    });
+
+    const goldOp = path.join(tmpRoot, 'operators', 'op-a', '.jinn-client');
+    await expect(fs.access(path.join(goldOp, 'engine'))).rejects.toThrow();
+    await expect(fs.access(path.join(goldOp, 'daemon-20260101.log'))).rejects.toThrow();
+    await expect(fs.access(path.join(goldOp, 'jinn.db.bak-20260101'))).rejects.toThrow();
+
+    await fs.rm(dirtySource, { recursive: true, force: true });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd client && yarn vitest run test/release/substrate/adopt.test.ts`
+Expected: FAIL with `Cannot find module '../../../scripts/release/substrate-adopt'`
+
+- [ ] **Step 3: Implement substrate-adopt**
+
+```typescript
+// client/scripts/release/substrate-adopt.ts
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { goldPath } from './substrate-paths';
+import type { Manifest } from './types';
+import { ManifestSchema } from './types';
+
+const EXCLUDE_DIRS = new Set(['engine']);
+const EXCLUDE_PATTERNS: RegExp[] = [
+  /^jinn\.db\.bak/,
+  /^config\.before/,
+  /^config\.json\.pre/,
+  /^daemon-/,
+  /\.log$/,
+  /^run-/,
+];
+
+export interface AdoptOptions {
+  sourceDir: string;            // path to the existing .jinn-client/ dir
+  opName: string;               // "op-a", "op-b", etc.
+  role: Manifest['role'];
+  shape: Manifest['shape'];
+  apiPort: number;
+  substrateRoot?: string;
+}
+
+async function copyTreeWithExcludes(srcDir: string, dstDir: string): Promise<void> {
+  await fs.mkdir(dstDir, { recursive: true });
+  const entries = await fs.readdir(srcDir, { withFileTypes: true });
+  for (const ent of entries) {
+    if (EXCLUDE_DIRS.has(ent.name)) continue;
+    if (EXCLUDE_PATTERNS.some((re) => re.test(ent.name))) continue;
+    const srcPath = path.join(srcDir, ent.name);
+    const dstPath = path.join(dstDir, ent.name);
+    if (ent.isDirectory()) {
+      await copyTreeWithExcludes(srcPath, dstPath);
+    } else if (ent.isFile()) {
+      await fs.copyFile(srcPath, dstPath);
+      // preserve mode (keystore-password should remain chmod 600)
+      const stat = await fs.stat(srcPath);
+      await fs.chmod(dstPath, stat.mode);
+    }
+  }
+}
+
+async function readJsonOrNull<T>(p: string): Promise<T | null> {
+  try {
+    return JSON.parse(await fs.readFile(p, 'utf-8')) as T;
+  } catch {
+    return null;
+  }
+}
+
+interface SourceEarningState {
+  master_address: string;
+  chain: string;
+  fleet_agent_id?: string;
+  fleet_safe_address?: string;
+  fleet_identity_registry?: string;
+  fleet_stage?: string;
+  services?: Array<{
+    agent_address: string;
+    safe_address: string;
+    service_id: number;
+    mech_address?: string;
+    staking_address?: string;
+    identity_registry_address?: string;
+    step?: string;
+  }>;
+}
+
+interface SourceConfig {
+  rpcUrl?: string;
+  apiPort?: number;
+  joinedSolverNets?: Record<string, unknown>;
+}
+
+export async function adoptOperator(opts: AdoptOptions): Promise<void> {
+  const gold = goldPath(opts.opName, opts.substrateRoot);
+  const goldJinn = path.join(gold, '.jinn-client');
+
+  // 1. Clear any existing gold for this op
+  await fs.rm(gold, { recursive: true, force: true });
+  await fs.mkdir(goldJinn, { recursive: true });
+
+  // 2. Copy the source dir with excludes
+  await copyTreeWithExcludes(opts.sourceDir, goldJinn);
+
+  // 3. Rewrite apiPort in the copied config.json
+  const cfgPath = path.join(goldJinn, 'config.json');
+  const cfg = await readJsonOrNull<SourceConfig>(cfgPath);
+  if (cfg) {
+    cfg.apiPort = opts.apiPort;
+    await fs.writeFile(cfgPath, JSON.stringify(cfg, null, 2) + '\n');
+  }
+
+  // 4. Read earning_state.json to populate manifest
+  const statePath = path.join(goldJinn, 'earning', 'earning_state.json');
+  const state = await readJsonOrNull<SourceEarningState>(statePath);
+  if (!state) {
+    throw new Error(`source operator at ${opts.sourceDir} has no earning/earning_state.json`);
+  }
+  const svc = state.services?.[0];
+
+  // 5. Build manifest
+  const manifest: Manifest = {
+    substrateVersion: '1',
+    createdAt: new Date().toISOString(),
+    adoptedFrom: opts.sourceDir,
+    name: opts.opName,
+    shape: opts.shape,
+    role: opts.role,
+    network: state.chain === 'base-sepolia' ? 'base-sepolia' : 'base',
+    operator: {
+      masterAddress: state.master_address,
+      fleetAgentId: state.fleet_agent_id ?? null,
+      fleetSafeAddress: state.fleet_safe_address ?? null,
+      fleetStage: state.fleet_stage ?? null,
+      serviceId: svc?.service_id ?? 0,
+      serviceStep: svc?.step ?? 'unknown',
+      agentEoa: svc?.agent_address ?? '0x0000000000000000000000000000000000000000',
+      safeAddress: svc?.safe_address ?? '0x0000000000000000000000000000000000000000',
+      mechAddress: svc?.mech_address ?? '0x0000000000000000000000000000000000000000',
+      stakingAddress: svc?.staking_address ?? '0x0000000000000000000000000000000000000000',
+      identityRegistry: svc?.identity_registry_address ?? state.fleet_identity_registry ?? '0x0000000000000000000000000000000000000000',
+    },
+    config: {
+      apiPort: opts.apiPort,
+      rpcUrl: cfg?.rpcUrl ?? 'https://base-sepolia.example/unknown',
+      joinedSolverNets: cfg?.joinedSolverNets ? Object.keys(cfg.joinedSolverNets) : [],
+    },
+  };
+
+  // 6. Validate manifest before writing
+  ManifestSchema.parse(manifest);
+
+  // 7. Write manifest
+  await fs.writeFile(path.join(gold, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n');
+}
+
+async function cliMain(): Promise<void> {
+  // Parse --from <dir> --as <name> --role <role> --shape <shape> --apiPort <port>
+  // (one set of args; for multiple ops, invoke multiple times)
+  const args = process.argv.slice(2);
+  const argMap: Record<string, string> = {};
+  for (let i = 0; i < args.length; i++) {
+    if (args[i].startsWith('--')) {
+      const key = args[i].slice(2);
+      const val = args[i + 1];
+      if (!val) { console.error(`missing value for --${key}`); process.exit(2); }
+      argMap[key] = val;
+      i++;
+    }
+  }
+  const { from, as: opName, role, shape, apiPort } = argMap;
+  if (!from || !opName || !role || !shape || !apiPort) {
+    console.error('usage: substrate-adopt --from <.jinn-client-dir> --as <op-name> --role <launcher|participant|legacy-backup> --shape <current|pre-fleet> --apiPort <port>');
+    process.exit(2);
+  }
+  await adoptOperator({
+    sourceDir: from,
+    opName,
+    role: role as Manifest['role'],
+    shape: shape as Manifest['shape'],
+    apiPort: parseInt(apiPort, 10),
+  });
+  console.log(`adopted ${opName} from ${from}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  cliMain().catch((err) => {
+    console.error(err);
+    process.exit(2);
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd client && yarn vitest run test/release/substrate/adopt.test.ts`
+Expected: PASS, 4 tests passing
+
+- [ ] **Step 5: Run substrate-verify on the adopted result as a sanity check**
+
+```typescript
+// append to client/test/release/substrate/adopt.test.ts
+import { verifySubstrate } from '../../../scripts/release/substrate-verify';
+
+it('adopted op-a passes substrate-verify (skip on-chain)', async () => {
+  await adoptOperator({
+    sourceDir: fixtureDir,
+    opName: 'op-a',
+    role: 'launcher',
+    shape: 'current',
+    apiPort: 7332,
+    substrateRoot: tmpRoot,
+  });
+  const result = await verifySubstrate('op-a', { substrateRoot: tmpRoot, skipOnChain: true });
+  expect(result.ok).toBe(true);
+  expect(result.failures).toEqual([]);
+});
+```
+
+Run: `cd client && yarn vitest run test/release/substrate/adopt.test.ts`
+Expected: PASS, 5 tests passing
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/scripts/release/substrate-adopt.ts client/test/release/substrate/adopt.test.ts
+git commit -m "feat(substrate): add substrate-adopt for copying existing operator state into gold"
+```
+
+---
+
+## Task 7: substrate-copy — workspace creation
+
+**Files:**
+- Create: `client/scripts/release/substrate-copy.ts`
+- Test: `client/test/release/substrate/copy.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// client/test/release/substrate/copy.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { adoptOperator } from '../../../scripts/release/substrate-adopt';
+import { copyWorkspace } from '../../../scripts/release/substrate-copy';
+
+describe('substrate-copy', () => {
+  let tmpRoot: string;
+  const opAFixture = path.resolve(__dirname, 'fixtures', 'op-a-fixture', '.jinn-client');
+  const opBFixture = path.resolve(__dirname, 'fixtures', 'op-b-fixture', '.jinn-client');
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'substrate-copy-'));
+    await adoptOperator({ sourceDir: opAFixture, opName: 'op-a', role: 'launcher', shape: 'current', apiPort: 7332, substrateRoot: tmpRoot });
+    await adoptOperator({ sourceDir: opBFixture, opName: 'op-b', role: 'participant', shape: 'current', apiPort: 7333, substrateRoot: tmpRoot });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('creates per-run workspace from gold', async () => {
+    const handle = await copyWorkspace({ ops: ['op-a', 'op-b'], substrateRoot: tmpRoot });
+    expect(handle.runId).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-/);
+
+    for (const opName of ['op-a', 'op-b']) {
+      const wsOp = path.join(handle.workspaceRoot, opName);
+      await expect(fs.access(path.join(wsOp, 'manifest.json'))).resolves.toBeUndefined();
+      await expect(fs.access(path.join(wsOp, '.jinn-client', 'config.json'))).resolves.toBeUndefined();
+    }
+  });
+
+  it('teardown removes the workspace dir', async () => {
+    const handle = await copyWorkspace({ ops: ['op-a'], substrateRoot: tmpRoot });
+    expect(handle.workspaceRoot).toContain('workspaces');
+    await fs.access(handle.workspaceRoot);
+    await handle.teardown();
+    await expect(fs.access(handle.workspaceRoot)).rejects.toThrow();
+  });
+
+  it('teardown is idempotent', async () => {
+    const handle = await copyWorkspace({ ops: ['op-a'], substrateRoot: tmpRoot });
+    await handle.teardown();
+    await expect(handle.teardown()).resolves.toBeUndefined();
+  });
+
+  it('returns per-op paths for ergonomic use', async () => {
+    const handle = await copyWorkspace({ ops: ['op-a', 'op-b'], substrateRoot: tmpRoot });
+    expect(handle.opPaths['op-a']).toContain('op-a');
+    expect(handle.opPaths['op-b']).toContain('op-b');
+    expect(handle.opPaths['op-a']).not.toContain('op-b');
+  });
+
+  it('throws if requested op is not in gold', async () => {
+    await expect(copyWorkspace({ ops: ['op-z'], substrateRoot: tmpRoot })).rejects.toThrow(/op-z/);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd client && yarn vitest run test/release/substrate/copy.test.ts`
+Expected: FAIL with `Cannot find module '../../../scripts/release/substrate-copy'`
+
+- [ ] **Step 3: Implement substrate-copy**
+
+```typescript
+// client/scripts/release/substrate-copy.ts
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { goldPath, workspacePath, generateRunId } from './substrate-paths';
+
+export interface CopyWorkspaceOptions {
+  ops: string[];                    // names of gold ops to include
+  substrateRoot?: string;
+  runId?: string;                   // override the generated run-id
+}
+
+export interface WorkspaceHandle {
+  runId: string;
+  workspaceRoot: string;            // ~/jinn-dev/workspaces/<run-id>/
+  opPaths: Record<string, string>;  // opName → ~/jinn-dev/workspaces/<run-id>/<opName>/
+  teardown: () => Promise<void>;
+}
+
+async function copyDir(src: string, dst: string): Promise<void> {
+  await fs.mkdir(dst, { recursive: true });
+  const entries = await fs.readdir(src, { withFileTypes: true });
+  for (const ent of entries) {
+    const s = path.join(src, ent.name);
+    const d = path.join(dst, ent.name);
+    if (ent.isDirectory()) {
+      await copyDir(s, d);
+    } else if (ent.isFile()) {
+      await fs.copyFile(s, d);
+      const stat = await fs.stat(s);
+      await fs.chmod(d, stat.mode);
+    }
+  }
+}
+
+export async function copyWorkspace(opts: CopyWorkspaceOptions): Promise<WorkspaceHandle> {
+  const runId = opts.runId ?? generateRunId();
+  const opPaths: Record<string, string> = {};
+
+  // Validate every requested op exists in gold first
+  for (const opName of opts.ops) {
+    const src = goldPath(opName, opts.substrateRoot);
+    try {
+      await fs.access(src);
+    } catch {
+      throw new Error(`gold operator ${opName} not found at ${src}`);
+    }
+  }
+
+  // Copy each op
+  for (const opName of opts.ops) {
+    const src = goldPath(opName, opts.substrateRoot);
+    const dst = workspacePath(runId, opName, opts.substrateRoot);
+    await copyDir(src, dst);
+    opPaths[opName] = dst;
+  }
+
+  const workspaceRoot = path.dirname(opPaths[opts.ops[0]]);
+
+  // Tag the workspace with provenance
+  await fs.writeFile(
+    path.join(workspaceRoot, '.created-by'),
+    JSON.stringify({ runId, createdAt: new Date().toISOString(), ops: opts.ops }, null, 2) + '\n',
+  );
+
+  return {
+    runId,
+    workspaceRoot,
+    opPaths,
+    teardown: async () => {
+      await fs.rm(workspaceRoot, { recursive: true, force: true });
+    },
+  };
+}
+
+async function cliMain(): Promise<void> {
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    console.error('usage: substrate-copy <op-name> [<op-name> ...]');
+    process.exit(2);
+  }
+  const handle = await copyWorkspace({ ops: args });
+  console.log(JSON.stringify({ runId: handle.runId, workspaceRoot: handle.workspaceRoot, opPaths: handle.opPaths }, null, 2));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  cliMain().catch((err) => {
+    console.error(err);
+    process.exit(2);
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd client && yarn vitest run test/release/substrate/copy.test.ts`
+Expected: PASS, 5 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/scripts/release/substrate-copy.ts client/test/release/substrate/copy.test.ts
+git commit -m "feat(substrate): add substrate-copy for per-run workspace creation"
+```
+
+---
+
+## Task 8: substrate-topup — balance check and gap surfacing
+
+**Files:**
+- Create: `client/scripts/release/substrate-topup.ts`
+- Test: `client/test/release/substrate/topup.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// client/test/release/substrate/topup.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { adoptOperator } from '../../../scripts/release/substrate-adopt';
+import { checkSubstrateTopup } from '../../../scripts/release/substrate-topup';
+import { spawnAnvilFork, type AnvilForkHandle } from './helpers/anvil-fork';
+
+describe('substrate-topup', () => {
+  let tmpRoot: string;
+  let anvil: AnvilForkHandle;
+  const opAFixture = path.resolve(__dirname, 'fixtures', 'op-a-fixture', '.jinn-client');
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'substrate-topup-'));
+    anvil = await spawnAnvilFork();
+    await adoptOperator({ sourceDir: opAFixture, opName: 'op-a', role: 'launcher', shape: 'current', apiPort: 7332, substrateRoot: tmpRoot });
+    // Override the manifest's rpcUrl to the local Anvil for the test
+    const manifestPath = path.join(tmpRoot, 'operators', 'op-a', 'manifest.json');
+    const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf-8'));
+    manifest.config.rpcUrl = anvil.rpcUrl;
+    await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+  });
+
+  afterEach(async () => {
+    await anvil.stop();
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('reports ok=false when master ETH balance is zero', async () => {
+    const result = await checkSubstrateTopup('op-a', { substrateRoot: tmpRoot });
+    expect(result.ok).toBe(false);
+    expect(result.needs.some((n) => n.resource === 'ETH' && n.have === 0n)).toBe(true);
+  });
+
+  it('reports the ETH delta to topup', async () => {
+    const result = await checkSubstrateTopup('op-a', { substrateRoot: tmpRoot });
+    const ethNeed = result.needs.find((n) => n.resource === 'ETH');
+    expect(ethNeed).toBeDefined();
+    expect(ethNeed!.want).toBeGreaterThan(ethNeed!.have);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd client && yarn vitest run test/release/substrate/topup.test.ts`
+Expected: FAIL with `Cannot find module '../../../scripts/release/substrate-topup'`
+
+- [ ] **Step 3: Implement substrate-topup**
+
+```typescript
+// client/scripts/release/substrate-topup.ts
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { createPublicClient, http, parseAbi, type Address } from 'viem';
+import { baseSepolia } from 'viem/chains';
+import { ManifestSchema, type TopupResult, type Manifest } from './types';
+import { goldPath } from './substrate-paths';
+
+const TARGET_ETH_WEI = 5_000_000_000_000_000n;       // 0.005 ETH
+const TARGET_USDC_UNITS = 1_000_000n;                // 1.00 USDC (6 decimals)
+const USDC_BASE_SEPOLIA: Address = '0x036CbD53842c5426634e7929541eC2318f3dCF7e';
+const ERC20_ABI = parseAbi(['function balanceOf(address) view returns (uint256)']);
+
+export interface TopupOptions {
+  substrateRoot?: string;
+}
+
+export async function checkSubstrateTopup(opName: string, opts: TopupOptions = {}): Promise<TopupResult> {
+  const opDir = goldPath(opName, opts.substrateRoot);
+  const manifestRaw = await fs.readFile(path.join(opDir, 'manifest.json'), 'utf-8');
+  const manifest: Manifest = ManifestSchema.parse(JSON.parse(manifestRaw));
+
+  const client = createPublicClient({ chain: baseSepolia, transport: http(manifest.config.rpcUrl) });
+  const needs: TopupResult['needs'] = [];
+
+  // ETH on master EOA (for posting txs from substrate ops)
+  const ethBalance = await client.getBalance({ address: manifest.operator.masterAddress as Address });
+  if (ethBalance < TARGET_ETH_WEI) {
+    needs.push({ resource: 'ETH', have: ethBalance, want: TARGET_ETH_WEI });
+  }
+
+  // USDC on Safe (for x402 payments — only if op participates in donation scenarios)
+  try {
+    const usdcBalance = await client.readContract({
+      address: USDC_BASE_SEPOLIA,
+      abi: ERC20_ABI,
+      functionName: 'balanceOf',
+      args: [manifest.operator.safeAddress as Address],
+    });
+    if (usdcBalance < TARGET_USDC_UNITS) {
+      needs.push({ resource: 'USDC', have: usdcBalance, want: TARGET_USDC_UNITS });
+    }
+  } catch {
+    // USDC token might not be deployed on the local fork; treat as zero
+    needs.push({ resource: 'USDC', have: 0n, want: TARGET_USDC_UNITS });
+  }
+
+  return { opName, needs, ok: needs.length === 0 };
+}
+
+async function cliMain(): Promise<void> {
+  const opName = process.argv[2];
+  if (!opName) {
+    console.error('usage: substrate-topup <op-name>');
+    process.exit(2);
+  }
+  const result = await checkSubstrateTopup(opName);
+  console.log(JSON.stringify(
+    {
+      opName: result.opName,
+      ok: result.ok,
+      needs: result.needs.map((n) => ({ ...n, have: n.have.toString(), want: n.want.toString() })),
+    },
+    null,
+    2,
+  ));
+  if (!result.ok) {
+    console.error('\nSubstrate op has low balances. Fund manually or via release-bot wallet:');
+    for (const n of result.needs) {
+      console.error(`  - ${n.resource}: have ${n.have.toString()}, want ${n.want.toString()}`);
+    }
+    process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  cliMain().catch((err) => {
+    console.error(err);
+    process.exit(2);
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd client && yarn vitest run test/release/substrate/topup.test.ts`
+Expected: PASS, 2 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/scripts/release/substrate-topup.ts client/test/release/substrate/topup.test.ts
+git commit -m "feat(substrate): add substrate-topup balance check (surface gaps, no auto-drip)"
+```
+
+---
+
+## Task 9: substrate-reap — workspace age-based pruning
+
+**Files:**
+- Create: `client/scripts/release/substrate-reap.ts`
+- Test: `client/test/release/substrate/reap.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// client/test/release/substrate/reap.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { reapWorkspaces } from '../../../scripts/release/substrate-reap';
+
+describe('substrate-reap', () => {
+  let tmpRoot: string;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'substrate-reap-'));
+    await fs.mkdir(path.join(tmpRoot, 'workspaces'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  async function seedWorkspace(name: string, ageDays: number): Promise<void> {
+    const wsDir = path.join(tmpRoot, 'workspaces', name);
+    await fs.mkdir(wsDir, { recursive: true });
+    await fs.writeFile(path.join(wsDir, '.created-by'), JSON.stringify({ runId: name }));
+    const ageMs = Date.now() - ageDays * 24 * 60 * 60 * 1000;
+    const time = new Date(ageMs);
+    await fs.utimes(wsDir, time, time);
+  }
+
+  it('removes workspaces older than 7 days', async () => {
+    await seedWorkspace('old-workspace', 10);
+    await seedWorkspace('fresh-workspace', 1);
+
+    const result = await reapWorkspaces({ substrateRoot: tmpRoot, maxAgeDays: 7 });
+
+    expect(result.reaped).toEqual(['old-workspace']);
+    await expect(fs.access(path.join(tmpRoot, 'workspaces', 'old-workspace'))).rejects.toThrow();
+    await expect(fs.access(path.join(tmpRoot, 'workspaces', 'fresh-workspace'))).resolves.toBeUndefined();
+  });
+
+  it('returns empty list when nothing is old enough', async () => {
+    await seedWorkspace('fresh-1', 2);
+    await seedWorkspace('fresh-2', 5);
+
+    const result = await reapWorkspaces({ substrateRoot: tmpRoot, maxAgeDays: 7 });
+
+    expect(result.reaped).toEqual([]);
+    expect(result.kept).toHaveLength(2);
+  });
+
+  it('handles empty workspaces dir gracefully', async () => {
+    const result = await reapWorkspaces({ substrateRoot: tmpRoot, maxAgeDays: 7 });
+    expect(result.reaped).toEqual([]);
+    expect(result.kept).toEqual([]);
+  });
+
+  it('skips non-directory entries', async () => {
+    await fs.writeFile(path.join(tmpRoot, 'workspaces', 'a-file.txt'), 'not a dir');
+    const result = await reapWorkspaces({ substrateRoot: tmpRoot, maxAgeDays: 7 });
+    expect(result.reaped).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd client && yarn vitest run test/release/substrate/reap.test.ts`
+Expected: FAIL with `Cannot find module '../../../scripts/release/substrate-reap'`
+
+- [ ] **Step 3: Implement substrate-reap**
+
+```typescript
+// client/scripts/release/substrate-reap.ts
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { workspacesRoot } from './substrate-paths';
+
+export interface ReapOptions {
+  substrateRoot?: string;
+  maxAgeDays?: number;             // default 7
+}
+
+export interface ReapResult {
+  reaped: string[];                // workspace dir names removed
+  kept: string[];                  // workspace dir names retained
+}
+
+export async function reapWorkspaces(opts: ReapOptions = {}): Promise<ReapResult> {
+  const maxAgeDays = opts.maxAgeDays ?? 7;
+  const root = workspacesRoot(opts.substrateRoot);
+  const cutoffMs = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
+
+  const reaped: string[] = [];
+  const kept: string[] = [];
+
+  let entries: Awaited<ReturnType<typeof fs.readdir>>;
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { reaped, kept };
+    }
+    throw err;
+  }
+
+  for (const ent of entries) {
+    if (!ent.isDirectory()) continue;
+    const fullPath = path.join(root, ent.name);
+    const stat = await fs.stat(fullPath);
+    if (stat.mtimeMs < cutoffMs) {
+      await fs.rm(fullPath, { recursive: true, force: true });
+      reaped.push(ent.name);
+    } else {
+      kept.push(ent.name);
+    }
+  }
+
+  return { reaped, kept };
+}
+
+async function cliMain(): Promise<void> {
+  const result = await reapWorkspaces();
+  console.log(JSON.stringify(result, null, 2));
+  if (result.reaped.length > 0) {
+    console.error(`reaped ${result.reaped.length} workspace(s) older than 7 days`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  cliMain().catch((err) => {
+    console.error(err);
+    process.exit(2);
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd client && yarn vitest run test/release/substrate/reap.test.ts`
+Expected: PASS, 4 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/scripts/release/substrate-reap.ts client/test/release/substrate/reap.test.ts
+git commit -m "feat(substrate): add substrate-reap for workspace age-based pruning"
+```
+
+---
+
+## Task 10: Wire yarn scripts in package.json
+
+**Files:**
+- Modify: `client/package.json`
+
+- [ ] **Step 1: Read the current package.json scripts section**
+
+Run: `cd client && cat package.json | head -50`
+Expected output shows existing `scripts:` block.
+
+- [ ] **Step 2: Add the substrate-related yarn scripts**
+
+Open `client/package.json` and add these entries inside the `"scripts"` object (preserve existing entries; add alphabetically near other release/staking scripts):
+
+```json
+{
+  "scripts": {
+    "substrate:adopt": "tsx scripts/release/substrate-adopt.ts",
+    "substrate:copy": "tsx scripts/release/substrate-copy.ts",
+    "substrate:verify": "tsx scripts/release/substrate-verify.ts",
+    "substrate:topup": "tsx scripts/release/substrate-topup.ts",
+    "substrate:reap": "tsx scripts/release/substrate-reap.ts"
+  }
+}
+```
+
+(If `tsx` isn't already a devDependency, check by running `cd client && yarn list --pattern tsx | head -3`. If absent, this task should not add it — surface as a follow-up. If present, the entries above work directly.)
+
+- [ ] **Step 3: Verify yarn scripts run (smoke test the help paths)**
+
+Run: `cd client && yarn substrate:adopt 2>&1 | head -5`
+Expected output: `usage: substrate-adopt --from <.jinn-client-dir> --as <op-name> ...` (and exit code 2)
+
+Run: `cd client && yarn substrate:verify 2>&1 | head -5`
+Expected output: `usage: substrate-verify <op-name> [--skip-on-chain]`
+
+Run: `cd client && yarn substrate:copy 2>&1 | head -5`
+Expected output: `usage: substrate-copy <op-name> [<op-name> ...]`
+
+Run: `cd client && yarn substrate:topup 2>&1 | head -5`
+Expected output: `usage: substrate-topup <op-name>`
+
+Run: `cd client && yarn substrate:reap 2>&1 | tail -5`
+Expected output: `{ "reaped": [], "kept": [...] }` (exit 0 if substrate exists; ENOENT-handled if not)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/package.json
+git commit -m "chore(substrate): wire yarn scripts for substrate lifecycle ops"
+```
+
+---
+
+## Task 11: README for substrate scripts
+
+**Files:**
+- Create: `client/scripts/release/README.md`
+
+- [ ] **Step 1: Write the README**
+
+```markdown
+# Substrate scripts
+
+Lifecycle scripts for the test-operator substrate at `~/jinn-dev/operators/`.
+Spec: `docs/superpowers/specs/2026-05-19-release-readiness-and-substrate-design.md`.
+
+## Operations
+
+### substrate-adopt
+
+Copy an existing operator state dir into the gold substrate. One operator at a time.
+
+```bash
+yarn substrate:adopt \
+  --from ~/.jinn-client/ \
+  --as op-a \
+  --role launcher \
+  --shape current \
+  --apiPort 7332
+```
+
+Excludes `engine/`, `*.log`, `jinn.db.bak*`, `config.before*`, `config.json.pre*`, `daemon-*`, `run-*` from the copy. Writes `manifest.json` with identity captured from `earning/earning_state.json`.
+
+### substrate-copy
+
+Per-run workspace copy from gold. Returns a JSON handle with `runId`, `workspaceRoot`, and `opPaths`.
+
+```bash
+yarn substrate:copy op-a op-b
+```
+
+The workspace lives at `~/jinn-dev/workspaces/<run-id>/`. Caller is responsible for teardown (`rm -rf $workspaceRoot`) — or use `reapWorkspaces()` to garbage-collect.
+
+### substrate-verify
+
+Manifest schema check plus on-chain identity verification.
+
+```bash
+yarn substrate:verify op-a
+yarn substrate:verify op-a --skip-on-chain
+```
+
+Exits non-zero on any failure. JSON result on stdout includes `failures`, `warnings`, and `onChain` snapshot.
+
+### substrate-topup
+
+Reports low balances on substrate operators. Does not auto-drip; surfaces gaps for manual top-up via faucet or release-bot wallet.
+
+```bash
+yarn substrate:topup op-a
+```
+
+Targets: 0.005 ETH master, 1.00 USDC safe. Exits non-zero if any below threshold.
+
+### substrate-reap
+
+Garbage-collects workspaces older than 7 days under `~/jinn-dev/workspaces/`.
+
+```bash
+yarn substrate:reap
+```
+
+Safe to run any time. JSON result on stdout shows `reaped` and `kept` workspace names.
+
+## Programmatic API
+
+Each script exports its core function for use from other scripts or skills:
+
+```typescript
+import { adoptOperator } from 'client/scripts/release/substrate-adopt';
+import { copyWorkspace } from 'client/scripts/release/substrate-copy';
+import { verifySubstrate } from 'client/scripts/release/substrate-verify';
+import { checkSubstrateTopup } from 'client/scripts/release/substrate-topup';
+import { reapWorkspaces } from 'client/scripts/release/substrate-reap';
+```
+
+## Manifest schema
+
+See `types.ts` for the Zod schema and `Manifest` TypeScript type.
+
+## Failure modes
+
+| Operation | Failure | Recovery |
+|---|---|---|
+| adopt | source dir missing earning_state.json | fix source state or pick a different source |
+| verify | manifest schema mismatch | re-adopt (substrate may have changed shape) |
+| verify | on-chain agentId doesn't match safeAddress | substrate is stale; investigate |
+| verify | master ETH balance too low | run substrate-topup; fund manually |
+| copy | requested op not in gold | run substrate-adopt for that op first |
+| topup | low balance | fund manually from release-bot wallet |
+| reap | none expected — idempotent | n/a |
+```
+
+Save as `client/scripts/release/README.md`.
+
+- [ ] **Step 2: Verify the file**
+
+Run: `cd client && cat scripts/release/README.md | head -20`
+Expected: README content shown.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/scripts/release/README.md
+git commit -m "docs(substrate): add README for substrate lifecycle scripts"
+```
+
+---
+
+## Task 12: Re-adopt the current on-disk substrate using the new scripts
+
+**Files:**
+- None modified; this is an integration sanity check.
+
+This task validates that the scripts can reproduce the manual adoption we performed during the spec brainstorm. The existing on-disk substrate at `~/jinn-dev/operators/op-{a,b,c-legacy}/` was created manually with python; this task confirms `substrate-adopt.ts` produces equivalent state.
+
+- [ ] **Step 1: Verify the current substrate exists and passes verify**
+
+Run:
+```bash
+cd client
+yarn substrate:verify op-a --skip-on-chain
+yarn substrate:verify op-b --skip-on-chain
+yarn substrate:verify op-c-legacy --skip-on-chain
+```
+
+Expected: all three return `"ok": true` (manifests written during brainstorm should pass schema).
+
+- [ ] **Step 2: Snapshot the current manifests for comparison**
+
+Run:
+```bash
+mkdir -p /tmp/substrate-snapshot-baseline
+cp ~/jinn-dev/operators/op-a/manifest.json /tmp/substrate-snapshot-baseline/op-a.json
+cp ~/jinn-dev/operators/op-b/manifest.json /tmp/substrate-snapshot-baseline/op-b.json
+cp ~/jinn-dev/operators/op-c-legacy/manifest.json /tmp/substrate-snapshot-baseline/op-c-legacy.json
+```
+
+- [ ] **Step 3: Re-adopt op-a via the new script into a tmp substrate root**
+
+Run:
+```bash
+cd client
+TMP_ROOT=$(mktemp -d)
+yarn substrate:adopt \
+  --from ~/.jinn-client/ \
+  --as op-a \
+  --role launcher \
+  --shape current \
+  --apiPort 7332
+# (the above writes to $HOME/jinn-dev/operators/op-a — replacing the manual one;
+#  if you want to keep both, override substrateRoot via env or use the API directly)
+```
+
+For a non-destructive check, use the programmatic API in a one-off script:
+```bash
+cd client
+node -e "
+  require('tsx/cjs');
+  require('./scripts/release/substrate-adopt').adoptOperator({
+    sourceDir: process.env.HOME + '/.jinn-client',
+    opName: 'op-a',
+    role: 'launcher',
+    shape: 'current',
+    apiPort: 7332,
+    substrateRoot: '$TMP_ROOT',
+  }).then(() => console.log('done'));
+"
+```
+
+- [ ] **Step 4: Compare manifests (excluding createdAt timestamp which legitimately differs)**
+
+Run:
+```bash
+jq 'del(.createdAt)' /tmp/substrate-snapshot-baseline/op-a.json > /tmp/baseline-no-ts.json
+jq 'del(.createdAt)' $TMP_ROOT/operators/op-a/manifest.json > /tmp/new-no-ts.json
+diff /tmp/baseline-no-ts.json /tmp/new-no-ts.json
+```
+
+Expected: no diff (or only ordering differences within objects, which are semantically equivalent).
+
+If there's a real diff, investigate which field drifted and fix `substrate-adopt.ts` to match the manual adoption.
+
+- [ ] **Step 5: Tear down the tmp substrate**
+
+```bash
+rm -rf $TMP_ROOT /tmp/substrate-snapshot-baseline /tmp/baseline-no-ts.json /tmp/new-no-ts.json
+```
+
+- [ ] **Step 6: Commit a small fix if needed, otherwise mark task complete**
+
+If a fix was needed, commit it:
+```bash
+git add client/scripts/release/substrate-adopt.ts
+git commit -m "fix(substrate): align substrate-adopt with manual-adoption output"
+```
+
+Otherwise no commit is needed — this task is a validation gate.
+
+---
+
+## Self-review
+
+### Spec coverage
+
+| Spec requirement | Covered by | Status |
+|---|---|---|
+| §2 path layout | Task 2 (paths) | ✓ |
+| §2 manifest schema | Task 1 (types) | ✓ |
+| §2 substrate-adopt | Task 6 | ✓ |
+| §2 substrate-copy | Task 7 | ✓ |
+| §2 substrate-verify | Tasks 4, 5 | ✓ |
+| §2 substrate-topup | Task 8 | ✓ |
+| §2 workspace reaper | Task 9 | ✓ |
+| §7 funding maintenance | Task 8 (surfaces gaps) | ✓ (no auto-drip in v1, as specified) |
+| §7 substrate-snapshot (bootstrap fresh) | deferred per spec | ✓ (intentionally out of scope) |
+
+### Placeholder scan
+
+No TBDs, TODOs, "add appropriate error handling", or "similar to Task N" — each task contains complete code and exact commands.
+
+### Type consistency
+
+Confirmed:
+- `Manifest` type matches across types.ts, substrate-adopt, substrate-verify, substrate-topup, substrate-copy.
+- `verifySubstrate(opName, opts)` signature consistent across Task 4 and Task 5.
+- `WorkspaceHandle` interface defined in Task 7 used as the contract for downstream consumers (release-prep, future plans).
+- `goldPath(opName, substrateRoot?)` signature consistent.
+
+### Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-19-substrate-foundation-plan.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. Uses `superpowers:subagent-driven-development`.
+
+2. **Inline Execution** — Execute tasks in this session using `superpowers:executing-plans`, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/plans/2026-05-19-substrate-foundation-plan.md
+++ b/docs/superpowers/plans/2026-05-19-substrate-foundation-plan.md
@@ -274,7 +274,9 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 
 export function defaultSubstrateRoot(): string {
-  return path.join(os.homedir(), 'jinn-dev');
+  // Use HOME env var first so tests can override (Task 2's tests set process.env.HOME).
+  // `||` not `??` so an empty-string HOME also falls back to os.homedir().
+  return path.join(process.env.HOME || os.homedir(), 'jinn-dev');
 }
 
 export function goldPath(opName: string, substrateRoot: string = defaultSubstrateRoot()): string {
@@ -602,7 +604,20 @@ async function cliMain(): Promise<void> {
   }
   const skipOnChain = process.argv.includes('--skip-on-chain');
   const result = await verifySubstrate(opName, { skipOnChain });
-  console.log(JSON.stringify(result, null, 2));
+  // BigInts in result.onChain (ethBalanceWei, olasBalanceWei) crash JSON.stringify
+  // with `TypeError: Do not know how to serialize a BigInt`. Convert to string for
+  // CLI output. Programmatic callers get the raw BigInts via the verifySubstrate return.
+  const printable = {
+    ...result,
+    onChain: result.onChain
+      ? {
+          ...result.onChain,
+          ethBalanceWei: result.onChain.ethBalanceWei.toString(),
+          olasBalanceWei: result.onChain.olasBalanceWei?.toString() ?? null,
+        }
+      : null,
+  };
+  console.log(JSON.stringify(printable, null, 2));
   process.exit(result.ok ? 0 : 1);
 }
 
@@ -1076,6 +1091,20 @@ export async function adoptOperator(opts: AdoptOptions): Promise<void> {
     throw new Error(`source operator at ${opts.sourceDir} has no earning/earning_state.json`);
   }
   const svc = state.services?.[0];
+  // Throw rather than ?? to a sentinel: silently substituting zeros/fakes when the
+  // source is half-bootstrapped masks real config problems. The resulting manifest
+  // would claim valid identity while pointing at 0x0000... addresses — worse than
+  // failing fast.
+  if (!svc) {
+    throw new Error(
+      `source operator at ${opts.sourceDir} has earning_state.json with no services entry — operator may not have reached the service-registration step yet`,
+    );
+  }
+  if (!cfg || !cfg.rpcUrl) {
+    throw new Error(
+      `source operator at ${opts.sourceDir} has config.json without rpcUrl — cannot derive substrate manifest`,
+    );
+  }
 
   // 5. Build manifest
   const manifest: Manifest = {
@@ -1091,18 +1120,18 @@ export async function adoptOperator(opts: AdoptOptions): Promise<void> {
       fleetAgentId: state.fleet_agent_id ?? null,
       fleetSafeAddress: state.fleet_safe_address ?? null,
       fleetStage: state.fleet_stage ?? null,
-      serviceId: svc?.service_id ?? 0,
-      serviceStep: svc?.step ?? 'unknown',
-      agentEoa: svc?.agent_address ?? '0x0000000000000000000000000000000000000000',
-      safeAddress: svc?.safe_address ?? '0x0000000000000000000000000000000000000000',
-      mechAddress: svc?.mech_address ?? '0x0000000000000000000000000000000000000000',
-      stakingAddress: svc?.staking_address ?? '0x0000000000000000000000000000000000000000',
-      identityRegistry: svc?.identity_registry_address ?? state.fleet_identity_registry ?? '0x0000000000000000000000000000000000000000',
+      serviceId: svc.service_id,
+      serviceStep: svc.step ?? 'unknown',
+      agentEoa: svc.agent_address,
+      safeAddress: svc.safe_address,
+      mechAddress: svc.mech_address ?? '0x0000000000000000000000000000000000000000',
+      stakingAddress: svc.staking_address ?? '0x0000000000000000000000000000000000000000',
+      identityRegistry: svc.identity_registry_address ?? state.fleet_identity_registry ?? '0x0000000000000000000000000000000000000000',
     },
     config: {
       apiPort: opts.apiPort,
-      rpcUrl: cfg?.rpcUrl ?? 'https://base-sepolia.example/unknown',
-      joinedSolverNets: cfg?.joinedSolverNets ? Object.keys(cfg.joinedSolverNets) : [],
+      rpcUrl: cfg.rpcUrl,
+      joinedSolverNets: cfg.joinedSolverNets ? Object.keys(cfg.joinedSolverNets) : [],
     },
   };
 

--- a/docs/superpowers/plans/2026-05-19-testing-jinn-app-multi-op-plan.md
+++ b/docs/superpowers/plans/2026-05-19-testing-jinn-app-multi-op-plan.md
@@ -144,10 +144,18 @@ export function makeHandshakeCollector(timeoutMs: number): HandshakeCollector {
   return {
     feed(chunk: string) {
       buffer += chunk;
-      const url = extractHandshakeUrl(buffer);
-      if (url) {
-        clearTimeout(timer);
-        resolve(url);
+      // Split on newlines so the regex doesn't match a partial URL that's
+      // been buffered across two chunk arrivals (e.g. `http://12` then
+      // `7.0.0.1:7332/...`). Only check complete (newline-terminated) lines.
+      const lines = buffer.split(/\r?\n/);
+      const completeLines = lines.slice(0, -1);
+      for (const line of completeLines) {
+        const url = extractHandshakeUrl(line);
+        if (url) {
+          clearTimeout(timer);
+          resolve(url);
+          return;
+        }
       }
     },
     promise,
@@ -332,10 +340,27 @@ export async function spawnMultiOpDaemons(opts: SpawnMultiOpOptions): Promise<Mu
     }
   }
 
+  // When the test seed config has an unreachable rpcUrl (e.g. a dummy hostname
+  // used in beforeAll setup), JINN_RPC_URL overrides config so the daemon's
+  // RPC preflight can pass. config.ts gives JINN_RPC_URL unconditional precedence
+  // over BASE_RPC_URL and BASE_SEPOLIA_RPC_URL, so the helper must consult any
+  // RPC URL the caller put in extraEnv (e.g. an Anvil fork URL) and surface it
+  // through JINN_RPC_URL — otherwise extraEnv.BASE_RPC_URL would be silently
+  // overridden by the host fallback. Resolution order: extraEnv.JINN_RPC_URL,
+  // extraEnv.BASE_RPC_URL, host JINN_RPC_URL, host BASE_SEPOLIA_RPC_URL, then
+  // the public Tenderly gateway (matches config.ts:986).
+  const fallbackRpcUrl =
+    opts.extraEnv?.['JINN_RPC_URL'] ??
+    opts.extraEnv?.['BASE_RPC_URL'] ??
+    process.env['JINN_RPC_URL'] ??
+    process.env['BASE_SEPOLIA_RPC_URL'] ??
+    'https://base-sepolia.gateway.tenderly.co/75tyLMQuD8EHpXxMwINIKu';
+
   try {
     for (const op of opts.ops) {
       const env: NodeJS.ProcessEnv = {
         ...process.env,
+        JINN_RPC_URL: fallbackRpcUrl,
         ...opts.extraEnv,
         HOME: op.home,
         JINN_API_PORT: op.apiPort.toString(),
@@ -487,7 +512,10 @@ Two flavors:
 1. **Substrate-derived workspaces** — use Plan A's `substrate-copy.ts` to create per-run isolated copies of `op-a` / `op-b` from gold. Best for scenarios that need pre-bootstrapped identity (most T2.x scenarios).
 
    ```typescript
-   import { copyWorkspace } from '@/scripts/release/substrate-copy';
+   // Path relative to the importing file. Plan A's substrate-copy lives at
+   // `client/scripts/release/substrate-copy.ts` (outside `src/`, so the `@/`
+   // alias does NOT reach it — use a relative path).
+   import { copyWorkspace } from '../../scripts/release/substrate-copy';
 
    const handle = await copyWorkspace({ ops: ['op-a', 'op-b'] });
    // handle.opPaths['op-a'] → '/Users/.../jinn-dev/workspaces/<run-id>/op-a/'
@@ -737,7 +765,12 @@ For automated regression coverage of two-operator flows. Tests live under `clien
 import { test, expect, type Page } from '@playwright/test';
 import { spawnMultiOpDaemons, type MultiOpHandle } from '../../helpers/multi-op-daemon';
 import { copyWorkspace } from '../../../scripts/release/substrate-copy';
-import { mockDaemonApi } from '../helpers/mock-daemon-api';   // existing single-op mock helper
+// `mockDaemonApi` is currently a private function inside
+// `client/test/dashboard/spa-config.e2e.test.ts` (line ~130). Before
+// landing multi-op tests, Plan C/D needs to extract it to a shared module —
+// e.g. `client/test/dashboard/helpers/mock-daemon-api.ts` — and accept a
+// `port` argument (the single-op version is hardcoded to 7332).
+import { mockDaemonApi } from '../helpers/mock-daemon-api';
 
 let workspace: Awaited<ReturnType<typeof copyWorkspace>>;
 let daemons: MultiOpHandle;
@@ -930,6 +963,8 @@ Load every SPA route against a mocked daemon API. For each route, assert:
 
 ```typescript
 import { test, expect, type Page } from '@playwright/test';
+// `mockDaemonApi` is currently private inside `client/test/dashboard/spa-config.e2e.test.ts`.
+// Plan C/D should extract it to a shared module before this test can import.
 import { mockDaemonApi } from '../helpers/mock-daemon-api';
 import { ROUTES } from '../../../src/dashboard/spa/src/routes';   // exported list of route paths
 
@@ -1000,7 +1035,7 @@ These belong in T2.x (cross-op) and Tier 3 (real testnet) scenarios.
 ## Dependencies
 
 - The SPA must export a `ROUTES` constant from a single module so this test parameterizes correctly. If `ROUTES` doesn't exist yet, Plan C/D's implementation should add it (small refactor — extract route table from App.tsx).
-- `mockDaemonApi` helper from single-op tests (already exists).
+- `mockDaemonApi` helper — currently a private function inside `client/test/dashboard/spa-config.e2e.test.ts:~130` (single-arg, hardcoded port 7332). Plan C/D should extract it to a shared module (e.g. `client/test/dashboard/helpers/mock-daemon-api.ts`) before the multi-op tests can import it.
 ```
 
 - [ ] **Step 2: Commit**
@@ -1197,14 +1232,25 @@ This is the Anvil-fork mechanical counterpart to Tier 3's real-testnet variant. 
 ## Steps
 
 ```typescript
+import { spawnAnvilFork } from '../_support/chain/anvil';   // base-fork helper
+import { baseSepolia } from 'viem/chains';
+
 const workspace = await copyWorkspace({ ops: ['op-a', 'op-b'] });
-const anvil = await spawnAnvilForkOfBaseSepolia();    // existing helper, returns rpcUrl + cleanup
+const anvil = await spawnAnvilFork({
+  forkUrl: process.env['BASE_SEPOLIA_RPC_URL']!,
+  chain: baseSepolia,
+  silent: true,
+});
 const daemons = await spawnMultiOpDaemons({
   ops: [
     { name: 'op-a', home: workspace.opPaths['op-a'], apiPort: 7732 },
     { name: 'op-b', home: workspace.opPaths['op-b'], apiPort: 7733 },
   ],
-  extraEnv: { BASE_RPC_URL: anvil.rpcUrl, JINN_HARNESS_STUB_INSTANCE: KNOWN_INSTANCE_ID },
+  // JINN_RPC_URL — not BASE_RPC_URL — because config.ts gives JINN_RPC_URL
+  // unconditional precedence; the spawn helper surfaces extraEnv RPC keys
+  // through JINN_RPC_URL so this works either way, but using JINN_RPC_URL
+  // here makes the precedence explicit.
+  extraEnv: { JINN_RPC_URL: anvil.rpcUrl, JINN_HARNESS_STUB_INSTANCE: KNOWN_INSTANCE_ID },
 });
 
 // 1. op-a posts a known-solvable task
@@ -1245,7 +1291,7 @@ expect(opBActivity.verdictsCount).toBeGreaterThan(0);
 
 // 6. Cleanup
 await daemons.teardown();
-await anvil.stop();
+await anvil.teardown();
 await workspace.teardown();
 ```
 
@@ -1293,8 +1339,8 @@ This avoids the ~$0.10 API call per run while exercising the rest of the loop.
 ## Dependencies
 
 - Substrate workspace from Plan A
-- Existing `spawnAnvilForkOfBaseSepolia` helper (from `client/test/e2e/task-first-helpers.ts`)
-- Existing JinnRouter V3 fork-upgrade pattern (same file)
+- Existing `spawnAnvilFork` helper at `client/test/_support/chain/anvil.ts`. Pass `forkUrl: BASE_SEPOLIA_RPC_URL` and `chain: baseSepolia` for a Base Sepolia fork (no convenience wrapper today). Teardown via `harness.teardown()`. The full Task-First fork runner at `client/test/e2e/task-first-helpers.ts` (`runBaseSepoliaForkTaskFirstFullLoop`) shows the JinnRouter V3 fork-upgrade pattern.
+- Existing JinnRouter V3 fork-upgrade pattern (in `client/test/e2e/task-first-helpers.ts`)
 - Stubbed harness registration mechanism — to be added or extended in Plan C/D if not present
 - KNOWN_INSTANCE_ID, KNOWN_REPO, KNOWN_COMMIT, KNOWN_EXPECTED_VERDICT — fixture constants for a known-solvable SWE-rebench instance (existing pattern in `client/test/release/tier-2/fixtures/`)
 
@@ -1350,21 +1396,27 @@ This catches a class of bug invisible to single-op tests and to mocked multi-op 
 
 ```typescript
 import { test, expect } from '@playwright/test';
+import { baseSepolia } from 'viem/chains';
 import { spawnMultiOpDaemons } from '../../helpers/multi-op-daemon';
 import { copyWorkspace } from '../../../scripts/release/substrate-copy';
-import { spawnAnvilForkOfBaseSepolia } from '../../e2e/task-first-helpers';
+import { spawnAnvilFork } from '../../_support/chain/anvil';
 
 let workspace, daemons, anvil, opAUrl, opBUrl;
 
 test.beforeAll(async () => {
   workspace = await copyWorkspace({ ops: ['op-a', 'op-b'] });
-  anvil = await spawnAnvilForkOfBaseSepolia();
+  anvil = await spawnAnvilFork({
+    forkUrl: process.env['BASE_SEPOLIA_RPC_URL']!,
+    chain: baseSepolia,
+    silent: true,
+  });
   daemons = await spawnMultiOpDaemons({
     ops: [
       { name: 'op-a', home: workspace.opPaths['op-a'], apiPort: 7732 },
       { name: 'op-b', home: workspace.opPaths['op-b'], apiPort: 7733 },
     ],
-    extraEnv: { BASE_RPC_URL: anvil.rpcUrl },
+    // JINN_RPC_URL — config.ts gives it unconditional precedence over BASE_RPC_URL.
+    extraEnv: { JINN_RPC_URL: anvil.rpcUrl },
   });
   opAUrl = daemons.daemons['op-a'].handshakeUrl ?? `http://127.0.0.1:7732/`;
   opBUrl = daemons.daemons['op-b'].handshakeUrl ?? `http://127.0.0.1:7733/`;
@@ -1372,7 +1424,7 @@ test.beforeAll(async () => {
 
 test.afterAll(async () => {
   await daemons?.teardown();
-  await anvil?.stop();
+  await anvil?.teardown();
   await workspace?.teardown();
 });
 
@@ -1469,7 +1521,7 @@ test('op-a launches → op-b sees → op-b joins → op-a sees join', async ({ b
 ## Dependencies
 
 - Substrate workspace from Plan A
-- spawnAnvilForkOfBaseSepolia helper (existing)
+- `spawnAnvilFork` helper at `client/test/_support/chain/anvil.ts` (pass `forkUrl: BASE_SEPOLIA_RPC_URL` + `chain: baseSepolia` for a Base Sepolia fork)
 - The SPA Launcher Create wizard's data-testid attributes (`manifest-cid` etc.) — may need to be added to the SPA in Plan C/D if missing
 - The Operator catalog page at `/operator/...` (existing in v0.1.6)
 - The launched-SolverNet dashboard at `/launcher/launched/:id` (existing in v0.1.6)

--- a/docs/superpowers/plans/2026-05-19-testing-jinn-app-multi-op-plan.md
+++ b/docs/superpowers/plans/2026-05-19-testing-jinn-app-multi-op-plan.md
@@ -1,0 +1,1661 @@
+# testing-jinn-app multi-op extension implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the existing `testing-jinn-app` skill at `.claude/skills/testing-jinn-app/SKILL.md` to cover multi-operator scenarios. Ships documentation (skill extension + 7 reference docs) plus minimal helper code (multi-op daemon spawn helper + handshake URL capture) that the scenario implementations in Plans C/D consume. Existing single-op recipes stay unchanged.
+
+**Architecture:** Skill is the library; release-prep is the gate runner; release-readiness is the audit. This plan delivers the library. Reference docs describe scenarios at the level of detail Plans C/D's implementation tasks need; minimal helpers (`multi-op-daemon.ts`, `handshake-url.ts`) live in `client/test/helpers/` so Plans C/D import them. The scenario recipes (`scenario-*.md`) are the contract between Plans B (recipe writer) and Plans C/D (recipe consumer).
+
+**Tech Stack:** Markdown for skill + reference docs. TypeScript + Vitest + `child_process` for the spawn helper. Helpers test against a real daemon spawn using a dedicated tmp HOME (no substrate dependency — uses the existing single-op `HOME=$tmpdir` pattern from the current skill).
+
+**Dependencies:**
+- **Plan A (substrate foundation)** — required for runtime of T2.x scenarios in Plans C/D, but NOT for any task in Plan B. Plan B's helpers operate on arbitrary HOME dirs and don't import substrate scripts. The scenario reference docs *describe* how to use substrate-derived workspaces, but the descriptions are static.
+- **No other plans** — Plan B can be written and executed independently.
+
+---
+
+## File structure
+
+**Source files (all new under `client/test/helpers/`):**
+
+| Path | Responsibility |
+|---|---|
+| `client/test/helpers/handshake-url.ts` | Parse handshake URL from a daemon's stdout stream |
+| `client/test/helpers/multi-op-daemon.ts` | Spawn N concurrent daemons with distinct HOMEs and ports; return handles |
+
+**Test files:**
+
+| Path | Covers |
+|---|---|
+| `client/test/helpers/handshake-url.test.ts` | URL parsing for various stdout shapes |
+| `client/test/helpers/multi-op-daemon.test.ts` | Spawn lifecycle: start, ready, teardown |
+
+**Skill files (under `.claude/skills/testing-jinn-app/`):**
+
+| Path | New / modified | Responsibility |
+|---|---|---|
+| `.claude/skills/testing-jinn-app/SKILL.md` | modified | Add "Multi-operator scenarios" section + extend "Things to watch for" |
+| `.claude/skills/testing-jinn-app/references/multi-op-spawn.md` | new | Bash + TypeScript spawn recipes |
+| `.claude/skills/testing-jinn-app/references/multi-op-chrome-devtools.md` | new | Multi-page chrome-devtools driving pattern |
+| `.claude/skills/testing-jinn-app/references/multi-op-playwright.md` | new | Playwright two-daemon test template |
+| `.claude/skills/testing-jinn-app/references/scenario-spa-route-smoke.md` | new | T1.4 recipe (single-op, route smoke) |
+| `.claude/skills/testing-jinn-app/references/scenario-cross-op-donation.md` | new | T2.1 recipe |
+| `.claude/skills/testing-jinn-app/references/scenario-producer-evaluator.md` | new | T2.2 recipe |
+| `.claude/skills/testing-jinn-app/references/scenario-multi-op-spa-flow.md` | new | T2.3 recipe |
+
+No modifications to `client/package.json` or `playwright.config.ts` in this plan — Plans C/D do those.
+
+---
+
+## Task 1: Handshake URL parser
+
+**Files:**
+- Create: `client/test/helpers/handshake-url.ts`
+- Test: `client/test/helpers/handshake-url.test.ts`
+
+The daemon emits a one-time-use handshake URL on stdout/stderr at startup like `UI handshake URL: http://127.0.0.1:7332/auth?token=abc`. This helper extracts it from a stream of stdout lines.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// client/test/helpers/handshake-url.test.ts
+import { describe, it, expect } from 'vitest';
+import { extractHandshakeUrl, makeHandshakeCollector } from './handshake-url';
+
+describe('extractHandshakeUrl', () => {
+  it('extracts URL from a typical daemon line', () => {
+    const line = '[server] UI handshake URL: http://127.0.0.1:7332/auth/handshake?token=abc123';
+    expect(extractHandshakeUrl(line)).toBe('http://127.0.0.1:7332/auth/handshake?token=abc123');
+  });
+
+  it('returns null on non-matching lines', () => {
+    expect(extractHandshakeUrl('some unrelated log line')).toBeNull();
+    expect(extractHandshakeUrl('')).toBeNull();
+  });
+
+  it('handles whitespace variation between label and URL', () => {
+    const line = 'UI handshake URL:       http://localhost:7332/x';
+    expect(extractHandshakeUrl(line)).toBe('http://localhost:7332/x');
+  });
+
+  it('does not match if URL is missing', () => {
+    expect(extractHandshakeUrl('UI handshake URL:')).toBeNull();
+  });
+});
+
+describe('makeHandshakeCollector', () => {
+  it('resolves when URL appears in a chunk', async () => {
+    const collector = makeHandshakeCollector(5000);
+    collector.feed('startup line\n');
+    collector.feed('UI handshake URL: http://127.0.0.1:7332/auth?t=xyz\n');
+    const url = await collector.promise;
+    expect(url).toBe('http://127.0.0.1:7332/auth?t=xyz');
+  });
+
+  it('handles URL split across two feed calls', async () => {
+    const collector = makeHandshakeCollector(5000);
+    collector.feed('UI handshake URL: http://12');
+    collector.feed('7.0.0.1:7332/auth?t=split\n');
+    const url = await collector.promise;
+    expect(url).toBe('http://127.0.0.1:7332/auth?t=split');
+  });
+
+  it('rejects after timeout if URL never arrives', async () => {
+    const collector = makeHandshakeCollector(50);
+    collector.feed('only unrelated lines\n');
+    await expect(collector.promise).rejects.toThrow(/timed out/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd client && yarn vitest run test/helpers/handshake-url.test.ts`
+Expected: FAIL with `Cannot find module './handshake-url'`
+
+- [ ] **Step 3: Implement handshake-url.ts**
+
+```typescript
+// client/test/helpers/handshake-url.ts
+
+const HANDSHAKE_RE = /UI handshake URL:\s+(\S+)/;
+
+export function extractHandshakeUrl(line: string): string | null {
+  const m = line.match(HANDSHAKE_RE);
+  return m ? m[1] : null;
+}
+
+export interface HandshakeCollector {
+  feed: (chunk: string) => void;
+  promise: Promise<string>;
+}
+
+export function makeHandshakeCollector(timeoutMs: number): HandshakeCollector {
+  let buffer = '';
+  let resolve!: (url: string) => void;
+  let reject!: (err: Error) => void;
+  const promise = new Promise<string>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  const timer = setTimeout(() => {
+    reject(new Error(`handshake URL collector timed out after ${timeoutMs}ms; buffered: ${buffer.slice(0, 200)}`));
+  }, timeoutMs);
+  return {
+    feed(chunk: string) {
+      buffer += chunk;
+      const url = extractHandshakeUrl(buffer);
+      if (url) {
+        clearTimeout(timer);
+        resolve(url);
+      }
+    },
+    promise,
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd client && yarn vitest run test/helpers/handshake-url.test.ts`
+Expected: PASS, 7 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/test/helpers/handshake-url.ts client/test/helpers/handshake-url.test.ts
+git commit -m "test(helpers): add handshake URL parser for daemon spawn helpers"
+```
+
+---
+
+## Task 2: Multi-op daemon spawn helper
+
+**Files:**
+- Create: `client/test/helpers/multi-op-daemon.ts`
+- Test: `client/test/helpers/multi-op-daemon.test.ts`
+
+The helper spawns N daemon processes, each with its own HOME (substrate-derived or fresh tmp) and apiPort. Returns handles that include the handshake URL and a teardown function.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// client/test/helpers/multi-op-daemon.test.ts
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { spawnMultiOpDaemons, type MultiOpHandle } from './multi-op-daemon';
+
+describe('spawnMultiOpDaemons', () => {
+  let tmpRoot: string;
+  let opAHome: string;
+  let opBHome: string;
+
+  beforeAll(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'multi-op-helper-'));
+    opAHome = path.join(tmpRoot, 'op-a');
+    opBHome = path.join(tmpRoot, 'op-b');
+    await fs.mkdir(path.join(opAHome, '.jinn-client'), { recursive: true });
+    await fs.mkdir(path.join(opBHome, '.jinn-client'), { recursive: true });
+    // Seed minimal config so the daemon doesn't error out on missing fields.
+    // (Real tests will use substrate-copy workspaces; this test just exercises the helper.)
+    const minimalCfg = (port: number) => JSON.stringify({
+      network: 'testnet',
+      apiPort: port,
+      rpcUrl: 'https://base-sepolia.example/dummy',
+      pollIntervalMs: 5000,
+    });
+    await fs.writeFile(path.join(opAHome, '.jinn-client', 'config.json'), minimalCfg(7732));
+    await fs.writeFile(path.join(opBHome, '.jinn-client', 'config.json'), minimalCfg(7733));
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('spawns N daemons with distinct ports and returns handles', async () => {
+    // NOTE: this test requires `yarn build` has been run (dist/bin/jinn.js exists).
+    // If dist is missing, it should skip rather than fail.
+    const distPath = path.resolve(__dirname, '..', '..', 'dist', 'bin', 'jinn.js');
+    try { await fs.access(distPath); } catch {
+      // dist not built; skip
+      return;
+    }
+
+    let handle: MultiOpHandle | undefined;
+    try {
+      handle = await spawnMultiOpDaemons({
+        ops: [
+          { name: 'op-a', home: opAHome, apiPort: 7732 },
+          { name: 'op-b', home: opBHome, apiPort: 7733 },
+        ],
+        readyTimeoutMs: 30000,
+      });
+      expect(Object.keys(handle.daemons).sort()).toEqual(['op-a', 'op-b']);
+      // handshakeUrl may be present only if the daemon emits it; bootstrap-incomplete daemons may not.
+      // The contract: each daemon has a pid and an apiPort.
+      expect(handle.daemons['op-a'].apiPort).toBe(7732);
+      expect(handle.daemons['op-b'].apiPort).toBe(7733);
+      expect(handle.daemons['op-a'].pid).toBeGreaterThan(0);
+      expect(handle.daemons['op-b'].pid).toBeGreaterThan(0);
+    } finally {
+      if (handle) await handle.teardown();
+    }
+  }, 60000);
+
+  it('teardown is idempotent', async () => {
+    const distPath = path.resolve(__dirname, '..', '..', 'dist', 'bin', 'jinn.js');
+    try { await fs.access(distPath); } catch { return; }
+
+    const handle = await spawnMultiOpDaemons({
+      ops: [{ name: 'op-a', home: opAHome, apiPort: 7734 }],
+      readyTimeoutMs: 30000,
+    });
+    await handle.teardown();
+    await expect(handle.teardown()).resolves.toBeUndefined();
+  }, 60000);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd client && yarn vitest run test/helpers/multi-op-daemon.test.ts`
+Expected: FAIL with `Cannot find module './multi-op-daemon'`
+
+- [ ] **Step 3: Implement multi-op-daemon.ts**
+
+```typescript
+// client/test/helpers/multi-op-daemon.ts
+import { spawn, type ChildProcess } from 'node:child_process';
+import * as path from 'node:path';
+import { makeHandshakeCollector } from './handshake-url';
+
+export interface OpSpec {
+  name: string;
+  home: string;                 // HOME directory containing .jinn-client/
+  apiPort: number;
+}
+
+export interface DaemonHandle {
+  name: string;
+  pid: number;
+  apiPort: number;
+  handshakeUrl: string | null;  // null if not emitted within readyTimeoutMs
+  process: ChildProcess;
+}
+
+export interface MultiOpHandle {
+  daemons: Record<string, DaemonHandle>;
+  teardown: () => Promise<void>;
+}
+
+export interface SpawnMultiOpOptions {
+  ops: OpSpec[];
+  readyTimeoutMs?: number;      // default 30s
+  jinnBinPath?: string;         // default: resolve from cwd / dist/bin/jinn.js
+  extraEnv?: NodeJS.ProcessEnv;
+}
+
+async function waitForBootstrap(apiPort: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${apiPort}/v1/bootstrap`, { method: 'GET' });
+      if (res.status === 200 || res.status === 401) return;
+    } catch {
+      // not yet
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`daemon on port ${apiPort} did not become reachable within ${timeoutMs}ms`);
+}
+
+export async function spawnMultiOpDaemons(opts: SpawnMultiOpOptions): Promise<MultiOpHandle> {
+  const readyTimeoutMs = opts.readyTimeoutMs ?? 30000;
+  const jinnBin = opts.jinnBinPath ?? path.resolve(process.cwd(), 'dist', 'bin', 'jinn.js');
+
+  const daemons: Record<string, DaemonHandle> = {};
+  const processes: ChildProcess[] = [];
+
+  async function killAll(): Promise<void> {
+    for (const proc of processes) {
+      if (!proc.killed && proc.pid) {
+        try { proc.kill('SIGTERM'); } catch {}
+      }
+    }
+    await new Promise((r) => setTimeout(r, 200));
+    for (const proc of processes) {
+      if (!proc.killed && proc.pid) {
+        try { proc.kill('SIGKILL'); } catch {}
+      }
+    }
+  }
+
+  try {
+    for (const op of opts.ops) {
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        ...opts.extraEnv,
+        HOME: op.home,
+        JINN_API_PORT: op.apiPort.toString(),
+      };
+      const proc = spawn('node', [jinnBin, 'run', '--no-ui'], {
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      processes.push(proc);
+
+      const collector = makeHandshakeCollector(readyTimeoutMs);
+      proc.stdout?.on('data', (chunk) => collector.feed(chunk.toString()));
+      proc.stderr?.on('data', (chunk) => collector.feed(chunk.toString()));
+
+      // Wait for bootstrap to be reachable
+      await waitForBootstrap(op.apiPort, readyTimeoutMs);
+
+      // Best-effort handshake URL capture (may not emit if daemon is in non-running mode)
+      let handshakeUrl: string | null = null;
+      try {
+        handshakeUrl = await Promise.race([
+          collector.promise,
+          new Promise<string>((_, rej) => setTimeout(() => rej(new Error('handshake not emitted')), 2000)),
+        ]);
+      } catch {
+        handshakeUrl = null;
+      }
+
+      daemons[op.name] = {
+        name: op.name,
+        pid: proc.pid ?? -1,
+        apiPort: op.apiPort,
+        handshakeUrl,
+        process: proc,
+      };
+    }
+  } catch (err) {
+    await killAll();
+    throw err;
+  }
+
+  let torn = false;
+  return {
+    daemons,
+    teardown: async () => {
+      if (torn) return;
+      torn = true;
+      await killAll();
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Build the client and run the test**
+
+Run: `cd client && yarn build && yarn vitest run test/helpers/multi-op-daemon.test.ts`
+Expected: PASS, 2 tests passing (or skipping if `dist/bin/jinn.js` somehow missing after build)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/test/helpers/multi-op-daemon.ts client/test/helpers/multi-op-daemon.test.ts
+git commit -m "test(helpers): add multi-op daemon spawn helper"
+```
+
+---
+
+## Task 3: Update testing-jinn-app SKILL.md — multi-operator section header
+
+**Files:**
+- Modify: `.claude/skills/testing-jinn-app/SKILL.md`
+
+Add a new top-level section to the existing SKILL.md, immediately after the "Automated E2E (Playwright)" section. Existing single-op recipes stay unchanged.
+
+- [ ] **Step 1: Read the current SKILL.md to find the insertion point**
+
+Run: `cat .claude/skills/testing-jinn-app/SKILL.md | grep -n "^## " | head -20`
+Expected output: section headers with line numbers. Find the section just before "Quick reference" (the manual smoke + Playwright recipes end before that summary section).
+
+- [ ] **Step 2: Insert the multi-operator section**
+
+Open `.claude/skills/testing-jinn-app/SKILL.md` and insert the following new section AFTER the "Automated E2E (Playwright)" section and BEFORE "Quick reference":
+
+```markdown
+## Multi-operator scenarios
+
+The single-op recipes above (manual smoke, automated E2E) cover testing one operator in isolation. Multi-operator scenarios — where two daemons interact via the chain and via the operator app — require additional infrastructure that this section documents. Reference docs in `references/` cover each pattern in detail.
+
+Spawn pattern: two (or more) daemons run concurrently against distinct HOMEs (substrate-derived workspaces from Plan A's `substrate-copy`, or fresh tmp HOMEs for clean-state E2Es). Each daemon gets a distinct `JINN_API_PORT`. Helpers in `client/test/helpers/multi-op-daemon.ts` wrap the spawn + teardown lifecycle.
+
+Three method-pattern reference docs cover the mechanics:
+
+- [`references/multi-op-spawn.md`](references/multi-op-spawn.md) — bash + TypeScript spawn recipes; port management; teardown.
+- [`references/multi-op-chrome-devtools.md`](references/multi-op-chrome-devtools.md) — multi-page chrome-devtools driving for cross-op manual smoke.
+- [`references/multi-op-playwright.md`](references/multi-op-playwright.md) — Playwright template for two-daemon automated tests.
+
+Four scenario reference docs are the contracts release-prep's gate runner consumes. Each describes one scenario at the level of detail an implementer needs:
+
+- [`references/scenario-spa-route-smoke.md`](references/scenario-spa-route-smoke.md) — T1.4: load every SPA route against a mocked daemon, assert clean.
+- [`references/scenario-cross-op-donation.md`](references/scenario-cross-op-donation.md) — T2.1: op-a produces corpus artifact, op-b consumes via x402.
+- [`references/scenario-producer-evaluator.md`](references/scenario-producer-evaluator.md) — T2.2: op-a solves task on Anvil-fork, op-b evaluates.
+- [`references/scenario-multi-op-spa-flow.md`](references/scenario-multi-op-spa-flow.md) — T2.3: op-a launches SolverNet via SPA, op-b joins via SPA, both observe each other.
+
+### Things to watch for (multi-op specific)
+
+In addition to the single-op concerns listed earlier:
+
+- **Cross-operator visibility lag** — op-b sees op-a's actions only after the indexer has caught up (~2 indexer-poll-intervals). Wait, don't assume instant.
+- **Identity collisions** — spawning two daemons with the same HOME means both fight for the same agentId/Safe/nonce. Always verify *both* apiPort AND source HOME directory are distinct before spawning.
+- **Workspace bleed** — substrate-derived workspaces under `~/jinn-dev/workspaces/` are auto-pruned at 7 days by `substrate-reap`. Don't leave a workspace assumed to be there between test runs; either own its lifecycle or use a fresh one each test.
+- **Substrate staleness** — if `substrate-verify` reports drift, all multi-op scenarios using substrate workspaces will fail in non-obvious ways. Run verify before any multi-op session.
+- **RPC saturation under concurrent load** — substrate ops currently share one Tenderly key (per spec §2). If both daemons hammer the RPC simultaneously, expect HTTP 429. Tracked as `jinn-mono-lrey`; for now, add jittered delays in scenarios where both daemons are RPC-active.
+```
+
+Save the file.
+
+- [ ] **Step 3: Sanity-check the insertion**
+
+Run: `grep -A 2 "## Multi-operator scenarios" .claude/skills/testing-jinn-app/SKILL.md | head -5`
+Expected output: the section header and its intro line.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/testing-jinn-app/SKILL.md
+git commit -m "docs(testing-jinn-app): add multi-operator scenarios section"
+```
+
+---
+
+## Task 4: Reference doc — multi-op-spawn.md
+
+**Files:**
+- Create: `.claude/skills/testing-jinn-app/references/multi-op-spawn.md`
+
+- [ ] **Step 1: Create the reference doc**
+
+Save the following as `.claude/skills/testing-jinn-app/references/multi-op-spawn.md`:
+
+```markdown
+# Multi-op daemon spawn
+
+How to spawn two or more `jinn` daemons concurrently for cross-operator testing. Two recipes — bash for ad-hoc use, TypeScript for automated tests.
+
+## Source of HOMEs
+
+Two flavors:
+
+1. **Substrate-derived workspaces** — use Plan A's `substrate-copy.ts` to create per-run isolated copies of `op-a` / `op-b` from gold. Best for scenarios that need pre-bootstrapped identity (most T2.x scenarios).
+
+   ```typescript
+   import { copyWorkspace } from '@/scripts/release/substrate-copy';
+
+   const handle = await copyWorkspace({ ops: ['op-a', 'op-b'] });
+   // handle.opPaths['op-a'] → '/Users/.../jinn-dev/workspaces/<run-id>/op-a/'
+   // teardown via handle.teardown() at end of test
+   ```
+
+2. **Fresh tmp HOMEs** — for clean-state E2E tests that don't need an existing identity (e.g. fresh-bootstrap scenarios). Each daemon gets its own `HOME=$tmpdir`.
+
+   ```typescript
+   const opAHome = await fs.mkdtemp(path.join(os.tmpdir(), 'fresh-op-a-'));
+   const opBHome = await fs.mkdtemp(path.join(os.tmpdir(), 'fresh-op-b-'));
+   // (Seed minimal config under <home>/.jinn-client/config.json as needed)
+   ```
+
+## Bash recipe (ad-hoc)
+
+```bash
+# Set up substrate workspace
+RUN_ID="$(date -u +%Y-%m-%dT%H-%M-%S)-$RANDOM"
+yarn substrate:copy op-a op-b
+# (parse runId from stdout; or skip and use fixed paths in dev)
+
+# Spawn op-a (apiPort 7332, persistent identity from substrate)
+HOME=~/jinn-dev/workspaces/$RUN_ID/op-a JINN_API_PORT=7332 \
+  node dist/bin/jinn.js run --no-ui > /tmp/op-a.log 2>&1 &
+OP_A_PID=$!
+
+# Spawn op-b (apiPort 7333)
+HOME=~/jinn-dev/workspaces/$RUN_ID/op-b JINN_API_PORT=7333 \
+  node dist/bin/jinn.js run --no-ui > /tmp/op-b.log 2>&1 &
+OP_B_PID=$!
+
+# Wait for both /v1/bootstrap to be reachable
+for port in 7332 7333; do
+  until curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:$port/v1/bootstrap | grep -qE "200|401"; do
+    sleep 0.25
+  done
+done
+
+# Capture handshake URLs from logs
+OP_A_URL="$(grep -m1 'UI handshake URL:' /tmp/op-a.log | sed 's/.*UI handshake URL:\s*//')"
+OP_B_URL="$(grep -m1 'UI handshake URL:' /tmp/op-b.log | sed 's/.*UI handshake URL:\s*//')"
+
+echo "op-a: $OP_A_URL"
+echo "op-b: $OP_B_URL"
+
+# Teardown
+trap "kill $OP_A_PID $OP_B_PID 2>/dev/null; rm -rf ~/jinn-dev/workspaces/$RUN_ID" EXIT
+```
+
+## TypeScript recipe (automated tests)
+
+Use the helper at `client/test/helpers/multi-op-daemon.ts`:
+
+```typescript
+import { spawnMultiOpDaemons, type MultiOpHandle } from '../helpers/multi-op-daemon';
+import { copyWorkspace } from '../../scripts/release/substrate-copy';
+
+let workspace: Awaited<ReturnType<typeof copyWorkspace>>;
+let daemons: MultiOpHandle;
+
+beforeAll(async () => {
+  workspace = await copyWorkspace({ ops: ['op-a', 'op-b'] });
+  daemons = await spawnMultiOpDaemons({
+    ops: [
+      { name: 'op-a', home: workspace.opPaths['op-a'], apiPort: 7732 },
+      { name: 'op-b', home: workspace.opPaths['op-b'], apiPort: 7733 },
+    ],
+    readyTimeoutMs: 30000,
+  });
+});
+
+afterAll(async () => {
+  await daemons.teardown();
+  await workspace.teardown();
+});
+
+it('does cross-op thing', async () => {
+  // daemons.daemons['op-a'].apiPort, .handshakeUrl, etc.
+});
+```
+
+## Port selection
+
+Substrate ops are pre-configured with apiPorts (op-a=7332, op-b=7333, op-c-legacy=7334). For tests that need different ports (e.g. avoiding collision with the daily-driver daemon at 7332), override via the `apiPort` option in the helper. The helper passes it as `JINN_API_PORT` env var; the daemon's config-resolution prefers env over config file.
+
+For parallel test files (separate Vitest workers), pick non-overlapping port ranges (e.g. 7332-7333 for one file, 7732-7733 for another).
+
+## Teardown contract
+
+- `daemons.teardown()` sends SIGTERM to all spawned processes, waits 200ms, then SIGKILL if still alive.
+- `daemons.teardown()` is idempotent — safe to call multiple times.
+- Use a `try { ... } finally { await daemons.teardown(); }` pattern in tests. Don't rely on `afterAll` alone — if `beforeAll` partially succeeded (op-a started, op-b failed), the partial spawn must still be cleaned up.
+
+## Common failure modes
+
+| Failure | Likely cause | Fix |
+|---|---|---|
+| `daemon on port X did not become reachable within Yms` | port collision with another process | check `lsof -i :X` |
+| `daemon on port X did not become reachable within Yms` | misconfigured HOME (config.json absent or malformed) | verify HOME/.jinn-client/config.json exists |
+| handshake URL is null | daemon never reached "running" mode (bootstrap incomplete in HOME) | substrate-verify the HOME; or use substrate-derived HOME |
+| teardown hangs | child process refusing SIGTERM | helper escalates to SIGKILL after 200ms; if test still hangs, increase the wait |
+```
+
+- [ ] **Step 2: Verify file readable**
+
+Run: `head -15 .claude/skills/testing-jinn-app/references/multi-op-spawn.md`
+Expected: first ~15 lines of the doc.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/testing-jinn-app/references/multi-op-spawn.md
+git commit -m "docs(testing-jinn-app): add multi-op-spawn reference"
+```
+
+---
+
+## Task 5: Reference doc — multi-op-chrome-devtools.md
+
+**Files:**
+- Create: `.claude/skills/testing-jinn-app/references/multi-op-chrome-devtools.md`
+
+- [ ] **Step 1: Create the reference doc**
+
+Save the following as `.claude/skills/testing-jinn-app/references/multi-op-chrome-devtools.md`:
+
+```markdown
+# Multi-op chrome-devtools driving
+
+For manual smoke tests where you drive two operator apps side by side. Uses the `chrome-devtools` MCP server's multi-page support.
+
+## Prereqs
+
+- Both daemons spawned (see [multi-op-spawn.md](multi-op-spawn.md)). Capture both handshake URLs.
+- `chrome-devtools` MCP loaded in your session. Verify with `ToolSearch query="chrome devtools navigate"` — if `mcp__chrome-devtools__new_page` and `mcp__chrome-devtools__select_page` don't surface, this MCP isn't loaded and the recipe below won't work; fall back to manual two-browser-window driving.
+
+## Recipe
+
+```typescript
+// 1. Open a page per operator
+const opAPage = await mcp__chrome_devtools__new_page({ url: opAHandshakeUrl });
+const opBPage = await mcp__chrome_devtools__new_page({ url: opBHandshakeUrl });
+
+// 2. Drive op-a — explicitly select before each action
+await mcp__chrome_devtools__select_page({ pageId: opAPage });
+await mcp__chrome_devtools__click({ selector: 'button:has-text("Create SolverNet")' });
+// ... wizard steps ...
+
+// 3. Drive op-b — explicitly select again
+await mcp__chrome_devtools__select_page({ pageId: opBPage });
+await mcp__chrome_devtools__navigate_page({ url: opBHandshakeUrl + '/operator/join' });
+await mcp__chrome_devtools__take_screenshot({});
+
+// 4. Cross-verify: switch back to op-a and check op-a sees op-b's action
+await mcp__chrome_devtools__select_page({ pageId: opAPage });
+await mcp__chrome_devtools__navigate_page({ url: opAHandshakeUrl + '/launcher/launched/<id>' });
+```
+
+## Critical rule: always select before acting
+
+chrome-devtools MCP maintains an "active page" pointer. Every click / type / navigate operates on the currently-selected page. If you fan out across two pages without explicit `select_page` calls, you'll drive whichever happened to be selected last — often the wrong one.
+
+**Pattern:**
+```typescript
+async function driveOnPage(pageId: string, action: () => Promise<void>): Promise<void> {
+  await mcp__chrome_devtools__select_page({ pageId });
+  await action();
+}
+```
+
+Wrap every cross-page operation in this pattern.
+
+## Cross-op visibility lag
+
+When op-a performs an action that op-b should see (e.g. op-a launches a SolverNet, op-b should see it in the catalog), there's a delay equal to:
+
+- One indexer poll interval (~5 sec for the Ponder indexer at default config)
+- Plus one SPA poll interval (~1.5 sec for useQuery defaults)
+
+**Don't assert op-b's view immediately after op-a's action.** Wait at least 10 seconds for indexer + SPA polls. Use `wait_for` with the expected DOM state, not a fixed sleep:
+
+```typescript
+await mcp__chrome_devtools__select_page({ pageId: opBPage });
+await mcp__chrome_devtools__wait_for({
+  text: 'my-new-solvernet',
+  timeout: 30000,                  // generous; indexer can lag
+});
+```
+
+## Screenshot conventions
+
+When reporting a multi-op smoke result, take screenshots of both pages at each critical state, named consistently:
+
+```typescript
+await mcp__chrome_devtools__select_page({ pageId: opAPage });
+await mcp__chrome_devtools__take_screenshot({ name: '01-op-a-after-create' });
+
+await mcp__chrome_devtools__select_page({ pageId: opBPage });
+await mcp__chrome_devtools__take_screenshot({ name: '02-op-b-catalog-shows-new' });
+```
+
+Screenshot pairs at each step make cross-op state comparison readable.
+
+## Common failure modes
+
+| Failure | Likely cause | Fix |
+|---|---|---|
+| Action happens on wrong page | forgot to `select_page` before action | wrap in `driveOnPage` helper |
+| op-b doesn't see op-a's change | not waiting for indexer/SPA poll | use `wait_for` with expected text, not sleep |
+| Stale screenshot | took screenshot before page actually updated | wait for the indicator DOM change first |
+| MCP not loaded | session doesn't have chrome-devtools MCP | check `ToolSearch query="chrome devtools navigate"`; fall back to Playwright recipe |
+```
+
+- [ ] **Step 2: Verify file readable**
+
+Run: `head -10 .claude/skills/testing-jinn-app/references/multi-op-chrome-devtools.md`
+Expected: first ~10 lines of the doc.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/testing-jinn-app/references/multi-op-chrome-devtools.md
+git commit -m "docs(testing-jinn-app): add multi-op chrome-devtools reference"
+```
+
+---
+
+## Task 6: Reference doc — multi-op-playwright.md
+
+**Files:**
+- Create: `.claude/skills/testing-jinn-app/references/multi-op-playwright.md`
+
+- [ ] **Step 1: Create the reference doc**
+
+Save the following as `.claude/skills/testing-jinn-app/references/multi-op-playwright.md`:
+
+```markdown
+# Multi-op Playwright template
+
+For automated regression coverage of two-operator flows. Tests live under `client/test/dashboard/multi-op/`. Pattern below mirrors the existing single-op `client/test/dashboard/spa-config.e2e.test.ts` but with two daemons + two Playwright pages.
+
+## Template
+
+```typescript
+// client/test/dashboard/multi-op/<scenario>.e2e.test.ts
+import { test, expect, type Page } from '@playwright/test';
+import { spawnMultiOpDaemons, type MultiOpHandle } from '../../helpers/multi-op-daemon';
+import { copyWorkspace } from '../../../scripts/release/substrate-copy';
+import { mockDaemonApi } from '../helpers/mock-daemon-api';   // existing single-op mock helper
+
+let workspace: Awaited<ReturnType<typeof copyWorkspace>>;
+let daemons: MultiOpHandle;
+let opAUrl: string;
+let opBUrl: string;
+
+test.beforeAll(async () => {
+  workspace = await copyWorkspace({ ops: ['op-a', 'op-b'] });
+  daemons = await spawnMultiOpDaemons({
+    ops: [
+      { name: 'op-a', home: workspace.opPaths['op-a'], apiPort: 7732 },
+      { name: 'op-b', home: workspace.opPaths['op-b'], apiPort: 7733 },
+    ],
+    readyTimeoutMs: 30000,
+  });
+  opAUrl = daemons.daemons['op-a'].handshakeUrl ?? `http://127.0.0.1:7732/`;
+  opBUrl = daemons.daemons['op-b'].handshakeUrl ?? `http://127.0.0.1:7733/`;
+});
+
+test.afterAll(async () => {
+  await daemons?.teardown();
+  await workspace?.teardown();
+});
+
+test('op-a launches SolverNet → op-b sees it within 30s', async ({ browser }) => {
+  // Create two isolated contexts — separate cookies, separate state per op
+  const opACtx = await browser.newContext();
+  const opBCtx = await browser.newContext();
+  const opAPage = await opACtx.newPage();
+  const opBPage = await opBCtx.newPage();
+
+  // Optional: mock daemon API per page (matches the single-op pattern)
+  await mockDaemonApi(opAPage, { port: 7732 });
+  await mockDaemonApi(opBPage, { port: 7733 });
+
+  await opAPage.goto(opAUrl);
+  await opBPage.goto(opBUrl);
+
+  // Drive op-a (Launcher Create wizard)
+  await opAPage.getByRole('link', { name: /launcher/i }).click();
+  await opAPage.getByRole('button', { name: /create solvernet/i }).click();
+  // ... wizard steps ...
+  await opAPage.getByRole('button', { name: /launch/i }).click();
+  await expect(opAPage.getByText(/launched/i)).toBeVisible({ timeout: 60000 });
+
+  // Verify op-b sees the new SolverNet within 30s of launch
+  await opBPage.goto(opBUrl + '/operator/join');
+  await expect(opBPage.getByText(/new-solvernet-name/i)).toBeVisible({ timeout: 30000 });
+
+  await opACtx.close();
+  await opBCtx.close();
+});
+```
+
+## Two pages, two contexts
+
+Use **separate Playwright `BrowserContext`** instances per operator. Each context has its own cookies, localStorage, and session. If you reuse one context with two pages, the second page's auth state will collide with the first.
+
+```typescript
+const opACtx = await browser.newContext();
+const opAPage = await opACtx.newPage();
+
+const opBCtx = await browser.newContext();
+const opBPage = await opBCtx.newPage();
+```
+
+## Mock vs real daemon
+
+Two modes, choose per scenario:
+
+### Mocked (T1.4 SPA route smoke, T2.3 multi-op SPA flow lite variant)
+
+Each Playwright page gets its own `mockDaemonApi(page, { port })` call. Reuses the existing single-op mock helper. Fast, deterministic, doesn't need real daemons running — but doesn't catch bugs that only surface with real daemon state.
+
+### Real (T2.1, T2.2, T2.3 full variant)
+
+No `mockDaemonApi` call. Pages talk to the real daemons started by `spawnMultiOpDaemons`. Slower, requires substrate, exercises real RPC + indexer integration. Catches real integration bugs.
+
+## Helper conventions
+
+For tests that recur, lift the daemon spawn into a fixture file under `client/test/dashboard/multi-op/fixtures/`. Example:
+
+```typescript
+// fixtures/two-substrate-ops.ts
+import { test as base } from '@playwright/test';
+import { spawnMultiOpDaemons, type MultiOpHandle } from '../../../helpers/multi-op-daemon';
+import { copyWorkspace } from '../../../../scripts/release/substrate-copy';
+
+export const test = base.extend<{ daemons: MultiOpHandle; opAUrl: string; opBUrl: string }>({
+  daemons: async ({}, use) => {
+    const workspace = await copyWorkspace({ ops: ['op-a', 'op-b'] });
+    const daemons = await spawnMultiOpDaemons({
+      ops: [
+        { name: 'op-a', home: workspace.opPaths['op-a'], apiPort: 7732 },
+        { name: 'op-b', home: workspace.opPaths['op-b'], apiPort: 7733 },
+      ],
+    });
+    try {
+      await use(daemons);
+    } finally {
+      await daemons.teardown();
+      await workspace.teardown();
+    }
+  },
+  opAUrl: async ({ daemons }, use) => {
+    await use(daemons.daemons['op-a'].handshakeUrl ?? 'http://127.0.0.1:7732/');
+  },
+  opBUrl: async ({ daemons }, use) => {
+    await use(daemons.daemons['op-b'].handshakeUrl ?? 'http://127.0.0.1:7733/');
+  },
+});
+```
+
+## Common failure modes
+
+| Failure | Likely cause | Fix |
+|---|---|---|
+| op-b sees stale op-a state | indexer hasn't caught up | use `expect(...).toBeVisible({ timeout: 30000 })`, not `await page.waitForSelector(...)` |
+| Auth/cookie collision | reused single context for two operators | always two `browser.newContext()` calls |
+| Daemon spawn timeout | dist/bin/jinn.js missing or stale | `yarn build` before running |
+| Tests pass locally, flake in CI | RPC saturation or test parallelism | run multi-op tests with `workers: 1` for now (see jinn-mono-lrey) |
+| `mockDaemonApi` doesn't intercept | wrong port arg | helper takes port; verify the page's daemon URL matches |
+
+## Running the tests
+
+Single multi-op file:
+```bash
+cd client && yarn build && yarn playwright test --config=playwright.config.ts test/dashboard/multi-op/<scenario>.e2e.test.ts
+```
+
+All multi-op:
+```bash
+cd client && yarn build && yarn playwright test --config=playwright.config.ts test/dashboard/multi-op/
+```
+
+Sequential (avoid RPC saturation):
+```bash
+cd client && yarn playwright test --config=playwright.config.ts --workers=1 test/dashboard/multi-op/
+```
+```
+
+- [ ] **Step 2: Verify file readable**
+
+Run: `head -10 .claude/skills/testing-jinn-app/references/multi-op-playwright.md`
+Expected: first ~10 lines.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/testing-jinn-app/references/multi-op-playwright.md
+git commit -m "docs(testing-jinn-app): add multi-op Playwright template reference"
+```
+
+---
+
+## Task 7: Scenario doc — scenario-spa-route-smoke.md (T1.4)
+
+**Files:**
+- Create: `.claude/skills/testing-jinn-app/references/scenario-spa-route-smoke.md`
+
+- [ ] **Step 1: Create the doc**
+
+Save the following as `.claude/skills/testing-jinn-app/references/scenario-spa-route-smoke.md`:
+
+```markdown
+# Scenario T1.4 — SPA route smoke
+
+**Tier:** 1 (single-op, route-mocked, runs on every push)
+**Wall-clock budget:** 30s
+**Catches:** broken routes, missing endpoint mocks, JS errors introduced by new SPA code, React error boundary firings.
+
+## Goal
+
+Load every SPA route against a mocked daemon API. For each route, assert:
+1. No JS error in `page.on('pageerror', ...)`.
+2. No React error boundary visible (no `[data-error-boundary]` element).
+3. No "endpoint not mocked" console error from missing route intercepts.
+4. The page renders past the initial spinner (some recognizable DOM element appears within 5s).
+
+## Implementation location
+
+`client/test/dashboard/release-prep/spa-route-smoke.e2e.test.ts`
+
+## Inputs
+
+- Routes list: extracted from `client/src/dashboard/spa/src/App.tsx` (the React Router config). The test imports the route table from a single source of truth.
+- Mocked daemon API: reuses the existing `mockDaemonApi(page)` helper from single-op tests (e.g. `client/test/dashboard/spa-config.e2e.test.ts`).
+
+## Setup
+
+```typescript
+import { test, expect, type Page } from '@playwright/test';
+import { mockDaemonApi } from '../helpers/mock-daemon-api';
+import { ROUTES } from '../../../src/dashboard/spa/src/routes';   // exported list of route paths
+
+let consoleErrors: string[] = [];
+let pageErrors: Error[] = [];
+
+test.beforeEach(async ({ page }) => {
+  consoleErrors = [];
+  pageErrors = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+  page.on('pageerror', (err) => pageErrors.push(err));
+  await mockDaemonApi(page);
+});
+
+for (const route of ROUTES) {
+  test(`SPA renders clean at ${route}`, async ({ page }) => {
+    await page.goto(`http://127.0.0.1:7332${route}`);
+    await page.waitForSelector('main, [data-page-loaded], [data-app-shell]', { timeout: 5000 });
+    expect(pageErrors).toHaveLength(0);
+    expect(consoleErrors.filter((e) => !e.includes('expected harmless pattern'))).toHaveLength(0);
+    await expect(page.locator('[data-error-boundary]')).toHaveCount(0);
+  });
+}
+```
+
+## Routes to cover (initial)
+
+Derived from the existing SPA routes; the actual implementation should import a shared `ROUTES` constant rather than hardcoding here:
+
+- `/` (root → overview redirect)
+- `/overview`
+- `/configuration`
+- `/configuration#network`
+- `/configuration#security`
+- `/launcher`
+- `/launcher/create`
+- `/launcher/launched/:placeholder-id`  (with a known mock id)
+- `/operator/join/:placeholder-cid` (with a known mock cid)
+- `/network`
+- `/build`
+
+The test parameterizes over this list; one test per route.
+
+## Failure semantics
+
+- `pageerror` array non-empty → fail with the captured error stack
+- React error boundary visible → fail with the boundary's text content (helps debugging)
+- Console errors non-empty (after filtering known harmless patterns) → fail with all error messages
+- Route doesn't reach the "rendered" sentinel within 5s → fail with "route did not render"
+
+The "known harmless" filter list lives in the test file (e.g. ResizeObserver loop warnings). It starts empty and gets entries added when needed, each with a comment explaining why.
+
+## What this scenario does NOT catch
+
+- Real-daemon behavior (uses mocks)
+- Cross-operator state synchronization
+- Integration bugs between SPA and real daemon API
+- Visual regressions (no screenshot comparison)
+
+These belong in T2.x (cross-op) and Tier 3 (real testnet) scenarios.
+
+## Wall-clock
+
+~30 seconds total: ~3 seconds per route × ~11 routes. Runs in parallel within Playwright's default worker count.
+
+## Dependencies
+
+- The SPA must export a `ROUTES` constant from a single module so this test parameterizes correctly. If `ROUTES` doesn't exist yet, Plan C/D's implementation should add it (small refactor — extract route table from App.tsx).
+- `mockDaemonApi` helper from single-op tests (already exists).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/skills/testing-jinn-app/references/scenario-spa-route-smoke.md
+git commit -m "docs(testing-jinn-app): add T1.4 SPA route smoke scenario reference"
+```
+
+---
+
+## Task 8: Scenario doc — scenario-cross-op-donation.md (T2.1)
+
+**Files:**
+- Create: `.claude/skills/testing-jinn-app/references/scenario-cross-op-donation.md`
+
+- [ ] **Step 1: Create the doc**
+
+Save the following as `.claude/skills/testing-jinn-app/references/scenario-cross-op-donation.md`:
+
+```markdown
+# Scenario T2.1 — Cross-operator donation
+
+**Tier:** 2 (substrate-derived workspace, runs in release-prep)
+**Wall-clock budget:** 5 minutes
+**Catches:** x402 + ERC-8128 handshake regressions, corpus indexer attribution bugs, payment-gated artifact access bugs.
+
+## Goal
+
+op-a produces a corpus artifact, indexer picks it up, op-b queries Discovery API for the artifact, op-b pays x402 USDC, op-b retrieves the artifact, signature + payload validate end-to-end.
+
+This is the gate that should have caught the #310 silent breakage (donation-consumption gate was passing because Op A wasn't producing, so consumption couldn't verify).
+
+## Implementation location
+
+`client/test/release/tier-2/T2.1-cross-op-donation.ts`
+
+## Setup
+
+- substrate workspace via `copyWorkspace({ ops: ['op-a', 'op-b'] })`
+- both daemons spawned with substrate-derived HOMEs, distinct apiPorts (7732, 7733)
+- Anvil-fork RPC (forks Base Sepolia); both daemons' configs point at this fork URL
+- op-a config: `solverNets.<name>.roles = ['solving']` for the chosen SolverNet
+- op-b config: joined to the same SolverNet via `joinedSolverNets[<manifestCid>]`
+
+## Steps
+
+```typescript
+// 1. Spawn daemons + workspace (see multi-op-playwright.md template)
+const workspace = await copyWorkspace({ ops: ['op-a', 'op-b'] });
+const daemons = await spawnMultiOpDaemons({
+  ops: [
+    { name: 'op-a', home: workspace.opPaths['op-a'], apiPort: 7732 },
+    { name: 'op-b', home: workspace.opPaths['op-b'], apiPort: 7733 },
+  ],
+});
+
+// 2. op-a produces a corpus artifact
+//    Either: trigger via daemon API (POST /v1/corpus/produce) or wait for natural production tick
+const opARes = await fetch(`http://127.0.0.1:7732/v1/corpus/produce`, {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ solverNetManifestCid: KNOWN_MANIFEST_CID, payload: SAMPLE_PAYLOAD }),
+});
+const { artifactCid } = await opARes.json();
+
+// 3. Wait for indexer to pick it up (poll Discovery API)
+const indexedCid = await waitFor(async () => {
+  const res = await fetch(`http://127.0.0.1:7733/v1/discovery/corpus?cid=${artifactCid}`);
+  if (!res.ok) return null;
+  const body = await res.json();
+  return body.cid === artifactCid ? body : null;
+}, { timeoutMs: 60000, intervalMs: 2000 });
+expect(indexedCid).toBeTruthy();
+
+// 4. op-b queries Discovery API for the artifact (no payment yet — gated)
+const previewRes = await fetch(`http://127.0.0.1:7733/v1/corpus/${artifactCid}`);
+expect(previewRes.status).toBe(402);   // Payment required
+
+// 5. op-b initiates x402 payment
+const paymentRes = await fetch(`http://127.0.0.1:7733/v1/corpus/${artifactCid}/pay`, {
+  method: 'POST',
+});
+const { paymentTx } = await paymentRes.json();
+expect(paymentTx).toMatch(/^0x[a-fA-F0-9]{64}$/);
+
+// 6. op-b retrieves the artifact (with payment proof)
+const retrievedRes = await fetch(`http://127.0.0.1:7733/v1/corpus/${artifactCid}`, {
+  headers: { 'x-x402-payment': paymentTx },
+});
+expect(retrievedRes.status).toBe(200);
+const retrieved = await retrievedRes.json();
+expect(retrieved.payload).toEqual(SAMPLE_PAYLOAD);
+
+// 7. Verify the ERC-8128 signature on the artifact
+const sigValid = await verifyErc8128Signature(retrieved);
+expect(sigValid).toBe(true);
+
+// 8. Cleanup
+await daemons.teardown();
+await workspace.teardown();
+```
+
+## Assertions (summary)
+
+| # | Assertion | Why |
+|---|---|---|
+| A1 | op-a produces an artifact with a valid CID | producer side works |
+| A2 | indexer attributes the artifact to op-a within 60s | indexer cross-op visibility |
+| A3 | op-b's unpaid query returns 402 | gating works |
+| A4 | op-b's payment tx is mined | x402 payment side works |
+| A5 | op-b's paid retrieval returns 200 + correct payload | gating releases after payment |
+| A6 | ERC-8128 signature on retrieved artifact validates | end-to-end provenance |
+
+## Failure modes
+
+| Failure | Class | Triage |
+|---|---|---|
+| op-a never produces artifact | real-bug | BLOCKING — producer side broken |
+| indexer never sees artifact within 60s | flake-timing first attempt; real-bug on second | retry; if persistent, blocking |
+| op-b's preview returns 200 (no gate) | real-bug | BLOCKING — gate bypass |
+| Payment tx fails | flake-infra or real-bug | retry; if persistent, check x402 contract |
+| Paid retrieval returns 402 | real-bug | BLOCKING — payment not honored |
+| Signature mismatch | real-bug | BLOCKING — provenance broken |
+| RPC saturation mid-test | flake-infra | retry once with jittered delay |
+
+## Wall-clock
+
+~5 minutes:
+- 30s daemon spawn
+- 60s artifact production + indexer
+- 60s payment + retrieval
+- 30s signature verification
+- ~30s setup/teardown overhead
+
+## Dependencies
+
+- Substrate workspace via Plan A's `substrate-copy`
+- Daemon HTTP API endpoints: `/v1/corpus/produce`, `/v1/corpus/:cid`, `/v1/corpus/:cid/pay`, `/v1/discovery/corpus` (these mostly exist in v0.1.6; verify shape at implementation time)
+- Anvil-fork-of-Base-Sepolia RPC (existing pattern in client/test/e2e/)
+- KNOWN_MANIFEST_CID — the substrate-pinned SolverNet manifest that both ops are joined to (read from op-a's manifest.json or config.json)
+- Existing helper: `verifyErc8128Signature` (or implement inline using the existing ERC-8128 module)
+
+## What this scenario does NOT catch
+
+- Real-network token economics (use Tier 3 for that)
+- Indexer behavior under high write load (this scenario is one writer, one reader)
+- Cross-chain donation scenarios
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/skills/testing-jinn-app/references/scenario-cross-op-donation.md
+git commit -m "docs(testing-jinn-app): add T2.1 cross-op donation scenario reference"
+```
+
+---
+
+## Task 9: Scenario doc — scenario-producer-evaluator.md (T2.2)
+
+**Files:**
+- Create: `.claude/skills/testing-jinn-app/references/scenario-producer-evaluator.md`
+
+- [ ] **Step 1: Create the doc**
+
+Save the following as `.claude/skills/testing-jinn-app/references/scenario-producer-evaluator.md`:
+
+```markdown
+# Scenario T2.2 — Producer/evaluator (Anvil-fork)
+
+**Tier:** 2 (substrate-derived workspace, Anvil-fork, runs in release-prep)
+**Wall-clock budget:** 5 minutes
+**Catches:** claim → solve → deliver → evaluate loop regressions; activity-counter increments; verdict pipeline end-to-end mechanically.
+
+## Goal
+
+op-a posts a known-solvable SWE-rebench v2 task, claims it, solves it via a *stubbed harness* (deterministic cached solution), delivers; op-b claims the verdict request, evaluates via real evaluator Docker image, posts verdict. Assert verdictCode matches expected.
+
+This is the Anvil-fork mechanical counterpart to Tier 3's real-testnet variant. Same loop, but stubbed harness (no real OpenRouter spend) and forked chain.
+
+## Implementation location
+
+`client/test/release/tier-2/T2.2-producer-evaluator-fork.ts`
+
+## Setup
+
+- substrate workspace via `copyWorkspace({ ops: ['op-a', 'op-b'] })`
+- Anvil fork of Base Sepolia at the substrate's last-known-good block; impersonate proxy owner; upgrade JinnRouter to V3 inline (existing pattern in `client/test/e2e/task-first-helpers.ts`)
+- op-a config: `roles: ['solving']` for swe-rebench-v2 SolverNet
+- op-b config: `roles: ['evaluating']` for same SolverNet
+- Harness stub: register a fake harness that returns a canned solution for the known-instance task (so no real OpenRouter call happens)
+
+## Steps
+
+```typescript
+const workspace = await copyWorkspace({ ops: ['op-a', 'op-b'] });
+const anvil = await spawnAnvilForkOfBaseSepolia();    // existing helper, returns rpcUrl + cleanup
+const daemons = await spawnMultiOpDaemons({
+  ops: [
+    { name: 'op-a', home: workspace.opPaths['op-a'], apiPort: 7732 },
+    { name: 'op-b', home: workspace.opPaths['op-b'], apiPort: 7733 },
+  ],
+  extraEnv: { BASE_RPC_URL: anvil.rpcUrl, JINN_HARNESS_STUB_INSTANCE: KNOWN_INSTANCE_ID },
+});
+
+// 1. op-a posts a known-solvable task
+const postRes = await fetch(`http://127.0.0.1:7732/v1/tasks`, {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({
+    solverType: 'swe-rebench-v2.v1',
+    spec: { instanceId: KNOWN_INSTANCE_ID, repo: KNOWN_REPO, commit: KNOWN_COMMIT },
+  }),
+});
+const { taskId, requestId } = await postRes.json();
+
+// 2. Wait for op-a to claim + solve + deliver (auto via solving role)
+const delivered = await waitFor(async () => {
+  const res = await fetch(`http://127.0.0.1:7732/v1/tasks/${taskId}`);
+  const body = await res.json();
+  return body.state === 'DELIVERED' ? body : null;
+}, { timeoutMs: 90000, intervalMs: 2000 });
+expect(delivered.deliveryTxHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
+
+// 3. Wait for op-b to claim verdict request + run evaluator + post verdict
+const verdict = await waitFor(async () => {
+  const res = await fetch(`http://127.0.0.1:7733/v1/verdicts?taskId=${taskId}`);
+  const body = await res.json();
+  return body.verdicts?.length > 0 ? body.verdicts[0] : null;
+}, { timeoutMs: 120000, intervalMs: 2000 });
+
+// 4. Assertions
+expect(verdict.verdictCode).toBe(KNOWN_EXPECTED_VERDICT);   // 1 if patch applies + tests pass
+expect(verdict.verdictTxHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
+
+// 5. Activity counters incremented
+const opAActivity = await fetch(`http://127.0.0.1:7732/v1/activity`).then(r => r.json());
+expect(opAActivity.deliveriesCount).toBeGreaterThan(0);
+const opBActivity = await fetch(`http://127.0.0.1:7733/v1/activity`).then(r => r.json());
+expect(opBActivity.verdictsCount).toBeGreaterThan(0);
+
+// 6. Cleanup
+await daemons.teardown();
+await anvil.stop();
+await workspace.teardown();
+```
+
+## Assertions (summary)
+
+| # | Assertion | Why |
+|---|---|---|
+| A1 | Task post returns valid taskId + requestId | task admission works |
+| A2 | op-a delivers within 90s | producer side: claim + stubbed solve + deliver loop closes |
+| A3 | delivery has a valid tx hash | on-chain delivery succeeded |
+| A4 | op-b posts verdict within 120s of delivery | evaluator side: claim + eval + verdict loop closes |
+| A5 | verdictCode matches KNOWN_EXPECTED_VERDICT | substrate recheck + scoring is correct |
+| A6 | op-a deliveriesCount incremented | activity-counter accounting works |
+| A7 | op-b verdictsCount incremented | activity-counter accounting works |
+
+## Stubbed harness
+
+Activated via `JINN_HARNESS_STUB_INSTANCE=<instance-id>` env var. The stub:
+- Pattern-matches on instance ID; only stubs the one we're testing.
+- Returns a canned patch from `client/test/release/tier-2/fixtures/<instance-id>.patch`.
+- Logs that it stubbed (so a real-harness-still-invoked regression would show absent stub logs).
+
+This avoids the ~$0.10 API call per run while exercising the rest of the loop.
+
+## Failure modes
+
+| Failure | Class | Triage |
+|---|---|---|
+| Task post returns 4xx | real-bug | BLOCKING — admission gate broken |
+| op-a never delivers within 90s | could be: harness stub not picked up; daemon misconfig; chain stall | inspect logs; flake on first, real-bug on retry |
+| Delivery tx revert | real-bug | BLOCKING — JinnRouter regression |
+| op-b never picks up verdict request | real-bug | BLOCKING — evaluator role inactive |
+| Evaluator Docker fails to run | flake-infra (Docker daemon) or real-bug (image broken) | check `docker ps`; retry |
+| verdictCode mismatches expected | real-bug | BLOCKING — substrate/scoring regression |
+| Activity counter not incremented | real-bug | BLOCKING — accounting regression |
+
+## Wall-clock
+
+~5 minutes:
+- 30s daemon spawn + Anvil fork
+- 90s producer loop
+- 120s evaluator loop
+- 30s setup/teardown
+
+## Dependencies
+
+- Substrate workspace from Plan A
+- Existing `spawnAnvilForkOfBaseSepolia` helper (from `client/test/e2e/task-first-helpers.ts`)
+- Existing JinnRouter V3 fork-upgrade pattern (same file)
+- Stubbed harness registration mechanism — to be added or extended in Plan C/D if not present
+- KNOWN_INSTANCE_ID, KNOWN_REPO, KNOWN_COMMIT, KNOWN_EXPECTED_VERDICT — fixture constants for a known-solvable SWE-rebench instance (existing pattern in `client/test/release/tier-2/fixtures/`)
+
+## What this scenario does NOT catch
+
+- Real OpenRouter API behavior (Tier 3 covers that)
+- Real RPC behavior under load (this uses Anvil; Tier 3 uses real testnet)
+- Cross-chain verdict flows
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/skills/testing-jinn-app/references/scenario-producer-evaluator.md
+git commit -m "docs(testing-jinn-app): add T2.2 producer/evaluator Anvil-fork scenario reference"
+```
+
+---
+
+## Task 10: Scenario doc — scenario-multi-op-spa-flow.md (T2.3)
+
+**Files:**
+- Create: `.claude/skills/testing-jinn-app/references/scenario-multi-op-spa-flow.md`
+
+- [ ] **Step 1: Create the doc**
+
+Save the following as `.claude/skills/testing-jinn-app/references/scenario-multi-op-spa-flow.md`:
+
+```markdown
+# Scenario T2.3 — Multi-op SPA flow
+
+**Tier:** 2 (substrate-derived workspace, Anvil-fork, runs in release-prep)
+**Wall-clock budget:** 5 minutes
+**Catches:** cross-op UI flows that pass with mocks but break with real daemons; SPA-side state synchronization; Launcher → Operator catalog visibility.
+
+## Goal
+
+op-a launches a SolverNet via the SPA Launcher Create wizard. op-b sees it appear in the Operator catalog. op-b joins via the SPA. op-a's launched-SolverNet dashboard shows op-b's join.
+
+This catches a class of bug invisible to single-op tests and to mocked multi-op tests: real-daemon state propagation through the SPA.
+
+## Implementation location
+
+`client/test/dashboard/multi-op/launcher-join-flow.e2e.test.ts`
+
+## Setup
+
+- substrate workspace via `copyWorkspace({ ops: ['op-a', 'op-b'] })`
+- both daemons spawned via `spawnMultiOpDaemons` against Anvil-fork RPC
+- Playwright with two contexts (one per operator) — see [multi-op-playwright.md](multi-op-playwright.md)
+
+## Steps
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { spawnMultiOpDaemons } from '../../helpers/multi-op-daemon';
+import { copyWorkspace } from '../../../scripts/release/substrate-copy';
+import { spawnAnvilForkOfBaseSepolia } from '../../e2e/task-first-helpers';
+
+let workspace, daemons, anvil, opAUrl, opBUrl;
+
+test.beforeAll(async () => {
+  workspace = await copyWorkspace({ ops: ['op-a', 'op-b'] });
+  anvil = await spawnAnvilForkOfBaseSepolia();
+  daemons = await spawnMultiOpDaemons({
+    ops: [
+      { name: 'op-a', home: workspace.opPaths['op-a'], apiPort: 7732 },
+      { name: 'op-b', home: workspace.opPaths['op-b'], apiPort: 7733 },
+    ],
+    extraEnv: { BASE_RPC_URL: anvil.rpcUrl },
+  });
+  opAUrl = daemons.daemons['op-a'].handshakeUrl ?? `http://127.0.0.1:7732/`;
+  opBUrl = daemons.daemons['op-b'].handshakeUrl ?? `http://127.0.0.1:7733/`;
+});
+
+test.afterAll(async () => {
+  await daemons?.teardown();
+  await anvil?.stop();
+  await workspace?.teardown();
+});
+
+test('op-a launches → op-b sees → op-b joins → op-a sees join', async ({ browser }) => {
+  const opACtx = await browser.newContext();
+  const opBCtx = await browser.newContext();
+  const opAPage = await opACtx.newPage();
+  const opBPage = await opBCtx.newPage();
+
+  // === op-a: Launcher Create wizard ===
+  await opAPage.goto(opAUrl);
+  await opAPage.getByRole('link', { name: /launcher/i }).click();
+  await opAPage.getByRole('button', { name: /create solvernet/i }).click();
+
+  // Step 1: Define
+  const solverNetName = `t23-test-${Date.now()}`;
+  await opAPage.getByLabel(/name/i).fill(solverNetName);
+  await opAPage.getByLabel(/description/i).fill('T2.3 e2e test SolverNet');
+  await opAPage.getByRole('button', { name: /next/i }).click();
+
+  // Step 2: Review Contract
+  await opAPage.getByRole('button', { name: /next/i }).click();
+
+  // Step 3: Configure Generator
+  await opAPage.getByLabel(/cadence/i).fill('60000');   // 60s
+  await opAPage.getByRole('button', { name: /next/i }).click();
+
+  // Step 4: Configure Pricing
+  await opAPage.getByLabel(/price/i).fill('100');
+  await opAPage.getByRole('button', { name: /next/i }).click();
+
+  // Step 5: Review and Launch
+  await opAPage.getByRole('button', { name: /launch/i }).click();
+
+  // Wait for launch state machine to reach 'launched'
+  await expect(opAPage.getByText(/launched/i)).toBeVisible({ timeout: 120000 });
+  const manifestCid = await opAPage.getByTestId('manifest-cid').textContent();
+  expect(manifestCid).toMatch(/^bafkrei/);
+
+  // === op-b: Operator catalog sees op-a's SolverNet ===
+  await opBPage.goto(opBUrl);
+  await opBPage.getByRole('link', { name: /operator/i }).click();
+  await opBPage.getByRole('button', { name: /browse catalog/i }).click();
+  await expect(opBPage.getByText(solverNetName)).toBeVisible({ timeout: 30000 });
+
+  // === op-b joins via SPA ===
+  await opBPage.getByText(solverNetName).click();
+  await opBPage.getByRole('button', { name: /join/i }).click();
+  // Restart banner should appear (operator.join writes config; daemon doesn't hot-reload SolverNet config)
+  await expect(opBPage.getByText(/restart required/i)).toBeVisible({ timeout: 10000 });
+
+  // === op-a's launched dashboard reflects op-b's join ===
+  await opAPage.goto(opAUrl + '/launcher/launched');
+  await opAPage.getByText(solverNetName).click();
+  // Operator join is on-chain; SPA should poll and reflect within 30s
+  await expect(opAPage.getByText(/1 operator joined/i)).toBeVisible({ timeout: 30000 });
+
+  await opACtx.close();
+  await opBCtx.close();
+});
+```
+
+## Assertions (summary)
+
+| # | Assertion | Why |
+|---|---|---|
+| A1 | op-a wizard launch reaches `launched` state within 120s | Launcher state machine end-to-end |
+| A2 | manifest CID matches `bafkrei...` shape | pinning + on-chain registry write succeeded |
+| A3 | op-b's catalog shows the new SolverNet within 30s | global registry indexing works |
+| A4 | op-b's join writes operator-side config | operator.join RPC + restart banner |
+| A5 | op-a's launched dashboard shows "1 operator joined" within 30s | cross-op SPA polling correctness |
+
+## Failure modes
+
+| Failure | Class | Triage |
+|---|---|---|
+| Wizard wizard step doesn't advance | real-bug | BLOCKING — wizard UI regression |
+| Launch state machine times out before `launched` | could be: pinning hang, broadcast fail, indexer fail | inspect launch-progress record; flake on first |
+| op-b's catalog doesn't show within 30s | indexer slow OR catalog query broken | check Discovery API directly; if working, SPA-side bug |
+| op-b's join doesn't write config | real-bug | BLOCKING — operator.join broken |
+| Restart banner missing | real-bug | BLOCKING — restart semantics regression |
+| op-a's "1 operator joined" never appears | could be: on-chain operator-join missed, indexer lag, SPA polling broken | check on-chain first, then indexer, then SPA |
+
+## Wall-clock
+
+~5 minutes:
+- 30s daemon spawn + Anvil fork
+- 120s op-a launch
+- 30s op-b catalog lookup
+- 60s op-b join + restart banner
+- 30s op-a sees join
+- 30s setup/teardown
+
+## Dependencies
+
+- Substrate workspace from Plan A
+- spawnAnvilForkOfBaseSepolia helper (existing)
+- The SPA Launcher Create wizard's data-testid attributes (`manifest-cid` etc.) — may need to be added to the SPA in Plan C/D if missing
+- The Operator catalog page at `/operator/...` (existing in v0.1.6)
+- The launched-SolverNet dashboard at `/launcher/launched/:id` (existing in v0.1.6)
+
+## What this scenario does NOT catch
+
+- UX paper cuts (Tier 3 manual walkthrough covers these)
+- Real-network economics
+- Visual regressions
+- Operator's actual claim/solve flow (T2.2 covers that)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/skills/testing-jinn-app/references/scenario-multi-op-spa-flow.md
+git commit -m "docs(testing-jinn-app): add T2.3 multi-op SPA flow scenario reference"
+```
+
+---
+
+## Task 11: Final SKILL.md polish — Quick reference table update
+
+**Files:**
+- Modify: `.claude/skills/testing-jinn-app/SKILL.md`
+
+The existing skill has a "Quick reference" table near the bottom. Extend it with multi-op entries.
+
+- [ ] **Step 1: Read the current Quick reference table**
+
+Run: `awk '/## Quick reference/,/## Common mistakes/' .claude/skills/testing-jinn-app/SKILL.md`
+Expected output: the table.
+
+- [ ] **Step 2: Extend the table**
+
+Open `.claude/skills/testing-jinn-app/SKILL.md`. Find the existing Quick reference table:
+
+```markdown
+| Goal | Approach |
+|------|----------|
+| Spot a UX/layout bug | Manual + chrome-devtools, take screenshots |
+| Reproduce a reported issue | Manual + chrome-devtools, follow user's exact path |
+| Add regression coverage | Playwright E2E with `page.route` mocks |
+| Verify hash deep-links | Navigate to `/configuration#network` etc. |
+| Test against real chain state | Reuse a bootstrapped HOME, no mocks |
+| Test pure SPA wiring | Fresh HOME + mock all `/v1/*` endpoints |
+```
+
+Add these rows below the existing ones (before the next section):
+
+```markdown
+| Spot a cross-op visibility bug | Multi-op chrome-devtools — drive two pages, [`references/multi-op-chrome-devtools.md`](references/multi-op-chrome-devtools.md) |
+| Add cross-op regression coverage | Multi-op Playwright — [`references/multi-op-playwright.md`](references/multi-op-playwright.md) |
+| Test SPA route surface (T1.4) | [`references/scenario-spa-route-smoke.md`](references/scenario-spa-route-smoke.md) |
+| Test cross-op donation (T2.1) | [`references/scenario-cross-op-donation.md`](references/scenario-cross-op-donation.md) |
+| Test producer/evaluator on Anvil-fork (T2.2) | [`references/scenario-producer-evaluator.md`](references/scenario-producer-evaluator.md) |
+| Test multi-op SPA flow (T2.3) | [`references/scenario-multi-op-spa-flow.md`](references/scenario-multi-op-spa-flow.md) |
+```
+
+Save the file.
+
+- [ ] **Step 3: Sanity check**
+
+Run: `grep -c "T2\." .claude/skills/testing-jinn-app/SKILL.md`
+Expected: at least 5 (the new table rows + the references section).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/testing-jinn-app/SKILL.md
+git commit -m "docs(testing-jinn-app): extend Quick reference table with multi-op scenarios"
+```
+
+---
+
+## Task 12: README cross-reference + final verification
+
+**Files:**
+- None modified. This task is a final verification gate.
+
+- [ ] **Step 1: Verify all reference docs exist**
+
+Run:
+```bash
+ls .claude/skills/testing-jinn-app/references/
+```
+
+Expected output (alphabetical):
+```
+multi-op-chrome-devtools.md
+multi-op-playwright.md
+multi-op-spawn.md
+scenario-cross-op-donation.md
+scenario-multi-op-spa-flow.md
+scenario-producer-evaluator.md
+scenario-spa-route-smoke.md
+```
+
+(7 files)
+
+- [ ] **Step 2: Verify SKILL.md has the multi-op section**
+
+Run: `grep -c "Multi-operator scenarios" .claude/skills/testing-jinn-app/SKILL.md`
+Expected: at least 1 occurrence.
+
+- [ ] **Step 3: Verify helper files exist with tests**
+
+Run:
+```bash
+ls client/test/helpers/multi-op-daemon.ts client/test/helpers/multi-op-daemon.test.ts client/test/helpers/handshake-url.ts client/test/helpers/handshake-url.test.ts
+```
+
+Expected: all four files present.
+
+- [ ] **Step 4: Run all helper tests**
+
+Run: `cd client && yarn vitest run test/helpers/handshake-url.test.ts test/helpers/multi-op-daemon.test.ts`
+Expected: all tests pass (multi-op-daemon tests may auto-skip if dist is missing — that's fine for this verification step).
+
+- [ ] **Step 5: Verify cross-references in SKILL.md actually resolve**
+
+Run:
+```bash
+grep -oE 'references/[a-z-]+\.md' .claude/skills/testing-jinn-app/SKILL.md | sort -u | while read ref; do
+  if [ -f ".claude/skills/testing-jinn-app/$ref" ]; then
+    echo "OK   $ref"
+  else
+    echo "MISS $ref"
+  fi
+done
+```
+
+Expected: every line `OK <ref>`, no `MISS`.
+
+- [ ] **Step 6: Final commit (no-op if nothing to add)**
+
+If any verification step revealed a missing/broken reference, fix inline and commit. Otherwise this task is a validation gate with no commit required.
+
+---
+
+## Self-review
+
+### Spec coverage
+
+| Spec requirement | Covered by | Status |
+|---|---|---|
+| §5 SKILL.md multi-op section | Task 3 + Task 11 | ✓ |
+| §5 multi-op-spawn reference | Task 4 | ✓ |
+| §5 multi-op-chrome-devtools reference | Task 5 | ✓ |
+| §5 multi-op-playwright reference | Task 6 | ✓ |
+| §5 scenario-spa-route-smoke (T1.4) | Task 7 | ✓ |
+| §5 scenario-cross-op-donation (T2.1) | Task 8 | ✓ |
+| §5 scenario-producer-evaluator (T2.2) | Task 9 | ✓ |
+| §5 scenario-multi-op-spa-flow (T2.3) | Task 10 | ✓ |
+| §5 "Things to watch for" multi-op entries | Task 3 (embedded in SKILL.md section) | ✓ |
+| §5 minimal helper code (handshake URL + multi-op-daemon) | Tasks 1, 2 | ✓ |
+
+### Placeholder scan
+
+No "TBD" / "TODO" / "fill in details" in any task. Each task contains complete file content or complete code blocks. References to "Plan A's substrate-copy" and "Plan C/D's implementation" are intentional cross-plan references, not placeholders — the imports resolve once Plan A lands; the scenario recipes are intentionally consumed by Plans C/D.
+
+### Type consistency
+
+- `MultiOpHandle`, `DaemonHandle`, `OpSpec`, `SpawnMultiOpOptions` signatures consistent between Task 2 implementation and Task 6 multi-op-playwright reference doc.
+- `extractHandshakeUrl`, `makeHandshakeCollector` API consistent between Task 1 implementation and Task 2 consumer.
+- `copyWorkspace` reference (from Plan A) consistent across Tasks 6, 8, 9, 10 — signature matches Plan A's substrate-copy.
+
+### Cross-plan contract check
+
+This plan promises Plans C/D the following inputs:
+- `client/test/helpers/multi-op-daemon.ts` exports `spawnMultiOpDaemons(opts): Promise<MultiOpHandle>` (Task 2 delivers)
+- `client/test/helpers/handshake-url.ts` exports `extractHandshakeUrl`, `makeHandshakeCollector` (Task 1 delivers)
+- Seven reference docs at known paths (Tasks 3-10 deliver)
+
+Plans C/D's tasks should import these by exact path and consume the reference docs by reading them as authoritative scenario specs.
+
+### Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-19-testing-jinn-app-multi-op-plan.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven (recommended)** — Dispatch a fresh subagent per task, review between tasks. Uses `superpowers:subagent-driven-development`. This plan is mostly doc-writing; subagent dispatch is fast and parallelizes well.
+
+2. **Inline Execution** — Execute tasks in this session using `superpowers:executing-plans`, batch execution with checkpoints.
+
+Plan B has no runtime dependency on Plan A (the imports resolve once Plan A lands; the writing can happen in parallel). Plan A is currently being implemented by a separate background `claude` session — Plan B can be implemented in parallel by a different session, or sequentially after Plan A lands.
+
+Which approach?

--- a/docs/superpowers/plans/2026-05-19-tier-1-and-release-prep-plan.md
+++ b/docs/superpowers/plans/2026-05-19-tier-1-and-release-prep-plan.md
@@ -23,9 +23,12 @@
 |---|---|
 | `client/scripts/release/scenario-types.ts` | Shared `ScenarioVerdict`, `FailClass`, `ScenarioOptions` types |
 | `client/scripts/release/run-tier-1.ts` | Orchestrator: run T1.1–T1.4 in parallel, emit verdicts + marker |
-| `client/test/release/tier-1/T1.1-bootstrap-fresh-anvil.ts` | T1.1 callable + Vitest wrapper |
-| `client/test/release/tier-1/T1.2-harness-readiness-contract.ts` | T1.2 callable + Vitest wrapper |
-| `client/test/release/tier-1/T1.3-indexer-round-trip.ts` | T1.3 callable + Vitest wrapper |
+| `client/test/release/tier-1/T1.1-bootstrap-fresh-anvil.ts` | T1.1 callable (importable by the orchestrator without invoking Vitest) |
+| `client/test/release/tier-1/T1.1-bootstrap-fresh-anvil.test.ts` | T1.1 Vitest wrapper — imports the callable, asserts verdict shape |
+| `client/test/release/tier-1/T1.2-harness-readiness-contract.ts` | T1.2 callable |
+| `client/test/release/tier-1/T1.2-harness-readiness-contract.test.ts` | T1.2 Vitest wrapper |
+| `client/test/release/tier-1/T1.3-indexer-round-trip.ts` | T1.3 callable |
+| `client/test/release/tier-1/T1.3-indexer-round-trip.test.ts` | T1.3 Vitest wrapper |
 | `client/test/dashboard/release-prep/spa-route-smoke.e2e.test.ts` | T1.4 Playwright test |
 
 **New refactor outputs:**
@@ -420,8 +423,10 @@ git commit -m "feat(release): add ScenarioVerdict types + failure classifier"
 ## Task 4: T1.1 — bootstrap-fresh-anvil
 
 **Files:**
-- Create: `client/test/release/tier-1/T1.1-bootstrap-fresh-anvil.ts`
-- Test: included inline (Vitest in same file)
+- Create: `client/test/release/tier-1/T1.1-bootstrap-fresh-anvil.ts` (callable export only — no `vitest` imports)
+- Create: `client/test/release/tier-1/T1.1-bootstrap-fresh-anvil.test.ts` (Vitest wrapper that imports the callable)
+
+**NOTE (added 2026-05-19 from PR #347 execution):** Plan C's original task put the callable and the Vitest `describe` block in the same file. The orchestrator imports the callable; if the callable's file has top-level `describe`/`it` from `vitest`, those imports fire on every orchestrator run and crash outside a Vitest test context. Split into two files: the `.ts` file exports `runT11BootstrapFreshAnvil` only; the `.test.ts` file imports it and wraps with Vitest. The code below shows the original single-file shape — when executing, place the `runT11...` function (and its supporting imports) in `T1.1-bootstrap-fresh-anvil.ts`, and the `describe(...)` block (plus its `import { describe, it, expect } from 'vitest'`) in `T1.1-bootstrap-fresh-anvil.test.ts`. Same pattern applies to Tasks 5 and 6.
 
 **What this scenario does:** Spawn an Anvil fork of Base Sepolia, generate a fresh master EOA, fund it, run the bootstrap state machine through all 11 phases, assert phase=`complete`. Cleans up Anvil + tmpdir on exit.
 
@@ -586,7 +591,10 @@ git commit -m "feat(release): add T1.1 bootstrap-fresh-anvil scenario"
 ## Task 5: T1.2 — harness-readiness-contract
 
 **Files:**
-- Create: `client/test/release/tier-1/T1.2-harness-readiness-contract.ts`
+- Create: `client/test/release/tier-1/T1.2-harness-readiness-contract.ts` (callable export only)
+- Create: `client/test/release/tier-1/T1.2-harness-readiness-contract.test.ts` (Vitest wrapper)
+
+(See Task 4's NOTE about the file split. Apply the same split here.)
 
 **What this scenario does:** Spawn a fresh-HOME daemon (no bootstrap needed — daemon can run with a `mode: 'setup'` payload). Query `/v1/harnesses/readiness` and `/v1/harnesses/:name/readiness` for each known harness (`claude-code-learner`, `codex-code-learner`, `hermes-agent`). Assert each response has the expected shape (`{ name, ready: boolean, requirements: [...], reasons: [...] }`).
 
@@ -726,7 +734,12 @@ git commit -m "feat(release): add T1.2 harness-readiness-contract scenario"
 ## Task 6: T1.3 — indexer-round-trip
 
 **Files:**
-- Create: `client/test/release/tier-1/T1.3-indexer-round-trip.ts`
+- Create: `client/test/release/tier-1/T1.3-indexer-round-trip.ts` (callable export only)
+- Create: `client/test/release/tier-1/T1.3-indexer-round-trip.test.ts` (Vitest wrapper)
+
+(See Task 4's NOTE about the file split. Apply the same split here.)
+
+**Update from PR #347 execution:** the executing session marked T1.3 as `skip` because the Ponder spawn helper didn't exist yet. The session filed **GitHub issue #341** to track the Ponder helper. Plan D's Task 2 builds the helper, so the skip will lift when Plan D lands.
 
 **What this scenario does:** Spawn a local Ponder indexer + a daemon configured to use it. Post a task on Anvil fork. Query the Discovery API (`/v1/discovery/tasks` or equivalent). Assert the posted task appears with the correct schema.
 

--- a/docs/superpowers/plans/2026-05-19-tier-1-and-release-prep-plan.md
+++ b/docs/superpowers/plans/2026-05-19-tier-1-and-release-prep-plan.md
@@ -1,0 +1,1531 @@
+# Tier 1 + release-prep skill implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the mechanical-floor gate layer: four Tier 1 scenario implementations (T1.1–T1.4), an orchestrator that runs them in parallel and emits a structured verdict, the `release-prep` skill that documents how to invoke them, and the CI workflow migration that replaces today's brittle operator-gate step with the new Tier 1 step. Tier 2 scenarios stay as documented contracts (in Plan B's reference docs); their implementations land in Plan D.
+
+**Architecture:** Each scenario is a callable async function exported from `client/test/release/tier-1/<id>.ts` with a defined `ScenarioVerdict` return shape. The runner at `client/scripts/release/run-tier-1.ts` imports all four scenarios, runs them in parallel via `Promise.allSettled`, classifies failures, and prints a structured JSON verdict + a marker block. The `release-prep` skill SKILL.md describes how release-readiness should invoke it. CI workflow adds a `yarn release:tier-1` step that replaces `Release gate — operator-gate`.
+
+**Tech Stack:** TypeScript, Vitest (for testing scenarios in isolation), Playwright (T1.4 only), viem for chain interaction, child_process for daemon spawning. Reuses existing patterns from `client/scripts/staking-validate.ts`, `client/test/e2e/task-first-helpers.ts`, and `client/test/dashboard/spa-config.e2e.test.ts`.
+
+**Dependencies:**
+- **Plan B** — required for `multi-op-daemon.ts` (T1.x uses it for single-op spawn too), `handshake-url.ts`, and the `scenario-spa-route-smoke.md` reference doc that defines T1.4's contract.
+- **Plan A** — NOT required for runtime (Tier 1 doesn't use substrate). Plan C can land before A merges.
+- The existing fork-helper at `client/test/_support/chain/anvil.ts` (`spawnAnvilFork`) — verified to exist by Plan B's fold-back commit.
+
+---
+
+## File structure
+
+**New source files:**
+
+| Path | Responsibility |
+|---|---|
+| `client/scripts/release/scenario-types.ts` | Shared `ScenarioVerdict`, `FailClass`, `ScenarioOptions` types |
+| `client/scripts/release/run-tier-1.ts` | Orchestrator: run T1.1–T1.4 in parallel, emit verdicts + marker |
+| `client/test/release/tier-1/T1.1-bootstrap-fresh-anvil.ts` | T1.1 callable + Vitest wrapper |
+| `client/test/release/tier-1/T1.2-harness-readiness-contract.ts` | T1.2 callable + Vitest wrapper |
+| `client/test/release/tier-1/T1.3-indexer-round-trip.ts` | T1.3 callable + Vitest wrapper |
+| `client/test/dashboard/release-prep/spa-route-smoke.e2e.test.ts` | T1.4 Playwright test |
+
+**New refactor outputs:**
+
+| Path | Responsibility |
+|---|---|
+| `client/src/dashboard/spa/src/routes.ts` | Extracted `ROUTES` constant (for T1.4 to import) |
+| `client/test/dashboard/helpers/mock-daemon-api.ts` | Extracted `mockDaemonApi(page, port?)` from `spa-config.e2e.test.ts` |
+
+**New skill files:**
+
+| Path | Responsibility |
+|---|---|
+| `.claude/skills/release-prep/SKILL.md` | Skill description, invocation contract, output format |
+| `.claude/skills/release-prep/references/tier-1-scenarios.md` | Detailed shape per Tier 1 scenario |
+| `.claude/skills/release-prep/references/tier-2-scenarios.md` | Placeholder pointing at Plan B's scenario docs; expanded in Plan D |
+| `.claude/skills/release-prep/references/evidence-format.md` | Marker schema, evidence doc shape |
+| `.claude/skills/release-prep/references/failure-classification.md` | flake-infra / flake-timing / real-bug / agent-crash rules |
+
+**Modified files:**
+
+| Path | Change |
+|---|---|
+| `client/src/dashboard/spa/src/App.tsx` | Import `ROUTES` from the new module instead of inlining |
+| `client/test/dashboard/spa-config.e2e.test.ts` | Import `mockDaemonApi` from the extracted module |
+| `client/package.json` | Add `release:tier-1`, `release:tier-1:T1.1`, ... yarn scripts |
+| `.github/workflows/npm-publish.yml` | Replace `Release gate — operator-gate` step with `Tier 1 — mechanical floor` |
+
+---
+
+## Task 1: Extract `ROUTES` constant from App.tsx
+
+**Files:**
+- Create: `client/src/dashboard/spa/src/routes.ts`
+- Modify: `client/src/dashboard/spa/src/App.tsx`
+
+Small refactor so T1.4 can import the canonical route list instead of hardcoding.
+
+- [ ] **Step 1: Read the current App.tsx to find the route list**
+
+Run: `grep -n "Route\|path=" client/src/dashboard/spa/src/App.tsx | head -30`
+
+Expected: lines showing `<Route path="..."` declarations or a route table object.
+
+- [ ] **Step 2: Create the routes module**
+
+```typescript
+// client/src/dashboard/spa/src/routes.ts
+// Canonical SPA route list — single source of truth.
+// T1.4 SPA route smoke imports this so any new route automatically gets
+// covered by the route-smoke gate.
+
+export interface RouteSpec {
+  path: string;                       // pathname (no query/hash)
+  label: string;                      // human-readable name for test output
+  /** Test-only param substitutions for parameterized routes. */
+  params?: Record<string, string>;
+}
+
+export const ROUTES: RouteSpec[] = [
+  { path: '/', label: 'root' },
+  { path: '/overview', label: 'overview' },
+  { path: '/configuration', label: 'configuration' },
+  { path: '/configuration#network', label: 'configuration#network' },
+  { path: '/configuration#security', label: 'configuration#security' },
+  { path: '/launcher', label: 'launcher' },
+  { path: '/launcher/create', label: 'launcher-create' },
+  {
+    path: '/launcher/launched/:solverNetId',
+    label: 'launcher-launched',
+    params: { solverNetId: '5474_swe-rebench-v2-v1_edb172d3' },
+  },
+  {
+    path: '/operator/join/:cid',
+    label: 'operator-join',
+    params: { cid: 'bafkrei-mock-manifest-cid' },
+  },
+  { path: '/network', label: 'network' },
+  { path: '/build', label: 'build' },
+];
+
+/** Substitute :param tokens with the spec's `params` values. */
+export function expandRoutePath(spec: RouteSpec): string {
+  if (!spec.params) return spec.path;
+  let out = spec.path;
+  for (const [k, v] of Object.entries(spec.params)) {
+    out = out.replace(`:${k}`, v);
+  }
+  return out;
+}
+```
+
+- [ ] **Step 3: Update App.tsx to import the list**
+
+Open `client/src/dashboard/spa/src/App.tsx`. Replace the inline route declarations (whatever shape they take — `<Route>` JSX or a `createBrowserRouter` config) with code that maps over the `ROUTES` constant. The exact diff depends on the current App.tsx shape; the implementer should:
+
+1. Import `ROUTES` from `./routes`.
+2. Replace the inline route list with `ROUTES.map(...)` producing the equivalent JSX/config.
+3. Verify no route paths are lost; the imported `ROUTES` must be the canonical list, not a duplicate.
+
+If App.tsx uses a Routes object literal that's already hostable, just import it. If it uses JSX `<Route>` elements, factor them into the constant.
+
+- [ ] **Step 4: Verify SPA still builds + routes**
+
+Run: `cd client && yarn build`
+Expected: build succeeds with no new errors.
+
+Run: `cd client && yarn vitest run src/dashboard/spa/src/App.routing.test.tsx`
+Expected: PASS — existing routing tests still pass against the refactored code.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/dashboard/spa/src/routes.ts client/src/dashboard/spa/src/App.tsx
+git commit -m "refactor(spa): extract canonical ROUTES list for T1.4 route smoke"
+```
+
+---
+
+## Task 2: Extract `mockDaemonApi` to a shared module
+
+**Files:**
+- Create: `client/test/dashboard/helpers/mock-daemon-api.ts`
+- Modify: `client/test/dashboard/spa-config.e2e.test.ts` (use the extracted helper)
+- Test: extracted helper is exercised by the existing test file; no new test needed
+
+Per Plan B's fold-back, `mockDaemonApi` is currently a private function inside `spa-config.e2e.test.ts` with port 7332 hardcoded. Extract it to a shared module with a `port` argument so T1.4 and Plan D's multi-op tests can import it.
+
+- [ ] **Step 1: Read the current mockDaemonApi signature**
+
+Run: `grep -n "mockDaemonApi" client/test/dashboard/spa-config.e2e.test.ts | head -10`
+Expected: the function declaration line + usage sites.
+
+Run: `awk '/function mockDaemonApi/,/^}/' client/test/dashboard/spa-config.e2e.test.ts | head -100`
+Expected: the full function body.
+
+- [ ] **Step 2: Create the extracted module**
+
+```typescript
+// client/test/dashboard/helpers/mock-daemon-api.ts
+import type { Page } from '@playwright/test';
+
+export interface MockDaemonApiOptions {
+  /** Port the daemon would normally run on; route patterns include this. */
+  port?: number;
+}
+
+/**
+ * Intercept the daemon HTTP API endpoints the SPA polls. Use one call per
+ * Playwright page when running multi-op tests; each page gets its own
+ * isolated route table.
+ *
+ * Extracted from spa-config.e2e.test.ts so both single-op and multi-op
+ * tests can share the same mock surface.
+ */
+export async function mockDaemonApi(page: Page, opts: MockDaemonApiOptions = {}): Promise<void> {
+  const port = opts.port ?? 7332;
+  const base = `http://127.0.0.1:${port}`;
+
+  // /v1/bootstrap — running-mode payload
+  await page.route(`${base}/v1/bootstrap`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        mode: 'running',
+        fleet: { agentId: '5474', safeAddress: '0x0e767E28C6889CcD0DfB88E631a3702D56Ce24FC' },
+        chain: { id: 84532, name: 'base-sepolia' },
+        joinedSolverNets: {},
+      }),
+    });
+  });
+
+  // /v1/status — minimal status snapshot
+  await page.route(`${base}/v1/status`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ ok: true, loops: [] }),
+    });
+  });
+
+  // /auth/handshake** — suppress redirect, return ok
+  await page.route(`${base}/auth/handshake**`, async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' });
+  });
+
+  // (Add other endpoints currently hardcoded in spa-config.e2e.test.ts here.
+  //  The implementer should copy the full route list from there into this module.)
+}
+```
+
+**NOTE TO IMPLEMENTER:** The exact set of routes intercepted depends on what the SPA currently polls. The body above is a starting template; the implementer must copy the FULL route list from `spa-config.e2e.test.ts` and parameterize each by `port`. If the current implementation hardcodes `127.0.0.1:7332` anywhere, replace with the parameterized `base`.
+
+- [ ] **Step 3: Update spa-config.e2e.test.ts to use the extracted helper**
+
+Open `client/test/dashboard/spa-config.e2e.test.ts`. Replace the inline `mockDaemonApi` function with:
+
+```typescript
+import { mockDaemonApi } from './helpers/mock-daemon-api';
+```
+
+Delete the inline function. Verify all call sites still resolve (they should — same name, same signature for the single-arg case since `port` defaults to 7332).
+
+- [ ] **Step 4: Run the existing single-op tests to verify the extraction didn't break anything**
+
+Run: `cd client && yarn build && yarn playwright test --config=playwright.config.ts test/dashboard/spa-config.e2e.test.ts`
+Expected: same pass/fail as before the extraction (existing tests are the regression check).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/test/dashboard/helpers/mock-daemon-api.ts client/test/dashboard/spa-config.e2e.test.ts
+git commit -m "refactor(test): extract mockDaemonApi to shared helper with port arg"
+```
+
+---
+
+## Task 3: Scenario verdict types
+
+**Files:**
+- Create: `client/scripts/release/scenario-types.ts`
+- Test: `client/test/release/tier-1/scenario-types.test.ts`
+
+Shared types used by all four T1.x scenario implementations and the runner.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// client/test/release/tier-1/scenario-types.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+  ScenarioVerdictSchema,
+  classifyFailure,
+  type ScenarioVerdict,
+  type FailClass,
+} from '../../../scripts/release/scenario-types';
+
+describe('ScenarioVerdictSchema', () => {
+  it('parses a pass verdict', () => {
+    const v: ScenarioVerdict = {
+      scenarioId: 'T1.1',
+      verdict: 'pass',
+      wallClockMs: 5000,
+      evidencePath: '/tmp/T1.1.log',
+      failClass: null,
+      failNotes: null,
+    };
+    expect(() => ScenarioVerdictSchema.parse(v)).not.toThrow();
+  });
+
+  it('parses a fail verdict with class + notes', () => {
+    const v: ScenarioVerdict = {
+      scenarioId: 'T1.2',
+      verdict: 'fail',
+      wallClockMs: 30000,
+      evidencePath: '/tmp/T1.2.log',
+      failClass: 'real-bug',
+      failNotes: 'harness readiness returned malformed shape',
+    };
+    expect(() => ScenarioVerdictSchema.parse(v)).not.toThrow();
+  });
+
+  it('parses a skip verdict', () => {
+    const v: ScenarioVerdict = {
+      scenarioId: 'T1.3',
+      verdict: 'skip',
+      wallClockMs: 0,
+      evidencePath: '',
+      failClass: null,
+      failNotes: 'indexer not available locally',
+    };
+    expect(() => ScenarioVerdictSchema.parse(v)).not.toThrow();
+  });
+
+  it('rejects fail without failClass', () => {
+    const v = {
+      scenarioId: 'T1.1',
+      verdict: 'fail',
+      wallClockMs: 5000,
+      evidencePath: '/tmp/T1.1.log',
+      failClass: null,
+      failNotes: null,
+    };
+    expect(() => ScenarioVerdictSchema.parse(v)).toThrow();
+  });
+});
+
+describe('classifyFailure', () => {
+  it('classifies HTTP errors as flake-infra', () => {
+    expect(classifyFailure(new Error('HTTP request failed'))).toBe('flake-infra');
+    expect(classifyFailure(new Error('fetch failed: ECONNREFUSED'))).toBe('flake-infra');
+    expect(classifyFailure(new Error('socket hang up'))).toBe('flake-infra');
+  });
+
+  it('classifies timeout patterns as flake-timing', () => {
+    expect(classifyFailure(new Error('timed out after 30000ms'))).toBe('flake-timing');
+    expect(classifyFailure(new Error('Timeout waiting for selector'))).toBe('flake-timing');
+  });
+
+  it('classifies assertion failures as real-bug', () => {
+    expect(classifyFailure(new Error('expected 5 to equal 6'))).toBe('real-bug');
+    expect(classifyFailure(new Error('AssertionError: arrays differ'))).toBe('real-bug');
+  });
+
+  it('classifies unknown errors as real-bug (conservative default)', () => {
+    expect(classifyFailure(new Error('something unexpected'))).toBe('real-bug');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd client && yarn vitest run test/release/tier-1/scenario-types.test.ts`
+Expected: FAIL with `Cannot find module '../../../scripts/release/scenario-types'`
+
+- [ ] **Step 3: Implement scenario-types.ts**
+
+```typescript
+// client/scripts/release/scenario-types.ts
+import { z } from 'zod';
+
+export const FailClassSchema = z.enum(['real-bug', 'flake-infra', 'flake-timing', 'agent-crash']);
+export type FailClass = z.infer<typeof FailClassSchema>;
+
+export const VerdictKindSchema = z.enum(['pass', 'fail', 'skip']);
+export type VerdictKind = z.infer<typeof VerdictKindSchema>;
+
+export const ScenarioVerdictSchema = z.object({
+  scenarioId: z.string(),
+  verdict: VerdictKindSchema,
+  wallClockMs: z.number().int().nonnegative(),
+  evidencePath: z.string(),
+  failClass: FailClassSchema.nullable(),
+  failNotes: z.string().nullable(),
+}).refine(
+  (v) => v.verdict !== 'fail' || v.failClass !== null,
+  { message: 'fail verdicts must include a failClass' },
+);
+
+export type ScenarioVerdict = z.infer<typeof ScenarioVerdictSchema>;
+
+export interface ScenarioOptions {
+  /** Where the scenario should write its evidence (log file path). */
+  evidencePath: string;
+  /** Wall-clock budget in ms; scenario should abort if exceeded. */
+  wallClockBudgetMs?: number;
+  /** Optional RPC URL override. */
+  rpcUrl?: string;
+}
+
+const FLAKE_INFRA_PATTERNS = [
+  /HTTP request failed/i,
+  /ECONNREFUSED/i,
+  /ECONNRESET/i,
+  /socket hang up/i,
+  /network/i,
+  /getaddrinfo/i,
+];
+const FLAKE_TIMING_PATTERNS = [
+  /timed out/i,
+  /timeout/i,
+  /waiting for/i,
+];
+
+export function classifyFailure(err: unknown): FailClass {
+  const msg = err instanceof Error ? err.message : String(err);
+  for (const re of FLAKE_INFRA_PATTERNS) {
+    if (re.test(msg)) return 'flake-infra';
+  }
+  for (const re of FLAKE_TIMING_PATTERNS) {
+    if (re.test(msg)) return 'flake-timing';
+  }
+  return 'real-bug';
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd client && yarn vitest run test/release/tier-1/scenario-types.test.ts`
+Expected: PASS, 8 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/scripts/release/scenario-types.ts client/test/release/tier-1/scenario-types.test.ts
+git commit -m "feat(release): add ScenarioVerdict types + failure classifier"
+```
+
+---
+
+## Task 4: T1.1 — bootstrap-fresh-anvil
+
+**Files:**
+- Create: `client/test/release/tier-1/T1.1-bootstrap-fresh-anvil.ts`
+- Test: included inline (Vitest in same file)
+
+**What this scenario does:** Spawn an Anvil fork of Base Sepolia, generate a fresh master EOA, fund it, run the bootstrap state machine through all 11 phases, assert phase=`complete`. Cleans up Anvil + tmpdir on exit.
+
+Adapts the existing pattern from `client/scripts/staking-validate.ts`. The reusability: extract the core "bootstrap a fresh operator on Anvil fork" into a callable function that staking-validate and T1.1 both consume.
+
+- [ ] **Step 1: Survey the existing pattern**
+
+Run: `head -80 client/scripts/staking-validate.ts`
+Expected: existing script with phases. Note: phases include Anvil spawn, master EOA generation, funding, bootstrap-through-completion, on-chain verification.
+
+- [ ] **Step 2: Write a failing test for the scenario callable**
+
+```typescript
+// client/test/release/tier-1/T1.1-bootstrap-fresh-anvil.ts
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { runT11BootstrapFreshAnvil } from './T1.1-bootstrap-fresh-anvil';
+import type { ScenarioVerdict } from '../../../scripts/release/scenario-types';
+
+describe('T1.1 bootstrap-fresh-anvil', () => {
+  it('returns pass verdict when bootstrap completes', async () => {
+    const evidenceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'T1.1-evidence-'));
+    const evidencePath = path.join(evidenceDir, 'T1.1.log');
+    try {
+      const verdict: ScenarioVerdict = await runT11BootstrapFreshAnvil({
+        evidencePath,
+        wallClockBudgetMs: 120000,
+      });
+      expect(verdict.scenarioId).toBe('T1.1');
+      expect(verdict.verdict).toBe('pass');
+      expect(verdict.evidencePath).toBe(evidencePath);
+      expect(verdict.wallClockMs).toBeGreaterThan(0);
+      expect(verdict.failClass).toBeNull();
+      // Evidence file should contain phase markers
+      const log = await fs.readFile(evidencePath, 'utf-8');
+      expect(log).toContain('Phase 1');
+      expect(log).toContain('Phase 11');
+      expect(log).toContain('complete');
+    } finally {
+      await fs.rm(evidenceDir, { recursive: true, force: true });
+    }
+  }, 180000);
+
+  it('returns fail-real-bug verdict when bootstrap stalls', async () => {
+    const evidenceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'T1.1-evidence-stall-'));
+    const evidencePath = path.join(evidenceDir, 'T1.1.log');
+    try {
+      const verdict: ScenarioVerdict = await runT11BootstrapFreshAnvil({
+        evidencePath,
+        wallClockBudgetMs: 1000,                  // unrealistically short — forces timeout
+      });
+      expect(verdict.verdict).toBe('fail');
+      expect(verdict.failClass).toMatch(/^(flake-timing|real-bug)$/);
+    } finally {
+      await fs.rm(evidenceDir, { recursive: true, force: true });
+    }
+  }, 30000);
+});
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `cd client && yarn vitest run test/release/tier-1/T1.1-bootstrap-fresh-anvil.ts`
+Expected: FAIL with `Cannot find export 'runT11BootstrapFreshAnvil'`
+
+- [ ] **Step 4: Implement the callable**
+
+```typescript
+// Add above the describe block in the same file:
+import { spawnAnvilFork } from '../_support/chain/anvil';
+import { baseSepolia } from 'viem/chains';
+import { FleetBootstrapper } from '../../../src/earning/bootstrap';
+import { classifyFailure, type ScenarioVerdict, type ScenarioOptions } from '../../../scripts/release/scenario-types';
+
+export async function runT11BootstrapFreshAnvil(opts: ScenarioOptions): Promise<ScenarioVerdict> {
+  const started = Date.now();
+  let anvil: Awaited<ReturnType<typeof spawnAnvilFork>> | null = null;
+  const evidenceLines: string[] = [];
+  const log = (msg: string) => { evidenceLines.push(`[${new Date().toISOString()}] ${msg}`); };
+
+  try {
+    // 1. Spawn Anvil fork
+    log('Phase 0: spawn Anvil fork of Base Sepolia');
+    anvil = await spawnAnvilFork({
+      forkUrl: process.env['BASE_SEPOLIA_RPC_URL']!,
+      chain: baseSepolia,
+      silent: true,
+    });
+    log(`Anvil ready at ${anvil.rpcUrl}`);
+
+    // 2. Run bootstrap (the existing FleetBootstrapper, configured for Anvil fork)
+    //    The implementer should pattern-match on staking-validate.ts here: tmpdir for HOME,
+    //    fund master EOA via `cast send` against Anvil, then await bootstrapper.run().
+    //    Capture each phase transition into `evidenceLines`.
+
+    // [PSEUDOCODE — implementer fills in adapted from staking-validate.ts:]
+    //   const tmpHome = await fs.mkdtemp(...);
+    //   const bootstrapper = new FleetBootstrapper({ home: tmpHome, rpcUrl: anvil.rpcUrl, ... });
+    //   for await (const phase of bootstrapper.run({ onPhaseChange: ... })) { log(`Phase: ${phase}`); }
+    //   const finalState = await readEarningState(tmpHome);
+    //   if (finalState.fleet_stage !== 'stage1_and_2') throw new Error('bootstrap did not complete');
+
+    // Wall-clock budget check
+    if (opts.wallClockBudgetMs && Date.now() - started > opts.wallClockBudgetMs) {
+      throw new Error(`timed out after ${opts.wallClockBudgetMs}ms`);
+    }
+
+    log('Phase 11: complete');
+    await fs.writeFile(opts.evidencePath, evidenceLines.join('\n'));
+
+    return {
+      scenarioId: 'T1.1',
+      verdict: 'pass',
+      wallClockMs: Date.now() - started,
+      evidencePath: opts.evidencePath,
+      failClass: null,
+      failNotes: null,
+    };
+  } catch (err) {
+    const failClass = classifyFailure(err);
+    log(`FAILED: ${err instanceof Error ? err.message : String(err)}`);
+    await fs.writeFile(opts.evidencePath, evidenceLines.join('\n'));
+    return {
+      scenarioId: 'T1.1',
+      verdict: 'fail',
+      wallClockMs: Date.now() - started,
+      evidencePath: opts.evidencePath,
+      failClass,
+      failNotes: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    if (anvil) await anvil.teardown();
+  }
+}
+```
+
+**NOTE TO IMPLEMENTER:** The pseudocode section "[PSEUDOCODE — implementer fills in...]" needs to be replaced with real code adapted from `client/scripts/staking-validate.ts`. The existing pattern:
+- creates a tmpdir for HOME
+- generates a master EOA + funds it via cast against the Anvil RPC
+- instantiates `FleetBootstrapper` (or equivalent — check the current naming)
+- runs bootstrap and waits for completion
+- verifies on-chain state matches expectations
+
+Read `client/scripts/staking-validate.ts` in full first to understand the existing pattern; the T1.1 implementation should be a structural twin.
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `cd client && yarn build && yarn vitest run test/release/tier-1/T1.1-bootstrap-fresh-anvil.ts`
+Expected: PASS, 2 tests passing (the second test forces a timeout; verify failure classification works correctly).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/test/release/tier-1/T1.1-bootstrap-fresh-anvil.ts
+git commit -m "feat(release): add T1.1 bootstrap-fresh-anvil scenario"
+```
+
+---
+
+## Task 5: T1.2 — harness-readiness-contract
+
+**Files:**
+- Create: `client/test/release/tier-1/T1.2-harness-readiness-contract.ts`
+
+**What this scenario does:** Spawn a fresh-HOME daemon (no bootstrap needed — daemon can run with a `mode: 'setup'` payload). Query `/v1/harnesses/readiness` and `/v1/harnesses/:name/readiness` for each known harness (`claude-code-learner`, `codex-code-learner`, `hermes-agent`). Assert each response has the expected shape (`{ name, ready: boolean, requirements: [...], reasons: [...] }`).
+
+Catches the vh74-class regression where adding a new harness breaks the readiness contract for existing ones.
+
+- [ ] **Step 1: Write the failing test + implementation skeleton**
+
+```typescript
+// client/test/release/tier-1/T1.2-harness-readiness-contract.ts
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { spawnMultiOpDaemons } from '../../helpers/multi-op-daemon';
+import { classifyFailure, type ScenarioVerdict, type ScenarioOptions } from '../../../scripts/release/scenario-types';
+
+const KNOWN_HARNESSES = ['claude-code-learner', 'codex-code-learner', 'hermes-agent'] as const;
+
+interface HarnessReadiness {
+  name: string;
+  ready: boolean;
+  requirements: string[];
+  reasons: string[];
+}
+
+export async function runT12HarnessReadinessContract(opts: ScenarioOptions): Promise<ScenarioVerdict> {
+  const started = Date.now();
+  const evidenceLines: string[] = [];
+  const log = (msg: string) => { evidenceLines.push(`[${new Date().toISOString()}] ${msg}`); };
+
+  let daemons: Awaited<ReturnType<typeof spawnMultiOpDaemons>> | null = null;
+  let tmpHome: string | null = null;
+
+  try {
+    // 1. Set up a fresh tmpdir as HOME
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'T1.2-home-'));
+    await fs.mkdir(path.join(tmpHome, '.jinn-client'), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpHome, '.jinn-client', 'config.json'),
+      JSON.stringify({ network: 'testnet', apiPort: 7740, pollIntervalMs: 5000 }),
+    );
+    log(`tmp HOME: ${tmpHome}`);
+
+    // 2. Spawn daemon
+    daemons = await spawnMultiOpDaemons({
+      ops: [{ name: 't12', home: tmpHome, apiPort: 7740 }],
+      readyTimeoutMs: 30000,
+    });
+    log('daemon spawned');
+
+    // 3. Query the index endpoint
+    const indexRes = await fetch('http://127.0.0.1:7740/v1/harnesses/readiness');
+    if (!indexRes.ok) throw new Error(`/v1/harnesses/readiness returned ${indexRes.status}`);
+    const indexBody = await indexRes.json() as { harnesses: HarnessReadiness[] };
+    log(`index: ${indexBody.harnesses.length} harnesses reported`);
+
+    // 4. Assert every known harness is present
+    for (const expected of KNOWN_HARNESSES) {
+      const found = indexBody.harnesses.find((h) => h.name === expected);
+      if (!found) throw new Error(`harness ${expected} missing from /v1/harnesses/readiness`);
+      log(`  ${expected}: ready=${found.ready}, requirements=${found.requirements.length}`);
+    }
+
+    // 5. Query each harness's own readiness endpoint and assert shape matches
+    for (const name of KNOWN_HARNESSES) {
+      const res = await fetch(`http://127.0.0.1:7740/v1/harnesses/${name}/readiness`);
+      if (!res.ok) throw new Error(`/v1/harnesses/${name}/readiness returned ${res.status}`);
+      const body = await res.json() as HarnessReadiness;
+      if (body.name !== name) {
+        throw new Error(`/v1/harnesses/${name}/readiness returned name=${body.name}`);
+      }
+      if (typeof body.ready !== 'boolean') {
+        throw new Error(`/v1/harnesses/${name}/readiness returned ready=${typeof body.ready}`);
+      }
+      if (!Array.isArray(body.requirements)) {
+        throw new Error(`/v1/harnesses/${name}/readiness returned requirements not an array`);
+      }
+    }
+    log('all known harnesses have valid readiness shape');
+
+    await fs.writeFile(opts.evidencePath, evidenceLines.join('\n'));
+    return {
+      scenarioId: 'T1.2',
+      verdict: 'pass',
+      wallClockMs: Date.now() - started,
+      evidencePath: opts.evidencePath,
+      failClass: null,
+      failNotes: null,
+    };
+  } catch (err) {
+    log(`FAILED: ${err instanceof Error ? err.message : String(err)}`);
+    await fs.writeFile(opts.evidencePath, evidenceLines.join('\n'));
+    return {
+      scenarioId: 'T1.2',
+      verdict: 'fail',
+      wallClockMs: Date.now() - started,
+      evidencePath: opts.evidencePath,
+      failClass: classifyFailure(err),
+      failNotes: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    if (daemons) await daemons.teardown();
+    if (tmpHome) await fs.rm(tmpHome, { recursive: true, force: true });
+  }
+}
+
+describe('T1.2 harness-readiness-contract', () => {
+  it('returns pass verdict when all known harnesses report valid shape', async () => {
+    const evidenceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'T1.2-evidence-'));
+    const evidencePath = path.join(evidenceDir, 'T1.2.log');
+    try {
+      const verdict = await runT12HarnessReadinessContract({ evidencePath });
+      expect(verdict.scenarioId).toBe('T1.2');
+      expect(verdict.verdict).toBe('pass');
+      expect(verdict.failClass).toBeNull();
+    } finally {
+      await fs.rm(evidenceDir, { recursive: true, force: true });
+    }
+  }, 60000);
+});
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `cd client && yarn build && yarn vitest run test/release/tier-1/T1.2-harness-readiness-contract.ts`
+Expected: PASS (the test verifies real behavior against a spawned daemon — `yarn build` is required first).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/test/release/tier-1/T1.2-harness-readiness-contract.ts
+git commit -m "feat(release): add T1.2 harness-readiness-contract scenario"
+```
+
+---
+
+## Task 6: T1.3 — indexer-round-trip
+
+**Files:**
+- Create: `client/test/release/tier-1/T1.3-indexer-round-trip.ts`
+
+**What this scenario does:** Spawn a local Ponder indexer + a daemon configured to use it. Post a task on Anvil fork. Query the Discovery API (`/v1/discovery/tasks` or equivalent). Assert the posted task appears with the correct schema.
+
+This catches the fufn-class regression where indexer schema drifts away from what the daemon writes.
+
+**Complexity flag:** Local Ponder spawn is non-trivial. If a Ponder spawn helper doesn't already exist in `client/test/_support/`, this task should either:
+1. Create one (adds significant scope), or
+2. Skip this scenario for v1 of Tier 1 (mark as TODO; file GH issue).
+
+The implementer should first check `client/test/_support/` for a Ponder helper. If absent and creation is out of scope, file a GH issue (`gh issue create --label release-readiness --title 'Tier 1 T1.3 needs Ponder spawn helper'`) and skip this task. Tasks 7+ continue without T1.3.
+
+- [ ] **Step 1: Check for an existing Ponder spawn helper**
+
+Run: `find client/test -name "*ponder*" -o -name "*indexer*" 2>/dev/null | head -10`
+
+If results exist: continue with this task using the existing helper. If not: file a GH issue and skip to Task 7.
+
+- [ ] **Step 2 (if helper exists): Write the scenario**
+
+```typescript
+// client/test/release/tier-1/T1.3-indexer-round-trip.ts
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { spawnMultiOpDaemons } from '../../helpers/multi-op-daemon';
+import { spawnAnvilFork } from '../_support/chain/anvil';
+import { baseSepolia } from 'viem/chains';
+import { classifyFailure, type ScenarioVerdict, type ScenarioOptions } from '../../../scripts/release/scenario-types';
+// import { spawnPonderIndexer } from '../_support/indexer/ponder';   // path TBD by implementer
+
+export async function runT13IndexerRoundTrip(opts: ScenarioOptions): Promise<ScenarioVerdict> {
+  const started = Date.now();
+  const evidenceLines: string[] = [];
+  const log = (msg: string) => { evidenceLines.push(`[${new Date().toISOString()}] ${msg}`); };
+
+  // [PSEUDOCODE — implementer fills in:]
+  //   1. Spawn Anvil fork (existing helper)
+  //   2. Spawn Ponder indexer pointed at Anvil's RPC
+  //   3. Spawn a daemon with config pointing at Anvil + Ponder
+  //   4. POST a task via daemon API
+  //   5. Poll Ponder GraphQL until the task appears
+  //   6. Assert the indexed row matches what was posted (id, type, owner, etc.)
+  //   7. Cleanup all three
+
+  // Wall-clock budget: 60s
+
+  // For the v1 of this scenario, if Ponder spawn is too complex, mark as 'skip'
+  // verdict with failNotes explaining the gap, so the runner doesn't block.
+  await fs.writeFile(opts.evidencePath, evidenceLines.join('\n'));
+  return {
+    scenarioId: 'T1.3',
+    verdict: 'skip',
+    wallClockMs: Date.now() - started,
+    evidencePath: opts.evidencePath,
+    failClass: null,
+    failNotes: 'Implementation pending — see GH issue (filed in Step 1 if helper missing)',
+  };
+}
+
+describe('T1.3 indexer-round-trip', () => {
+  it('runs (or marks as skip if helper missing)', async () => {
+    const evidenceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'T1.3-evidence-'));
+    const evidencePath = path.join(evidenceDir, 'T1.3.log');
+    try {
+      const verdict = await runT13IndexerRoundTrip({ evidencePath });
+      expect(['pass', 'skip']).toContain(verdict.verdict);
+    } finally {
+      await fs.rm(evidenceDir, { recursive: true, force: true });
+    }
+  }, 90000);
+});
+```
+
+- [ ] **Step 3: Run test**
+
+Run: `cd client && yarn build && yarn vitest run test/release/tier-1/T1.3-indexer-round-trip.ts`
+Expected: PASS (either the real scenario passes, or it marks as skip — the test accepts either).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/test/release/tier-1/T1.3-indexer-round-trip.ts
+git commit -m "feat(release): add T1.3 indexer-round-trip scenario (or skip-stub if helper missing)"
+```
+
+---
+
+## Task 7: T1.4 — SPA route smoke
+
+**Files:**
+- Create: `client/test/dashboard/release-prep/spa-route-smoke.e2e.test.ts`
+
+**What this scenario does:** Per the contract in `.claude/skills/testing-jinn-app/references/scenario-spa-route-smoke.md` (Plan B): load every route in `ROUTES`, assert no JS errors / no React error boundaries / no missing-mock console errors / route renders past spinner.
+
+- [ ] **Step 1: Write the Playwright test**
+
+```typescript
+// client/test/dashboard/release-prep/spa-route-smoke.e2e.test.ts
+import { test, expect } from '@playwright/test';
+import { mockDaemonApi } from '../helpers/mock-daemon-api';
+import { ROUTES, expandRoutePath, type RouteSpec } from '../../../src/dashboard/spa/src/routes';
+
+// Patterns that may show up as console.error but are harmless noise.
+// Add entries only after investigating and confirming the error is genuinely benign.
+const HARMLESS_CONSOLE_ERROR_PATTERNS: RegExp[] = [
+  /ResizeObserver loop completed/i,
+];
+
+test.describe('T1.4 — SPA route smoke', () => {
+  for (const route of ROUTES) {
+    test(`renders clean at ${route.label}`, async ({ page }) => {
+      const consoleErrors: string[] = [];
+      const pageErrors: Error[] = [];
+
+      page.on('console', (msg) => {
+        if (msg.type() === 'error') consoleErrors.push(msg.text());
+      });
+      page.on('pageerror', (err) => pageErrors.push(err));
+
+      await mockDaemonApi(page);
+
+      const url = `http://127.0.0.1:7332${expandRoutePath(route)}`;
+      await page.goto(url);
+
+      // Wait for SOMETHING rendered. Tolerant: any of these means the SPA painted.
+      await page.waitForSelector(
+        'main, [data-page-loaded], [data-app-shell], [data-error-boundary], h1',
+        { timeout: 5000 },
+      );
+
+      // No JS errors
+      expect(pageErrors, `pageerror events at ${route.label}`).toHaveLength(0);
+
+      // No React error boundary visible
+      const boundaryCount = await page.locator('[data-error-boundary]').count();
+      expect(boundaryCount, `error boundary at ${route.label}`).toBe(0);
+
+      // No console errors after filtering harmless
+      const real = consoleErrors.filter(
+        (err) => !HARMLESS_CONSOLE_ERROR_PATTERNS.some((re) => re.test(err)),
+      );
+      expect(real, `console errors at ${route.label}`).toEqual([]);
+    });
+  }
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cd client && yarn build && yarn playwright test --config=playwright.config.ts test/dashboard/release-prep/spa-route-smoke.e2e.test.ts`
+Expected: PASS — one passing test per route in `ROUTES` (currently ~11).
+
+If a route fails: triage. Either the SPA has a bug (real catch), or the route's data dependency isn't mocked (extend `mockDaemonApi`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/test/dashboard/release-prep/spa-route-smoke.e2e.test.ts
+git commit -m "feat(release): add T1.4 SPA route smoke Playwright test"
+```
+
+---
+
+## Task 8: run-tier-1.ts orchestrator
+
+**Files:**
+- Create: `client/scripts/release/run-tier-1.ts`
+
+**What this script does:** Imports T1.1, T1.2, T1.3 callables. Runs them in parallel via `Promise.allSettled`. Invokes T1.4 via the Playwright CLI as a subprocess (since it's a different test runner). Collects all four verdicts. Prints a structured JSON summary + a marker block to stdout. Exits 0 if all pass, 1 if any `verdict=fail` with `failClass=real-bug`, 2 on internal error.
+
+- [ ] **Step 1: Implement the orchestrator**
+
+```typescript
+// client/scripts/release/run-tier-1.ts
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { spawn } from 'node:child_process';
+import { runT11BootstrapFreshAnvil } from '../../test/release/tier-1/T1.1-bootstrap-fresh-anvil';
+import { runT12HarnessReadinessContract } from '../../test/release/tier-1/T1.2-harness-readiness-contract';
+import { runT13IndexerRoundTrip } from '../../test/release/tier-1/T1.3-indexer-round-trip';
+import { type ScenarioVerdict, ScenarioVerdictSchema, classifyFailure } from './scenario-types';
+
+interface RunOptions {
+  outputDir?: string;          // default: ./tier-1-evidence/<timestamp>/
+  candidateVersion?: string;   // for marker block
+}
+
+async function runT14SpaRouteSmoke(outputDir: string): Promise<ScenarioVerdict> {
+  const started = Date.now();
+  const evidencePath = path.join(outputDir, 'T1.4.log');
+  return new Promise<ScenarioVerdict>((resolve) => {
+    const child = spawn(
+      'yarn',
+      [
+        'playwright',
+        'test',
+        '--config=playwright.config.ts',
+        'test/dashboard/release-prep/spa-route-smoke.e2e.test.ts',
+        '--reporter=line',
+      ],
+      { cwd: process.cwd(), stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
+    child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+    child.on('close', async (code) => {
+      await fs.writeFile(evidencePath, `=== stdout ===\n${stdout}\n=== stderr ===\n${stderr}\n=== exit code ===\n${code}\n`);
+      const verdict: ScenarioVerdict = {
+        scenarioId: 'T1.4',
+        verdict: code === 0 ? 'pass' : 'fail',
+        wallClockMs: Date.now() - started,
+        evidencePath,
+        failClass: code === 0 ? null : classifyFailure(new Error(stderr || stdout)),
+        failNotes: code === 0 ? null : `Playwright exited ${code}`,
+      };
+      resolve(verdict);
+    });
+  });
+}
+
+export async function runTier1(opts: RunOptions = {}): Promise<{ verdicts: ScenarioVerdict[]; allPassed: boolean }> {
+  const outputDir = opts.outputDir ?? path.join(
+    process.cwd(),
+    'tier-1-evidence',
+    new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19),
+  );
+  await fs.mkdir(outputDir, { recursive: true });
+
+  // Run T1.1-T1.3 callables in parallel
+  const scenarioPromises = [
+    runT11BootstrapFreshAnvil({ evidencePath: path.join(outputDir, 'T1.1.log'), wallClockBudgetMs: 120000 }),
+    runT12HarnessReadinessContract({ evidencePath: path.join(outputDir, 'T1.2.log') }),
+    runT13IndexerRoundTrip({ evidencePath: path.join(outputDir, 'T1.3.log') }),
+  ];
+  const settled = await Promise.allSettled(scenarioPromises);
+  const callableVerdicts: ScenarioVerdict[] = settled.map((result, idx) => {
+    if (result.status === 'fulfilled') return result.value;
+    const ids = ['T1.1', 'T1.2', 'T1.3'];
+    return {
+      scenarioId: ids[idx],
+      verdict: 'fail' as const,
+      wallClockMs: 0,
+      evidencePath: path.join(outputDir, `${ids[idx]}.log`),
+      failClass: 'agent-crash' as const,
+      failNotes: result.reason instanceof Error ? result.reason.message : String(result.reason),
+    };
+  });
+
+  // T1.4 needs a separate subprocess (Playwright)
+  const t14 = await runT14SpaRouteSmoke(outputDir);
+  const verdicts = [...callableVerdicts, t14];
+
+  // Validate all verdicts pass schema
+  for (const v of verdicts) ScenarioVerdictSchema.parse(v);
+
+  const allPassed = verdicts.every((v) => v.verdict === 'pass');
+
+  // Write summary
+  const summary = {
+    candidateVersion: opts.candidateVersion ?? 'unknown',
+    timestamp: new Date().toISOString(),
+    verdicts,
+    allPassed,
+  };
+  await fs.writeFile(path.join(outputDir, 'summary.json'), JSON.stringify(summary, null, 2));
+
+  // Marker block
+  const markerLines = [
+    '<!-- jinn-release-evidence:v1',
+    `release-candidate=${opts.candidateVersion ?? 'unknown'}`,
+    ...verdicts.map((v) => {
+      const key = `tier-1-${v.scenarioId.toLowerCase().replace(/\./g, '-')}`;
+      if (v.verdict === 'pass') return `${key}=passed`;
+      if (v.verdict === 'skip') return `${key}=skipped:${v.failNotes ?? 'no-reason'}`;
+      return `${key}=failed:${v.failClass}`;
+    }),
+    `tier-1-overall=${allPassed ? 'passed' : 'failed'}`,
+    '-->',
+  ];
+  await fs.writeFile(path.join(outputDir, 'marker.txt'), markerLines.join('\n') + '\n');
+
+  return { verdicts, allPassed };
+}
+
+async function cliMain(): Promise<void> {
+  const candidateVersion = process.argv[2];
+  const { verdicts, allPassed } = await runTier1({ candidateVersion });
+  console.log(JSON.stringify({ verdicts, allPassed }, null, 2));
+
+  // Real-bug failures exit non-zero; flake/skip exits zero (operator decides ship)
+  const hasRealBug = verdicts.some((v) => v.verdict === 'fail' && v.failClass === 'real-bug');
+  process.exit(hasRealBug ? 1 : 0);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  cliMain().catch((err) => {
+    console.error('run-tier-1 crashed:', err);
+    process.exit(2);
+  });
+}
+```
+
+- [ ] **Step 2: Manual smoke test**
+
+Run: `cd client && yarn build && tsx scripts/release/run-tier-1.ts v0.1.7-smoke`
+Expected: prints structured JSON verdicts; exits 0 or 1 depending on results. Creates `tier-1-evidence/<timestamp>/` with per-scenario logs + summary + marker.
+
+If the smoke test fails on real infrastructure issues (e.g. Anvil unavailable), that's a real environmental issue to fix — not a bug in the orchestrator.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/scripts/release/run-tier-1.ts
+git commit -m "feat(release): add run-tier-1 orchestrator"
+```
+
+---
+
+## Task 9: release-prep SKILL.md + tier-1-scenarios.md reference
+
+**Files:**
+- Create: `.claude/skills/release-prep/SKILL.md`
+- Create: `.claude/skills/release-prep/references/tier-1-scenarios.md`
+
+- [ ] **Step 1: Create the skill SKILL.md**
+
+Save as `.claude/skills/release-prep/SKILL.md`:
+
+```markdown
+# release-prep
+
+Mechanical gate-runner skill. Runs Tier 1 (and eventually Tier 2) scenarios against a candidate branch, classifies failures, emits a marker block ready to paste into a GitHub Release body.
+
+This skill is *not* the audit layer — that's `release-readiness`. release-prep runs gates and reports; it doesn't decide blocking vs deferrable. release-readiness invokes release-prep as a subagent.
+
+## When to use
+
+- Invoked by `release-readiness` during its Phase 5 validation.
+- Invoked manually when an operator wants gate evidence for a candidate SHA.
+- (Future) invoked by a CI workflow that wants on-every-push Tier 1 evidence.
+
+## Input contract
+
+```typescript
+interface ReleasePrepInput {
+  branchSha: string;
+  candidateVersion: string;
+  outputDir?: string;
+  scenarios?: ScenarioId[];     // optional; default = all enabled
+}
+```
+
+## Output
+
+- `<outputDir>/summary.json` — structured verdict list
+- `<outputDir>/marker.txt` — marker block for the release body
+- `<outputDir>/T1.1.log`, `T1.2.log`, etc. — per-scenario evidence
+
+## How to invoke
+
+```bash
+# Run all of Tier 1 against the current working tree
+cd client && tsx scripts/release/run-tier-1.ts <candidate-version>
+
+# Or via yarn
+yarn release:tier-1 <candidate-version>
+```
+
+## Tier 1 scenarios
+
+Detailed contracts: [`references/tier-1-scenarios.md`](references/tier-1-scenarios.md)
+
+| ID | Name | Wall-clock budget |
+|---|---|---|
+| T1.1 | bootstrap-fresh-anvil | 90s |
+| T1.2 | harness-readiness-contract | 30s |
+| T1.3 | indexer-round-trip | 60s |
+| T1.4 | SPA route smoke | 30s |
+
+All four run in parallel. Wall-clock for the tier ≈ max of the budgets (~90s).
+
+## Tier 2 scenarios
+
+Detailed contracts: [`references/tier-2-scenarios.md`](references/tier-2-scenarios.md) (placeholder; expanded by Plan D)
+
+Tier 2 implementations land in Plan D. release-prep's runner will be extended at that point to call a `run-tier-2.ts` orchestrator alongside `run-tier-1.ts`.
+
+## Failure classification
+
+[`references/failure-classification.md`](references/failure-classification.md)
+
+## Evidence format
+
+[`references/evidence-format.md`](references/evidence-format.md)
+
+## What this skill does NOT do
+
+- Decide ship/no-ship (release-readiness)
+- Triage gaps as blocking-vs-deferrable (release-readiness)
+- Run Tier 3 (release-readiness)
+- Modify the candidate branch in any way (read-only)
+```
+
+- [ ] **Step 2: Create the tier-1-scenarios reference doc**
+
+Save as `.claude/skills/release-prep/references/tier-1-scenarios.md`:
+
+```markdown
+# Tier 1 scenarios
+
+Four scenarios, all single-operator, all run on every push to `next` (canary cadence) plus inside `release-prep` for any candidate version. None of them use the substrate from Plan A — Tier 1 is bootstrap-from-scratch territory.
+
+## T1.1 — bootstrap-fresh-anvil
+
+**Catches:** u34i / h74p / k1ng / 3nc5 bootstrap-reliability bugs.
+
+**What it does:** Anvil-forks Base Sepolia, generates a fresh master EOA, funds it, runs the bootstrap state machine through all 11 phases. Asserts `phase=complete`.
+
+**Implementation:** `client/test/release/tier-1/T1.1-bootstrap-fresh-anvil.ts`
+
+**Wall-clock budget:** 90s
+
+## T1.2 — harness-readiness-contract
+
+**Catches:** vh74 per-harness auth regressions; harness-readiness shape drift; missing harnesses.
+
+**What it does:** Spawns a fresh-HOME daemon (setup mode is enough — no bootstrap needed). Queries `/v1/harnesses/readiness` (index) and `/v1/harnesses/:name/readiness` (per harness). Asserts every known harness (`claude-code-learner`, `codex-code-learner`, `hermes-agent`) is present and returns the expected shape.
+
+**Implementation:** `client/test/release/tier-1/T1.2-harness-readiness-contract.ts`
+
+**Wall-clock budget:** 30s
+
+## T1.3 — indexer-round-trip
+
+**Catches:** fufn eval-substrate / indexer schema drift.
+
+**What it does:** Spawns a local Ponder indexer + a daemon configured to use it (against an Anvil fork). Posts a task. Polls the Discovery API. Asserts the indexed row matches what was posted.
+
+**Implementation:** `client/test/release/tier-1/T1.3-indexer-round-trip.ts`
+
+**Wall-clock budget:** 60s
+
+**Status:** May be `skip` in v1 if a Ponder spawn helper isn't available. Tracked as a follow-up GH issue.
+
+## T1.4 — SPA route smoke
+
+**Catches:** broken routes, missing mocks, JS errors, React error boundary firings.
+
+**What it does:** Playwright test. Loads every route in `client/src/dashboard/spa/src/routes.ts` against a mocked daemon API. For each, asserts no JS error, no error boundary visible, no console error (after filtering harmless patterns), route renders past the spinner.
+
+**Implementation:** `client/test/dashboard/release-prep/spa-route-smoke.e2e.test.ts`
+
+**Wall-clock budget:** 30s per route × ~11 routes ≈ 5min sequential, ~30s parallel (Playwright's default workers).
+
+## Contract docs in testing-jinn-app
+
+The "what does this scenario actually exercise" docs are in `testing-jinn-app` references (Plan B). release-prep references just point at them:
+
+- T1.4: [`testing-jinn-app/references/scenario-spa-route-smoke.md`](../../testing-jinn-app/references/scenario-spa-route-smoke.md)
+- (T1.1-T1.3 are simple enough to be fully described by their implementation files; no separate contract doc needed.)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/release-prep/SKILL.md .claude/skills/release-prep/references/tier-1-scenarios.md
+git commit -m "docs(release-prep): add skill + tier-1-scenarios reference"
+```
+
+---
+
+## Task 10: release-prep references — evidence-format + failure-classification + tier-2 placeholder
+
+**Files:**
+- Create: `.claude/skills/release-prep/references/evidence-format.md`
+- Create: `.claude/skills/release-prep/references/failure-classification.md`
+- Create: `.claude/skills/release-prep/references/tier-2-scenarios.md`
+
+- [ ] **Step 1: Create evidence-format.md**
+
+Save:
+
+```markdown
+# Evidence format
+
+Each release-prep run produces three artifact types under `<outputDir>/`:
+
+1. **`summary.json`** — structured verdict list, parseable by release-readiness.
+
+   ```json
+   {
+     "candidateVersion": "v0.1.7",
+     "timestamp": "2026-05-26T11:30:00Z",
+     "verdicts": [
+       {
+         "scenarioId": "T1.1",
+         "verdict": "pass",
+         "wallClockMs": 87234,
+         "evidencePath": "tier-1-evidence/2026-05-26T11-30-00/T1.1.log",
+         "failClass": null,
+         "failNotes": null
+       },
+       { "scenarioId": "T1.2", "verdict": "pass", "..." : "..." }
+     ],
+     "allPassed": true
+   }
+   ```
+
+2. **`marker.txt`** — pasteable marker for the GitHub Release body.
+
+   ```
+   <!-- jinn-release-evidence:v1
+   release-candidate=v0.1.7
+   tier-1-t1-1=passed
+   tier-1-t1-2=passed
+   tier-1-t1-3=skipped:helper-pending
+   tier-1-t1-4=passed
+   tier-1-overall=passed
+   -->
+   ```
+
+   The schema extends the existing `jinn-release-evidence:v1` shape with `tier-1-*` keys. Each scenario gets one key shaped `tier-1-<id-lowercased-dot-to-dash>=<status>`. Status is one of `passed`, `failed:<failClass>`, or `skipped:<reason>`.
+
+3. **`<scenarioId>.log`** — per-scenario evidence file. Free-form text written by each scenario; convention is to include phase markers and timestamps.
+
+## Consumption
+
+`release-readiness` reads `summary.json` directly (structured). The marker block in `marker.txt` is what gets pasted into the GH Release body so the existing marker check in `.github/workflows/npm-publish.yml` validates it. The `.log` files are for humans investigating failures.
+
+## Output directory layout
+
+```
+tier-1-evidence/
+  2026-05-26T11-30-00-abc4/
+    summary.json
+    marker.txt
+    T1.1.log
+    T1.2.log
+    T1.3.log
+    T1.4.log
+```
+
+Older directories under `tier-1-evidence/` should be cleaned up periodically (analogous to substrate's workspace reaper). Out of scope for Plan C.
+```
+
+- [ ] **Step 2: Create failure-classification.md**
+
+Save:
+
+```markdown
+# Failure classification
+
+Every `fail` verdict has a `failClass` — release-readiness uses it to decide whether a fail blocks ship.
+
+## Classes
+
+| Class | Pattern | Triage default |
+|---|---|---|
+| `real-bug` | assertion failures, schema mismatches, unexpected returned values | BLOCKING |
+| `flake-infra` | HTTP errors, ECONNREFUSED, ECONNRESET, network errors, getaddrinfo failures | retry once → if persistent, DEFERRABLE |
+| `flake-timing` | "timed out", "timeout", "waiting for X" | retry once → if persistent, DEFERRABLE |
+| `agent-crash` | scenario itself threw before producing a verdict | escalate to human |
+
+## Detection
+
+`classifyFailure(err)` in `client/scripts/release/scenario-types.ts` regex-matches the error message against pattern lists. Conservative default: unknown errors are classified `real-bug` (so a genuine bug isn't accidentally treated as a flake).
+
+## Adding patterns
+
+When a real infrastructure issue keeps showing up as `real-bug`, extend the `FLAKE_INFRA_PATTERNS` or `FLAKE_TIMING_PATTERNS` lists in `scenario-types.ts`. Each addition should be accompanied by a regression test in `scenario-types.test.ts` so the classification is durable.
+
+## What release-readiness does with each class
+
+- `real-bug` → adds to BLOCKING gaps; closure subagent dispatched
+- `flake-infra` → retry once; if persistent, marks as DEFERRABLE with a `tier-1-...=flake-infra` marker
+- `flake-timing` → same as flake-infra
+- `agent-crash` → escalate to human; recommendation = DEFER with diagnostic in handoff doc
+```
+
+- [ ] **Step 3: Create tier-2-scenarios placeholder**
+
+Save:
+
+```markdown
+# Tier 2 scenarios
+
+**Status:** Placeholder. Implementations land in Plan D.
+
+Tier 2 scenarios run cross-operator against substrate-derived workspaces. The contracts (what each scenario asserts) are in `testing-jinn-app` reference docs:
+
+- T2.1 — cross-operator-donation: [`testing-jinn-app/references/scenario-cross-op-donation.md`](../../testing-jinn-app/references/scenario-cross-op-donation.md)
+- T2.2 — producer-evaluator-anvil-fork: [`testing-jinn-app/references/scenario-producer-evaluator.md`](../../testing-jinn-app/references/scenario-producer-evaluator.md)
+- T2.3 — multi-op-spa-flow: [`testing-jinn-app/references/scenario-multi-op-spa-flow.md`](../../testing-jinn-app/references/scenario-multi-op-spa-flow.md)
+
+When Plan D lands:
+- Implementations at `client/test/release/tier-2/T2.1.ts`, `T2.2.ts`, `T2.3.ts` (plus the Playwright one at `client/test/dashboard/multi-op/launcher-join-flow.e2e.test.ts`)
+- Orchestrator at `client/scripts/release/run-tier-2.ts`
+- This placeholder doc expanded with the same depth as `tier-1-scenarios.md`
+- release-prep SKILL.md's Tier 2 table populated with wall-clock budgets
+
+Plan D depends on Plan A (substrate), Plan B (helpers), and Plan C (release-prep skill scaffolding from this plan).
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/release-prep/references/evidence-format.md .claude/skills/release-prep/references/failure-classification.md .claude/skills/release-prep/references/tier-2-scenarios.md
+git commit -m "docs(release-prep): add evidence-format, failure-classification, tier-2 placeholder"
+```
+
+---
+
+## Task 11: CI workflow migration — replace operator-gate with Tier 1
+
+**Files:**
+- Modify: `.github/workflows/npm-publish.yml`
+
+The current workflow has a `Release gate — operator-gate` step that's been failing on infra (`jinn-mono-lrey`). Replace it with a `Tier 1 — mechanical floor` step that runs the new orchestrator.
+
+- [ ] **Step 1: Read the current operator-gate step**
+
+Run: `awk '/Release gate — operator-gate/,/^      -/' .github/workflows/npm-publish.yml | head -25`
+Expected: the existing `continue-on-error: true` operator-gate step.
+
+- [ ] **Step 2: Replace the step**
+
+Open `.github/workflows/npm-publish.yml`. Find this block:
+
+```yaml
+      # NOTE: marked continue-on-error 2026-05-19 because the gate
+      # saturates the Tenderly Base Sepolia key during a single run —
+      # multiple full fork operator bootstraps in one job exceed the
+      # quota and produce HTTP errors unrelated to the candidate release.
+      # See jinn-mono-lrey for the architectural follow-up
+      # (per-call RPC footprint, key isolation, fork-state caching, etc.).
+      # Until that lands, ship decisions rely on independent evidence
+      # (real testnet A3 verification, local release-prep gates).
+      - name: Release gate — operator-gate (staking + e2e on Anvil fork)
+        if: steps.meta.outputs.dist_tag == 'latest'
+        continue-on-error: true
+        run: yarn release:operator-gate
+```
+
+Replace with:
+
+```yaml
+      # Tier 1 — mechanical floor (per spec/2026-05-19 §3 of release-readiness design).
+      # Replaces the legacy operator-gate that saturated the Tenderly RPC under
+      # multi-bootstrap load (see jinn-mono-lrey). Tier 1 runs four scenarios
+      # (T1.1-T1.4) in parallel against a single Anvil fork; per-scenario budgets
+      # cap wall-clock; verdicts feed the release-evidence marker.
+      - name: Release gate — Tier 1 mechanical floor
+        if: steps.meta.outputs.dist_tag == 'latest'
+        run: yarn release:tier-1 "${{ steps.meta.outputs.publish_version }}"
+```
+
+Note: `continue-on-error: true` is REMOVED for Tier 1. Tier 1 is meant to be reliable; a flake here should fail the publish (operator can re-run if it was a real flake). If Tier 1 turns out to flake often in CI, file a GH issue and reconsider.
+
+- [ ] **Step 3: Verify YAML syntax**
+
+Run: `actionlint .github/workflows/npm-publish.yml` (if `actionlint` is available) OR rely on GitHub Actions to surface YAML errors on push.
+
+If `actionlint` isn't installed, manual check: indentation, key alignment. The step should integrate cleanly with the surrounding steps.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/npm-publish.yml
+git commit -m "ci(release): replace operator-gate with Tier 1 mechanical floor"
+```
+
+**NOTE:** This commit *changes CI behavior on the next push to `next`*. If Plans A-C land separately, ensure Plan A's substrate scripts are present on `next` before this commit lands, otherwise `yarn release:tier-1` will fail to import substrate paths. (Tier 1 itself doesn't use substrate, but the orchestrator imports `scenario-types.ts` which is in the same `client/scripts/release/` tree as substrate scripts — verify no cross-imports.)
+
+The implementer should verify `tsx scripts/release/run-tier-1.ts v0.1.7-smoke` runs cleanly *before* this commit lands.
+
+---
+
+## Task 12: README + yarn scripts wiring
+
+**Files:**
+- Modify: `client/package.json` (add yarn scripts)
+- Create: `client/scripts/release/README.md` (if not created by Plan A; otherwise extend it)
+
+- [ ] **Step 1: Add yarn scripts**
+
+Open `client/package.json`. In the `"scripts"` object, add:
+
+```json
+{
+  "scripts": {
+    "release:tier-1": "tsx scripts/release/run-tier-1.ts",
+    "release:tier-1:T1.1": "vitest run test/release/tier-1/T1.1-bootstrap-fresh-anvil.ts",
+    "release:tier-1:T1.2": "vitest run test/release/tier-1/T1.2-harness-readiness-contract.ts",
+    "release:tier-1:T1.3": "vitest run test/release/tier-1/T1.3-indexer-round-trip.ts",
+    "release:tier-1:T1.4": "playwright test --config=playwright.config.ts test/dashboard/release-prep/spa-route-smoke.e2e.test.ts"
+  }
+}
+```
+
+- [ ] **Step 2: Verify yarn scripts work**
+
+Run: `cd client && yarn release:tier-1:T1.2 2>&1 | tail -10`
+Expected: T1.2 test executes (passes or fails based on actual daemon behavior; orchestrator semantics not exercised by per-scenario yarn scripts).
+
+Run: `cd client && yarn release:tier-1 v0.1.7-yarn-smoke 2>&1 | tail -20`
+Expected: orchestrator runs all four scenarios, exits with verdict summary.
+
+- [ ] **Step 3: Update or create release README**
+
+If Plan A already created `client/scripts/release/README.md`, extend it with:
+
+```markdown
+## Tier 1 orchestrator
+
+`run-tier-1.ts` runs all four Tier 1 scenarios in parallel and emits a structured verdict.
+
+```bash
+yarn release:tier-1 <candidate-version>
+```
+
+Output goes to `tier-1-evidence/<timestamp>/` with `summary.json`, `marker.txt`, and per-scenario `.log` files.
+
+Per-scenario standalone invocations:
+
+```bash
+yarn release:tier-1:T1.1    # bootstrap-fresh-anvil
+yarn release:tier-1:T1.2    # harness-readiness-contract
+yarn release:tier-1:T1.3    # indexer-round-trip
+yarn release:tier-1:T1.4    # SPA route smoke
+```
+
+Spec: `docs/superpowers/specs/2026-05-19-release-readiness-and-substrate-design.md` §3.
+```
+
+If the README doesn't exist yet (Plan A hadn't landed), create it with both the substrate ops section (from Plan A) AND this Tier 1 section. The implementer should check Plan A's README content first.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/package.json client/scripts/release/README.md
+git commit -m "chore(release): wire yarn scripts + README for Tier 1"
+```
+
+---
+
+## Self-review
+
+### Spec coverage
+
+| Spec requirement | Covered by | Status |
+|---|---|---|
+| §3 release-prep skill | Tasks 9, 10 | ✓ |
+| §3 Tier 1 scenarios T1.1-T1.4 | Tasks 4-7 | ✓ |
+| §3 run-tier-1 orchestrator | Task 8 | ✓ |
+| §3 failure classification | Task 3 + Task 10 (doc) | ✓ |
+| §3 evidence + marker emission | Task 8 + Task 10 (doc) | ✓ |
+| §6 T1.4 SPA route smoke | Task 7 | ✓ |
+| §1 CI workflow migration | Task 11 | ✓ |
+| Plan B fold-back: mockDaemonApi extraction | Task 2 | ✓ |
+| Plan B fold-back: ROUTES export | Task 1 | ✓ |
+
+### Placeholder scan
+
+- Task 4 (T1.1) has a `[PSEUDOCODE — implementer fills in...]` block — necessarily, because adapting the existing `staking-validate.ts` requires reading its current state. This is flagged with explicit instructions to the implementer. Acceptable: the structural skeleton is concrete; only the bootstrap-loop call is left to adapt.
+- Task 6 (T1.3) has a similar PSEUDOCODE block plus a `skip` fallback path — necessary because the Ponder spawn helper may not exist yet. The plan provides the skip path so the orchestrator doesn't block.
+- All other tasks contain complete, copy-pasteable code.
+
+### Type consistency
+
+- `ScenarioVerdict`, `FailClass`, `ScenarioOptions` consistent across Tasks 3-8.
+- `runT11BootstrapFreshAnvil`, `runT12HarnessReadinessContract`, `runT13IndexerRoundTrip` signature identical: `(opts: ScenarioOptions) => Promise<ScenarioVerdict>`.
+- Import paths verified: `multi-op-daemon` and `handshake-url` from Plan B; `scenario-types` from this plan's Task 3; `spawnAnvilFork` from `client/test/_support/chain/anvil.ts` (verified to exist by Plan B's fold-back).
+
+### Cross-plan contract check
+
+This plan promises Plan D the following inputs:
+- `client/scripts/release/scenario-types.ts` — Plan D's Tier 2 scenarios use the same types.
+- `.claude/skills/release-prep/SKILL.md` — Plan D extends the Tier 2 section.
+- `.claude/skills/release-prep/references/tier-2-scenarios.md` placeholder — Plan D expands it.
+- `client/scripts/release/run-tier-1.ts` — Plan D may model `run-tier-2.ts` on it.
+
+This plan promises Plan E:
+- `.claude/skills/release-prep/SKILL.md` exists and is invocable as a subagent.
+- Evidence/marker format documented (Plan E's release-readiness consumes this output).
+
+### Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-19-tier-1-and-release-prep-plan.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven (recommended)** — Dispatch a fresh subagent per task. The plan has 12 tasks; subagent flow keeps the implementer's context per-task small and catches plan-spec bugs via the review pass (same pattern Plan B and Plan A executions used).
+
+2. **Inline Execution** — Execute tasks in this session via `superpowers:executing-plans`.
+
+Plan C depends on Plan B's helpers (`multi-op-daemon`, `handshake-url`, `mockDaemonApi`-extraction). If Plan B isn't merged yet, Plan C execution can still proceed on a branch based off the Plan B branch (`feat/testing-jinn-app-multi-op`). Once Plan B merges to `next`, rebase.
+
+Plan C does NOT depend on Plan A at runtime — Tier 1 scenarios don't touch the substrate. Plan A and Plan C can land in either order.
+
+Which approach?

--- a/docs/superpowers/plans/2026-05-19-tier-2-scenarios-plan.md
+++ b/docs/superpowers/plans/2026-05-19-tier-2-scenarios-plan.md
@@ -1,0 +1,1639 @@
+# Tier 2 scenarios implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the three Tier 2 scenarios (T2.1 cross-op donation, T2.2 producer/evaluator on Anvil-fork, T2.3 multi-op SPA flow), the `run-tier-2.ts` orchestrator that runs them in parallel against substrate-derived workspaces, the prerequisite infrastructure (shared substrate+fork+daemons helper, Ponder spawn helper if absent, stubbed harness for T2.2, SWE-rebench fixture), and the documentation that takes the `tier-2-scenarios.md` reference from placeholder (Plan C) to full spec.
+
+**Architecture:** Each scenario is a callable async function returning `ScenarioVerdict` (the shared shape from Plan C). T2.1 and T2.2 are pure TypeScript callables; T2.3 is a Playwright test invoked via subprocess from the orchestrator. All three scenarios start by calling a shared `setupTier2Scenario()` helper that creates a substrate workspace, spawns an Anvil fork, and spawns two daemons against the workspace — one helper, three call sites. The orchestrator (`run-tier-2.ts`) mirrors Plan C's `run-tier-1.ts` structure: parallel `Promise.allSettled`, verdict aggregation, marker emission, per-scenario evidence files.
+
+**Tech Stack:** TypeScript, Vitest, Playwright, viem. Reuses Plan A's substrate scripts, Plan B's `multi-op-daemon` + `handshake-url` helpers, Plan B's `mockDaemonApi` extraction, Plan C's `scenario-types`. Adds a Ponder spawn helper (if absent in the repo today) and a stubbed harness implementation hooked into the existing harness registry.
+
+**Dependencies:**
+- **Plan A** — substrate-copy, substrate-verify, substrate-paths. Tier 2 doesn't run without substrate.
+- **Plan B** — multi-op-daemon, handshake-url, mockDaemonApi (extracted in Plan C Task 2), `multi-op-playwright.md` reference doc.
+- **Plan C** — `scenario-types.ts` (ScenarioVerdict, classifyFailure), `release-prep` SKILL.md scaffolding (this plan extends it), `tier-2-scenarios.md` placeholder (this plan replaces it).
+- The existing fork helper `spawnAnvilFork` at `client/test/_support/chain/anvil.ts`.
+- The existing harness registry at `client/src/harnesses/impls/index.ts` (verify path during Task 3; CLAUDE.md says it's `buildHarnesses`).
+
+---
+
+## File structure
+
+**New source files:**
+
+| Path | Responsibility |
+|---|---|
+| `client/test/release/tier-2/tier-2-helpers.ts` | `setupTier2Scenario()` shared substrate+fork+daemons setup |
+| `client/test/release/tier-2/T2.1-cross-op-donation.ts` | T2.1 callable + Vitest wrapper |
+| `client/test/release/tier-2/T2.2-producer-evaluator.ts` | T2.2 callable + Vitest wrapper |
+| `client/test/release/tier-2/fixtures/<instance-id>.patch` | Canned solution patch for T2.2 |
+| `client/test/release/tier-2/fixtures/known-instance.ts` | Constants: KNOWN_INSTANCE_ID, KNOWN_REPO, KNOWN_COMMIT, KNOWN_EXPECTED_VERDICT |
+| `client/test/dashboard/multi-op/launcher-join-flow.e2e.test.ts` | T2.3 Playwright test |
+| `client/test/dashboard/multi-op/fixtures/two-substrate-ops.ts` | Playwright fixture: substrate + fork + daemons |
+| `client/scripts/release/run-tier-2.ts` | Orchestrator |
+| `client/test/_support/indexer/ponder.ts` | Ponder spawn helper (if absent in repo) |
+| `client/src/harnesses/impls/stub.ts` | Stubbed harness implementation (`JINN_HARNESS_STUB_INSTANCE`-gated) |
+
+**Modified files:**
+
+| Path | Change |
+|---|---|
+| `client/src/harnesses/impls/index.ts` | Register stub harness conditionally |
+| `client/src/dashboard/spa/src/pages/LauncherLaunched.tsx` | Add `data-testid="manifest-cid"` and `data-testid="operator-count"` (if missing) |
+| `.claude/skills/release-prep/SKILL.md` | Real Tier 2 wall-clock budgets in the table |
+| `.claude/skills/release-prep/references/tier-2-scenarios.md` | Full doc (replaces placeholder) |
+| `client/package.json` | Add `release:tier-2`, `release:tier-2:T2.1`, ... yarn scripts |
+
+---
+
+## Task 1: Shared Tier 2 setup helper
+
+**Files:**
+- Create: `client/test/release/tier-2/tier-2-helpers.ts`
+- Test: `client/test/release/tier-2/tier-2-helpers.test.ts`
+
+Every Tier 2 scenario does the same opening dance: copy substrate workspace → spawn Anvil fork → spawn two daemons against workspace homes with the fork RPC → wait for both daemons reachable. Extract once.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// client/test/release/tier-2/tier-2-helpers.test.ts
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { setupTier2Scenario } from './tier-2-helpers';
+
+describe('setupTier2Scenario', () => {
+  it('returns a handle with workspace, anvil, and two daemon URLs', async () => {
+    // This test requires Plan A's substrate to exist at ~/jinn-dev/operators/.
+    // Skip if not present (e.g. fresh checkout pre-Plan-A).
+    const goldOpA = path.join(os.homedir(), 'jinn-dev', 'operators', 'op-a');
+    try { await fs.access(goldOpA); } catch { return; }
+
+    let handle: Awaited<ReturnType<typeof setupTier2Scenario>> | undefined;
+    try {
+      handle = await setupTier2Scenario({
+        scenarioId: 'T2.X-test',
+        portBase: 7740,
+      });
+      expect(handle.workspace.opPaths['op-a']).toContain('op-a');
+      expect(handle.workspace.opPaths['op-b']).toContain('op-b');
+      expect(handle.anvilRpcUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+      expect(handle.daemons.daemons['op-a'].apiPort).toBe(7740);
+      expect(handle.daemons.daemons['op-b'].apiPort).toBe(7741);
+    } finally {
+      if (handle) await handle.teardown();
+    }
+  }, 90000);
+
+  it('teardown is idempotent and cleans up workspace + anvil + daemons', async () => {
+    const goldOpA = path.join(os.homedir(), 'jinn-dev', 'operators', 'op-a');
+    try { await fs.access(goldOpA); } catch { return; }
+
+    const handle = await setupTier2Scenario({ scenarioId: 'T2.X-cleanup', portBase: 7742 });
+    const workspaceRoot = handle.workspace.workspaceRoot;
+    await handle.teardown();
+    await expect(fs.access(workspaceRoot)).rejects.toThrow();
+    // Idempotent
+    await expect(handle.teardown()).resolves.toBeUndefined();
+  }, 90000);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd client && yarn vitest run test/release/tier-2/tier-2-helpers.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the helper**
+
+```typescript
+// client/test/release/tier-2/tier-2-helpers.ts
+import { baseSepolia } from 'viem/chains';
+import { copyWorkspace, type WorkspaceHandle } from '../../../scripts/release/substrate-copy';
+import { spawnAnvilFork } from '../../_support/chain/anvil';
+import { spawnMultiOpDaemons, type MultiOpHandle } from '../../helpers/multi-op-daemon';
+
+export interface Tier2SetupOptions {
+  scenarioId: string;                  // for run-id and debugging
+  portBase: number;                    // op-a gets portBase, op-b gets portBase+1
+  extraEnv?: NodeJS.ProcessEnv;        // additional env per daemon (e.g. JINN_HARNESS_STUB_INSTANCE)
+  ops?: string[];                      // default: ['op-a', 'op-b']
+}
+
+export interface Tier2Handle {
+  workspace: WorkspaceHandle;
+  anvil: Awaited<ReturnType<typeof spawnAnvilFork>>;
+  anvilRpcUrl: string;
+  daemons: MultiOpHandle;
+  teardown: () => Promise<void>;
+}
+
+export async function setupTier2Scenario(opts: Tier2SetupOptions): Promise<Tier2Handle> {
+  const ops = opts.ops ?? ['op-a', 'op-b'];
+  if (ops.length < 1 || ops.length > 3) {
+    throw new Error(`setupTier2Scenario expects 1-3 ops, got ${ops.length}`);
+  }
+
+  let workspace: WorkspaceHandle | null = null;
+  let anvil: Awaited<ReturnType<typeof spawnAnvilFork>> | null = null;
+  let daemons: MultiOpHandle | null = null;
+
+  const cleanup = async () => {
+    if (daemons) { try { await daemons.teardown(); } catch {} }
+    if (anvil) { try { await anvil.teardown(); } catch {} }
+    if (workspace) { try { await workspace.teardown(); } catch {} }
+  };
+
+  try {
+    // 1. Substrate workspace copy
+    workspace = await copyWorkspace({ ops, runId: `${opts.scenarioId}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}` });
+
+    // 2. Anvil fork of Base Sepolia (one per scenario)
+    const forkUrl = process.env['BASE_SEPOLIA_RPC_URL'];
+    if (!forkUrl) {
+      throw new Error('BASE_SEPOLIA_RPC_URL must be set to fork Base Sepolia for Tier 2 scenarios');
+    }
+    anvil = await spawnAnvilFork({ forkUrl, chain: baseSepolia, silent: true });
+
+    // 3. Spawn daemons against workspace homes with fork RPC override
+    daemons = await spawnMultiOpDaemons({
+      ops: ops.map((name, i) => ({
+        name,
+        home: workspace!.opPaths[name],
+        apiPort: opts.portBase + i,
+      })),
+      // JINN_RPC_URL — not BASE_RPC_URL — because config.ts gives JINN_RPC_URL
+      // unconditional precedence. The spawn helper surfaces extraEnv RPC keys
+      // through JINN_RPC_URL anyway, but explicit at the call site is clearer.
+      extraEnv: { JINN_RPC_URL: anvil.rpcUrl, ...opts.extraEnv },
+      readyTimeoutMs: 45000,
+    });
+
+    let torn = false;
+    return {
+      workspace,
+      anvil,
+      anvilRpcUrl: anvil.rpcUrl,
+      daemons,
+      teardown: async () => {
+        if (torn) return;
+        torn = true;
+        await cleanup();
+      },
+    };
+  } catch (err) {
+    await cleanup();
+    throw err;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd client && yarn build && yarn vitest run test/release/tier-2/tier-2-helpers.test.ts`
+Expected: tests pass if substrate exists; skip cleanly otherwise.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/test/release/tier-2/tier-2-helpers.ts client/test/release/tier-2/tier-2-helpers.test.ts
+git commit -m "test(release): add shared Tier 2 setup helper (substrate + fork + daemons)"
+```
+
+---
+
+## Task 2: Ponder spawn helper
+
+**Files:**
+- Verify existence or create: `client/test/_support/indexer/ponder.ts`
+- Test: `client/test/_support/indexer/ponder.test.ts`
+
+T2.1 and T2.3 need an indexer running. T2.2 doesn't (it reads on-chain directly).
+
+- [ ] **Step 1: Check for an existing helper**
+
+Run: `find client -name "*ponder*" -type f 2>/dev/null | head -10`
+Expected: either an existing helper file, or nothing.
+
+If `client/test/_support/indexer/ponder.ts` (or similar) already exists, skip to Step 5 (verify its API matches what this plan assumes). If absent, continue Steps 2-4.
+
+- [ ] **Step 2: Survey the indexer code to understand startup**
+
+Run: `find . -path ./node_modules -prune -o -name "ponder.config.ts" -print 2>/dev/null | head -5`
+Expected: a ponder config file (likely at `indexer/ponder.config.ts` or similar).
+
+Run: `find . -path ./node_modules -prune -o -name "package.json" -print 2>/dev/null | xargs grep -l "ponder" 2>/dev/null | head -5`
+Expected: package.json files referencing Ponder — these tell us the package layout.
+
+The implementer should determine how Ponder is normally started (yarn script in the indexer package, etc.) before writing the helper.
+
+- [ ] **Step 3: Write the failing test**
+
+```typescript
+// client/test/_support/indexer/ponder.test.ts
+import { describe, it, expect } from 'vitest';
+import { spawnPonderIndexer } from './ponder';
+
+describe('spawnPonderIndexer', () => {
+  it('starts a local Ponder pointed at a given RPC and shuts down cleanly', async () => {
+    // Skip if Ponder package isn't present in the repo (e.g. monorepo subset).
+    let indexer: Awaited<ReturnType<typeof spawnPonderIndexer>> | undefined;
+    try {
+      indexer = await spawnPonderIndexer({
+        rpcUrl: 'http://127.0.0.1:8545',          // dummy; the test asserts startup, not E2E
+        chainId: 84532,
+        readyTimeoutMs: 30000,
+      });
+      expect(indexer.graphqlUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/graphql$/);
+      expect(indexer.port).toBeGreaterThan(0);
+    } finally {
+      if (indexer) await indexer.teardown();
+    }
+  }, 60000);
+
+  it('teardown is idempotent', async () => {
+    let indexer: Awaited<ReturnType<typeof spawnPonderIndexer>> | undefined;
+    try {
+      indexer = await spawnPonderIndexer({ rpcUrl: 'http://127.0.0.1:8545', chainId: 84532 });
+    } catch {
+      return;       // accept failure on environments without Ponder
+    }
+    await indexer.teardown();
+    await expect(indexer.teardown()).resolves.toBeUndefined();
+  }, 60000);
+});
+```
+
+- [ ] **Step 4: Implement the spawn helper**
+
+```typescript
+// client/test/_support/indexer/ponder.ts
+import { spawn, type ChildProcess } from 'node:child_process';
+import * as path from 'node:path';
+import * as net from 'node:net';
+
+export interface PonderHandle {
+  graphqlUrl: string;
+  port: number;
+  process: ChildProcess;
+  teardown: () => Promise<void>;
+}
+
+export interface SpawnPonderOptions {
+  rpcUrl: string;
+  chainId: number;
+  port?: number;                       // default: random
+  ponderRoot?: string;                 // default: resolve from repo root
+  readyTimeoutMs?: number;             // default 30s
+}
+
+async function pickFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.unref();
+    srv.on('error', reject);
+    srv.listen(0, () => {
+      const p = (srv.address() as net.AddressInfo).port;
+      srv.close(() => resolve(p));
+    });
+  });
+}
+
+async function waitForGraphql(url: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ query: '{ __typename }' }),
+      });
+      if (res.ok) return;
+    } catch {
+      // not yet
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`Ponder GraphQL at ${url} did not become reachable within ${timeoutMs}ms`);
+}
+
+export async function spawnPonderIndexer(opts: SpawnPonderOptions): Promise<PonderHandle> {
+  const port = opts.port ?? (await pickFreePort());
+  const readyTimeoutMs = opts.readyTimeoutMs ?? 30000;
+  // IMPLEMENTER: resolve the Ponder package root and the correct invocation.
+  // Common shape (verify against this repo's actual layout):
+  //   const ponderRoot = opts.ponderRoot ?? path.resolve(process.cwd(), '..', 'indexer');
+  //   const args = ['dev', '--port', port.toString()];
+  //   const env = { ...process.env, PONDER_RPC_URL_<chainId>: opts.rpcUrl };
+  const ponderRoot = opts.ponderRoot ?? path.resolve(process.cwd(), '..', 'indexer');
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    [`PONDER_RPC_URL_${opts.chainId}`]: opts.rpcUrl,
+  };
+  const child = spawn('yarn', ['dev', '--port', port.toString()], {
+    cwd: ponderRoot,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const graphqlUrl = `http://127.0.0.1:${port}/graphql`;
+  try {
+    await waitForGraphql(graphqlUrl, readyTimeoutMs);
+  } catch (err) {
+    child.kill('SIGTERM');
+    throw err;
+  }
+  let torn = false;
+  return {
+    graphqlUrl,
+    port,
+    process: child,
+    teardown: async () => {
+      if (torn) return;
+      torn = true;
+      try { child.kill('SIGTERM'); } catch {}
+      await new Promise((r) => setTimeout(r, 300));
+      if (!child.killed) { try { child.kill('SIGKILL'); } catch {} }
+    },
+  };
+}
+```
+
+**NOTE TO IMPLEMENTER:** The `ponderRoot` and `args` resolution depends on this repo's actual indexer layout. The implementer should:
+1. `cat <ponder-package>/package.json` to find the dev script.
+2. Determine the correct env var name for the chain RPC (Ponder convention is `PONDER_RPC_URL_<chainId>`).
+3. Adjust the spawn invocation to match.
+
+If Ponder's dev mode is too slow for test invocation (warm-up + initial sync), consider a `start` mode against a pre-built artifact, or a separate test fixture.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd client && yarn vitest run test/_support/indexer/ponder.test.ts`
+Expected: pass if Ponder is reachable, skip if not.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/test/_support/indexer/ponder.ts client/test/_support/indexer/ponder.test.ts
+git commit -m "test(_support): add Ponder spawn helper for Tier 2 scenarios"
+```
+
+---
+
+## Task 3: Stubbed harness for T2.2
+
+**Files:**
+- Create: `client/src/harnesses/impls/stub.ts`
+- Modify: `client/src/harnesses/impls/index.ts` (register conditionally)
+- Test: `client/test/harnesses/stub.test.ts`
+
+T2.2 needs a harness that returns a canned solution without calling any LLM. Gated by `JINN_HARNESS_STUB_INSTANCE=<instance-id>` env var.
+
+- [ ] **Step 1: Survey the existing harness registry**
+
+Run: `cat client/src/harnesses/impls/index.ts`
+Expected: a `buildHarnesses(...)` function that returns a map/list of harness implementations. Read the existing harness shape (e.g. `claude-code-learner`, `codex-code-learner`, `hermes-agent`) to understand the interface.
+
+The implementer should determine:
+- What's the harness interface? (likely `{ name, isReady(), solve(taskSpec) }` or similar)
+- How does `buildHarnesses` decide which to include?
+- What does `solve()` return?
+
+- [ ] **Step 2: Write the failing test**
+
+```typescript
+// client/test/harnesses/stub.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { createStubHarness } from '../../src/harnesses/impls/stub';
+
+describe('stub harness', () => {
+  let fixturesDir: string;
+
+  beforeEach(async () => {
+    fixturesDir = await fs.mkdtemp(path.join(os.tmpdir(), 'stub-fixtures-'));
+    await fs.writeFile(
+      path.join(fixturesDir, 'known-instance.patch'),
+      'diff --git a/foo.py b/foo.py\n--- a/foo.py\n+++ b/foo.py\n@@ -1 +1 @@\n-old\n+new\n',
+    );
+  });
+
+  afterEach(async () => {
+    await fs.rm(fixturesDir, { recursive: true, force: true });
+  });
+
+  it('returns the canned patch when instance matches', async () => {
+    const harness = createStubHarness({ fixturesDir, instanceMatcher: 'known-instance' });
+    expect(harness.name).toBe('harness:stub');
+    const result = await harness.solve({ instanceId: 'known-instance', repo: 'r', commit: 'c' });
+    expect(result.patch).toContain('diff --git a/foo.py');
+  });
+
+  it('throws when instance does not match', async () => {
+    const harness = createStubHarness({ fixturesDir, instanceMatcher: 'known-instance' });
+    await expect(harness.solve({ instanceId: 'other-instance', repo: 'r', commit: 'c' })).rejects.toThrow(/does not match/);
+  });
+
+  it('reports ready', async () => {
+    const harness = createStubHarness({ fixturesDir, instanceMatcher: 'known-instance' });
+    const ready = await harness.isReady();
+    expect(ready.ready).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `cd client && yarn vitest run test/harnesses/stub.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 4: Implement the stub harness**
+
+```typescript
+// client/src/harnesses/impls/stub.ts
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+export interface StubHarnessOptions {
+  fixturesDir: string;                 // where to look for <instanceMatcher>.patch
+  instanceMatcher: string;             // instance ID this stub will respond to
+}
+
+interface SolveTaskSpec {
+  instanceId: string;
+  repo: string;
+  commit: string;
+}
+
+interface SolveResult {
+  patch: string;
+  envelope?: Record<string, unknown>;
+}
+
+interface ReadinessReport {
+  name: string;
+  ready: boolean;
+  requirements: string[];
+  reasons: string[];
+}
+
+export interface StubHarness {
+  name: string;
+  isReady: () => Promise<ReadinessReport>;
+  solve: (taskSpec: SolveTaskSpec) => Promise<SolveResult>;
+}
+
+export function createStubHarness(opts: StubHarnessOptions): StubHarness {
+  return {
+    name: 'harness:stub',
+    async isReady() {
+      return { name: 'harness:stub', ready: true, requirements: [], reasons: [] };
+    },
+    async solve(taskSpec) {
+      if (taskSpec.instanceId !== opts.instanceMatcher) {
+        throw new Error(`stub harness: taskSpec.instanceId=${taskSpec.instanceId} does not match configured instanceMatcher=${opts.instanceMatcher}`);
+      }
+      const patchPath = path.join(opts.fixturesDir, `${opts.instanceMatcher}.patch`);
+      const patch = await fs.readFile(patchPath, 'utf-8');
+      return { patch };
+    },
+  };
+}
+
+/**
+ * Activated when env JINN_HARNESS_STUB_INSTANCE is set. Reads
+ * fixtures from JINN_HARNESS_STUB_FIXTURES_DIR (default:
+ * <repo>/client/test/release/tier-2/fixtures).
+ */
+export function maybeCreateStubHarnessFromEnv(): StubHarness | null {
+  const instanceMatcher = process.env['JINN_HARNESS_STUB_INSTANCE'];
+  if (!instanceMatcher) return null;
+  const fixturesDir = process.env['JINN_HARNESS_STUB_FIXTURES_DIR']
+    ?? path.resolve(process.cwd(), 'test', 'release', 'tier-2', 'fixtures');
+  return createStubHarness({ instanceMatcher, fixturesDir });
+}
+```
+
+- [ ] **Step 5: Wire into the harness registry**
+
+Open `client/src/harnesses/impls/index.ts`. Add to the `buildHarnesses(...)` function (or equivalent shape):
+
+```typescript
+import { maybeCreateStubHarnessFromEnv } from './stub';
+
+// Inside buildHarnesses(...), after registering production harnesses:
+const stub = maybeCreateStubHarnessFromEnv();
+if (stub) {
+  harnesses.push(stub);   // or whatever the registry shape uses
+}
+```
+
+**IMPLEMENTER:** Adjust the integration to match the actual registry shape. The principle: when `JINN_HARNESS_STUB_INSTANCE` is set, the stub harness is available alongside (or replacing — TBD by registry shape) the production ones.
+
+- [ ] **Step 6: Run tests**
+
+Run: `cd client && yarn vitest run test/harnesses/stub.test.ts`
+Expected: PASS, 3 tests passing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add client/src/harnesses/impls/stub.ts client/src/harnesses/impls/index.ts client/test/harnesses/stub.test.ts
+git commit -m "feat(harnesses): add env-gated stub harness for T2.2 producer/evaluator gate"
+```
+
+---
+
+## Task 4: SWE-rebench v2 fixture for T2.2
+
+**Files:**
+- Create: `client/test/release/tier-2/fixtures/known-instance.ts`
+- Create: `client/test/release/tier-2/fixtures/<INSTANCE_ID>.patch`
+
+T2.2 needs a known-solvable SWE-rebench v2 instance: a real instance ID, a canned patch that applies cleanly, and an expected verdict outcome.
+
+- [ ] **Step 1: Pick a known-solvable instance**
+
+The simplest path: reuse the same instance the v0.1.6 A3 verification used — `sympy__sympy-27510` (the one Op A solved with `verdictCode=1`). Its solution patch and applied state are recorded in the v0.1.6 stewardship log.
+
+Run: `grep -r "sympy__sympy-27510" log/decisions/ 2>/dev/null | head -5`
+Expected: references in the v0.1.6 stewardship log with solution CIDs.
+
+If those CIDs are still pinned on IPFS, the canned patch can be retrieved from there. Otherwise, the implementer picks a different instance from the SWE-rebench v2 admission pool and runs the existing harness once locally to obtain a verified-good patch.
+
+- [ ] **Step 2: Write the fixture constants**
+
+```typescript
+// client/test/release/tier-2/fixtures/known-instance.ts
+
+/**
+ * Fixture: a known-solvable SWE-rebench v2 instance for T2.2.
+ *
+ * Selection criteria:
+ *   - Currently admitted to the SWE-rebench v2 pool (verdict-time recheck won't reject it).
+ *   - Small repo, fast clone.
+ *   - Has a known-good solution patch that produces `verdictCode=1` against the
+ *     evaluator's Docker image at the digest pinned in client/src/eval/admission.
+ *
+ * If the SWE-rebench pool rebuild invalidates this instance, replace it with
+ * another admitted instance + its patch. See `<instance-id>.patch` next to this file.
+ */
+
+export const KNOWN_INSTANCE_ID = 'sympy__sympy-27510';
+export const KNOWN_REPO = 'sympy/sympy';
+export const KNOWN_COMMIT = 'PLACEHOLDER';            // implementer fills from v0.1.6 stewardship log
+export const KNOWN_EXPECTED_VERDICT = 1;              // 1 = passed; 0 = failed
+export const KNOWN_PATCH_FILE = `${KNOWN_INSTANCE_ID}.patch`;
+
+/**
+ * Manifest CID under which this instance was admitted (for cross-checks against
+ * the SolverNet's manifest at runtime).
+ */
+export const KNOWN_MANIFEST_CID = 'bafkreichdzxtjav3rh5boyybgx6wolh7boqedxix4vvw44slfppwppshpi';
+```
+
+**IMPLEMENTER:** Fill `KNOWN_COMMIT` from the v0.1.6 stewardship log (`log/decisions/2026-05-19-v0.1.6-stewardship.md` — A3 verification section). If the commit isn't recorded there, look up the instance in the SWE-rebench v2 admission manifest at runtime via the existing eval-substrate code.
+
+- [ ] **Step 3: Write the patch file**
+
+The patch file `<KNOWN_INSTANCE_ID>.patch` should be the actual unified-diff text that was verified to produce `verdictCode=1` during the v0.1.6 A3 verification.
+
+Path: `client/test/release/tier-2/fixtures/sympy__sympy-27510.patch`
+
+**IMPLEMENTER:** Retrieve the patch via:
+1. The solution-CID IPFS pin from the v0.1.6 stewardship log (recorded in `log/decisions/`). The envelope contains the patch in its trajectory.
+2. Or, re-run the harness once against the known instance to produce a fresh patch, then commit it.
+
+The file should be exactly the patch text — no JSON wrapping, no envelope. The stub harness reads it raw and the daemon's delivery flow wraps it in the standard envelope.
+
+If the patch is large (>50KB), commit it but flag in a comment that it's a fixture and shouldn't be edited.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/test/release/tier-2/fixtures/known-instance.ts client/test/release/tier-2/fixtures/sympy__sympy-27510.patch
+git commit -m "test(release): add SWE-rebench v2 fixture instance + canned solution for T2.2"
+```
+
+---
+
+## Task 5: T2.1 — cross-operator donation
+
+**Files:**
+- Create: `client/test/release/tier-2/T2.1-cross-op-donation.ts`
+
+**What this scenario does:** Per the contract in `.claude/skills/testing-jinn-app/references/scenario-cross-op-donation.md` (Plan B): op-a produces a corpus artifact, indexer attributes it, op-b queries via Discovery API (returns 402), op-b pays x402, op-b retrieves (returns 200 with valid payload + ERC-8128 signature).
+
+- [ ] **Step 1: Survey the existing x402 test pattern**
+
+Run: `cat client/test/x402-corpus-read-twoop.e2e.test.ts | head -100`
+Expected: existing two-op corpus-read pattern. Note the daemon API endpoints used, the payment flow, the assertion shape.
+
+The implementer's job: adapt this pattern to T2.1's substrate-workspace + Anvil-fork setup (using `setupTier2Scenario` from Task 1) and to emit a `ScenarioVerdict`.
+
+- [ ] **Step 2: Write the scenario callable + Vitest wrapper**
+
+```typescript
+// client/test/release/tier-2/T2.1-cross-op-donation.ts
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { setupTier2Scenario, type Tier2Handle } from './tier-2-helpers';
+import { spawnPonderIndexer } from '../../_support/indexer/ponder';
+import { classifyFailure, type ScenarioVerdict, type ScenarioOptions } from '../../../scripts/release/scenario-types';
+
+const SAMPLE_PAYLOAD = {
+  kind: 'corpus-read',
+  topic: 'T2.1-fixture',
+  body: 'donation-scenario-fixture-payload',
+  ts: Date.now(),
+};
+
+async function waitFor<T>(
+  fn: () => Promise<T | null>,
+  opts: { timeoutMs: number; intervalMs?: number; label?: string },
+): Promise<T> {
+  const interval = opts.intervalMs ?? 2000;
+  const deadline = Date.now() + opts.timeoutMs;
+  while (Date.now() < deadline) {
+    const result = await fn();
+    if (result !== null) return result;
+    await new Promise((r) => setTimeout(r, interval));
+  }
+  throw new Error(`waitFor${opts.label ? ` (${opts.label})` : ''} timed out after ${opts.timeoutMs}ms`);
+}
+
+export async function runT21CrossOpDonation(opts: ScenarioOptions): Promise<ScenarioVerdict> {
+  const started = Date.now();
+  const evidenceLines: string[] = [];
+  const log = (msg: string) => evidenceLines.push(`[${new Date().toISOString()}] ${msg}`);
+
+  let handle: Tier2Handle | null = null;
+  let indexer: Awaited<ReturnType<typeof spawnPonderIndexer>> | null = null;
+
+  try {
+    log('1. setup substrate workspace + fork + daemons');
+    handle = await setupTier2Scenario({ scenarioId: 'T2.1', portBase: 7750 });
+    log(`   workspace: ${handle.workspace.workspaceRoot}`);
+    log(`   anvil: ${handle.anvilRpcUrl}`);
+
+    log('2. spawn Ponder indexer against fork');
+    indexer = await spawnPonderIndexer({ rpcUrl: handle.anvilRpcUrl, chainId: 84532, readyTimeoutMs: 45000 });
+    log(`   indexer: ${indexer.graphqlUrl}`);
+
+    const opAPort = handle.daemons.daemons['op-a'].apiPort;
+    const opBPort = handle.daemons.daemons['op-b'].apiPort;
+
+    log('3. op-a produces a corpus artifact');
+    const produceRes = await fetch(`http://127.0.0.1:${opAPort}/v1/corpus/produce`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(SAMPLE_PAYLOAD),
+    });
+    if (!produceRes.ok) {
+      throw new Error(`/v1/corpus/produce returned ${produceRes.status}: ${await produceRes.text()}`);
+    }
+    const produced = await produceRes.json() as { artifactCid: string };
+    log(`   artifact CID: ${produced.artifactCid}`);
+
+    log('4. wait for indexer attribution');
+    await waitFor(async () => {
+      const r = await fetch(`http://127.0.0.1:${opBPort}/v1/discovery/corpus?cid=${produced.artifactCid}`);
+      if (!r.ok) return null;
+      const body = await r.json() as { cid?: string };
+      return body.cid === produced.artifactCid ? body : null;
+    }, { timeoutMs: 60000, label: 'indexer-attribution' });
+    log('   indexer saw the artifact');
+
+    log('5. op-b unpaid query — expect 402');
+    const previewRes = await fetch(`http://127.0.0.1:${opBPort}/v1/corpus/${produced.artifactCid}`);
+    if (previewRes.status !== 402) {
+      throw new Error(`expected 402 (payment required) for unpaid query, got ${previewRes.status}`);
+    }
+    log('   correctly gated');
+
+    log('6. op-b pays x402');
+    const payRes = await fetch(`http://127.0.0.1:${opBPort}/v1/corpus/${produced.artifactCid}/pay`, {
+      method: 'POST',
+    });
+    if (!payRes.ok) {
+      throw new Error(`/v1/corpus/${produced.artifactCid}/pay returned ${payRes.status}`);
+    }
+    const paid = await payRes.json() as { paymentTx?: string };
+    if (!paid.paymentTx || !/^0x[a-fA-F0-9]{64}$/.test(paid.paymentTx)) {
+      throw new Error(`expected paymentTx hash, got ${JSON.stringify(paid)}`);
+    }
+    log(`   payment tx: ${paid.paymentTx}`);
+
+    log('7. op-b retrieves with payment proof');
+    const retrievedRes = await fetch(`http://127.0.0.1:${opBPort}/v1/corpus/${produced.artifactCid}`, {
+      headers: { 'x-x402-payment': paid.paymentTx },
+    });
+    if (retrievedRes.status !== 200) {
+      throw new Error(`expected 200 for paid retrieval, got ${retrievedRes.status}`);
+    }
+    const retrieved = await retrievedRes.json() as { payload?: typeof SAMPLE_PAYLOAD; signature?: unknown };
+    if (!retrieved.payload || retrieved.payload.body !== SAMPLE_PAYLOAD.body) {
+      throw new Error('retrieved payload does not match what was produced');
+    }
+    if (!retrieved.signature) {
+      throw new Error('retrieved artifact has no signature field');
+    }
+    log('   payload + signature match');
+
+    await fs.writeFile(opts.evidencePath, evidenceLines.join('\n'));
+    return {
+      scenarioId: 'T2.1',
+      verdict: 'pass',
+      wallClockMs: Date.now() - started,
+      evidencePath: opts.evidencePath,
+      failClass: null,
+      failNotes: null,
+    };
+  } catch (err) {
+    log(`FAILED: ${err instanceof Error ? err.message : String(err)}`);
+    await fs.writeFile(opts.evidencePath, evidenceLines.join('\n'));
+    return {
+      scenarioId: 'T2.1',
+      verdict: 'fail',
+      wallClockMs: Date.now() - started,
+      evidencePath: opts.evidencePath,
+      failClass: classifyFailure(err),
+      failNotes: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    if (indexer) { try { await indexer.teardown(); } catch {} }
+    if (handle) { try { await handle.teardown(); } catch {} }
+  }
+}
+
+describe('T2.1 cross-op-donation', () => {
+  it('returns pass when full producer-consumer handshake closes', async () => {
+    const evidenceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'T2.1-evidence-'));
+    const evidencePath = path.join(evidenceDir, 'T2.1.log');
+    try {
+      const verdict = await runT21CrossOpDonation({ evidencePath, wallClockBudgetMs: 5 * 60 * 1000 });
+      // If skip (Ponder unavailable), accept. Otherwise expect pass.
+      expect(['pass', 'fail', 'skip']).toContain(verdict.verdict);
+      if (verdict.verdict === 'fail') {
+        console.error('T2.1 failed:', verdict.failNotes);
+      }
+    } finally {
+      await fs.rm(evidenceDir, { recursive: true, force: true });
+    }
+  }, 6 * 60 * 1000);
+});
+```
+
+**IMPLEMENTER:** The exact daemon API endpoint shapes (`/v1/corpus/produce`, `/v1/corpus/:cid`, `/v1/corpus/:cid/pay`) need to match what the daemon actually exposes in v0.1.6. Read `client/src/api/server.ts` (and any route definitions) to confirm. If the endpoint paths differ, update the test to match the real surface. If the endpoints don't exist at all (the scenario was written speculatively), file a GH issue and mark T2.1 as skip in this Tier; the proper fix is to add the endpoints in a follow-up.
+
+- [ ] **Step 3: Run the test**
+
+Run: `cd client && yarn build && yarn vitest run test/release/tier-2/T2.1-cross-op-donation.ts`
+Expected: pass if substrate + Ponder + daemon endpoints all align; fail with structured verdict otherwise (no test assertion failure).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/test/release/tier-2/T2.1-cross-op-donation.ts
+git commit -m "feat(release): add T2.1 cross-op donation scenario"
+```
+
+---
+
+## Task 6: T2.2 — producer/evaluator on Anvil-fork
+
+**Files:**
+- Create: `client/test/release/tier-2/T2.2-producer-evaluator.ts`
+
+**What this scenario does:** Per `.claude/skills/testing-jinn-app/references/scenario-producer-evaluator.md`: op-a posts a known-solvable SWE-rebench v2 task, claims, solves via the stubbed harness, delivers; op-b claims the verdict request, runs the real evaluator Docker image, posts verdict. Assert `verdictCode === KNOWN_EXPECTED_VERDICT`. Activity counters increment.
+
+- [ ] **Step 1: Write the scenario callable + Vitest wrapper**
+
+```typescript
+// client/test/release/tier-2/T2.2-producer-evaluator.ts
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { setupTier2Scenario, type Tier2Handle } from './tier-2-helpers';
+import { classifyFailure, type ScenarioVerdict, type ScenarioOptions } from '../../../scripts/release/scenario-types';
+import {
+  KNOWN_INSTANCE_ID,
+  KNOWN_REPO,
+  KNOWN_COMMIT,
+  KNOWN_EXPECTED_VERDICT,
+} from './fixtures/known-instance';
+
+async function waitFor<T>(
+  fn: () => Promise<T | null>,
+  opts: { timeoutMs: number; intervalMs?: number; label?: string },
+): Promise<T> {
+  const interval = opts.intervalMs ?? 2000;
+  const deadline = Date.now() + opts.timeoutMs;
+  while (Date.now() < deadline) {
+    const result = await fn();
+    if (result !== null) return result;
+    await new Promise((r) => setTimeout(r, interval));
+  }
+  throw new Error(`waitFor${opts.label ? ` (${opts.label})` : ''} timed out after ${opts.timeoutMs}ms`);
+}
+
+export async function runT22ProducerEvaluator(opts: ScenarioOptions): Promise<ScenarioVerdict> {
+  const started = Date.now();
+  const evidenceLines: string[] = [];
+  const log = (msg: string) => evidenceLines.push(`[${new Date().toISOString()}] ${msg}`);
+
+  let handle: Tier2Handle | null = null;
+
+  try {
+    log('1. setup substrate workspace + fork + daemons (with stub harness env)');
+    const fixturesDir = path.resolve(__dirname, 'fixtures');
+    handle = await setupTier2Scenario({
+      scenarioId: 'T2.2',
+      portBase: 7752,
+      extraEnv: {
+        JINN_HARNESS_STUB_INSTANCE: KNOWN_INSTANCE_ID,
+        JINN_HARNESS_STUB_FIXTURES_DIR: fixturesDir,
+      },
+    });
+    log(`   workspace: ${handle.workspace.workspaceRoot}`);
+    log(`   anvil: ${handle.anvilRpcUrl}`);
+
+    const opAPort = handle.daemons.daemons['op-a'].apiPort;
+    const opBPort = handle.daemons.daemons['op-b'].apiPort;
+
+    log('2. op-a posts a known-solvable task');
+    const postRes = await fetch(`http://127.0.0.1:${opAPort}/v1/tasks`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        solverType: 'swe-rebench-v2.v1',
+        spec: { instanceId: KNOWN_INSTANCE_ID, repo: KNOWN_REPO, commit: KNOWN_COMMIT },
+      }),
+    });
+    if (!postRes.ok) throw new Error(`/v1/tasks returned ${postRes.status}: ${await postRes.text()}`);
+    const posted = await postRes.json() as { taskId: string; requestId: string };
+    log(`   taskId: ${posted.taskId}, requestId: ${posted.requestId}`);
+
+    log('3. wait for op-a to claim + solve (stubbed) + deliver');
+    const delivered = await waitFor(async () => {
+      const r = await fetch(`http://127.0.0.1:${opAPort}/v1/tasks/${posted.taskId}`);
+      if (!r.ok) return null;
+      const body = await r.json() as { state?: string; deliveryTxHash?: string };
+      return body.state === 'DELIVERED' && body.deliveryTxHash ? body : null;
+    }, { timeoutMs: 90000, label: 'op-a-delivery' });
+    log(`   deliveryTx: ${delivered.deliveryTxHash}`);
+
+    log('4. wait for op-b to claim verdict request, run evaluator, post verdict');
+    const verdict = await waitFor(async () => {
+      const r = await fetch(`http://127.0.0.1:${opBPort}/v1/verdicts?taskId=${posted.taskId}`);
+      if (!r.ok) return null;
+      const body = await r.json() as { verdicts?: Array<{ verdictCode: number; verdictTxHash?: string }> };
+      return body.verdicts && body.verdicts.length > 0 ? body.verdicts[0] : null;
+    }, { timeoutMs: 120000, label: 'op-b-verdict' });
+    log(`   verdictCode: ${verdict.verdictCode}, verdictTx: ${verdict.verdictTxHash}`);
+
+    log('5. assert verdict matches expected');
+    if (verdict.verdictCode !== KNOWN_EXPECTED_VERDICT) {
+      throw new Error(`expected verdictCode=${KNOWN_EXPECTED_VERDICT}, got ${verdict.verdictCode}`);
+    }
+
+    log('6. assert activity counters incremented');
+    const opAActivity = await fetch(`http://127.0.0.1:${opAPort}/v1/activity`).then((r) => r.json()) as { deliveriesCount?: number };
+    if (!opAActivity.deliveriesCount || opAActivity.deliveriesCount < 1) {
+      throw new Error(`op-a deliveriesCount expected >= 1, got ${opAActivity.deliveriesCount}`);
+    }
+    const opBActivity = await fetch(`http://127.0.0.1:${opBPort}/v1/activity`).then((r) => r.json()) as { verdictsCount?: number };
+    if (!opBActivity.verdictsCount || opBActivity.verdictsCount < 1) {
+      throw new Error(`op-b verdictsCount expected >= 1, got ${opBActivity.verdictsCount}`);
+    }
+    log('   activity counters correct');
+
+    await fs.writeFile(opts.evidencePath, evidenceLines.join('\n'));
+    return {
+      scenarioId: 'T2.2',
+      verdict: 'pass',
+      wallClockMs: Date.now() - started,
+      evidencePath: opts.evidencePath,
+      failClass: null,
+      failNotes: null,
+    };
+  } catch (err) {
+    log(`FAILED: ${err instanceof Error ? err.message : String(err)}`);
+    await fs.writeFile(opts.evidencePath, evidenceLines.join('\n'));
+    return {
+      scenarioId: 'T2.2',
+      verdict: 'fail',
+      wallClockMs: Date.now() - started,
+      evidencePath: opts.evidencePath,
+      failClass: classifyFailure(err),
+      failNotes: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    if (handle) { try { await handle.teardown(); } catch {} }
+  }
+}
+
+describe('T2.2 producer-evaluator', () => {
+  it('returns a structured verdict (pass/fail/skip)', async () => {
+    const evidenceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'T2.2-evidence-'));
+    const evidencePath = path.join(evidenceDir, 'T2.2.log');
+    try {
+      const verdict = await runT22ProducerEvaluator({ evidencePath, wallClockBudgetMs: 5 * 60 * 1000 });
+      expect(['pass', 'fail', 'skip']).toContain(verdict.verdict);
+      if (verdict.verdict === 'fail') {
+        console.error('T2.2 failed:', verdict.failNotes);
+      }
+    } finally {
+      await fs.rm(evidenceDir, { recursive: true, force: true });
+    }
+  }, 6 * 60 * 1000);
+});
+```
+
+**IMPLEMENTER:** The endpoints (`/v1/tasks`, `/v1/tasks/:id`, `/v1/verdicts`, `/v1/activity`) must match the real daemon surface in v0.1.6. Verify against `client/src/api/server.ts`. If a route doesn't exist, surface as a follow-up GH issue and mark T2.2 as skip; the test can't run without those routes.
+
+- [ ] **Step 2: Run the test**
+
+Run: `cd client && yarn build && yarn vitest run test/release/tier-2/T2.2-producer-evaluator.ts`
+Expected: pass if substrate + fork + stub + endpoints + Docker evaluator all align.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/test/release/tier-2/T2.2-producer-evaluator.ts
+git commit -m "feat(release): add T2.2 producer-evaluator Anvil-fork scenario"
+```
+
+---
+
+## Task 7: Playwright fixture for two-substrate-ops
+
+**Files:**
+- Create: `client/test/dashboard/multi-op/fixtures/two-substrate-ops.ts`
+
+Shared Playwright fixture used by T2.3 (and future multi-op SPA tests). Wraps the `setupTier2Scenario` helper into the Playwright test-extend pattern.
+
+- [ ] **Step 1: Implement the fixture**
+
+```typescript
+// client/test/dashboard/multi-op/fixtures/two-substrate-ops.ts
+import { test as base } from '@playwright/test';
+import { setupTier2Scenario, type Tier2Handle } from '../../../release/tier-2/tier-2-helpers';
+
+interface TwoSubstrateOpsFixtures {
+  tier2: Tier2Handle;
+  opAUrl: string;
+  opBUrl: string;
+}
+
+export const test = base.extend<TwoSubstrateOpsFixtures>({
+  tier2: async ({}, use, testInfo) => {
+    const handle = await setupTier2Scenario({
+      scenarioId: testInfo.titlePath.join('-').replace(/[^a-zA-Z0-9-]/g, '_'),
+      portBase: 7754,
+    });
+    try {
+      await use(handle);
+    } finally {
+      await handle.teardown();
+    }
+  },
+  opAUrl: async ({ tier2 }, use) => {
+    const url = tier2.daemons.daemons['op-a'].handshakeUrl ?? `http://127.0.0.1:${tier2.daemons.daemons['op-a'].apiPort}/`;
+    await use(url);
+  },
+  opBUrl: async ({ tier2 }, use) => {
+    const url = tier2.daemons.daemons['op-b'].handshakeUrl ?? `http://127.0.0.1:${tier2.daemons.daemons['op-b'].apiPort}/`;
+    await use(url);
+  },
+});
+
+export { expect } from '@playwright/test';
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add client/test/dashboard/multi-op/fixtures/two-substrate-ops.ts
+git commit -m "test(multi-op): add Playwright fixture for two-substrate-ops"
+```
+
+---
+
+## Task 8: T2.3 — multi-op SPA flow
+
+**Files:**
+- Create: `client/test/dashboard/multi-op/launcher-join-flow.e2e.test.ts`
+
+Per Plan B's `scenario-multi-op-spa-flow.md`: op-a launches a SolverNet via the SPA Launcher Create wizard. op-b sees it appear in the Operator catalog. op-b joins via the SPA. op-a's launched dashboard shows "1 operator joined."
+
+- [ ] **Step 1: Write the test**
+
+```typescript
+// client/test/dashboard/multi-op/launcher-join-flow.e2e.test.ts
+import { test, expect } from './fixtures/two-substrate-ops';
+
+test('T2.3 — op-a launches, op-b joins, both observe each other', async ({ browser, opAUrl, opBUrl }) => {
+  test.setTimeout(5 * 60 * 1000);
+
+  const opACtx = await browser.newContext();
+  const opBCtx = await browser.newContext();
+  const opAPage = await opACtx.newPage();
+  const opBPage = await opBCtx.newPage();
+
+  try {
+    // ===== op-a: Launcher Create wizard =====
+    await opAPage.goto(opAUrl);
+    await opAPage.getByRole('link', { name: /launcher/i }).click();
+    await opAPage.getByRole('button', { name: /create solvernet/i }).click();
+
+    const solverNetName = `t23-${Date.now()}`;
+
+    // Step 1: Define
+    await opAPage.getByLabel(/name/i).fill(solverNetName);
+    await opAPage.getByLabel(/description/i).fill('T2.3 e2e test SolverNet');
+    await opAPage.getByRole('button', { name: /next/i }).click();
+
+    // Step 2: Review Contract
+    await opAPage.getByRole('button', { name: /next/i }).click();
+
+    // Step 3: Configure Generator
+    await opAPage.getByLabel(/cadence/i).fill('60000');
+    await opAPage.getByRole('button', { name: /next/i }).click();
+
+    // Step 4: Configure Pricing
+    await opAPage.getByLabel(/price/i).fill('100');
+    await opAPage.getByRole('button', { name: /next/i }).click();
+
+    // Step 5: Review and Launch
+    await opAPage.getByRole('button', { name: /launch/i }).click();
+
+    // Wait for state machine to reach 'launched'
+    await expect(opAPage.getByText(/launched/i).first()).toBeVisible({ timeout: 120000 });
+    const manifestCid = await opAPage.getByTestId('manifest-cid').textContent({ timeout: 10000 });
+    expect(manifestCid).toMatch(/^bafkrei/);
+
+    // ===== op-b: Catalog sees op-a's SolverNet =====
+    await opBPage.goto(opBUrl);
+    await opBPage.getByRole('link', { name: /operator/i }).click();
+    await opBPage.getByRole('button', { name: /browse catalog/i }).click();
+
+    // Allow indexer + SPA polling lag (~30s).
+    await expect(opBPage.getByText(solverNetName)).toBeVisible({ timeout: 60000 });
+
+    // ===== op-b joins =====
+    await opBPage.getByText(solverNetName).click();
+    await opBPage.getByRole('button', { name: /^join$/i }).click();
+    await expect(opBPage.getByText(/restart required/i)).toBeVisible({ timeout: 10000 });
+
+    // ===== op-a sees op-b's join =====
+    await opAPage.goto(`${opAUrl}/launcher/launched`);
+    await opAPage.getByText(solverNetName).click();
+    await expect(opAPage.getByTestId('operator-count')).toHaveText(/1/, { timeout: 60000 });
+  } finally {
+    await opACtx.close();
+    await opBCtx.close();
+  }
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cd client && yarn build && yarn playwright test --config=playwright.config.ts test/dashboard/multi-op/launcher-join-flow.e2e.test.ts`
+Expected: PASS, or fail with a specific selector — in which case Task 9 (SPA test-id additions) is needed.
+
+If the test passes without Task 9 because semantic queries are sufficient, mark Task 9 as skipped.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/test/dashboard/multi-op/launcher-join-flow.e2e.test.ts
+git commit -m "feat(release): add T2.3 multi-op SPA flow Playwright test"
+```
+
+---
+
+## Task 9: SPA test-id additions (conditional)
+
+**Files (only if Task 8 failed on missing testids):**
+- Modify: `client/src/dashboard/spa/src/pages/LauncherLaunched.tsx` (or wherever manifest-cid + operator-count are rendered)
+- Test: `client/test/dashboard/multi-op/launcher-join-flow.e2e.test.ts` re-run to verify
+
+The T2.3 test references `data-testid="manifest-cid"` and `data-testid="operator-count"`. If these don't exist on the launched-SolverNet dashboard, add them.
+
+- [ ] **Step 1: Find the launched-SolverNet dashboard component**
+
+Run: `find client/src/dashboard/spa -name "LauncherLaunched*" -o -name "*Launched*" 2>/dev/null | head -5`
+Expected: the component file(s) for the launched-SolverNet dashboard.
+
+Run: `grep -rn "manifest-cid\|operator-count\|data-testid" client/src/dashboard/spa/src/pages 2>/dev/null | head -10`
+Expected: any existing test-ids on the page.
+
+- [ ] **Step 2: Add test-ids**
+
+Find the JSX element that renders the manifest CID. Add `data-testid="manifest-cid"`:
+
+```tsx
+<span data-testid="manifest-cid">{launchedRecord.manifestCid}</span>
+```
+
+Find the element that renders the operator count (e.g. "1 operator joined"). Add `data-testid="operator-count"` to the element holding the count number:
+
+```tsx
+<span data-testid="operator-count">{joinedOperators.length}</span>
+```
+
+These should be additive — don't change existing markup or accessibility.
+
+- [ ] **Step 3: Re-run T2.3**
+
+Run: `cd client && yarn build && yarn playwright test --config=playwright.config.ts test/dashboard/multi-op/launcher-join-flow.e2e.test.ts`
+Expected: PASS now that test-ids exist.
+
+- [ ] **Step 4: Commit (if any changes were needed)**
+
+```bash
+git add client/src/dashboard/spa/src/pages/LauncherLaunched.tsx
+git commit -m "ui(launcher): add data-testid attributes for T2.3 cross-op visibility test"
+```
+
+If Task 8 passed without changes, mark this task as skipped (no commit).
+
+---
+
+## Task 10: run-tier-2.ts orchestrator
+
+**Files:**
+- Create: `client/scripts/release/run-tier-2.ts`
+
+Mirrors Plan C's `run-tier-1.ts` shape. 2 callable scenarios + 1 Playwright subprocess.
+
+- [ ] **Step 1: Implement the orchestrator**
+
+```typescript
+// client/scripts/release/run-tier-2.ts
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { spawn } from 'node:child_process';
+import { runT21CrossOpDonation } from '../../test/release/tier-2/T2.1-cross-op-donation';
+import { runT22ProducerEvaluator } from '../../test/release/tier-2/T2.2-producer-evaluator';
+import { type ScenarioVerdict, ScenarioVerdictSchema, classifyFailure } from './scenario-types';
+
+interface RunOptions {
+  outputDir?: string;
+  candidateVersion?: string;
+}
+
+async function runT23MultiOpSpaFlow(outputDir: string): Promise<ScenarioVerdict> {
+  const started = Date.now();
+  const evidencePath = path.join(outputDir, 'T2.3.log');
+  return new Promise<ScenarioVerdict>((resolve) => {
+    const child = spawn(
+      'yarn',
+      [
+        'playwright',
+        'test',
+        '--config=playwright.config.ts',
+        'test/dashboard/multi-op/launcher-join-flow.e2e.test.ts',
+        '--reporter=line',
+      ],
+      { cwd: process.cwd(), stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
+    child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+    child.on('close', async (code) => {
+      await fs.writeFile(evidencePath, `=== stdout ===\n${stdout}\n=== stderr ===\n${stderr}\n=== exit code ===\n${code}\n`);
+      resolve({
+        scenarioId: 'T2.3',
+        verdict: code === 0 ? 'pass' : 'fail',
+        wallClockMs: Date.now() - started,
+        evidencePath,
+        failClass: code === 0 ? null : classifyFailure(new Error(stderr || stdout)),
+        failNotes: code === 0 ? null : `Playwright exited ${code}`,
+      });
+    });
+  });
+}
+
+export async function runTier2(opts: RunOptions = {}): Promise<{ verdicts: ScenarioVerdict[]; allPassed: boolean }> {
+  const outputDir = opts.outputDir ?? path.join(
+    process.cwd(),
+    'tier-2-evidence',
+    new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19),
+  );
+  await fs.mkdir(outputDir, { recursive: true });
+
+  // Run callable scenarios + Playwright in parallel
+  const callablePromises = [
+    runT21CrossOpDonation({ evidencePath: path.join(outputDir, 'T2.1.log'), wallClockBudgetMs: 5 * 60 * 1000 }),
+    runT22ProducerEvaluator({ evidencePath: path.join(outputDir, 'T2.2.log'), wallClockBudgetMs: 5 * 60 * 1000 }),
+  ];
+  const playwrightPromise = runT23MultiOpSpaFlow(outputDir);
+
+  const [t21Settled, t22Settled, t23] = await Promise.all([
+    ...callablePromises.map((p) => p.catch((err) => ({
+      __crashed: true,
+      err,
+    } as const))),
+    playwrightPromise,
+  ]) as [
+    ScenarioVerdict | { __crashed: true; err: unknown },
+    ScenarioVerdict | { __crashed: true; err: unknown },
+    ScenarioVerdict,
+  ];
+
+  const toVerdict = (id: string, settled: ScenarioVerdict | { __crashed: true; err: unknown }, evidencePath: string): ScenarioVerdict => {
+    if ('__crashed' in settled) {
+      return {
+        scenarioId: id,
+        verdict: 'fail' as const,
+        wallClockMs: 0,
+        evidencePath,
+        failClass: 'agent-crash' as const,
+        failNotes: settled.err instanceof Error ? settled.err.message : String(settled.err),
+      };
+    }
+    return settled;
+  };
+
+  const verdicts = [
+    toVerdict('T2.1', t21Settled, path.join(outputDir, 'T2.1.log')),
+    toVerdict('T2.2', t22Settled, path.join(outputDir, 'T2.2.log')),
+    t23,
+  ];
+
+  for (const v of verdicts) ScenarioVerdictSchema.parse(v);
+
+  const allPassed = verdicts.every((v) => v.verdict === 'pass');
+
+  const summary = {
+    candidateVersion: opts.candidateVersion ?? 'unknown',
+    timestamp: new Date().toISOString(),
+    verdicts,
+    allPassed,
+  };
+  await fs.writeFile(path.join(outputDir, 'summary.json'), JSON.stringify(summary, null, 2));
+
+  const markerLines = [
+    '<!-- jinn-release-evidence:v1',
+    `release-candidate=${opts.candidateVersion ?? 'unknown'}`,
+    ...verdicts.map((v) => {
+      const key = `tier-2-${v.scenarioId.toLowerCase().replace(/\./g, '-')}`;
+      if (v.verdict === 'pass') return `${key}=passed`;
+      if (v.verdict === 'skip') return `${key}=skipped:${v.failNotes ?? 'no-reason'}`;
+      return `${key}=failed:${v.failClass}`;
+    }),
+    `tier-2-overall=${allPassed ? 'passed' : 'failed'}`,
+    '-->',
+  ];
+  await fs.writeFile(path.join(outputDir, 'marker.txt'), markerLines.join('\n') + '\n');
+
+  return { verdicts, allPassed };
+}
+
+async function cliMain(): Promise<void> {
+  const candidateVersion = process.argv[2];
+  const { verdicts, allPassed } = await runTier2({ candidateVersion });
+  console.log(JSON.stringify({ verdicts, allPassed }, null, 2));
+  const hasRealBug = verdicts.some((v) => v.verdict === 'fail' && v.failClass === 'real-bug');
+  process.exit(hasRealBug ? 1 : 0);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  cliMain().catch((err) => {
+    console.error('run-tier-2 crashed:', err);
+    process.exit(2);
+  });
+}
+```
+
+- [ ] **Step 2: Smoke test**
+
+Run: `cd client && yarn build && tsx scripts/release/run-tier-2.ts v0.1.7-smoke`
+Expected: orchestrator runs all three scenarios in parallel, prints structured verdicts, creates `tier-2-evidence/<timestamp>/`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/scripts/release/run-tier-2.ts
+git commit -m "feat(release): add run-tier-2 orchestrator"
+```
+
+---
+
+## Task 11: release-prep SKILL.md Tier 2 section update
+
+**Files:**
+- Modify: `.claude/skills/release-prep/SKILL.md`
+
+Plan C left a Tier 2 placeholder pointing at `references/tier-2-scenarios.md`. Now that scenarios exist, update the Tier 2 table.
+
+- [ ] **Step 1: Find the Tier 2 section in SKILL.md**
+
+Run: `grep -n "Tier 2" .claude/skills/release-prep/SKILL.md`
+Expected: section heading + table location.
+
+- [ ] **Step 2: Update the Tier 2 section**
+
+Replace:
+
+```markdown
+## Tier 2 scenarios
+
+Detailed contracts: [`references/tier-2-scenarios.md`](references/tier-2-scenarios.md) (placeholder; expanded by Plan D)
+
+Tier 2 implementations land in Plan D. release-prep's runner will be extended at that point to call a `run-tier-2.ts` orchestrator alongside `run-tier-1.ts`.
+```
+
+With:
+
+```markdown
+## Tier 2 scenarios
+
+Detailed contracts: [`references/tier-2-scenarios.md`](references/tier-2-scenarios.md)
+
+| ID | Name | Wall-clock budget |
+|---|---|---|
+| T2.1 | cross-operator-donation | 5min |
+| T2.2 | producer-evaluator-anvil-fork | 5min |
+| T2.3 | multi-op-spa-flow | 5min |
+
+All three run in parallel against separate substrate workspaces. Wall-clock for the tier ≈ max of the budgets (~5min).
+
+Tier 2 is invoked from release-readiness's Phase 5 (per spec §4). Standalone invocation:
+
+```bash
+yarn release:tier-2 <candidate-version>
+```
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/release-prep/SKILL.md
+git commit -m "docs(release-prep): replace Tier 2 placeholder with real budgets + invocation"
+```
+
+---
+
+## Task 12: tier-2-scenarios.md full doc
+
+**Files:**
+- Modify (replace contents): `.claude/skills/release-prep/references/tier-2-scenarios.md`
+
+- [ ] **Step 1: Replace the placeholder with full content**
+
+Save:
+
+```markdown
+# Tier 2 scenarios
+
+Three scenarios, all multi-operator, all running against substrate-derived workspaces with an Anvil-fork-of-Base-Sepolia RPC. Tier 2 is invoked by `release-prep` during release-readiness Phase 5; not on every push.
+
+The "what does this scenario actually exercise" contracts live in `testing-jinn-app` (one doc per scenario, Plan B). The "how is it wired and what's the runtime shape" details are below.
+
+## T2.1 — cross-operator-donation
+
+**Catches:** x402 + ERC-8128 handshake regressions; corpus indexer attribution bugs; payment-gated artifact access bugs. Designed to catch the #310 class of silent failure.
+
+**Contract:** [`testing-jinn-app/references/scenario-cross-op-donation.md`](../../testing-jinn-app/references/scenario-cross-op-donation.md)
+
+**Implementation:** `client/test/release/tier-2/T2.1-cross-op-donation.ts`
+
+**Wall-clock budget:** 5 minutes
+
+**Prerequisites:**
+- Substrate workspace via Plan A's `substrate-copy`.
+- Local Ponder indexer (helper at `client/test/_support/indexer/ponder.ts`).
+- Daemon endpoints: `/v1/corpus/produce`, `/v1/corpus/:cid`, `/v1/corpus/:cid/pay`, `/v1/discovery/corpus`.
+
+## T2.2 — producer-evaluator-anvil-fork
+
+**Catches:** Claim → solve → deliver → evaluate loop regressions; activity-counter incorrectness; verdict pipeline mechanics.
+
+**Contract:** [`testing-jinn-app/references/scenario-producer-evaluator.md`](../../testing-jinn-app/references/scenario-producer-evaluator.md)
+
+**Implementation:** `client/test/release/tier-2/T2.2-producer-evaluator.ts`
+
+**Wall-clock budget:** 5 minutes
+
+**Prerequisites:**
+- Substrate workspace via Plan A's `substrate-copy`.
+- Stubbed harness via `JINN_HARNESS_STUB_INSTANCE` env (Task 3).
+- SWE-rebench v2 fixture at `client/test/release/tier-2/fixtures/` (Task 4).
+- Daemon endpoints: `/v1/tasks`, `/v1/tasks/:id`, `/v1/verdicts`, `/v1/activity`.
+
+## T2.3 — multi-op-spa-flow
+
+**Catches:** Cross-op UI flows that pass with mocks but break with real daemons; SPA state synchronization; Launcher → Operator catalog visibility.
+
+**Contract:** [`testing-jinn-app/references/scenario-multi-op-spa-flow.md`](../../testing-jinn-app/references/scenario-multi-op-spa-flow.md)
+
+**Implementation:** `client/test/dashboard/multi-op/launcher-join-flow.e2e.test.ts` (Playwright, invoked via subprocess from the orchestrator)
+
+**Wall-clock budget:** 5 minutes
+
+**Prerequisites:**
+- Substrate workspace via Plan A's `substrate-copy`.
+- SPA test-id attributes (`manifest-cid`, `operator-count`) — added in Task 9 if missing.
+- The Playwright two-substrate-ops fixture at `client/test/dashboard/multi-op/fixtures/two-substrate-ops.ts`.
+
+## Parallelism
+
+All three scenarios run in parallel via `client/scripts/release/run-tier-2.ts`. Each gets its own:
+- Substrate workspace (port-isolated daemons)
+- Anvil fork
+- Ponder indexer (T2.1, T2.3; T2.2 doesn't need it)
+
+Total wall-clock at full parallelism ≈ max(scenario wall-clocks) ≈ 5 minutes.
+
+## RPC budget
+
+Tier 2 is the tier that historically saturates Tenderly (jinn-mono-lrey). The architectural fix is:
+- Use substrate-derived workspaces (no re-bootstrap inside the gate).
+- One Anvil fork per scenario; both daemons in a scenario share that fork.
+- The fork lazy-fetches state from the upstream RPC, but workspace ops already have their identity state cached.
+
+This should keep one Tier 2 run under the per-key rate limit. Concurrent Tier 2 runs (e.g. parallel CI workers) can still saturate. For now, run-tier-2 is single-instance.
+
+## Failure modes
+
+| Failure | Class | Triage |
+|---|---|---|
+| Substrate stale | n/a | Block run, instruct re-adopt |
+| Anvil fork lazy-fetch stalls | flake-infra | Retry once; if persistent, jinn-mono-lrey territory |
+| Ponder spawn timeout | flake-infra (env) or real-bug (Ponder config) | Inspect Ponder logs |
+| Daemon endpoint 4xx/5xx unrelated to scenario | real-bug | BLOCKING — API surface regression |
+| Cross-op visibility lag exceeds budget | flake-timing | Retry once with extended timeout |
+| Verdict mismatch in T2.2 | real-bug | BLOCKING — substrate/scoring regression |
+| Playwright selector miss in T2.3 | real-bug | UI changed without test-id update |
+
+## Invocation
+
+```bash
+# All three scenarios via the orchestrator
+yarn release:tier-2 <candidate-version>
+
+# Per-scenario standalone
+yarn release:tier-2:T2.1
+yarn release:tier-2:T2.2
+yarn release:tier-2:T2.3
+```
+
+Output: `tier-2-evidence/<timestamp>/` with `summary.json`, `marker.txt`, per-scenario `.log` files.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/skills/release-prep/references/tier-2-scenarios.md
+git commit -m "docs(release-prep): replace tier-2-scenarios placeholder with full doc"
+```
+
+---
+
+## Task 13: yarn scripts wiring
+
+**Files:**
+- Modify: `client/package.json`
+
+- [ ] **Step 1: Add the Tier 2 yarn scripts**
+
+In `client/package.json`'s `scripts` object, add:
+
+```json
+{
+  "scripts": {
+    "release:tier-2": "tsx scripts/release/run-tier-2.ts",
+    "release:tier-2:T2.1": "vitest run test/release/tier-2/T2.1-cross-op-donation.ts",
+    "release:tier-2:T2.2": "vitest run test/release/tier-2/T2.2-producer-evaluator.ts",
+    "release:tier-2:T2.3": "playwright test --config=playwright.config.ts test/dashboard/multi-op/launcher-join-flow.e2e.test.ts"
+  }
+}
+```
+
+- [ ] **Step 2: Verify the yarn scripts run**
+
+Run: `cd client && yarn release:tier-2 v0.1.7-yarn-smoke 2>&1 | tail -20`
+Expected: orchestrator executes; verdicts emitted (pass/fail/skip per scenario).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/package.json
+git commit -m "chore(release): wire yarn scripts for Tier 2"
+```
+
+---
+
+## Task 14: End-to-end smoke + final verification
+
+**Files:**
+- None modified. This is a verification gate.
+
+- [ ] **Step 1: Confirm Tier 2 prerequisites are present**
+
+Run:
+```bash
+cd client
+# Substrate
+yarn substrate:verify op-a --skip-on-chain
+yarn substrate:verify op-b --skip-on-chain
+
+# Stub harness fixture
+ls test/release/tier-2/fixtures/
+
+# Ponder helper exists
+ls test/_support/indexer/ponder.ts
+
+# SPA test-ids (if Task 9 was needed)
+grep "manifest-cid\|operator-count" src/dashboard/spa/src/pages/LauncherLaunched.tsx 2>/dev/null
+```
+
+Expected: all checks pass (or document gaps and skip the next step).
+
+- [ ] **Step 2: Run full Tier 2 against a candidate**
+
+Run: `cd client && BASE_SEPOLIA_RPC_URL=$BASE_SEPOLIA_RPC_URL yarn release:tier-2 v0.1.7-final-smoke`
+Expected: orchestrator runs all three scenarios. At minimum, all three should return a structured verdict (pass/fail/skip with classification). Best case: all three pass.
+
+If any scenario returns `fail:real-bug`, triage:
+- T2.1 — is it the daemon API surface mismatch? File GH issue.
+- T2.2 — is it the harness stub not being picked up? Debug the env wiring.
+- T2.3 — is it a selector issue? Re-run Task 9 to add missing test-ids.
+
+If any scenario returns `fail:flake-*`, re-run once. If persistent, file GH issue and document as known-flake.
+
+- [ ] **Step 3: No commit unless gaps were found**
+
+If gaps required additional commits (e.g. extra test-ids, env wiring fixes), they should land in their respective task commits. Final task is a verification gate.
+
+---
+
+## Self-review
+
+### Spec coverage
+
+| Spec requirement | Covered by | Status |
+|---|---|---|
+| §3 Tier 2 scenarios T2.1-T2.3 | Tasks 5, 6, 8 | ✓ |
+| §3 run-tier-2 orchestrator | Task 10 | ✓ |
+| §3 release-prep Tier 2 documentation | Tasks 11, 12 | ✓ |
+| §6 stubbed harness for T2.2 | Task 3 | ✓ |
+| §6 SWE-rebench fixture | Task 4 | ✓ |
+| §6 Ponder spawn helper | Task 2 | ✓ |
+| §6 shared Tier 2 setup helper | Task 1 | ✓ |
+| §6 Playwright two-substrate-ops fixture | Task 7 | ✓ |
+| Plan B fold-back: SPA test-ids referenced | Task 9 (conditional) | ✓ |
+
+### Placeholder scan
+
+- Task 2 (Ponder helper) has implementer notes for repo-specific spawn invocation — necessary because the exact Ponder package layout depends on the monorepo structure. Acceptable.
+- Task 3 (stub harness) has implementer notes for the registry integration — necessary because the harness registry shape needs verification. Acceptable.
+- Task 4 (SWE-rebench fixture) has `KNOWN_COMMIT: 'PLACEHOLDER'` — explicit instruction for the implementer to fill from the v0.1.6 stewardship log. Acceptable as it's a fixture data point, not a code placeholder.
+- All other tasks have complete code.
+
+### Type consistency
+
+- `ScenarioVerdict` consistent across Tasks 5, 6, 8 (returned by all three scenarios).
+- `Tier2Handle` defined in Task 1 used by Tasks 5, 6, 7.
+- `setupTier2Scenario(opts)` signature consistent in Tasks 1, 5, 6, 7.
+- Yarn script names (`release:tier-2`, `release:tier-2:T2.1`, ...) consistent with Plan C's Tier 1 naming.
+
+### Cross-plan contract check
+
+This plan consumes from Plan A: `substrate-copy`, `substrate-paths`, `substrate-verify`. Cross-verified.
+This plan consumes from Plan B: `multi-op-daemon`, `handshake-url`. Cross-verified.
+This plan consumes from Plan C: `scenario-types`, the `release-prep` SKILL.md scaffolding, `run-tier-1.ts` as the structural model for `run-tier-2.ts`. Cross-verified.
+
+This plan promises Plan E:
+- A working Tier 2 invocation via `yarn release:tier-2 <version>` that emits structured verdicts.
+- An extended `release-prep` skill with both tiers populated.
+- Plan E's `release-readiness` skill can invoke release-prep as a subagent and consume the verdicts.
+
+### Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-19-tier-2-scenarios-plan.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven (recommended)** — Dispatch a fresh subagent per task. 14 tasks; subagent-driven works well here because adapter code (daemon API endpoints, harness registry shape) varies and per-task review catches misadaptations.
+
+2. **Inline Execution** — Execute tasks in this session via `superpowers:executing-plans`. Less robust given the adapter-heavy code in this plan; subagent review is more valuable here than for Plan A.
+
+Plan D depends on:
+- **Plan A merged** — substrate scripts must be on `next` (or merged into Plan D's branch) for runtime.
+- **Plan B merged** — multi-op-daemon + handshake-url must be importable.
+- **Plan C merged or branch-stacked** — scenario-types, release-prep skill scaffolding.
+
+If Plans A/B/C haven't merged yet, dispatch Plan D against a branch that's already stacked on top of all three (analogous to Plan C being stacked on Plan B). The dispatched session should first `git merge` the prerequisite branches before starting Task 1.
+
+Which approach?

--- a/docs/superpowers/plans/2026-05-19-tier-2-scenarios-plan.md
+++ b/docs/superpowers/plans/2026-05-19-tier-2-scenarios-plan.md
@@ -164,10 +164,12 @@ export async function setupTier2Scenario(opts: Tier2SetupOptions): Promise<Tier2
         home: workspace!.opPaths[name],
         apiPort: opts.portBase + i,
       })),
-      // JINN_RPC_URL — not BASE_RPC_URL — because config.ts gives JINN_RPC_URL
-      // unconditional precedence. The spawn helper surfaces extraEnv RPC keys
-      // through JINN_RPC_URL anyway, but explicit at the call site is clearer.
-      extraEnv: { JINN_RPC_URL: anvil.rpcUrl, ...opts.extraEnv },
+      // Spread extraEnv FIRST, then set JINN_RPC_URL — fork URL must win.
+      // Inverse order ({ JINN_RPC_URL: anvil.rpcUrl, ...opts.extraEnv }) would
+      // let a caller-supplied opts.extraEnv.JINN_RPC_URL silently override the
+      // fork RPC, breaking fork isolation. config.ts gives JINN_RPC_URL
+      // unconditional precedence over BASE_RPC_URL/BASE_SEPOLIA_RPC_URL.
+      extraEnv: { ...opts.extraEnv, JINN_RPC_URL: anvil.rpcUrl },
       readyTimeoutMs: 45000,
     });
 
@@ -452,6 +454,8 @@ Expected: FAIL — module not found.
 
 - [ ] **Step 4: Implement the stub harness**
 
+**NOTE (added from PR #352 execution):** Plan D's original code below shows a simplified `StubHarness` interface (`{ name, isReady, solve }`). The real `Harness` interface at `client/src/harnesses/types.ts` is richer: `name`, `version`, `supports(ctx)`, `prepare()`, `solve(...)`, etc. The executing session adopted the real interface (Path A — implement against what exists) rather than bridging. Use the real `Harness` interface; the simplified shape below is conceptual.
+
 ```typescript
 // client/src/harnesses/impls/stub.ts
 import * as fs from 'node:fs/promises';
@@ -624,6 +628,8 @@ git commit -m "test(release): add SWE-rebench v2 fixture instance + canned solut
 
 **Files:**
 - Create: `client/test/release/tier-2/T2.1-cross-op-donation.ts`
+
+**NOTE (added from PR #352 execution):** The endpoints `/v1/corpus/produce`, `/v1/corpus/:cid`, `/v1/corpus/:cid/pay`, `/v1/discovery/corpus` do NOT exist in the v0.1.6 daemon — they were speculative in Plan B's scenario doc. The executing session implemented T2.1 with a **skip-on-prereq** pattern: probe for endpoint existence first; if missing, return `verdict: 'skip'` with a `failNotes` referencing the GH issue tracking the gap. **GH issue #349** filed for the missing endpoints. T2.1 will activate once those endpoints land. Adapt the code below to use the skip-on-prereq pattern (probe the endpoint with a HEAD request or a minimal POST; if 404, skip).
 
 **What this scenario does:** Per the contract in `.claude/skills/testing-jinn-app/references/scenario-cross-op-donation.md` (Plan B): op-a produces a corpus artifact, indexer attributes it, op-b queries via Discovery API (returns 402), op-b pays x402, op-b retrieves (returns 200 with valid payload + ERC-8128 signature).
 
@@ -809,6 +815,8 @@ git commit -m "feat(release): add T2.1 cross-op donation scenario"
 
 **Files:**
 - Create: `client/test/release/tier-2/T2.2-producer-evaluator.ts`
+
+**NOTE (added from PR #352 execution):** Same skip-on-prereq pattern as Task 5. The endpoints `/v1/tasks` (POST), `/v1/tasks/:id`, `/v1/verdicts`, `/v1/activity` don't all exist in v0.1.6 in the shapes assumed here. **GH issue #350** filed for the missing endpoints. T2.2 returns `verdict: 'skip'` until the endpoints land. Adapt the code below to probe + skip on 404.
 
 **What this scenario does:** Per `.claude/skills/testing-jinn-app/references/scenario-producer-evaluator.md`: op-a posts a known-solvable SWE-rebench v2 task, claims, solves via the stubbed harness, delivers; op-b claims the verdict request, runs the real evaluator Docker image, posts verdict. Assert `verdictCode === KNOWN_EXPECTED_VERDICT`. Activity counters increment.
 
@@ -1126,6 +1134,10 @@ git commit -m "feat(release): add T2.3 multi-op SPA flow Playwright test"
 - Test: `client/test/dashboard/multi-op/launcher-join-flow.e2e.test.ts` re-run to verify
 
 The T2.3 test references `data-testid="manifest-cid"` and `data-testid="operator-count"`. If these don't exist on the launched-SolverNet dashboard, add them.
+
+**NOTE (added from PR #352 execution):**
+- `manifest-cid` was added cleanly — it aliases existing manifest data.
+- `operator-count` was NOT added: the launched-record data shape doesn't include operator-join counts yet. The session deliberately filed **GH issue #351** instead of speculatively wiring a data path that doesn't exist. T2.3 currently asserts on `manifest-cid` only and skips the "1 operator joined" assertion until #351 is resolved.
 
 - [ ] **Step 1: Find the launched-SolverNet dashboard component**
 

--- a/docs/superpowers/specs/2026-05-19-release-readiness-and-substrate-design.md
+++ b/docs/superpowers/specs/2026-05-19-release-readiness-and-substrate-design.md
@@ -1,0 +1,736 @@
+# Release-readiness and test-operator substrate
+
+**Version:** v0.1
+**Date:** 2026-05-19
+**Authors:** Adriano Bradley, Claude Opus 4.7
+**Status:** draft
+
+## Why
+
+The v0.1.6 cut on 2026-05-19 spent roughly three hours fighting four distinct CI gate failures (Tenderly rate-limit on public RPC fallback, a `transcript-watcher` test flake, an Anvil stake-stall, a Tenderly rate-limit on the high-quota key after multi-bootstrap saturation). None of the gates caught a real release bug. The ship decision was carried by independent evidence — a manual A3 verification on real Base Sepolia producing `verdictCode=1` on a real `sympy__sympy-27510` solve.
+
+That pattern is structural, not incidental. The current release gates do three things wrong:
+
+1. **They catch their own infrastructure flakes, not release bugs.** The bugs that bit v0.1.6 (Hermes provider routing #293/#298, MCP launcher path #294/#299, ghost-task class #300, eval-substrate silently broken for three weeks before fufn) were all caught by humans and agents *using the app on testnet*, not by CI gates.
+2. **They re-bootstrap from scratch on every run.** Each `bootstrapBaseSepoliaForkOperator` call hammers the fork-source RPC for storage and code fetches. By the third call in one job, even the high-quota Tenderly key returns HTTP errors. This is `jinn-mono-lrey`.
+3. **They don't audit the app.** Operator-app surfaces (the dashboard SPA) are what users actually see and use. The current gates verify chain mechanics and never load a page.
+
+There's also a deeper gap: there is no codified path from "we think this is ready to ship" to "it actually is ready." The current Monday-cut flow draws a draft and asks a human to decide. The human decision is good, but it relies on memory of what changed and trust in unstated checks — both of which decay.
+
+This spec proposes a substrate-anchored test infrastructure plus two new skills that compose into a reliable, advisory release-readiness process. The goal is to make the v0.1.6 outcome (ship-on-independent-evidence with full audit trail) the default, not the exception.
+
+## §1 Architecture overview
+
+Two new skills sit on a shared on-disk substrate. The existing `testing-jinn-app` skill extends to cover multi-operator scenarios.
+
+```
+                       ┌─────────────────────────────────────────┐
+                       │      release-readiness  (meta-skill)    │
+                       │  audit canon → triage gaps → drive      │
+                       │  closure → invoke release-prep → invoke │
+                       │  Tier 3 → emit handoff doc              │
+                       └────────────────┬────────────────────────┘
+                                        │ invokes
+                                        ▼
+                       ┌─────────────────────────────────────────┐
+                       │      release-prep  (mechanical skill)   │
+                       │  copy substrate → run Tier 1 + Tier 2   │
+                       │  → emit jinn-release-evidence marker    │
+                       └────────────────┬────────────────────────┘
+                                        │ uses
+                                        ▼
+   ┌──────────────────────────────────────────────────────────────────┐
+   │   Persistent test-operator substrate                             │
+   │   ~/jinn-dev/operators/op-{a,b,c-legacy}/  (gold copy)           │
+   │   ~/jinn-dev/workspaces/<run-id>/op-{a,b}/  (per-run, ephemeral) │
+   └──────────────────────────────────────────────────────────────────┘
+                                        ▲
+                                        │ uses
+                       ┌─────────────────────────────────────────┐
+                       │   testing-jinn-app  (existing, extended)│
+                       │   spawn daemon(s) → drive via Playwright│
+                       │   / chrome-devtools → assert            │
+                       └─────────────────────────────────────────┘
+```
+
+### Three tiers of evidence
+
+- **Tier 1** — single-operator mechanics on Anvil. Runs on every push to `next` (canary cadence). ~4 min budget. Catches bootstrap-reliability, harness-readiness, indexer-schema, and SPA-route regressions.
+- **Tier 2** — cross-operator scenarios against substrate-derived workspaces (Anvil-fork). Runs in `release-prep`. ~15 min budget. Catches donation-handshake, producer/evaluator-loop, and multi-op SPA bugs.
+- **Tier 3** — real Base Sepolia testnet, real Hermes, real verdict. Runs in `release-readiness` (human-invoked mode only). ~10 min, ~$0.10 API spend. **The only required gate for a named cut.**
+
+### Architectural backbone
+
+The substrate gets *copied* into a workspace at the start of each Tier 2 run. The gate never bootstraps. This single decision dissolves the failure modes that bit v0.1.6 — no Tenderly saturation, no Anvil stake-stalls, no Stage-1 timeouts under multi-bootstrap load.
+
+### New artifacts on disk
+
+- `~/jinn-dev/operators/op-{a,b,c-legacy}/` — gold-copy substrate (slow-changing, manually refreshed when contracts or schemas drift). **Adopted 2026-05-19 from existing fully-bootstrapped operators; details in §2.**
+- `docs/release/<version>/release-prep-evidence.md` — gate output, marker-ready
+- `docs/release/<version>/handoff.md` — release-readiness output, structured for human review
+
+### Files this spec creates or modifies
+
+| Path | New / modified | Purpose |
+|---|---|---|
+| `.claude/skills/testing-jinn-app/SKILL.md` | modified | Extend with multi-operator section |
+| `.claude/skills/testing-jinn-app/references/*` | new | Multi-op recipes + scenario reference docs |
+| `.claude/skills/release-prep/SKILL.md` | new | Mechanical gate-runner skill |
+| `.claude/skills/release-prep/references/*` | new | Tier-1, Tier-2, evidence format, failure classification |
+| `.claude/skills/release-readiness/SKILL.md` | new | Meta audit + triage + closure skill |
+| `.claude/skills/release-readiness/references/*` | new | Static checklist, canon prompts, triage taxonomy, handoff template |
+| `client/scripts/release/substrate-{adopt,copy,verify,topup}.ts` | new | Substrate lifecycle scripts |
+| `client/test/release/tier-1/*.ts` | new | T1.1–T1.4 implementations |
+| `client/test/release/tier-2/*.ts` | new | T2.1–T2.3 implementations |
+| `client/test/release/tier-3/*.ts` | new | T3.1 implementation |
+| `.github/workflows/npm-publish.yml` | modified | Replace `operator-gate` with Tier 1 scenarios |
+
+## §2 Test-operator substrate
+
+### Path layout
+
+```
+~/jinn-dev/
+├── operators/                              # GOLD COPY — slow-changing, read-mostly
+│   ├── op-a/                               # Launcher; adopted from ~/.jinn-client/
+│   │   ├── manifest.json                   # identity, role, on-chain addresses
+│   │   └── .jinn-client/
+│   │       ├── config.json                 # apiPort=7332
+│   │       ├── earning/                    # state + master keystore + launched SolverNet records
+│   │       ├── keystore-password           # chmod 600
+│   │       ├── disclaimer-acknowledged
+│   │       ├── installed-harnesses.json
+│   │       └── operator-mcp-config.json
+│   ├── op-b/                               # Participant; adopted from ~/jinn-canary-test/home/.jinn-client/
+│   │   ├── manifest.json
+│   │   └── .jinn-client/                   # apiPort=7333
+│   └── op-c-legacy/                        # Legacy-backup; adopted from ~/.jinn-testnet-acceptance/
+│       ├── manifest.json
+│       └── .jinn-client/                   # apiPort=7334, pre-fleet bootstrap shape
+└── workspaces/                             # PER-RUN — copied from gold, torn down after
+    └── <run-id>/
+        ├── op-a/
+        └── op-b/
+```
+
+The substrate lives outside any git checkout (survives worktree deletes). Each operator has a `manifest.json` capturing its identity, role, on-chain bindings, and the substrate-version it was generated under.
+
+### Manifest schema
+
+```json
+{
+  "substrateVersion": "1",
+  "createdAt": "2026-05-19T14:47:19Z",
+  "adoptedFrom": "~/.jinn-client/",
+  "name": "op-a",
+  "shape": "current",                       // "current" | "pre-fleet"
+  "role": "launcher",                       // "launcher" | "participant" | "legacy-backup"
+  "network": "base-sepolia",
+  "operator": {
+    "masterAddress": "0xE64bAf00...",
+    "fleetAgentId": "5474",
+    "fleetSafeAddress": "0x0e767E28...",
+    "fleetStage": "stage1_and_2",
+    "serviceId": 46,
+    "serviceStep": "complete",
+    "agentEoa": "0x63192d38...",
+    "safeAddress": "0x0e767E28...",
+    "mechAddress": "0x9c415369...",
+    "stakingAddress": "0x24e34E50...",
+    "identityRegistry": "0x8004A818..."
+  },
+  "config": {
+    "apiPort": 7332,
+    "rpcUrl": "https://base-sepolia.gateway.tenderly.co/...",
+    "joinedSolverNets": ["bafkrei..."]
+  }
+}
+```
+
+### Adopted substrate (as of 2026-05-19)
+
+The substrate exists. Adoption was performed during this spec's brainstorm and committed before writing the doc.
+
+| Op | Source | Master | AgentId | Service | Shape | Role | apiPort |
+|---|---|---|---|---|---|---|---|
+| op-a | `~/.jinn-client/` | `0xE64bAf00...` | 5474 | 46 | current | launcher | 7332 |
+| op-b | `~/jinn-canary-test/home/.jinn-client/` | `0x09040a87...` | 5941 | 56 | current | participant | 7333 |
+| op-c-legacy | `~/.jinn-testnet-acceptance/.jinn-client/` | `0xC1494C7F...` | — | 26 | pre-fleet | legacy-backup | 7334 |
+
+Total disk cost: 88KB across all three (no `engine/work/` cache included). Each op holds only the minimum to spawn a daemon at the right identity: config, earning state, keystores, password, and the lightweight acknowledgement files.
+
+### Lifecycle operations
+
+| Script | Purpose | When |
+|---|---|---|
+| `substrate-adopt.ts` | Copy from existing operator dirs into gold | One-time per substrate refresh |
+| `substrate-copy.ts` | Per-run workspace copy from gold | Start of every Tier 2 run |
+| `substrate-verify.ts` | Manifest + on-chain health check | Start of every release-prep / release-readiness run |
+| `substrate-topup.ts` | Top up Tier 3 funding (ETH + USDC) | Pre-Tier-3 check |
+| `substrate-snapshot.ts` | Bootstrap fresh from scratch (rare) | Deferred — only when adopt + upgrade can't recover |
+
+### Workspace lifecycle
+
+Each Tier 2 run gets `<run-id> = YYYY-MM-DDTHH-MM-SS-<rand4>`. `substrate-copy.ts` copies op-a and op-b into `~/jinn-dev/workspaces/<run-id>/`. Scenarios run against the workspace; gold copy is never touched. At end of run, the workspace is `rm -rf`'d. A background reaper auto-prunes workspaces older than 7 days at the start of every release-prep run.
+
+### Tier 3 substrate use
+
+Tier 3 (real testnet) does **not** copy. It runs daemons directly against the gold copy because the on-chain identity in the gold copy *is* the real-Base-Sepolia identity. Mutations are limited to append operations (task post, solve, verdict). Funding drains and is replenished by `substrate-topup.ts`.
+
+### Mutual exclusion with daily-driver daemon
+
+Substrate operators share their on-chain identity with the daily-driver operator at `~/.jinn-client/` (op-a's source) and `~/jinn-canary-test/...` (op-b's source). Running a substrate daemon on real Base Sepolia while the daily driver is also running results in two daemons fighting for the same nonce/claim/Safe. Rules:
+
+- **Tier 3 (real testnet):** human-invoked mode SIGTERMs daily-driver daemons before Phase 5, restarts after. Autonomous mode skips Tier 3 if daily drivers running.
+- **Tier 2 (Anvil-fork):** safe to run alongside daily driver. Fork is sandboxed.
+- **Tier 1:** no substrate, no conflict.
+
+Detection: `release-readiness` Phase 1 checks ports 7331/7332 on localhost.
+
+### Refresh policy
+
+The gold copy is regenerated when `substrate-verify` reports drift: contracts moved, schema changed, or substrate operator lost staking status. Regeneration is deliberate (manual or scripted via `substrate-snapshot`), not automatic — a fresh substrate burns testnet OLAS bond and shifts agentIds.
+
+## §3 release-prep skill
+
+### Skill location
+
+```
+.claude/skills/release-prep/
+├── SKILL.md
+└── references/
+    ├── tier-1-scenarios.md
+    ├── tier-2-scenarios.md
+    ├── evidence-format.md
+    └── failure-classification.md
+```
+
+### Input contract
+
+```typescript
+interface ReleasePrepInput {
+  branchSha: string;
+  candidateVersion: string;
+  substrateRoot?: string;               // default: ~/jinn-dev/operators/
+  scenarios?: ScenarioId[];             // optional override; default: all enabled
+  outputDir?: string;                   // default: docs/release/<candidateVersion>/
+  parallelism?: number;                 // default: 4
+}
+```
+
+Invocable three ways: from `release-readiness` (subagent dispatch), from a human (`Skill release-prep ...`), or from a future cron. Same contract.
+
+### Five-phase process
+
+```
+1. Preflight
+   ├─ checkout branchSha into a worktree
+   ├─ build the client (yarn build)
+   ├─ verify substrate health
+   │  └─ FAIL: emit "substrate stale, re-adopt" and stop
+   └─ allocate run-id
+
+2. Tier 1 — fan out (parallel, no substrate, ~90s wall-clock)
+   ├─ subagent: T1.1 bootstrap-fresh-anvil (90s budget)
+   ├─ subagent: T1.2 harness-readiness-contract (30s budget)
+   ├─ subagent: T1.3 indexer-round-trip (60s budget)
+   ├─ subagent: T1.4 SPA route smoke (30s budget)
+   └─ collect verdicts
+
+3. Tier 2 — fan out (parallel, substrate-derived workspaces, ~5min wall-clock)
+   ├─ substrate-copy op-a + op-b into per-scenario workspaces
+   ├─ subagent: T2.1 cross-operator-donation (5min budget)
+   ├─ subagent: T2.2 producer-evaluator-anvil-fork (5min budget)
+   ├─ subagent: T2.3 multi-op SPA flow (5min budget)
+   └─ collect verdicts; tear down workspaces
+
+4. Synthesis
+   ├─ aggregate verdicts (pass / skip:<reason> / fail:<class>)
+   ├─ classify each fail: real-bug | flake-infra | flake-timing | agent-crash
+   ├─ write evidence doc: docs/release/<candidateVersion>/release-prep-evidence.md
+   └─ emit marker block to stdout
+
+5. Cleanup
+   └─ remove worktree, reap any orphaned workspaces
+```
+
+### Subagent dispatch model
+
+Each scenario runs as a separate subagent. Per-scenario workspace isolation (each scenario gets its own copy of the substrate) so parallel scenarios don't share daemon state. Subagent receives worktree path, scenario reference doc, workspace path, output path. Reports back a structured verdict:
+
+```json
+{
+  "scenarioId": "T2.1",
+  "verdict": "pass" | "skip:<reason>" | "fail:<class>",
+  "wallClockMs": 312000,
+  "evidencePath": "docs/release/v0.1.7/release-prep-evidence/T2.1.log",
+  "failClass": null | "real-bug" | "flake-infra" | "flake-timing" | "agent-crash",
+  "failNotes": "..."
+}
+```
+
+### Failure classification
+
+| Class | Detection | Action |
+|---|---|---|
+| substrate stale | substrate-verify before fan-out | block run, instruct re-adopt |
+| scenario timeout | wall-clock budget exceeded | mark `fail:flake-timing`, save evidence |
+| scenario RPC error | error message regex (HTTP / network / timeout) | retry once; mark `fail:flake-infra` if second fails |
+| scenario assertion fail | non-flake error | mark `fail:real-bug`, save evidence |
+| workspace teardown fails | rm error | log to reaper, don't block run |
+| subagent crashes | Agent tool error | mark `fail:agent-crash`, save partial evidence |
+
+`flake-*` and `agent-crash` verdicts pass through informationally; they don't block ship by themselves. `real-bug` blocks. `release-readiness` has final say.
+
+### Evidence output
+
+`docs/release/<candidateVersion>/release-prep-evidence.md` plus per-scenario log files under `release-prep-evidence/`. The summary doc embeds a marker block (extends the current `jinn-release-evidence:v1` schema) with per-scenario keys ready to paste into the GitHub Release body.
+
+### Explicit non-goals
+
+- Tier 3 (real testnet) — owned by release-readiness.
+- Triage (blocking-vs-deferrable classification of findings) — owned by release-readiness.
+- Gap closure — owned by release-readiness.
+- Human handoff — owned by release-readiness.
+
+## §4 release-readiness skill
+
+### Skill location
+
+```
+.claude/skills/release-readiness/
+├── SKILL.md
+└── references/
+    ├── static-checklist.md
+    ├── canon-audit-prompts.md
+    ├── triage-taxonomy.md
+    ├── handoff-doc-template.md
+    ├── tier-3-scenario.md
+    └── autonomous-vs-invoked.md
+```
+
+### Input contract
+
+```typescript
+interface ReleaseReadinessInput {
+  candidateVersion: string;
+  branchSha: string;
+  lastReleasedSha?: string;             // diff anchor; defaults to v<prev> tag
+  mode: "human-invoked" | "autonomous";
+  substrateRoot?: string;
+  outputDir?: string;
+  forceShip?: boolean;                  // emergency override, logged in handoff
+}
+```
+
+### Subagent-first design principle
+
+Main agent is a thin coordinator. Anything requiring non-trivial context (canon doc, code section, PR diff, daemon log) runs as a subagent. Main agent only sees structured verdicts. Per-run subagent count: ~6-9 fixed plus one per blocking gap. Main agent's working context stays ~50K tokens regardless of release size.
+
+| Operation | Where | Why |
+|---|---|---|
+| Phase 1 setup (git diff, gh issue queries, substrate-verify) | main | Pure command output |
+| Phase 2 mechanical checks (C2, C5, C6, C9 — grep/AST) | main | No context loading |
+| Phase 2 judgmental + canon pass (C1, C3, C4, C7, C8, C10, C11 + all canon docs) | **1 subagent** | Cross-cutting findings benefit from unified reasoning |
+| Phase 3 triage (classify all gaps) | **1 subagent** | Relative priority across gaps requires unified view |
+| Phase 4 closure (fix + PR) | **1 subagent per gap** | Inherently independent work |
+| Phase 4 PR review per closure | **1 subagent per PR** | Loads PR diff |
+| Phase 5 release-prep | **subagent (the skill itself)** | Already its own skill |
+| Phase 5 Tier 3 scenario | **1 subagent** | Long-running |
+| Phase 6 handoff doc drafting | **1 subagent** | Composes output |
+| Phase 6 SHIP/DEFER/BLOCK decision | main | Terminal judgment stays in main |
+| Phase 7 terminal | main | One-shot notification |
+
+### Seven-phase process
+
+```
+Phase 1: Setup
+  ├─ resolve diff: git log lastReleasedSha..branchSha
+  ├─ load canon: PRINCIPLES.md, SPEC.md, BRAND.md, GROWTH.md, GLOSSARY.md
+  ├─ load operational memory (file-based memory directory)
+  ├─ query open release-blocker issues: gh issue list --label release-blocker
+  └─ verify substrate health
+
+Phase 2: Audit
+  ├─ main runs mechanical checks: C2 / C5 / C6 / C9 (grep/AST)
+  ├─ dispatch judgmental audit subagent (full diff + all canon + check items)
+  └─ collect unified findings list
+
+Phase 3: Triage
+  ├─ dispatch triage subagent
+  ├─ subagent classifies each gap; surfaces cross-cutting concerns
+  ├─ ALREADY-MET: link to evidence
+  ├─ DEFERRABLE: emit gh issue create shell with proposed labels/milestone
+  └─ BLOCKING: queue for Phase 4
+
+Phase 4: Closure (skipped if no BLOCKING)
+  ├─ For each BLOCKING gap, dispatch closure subagent in parallel
+  ├─ Subagent reports: PR URL or escalate=true with reason
+  ├─ For each PR: dispatch PR-review subagent
+  ├─ Main: cross-account merge via dual-account flow if approved
+  └─ After 3 failed close attempts on same gap: BLOCKING-ESCALATED
+       gap remains BLOCKING; recommendation shifts to DEFER
+
+Phase 5: Validate
+  ├─ Invoke release-prep skill with branchSha
+  ├─ Invoke Tier 3 scenario subagent
+  └─ Aggregate
+
+Phase 6: Synthesize
+  ├─ Dispatch handoff-doc-drafting subagent
+  ├─ Main determines recommendation:
+  │    SHIP   if all BLOCKING closed AND Tier 3 passed
+  │    DEFER  if BLOCKING escalated OR Tier 3 failed AND independent evidence weak
+  │    BLOCK  if Tier 3 produced a clear regression
+  ├─ Write final handoff to docs/release/<candidateVersion>/handoff.md
+  ├─ Emit final marker block
+  └─ Append one-line entry to log/decisions/release-readiness-runs.md
+
+Phase 7: Terminal
+  ├─ human-invoked: emit "handoff at <path>; recommendation: SHIP/DEFER/BLOCK"
+  └─ autonomous: gh issue create --label release-ready ...
+```
+
+### Static checklist (C1-C11)
+
+| # | Concern | Triggers when… | Where it runs |
+|---|---|---|---|
+| C1 | operator-app-principle | diff touches `client/src/dashboard/` or operator-facing copy | judgmental subagent |
+| C2 | bootstrap-phase change | diff touches `client/src/earning/bootstrap.ts` | main (grep) |
+| C3 | per-harness readiness | new harness or auth flow change | judgmental subagent |
+| C4 | eval admission / verdict recheck | diff touches eval admission or substrate hashing | judgmental subagent |
+| C5 | task admission filter | diff touches floor / DiscoveryAPI filter / claim eligibility | main (grep) |
+| C6 | canon doc movement | diff touches PRINCIPLES.md / SPEC.md / BRAND.md / GROWTH.md / GLOSSARY.md | main (grep) |
+| C7 | memory invariant violation | diff contradicts stored memory file | judgmental subagent |
+| C8 | wiring-seam coverage | value computed in 2+ modules without single-source helper | judgmental subagent |
+| C9 | release-evidence marker schema | diff touches `.github/workflows/npm-publish.yml` marker check | main (grep) |
+| C10 | spec freshness | spec referenced in code no longer matches code | judgmental subagent |
+| C11 | skill currency | diff touches operator-facing UI / CLI verbs / public surfaces | judgmental subagent |
+
+C11 is the recursion that keeps the system honest. Every release sweeps `.claude/skills/*/SKILL.md` against the diff. Drift is BLOCKING if the skill makes false claims about changed surface (operator hits a wall), DEFERRABLE otherwise.
+
+### Triage taxonomy
+
+**BLOCKING:** PRINCIPLES.md violation introduced by branch, operator-app-principle violation in new UI copy, canon doc moved without ratification, bootstrap/auth/eval substrate regression, wiring-seam drift introduced, Tier 3 regression, skill makes false claims about changed surface.
+
+**DEFERRABLE:** Spec-drift in unreferenced area, pre-existing open issue, quality-of-life concerns, Tier 1/2 flake-class failures, skill doesn't yet cover new surface but existing surface accurate, anything previously triaged as "next release."
+
+**ALREADY-MET:** Static check passed without finding, concern covered by existing test/spec, concern resolved by a commit in window.
+
+### Closure flow
+
+For each BLOCKING gap, dispatch subagent: "investigate, propose fix, implement on a worktree branch off `next`, add regression test, push, file PR." Main agent reads PR-review subagent's report and cross-account approves. Three escalations on same gap shifts recommendation to DEFER.
+
+Cross-account flow: closure subagent pushes as `ritsuKai2000`; main agent does cross-account approve via `ritsukai`. Author can't self-approve in GitHub.
+
+**All issue tracking uses `gh issue` with structured labels and milestones. bd is not used in this skill.**
+
+### Tier 3 scenario
+
+The load-bearing real-testnet evidence — codified A3 verification.
+
+Pre-conditions: daily-driver daemons SIGTERM'd, substrate-topup verified, API key available.
+
+Execution: spawn op-a + op-b daemons from gold substrate, op-a posts a small SWE-rebench v2 task, op-a claims and solves via real Hermes (real OpenRouter API, ~$0.05-$0.10), op-a delivers, op-b claims verdict request, runs real evaluator Docker image, scores, asserts verdictCode matches expected.
+
+Output: tx hashes, IPFS CIDs, wall-clock time, cost, verdict, evidence path under `docs/release/<version>/tier-3-evidence/`.
+
+Budgets: 10 min hard wall-clock, $0.25 API + 0.001 ETH cost cap.
+
+Failure modes: daemon won't start → BLOCK with stderr; task post fails → BLOCK; solve times out → flake first attempt, BLOCK on second; verdict mismatches → REAL REGRESSION (recommendation = BLOCK).
+
+### Handoff doc structure
+
+```
+# Release-readiness handoff — v0.1.7
+Generated: <timestamp>
+Branch SHA: <sha>
+Mode: human-invoked | autonomous
+Audited against last released: v0.1.6 @ <sha>
+Run-id: <run-id>
+
+## Recommendation: SHIP / DEFER / BLOCK
+[reasoning]
+
+## Diff under audit
+[PRs in window, LOC, surfaces touched]
+
+## Gap log
+### Blocking — CLOSED
+### Deferrable — FILED (GitHub issues with milestones)
+### Already met
+
+## release-prep evidence
+[embedded marker block]
+
+## Tier 3 evidence
+[scenario, harness, verdict, tx hashes, IPFS CIDs, cost, wall-clock]
+
+## Walk-through script for human pass
+[diff-derived must-checks by surface]
+
+## Open questions for human
+
+## Independent evidence
+[any out-of-band signal]
+
+## Marker block (final)
+[extends jinn-release-evidence:v1 with tier-3-* and release-readiness-* keys]
+```
+
+### Marker schema extension
+
+The current `jinn-release-evidence:v1` marker gains new keys:
+
+- `tier-1-bootstrap=passed|skipped:#<issue>|failed`
+- `tier-1-harness-readiness=...`
+- `tier-1-indexer-roundtrip=...`
+- `tier-1-spa-route-smoke=...`
+- `tier-2-cross-op-donation=...`
+- `tier-2-producer-evaluator=...`
+- `tier-2-multi-op-spa-flow=...`
+- `tier-3-producer-evaluator-real=...`
+- `release-readiness-recommendation=SHIP|DEFER|BLOCK`
+- `release-readiness-handoff=docs/release/v0.1.7/handoff.md`
+- `release-readiness-run=<run-id>`
+
+The current keys (`release-client-prepare`, `donation-consumption`, `app-first-testnet-acceptance`) are superseded by the per-scenario keys. Migration is one workflow edit + one decision-log entry.
+
+### GitHub labels
+
+Three new labels needed on the repo:
+- `release-readiness` — issues filed by the skill (informational, tracks runs)
+- `release-blocker` — gaps blocking the current cut
+- `skill-drift` — C11 findings on SKILL.md outdatedness
+
+GitHub Milestones (`v0.1.8`, `v0.1.9`, etc.) supply target-release semantics for deferrable gaps.
+
+### Autonomous vs human-invoked
+
+**Human-invoked mode:** Daily-driver daemons SIGTERM'd before Tier 3, restarted after. Tier 3 runs. Cost budget permissive. Phase 7 ends with "handoff ready at `<path>`."
+
+**Autonomous mode:** Daily-driver daemons not touched. Tier 3 SKIPPED if daily drivers running. If skipped, recommendation is `INSUFFICIENT-EVIDENCE-FOR-SHIP; needs human-invoked re-run`. Cost budget tighter. Phase 7 ends with a GitHub issue.
+
+### Integration with existing release cadence
+
+Current state (no cron yet):
+
+```
+Friday evening (manual):
+  human invokes: Skill release-readiness --candidateVersion v0.1.7 --mode autonomous
+  skill runs over weekend (audit + closure + release-prep; Tier 3 SKIPPED)
+  Saturday/Sunday: GH issue filed when complete
+  handoff doc lands at docs/release/v0.1.7/handoff.md
+
+Monday morning:
+  human reads handoff
+  if all looks good: re-invoke with --mode human-invoked for Tier 3
+  Tier 3 runs (~10 min)
+  handoff doc updates with verdict
+  human decides SHIP/DEFER/BLOCK
+  human publishes (or doesn't)
+```
+
+Future (cron, follow-up GH issue):
+
+```
+Friday 23:00 UTC: GH Actions cron fires autonomous mode
+  workflow runs the skill against next HEAD
+  posts handoff doc as a comment on the existing Monday-draft GH Release
+Monday: human picks up, runs human-invoked for Tier 3, decides
+```
+
+### Explicit non-goals
+
+- Publishing the release (always advisory)
+- Modifying canon docs unilaterally
+- Re-running release-prep gates when they already ran against the same SHA
+- Killing operator daemons in autonomous mode
+- Running Tier 3 in autonomous mode
+- Using bd (all issue tracking via `gh issue`)
+
+## §5 testing-jinn-app extension
+
+The existing skill at `.claude/skills/testing-jinn-app/SKILL.md` covers single-operator dashboard testing. It stays unchanged for those use cases. This section adds a multi-operator section and reference docs.
+
+### New section in SKILL.md: "Multi-operator scenarios"
+
+Covers the substrate-anchored spawn pattern, port management, chrome-devtools multi-page driving, Playwright multi-op test templates.
+
+### New reference docs
+
+```
+.claude/skills/testing-jinn-app/references/
+├── multi-op-spawn.md
+├── multi-op-chrome-devtools.md
+├── multi-op-playwright.md
+├── scenario-cross-op-donation.md            # T2.1 recipe
+├── scenario-producer-evaluator.md           # T2.2 recipe
+├── scenario-spa-route-smoke.md              # T1.4 recipe
+└── scenario-multi-op-spa-flow.md            # T2.3 recipe
+```
+
+### Multi-operator spawn pattern
+
+Substrate-derived workspaces, distinct ports per op (7332/7333/7334), per-daemon handshake URL capture, trap-based teardown.
+
+### Failure modes added to "Things to watch for"
+
+- Cross-operator visibility lag (op-b sees op-a's actions only after indexer catch-up)
+- Identity collisions (two daemons with same HOME = same on-chain identity = nonce conflict)
+- Workspace bleed (workspaces auto-pruned at 7 days; don't assume persistence between runs)
+- Substrate staleness (run substrate-verify before any multi-op session)
+- RPC saturation under concurrent load (one shared Tenderly key; add jittered delays in RPC-heavy multi-op scenarios)
+
+### What stays unchanged
+
+Single-op manual smoke (chrome-devtools), single-op Playwright E2E (route-mocked), "rebuild before test," `/v1/bootstrap` readiness wait, handshake-URL-per-spawn, mocking taxonomy.
+
+### Relationship to release-prep and release-readiness
+
+```
+testing-jinn-app          provides the building blocks (recipes)
+       │
+       │ scenarios consumed by
+       ▼
+release-prep              runs scenarios as gates, emits marker
+       │
+       │ marker consumed by
+       ▼
+release-readiness         audits, triages, runs Tier 3, hands off
+```
+
+testing-jinn-app is the **library**. release-prep is the **gate runner**. release-readiness is the **audit + decision skill**. Scenarios are written once in testing-jinn-app and consumed by release-prep — no duplication.
+
+## §6 Scenario inventory (consolidated)
+
+| ID | Tier | Name | Substrate | Lives in | Catches | Wall-clock |
+|---|---|---|---|---|---|---|
+| T1.1 | 1 | bootstrap-fresh-anvil | no | `client/test/release/tier-1/T1.1.ts` | u34i / h74p / k1ng bootstrap reliability | 90s |
+| T1.2 | 1 | harness-readiness-contract | no | `client/test/release/tier-1/T1.2.ts` | vh74 per-harness auth regressions | 30s |
+| T1.3 | 1 | indexer-round-trip | no | `client/test/release/tier-1/T1.3.ts` | fufn eval-substrate, indexer schema drift | 60s |
+| T1.4 | 1 | SPA route smoke | no | `client/test/dashboard/release-prep/spa-route-smoke.e2e.test.ts` | broken routes, missing mocks, JS errors | 30s |
+| T2.1 | 2 | cross-operator-donation | yes | `client/test/release/tier-2/T2.1.ts` | x402 + ERC-8128 handshake regressions | 5m |
+| T2.2 | 2 | producer-evaluator-anvil-fork | yes | `client/test/release/tier-2/T2.2.ts` | claim → solve → deliver → evaluate loop | 5m |
+| T2.3 | 2 | multi-op SPA flow | yes | `client/test/dashboard/multi-op/launcher-join-flow.e2e.test.ts` | cross-op UI bugs invisible under mocks | 5m |
+| T3.1 | 3 | producer-evaluator real-testnet | yes (gold, no copy) | `client/test/release/tier-3/T3.1.ts` | load-bearing real-network verdict | 10m |
+
+**Budget vs expected wall-clock.** Scenarios within a tier run in parallel (each in its own subagent + workspace), so wall-clock for a tier is the *max* of its scenarios, not the sum. Budget is the cap (timeout) per scenario.
+
+- Tier 1 — budget per scenario: 90s; tier wall-clock (parallel max): ~90s
+- Tier 2 — budget per scenario: 5min; tier wall-clock (parallel max): ~5min
+- Tier 3 — single scenario, sequential: ~10min
+
+release-prep wall-clock (Tier 1 + Tier 2 parallel) ≈ 6-7 min. release-readiness end-to-end (release-prep + Tier 3 + audit + closure for a clean release) ≈ 25-35 min.
+
+## §7 Lifecycle, error handling, edge cases
+
+### Substrate funding maintenance (Tier 3)
+
+| Resource | Per op | Top-up trigger | Source |
+|---|---|---|---|
+| ETH | 0.005 | < 0.002 | Base Sepolia faucet / release-bot wallet |
+| USDC | 1.00 | < 0.10 | manual seed, then x402 cycles |
+| OLAS bond | constant | never drains | staked once at substrate creation |
+
+`substrate-topup.ts` runs at start of Tier 3. If balances below threshold, attempts faucet drip; if drained, blocks with operator-app-principle-style escalation.
+
+### Recovery from interrupted runs
+
+No resume. If interrupted, restart from Phase 1. Phases 1-3 are cheap (~5 min). Phase 4 PRs left mid-air can be picked up manually; agent re-audits. Phase 5 is idempotent. Phase 6/7 is a function of inputs.
+
+### API key budget for Tier 3
+
+Per-run cost ~$0.05-$0.10. Weekly cadence ~$0.40-$0.80 / month autonomous + ~$0.20-$0.40 human-invoked. Per-run cap: $0.25 in Tier 3 scenario; abort if exceeded.
+
+### Workspace garbage collection
+
+Trap-handler teardown at end of every run. Background reaper auto-deletes workspaces older than 7 days at start of every release-prep run. Workspaces tagged with `.created-by` for orphan detection.
+
+### Skill-self-update recursion
+
+When release-readiness audits a diff touching its own SKILL.md or references, C11 fires. The skill audits itself. Closure flow dispatches subagent to update the SKILL.md in the same PR.
+
+### Cron not yet wired
+
+Captured as follow-up GitHub issue: "Wire release-readiness autonomous-mode to a Friday 23:00 UTC GitHub Actions schedule." Until that lands, weekend invocation is manual.
+
+## §8 Testing the meta-system
+
+### Unit-ish tests for the skill's own functions
+
+- `client/test/release-skill/audit.test.ts` — known diff + canon corpus, assert findings match expected.
+- `client/test/release-skill/triage.test.ts` — known findings, assert classifications.
+- `client/test/release-skill/handoff-doc.test.ts` — known inputs, assert doc structure.
+
+### Mock canon + diff fixtures
+
+`client/test/release-skill/fixtures/` — one fixture per checklist item plus cross-cutting cases.
+
+### Smoke run against known-good release
+
+Retrospectively run the skill against `v0.1.6`. Expected: recommendation = SHIP, deferrable gaps match what we actually filed (#320, etc.). Catches regressions in the skill itself.
+
+### What's hard to test
+
+The judgmental subagent's reasoning. Fixtures assert *structure* (right number of findings, right severity buckets), not specific reasoning text. Regression-on-known-good catches signal degradation.
+
+## §9 Open questions and acknowledged limitations
+
+### Open questions (resolve in implementation or later)
+
+1. **PRINCIPLES.md vs memory conflict resolution.** PRINCIPLES.md is privileged canon; memory is operational guidance below. Edge cases will emerge.
+2. **What counts as "blocking" for skill-drift.** Clear cases at the extremes; middle ground needs judgment captured in `references/triage-taxonomy.md`.
+3. **How long to keep handoff docs.** Forever, probably. Archive policy deferred until volume justifies.
+4. **Migration path for older releases.** No retroactive migration; forward only.
+5. **Hotfix flow integration.** Tentative: hotfixes skip release-readiness; post-incident GH issue files "audit this hotfix against canon retroactively."
+
+### Acknowledged limitations
+
+- Auto-trigger via cron not wired in v1 (follow-up GH issue).
+- One shared Tenderly RPC key (jinn-mono-lrey tracks fix).
+- Tier 3 cost accumulates ~$0.40-$0.80 / month.
+- engine/work/ cleanup unresolved (#320).
+- Substrate can drift silently between runs (`substrate-verify` catches at start).
+- No concurrent release-candidate support in v1.
+
+### What's *not* an acknowledged limitation
+
+- Subagent reasoning fidelity — property of underlying tools; §8 catches signal degradation.
+- "Gate caught a flake" failure mode — addressed by failure classification.
+- "Ship without Tier 3 evidence" emergency case — handled by `forceShip` with audit log.
+
+## Implementation notes
+
+### Out of scope for this spec
+
+- Cron wiring for autonomous-mode auto-trigger (separate GH issue).
+- jinn-mono-lrey architectural fix (separate work).
+- Engine/work/ cleanup #320 (separate work).
+- Multi-version-in-flight support (defer until needed).
+- Mainnet release-readiness flow (v0.1.x is testnet only; mainnet has different evidence requirements).
+
+### Build sequence
+
+A `writing-plans`-produced plan will sequence the implementation. Rough ordering by dependency:
+
+1. Substrate lifecycle scripts (`substrate-adopt`, `substrate-copy`, `substrate-verify`, `substrate-topup`) — foundation for everything else.
+2. testing-jinn-app extension (multi-op recipes, scenario reference docs) — building blocks release-prep consumes.
+3. Tier 1 + Tier 2 scenario implementations (T1.1–T1.4, T2.1–T2.3).
+4. release-prep skill + its SKILL.md and references.
+5. Tier 3 scenario (T3.1).
+6. release-readiness skill + its SKILL.md and references.
+7. Workflow migration (`.github/workflows/npm-publish.yml` Tier 1 integration, marker schema extension).
+8. Smoke run against v0.1.6 retrospectively.
+9. First production use on v0.1.7.
+
+Substrate adoption itself (the on-disk artifacts) was performed during this spec's brainstorm and is committed before doc finalization. See §2 inventory table.
+
+## References
+
+- `log/decisions/2026-05-19-v0.1.6-stewardship.md` — the v0.1.6 stewardship log that produced the empirical evidence motivating this design.
+- `PRINCIPLES.md` — canon source of truth audited by release-readiness.
+- `docs/engineering/handbook.md` §Cadence — two-train release cadence this skill integrates into.
+- `spec/2026-04-28-canonical-docs.md` — canonical-docs policy referenced by C6.
+- `docs/superpowers/specs/2026-04-24-test-architecture-design.md` — broader test architecture this spec composes with.
+- GitHub issues: `jinn-mono-lrey` (RPC architecture), `#320` (engine/work cleanup), `#310` (donation-consumption), `#312`/`#313` (marker relaxation pattern), `#295`/`#296`/`#297`/`#300`/`#302`/`#304`/`#307`/`#308`/`#309` (v0.1.6 follow-ups).


### PR DESCRIPTION
## Summary

Design spec for the test-operator substrate plus two new skills (\`release-prep\` and \`release-readiness\`) that compose into an audit-driven release process.

**Motivation:** the v0.1.6 cut on 2026-05-19 spent ~3 hours fighting four distinct CI gate failures and caught zero release bugs; ship was carried by independent manual A3 verification on real Base Sepolia. Pattern is structural: current gates re-bootstrap on every call (saturating RPC keys), test mechanics not experience, and don't audit the app.

**Design (full detail in the spec):**
- Three-tier evidence model: T1 mechanical on every push; T2 cross-op on substrate-derived workspaces; T3 real testnet (the only required gate for a named cut)
- Persistent test-operator substrate at \`~/jinn-dev/operators/op-{a,b,c-legacy}/\` (adopted 2026-05-19 from existing fully-bootstrapped operators; 88KB total — substrate exists, see §2 for inventory)
- \`release-prep\` skill (mechanical: copy substrate, run T1+T2, emit marker)
- \`release-readiness\` skill (meta: audit canon, triage gaps, drive closure, invoke release-prep + T3, hand off to human)
- \`testing-jinn-app\` extension (multi-op recipes + scenario reference docs)
- Subagent-first design: ~6-9 subagents per release-readiness run; main agent stays a thin coordinator
- All issue tracking via \`gh issue\` (bd deprecated for these skills)

**Out of scope (separate follow-ups):**
- Cron wiring for autonomous-mode auto-trigger
- jinn-mono-lrey RPC architecture fix
- #320 engine/work cleanup

## Test plan

- [ ] Spec reviewed by CODEOWNERS
- [ ] Approve + merge to \`next\`
- [ ] Implementation plan (writing-plans skill output) follows in a separate doc + PRs
- [ ] First production use on v0.1.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)