### PR TITLE
feat(testing-jinn-app): multi-operator extension (Plan B)

### DIFF
--- a/.claude/skills/testing-jinn-app/SKILL.md
+++ b/.claude/skills/testing-jinn-app/SKILL.md
@@ -84,6 +84,35 @@ Live template: `client/test/dashboard/spa-config.e2e.test.ts`. The pattern:
 
 Run a single E2E file: `yarn build && playwright test --config=playwright.config.ts test/dashboard/spa-config.e2e.test.ts` (model after the `e2e:spa` script in `client/package.json`).
 
+## Multi-operator scenarios
+
+The single-op recipes above (manual smoke, automated E2E) cover testing one operator in isolation. Multi-operator scenarios — where two daemons interact via the chain and via the operator app — require additional infrastructure that this section documents. Reference docs in `references/` cover each pattern in detail.
+
+Spawn pattern: two (or more) daemons run concurrently against distinct HOMEs (substrate-derived workspaces from Plan A's `substrate-copy`, or fresh tmp HOMEs for clean-state E2Es). Each daemon gets a distinct `JINN_API_PORT`. Helpers in `client/test/helpers/multi-op-daemon.ts` wrap the spawn + teardown lifecycle.
+
+Three method-pattern reference docs cover the mechanics:
+
+- [`references/multi-op-spawn.md`](references/multi-op-spawn.md) — bash + TypeScript spawn recipes; port management; teardown.
+- [`references/multi-op-chrome-devtools.md`](references/multi-op-chrome-devtools.md) — multi-page chrome-devtools driving for cross-op manual smoke.
+- [`references/multi-op-playwright.md`](references/multi-op-playwright.md) — Playwright template for two-daemon automated tests.
+
+Four scenario reference docs are the contracts release-prep's gate runner consumes. Each describes one scenario at the level of detail an implementer needs:
+
+- [`references/scenario-spa-route-smoke.md`](references/scenario-spa-route-smoke.md) — T1.4: load every SPA route against a mocked daemon, assert clean.
+- [`references/scenario-cross-op-donation.md`](references/scenario-cross-op-donation.md) — T2.1: op-a produces corpus artifact, op-b consumes via x402.
+- [`references/scenario-producer-evaluator.md`](references/scenario-producer-evaluator.md) — T2.2: op-a solves task on Anvil-fork, op-b evaluates.
+- [`references/scenario-multi-op-spa-flow.md`](references/scenario-multi-op-spa-flow.md) — T2.3: op-a launches SolverNet via SPA, op-b joins via SPA, both observe each other.
+
+### Things to watch for (multi-op specific)
+
+In addition to the single-op concerns listed earlier:
+
+- **Cross-operator visibility lag** — op-b sees op-a's actions only after the indexer has caught up (~2 indexer-poll-intervals). Wait, don't assume instant.
+- **Identity collisions** — spawning two daemons with the same HOME means both fight for the same agentId/Safe/nonce. Always verify *both* apiPort AND source HOME directory are distinct before spawning.
+- **Workspace bleed** — substrate-derived workspaces under `~/jinn-dev/workspaces/` are auto-pruned at 7 days by `substrate-reap`. Don't leave a workspace assumed to be there between test runs; either own its lifecycle or use a fresh one each test.
+- **Substrate staleness** — if `substrate-verify` reports drift, all multi-op scenarios using substrate workspaces will fail in non-obvious ways. Run verify before any multi-op session.
+- **RPC saturation under concurrent load** — substrate ops currently share one Tenderly key (per spec §2). If both daemons hammer the RPC simultaneously, expect HTTP 429. Tracked as `jinn-mono-lrey`; for now, add jittered delays in scenarios where both daemons are RPC-active.
+
 ## Quick reference
 
 | Goal | Approach |

--- a/.claude/skills/testing-jinn-app/SKILL.md
+++ b/.claude/skills/testing-jinn-app/SKILL.md
@@ -123,6 +123,12 @@ In addition to the single-op concerns listed earlier:
 | Verify hash deep-links | Navigate to `/configuration#network` etc. |
 | Test against real chain state | Reuse a bootstrapped HOME, no mocks |
 | Test pure SPA wiring | Fresh HOME + mock all `/v1/*` endpoints |
+| Spot a cross-op visibility bug | Multi-op chrome-devtools — drive two pages, [`references/multi-op-chrome-devtools.md`](references/multi-op-chrome-devtools.md) |
+| Add cross-op regression coverage | Multi-op Playwright — [`references/multi-op-playwright.md`](references/multi-op-playwright.md) |
+| Test SPA route surface (T1.4) | [`references/scenario-spa-route-smoke.md`](references/scenario-spa-route-smoke.md) |
+| Test cross-op donation (T2.1) | [`references/scenario-cross-op-donation.md`](references/scenario-cross-op-donation.md) |
+| Test producer/evaluator on Anvil-fork (T2.2) | [`references/scenario-producer-evaluator.md`](references/scenario-producer-evaluator.md) |
+| Test multi-op SPA flow (T2.3) | [`references/scenario-multi-op-spa-flow.md`](references/scenario-multi-op-spa-flow.md) |
 
 ## Common mistakes
 

--- a/.claude/skills/testing-jinn-app/references/multi-op-chrome-devtools.md
+++ b/.claude/skills/testing-jinn-app/references/multi-op-chrome-devtools.md
@@ -1,0 +1,84 @@
+# Multi-op chrome-devtools driving
+
+For manual smoke tests where you drive two operator apps side by side. Uses the `chrome-devtools` MCP server's multi-page support.
+
+## Prereqs
+
+- Both daemons spawned (see [multi-op-spawn.md](multi-op-spawn.md)). Capture both handshake URLs.
+- `chrome-devtools` MCP loaded in your session. Verify with `ToolSearch query="chrome devtools navigate"` — if `mcp__chrome-devtools__new_page` and `mcp__chrome-devtools__select_page` don't surface, this MCP isn't loaded and the recipe below won't work; fall back to manual two-browser-window driving.
+
+## Recipe
+
+```typescript
+// 1. Open a page per operator
+const opAPage = await mcp__chrome_devtools__new_page({ url: opAHandshakeUrl });
+const opBPage = await mcp__chrome_devtools__new_page({ url: opBHandshakeUrl });
+
+// 2. Drive op-a — explicitly select before each action
+await mcp__chrome_devtools__select_page({ pageId: opAPage });
+await mcp__chrome_devtools__click({ selector: 'button:has-text("Create SolverNet")' });
+// ... wizard steps ...
+
+// 3. Drive op-b — explicitly select again
+await mcp__chrome_devtools__select_page({ pageId: opBPage });
+await mcp__chrome_devtools__navigate_page({ url: opBHandshakeUrl + '/operator/join' });
+await mcp__chrome_devtools__take_screenshot({});
+
+// 4. Cross-verify: switch back to op-a and check op-a sees op-b's action
+await mcp__chrome_devtools__select_page({ pageId: opAPage });
+await mcp__chrome_devtools__navigate_page({ url: opAHandshakeUrl + '/launcher/launched/<id>' });
+```
+
+## Critical rule: always select before acting
+
+chrome-devtools MCP maintains an "active page" pointer. Every click / type / navigate operates on the currently-selected page. If you fan out across two pages without explicit `select_page` calls, you'll drive whichever happened to be selected last — often the wrong one.
+
+**Pattern:**
+```typescript
+async function driveOnPage(pageId: string, action: () => Promise<void>): Promise<void> {
+  await mcp__chrome_devtools__select_page({ pageId });
+  await action();
+}
+```
+
+Wrap every cross-page operation in this pattern.
+
+## Cross-op visibility lag
+
+When op-a performs an action that op-b should see (e.g. op-a launches a SolverNet, op-b should see it in the catalog), there's a delay equal to:
+
+- One indexer poll interval (~5 sec for the Ponder indexer at default config)
+- Plus one SPA poll interval (~1.5 sec for useQuery defaults)
+
+**Don't assert op-b's view immediately after op-a's action.** Wait at least 10 seconds for indexer + SPA polls. Use `wait_for` with the expected DOM state, not a fixed sleep:
+
+```typescript
+await mcp__chrome_devtools__select_page({ pageId: opBPage });
+await mcp__chrome_devtools__wait_for({
+  text: 'my-new-solvernet',
+  timeout: 30000,                  // generous; indexer can lag
+});
+```
+
+## Screenshot conventions
+
+When reporting a multi-op smoke result, take screenshots of both pages at each critical state, named consistently:
+
+```typescript
+await mcp__chrome_devtools__select_page({ pageId: opAPage });
+await mcp__chrome_devtools__take_screenshot({ name: '01-op-a-after-create' });
+
+await mcp__chrome_devtools__select_page({ pageId: opBPage });
+await mcp__chrome_devtools__take_screenshot({ name: '02-op-b-catalog-shows-new' });
+```
+
+Screenshot pairs at each step make cross-op state comparison readable.
+
+## Common failure modes
+
+| Failure | Likely cause | Fix |
+|---|---|---|
+| Action happens on wrong page | forgot to `select_page` before action | wrap in `driveOnPage` helper |
+| op-b doesn't see op-a's change | not waiting for indexer/SPA poll | use `wait_for` with expected text, not sleep |
+| Stale screenshot | took screenshot before page actually updated | wait for the indicator DOM change first |
+| MCP not loaded | session doesn't have chrome-devtools MCP | check `ToolSearch query="chrome devtools navigate"`; fall back to Playwright recipe |

--- a/.claude/skills/testing-jinn-app/references/multi-op-playwright.md
+++ b/.claude/skills/testing-jinn-app/references/multi-op-playwright.md
@@ -1,0 +1,151 @@
+# Multi-op Playwright template
+
+For automated regression coverage of two-operator flows. Tests live under `client/test/dashboard/multi-op/`. Pattern below mirrors the existing single-op `client/test/dashboard/spa-config.e2e.test.ts` but with two daemons + two Playwright pages.
+
+## Template
+
+```typescript
+// client/test/dashboard/multi-op/<scenario>.e2e.test.ts
+import { test, expect, type Page } from '@playwright/test';
+import { spawnMultiOpDaemons, type MultiOpHandle } from '../../helpers/multi-op-daemon';
+import { copyWorkspace } from '../../../scripts/release/substrate-copy';
+import { mockDaemonApi } from '../helpers/mock-daemon-api';   // existing single-op mock helper
+
+let workspace: Awaited<ReturnType<typeof copyWorkspace>>;
+let daemons: MultiOpHandle;
+let opAUrl: string;
+let opBUrl: string;
+
+test.beforeAll(async () => {
+  workspace = await copyWorkspace({ ops: ['op-a', 'op-b'] });
+  daemons = await spawnMultiOpDaemons({
+    ops: [
+      { name: 'op-a', home: workspace.opPaths['op-a'], apiPort: 7732 },
+      { name: 'op-b', home: workspace.opPaths['op-b'], apiPort: 7733 },
+    ],
+    readyTimeoutMs: 30000,
+  });
+  opAUrl = daemons.daemons['op-a'].handshakeUrl ?? `http://127.0.0.1:7732/`;
+  opBUrl = daemons.daemons['op-b'].handshakeUrl ?? `http://127.0.0.1:7733/`;
+});
+
+test.afterAll(async () => {
+  await daemons?.teardown();
+  await workspace?.teardown();
+});
+
+test('op-a launches SolverNet → op-b sees it within 30s', async ({ browser }) => {
+  // Create two isolated contexts — separate cookies, separate state per op
+  const opACtx = await browser.newContext();
+  const opBCtx = await browser.newContext();
+  const opAPage = await opACtx.newPage();
+  const opBPage = await opBCtx.newPage();
+
+  // Optional: mock daemon API per page (matches the single-op pattern)
+  await mockDaemonApi(opAPage, { port: 7732 });
+  await mockDaemonApi(opBPage, { port: 7733 });
+
+  await opAPage.goto(opAUrl);
+  await opBPage.goto(opBUrl);
+
+  // Drive op-a (Launcher Create wizard)
+  await opAPage.getByRole('link', { name: /launcher/i }).click();
+  await opAPage.getByRole('button', { name: /create solvernet/i }).click();
+  // ... wizard steps ...
+  await opAPage.getByRole('button', { name: /launch/i }).click();
+  await expect(opAPage.getByText(/launched/i)).toBeVisible({ timeout: 60000 });
+
+  // Verify op-b sees the new SolverNet within 30s of launch
+  await opBPage.goto(opBUrl + '/operator/join');
+  await expect(opBPage.getByText(/new-solvernet-name/i)).toBeVisible({ timeout: 30000 });
+
+  await opACtx.close();
+  await opBCtx.close();
+});
+```
+
+## Two pages, two contexts
+
+Use **separate Playwright `BrowserContext`** instances per operator. Each context has its own cookies, localStorage, and session. If you reuse one context with two pages, the second page's auth state will collide with the first.
+
+```typescript
+const opACtx = await browser.newContext();
+const opAPage = await opACtx.newPage();
+
+const opBCtx = await browser.newContext();
+const opBPage = await opBCtx.newPage();
+```
+
+## Mock vs real daemon
+
+Two modes, choose per scenario:
+
+### Mocked (T1.4 SPA route smoke, T2.3 multi-op SPA flow lite variant)
+
+Each Playwright page gets its own `mockDaemonApi(page, { port })` call. Reuses the existing single-op mock helper. Fast, deterministic, doesn't need real daemons running — but doesn't catch bugs that only surface with real daemon state.
+
+### Real (T2.1, T2.2, T2.3 full variant)
+
+No `mockDaemonApi` call. Pages talk to the real daemons started by `spawnMultiOpDaemons`. Slower, requires substrate, exercises real RPC + indexer integration. Catches real integration bugs.
+
+## Helper conventions
+
+For tests that recur, lift the daemon spawn into a fixture file under `client/test/dashboard/multi-op/fixtures/`. Example:
+
+```typescript
+// fixtures/two-substrate-ops.ts
+import { test as base } from '@playwright/test';
+import { spawnMultiOpDaemons, type MultiOpHandle } from '../../../helpers/multi-op-daemon';
+import { copyWorkspace } from '../../../../scripts/release/substrate-copy';
+
+export const test = base.extend<{ daemons: MultiOpHandle; opAUrl: string; opBUrl: string }>({
+  daemons: async ({}, use) => {
+    const workspace = await copyWorkspace({ ops: ['op-a', 'op-b'] });
+    const daemons = await spawnMultiOpDaemons({
+      ops: [
+        { name: 'op-a', home: workspace.opPaths['op-a'], apiPort: 7732 },
+        { name: 'op-b', home: workspace.opPaths['op-b'], apiPort: 7733 },
+      ],
+    });
+    try {
+      await use(daemons);
+    } finally {
+      await daemons.teardown();
+      await workspace.teardown();
+    }
+  },
+  opAUrl: async ({ daemons }, use) => {
+    await use(daemons.daemons['op-a'].handshakeUrl ?? 'http://127.0.0.1:7732/');
+  },
+  opBUrl: async ({ daemons }, use) => {
+    await use(daemons.daemons['op-b'].handshakeUrl ?? 'http://127.0.0.1:7733/');
+  },
+});
+```
+
+## Common failure modes
+
+| Failure | Likely cause | Fix |
+|---|---|---|
+| op-b sees stale op-a state | indexer hasn't caught up | use `expect(...).toBeVisible({ timeout: 30000 })`, not `await page.waitForSelector(...)` |
+| Auth/cookie collision | reused single context for two operators | always two `browser.newContext()` calls |
+| Daemon spawn timeout | dist/bin/jinn.js missing or stale | `yarn build` before running |
+| Tests pass locally, flake in CI | RPC saturation or test parallelism | run multi-op tests with `workers: 1` for now (see jinn-mono-lrey) |
+| `mockDaemonApi` doesn't intercept | wrong port arg | helper takes port; verify the page's daemon URL matches |
+
+## Running the tests
+
+Single multi-op file:
+```bash
+cd client && yarn build && yarn playwright test --config=playwright.config.ts test/dashboard/multi-op/<scenario>.e2e.test.ts
+```
+
+All multi-op:
+```bash
+cd client && yarn build && yarn playwright test --config=playwright.config.ts test/dashboard/multi-op/
+```
+
+Sequential (avoid RPC saturation):
+```bash
+cd client && yarn playwright test --config=playwright.config.ts --workers=1 test/dashboard/multi-op/
+```

--- a/.claude/skills/testing-jinn-app/references/multi-op-playwright.md
+++ b/.claude/skills/testing-jinn-app/references/multi-op-playwright.md
@@ -2,6 +2,19 @@
 
 For automated regression coverage of two-operator flows. Tests live under `client/test/dashboard/multi-op/`. Pattern below mirrors the existing single-op `client/test/dashboard/spa-config.e2e.test.ts` but with two daemons + two Playwright pages.
 
+> **Prerequisites — not yet on the Plan B branch.**
+> - **Plan A's `substrate-copy.ts`.** The templates below import `copyWorkspace`
+>   from `client/scripts/release/substrate-copy.ts`. That file is a Plan A
+>   artifact and does not exist on this branch.
+> - **A shared, port-aware `mockDaemonApi`.** The templates call
+>   `mockDaemonApi(page, { port })` — a two-arg form. The current
+>   `mockDaemonApi` is a private single-arg function inside
+>   `client/test/dashboard/spa-config.e2e.test.ts` with the port hardcoded to
+>   7332. It must first be extracted to a shared module (e.g.
+>   `client/test/dashboard/helpers/mock-daemon-api.ts`) and extended to accept
+>   a `port` argument. **Plan C does this extraction.** Until both land, the
+>   mocked variant of these templates will not compile.
+
 ## Template
 
 ```typescript
@@ -87,7 +100,7 @@ Two modes, choose per scenario:
 
 ### Mocked (T1.4 SPA route smoke, T2.3 multi-op SPA flow lite variant)
 
-Each Playwright page gets its own `mockDaemonApi(page, { port })` call. Reuses the existing single-op mock helper. Fast, deterministic, doesn't need real daemons running — but doesn't catch bugs that only surface with real daemon state.
+Each Playwright page gets its own `mockDaemonApi(page, { port })` call. Reuses the existing single-op mock helper — **but only once it is extracted to a shared, port-aware module (Plan C); see the Prerequisites note at the top.** Fast, deterministic, doesn't need real daemons running — but doesn't catch bugs that only surface with real daemon state.
 
 ### Real (T2.1, T2.2, T2.3 full variant)
 

--- a/.claude/skills/testing-jinn-app/references/multi-op-playwright.md
+++ b/.claude/skills/testing-jinn-app/references/multi-op-playwright.md
@@ -9,7 +9,12 @@ For automated regression coverage of two-operator flows. Tests live under `clien
 import { test, expect, type Page } from '@playwright/test';
 import { spawnMultiOpDaemons, type MultiOpHandle } from '../../helpers/multi-op-daemon';
 import { copyWorkspace } from '../../../scripts/release/substrate-copy';
-import { mockDaemonApi } from '../helpers/mock-daemon-api';   // existing single-op mock helper
+// `mockDaemonApi` is currently a private function inside
+// `client/test/dashboard/spa-config.e2e.test.ts` (see line ~130). Before
+// landing multi-op tests, Plan C/D needs to extract it to a shared module —
+// e.g. `client/test/dashboard/helpers/mock-daemon-api.ts` — and accept a
+// `port` argument (the single-op version is hardcoded to 7332).
+import { mockDaemonApi } from '../helpers/mock-daemon-api';
 
 let workspace: Awaited<ReturnType<typeof copyWorkspace>>;
 let daemons: MultiOpHandle;

--- a/.claude/skills/testing-jinn-app/references/multi-op-spawn.md
+++ b/.claude/skills/testing-jinn-app/references/multi-op-spawn.md
@@ -1,0 +1,114 @@
+# Multi-op daemon spawn
+
+How to spawn two or more `jinn` daemons concurrently for cross-operator testing. Two recipes — bash for ad-hoc use, TypeScript for automated tests.
+
+## Source of HOMEs
+
+Two flavors:
+
+1. **Substrate-derived workspaces** — use Plan A's `substrate-copy.ts` to create per-run isolated copies of `op-a` / `op-b` from gold. Best for scenarios that need pre-bootstrapped identity (most T2.x scenarios).
+
+   ```typescript
+   import { copyWorkspace } from '@/scripts/release/substrate-copy';
+
+   const handle = await copyWorkspace({ ops: ['op-a', 'op-b'] });
+   // handle.opPaths['op-a'] → '/Users/.../jinn-dev/workspaces/<run-id>/op-a/'
+   // teardown via handle.teardown() at end of test
+   ```
+
+2. **Fresh tmp HOMEs** — for clean-state E2E tests that don't need an existing identity (e.g. fresh-bootstrap scenarios). Each daemon gets its own `HOME=$tmpdir`.
+
+   ```typescript
+   const opAHome = await fs.mkdtemp(path.join(os.tmpdir(), 'fresh-op-a-'));
+   const opBHome = await fs.mkdtemp(path.join(os.tmpdir(), 'fresh-op-b-'));
+   // (Seed minimal config under <home>/.jinn-client/config.json as needed)
+   ```
+
+## Bash recipe (ad-hoc)
+
+```bash
+# Set up substrate workspace
+RUN_ID="$(date -u +%Y-%m-%dT%H-%M-%S)-$RANDOM"
+yarn substrate:copy op-a op-b
+# (parse runId from stdout; or skip and use fixed paths in dev)
+
+# Spawn op-a (apiPort 7332, persistent identity from substrate)
+HOME=~/jinn-dev/workspaces/$RUN_ID/op-a JINN_API_PORT=7332 \
+  node dist/bin/jinn.js run --no-ui > /tmp/op-a.log 2>&1 &
+OP_A_PID=$!
+
+# Spawn op-b (apiPort 7333)
+HOME=~/jinn-dev/workspaces/$RUN_ID/op-b JINN_API_PORT=7333 \
+  node dist/bin/jinn.js run --no-ui > /tmp/op-b.log 2>&1 &
+OP_B_PID=$!
+
+# Wait for both /v1/bootstrap to be reachable
+for port in 7332 7333; do
+  until curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:$port/v1/bootstrap | grep -qE "200|401"; do
+    sleep 0.25
+  done
+done
+
+# Capture handshake URLs from logs
+OP_A_URL="$(grep -m1 'UI handshake URL:' /tmp/op-a.log | sed 's/.*UI handshake URL:\s*//')"
+OP_B_URL="$(grep -m1 'UI handshake URL:' /tmp/op-b.log | sed 's/.*UI handshake URL:\s*//')"
+
+echo "op-a: $OP_A_URL"
+echo "op-b: $OP_B_URL"
+
+# Teardown
+trap "kill $OP_A_PID $OP_B_PID 2>/dev/null; rm -rf ~/jinn-dev/workspaces/$RUN_ID" EXIT
+```
+
+## TypeScript recipe (automated tests)
+
+Use the helper at `client/test/helpers/multi-op-daemon.ts`:
+
+```typescript
+import { spawnMultiOpDaemons, type MultiOpHandle } from '../helpers/multi-op-daemon';
+import { copyWorkspace } from '../../scripts/release/substrate-copy';
+
+let workspace: Awaited<ReturnType<typeof copyWorkspace>>;
+let daemons: MultiOpHandle;
+
+beforeAll(async () => {
+  workspace = await copyWorkspace({ ops: ['op-a', 'op-b'] });
+  daemons = await spawnMultiOpDaemons({
+    ops: [
+      { name: 'op-a', home: workspace.opPaths['op-a'], apiPort: 7732 },
+      { name: 'op-b', home: workspace.opPaths['op-b'], apiPort: 7733 },
+    ],
+    readyTimeoutMs: 30000,
+  });
+});
+
+afterAll(async () => {
+  await daemons.teardown();
+  await workspace.teardown();
+});
+
+it('does cross-op thing', async () => {
+  // daemons.daemons['op-a'].apiPort, .handshakeUrl, etc.
+});
+```
+
+## Port selection
+
+Substrate ops are pre-configured with apiPorts (op-a=7332, op-b=7333, op-c-legacy=7334). For tests that need different ports (e.g. avoiding collision with the daily-driver daemon at 7332), override via the `apiPort` option in the helper. The helper passes it as `JINN_API_PORT` env var; the daemon's config-resolution prefers env over config file.
+
+For parallel test files (separate Vitest workers), pick non-overlapping port ranges (e.g. 7332-7333 for one file, 7732-7733 for another).
+
+## Teardown contract
+
+- `daemons.teardown()` sends SIGTERM to all spawned processes, waits 200ms, then SIGKILL if still alive.
+- `daemons.teardown()` is idempotent — safe to call multiple times.
+- Use a `try { ... } finally { await daemons.teardown(); }` pattern in tests. Don't rely on `afterAll` alone — if `beforeAll` partially succeeded (op-a started, op-b failed), the partial spawn must still be cleaned up.
+
+## Common failure modes
+
+| Failure | Likely cause | Fix |
+|---|---|---|
+| `daemon on port X did not become reachable within Yms` | port collision with another process | check `lsof -i :X` |
+| `daemon on port X did not become reachable within Yms` | misconfigured HOME (config.json absent or malformed) | verify HOME/.jinn-client/config.json exists |
+| handshake URL is null | daemon never reached "running" mode (bootstrap incomplete in HOME) | substrate-verify the HOME; or use substrate-derived HOME |
+| teardown hangs | child process refusing SIGTERM | helper escalates to SIGKILL after 200ms; if test still hangs, increase the wait |

--- a/.claude/skills/testing-jinn-app/references/multi-op-spawn.md
+++ b/.claude/skills/testing-jinn-app/references/multi-op-spawn.md
@@ -9,7 +9,10 @@ Two flavors:
 1. **Substrate-derived workspaces** — use Plan A's `substrate-copy.ts` to create per-run isolated copies of `op-a` / `op-b` from gold. Best for scenarios that need pre-bootstrapped identity (most T2.x scenarios).
 
    ```typescript
-   import { copyWorkspace } from '@/scripts/release/substrate-copy';
+   // Path relative to the importing file. Plan A's substrate-copy lives at
+   // `client/scripts/release/substrate-copy.ts` (outside `src/`, so the `@/`
+   // alias does NOT reach it — use a relative path).
+   import { copyWorkspace } from '../../scripts/release/substrate-copy';
 
    const handle = await copyWorkspace({ ops: ['op-a', 'op-b'] });
    // handle.opPaths['op-a'] → '/Users/.../jinn-dev/workspaces/<run-id>/op-a/'

--- a/.claude/skills/testing-jinn-app/references/multi-op-spawn.md
+++ b/.claude/skills/testing-jinn-app/references/multi-op-spawn.md
@@ -95,6 +95,14 @@ it('does cross-op thing', async () => {
 });
 ```
 
+## Readiness timeout
+
+`readyTimeoutMs` (default 30s) is applied **per daemon**, not per group. The
+helper spawns and awaits each daemon in `ops` sequentially, so the worst-case
+total wall time for a group of N daemons is `N × readyTimeoutMs`. Size the
+timeout for a single daemon's bootstrap, and account for the multiplier when
+setting a test's overall timeout (e.g. Vitest `testTimeout`).
+
 ## Port selection
 
 Substrate ops are pre-configured with apiPorts (op-a=7332, op-b=7333, op-c-legacy=7334). For tests that need different ports (e.g. avoiding collision with the daily-driver daemon at 7332), override via the `apiPort` option in the helper. The helper passes it as `JINN_API_PORT` env var; the daemon's config-resolution prefers env over config file.

--- a/.claude/skills/testing-jinn-app/references/scenario-cross-op-donation.md
+++ b/.claude/skills/testing-jinn-app/references/scenario-cross-op-donation.md
@@ -1,0 +1,127 @@
+# Scenario T2.1 — Cross-operator donation
+
+**Tier:** 2 (substrate-derived workspace, runs in release-prep)
+**Wall-clock budget:** 5 minutes
+**Catches:** x402 + ERC-8128 handshake regressions, corpus indexer attribution bugs, payment-gated artifact access bugs.
+
+## Goal
+
+op-a produces a corpus artifact, indexer picks it up, op-b queries Discovery API for the artifact, op-b pays x402 USDC, op-b retrieves the artifact, signature + payload validate end-to-end.
+
+This is the gate that should have caught the #310 silent breakage (donation-consumption gate was passing because Op A wasn't producing, so consumption couldn't verify).
+
+## Implementation location
+
+`client/test/release/tier-2/T2.1-cross-op-donation.ts`
+
+## Setup
+
+- substrate workspace via `copyWorkspace({ ops: ['op-a', 'op-b'] })`
+- both daemons spawned with substrate-derived HOMEs, distinct apiPorts (7732, 7733)
+- Anvil-fork RPC (forks Base Sepolia); both daemons' configs point at this fork URL
+- op-a config: `solverNets.<name>.roles = ['solving']` for the chosen SolverNet
+- op-b config: joined to the same SolverNet via `joinedSolverNets[<manifestCid>]`
+
+## Steps
+
+```typescript
+// 1. Spawn daemons + workspace (see multi-op-playwright.md template)
+const workspace = await copyWorkspace({ ops: ['op-a', 'op-b'] });
+const daemons = await spawnMultiOpDaemons({
+  ops: [
+    { name: 'op-a', home: workspace.opPaths['op-a'], apiPort: 7732 },
+    { name: 'op-b', home: workspace.opPaths['op-b'], apiPort: 7733 },
+  ],
+});
+
+// 2. op-a produces a corpus artifact
+//    Either: trigger via daemon API (POST /v1/corpus/produce) or wait for natural production tick
+const opARes = await fetch(`http://127.0.0.1:7732/v1/corpus/produce`, {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ solverNetManifestCid: KNOWN_MANIFEST_CID, payload: SAMPLE_PAYLOAD }),
+});
+const { artifactCid } = await opARes.json();
+
+// 3. Wait for indexer to pick it up (poll Discovery API)
+const indexedCid = await waitFor(async () => {
+  const res = await fetch(`http://127.0.0.1:7733/v1/discovery/corpus?cid=${artifactCid}`);
+  if (!res.ok) return null;
+  const body = await res.json();
+  return body.cid === artifactCid ? body : null;
+}, { timeoutMs: 60000, intervalMs: 2000 });
+expect(indexedCid).toBeTruthy();
+
+// 4. op-b queries Discovery API for the artifact (no payment yet — gated)
+const previewRes = await fetch(`http://127.0.0.1:7733/v1/corpus/${artifactCid}`);
+expect(previewRes.status).toBe(402);   // Payment required
+
+// 5. op-b initiates x402 payment
+const paymentRes = await fetch(`http://127.0.0.1:7733/v1/corpus/${artifactCid}/pay`, {
+  method: 'POST',
+});
+const { paymentTx } = await paymentRes.json();
+expect(paymentTx).toMatch(/^0x[a-fA-F0-9]{64}$/);
+
+// 6. op-b retrieves the artifact (with payment proof)
+const retrievedRes = await fetch(`http://127.0.0.1:7733/v1/corpus/${artifactCid}`, {
+  headers: { 'x-x402-payment': paymentTx },
+});
+expect(retrievedRes.status).toBe(200);
+const retrieved = await retrievedRes.json();
+expect(retrieved.payload).toEqual(SAMPLE_PAYLOAD);
+
+// 7. Verify the ERC-8128 signature on the artifact
+const sigValid = await verifyErc8128Signature(retrieved);
+expect(sigValid).toBe(true);
+
+// 8. Cleanup
+await daemons.teardown();
+await workspace.teardown();
+```
+
+## Assertions (summary)
+
+| # | Assertion | Why |
+|---|---|---|
+| A1 | op-a produces an artifact with a valid CID | producer side works |
+| A2 | indexer attributes the artifact to op-a within 60s | indexer cross-op visibility |
+| A3 | op-b's unpaid query returns 402 | gating works |
+| A4 | op-b's payment tx is mined | x402 payment side works |
+| A5 | op-b's paid retrieval returns 200 + correct payload | gating releases after payment |
+| A6 | ERC-8128 signature on retrieved artifact validates | end-to-end provenance |
+
+## Failure modes
+
+| Failure | Class | Triage |
+|---|---|---|
+| op-a never produces artifact | real-bug | BLOCKING — producer side broken |
+| indexer never sees artifact within 60s | flake-timing first attempt; real-bug on second | retry; if persistent, blocking |
+| op-b's preview returns 200 (no gate) | real-bug | BLOCKING — gate bypass |
+| Payment tx fails | flake-infra or real-bug | retry; if persistent, check x402 contract |
+| Paid retrieval returns 402 | real-bug | BLOCKING — payment not honored |
+| Signature mismatch | real-bug | BLOCKING — provenance broken |
+| RPC saturation mid-test | flake-infra | retry once with jittered delay |
+
+## Wall-clock
+
+~5 minutes:
+- 30s daemon spawn
+- 60s artifact production + indexer
+- 60s payment + retrieval
+- 30s signature verification
+- ~30s setup/teardown overhead
+
+## Dependencies
+
+- Substrate workspace via Plan A's `substrate-copy`
+- Daemon HTTP API endpoints: `/v1/corpus/produce`, `/v1/corpus/:cid`, `/v1/corpus/:cid/pay`, `/v1/discovery/corpus` (these mostly exist in v0.1.6; verify shape at implementation time)
+- Anvil-fork-of-Base-Sepolia RPC (existing pattern in client/test/e2e/)
+- KNOWN_MANIFEST_CID — the substrate-pinned SolverNet manifest that both ops are joined to (read from op-a's manifest.json or config.json)
+- Existing helper: `verifyErc8128Signature` (or implement inline using the existing ERC-8128 module)
+
+## What this scenario does NOT catch
+
+- Real-network token economics (use Tier 3 for that)
+- Indexer behavior under high write load (this scenario is one writer, one reader)
+- Cross-chain donation scenarios

--- a/.claude/skills/testing-jinn-app/references/scenario-cross-op-donation.md
+++ b/.claude/skills/testing-jinn-app/references/scenario-cross-op-donation.md
@@ -4,6 +4,11 @@
 **Wall-clock budget:** 5 minutes
 **Catches:** x402 + ERC-8128 handshake regressions, corpus indexer attribution bugs, payment-gated artifact access bugs.
 
+> **Prerequisite: Plan A's `substrate-copy.ts`.** This scenario imports
+> `copyWorkspace` from `client/scripts/release/substrate-copy.ts`, a Plan A
+> artifact. It does not exist on the Plan B branch — this scenario is not
+> runnable until Plan A lands.
+
 ## Goal
 
 op-a produces a corpus artifact, indexer picks it up, op-b queries Discovery API for the artifact, op-b pays x402 USDC, op-b retrieves the artifact, signature + payload validate end-to-end.

--- a/.claude/skills/testing-jinn-app/references/scenario-cross-op-donation.md
+++ b/.claude/skills/testing-jinn-app/references/scenario-cross-op-donation.md
@@ -8,7 +8,7 @@
 
 op-a produces a corpus artifact, indexer picks it up, op-b queries Discovery API for the artifact, op-b pays x402 USDC, op-b retrieves the artifact, signature + payload validate end-to-end.
 
-This is the gate that should have caught the #310 silent breakage (donation-consumption gate was passing because Op A wasn't producing, so consumption couldn't verify).
+This is the gate that should have caught the #310 silent breakage (donation-consumption gate was passing because op-a wasn't producing, so consumption couldn't verify).
 
 ## Implementation location
 

--- a/.claude/skills/testing-jinn-app/references/scenario-multi-op-spa-flow.md
+++ b/.claude/skills/testing-jinn-app/references/scenario-multi-op-spa-flow.md
@@ -1,0 +1,156 @@
+# Scenario T2.3 — Multi-op SPA flow
+
+**Tier:** 2 (substrate-derived workspace, Anvil-fork, runs in release-prep)
+**Wall-clock budget:** 5 minutes
+**Catches:** cross-op UI flows that pass with mocks but break with real daemons; SPA-side state synchronization; Launcher → Operator catalog visibility.
+
+## Goal
+
+op-a launches a SolverNet via the SPA Launcher Create wizard. op-b sees it appear in the Operator catalog. op-b joins via the SPA. op-a's launched-SolverNet dashboard shows op-b's join.
+
+This catches a class of bug invisible to single-op tests and to mocked multi-op tests: real-daemon state propagation through the SPA.
+
+## Implementation location
+
+`client/test/dashboard/multi-op/launcher-join-flow.e2e.test.ts`
+
+## Setup
+
+- substrate workspace via `copyWorkspace({ ops: ['op-a', 'op-b'] })`
+- both daemons spawned via `spawnMultiOpDaemons` against Anvil-fork RPC
+- Playwright with two contexts (one per operator) — see [multi-op-playwright.md](multi-op-playwright.md)
+
+## Steps
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { spawnMultiOpDaemons } from '../../helpers/multi-op-daemon';
+import { copyWorkspace } from '../../../scripts/release/substrate-copy';
+import { spawnAnvilForkOfBaseSepolia } from '../../e2e/task-first-helpers';
+
+let workspace, daemons, anvil, opAUrl, opBUrl;
+
+test.beforeAll(async () => {
+  workspace = await copyWorkspace({ ops: ['op-a', 'op-b'] });
+  anvil = await spawnAnvilForkOfBaseSepolia();
+  daemons = await spawnMultiOpDaemons({
+    ops: [
+      { name: 'op-a', home: workspace.opPaths['op-a'], apiPort: 7732 },
+      { name: 'op-b', home: workspace.opPaths['op-b'], apiPort: 7733 },
+    ],
+    extraEnv: { BASE_RPC_URL: anvil.rpcUrl },
+  });
+  opAUrl = daemons.daemons['op-a'].handshakeUrl ?? `http://127.0.0.1:7732/`;
+  opBUrl = daemons.daemons['op-b'].handshakeUrl ?? `http://127.0.0.1:7733/`;
+});
+
+test.afterAll(async () => {
+  await daemons?.teardown();
+  await anvil?.stop();
+  await workspace?.teardown();
+});
+
+test('op-a launches → op-b sees → op-b joins → op-a sees join', async ({ browser }) => {
+  const opACtx = await browser.newContext();
+  const opBCtx = await browser.newContext();
+  const opAPage = await opACtx.newPage();
+  const opBPage = await opBCtx.newPage();
+
+  // === op-a: Launcher Create wizard ===
+  await opAPage.goto(opAUrl);
+  await opAPage.getByRole('link', { name: /launcher/i }).click();
+  await opAPage.getByRole('button', { name: /create solvernet/i }).click();
+
+  // Step 1: Define
+  const solverNetName = `t23-test-${Date.now()}`;
+  await opAPage.getByLabel(/name/i).fill(solverNetName);
+  await opAPage.getByLabel(/description/i).fill('T2.3 e2e test SolverNet');
+  await opAPage.getByRole('button', { name: /next/i }).click();
+
+  // Step 2: Review Contract
+  await opAPage.getByRole('button', { name: /next/i }).click();
+
+  // Step 3: Configure Generator
+  await opAPage.getByLabel(/cadence/i).fill('60000');   // 60s
+  await opAPage.getByRole('button', { name: /next/i }).click();
+
+  // Step 4: Configure Pricing
+  await opAPage.getByLabel(/price/i).fill('100');
+  await opAPage.getByRole('button', { name: /next/i }).click();
+
+  // Step 5: Review and Launch
+  await opAPage.getByRole('button', { name: /launch/i }).click();
+
+  // Wait for launch state machine to reach 'launched'
+  await expect(opAPage.getByText(/launched/i)).toBeVisible({ timeout: 120000 });
+  const manifestCid = await opAPage.getByTestId('manifest-cid').textContent();
+  expect(manifestCid).toMatch(/^bafkrei/);
+
+  // === op-b: Operator catalog sees op-a's SolverNet ===
+  await opBPage.goto(opBUrl);
+  await opBPage.getByRole('link', { name: /operator/i }).click();
+  await opBPage.getByRole('button', { name: /browse catalog/i }).click();
+  await expect(opBPage.getByText(solverNetName)).toBeVisible({ timeout: 30000 });
+
+  // === op-b joins via SPA ===
+  await opBPage.getByText(solverNetName).click();
+  await opBPage.getByRole('button', { name: /join/i }).click();
+  // Restart banner should appear (operator.join writes config; daemon doesn't hot-reload SolverNet config)
+  await expect(opBPage.getByText(/restart required/i)).toBeVisible({ timeout: 10000 });
+
+  // === op-a's launched dashboard reflects op-b's join ===
+  await opAPage.goto(opAUrl + '/launcher/launched');
+  await opAPage.getByText(solverNetName).click();
+  // Operator join is on-chain; SPA should poll and reflect within 30s
+  await expect(opAPage.getByText(/1 operator joined/i)).toBeVisible({ timeout: 30000 });
+
+  await opACtx.close();
+  await opBCtx.close();
+});
+```
+
+## Assertions (summary)
+
+| # | Assertion | Why |
+|---|---|---|
+| A1 | op-a wizard launch reaches `launched` state within 120s | Launcher state machine end-to-end |
+| A2 | manifest CID matches `bafkrei...` shape | pinning + on-chain registry write succeeded |
+| A3 | op-b's catalog shows the new SolverNet within 30s | global registry indexing works |
+| A4 | op-b's join writes operator-side config | operator.join RPC + restart banner |
+| A5 | op-a's launched dashboard shows "1 operator joined" within 30s | cross-op SPA polling correctness |
+
+## Failure modes
+
+| Failure | Class | Triage |
+|---|---|---|
+| Wizard wizard step doesn't advance | real-bug | BLOCKING — wizard UI regression |
+| Launch state machine times out before `launched` | could be: pinning hang, broadcast fail, indexer fail | inspect launch-progress record; flake on first |
+| op-b's catalog doesn't show within 30s | indexer slow OR catalog query broken | check Discovery API directly; if working, SPA-side bug |
+| op-b's join doesn't write config | real-bug | BLOCKING — operator.join broken |
+| Restart banner missing | real-bug | BLOCKING — restart semantics regression |
+| op-a's "1 operator joined" never appears | could be: on-chain operator-join missed, indexer lag, SPA polling broken | check on-chain first, then indexer, then SPA |
+
+## Wall-clock
+
+~5 minutes:
+- 30s daemon spawn + Anvil fork
+- 120s op-a launch
+- 30s op-b catalog lookup
+- 60s op-b join + restart banner
+- 30s op-a sees join
+- 30s setup/teardown
+
+## Dependencies
+
+- Substrate workspace from Plan A
+- spawnAnvilForkOfBaseSepolia helper (existing)
+- The SPA Launcher Create wizard's data-testid attributes (`manifest-cid` etc.) — may need to be added to the SPA in Plan C/D if missing
+- The Operator catalog page at `/operator/...` (existing in v0.1.6)
+- The launched-SolverNet dashboard at `/launcher/launched/:id` (existing in v0.1.6)
+
+## What this scenario does NOT catch
+
+- UX paper cuts (Tier 3 manual walkthrough covers these)
+- Real-network economics
+- Visual regressions
+- Operator's actual claim/solve flow (T2.2 covers that)

--- a/.claude/skills/testing-jinn-app/references/scenario-multi-op-spa-flow.md
+++ b/.claude/skills/testing-jinn-app/references/scenario-multi-op-spa-flow.md
@@ -24,21 +24,27 @@ This catches a class of bug invisible to single-op tests and to mocked multi-op 
 
 ```typescript
 import { test, expect } from '@playwright/test';
+import { baseSepolia } from 'viem/chains';
 import { spawnMultiOpDaemons } from '../../helpers/multi-op-daemon';
 import { copyWorkspace } from '../../../scripts/release/substrate-copy';
-import { spawnAnvilForkOfBaseSepolia } from '../../e2e/task-first-helpers';
+import { spawnAnvilFork } from '../../_support/chain/anvil';
 
 let workspace, daemons, anvil, opAUrl, opBUrl;
 
 test.beforeAll(async () => {
   workspace = await copyWorkspace({ ops: ['op-a', 'op-b'] });
-  anvil = await spawnAnvilForkOfBaseSepolia();
+  anvil = await spawnAnvilFork({
+    forkUrl: process.env['BASE_SEPOLIA_RPC_URL']!,
+    chain: baseSepolia,
+    silent: true,
+  });
   daemons = await spawnMultiOpDaemons({
     ops: [
       { name: 'op-a', home: workspace.opPaths['op-a'], apiPort: 7732 },
       { name: 'op-b', home: workspace.opPaths['op-b'], apiPort: 7733 },
     ],
-    extraEnv: { BASE_RPC_URL: anvil.rpcUrl },
+    // JINN_RPC_URL — config.ts gives it unconditional precedence over BASE_RPC_URL.
+    extraEnv: { JINN_RPC_URL: anvil.rpcUrl },
   });
   opAUrl = daemons.daemons['op-a'].handshakeUrl ?? `http://127.0.0.1:7732/`;
   opBUrl = daemons.daemons['op-b'].handshakeUrl ?? `http://127.0.0.1:7733/`;
@@ -46,7 +52,7 @@ test.beforeAll(async () => {
 
 test.afterAll(async () => {
   await daemons?.teardown();
-  await anvil?.stop();
+  await anvil?.teardown();
   await workspace?.teardown();
 });
 
@@ -143,7 +149,7 @@ test('op-a launches → op-b sees → op-b joins → op-a sees join', async ({ b
 ## Dependencies
 
 - Substrate workspace from Plan A
-- spawnAnvilForkOfBaseSepolia helper (existing)
+- `spawnAnvilFork` helper at `client/test/_support/chain/anvil.ts` (pass `forkUrl: BASE_SEPOLIA_RPC_URL` + `chain: baseSepolia` for a Base Sepolia fork)
 - The SPA Launcher Create wizard's data-testid attributes (`manifest-cid` etc.) — may need to be added to the SPA in Plan C/D if missing
 - The Operator catalog page at `/operator/...` (existing in v0.1.6)
 - The launched-SolverNet dashboard at `/launcher/launched/:id` (existing in v0.1.6)

--- a/.claude/skills/testing-jinn-app/references/scenario-multi-op-spa-flow.md
+++ b/.claude/skills/testing-jinn-app/references/scenario-multi-op-spa-flow.md
@@ -129,7 +129,7 @@ test('op-a launches → op-b sees → op-b joins → op-a sees join', async ({ b
 
 | Failure | Class | Triage |
 |---|---|---|
-| Wizard wizard step doesn't advance | real-bug | BLOCKING — wizard UI regression |
+| Wizard step doesn't advance | real-bug | BLOCKING — wizard UI regression |
 | Launch state machine times out before `launched` | could be: pinning hang, broadcast fail, indexer fail | inspect launch-progress record; flake on first |
 | op-b's catalog doesn't show within 30s | indexer slow OR catalog query broken | check Discovery API directly; if working, SPA-side bug |
 | op-b's join doesn't write config | real-bug | BLOCKING — operator.join broken |

--- a/.claude/skills/testing-jinn-app/references/scenario-multi-op-spa-flow.md
+++ b/.claude/skills/testing-jinn-app/references/scenario-multi-op-spa-flow.md
@@ -4,6 +4,11 @@
 **Wall-clock budget:** 5 minutes
 **Catches:** cross-op UI flows that pass with mocks but break with real daemons; SPA-side state synchronization; Launcher → Operator catalog visibility.
 
+> **Prerequisite: Plan A's `substrate-copy.ts`.** This scenario imports
+> `copyWorkspace` from `client/scripts/release/substrate-copy.ts`, a Plan A
+> artifact. It does not exist on the Plan B branch — this scenario is not
+> runnable until Plan A lands.
+
 ## Goal
 
 op-a launches a SolverNet via the SPA Launcher Create wizard. op-b sees it appear in the Operator catalog. op-b joins via the SPA. op-a's launched-SolverNet dashboard shows op-b's join.

--- a/.claude/skills/testing-jinn-app/references/scenario-producer-evaluator.md
+++ b/.claude/skills/testing-jinn-app/references/scenario-producer-evaluator.md
@@ -4,6 +4,11 @@
 **Wall-clock budget:** 5 minutes
 **Catches:** claim → solve → deliver → evaluate loop regressions; activity-counter increments; verdict pipeline end-to-end mechanically.
 
+> **Prerequisite: Plan A's `substrate-copy.ts`.** This scenario imports
+> `copyWorkspace` from `client/scripts/release/substrate-copy.ts`, a Plan A
+> artifact. It does not exist on the Plan B branch — this scenario is not
+> runnable until Plan A lands.
+
 ## Goal
 
 op-a posts a known-solvable SWE-rebench v2 task, claims it, solves it via a *stubbed harness* (deterministic cached solution), delivers; op-b claims the verdict request, evaluates via real evaluator Docker image, posts verdict. Assert verdictCode matches expected.

--- a/.claude/skills/testing-jinn-app/references/scenario-producer-evaluator.md
+++ b/.claude/skills/testing-jinn-app/references/scenario-producer-evaluator.md
@@ -1,0 +1,133 @@
+# Scenario T2.2 — Producer/evaluator (Anvil-fork)
+
+**Tier:** 2 (substrate-derived workspace, Anvil-fork, runs in release-prep)
+**Wall-clock budget:** 5 minutes
+**Catches:** claim → solve → deliver → evaluate loop regressions; activity-counter increments; verdict pipeline end-to-end mechanically.
+
+## Goal
+
+op-a posts a known-solvable SWE-rebench v2 task, claims it, solves it via a *stubbed harness* (deterministic cached solution), delivers; op-b claims the verdict request, evaluates via real evaluator Docker image, posts verdict. Assert verdictCode matches expected.
+
+This is the Anvil-fork mechanical counterpart to Tier 3's real-testnet variant. Same loop, but stubbed harness (no real OpenRouter spend) and forked chain.
+
+## Implementation location
+
+`client/test/release/tier-2/T2.2-producer-evaluator-fork.ts`
+
+## Setup
+
+- substrate workspace via `copyWorkspace({ ops: ['op-a', 'op-b'] })`
+- Anvil fork of Base Sepolia at the substrate's last-known-good block; impersonate proxy owner; upgrade JinnRouter to V3 inline (existing pattern in `client/test/e2e/task-first-helpers.ts`)
+- op-a config: `roles: ['solving']` for swe-rebench-v2 SolverNet
+- op-b config: `roles: ['evaluating']` for same SolverNet
+- Harness stub: register a fake harness that returns a canned solution for the known-instance task (so no real OpenRouter call happens)
+
+## Steps
+
+```typescript
+const workspace = await copyWorkspace({ ops: ['op-a', 'op-b'] });
+const anvil = await spawnAnvilForkOfBaseSepolia();    // existing helper, returns rpcUrl + cleanup
+const daemons = await spawnMultiOpDaemons({
+  ops: [
+    { name: 'op-a', home: workspace.opPaths['op-a'], apiPort: 7732 },
+    { name: 'op-b', home: workspace.opPaths['op-b'], apiPort: 7733 },
+  ],
+  extraEnv: { BASE_RPC_URL: anvil.rpcUrl, JINN_HARNESS_STUB_INSTANCE: KNOWN_INSTANCE_ID },
+});
+
+// 1. op-a posts a known-solvable task
+const postRes = await fetch(`http://127.0.0.1:7732/v1/tasks`, {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({
+    solverType: 'swe-rebench-v2.v1',
+    spec: { instanceId: KNOWN_INSTANCE_ID, repo: KNOWN_REPO, commit: KNOWN_COMMIT },
+  }),
+});
+const { taskId, requestId } = await postRes.json();
+
+// 2. Wait for op-a to claim + solve + deliver (auto via solving role)
+const delivered = await waitFor(async () => {
+  const res = await fetch(`http://127.0.0.1:7732/v1/tasks/${taskId}`);
+  const body = await res.json();
+  return body.state === 'DELIVERED' ? body : null;
+}, { timeoutMs: 90000, intervalMs: 2000 });
+expect(delivered.deliveryTxHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
+
+// 3. Wait for op-b to claim verdict request + run evaluator + post verdict
+const verdict = await waitFor(async () => {
+  const res = await fetch(`http://127.0.0.1:7733/v1/verdicts?taskId=${taskId}`);
+  const body = await res.json();
+  return body.verdicts?.length > 0 ? body.verdicts[0] : null;
+}, { timeoutMs: 120000, intervalMs: 2000 });
+
+// 4. Assertions
+expect(verdict.verdictCode).toBe(KNOWN_EXPECTED_VERDICT);   // 1 if patch applies + tests pass
+expect(verdict.verdictTxHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
+
+// 5. Activity counters incremented
+const opAActivity = await fetch(`http://127.0.0.1:7732/v1/activity`).then(r => r.json());
+expect(opAActivity.deliveriesCount).toBeGreaterThan(0);
+const opBActivity = await fetch(`http://127.0.0.1:7733/v1/activity`).then(r => r.json());
+expect(opBActivity.verdictsCount).toBeGreaterThan(0);
+
+// 6. Cleanup
+await daemons.teardown();
+await anvil.stop();
+await workspace.teardown();
+```
+
+## Assertions (summary)
+
+| # | Assertion | Why |
+|---|---|---|
+| A1 | Task post returns valid taskId + requestId | task admission works |
+| A2 | op-a delivers within 90s | producer side: claim + stubbed solve + deliver loop closes |
+| A3 | delivery has a valid tx hash | on-chain delivery succeeded |
+| A4 | op-b posts verdict within 120s of delivery | evaluator side: claim + eval + verdict loop closes |
+| A5 | verdictCode matches KNOWN_EXPECTED_VERDICT | substrate recheck + scoring is correct |
+| A6 | op-a deliveriesCount incremented | activity-counter accounting works |
+| A7 | op-b verdictsCount incremented | activity-counter accounting works |
+
+## Stubbed harness
+
+Activated via `JINN_HARNESS_STUB_INSTANCE=<instance-id>` env var. The stub:
+- Pattern-matches on instance ID; only stubs the one we're testing.
+- Returns a canned patch from `client/test/release/tier-2/fixtures/<instance-id>.patch`.
+- Logs that it stubbed (so a real-harness-still-invoked regression would show absent stub logs).
+
+This avoids the ~$0.10 API call per run while exercising the rest of the loop.
+
+## Failure modes
+
+| Failure | Class | Triage |
+|---|---|---|
+| Task post returns 4xx | real-bug | BLOCKING — admission gate broken |
+| op-a never delivers within 90s | could be: harness stub not picked up; daemon misconfig; chain stall | inspect logs; flake on first, real-bug on retry |
+| Delivery tx revert | real-bug | BLOCKING — JinnRouter regression |
+| op-b never picks up verdict request | real-bug | BLOCKING — evaluator role inactive |
+| Evaluator Docker fails to run | flake-infra (Docker daemon) or real-bug (image broken) | check `docker ps`; retry |
+| verdictCode mismatches expected | real-bug | BLOCKING — substrate/scoring regression |
+| Activity counter not incremented | real-bug | BLOCKING — accounting regression |
+
+## Wall-clock
+
+~5 minutes:
+- 30s daemon spawn + Anvil fork
+- 90s producer loop
+- 120s evaluator loop
+- 30s setup/teardown
+
+## Dependencies
+
+- Substrate workspace from Plan A
+- Existing `spawnAnvilForkOfBaseSepolia` helper (from `client/test/e2e/task-first-helpers.ts`)
+- Existing JinnRouter V3 fork-upgrade pattern (same file)
+- Stubbed harness registration mechanism — to be added or extended in Plan C/D if not present
+- KNOWN_INSTANCE_ID, KNOWN_REPO, KNOWN_COMMIT, KNOWN_EXPECTED_VERDICT — fixture constants for a known-solvable SWE-rebench instance (existing pattern in `client/test/release/tier-2/fixtures/`)
+
+## What this scenario does NOT catch
+
+- Real OpenRouter API behavior (Tier 3 covers that)
+- Real RPC behavior under load (this uses Anvil; Tier 3 uses real testnet)
+- Cross-chain verdict flows

--- a/.claude/skills/testing-jinn-app/references/scenario-producer-evaluator.md
+++ b/.claude/skills/testing-jinn-app/references/scenario-producer-evaluator.md
@@ -25,14 +25,25 @@ This is the Anvil-fork mechanical counterpart to Tier 3's real-testnet variant. 
 ## Steps
 
 ```typescript
+import { spawnAnvilFork } from '../_support/chain/anvil';   // base-fork helper
+import { baseSepolia } from 'viem/chains';
+
 const workspace = await copyWorkspace({ ops: ['op-a', 'op-b'] });
-const anvil = await spawnAnvilForkOfBaseSepolia();    // existing helper, returns rpcUrl + cleanup
+const anvil = await spawnAnvilFork({
+  forkUrl: process.env['BASE_SEPOLIA_RPC_URL']!,
+  chain: baseSepolia,
+  silent: true,
+});
 const daemons = await spawnMultiOpDaemons({
   ops: [
     { name: 'op-a', home: workspace.opPaths['op-a'], apiPort: 7732 },
     { name: 'op-b', home: workspace.opPaths['op-b'], apiPort: 7733 },
   ],
-  extraEnv: { BASE_RPC_URL: anvil.rpcUrl, JINN_HARNESS_STUB_INSTANCE: KNOWN_INSTANCE_ID },
+  // JINN_RPC_URL — not BASE_RPC_URL — because config.ts gives JINN_RPC_URL
+  // unconditional precedence; the spawn helper surfaces extraEnv RPC keys
+  // through JINN_RPC_URL so this works either way, but using JINN_RPC_URL
+  // here makes the precedence explicit.
+  extraEnv: { JINN_RPC_URL: anvil.rpcUrl, JINN_HARNESS_STUB_INSTANCE: KNOWN_INSTANCE_ID },
 });
 
 // 1. op-a posts a known-solvable task
@@ -73,7 +84,7 @@ expect(opBActivity.verdictsCount).toBeGreaterThan(0);
 
 // 6. Cleanup
 await daemons.teardown();
-await anvil.stop();
+await anvil.teardown();
 await workspace.teardown();
 ```
 
@@ -121,8 +132,8 @@ This avoids the ~$0.10 API call per run while exercising the rest of the loop.
 ## Dependencies
 
 - Substrate workspace from Plan A
-- Existing `spawnAnvilForkOfBaseSepolia` helper (from `client/test/e2e/task-first-helpers.ts`)
-- Existing JinnRouter V3 fork-upgrade pattern (same file)
+- Existing `spawnAnvilFork` helper at `client/test/_support/chain/anvil.ts`. Pass `forkUrl: BASE_SEPOLIA_RPC_URL` and `chain: baseSepolia` for a Base Sepolia fork (no convenience wrapper today). Teardown via `harness.teardown()`. The full Task-First fork runner at `client/test/e2e/task-first-helpers.ts` (`runBaseSepoliaForkTaskFirstFullLoop`) shows the JinnRouter V3 fork-upgrade pattern.
+- Existing JinnRouter V3 fork-upgrade pattern (in `client/test/e2e/task-first-helpers.ts`)
 - Stubbed harness registration mechanism — to be added or extended in Plan C/D if not present
 - KNOWN_INSTANCE_ID, KNOWN_REPO, KNOWN_COMMIT, KNOWN_EXPECTED_VERDICT — fixture constants for a known-solvable SWE-rebench instance (existing pattern in `client/test/release/tier-2/fixtures/`)
 

--- a/.claude/skills/testing-jinn-app/references/scenario-spa-route-smoke.md
+++ b/.claude/skills/testing-jinn-app/references/scenario-spa-route-smoke.md
@@ -1,0 +1,98 @@
+# Scenario T1.4 — SPA route smoke
+
+**Tier:** 1 (single-op, route-mocked, runs on every push)
+**Wall-clock budget:** 30s
+**Catches:** broken routes, missing endpoint mocks, JS errors introduced by new SPA code, React error boundary firings.
+
+## Goal
+
+Load every SPA route against a mocked daemon API. For each route, assert:
+1. No JS error in `page.on('pageerror', ...)`.
+2. No React error boundary visible (no `[data-error-boundary]` element).
+3. No "endpoint not mocked" console error from missing route intercepts.
+4. The page renders past the initial spinner (some recognizable DOM element appears within 5s).
+
+## Implementation location
+
+`client/test/dashboard/release-prep/spa-route-smoke.e2e.test.ts`
+
+## Inputs
+
+- Routes list: extracted from `client/src/dashboard/spa/src/App.tsx` (the React Router config). The test imports the route table from a single source of truth.
+- Mocked daemon API: reuses the existing `mockDaemonApi(page)` helper from single-op tests (e.g. `client/test/dashboard/spa-config.e2e.test.ts`).
+
+## Setup
+
+```typescript
+import { test, expect, type Page } from '@playwright/test';
+import { mockDaemonApi } from '../helpers/mock-daemon-api';
+import { ROUTES } from '../../../src/dashboard/spa/src/routes';   // exported list of route paths
+
+let consoleErrors: string[] = [];
+let pageErrors: Error[] = [];
+
+test.beforeEach(async ({ page }) => {
+  consoleErrors = [];
+  pageErrors = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+  page.on('pageerror', (err) => pageErrors.push(err));
+  await mockDaemonApi(page);
+});
+
+for (const route of ROUTES) {
+  test(`SPA renders clean at ${route}`, async ({ page }) => {
+    await page.goto(`http://127.0.0.1:7332${route}`);
+    await page.waitForSelector('main, [data-page-loaded], [data-app-shell]', { timeout: 5000 });
+    expect(pageErrors).toHaveLength(0);
+    expect(consoleErrors.filter((e) => !e.includes('expected harmless pattern'))).toHaveLength(0);
+    await expect(page.locator('[data-error-boundary]')).toHaveCount(0);
+  });
+}
+```
+
+## Routes to cover (initial)
+
+Derived from the existing SPA routes; the actual implementation should import a shared `ROUTES` constant rather than hardcoding here:
+
+- `/` (root → overview redirect)
+- `/overview`
+- `/configuration`
+- `/configuration#network`
+- `/configuration#security`
+- `/launcher`
+- `/launcher/create`
+- `/launcher/launched/:placeholder-id`  (with a known mock id)
+- `/operator/join/:placeholder-cid` (with a known mock cid)
+- `/network`
+- `/build`
+
+The test parameterizes over this list; one test per route.
+
+## Failure semantics
+
+- `pageerror` array non-empty → fail with the captured error stack
+- React error boundary visible → fail with the boundary's text content (helps debugging)
+- Console errors non-empty (after filtering known harmless patterns) → fail with all error messages
+- Route doesn't reach the "rendered" sentinel within 5s → fail with "route did not render"
+
+The "known harmless" filter list lives in the test file (e.g. ResizeObserver loop warnings). It starts empty and gets entries added when needed, each with a comment explaining why.
+
+## What this scenario does NOT catch
+
+- Real-daemon behavior (uses mocks)
+- Cross-operator state synchronization
+- Integration bugs between SPA and real daemon API
+- Visual regressions (no screenshot comparison)
+
+These belong in T2.x (cross-op) and Tier 3 (real testnet) scenarios.
+
+## Wall-clock
+
+~30 seconds total: ~3 seconds per route × ~11 routes. Runs in parallel within Playwright's default worker count.
+
+## Dependencies
+
+- The SPA must export a `ROUTES` constant from a single module so this test parameterizes correctly. If `ROUTES` doesn't exist yet, Plan C/D's implementation should add it (small refactor — extract route table from App.tsx).
+- `mockDaemonApi` helper from single-op tests (already exists).

--- a/.claude/skills/testing-jinn-app/references/scenario-spa-route-smoke.md
+++ b/.claude/skills/testing-jinn-app/references/scenario-spa-route-smoke.md
@@ -25,6 +25,8 @@ Load every SPA route against a mocked daemon API. For each route, assert:
 
 ```typescript
 import { test, expect, type Page } from '@playwright/test';
+// `mockDaemonApi` is currently private inside `client/test/dashboard/spa-config.e2e.test.ts`.
+// Plan C/D should extract it to a shared module before this test can import.
 import { mockDaemonApi } from '../helpers/mock-daemon-api';
 import { ROUTES } from '../../../src/dashboard/spa/src/routes';   // exported list of route paths
 
@@ -95,4 +97,4 @@ These belong in T2.x (cross-op) and Tier 3 (real testnet) scenarios.
 ## Dependencies
 
 - The SPA must export a `ROUTES` constant from a single module so this test parameterizes correctly. If `ROUTES` doesn't exist yet, Plan C/D's implementation should add it (small refactor — extract route table from App.tsx).
-- `mockDaemonApi` helper from single-op tests (already exists).
+- `mockDaemonApi` helper — currently a private function inside `client/test/dashboard/spa-config.e2e.test.ts:~130` (single-arg, hardcoded port 7332). Plan C/D should extract it to a shared module (e.g. `client/test/dashboard/helpers/mock-daemon-api.ts`) before the multi-op tests can import it.

--- a/client/test/helpers/handshake-url.test.ts
+++ b/client/test/helpers/handshake-url.test.ts
@@ -44,4 +44,25 @@ describe('makeHandshakeCollector', () => {
     collector.feed('only unrelated lines\n');
     await expect(collector.promise).rejects.toThrow(/timed out/i);
   });
+
+  it('does not retain already-scanned complete lines in the buffer', async () => {
+    const collector = makeHandshakeCollector(50);
+    // Emit a large volume of complete (newline-terminated) noise lines.
+    for (let i = 0; i < 1000; i++) {
+      collector.feed(`noise log line ${i} with some padding text\n`);
+    }
+    // The timeout error reports the buffered tail; if scanned lines were
+    // retained it would be huge. Only an unterminated partial may remain.
+    await expect(collector.promise).rejects.toThrow(/buffered: $/);
+  });
+
+  it('keeps the trailing partial line across feeds and still matches', async () => {
+    const collector = makeHandshakeCollector(5000);
+    for (let i = 0; i < 500; i++) {
+      collector.feed(`noise line ${i}\n`);
+    }
+    collector.feed('UI handshake URL: http://127');
+    collector.feed('.0.0.1:7332/auth?t=tail\n');
+    expect(await collector.promise).toBe('http://127.0.0.1:7332/auth?t=tail');
+  });
 });

--- a/client/test/helpers/handshake-url.test.ts
+++ b/client/test/helpers/handshake-url.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { extractHandshakeUrl, makeHandshakeCollector } from './handshake-url';
+
+describe('extractHandshakeUrl', () => {
+  it('extracts URL from a typical daemon line', () => {
+    const line = '[server] UI handshake URL: http://127.0.0.1:7332/auth/handshake?token=abc123';
+    expect(extractHandshakeUrl(line)).toBe('http://127.0.0.1:7332/auth/handshake?token=abc123');
+  });
+
+  it('returns null on non-matching lines', () => {
+    expect(extractHandshakeUrl('some unrelated log line')).toBeNull();
+    expect(extractHandshakeUrl('')).toBeNull();
+  });
+
+  it('handles whitespace variation between label and URL', () => {
+    const line = 'UI handshake URL:       http://localhost:7332/x';
+    expect(extractHandshakeUrl(line)).toBe('http://localhost:7332/x');
+  });
+
+  it('does not match if URL is missing', () => {
+    expect(extractHandshakeUrl('UI handshake URL:')).toBeNull();
+  });
+});
+
+describe('makeHandshakeCollector', () => {
+  it('resolves when URL appears in a chunk', async () => {
+    const collector = makeHandshakeCollector(5000);
+    collector.feed('startup line\n');
+    collector.feed('UI handshake URL: http://127.0.0.1:7332/auth?t=xyz\n');
+    const url = await collector.promise;
+    expect(url).toBe('http://127.0.0.1:7332/auth?t=xyz');
+  });
+
+  it('handles URL split across two feed calls', async () => {
+    const collector = makeHandshakeCollector(5000);
+    collector.feed('UI handshake URL: http://12');
+    collector.feed('7.0.0.1:7332/auth?t=split\n');
+    const url = await collector.promise;
+    expect(url).toBe('http://127.0.0.1:7332/auth?t=split');
+  });
+
+  it('rejects after timeout if URL never arrives', async () => {
+    const collector = makeHandshakeCollector(50);
+    collector.feed('only unrelated lines\n');
+    await expect(collector.promise).rejects.toThrow(/timed out/i);
+  });
+});

--- a/client/test/helpers/handshake-url.ts
+++ b/client/test/helpers/handshake-url.ts
@@ -8,6 +8,13 @@ export function extractHandshakeUrl(line: string): string | null {
 export interface HandshakeCollector {
   feed: (chunk: string) => void;
   promise: Promise<string>;
+  /**
+   * Clears the pending timeout and marks the collector settled so further
+   * `feed()` calls become no-ops. Idempotent. Callers should still detach
+   * their own stream listeners; `promise` settling (resolve/reject/dispose)
+   * is the signal to do so.
+   */
+  dispose: () => void;
 }
 
 export function makeHandshakeCollector(timeoutMs: number): HandshakeCollector {
@@ -43,5 +50,13 @@ export function makeHandshakeCollector(timeoutMs: number): HandshakeCollector {
       }
     },
     promise,
+    dispose() {
+      if (settled) {
+        clearTimeout(timer);
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+    },
   };
 }

--- a/client/test/helpers/handshake-url.ts
+++ b/client/test/helpers/handshake-url.ts
@@ -12,6 +12,7 @@ export interface HandshakeCollector {
 
 export function makeHandshakeCollector(timeoutMs: number): HandshakeCollector {
   let buffer = '';
+  let settled = false;
   let resolve!: (url: string) => void;
   let reject!: (err: Error) => void;
   const promise = new Promise<string>((res, rej) => {
@@ -19,17 +20,22 @@ export function makeHandshakeCollector(timeoutMs: number): HandshakeCollector {
     reject = rej;
   });
   const timer = setTimeout(() => {
+    if (settled) return;
+    settled = true;
     reject(new Error(`handshake URL collector timed out after ${timeoutMs}ms; buffered: ${buffer.slice(0, 200)}`));
   }, timeoutMs);
   return {
     feed(chunk: string) {
+      if (settled) return;
       buffer += chunk;
       const lines = buffer.split(/\r?\n/);
-      // All lines except the last are complete (terminated by a newline)
-      const completeLines = lines.slice(0, -1);
-      for (const line of completeLines) {
+      // Keep only the trailing unterminated partial line; everything before it
+      // is complete and has been scanned, so it must not accumulate in buffer.
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
         const url = extractHandshakeUrl(line);
         if (url) {
+          settled = true;
           clearTimeout(timer);
           resolve(url);
           return;

--- a/client/test/helpers/handshake-url.ts
+++ b/client/test/helpers/handshake-url.ts
@@ -1,0 +1,41 @@
+const HANDSHAKE_RE = /UI handshake URL:\s+(\S+)/;
+
+export function extractHandshakeUrl(line: string): string | null {
+  const m = line.match(HANDSHAKE_RE);
+  return m ? m[1] : null;
+}
+
+export interface HandshakeCollector {
+  feed: (chunk: string) => void;
+  promise: Promise<string>;
+}
+
+export function makeHandshakeCollector(timeoutMs: number): HandshakeCollector {
+  let buffer = '';
+  let resolve!: (url: string) => void;
+  let reject!: (err: Error) => void;
+  const promise = new Promise<string>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  const timer = setTimeout(() => {
+    reject(new Error(`handshake URL collector timed out after ${timeoutMs}ms; buffered: ${buffer.slice(0, 200)}`));
+  }, timeoutMs);
+  return {
+    feed(chunk: string) {
+      buffer += chunk;
+      const lines = buffer.split(/\r?\n/);
+      // All lines except the last are complete (terminated by a newline)
+      const completeLines = lines.slice(0, -1);
+      for (const line of completeLines) {
+        const url = extractHandshakeUrl(line);
+        if (url) {
+          clearTimeout(timer);
+          resolve(url);
+          return;
+        }
+      }
+    },
+    promise,
+  };
+}

--- a/client/test/helpers/multi-op-daemon.test.ts
+++ b/client/test/helpers/multi-op-daemon.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { spawnMultiOpDaemons, type MultiOpHandle } from './multi-op-daemon';
+
+describe('spawnMultiOpDaemons', () => {
+  let tmpRoot: string;
+  let opAHome: string;
+  let opBHome: string;
+
+  beforeAll(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'multi-op-helper-'));
+    opAHome = path.join(tmpRoot, 'op-a');
+    opBHome = path.join(tmpRoot, 'op-b');
+    await fs.mkdir(path.join(opAHome, '.jinn-client'), { recursive: true });
+    await fs.mkdir(path.join(opBHome, '.jinn-client'), { recursive: true });
+    // Seed minimal config so the daemon doesn't error out on missing fields.
+    // (Real tests will use substrate-copy workspaces; this test just exercises the helper.)
+    const minimalCfg = (port: number) => JSON.stringify({
+      network: 'testnet',
+      apiPort: port,
+      rpcUrl: 'https://base-sepolia.example/dummy',
+      pollIntervalMs: 5000,
+    });
+    await fs.writeFile(path.join(opAHome, '.jinn-client', 'config.json'), minimalCfg(7732));
+    await fs.writeFile(path.join(opBHome, '.jinn-client', 'config.json'), minimalCfg(7733));
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('spawns N daemons with distinct ports and returns handles', async () => {
+    // NOTE: this test requires `yarn build` has been run (dist/bin/jinn.js exists).
+    // If dist is missing, it should skip rather than fail.
+    const distPath = path.resolve(__dirname, '..', '..', 'dist', 'bin', 'jinn.js');
+    try { await fs.access(distPath); } catch {
+      // dist not built; skip
+      return;
+    }
+
+    let handle: MultiOpHandle | undefined;
+    try {
+      handle = await spawnMultiOpDaemons({
+        ops: [
+          { name: 'op-a', home: opAHome, apiPort: 7732 },
+          { name: 'op-b', home: opBHome, apiPort: 7733 },
+        ],
+        readyTimeoutMs: 30000,
+      });
+      expect(Object.keys(handle.daemons).sort()).toEqual(['op-a', 'op-b']);
+      // handshakeUrl may be present only if the daemon emits it; bootstrap-incomplete daemons may not.
+      // The contract: each daemon has a pid and an apiPort.
+      expect(handle.daemons['op-a'].apiPort).toBe(7732);
+      expect(handle.daemons['op-b'].apiPort).toBe(7733);
+      expect(handle.daemons['op-a'].pid).toBeGreaterThan(0);
+      expect(handle.daemons['op-b'].pid).toBeGreaterThan(0);
+    } finally {
+      if (handle) await handle.teardown();
+    }
+  }, 60000);
+
+  it('teardown is idempotent', async () => {
+    const distPath = path.resolve(__dirname, '..', '..', 'dist', 'bin', 'jinn.js');
+    try { await fs.access(distPath); } catch { return; }
+
+    const handle = await spawnMultiOpDaemons({
+      ops: [{ name: 'op-a', home: opAHome, apiPort: 7734 }],
+      readyTimeoutMs: 30000,
+    });
+    await handle.teardown();
+    await expect(handle.teardown()).resolves.toBeUndefined();
+  }, 60000);
+});

--- a/client/test/helpers/multi-op-daemon.ts
+++ b/client/test/helpers/multi-op-daemon.ts
@@ -50,28 +50,22 @@ export async function spawnMultiOpDaemons(opts: SpawnMultiOpOptions): Promise<Mu
   const processes: ChildProcess[] = [];
 
   async function killAll(): Promise<void> {
-    for (const proc of processes) {
-      if (!proc.killed && proc.pid) {
-        try { proc.kill('SIGTERM'); } catch {}
+    const signal = (sig: NodeJS.Signals) => {
+      for (const proc of processes) {
+        if (!proc.killed && proc.pid) {
+          try { proc.kill(sig); } catch {}
+        }
       }
-    }
+    };
+    signal('SIGTERM');
     await new Promise((r) => setTimeout(r, 200));
-    for (const proc of processes) {
-      if (!proc.killed && proc.pid) {
-        try { proc.kill('SIGKILL'); } catch {}
-      }
-    }
+    signal('SIGKILL');
   }
 
-  // When the test seed config has an unreachable rpcUrl (e.g. a dummy hostname
-  // used in beforeAll setup), JINN_RPC_URL overrides config so the daemon's
-  // RPC preflight can pass. config.ts gives JINN_RPC_URL unconditional precedence
-  // over BASE_RPC_URL and BASE_SEPOLIA_RPC_URL, so the helper must consult any
-  // RPC URL the caller put in extraEnv (e.g. an Anvil fork URL) and surface it
-  // through JINN_RPC_URL — otherwise extraEnv.BASE_RPC_URL would be silently
-  // overridden by the host fallback. Resolution order: extraEnv.JINN_RPC_URL,
-  // extraEnv.BASE_RPC_URL, host JINN_RPC_URL, host BASE_SEPOLIA_RPC_URL, then
-  // the public Tenderly gateway (matches config.ts:986).
+  // config.ts gives JINN_RPC_URL unconditional precedence over BASE_RPC_URL,
+  // so any RPC URL the caller passed in extraEnv must be surfaced through it.
+  // Resolution order: extraEnv JINN/BASE RPC URL, host JINN/BASE_SEPOLIA RPC
+  // URL, then the public Tenderly gateway (matches config.ts:986).
   const fallbackRpcUrl =
     opts.extraEnv?.['JINN_RPC_URL'] ??
     opts.extraEnv?.['BASE_RPC_URL'] ??

--- a/client/test/helpers/multi-op-daemon.ts
+++ b/client/test/helpers/multi-op-daemon.ts
@@ -76,9 +76,6 @@ export async function spawnMultiOpDaemons(opts: SpawnMultiOpOptions): Promise<Mu
     for (const op of opts.ops) {
       const env: NodeJS.ProcessEnv = {
         ...process.env,
-        // Allow callers to supply their own RPC via extraEnv; only inject the
-        // fallback when neither JINN_RPC_URL nor BASE_SEPOLIA_RPC_URL is set in
-        // the process environment or extraEnv.
         JINN_RPC_URL: fallbackRpcUrl,
         ...opts.extraEnv,
         HOME: op.home,

--- a/client/test/helpers/multi-op-daemon.ts
+++ b/client/test/helpers/multi-op-daemon.ts
@@ -65,10 +65,10 @@ export async function spawnMultiOpDaemons(opts: SpawnMultiOpOptions): Promise<Mu
 
   // When the test seed config has an unreachable rpcUrl (e.g. a dummy hostname
   // used in beforeAll setup), JINN_RPC_URL overrides config so the daemon's
-  // RPC preflight can pass. Use BASE_SEPOLIA_RPC_URL from the host environment
-  // when available; otherwise fall back to the same public Tenderly gateway the
-  // daemon's config.ts uses as its default for testnet.
+  // RPC preflight can pass. Fallback chain: host JINN_RPC_URL, then
+  // BASE_SEPOLIA_RPC_URL, then the public Tenderly gateway (matches config.ts:986).
   const fallbackRpcUrl =
+    process.env['JINN_RPC_URL'] ??
     process.env['BASE_SEPOLIA_RPC_URL'] ??
     'https://base-sepolia.gateway.tenderly.co/75tyLMQuD8EHpXxMwINIKu';
 

--- a/client/test/helpers/multi-op-daemon.ts
+++ b/client/test/helpers/multi-op-daemon.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcess } from 'node:child_process';
-import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { makeHandshakeCollector } from './handshake-url';
 
 export interface OpSpec {
@@ -23,8 +23,14 @@ export interface MultiOpHandle {
 
 export interface SpawnMultiOpOptions {
   ops: OpSpec[];
-  readyTimeoutMs?: number;      // default 30s
-  jinnBinPath?: string;         // default: resolve from cwd / dist/bin/jinn.js
+  /**
+   * Per-daemon readiness timeout in milliseconds (default 30s). Applied
+   * independently to each daemon in `ops` — the worst-case total wall time
+   * for a group of N daemons is N × readyTimeoutMs, since daemons are spawned
+   * and awaited sequentially.
+   */
+  readyTimeoutMs?: number;
+  jinnBinPath?: string;         // default: dist/bin/jinn.js resolved relative to this module
   extraEnv?: NodeJS.ProcessEnv;
 }
 
@@ -44,7 +50,10 @@ async function waitForBootstrap(apiPort: number, timeoutMs: number): Promise<voi
 
 export async function spawnMultiOpDaemons(opts: SpawnMultiOpOptions): Promise<MultiOpHandle> {
   const readyTimeoutMs = opts.readyTimeoutMs ?? 30000;
-  const jinnBin = opts.jinnBinPath ?? path.resolve(process.cwd(), 'dist', 'bin', 'jinn.js');
+  // Resolve the built binary relative to this module rather than process.cwd(),
+  // which is unstable across test runners and invocation directories.
+  const jinnBin =
+    opts.jinnBinPath ?? fileURLToPath(new URL('../../dist/bin/jinn.js', import.meta.url));
 
   const daemons: Record<string, DaemonHandle> = {};
   const processes: ChildProcess[] = [];
@@ -89,8 +98,18 @@ export async function spawnMultiOpDaemons(opts: SpawnMultiOpOptions): Promise<Mu
       processes.push(proc);
 
       const collector = makeHandshakeCollector(readyTimeoutMs);
-      proc.stdout?.on('data', (chunk) => collector.feed(chunk.toString()));
-      proc.stderr?.on('data', (chunk) => collector.feed(chunk.toString()));
+      const onStdout = (chunk: Buffer | string) => collector.feed(chunk.toString());
+      const onStderr = (chunk: Buffer | string) => collector.feed(chunk.toString());
+      proc.stdout?.on('data', onStdout);
+      proc.stderr?.on('data', onStderr);
+      // Detach the handshake listeners once the collector settles, so they do
+      // not stay attached for the child's lifetime (MaxListenersExceededWarning
+      // risk across many daemons + no-op feed() churn).
+      const detachHandshakeListeners = () => {
+        proc.stdout?.off('data', onStdout);
+        proc.stderr?.off('data', onStderr);
+      };
+      collector.promise.then(detachHandshakeListeners, detachHandshakeListeners);
 
       // Wait for bootstrap to be reachable
       await waitForBootstrap(op.apiPort, readyTimeoutMs);
@@ -104,6 +123,11 @@ export async function spawnMultiOpDaemons(opts: SpawnMultiOpOptions): Promise<Mu
         ]);
       } catch {
         handshakeUrl = null;
+      } finally {
+        // If the 2s race lost, collector.promise may still be pending; dispose
+        // it so its timeout clears and detach the listeners now.
+        collector.dispose();
+        detachHandshakeListeners();
       }
 
       daemons[op.name] = {

--- a/client/test/helpers/multi-op-daemon.ts
+++ b/client/test/helpers/multi-op-daemon.ts
@@ -65,9 +65,16 @@ export async function spawnMultiOpDaemons(opts: SpawnMultiOpOptions): Promise<Mu
 
   // When the test seed config has an unreachable rpcUrl (e.g. a dummy hostname
   // used in beforeAll setup), JINN_RPC_URL overrides config so the daemon's
-  // RPC preflight can pass. Fallback chain: host JINN_RPC_URL, then
-  // BASE_SEPOLIA_RPC_URL, then the public Tenderly gateway (matches config.ts:986).
+  // RPC preflight can pass. config.ts gives JINN_RPC_URL unconditional precedence
+  // over BASE_RPC_URL and BASE_SEPOLIA_RPC_URL, so the helper must consult any
+  // RPC URL the caller put in extraEnv (e.g. an Anvil fork URL) and surface it
+  // through JINN_RPC_URL — otherwise extraEnv.BASE_RPC_URL would be silently
+  // overridden by the host fallback. Resolution order: extraEnv.JINN_RPC_URL,
+  // extraEnv.BASE_RPC_URL, host JINN_RPC_URL, host BASE_SEPOLIA_RPC_URL, then
+  // the public Tenderly gateway (matches config.ts:986).
   const fallbackRpcUrl =
+    opts.extraEnv?.['JINN_RPC_URL'] ??
+    opts.extraEnv?.['BASE_RPC_URL'] ??
     process.env['JINN_RPC_URL'] ??
     process.env['BASE_SEPOLIA_RPC_URL'] ??
     'https://base-sepolia.gateway.tenderly.co/75tyLMQuD8EHpXxMwINIKu';

--- a/client/test/helpers/multi-op-daemon.ts
+++ b/client/test/helpers/multi-op-daemon.ts
@@ -1,0 +1,133 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import * as path from 'node:path';
+import { makeHandshakeCollector } from './handshake-url';
+
+export interface OpSpec {
+  name: string;
+  home: string;                 // HOME directory containing .jinn-client/
+  apiPort: number;
+}
+
+export interface DaemonHandle {
+  name: string;
+  pid: number;
+  apiPort: number;
+  handshakeUrl: string | null;  // null if not emitted within readyTimeoutMs
+  process: ChildProcess;
+}
+
+export interface MultiOpHandle {
+  daemons: Record<string, DaemonHandle>;
+  teardown: () => Promise<void>;
+}
+
+export interface SpawnMultiOpOptions {
+  ops: OpSpec[];
+  readyTimeoutMs?: number;      // default 30s
+  jinnBinPath?: string;         // default: resolve from cwd / dist/bin/jinn.js
+  extraEnv?: NodeJS.ProcessEnv;
+}
+
+async function waitForBootstrap(apiPort: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${apiPort}/v1/bootstrap`, { method: 'GET' });
+      if (res.status === 200 || res.status === 401) return;
+    } catch {
+      // not yet
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`daemon on port ${apiPort} did not become reachable within ${timeoutMs}ms`);
+}
+
+export async function spawnMultiOpDaemons(opts: SpawnMultiOpOptions): Promise<MultiOpHandle> {
+  const readyTimeoutMs = opts.readyTimeoutMs ?? 30000;
+  const jinnBin = opts.jinnBinPath ?? path.resolve(process.cwd(), 'dist', 'bin', 'jinn.js');
+
+  const daemons: Record<string, DaemonHandle> = {};
+  const processes: ChildProcess[] = [];
+
+  async function killAll(): Promise<void> {
+    for (const proc of processes) {
+      if (!proc.killed && proc.pid) {
+        try { proc.kill('SIGTERM'); } catch {}
+      }
+    }
+    await new Promise((r) => setTimeout(r, 200));
+    for (const proc of processes) {
+      if (!proc.killed && proc.pid) {
+        try { proc.kill('SIGKILL'); } catch {}
+      }
+    }
+  }
+
+  // When the test seed config has an unreachable rpcUrl (e.g. a dummy hostname
+  // used in beforeAll setup), JINN_RPC_URL overrides config so the daemon's
+  // RPC preflight can pass. Use BASE_SEPOLIA_RPC_URL from the host environment
+  // when available; otherwise fall back to the same public Tenderly gateway the
+  // daemon's config.ts uses as its default for testnet.
+  const fallbackRpcUrl =
+    process.env['BASE_SEPOLIA_RPC_URL'] ??
+    'https://base-sepolia.gateway.tenderly.co/75tyLMQuD8EHpXxMwINIKu';
+
+  try {
+    for (const op of opts.ops) {
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        // Allow callers to supply their own RPC via extraEnv; only inject the
+        // fallback when neither JINN_RPC_URL nor BASE_SEPOLIA_RPC_URL is set in
+        // the process environment or extraEnv.
+        JINN_RPC_URL: fallbackRpcUrl,
+        ...opts.extraEnv,
+        HOME: op.home,
+        JINN_API_PORT: op.apiPort.toString(),
+      };
+      const proc = spawn('node', [jinnBin, 'run', '--no-ui'], {
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      processes.push(proc);
+
+      const collector = makeHandshakeCollector(readyTimeoutMs);
+      proc.stdout?.on('data', (chunk) => collector.feed(chunk.toString()));
+      proc.stderr?.on('data', (chunk) => collector.feed(chunk.toString()));
+
+      // Wait for bootstrap to be reachable
+      await waitForBootstrap(op.apiPort, readyTimeoutMs);
+
+      // Best-effort handshake URL capture (may not emit if daemon is in non-running mode)
+      let handshakeUrl: string | null = null;
+      try {
+        handshakeUrl = await Promise.race([
+          collector.promise,
+          new Promise<string>((_, rej) => setTimeout(() => rej(new Error('handshake not emitted')), 2000)),
+        ]);
+      } catch {
+        handshakeUrl = null;
+      }
+
+      daemons[op.name] = {
+        name: op.name,
+        pid: proc.pid ?? -1,
+        apiPort: op.apiPort,
+        handshakeUrl,
+        process: proc,
+      };
+    }
+  } catch (err) {
+    await killAll();
+    throw err;
+  }
+
+  let torn = false;
+  return {
+    daemons,
+    teardown: async () => {
+      if (torn) return;
+      torn = true;
+      await killAll();
+    },
+  };
+}

--- a/docs/superpowers/plans/2026-05-19-substrate-foundation-plan.md
+++ b/docs/superpowers/plans/2026-05-19-substrate-foundation-plan.md
@@ -1,0 +1,1992 @@
+# Substrate foundation implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Codify the test-operator substrate lifecycle as four production TypeScript scripts (`substrate-adopt`, `substrate-copy`, `substrate-verify`, `substrate-topup`) plus a workspace reaper. Each ships with unit + integration tests and a yarn-script entry point. The gold substrate already exists on disk (adopted manually 2026-05-19 during the spec brainstorm); this plan replaces the manual adoption with idempotent reproducible scripts.
+
+**Architecture:** Single shared types module (Zod schemas) feeds five focused scripts that each export a callable function plus a CLI main. Tests live alongside under `client/test/release/substrate/` and use Vitest with `tmp` dirs for filesystem isolation and an Anvil fork helper for on-chain reads (matches the existing `client/scripts/staking-validate.ts` test pattern).
+
+**Tech Stack:** TypeScript, Zod for schema validation (matches `client/src/earning/types.ts`), viem for on-chain reads (matches `client/src/earning/contracts.ts`), node:fs/promises for filesystem, Vitest for tests, Anvil fork for integration tests.
+
+---
+
+## File structure
+
+**Source files (all new under `client/scripts/release/`):**
+
+| Path | Responsibility |
+|---|---|
+| `client/scripts/release/types.ts` | Zod schemas: `ManifestSchema`, `VerifyResult`, `TopupResult` |
+| `client/scripts/release/substrate-paths.ts` | Path helpers: `goldPath()`, `workspacePath()`, `workspacesRoot()` |
+| `client/scripts/release/substrate-adopt.ts` | Adopt: copy from existing operator dir → gold dir, write manifest |
+| `client/scripts/release/substrate-copy.ts` | Per-run workspace copy from gold, port rewriting |
+| `client/scripts/release/substrate-verify.ts` | Manifest validation + on-chain identity check |
+| `client/scripts/release/substrate-topup.ts` | Balance check + low-balance gap surfacing (no auto-drip) |
+| `client/scripts/release/substrate-reap.ts` | Workspace garbage collection (>7 days) |
+| `client/scripts/release/README.md` | Usage documentation |
+
+**Test files (all new under `client/test/release/substrate/`):**
+
+| Path | Covers |
+|---|---|
+| `client/test/release/substrate/types.test.ts` | Manifest schema parse/validate |
+| `client/test/release/substrate/substrate-paths.test.ts` | Path resolution |
+| `client/test/release/substrate/adopt.test.ts` | Adopt + verify cycle on fixtures |
+| `client/test/release/substrate/copy.test.ts` | Workspace creation + port rewriting |
+| `client/test/release/substrate/verify.test.ts` | Manifest validation + on-chain (Anvil fork) |
+| `client/test/release/substrate/topup.test.ts` | Balance check report (Anvil fork) |
+| `client/test/release/substrate/reap.test.ts` | Workspace age-based pruning |
+| `client/test/release/substrate/fixtures/op-a-fixture/.jinn-client/*` | Minimal valid operator state |
+| `client/test/release/substrate/fixtures/op-b-fixture/.jinn-client/*` | Second fixture operator |
+| `client/test/release/substrate/helpers/anvil-fork.ts` | Anvil fork helper for integration tests |
+| `client/test/release/substrate/helpers/tmp-substrate.ts` | tmp-dir substrate helper for isolation |
+
+**Modified files:**
+
+| Path | Change |
+|---|---|
+| `client/package.json` | Add yarn scripts: `substrate:adopt`, `substrate:copy`, `substrate:verify`, `substrate:topup`, `substrate:reap` |
+
+---
+
+## Task 1: Manifest schema and shared types
+
+**Files:**
+- Create: `client/scripts/release/types.ts`
+- Test: `client/test/release/substrate/types.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// client/test/release/substrate/types.test.ts
+import { describe, it, expect } from 'vitest';
+import { ManifestSchema, type Manifest } from '../../../scripts/release/types';
+
+describe('ManifestSchema', () => {
+  const validManifest = {
+    substrateVersion: '1',
+    createdAt: '2026-05-19T14:47:19Z',
+    adoptedFrom: '~/.jinn-client/',
+    name: 'op-a',
+    shape: 'current' as const,
+    role: 'launcher' as const,
+    network: 'base-sepolia' as const,
+    operator: {
+      masterAddress: '0xE64bAf0073a71b0Cb2C0558bB16f24b45E1FB5CF',
+      fleetAgentId: '5474',
+      fleetSafeAddress: '0x0e767E28C6889CcD0DfB88E631a3702D56Ce24FC',
+      fleetStage: 'stage1_and_2',
+      serviceId: 46,
+      serviceStep: 'complete',
+      agentEoa: '0x63192d38350b796856cF002caC25c377D9A0DB5A',
+      safeAddress: '0x0e767E28C6889CcD0DfB88E631a3702D56Ce24FC',
+      mechAddress: '0x9c415369D0597e4867F419d256BD61D16a8C47b5',
+      stakingAddress: '0x24e34E5037956a5Feca1AAAfaA30297084C228B8',
+      identityRegistry: '0x8004A818BFB912233c491871b3d84c89A494BD9e',
+    },
+    config: {
+      apiPort: 7332,
+      rpcUrl: 'https://base-sepolia.gateway.tenderly.co/abc',
+      joinedSolverNets: ['bafkrei123'],
+    },
+  };
+
+  it('parses a valid manifest', () => {
+    const parsed = ManifestSchema.parse(validManifest);
+    expect(parsed.name).toBe('op-a');
+    expect(parsed.operator.fleetAgentId).toBe('5474');
+  });
+
+  it('rejects missing required field', () => {
+    const invalid = { ...validManifest, name: undefined };
+    expect(() => ManifestSchema.parse(invalid)).toThrow();
+  });
+
+  it('rejects invalid network value', () => {
+    const invalid = { ...validManifest, network: 'mainnet-pro' };
+    expect(() => ManifestSchema.parse(invalid)).toThrow();
+  });
+
+  it('accepts pre-fleet shape with null fleet fields', () => {
+    const preFleet: Manifest = {
+      ...validManifest,
+      name: 'op-c-legacy',
+      shape: 'pre-fleet',
+      role: 'legacy-backup',
+      operator: {
+        ...validManifest.operator,
+        fleetAgentId: null,
+        fleetSafeAddress: null,
+        fleetStage: null,
+      },
+    };
+    expect(() => ManifestSchema.parse(preFleet)).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client && yarn vitest run test/release/substrate/types.test.ts`
+Expected: FAIL with `Cannot find module '../../../scripts/release/types'`
+
+- [ ] **Step 3: Write the schema and types**
+
+```typescript
+// client/scripts/release/types.ts
+import { z } from 'zod';
+
+const AddressSchema = z.string().regex(/^0x[a-fA-F0-9]{40}$/, 'must be a 0x-prefixed 20-byte hex address');
+
+const ShapeSchema = z.enum(['current', 'pre-fleet']);
+const RoleSchema = z.enum(['launcher', 'participant', 'legacy-backup']);
+const NetworkSchema = z.enum(['base-sepolia', 'base']);
+
+const OperatorSchema = z.object({
+  masterAddress: AddressSchema,
+  fleetAgentId: z.string().nullable(),
+  fleetSafeAddress: AddressSchema.nullable(),
+  fleetStage: z.string().nullable(),
+  serviceId: z.number().int().positive(),
+  serviceStep: z.string(),
+  agentEoa: AddressSchema,
+  safeAddress: AddressSchema,
+  mechAddress: AddressSchema,
+  stakingAddress: AddressSchema,
+  identityRegistry: AddressSchema,
+});
+
+const ConfigSchema = z.object({
+  apiPort: z.number().int().positive(),
+  rpcUrl: z.string().url(),
+  joinedSolverNets: z.array(z.string()),
+});
+
+export const ManifestSchema = z.object({
+  substrateVersion: z.literal('1'),
+  createdAt: z.string().datetime(),
+  adoptedFrom: z.string(),
+  name: z.string(),
+  shape: ShapeSchema,
+  role: RoleSchema,
+  network: NetworkSchema,
+  operator: OperatorSchema,
+  config: ConfigSchema,
+});
+
+export type Manifest = z.infer<typeof ManifestSchema>;
+
+export interface VerifyResult {
+  opName: string;
+  ok: boolean;
+  failures: string[];           // each entry describes one failed check
+  warnings: string[];           // each entry describes a non-blocking concern
+  onChain: {
+    boundSafeAddress: string | null;
+    ethBalanceWei: bigint;
+    olasBalanceWei: bigint | null;
+  } | null;                     // null if on-chain check was skipped
+}
+
+export interface TopupResult {
+  opName: string;
+  needs: { resource: 'ETH' | 'USDC'; have: bigint; want: bigint }[];
+  ok: boolean;                  // true if all balances above their topup-trigger threshold
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd client && yarn vitest run test/release/substrate/types.test.ts`
+Expected: PASS, 4 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/scripts/release/types.ts client/test/release/substrate/types.test.ts
+git commit -m "feat(substrate): add manifest schema and shared types"
+```
+
+---
+
+## Task 2: Path resolution helpers
+
+**Files:**
+- Create: `client/scripts/release/substrate-paths.ts`
+- Test: `client/test/release/substrate/substrate-paths.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// client/test/release/substrate/substrate-paths.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as os from 'node:os';
+import {
+  goldPath,
+  workspacePath,
+  workspacesRoot,
+  defaultSubstrateRoot,
+} from '../../../scripts/release/substrate-paths';
+
+describe('substrate-paths', () => {
+  const originalEnv = { ...process.env };
+  beforeEach(() => { process.env = { ...originalEnv }; });
+  afterEach(() => { process.env = originalEnv; });
+
+  it('defaultSubstrateRoot resolves to ~/jinn-dev under HOME', () => {
+    process.env.HOME = '/Users/test';
+    expect(defaultSubstrateRoot()).toBe('/Users/test/jinn-dev');
+  });
+
+  it('goldPath composes correctly', () => {
+    process.env.HOME = '/Users/test';
+    expect(goldPath('op-a')).toBe('/Users/test/jinn-dev/operators/op-a');
+    expect(goldPath('op-b')).toBe('/Users/test/jinn-dev/operators/op-b');
+  });
+
+  it('workspacePath composes correctly', () => {
+    process.env.HOME = '/Users/test';
+    expect(workspacePath('run-123', 'op-a')).toBe('/Users/test/jinn-dev/workspaces/run-123/op-a');
+  });
+
+  it('workspacesRoot returns the workspaces dir', () => {
+    process.env.HOME = '/Users/test';
+    expect(workspacesRoot()).toBe('/Users/test/jinn-dev/workspaces');
+  });
+
+  it('accepts a custom substrateRoot override', () => {
+    expect(goldPath('op-a', '/custom/root')).toBe('/custom/root/operators/op-a');
+    expect(workspacePath('run-1', 'op-a', '/custom/root')).toBe('/custom/root/workspaces/run-1/op-a');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client && yarn vitest run test/release/substrate/substrate-paths.test.ts`
+Expected: FAIL with `Cannot find module '../../../scripts/release/substrate-paths'`
+
+- [ ] **Step 3: Write the helpers**
+
+```typescript
+// client/scripts/release/substrate-paths.ts
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+export function defaultSubstrateRoot(): string {
+  return path.join(os.homedir(), 'jinn-dev');
+}
+
+export function goldPath(opName: string, substrateRoot: string = defaultSubstrateRoot()): string {
+  return path.join(substrateRoot, 'operators', opName);
+}
+
+export function workspacesRoot(substrateRoot: string = defaultSubstrateRoot()): string {
+  return path.join(substrateRoot, 'workspaces');
+}
+
+export function workspacePath(runId: string, opName: string, substrateRoot: string = defaultSubstrateRoot()): string {
+  return path.join(workspacesRoot(substrateRoot), runId, opName);
+}
+
+export function generateRunId(): string {
+  const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  const rand = Math.random().toString(36).slice(2, 6);
+  return `${ts}-${rand}`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd client && yarn vitest run test/release/substrate/substrate-paths.test.ts`
+Expected: PASS, 5 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/scripts/release/substrate-paths.ts client/test/release/substrate/substrate-paths.test.ts
+git commit -m "feat(substrate): add path resolution helpers"
+```
+
+---
+
+## Task 3: Fixture operators for tests
+
+**Files:**
+- Create: `client/test/release/substrate/fixtures/op-a-fixture/.jinn-client/config.json`
+- Create: `client/test/release/substrate/fixtures/op-a-fixture/.jinn-client/keystore-password`
+- Create: `client/test/release/substrate/fixtures/op-a-fixture/.jinn-client/earning/earning_state.json`
+- Create: `client/test/release/substrate/fixtures/op-a-fixture/.jinn-client/earning/master_keystore.json`
+- Create: `client/test/release/substrate/fixtures/op-b-fixture/.jinn-client/...` (same shape, different identity)
+- Create: `client/test/release/substrate/fixtures/README.md`
+
+- [ ] **Step 1: Create the op-a-fixture config.json**
+
+```bash
+mkdir -p client/test/release/substrate/fixtures/op-a-fixture/.jinn-client/earning
+```
+
+```json
+{
+  "network": "testnet",
+  "rpcUrl": "https://base-sepolia.example/fixture-key",
+  "apiPort": 7332,
+  "joinedSolverNets": {
+    "bafkrei-fixture-cid": {
+      "name": "fixture-swe-rebench",
+      "manifestCid": "bafkrei-fixture-cid",
+      "roles": ["solving"],
+      "harness": "claude-code-learner",
+      "plugins": [],
+      "model": "claude-haiku-4-5-20251001"
+    }
+  }
+}
+```
+
+Save as `client/test/release/substrate/fixtures/op-a-fixture/.jinn-client/config.json`.
+
+- [ ] **Step 2: Create op-a-fixture earning_state.json**
+
+```json
+{
+  "master_address": "0x1111111111111111111111111111111111111111",
+  "chain": "base-sepolia",
+  "staking_mode": "standard",
+  "services": [
+    {
+      "index": 1,
+      "agent_address": "0x2222222222222222222222222222222222222222",
+      "safe_address": "0x3333333333333333333333333333333333333333",
+      "service_id": 9999,
+      "mech_address": "0x4444444444444444444444444444444444444444",
+      "staking_address": "0x5555555555555555555555555555555555555555",
+      "step": "complete",
+      "error": null,
+      "agent_id": "99001",
+      "agent_uri": "",
+      "identity_registry_address": "0x6666666666666666666666666666666666666666",
+      "agent_registered_tx": "0xfixture",
+      "safe_bound_to_agent": true,
+      "error_revert_reason": null,
+      "error_short_message": null
+    }
+  ],
+  "updated_at": "2026-05-01T00:00:00.000Z",
+  "fleet_agent_id": "99001",
+  "fleet_safe_address": "0x3333333333333333333333333333333333333333",
+  "fleet_identity_registry": "0x6666666666666666666666666666666666666666",
+  "fleet_stage": "stage1_and_2"
+}
+```
+
+Save as `client/test/release/substrate/fixtures/op-a-fixture/.jinn-client/earning/earning_state.json`.
+
+- [ ] **Step 3: Create op-a-fixture keystore + password**
+
+```json
+{ "version": 3, "id": "fixture-id", "address": "1111111111111111111111111111111111111111", "crypto": {"cipher": "aes-128-ctr", "ciphertext": "deadbeef", "cipherparams": {"iv": "00000000000000000000000000000000"}, "kdf": "scrypt", "kdfparams": {"dklen": 32, "n": 1024, "p": 1, "r": 8, "salt": "00"}, "mac": "00"} }
+```
+
+Save as `client/test/release/substrate/fixtures/op-a-fixture/.jinn-client/earning/master_keystore.json`.
+
+```
+fixture-password-not-real
+```
+
+Save as `client/test/release/substrate/fixtures/op-a-fixture/.jinn-client/keystore-password` (chmod 600 not needed for fixture but acceptable).
+
+- [ ] **Step 4: Repeat for op-b-fixture with different addresses and apiPort 7333**
+
+Create the same four files under `client/test/release/substrate/fixtures/op-b-fixture/.jinn-client/` with:
+- `master_address`: `0x7777777777777777777777777777777777777777`
+- `agent_id`: `99002`
+- All other addresses bumped to `0xAAAA...`, `0xBBBB...`, etc.
+- `apiPort`: 7333
+
+- [ ] **Step 5: Add README explaining fixtures**
+
+```markdown
+# Substrate test fixtures
+
+These are *not real* operator state. All addresses are placeholders (0x1111...,
+0x2222...). They exist purely for unit tests of substrate-adopt, substrate-copy,
+and substrate-verify. The on-chain identity referenced here does not exist on
+any real chain; tests that exercise on-chain reads must use the Anvil fork
+helper (`helpers/anvil-fork.ts`) to seed deterministic state.
+
+Two fixtures:
+- `op-a-fixture/` — launcher role, agentId 99001
+- `op-b-fixture/` — participant role, agentId 99002
+```
+
+Save as `client/test/release/substrate/fixtures/README.md`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/test/release/substrate/fixtures/
+git commit -m "test(substrate): add fixture operators for unit tests"
+```
+
+---
+
+## Task 4: substrate-verify — manifest validation
+
+**Files:**
+- Create: `client/scripts/release/substrate-verify.ts`
+- Test: `client/test/release/substrate/verify.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// client/test/release/substrate/verify.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { verifySubstrate } from '../../../scripts/release/substrate-verify';
+import type { Manifest } from '../../../scripts/release/types';
+
+describe('substrate-verify (manifest only)', () => {
+  let tmpRoot: string;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'substrate-verify-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  const validManifest: Manifest = {
+    substrateVersion: '1',
+    createdAt: '2026-05-19T14:47:19Z',
+    adoptedFrom: '~/.jinn-client/',
+    name: 'op-a',
+    shape: 'current',
+    role: 'launcher',
+    network: 'base-sepolia',
+    operator: {
+      masterAddress: '0xE64bAf0073a71b0Cb2C0558bB16f24b45E1FB5CF',
+      fleetAgentId: '5474',
+      fleetSafeAddress: '0x0e767E28C6889CcD0DfB88E631a3702D56Ce24FC',
+      fleetStage: 'stage1_and_2',
+      serviceId: 46,
+      serviceStep: 'complete',
+      agentEoa: '0x63192d38350b796856cF002caC25c377D9A0DB5A',
+      safeAddress: '0x0e767E28C6889CcD0DfB88E631a3702D56Ce24FC',
+      mechAddress: '0x9c415369D0597e4867F419d256BD61D16a8C47b5',
+      stakingAddress: '0x24e34E5037956a5Feca1AAAfaA30297084C228B8',
+      identityRegistry: '0x8004A818BFB912233c491871b3d84c89A494BD9e',
+    },
+    config: {
+      apiPort: 7332,
+      rpcUrl: 'https://base-sepolia.example/x',
+      joinedSolverNets: ['bafkrei1'],
+    },
+  };
+
+  async function seedOp(name: string, manifest: Manifest | null): Promise<void> {
+    const opDir = path.join(tmpRoot, 'operators', name);
+    await fs.mkdir(opDir, { recursive: true });
+    if (manifest !== null) {
+      await fs.writeFile(path.join(opDir, 'manifest.json'), JSON.stringify(manifest));
+    }
+  }
+
+  it('reports ok when manifest is valid and skipOnChain=true', async () => {
+    await seedOp('op-a', validManifest);
+    const result = await verifySubstrate('op-a', { substrateRoot: tmpRoot, skipOnChain: true });
+    expect(result.ok).toBe(true);
+    expect(result.failures).toEqual([]);
+  });
+
+  it('reports failure when manifest is missing', async () => {
+    await seedOp('op-a', null);
+    const result = await verifySubstrate('op-a', { substrateRoot: tmpRoot, skipOnChain: true });
+    expect(result.ok).toBe(false);
+    expect(result.failures.some((f) => f.includes('manifest.json'))).toBe(true);
+  });
+
+  it('reports failure when manifest fails schema validation', async () => {
+    await fs.mkdir(path.join(tmpRoot, 'operators', 'op-a'), { recursive: true });
+    await fs.writeFile(path.join(tmpRoot, 'operators', 'op-a', 'manifest.json'), '{"substrateVersion": "1"}');
+    const result = await verifySubstrate('op-a', { substrateRoot: tmpRoot, skipOnChain: true });
+    expect(result.ok).toBe(false);
+    expect(result.failures.some((f) => f.toLowerCase().includes('schema'))).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client && yarn vitest run test/release/substrate/verify.test.ts`
+Expected: FAIL with `Cannot find module '../../../scripts/release/substrate-verify'`
+
+- [ ] **Step 3: Write the substrate-verify manifest-only implementation**
+
+```typescript
+// client/scripts/release/substrate-verify.ts
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { ManifestSchema, type Manifest, type VerifyResult } from './types';
+import { goldPath } from './substrate-paths';
+
+export interface VerifyOptions {
+  substrateRoot?: string;
+  skipOnChain?: boolean;
+}
+
+export async function verifySubstrate(opName: string, opts: VerifyOptions = {}): Promise<VerifyResult> {
+  const failures: string[] = [];
+  const warnings: string[] = [];
+
+  const opDir = goldPath(opName, opts.substrateRoot);
+  const manifestPath = path.join(opDir, 'manifest.json');
+
+  // 1. Manifest exists
+  let manifestRaw: string;
+  try {
+    manifestRaw = await fs.readFile(manifestPath, 'utf-8');
+  } catch (err) {
+    failures.push(`manifest.json not found at ${manifestPath}`);
+    return { opName, ok: false, failures, warnings, onChain: null };
+  }
+
+  // 2. Manifest parses
+  let manifestJson: unknown;
+  try {
+    manifestJson = JSON.parse(manifestRaw);
+  } catch (err) {
+    failures.push(`manifest.json is not valid JSON: ${(err as Error).message}`);
+    return { opName, ok: false, failures, warnings, onChain: null };
+  }
+
+  // 3. Manifest validates against schema
+  const parseResult = ManifestSchema.safeParse(manifestJson);
+  if (!parseResult.success) {
+    failures.push(`manifest.json failed schema validation: ${parseResult.error.message}`);
+    return { opName, ok: false, failures, warnings, onChain: null };
+  }
+  const manifest: Manifest = parseResult.data;
+
+  // 4. Name in manifest matches the op being verified
+  if (manifest.name !== opName) {
+    failures.push(`manifest.name=${manifest.name} does not match expected opName=${opName}`);
+  }
+
+  // 5. Sanity: gold dir contains .jinn-client structure
+  const jinnClientDir = path.join(opDir, '.jinn-client');
+  try {
+    await fs.access(jinnClientDir);
+  } catch {
+    failures.push(`gold operator missing .jinn-client/ directory at ${jinnClientDir}`);
+  }
+
+  // 6. On-chain check (skip for now if requested)
+  if (opts.skipOnChain) {
+    return { opName, ok: failures.length === 0, failures, warnings, onChain: null };
+  }
+
+  // On-chain check implementation lands in Task 5
+  warnings.push('on-chain check not yet implemented; skipping');
+  return { opName, ok: failures.length === 0, failures, warnings, onChain: null };
+}
+
+async function cliMain(): Promise<void> {
+  const opName = process.argv[2];
+  if (!opName) {
+    console.error('usage: substrate-verify <op-name> [--skip-on-chain]');
+    process.exit(2);
+  }
+  const skipOnChain = process.argv.includes('--skip-on-chain');
+  const result = await verifySubstrate(opName, { skipOnChain });
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(result.ok ? 0 : 1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  cliMain().catch((err) => {
+    console.error(err);
+    process.exit(2);
+  });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd client && yarn vitest run test/release/substrate/verify.test.ts`
+Expected: PASS, 3 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/scripts/release/substrate-verify.ts client/test/release/substrate/verify.test.ts
+git commit -m "feat(substrate): add manifest-validating substrate-verify"
+```
+
+---
+
+## Task 5: substrate-verify — on-chain identity check
+
+**Files:**
+- Modify: `client/scripts/release/substrate-verify.ts`
+- Modify: `client/test/release/substrate/verify.test.ts` (add on-chain tests)
+- Create: `client/test/release/substrate/helpers/anvil-fork.ts`
+
+- [ ] **Step 1: Write the Anvil fork helper**
+
+```typescript
+// client/test/release/substrate/helpers/anvil-fork.ts
+import { spawn, type ChildProcess } from 'node:child_process';
+import * as net from 'node:net';
+
+export interface AnvilForkHandle {
+  rpcUrl: string;
+  port: number;
+  stop: () => Promise<void>;
+}
+
+async function pickFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.unref();
+    srv.on('error', reject);
+    srv.listen(0, () => {
+      const port = (srv.address() as net.AddressInfo).port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitForRpc(rpcUrl: string, timeoutMs = 10000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(rpcUrl, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'eth_blockNumber', params: [] }),
+      });
+      if (res.ok) return;
+    } catch {
+      // not yet
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`anvil at ${rpcUrl} did not become reachable within ${timeoutMs}ms`);
+}
+
+export async function spawnAnvilFork(opts: { forkUrl?: string; forkBlock?: number } = {}): Promise<AnvilForkHandle> {
+  const port = await pickFreePort();
+  const args = ['--port', port.toString(), '--silent'];
+  if (opts.forkUrl) {
+    args.push('--fork-url', opts.forkUrl);
+    if (opts.forkBlock !== undefined) {
+      args.push('--fork-block-number', opts.forkBlock.toString());
+    }
+  }
+  const child: ChildProcess = spawn('anvil', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+  const rpcUrl = `http://127.0.0.1:${port}`;
+  try {
+    await waitForRpc(rpcUrl);
+  } catch (err) {
+    child.kill('SIGTERM');
+    throw err;
+  }
+  return {
+    rpcUrl,
+    port,
+    stop: async () => {
+      child.kill('SIGTERM');
+      await new Promise((r) => setTimeout(r, 100));
+      if (!child.killed) child.kill('SIGKILL');
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Add a failing on-chain test**
+
+Append to `client/test/release/substrate/verify.test.ts`:
+
+```typescript
+import { spawnAnvilFork, type AnvilForkHandle } from './helpers/anvil-fork';
+import { createTestClient, createWalletClient, http, parseEther, type Address } from 'viem';
+import { baseSepolia } from 'viem/chains';
+import { privateKeyToAccount } from 'viem/accounts';
+
+describe('substrate-verify (on-chain check)', () => {
+  let tmpRoot: string;
+  let anvil: AnvilForkHandle;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'substrate-verify-onchain-'));
+    anvil = await spawnAnvilFork();
+  });
+
+  afterEach(async () => {
+    await anvil.stop();
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('reports failure when master EOA has zero ETH balance', async () => {
+    const opDir = path.join(tmpRoot, 'operators', 'op-a');
+    await fs.mkdir(path.join(opDir, '.jinn-client'), { recursive: true });
+    const manifest: Manifest = {
+      substrateVersion: '1',
+      createdAt: '2026-05-19T14:47:19Z',
+      adoptedFrom: '~/.jinn-client/',
+      name: 'op-a',
+      shape: 'current',
+      role: 'launcher',
+      network: 'base-sepolia',
+      operator: {
+        masterAddress: '0x1234567890123456789012345678901234567890',
+        fleetAgentId: '5474',
+        fleetSafeAddress: '0x0e767E28C6889CcD0DfB88E631a3702D56Ce24FC',
+        fleetStage: 'stage1_and_2',
+        serviceId: 46,
+        serviceStep: 'complete',
+        agentEoa: '0x63192d38350b796856cF002caC25c377D9A0DB5A',
+        safeAddress: '0x0e767E28C6889CcD0DfB88E631a3702D56Ce24FC',
+        mechAddress: '0x9c415369D0597e4867F419d256BD61D16a8C47b5',
+        stakingAddress: '0x24e34E5037956a5Feca1AAAfaA30297084C228B8',
+        identityRegistry: '0x8004A818BFB912233c491871b3d84c89A494BD9e',
+      },
+      config: { apiPort: 7332, rpcUrl: anvil.rpcUrl, joinedSolverNets: [] },
+    };
+    await fs.writeFile(path.join(opDir, 'manifest.json'), JSON.stringify(manifest));
+
+    const result = await verifySubstrate('op-a', { substrateRoot: tmpRoot, skipOnChain: false });
+
+    expect(result.onChain).not.toBeNull();
+    expect(result.onChain!.ethBalanceWei).toBe(0n);
+    expect(result.failures.some((f) => f.toLowerCase().includes('eth balance'))).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 3: Run to verify the new test fails**
+
+Run: `cd client && yarn vitest run test/release/substrate/verify.test.ts`
+Expected: 3 prior tests PASS; new on-chain test FAILS because on-chain check isn't implemented yet.
+
+- [ ] **Step 4: Implement the on-chain check**
+
+Replace the on-chain stub in `client/scripts/release/substrate-verify.ts` with:
+
+```typescript
+// Add at top of substrate-verify.ts
+import { createPublicClient, http, parseAbi, type Address } from 'viem';
+import { baseSepolia } from 'viem/chains';
+
+const MIN_MASTER_ETH_WEI = 2_000_000_000_000_000n;   // 0.002 ETH
+const IDENTITY_REGISTRY_ABI = parseAbi([
+  'function getAgentWallet(uint256 agentId) view returns (address)',
+]);
+const OLAS_TOKEN_ADDRESS_BASE_SEPOLIA: Address = '0x54330d28ca3357F294334BDC454a032e7f353416';
+const OLAS_TOKEN_ABI = parseAbi([
+  'function balanceOf(address account) view returns (uint256)',
+]);
+
+// Replace the warnings.push('on-chain check not yet implemented...') block with:
+const client = createPublicClient({ chain: baseSepolia, transport: http(manifest.config.rpcUrl) });
+const onChain = {
+  boundSafeAddress: null as string | null,
+  ethBalanceWei: 0n,
+  olasBalanceWei: null as bigint | null,
+};
+
+// Master ETH balance
+try {
+  onChain.ethBalanceWei = await client.getBalance({ address: manifest.operator.masterAddress as Address });
+  if (onChain.ethBalanceWei < MIN_MASTER_ETH_WEI) {
+    failures.push(`master ETH balance ${onChain.ethBalanceWei} below minimum ${MIN_MASTER_ETH_WEI}`);
+  }
+} catch (err) {
+  failures.push(`failed to read master ETH balance: ${(err as Error).message}`);
+}
+
+// AgentId binding (skip if pre-fleet shape)
+if (manifest.shape === 'current' && manifest.operator.fleetAgentId !== null && manifest.operator.fleetSafeAddress !== null) {
+  try {
+    const bound = await client.readContract({
+      address: manifest.operator.identityRegistry as Address,
+      abi: IDENTITY_REGISTRY_ABI,
+      functionName: 'getAgentWallet',
+      args: [BigInt(manifest.operator.fleetAgentId)],
+    });
+    onChain.boundSafeAddress = bound;
+    if (bound.toLowerCase() !== manifest.operator.fleetSafeAddress.toLowerCase()) {
+      failures.push(`identityRegistry.getAgentWallet(${manifest.operator.fleetAgentId})=${bound} does not match manifest.fleetSafeAddress=${manifest.operator.fleetSafeAddress}`);
+    }
+  } catch (err) {
+    failures.push(`failed to read identityRegistry.getAgentWallet: ${(err as Error).message}`);
+  }
+}
+
+// OLAS balance on Safe (informational; staked balance is locked so we just check)
+try {
+  onChain.olasBalanceWei = await client.readContract({
+    address: OLAS_TOKEN_ADDRESS_BASE_SEPOLIA,
+    abi: OLAS_TOKEN_ABI,
+    functionName: 'balanceOf',
+    args: [manifest.operator.safeAddress as Address],
+  });
+} catch {
+  // Non-blocking; legacy ops or future schema may not have OLAS readable
+}
+
+return { opName, ok: failures.length === 0, failures, warnings, onChain };
+```
+
+- [ ] **Step 5: Run all verify tests**
+
+Run: `cd client && yarn vitest run test/release/substrate/verify.test.ts`
+Expected: 4 tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/scripts/release/substrate-verify.ts client/test/release/substrate/verify.test.ts client/test/release/substrate/helpers/anvil-fork.ts
+git commit -m "feat(substrate): add on-chain identity verification to substrate-verify"
+```
+
+---
+
+## Task 6: substrate-adopt — single operator copy + manifest write
+
+**Files:**
+- Create: `client/scripts/release/substrate-adopt.ts`
+- Test: `client/test/release/substrate/adopt.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// client/test/release/substrate/adopt.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { adoptOperator } from '../../../scripts/release/substrate-adopt';
+
+describe('substrate-adopt', () => {
+  let tmpRoot: string;
+  const fixtureDir = path.resolve(__dirname, 'fixtures', 'op-a-fixture', '.jinn-client');
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'substrate-adopt-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('copies a source operator dir into gold with the expected layout', async () => {
+    await adoptOperator({
+      sourceDir: fixtureDir,
+      opName: 'op-a',
+      role: 'launcher',
+      shape: 'current',
+      apiPort: 7332,
+      substrateRoot: tmpRoot,
+    });
+
+    const goldOp = path.join(tmpRoot, 'operators', 'op-a');
+    await expect(fs.access(path.join(goldOp, 'manifest.json'))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(goldOp, '.jinn-client', 'config.json'))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(goldOp, '.jinn-client', 'earning', 'earning_state.json'))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(goldOp, '.jinn-client', 'keystore-password'))).resolves.toBeUndefined();
+  });
+
+  it('writes a manifest matching the source operator state', async () => {
+    await adoptOperator({
+      sourceDir: fixtureDir,
+      opName: 'op-a',
+      role: 'launcher',
+      shape: 'current',
+      apiPort: 7332,
+      substrateRoot: tmpRoot,
+    });
+
+    const manifestRaw = await fs.readFile(path.join(tmpRoot, 'operators', 'op-a', 'manifest.json'), 'utf-8');
+    const manifest = JSON.parse(manifestRaw);
+    expect(manifest.name).toBe('op-a');
+    expect(manifest.shape).toBe('current');
+    expect(manifest.role).toBe('launcher');
+    expect(manifest.network).toBe('base-sepolia');
+    expect(manifest.operator.masterAddress).toBe('0x1111111111111111111111111111111111111111');
+    expect(manifest.operator.fleetAgentId).toBe('99001');
+    expect(manifest.config.apiPort).toBe(7332);
+  });
+
+  it('rewrites apiPort in the copied config.json', async () => {
+    await adoptOperator({
+      sourceDir: fixtureDir,
+      opName: 'op-a',
+      role: 'launcher',
+      shape: 'current',
+      apiPort: 7340,
+      substrateRoot: tmpRoot,
+    });
+
+    const cfgRaw = await fs.readFile(path.join(tmpRoot, 'operators', 'op-a', '.jinn-client', 'config.json'), 'utf-8');
+    const cfg = JSON.parse(cfgRaw);
+    expect(cfg.apiPort).toBe(7340);
+  });
+
+  it('excludes engine/, logs, and backups from the copy', async () => {
+    // seed the source dir with some junk to make sure it's excluded
+    const dirtySource = await fs.mkdtemp(path.join(os.tmpdir(), 'dirty-source-'));
+    await fs.cp(fixtureDir, path.join(dirtySource, '.jinn-client'), { recursive: true });
+    await fs.mkdir(path.join(dirtySource, '.jinn-client', 'engine', 'work'), { recursive: true });
+    await fs.writeFile(path.join(dirtySource, '.jinn-client', 'engine', 'work', 'fake-task.json'), '{}');
+    await fs.writeFile(path.join(dirtySource, '.jinn-client', 'daemon-20260101.log'), 'old');
+    await fs.writeFile(path.join(dirtySource, '.jinn-client', 'jinn.db.bak-20260101'), 'backup');
+
+    await adoptOperator({
+      sourceDir: path.join(dirtySource, '.jinn-client'),
+      opName: 'op-a',
+      role: 'launcher',
+      shape: 'current',
+      apiPort: 7332,
+      substrateRoot: tmpRoot,
+    });
+
+    const goldOp = path.join(tmpRoot, 'operators', 'op-a', '.jinn-client');
+    await expect(fs.access(path.join(goldOp, 'engine'))).rejects.toThrow();
+    await expect(fs.access(path.join(goldOp, 'daemon-20260101.log'))).rejects.toThrow();
+    await expect(fs.access(path.join(goldOp, 'jinn.db.bak-20260101'))).rejects.toThrow();
+
+    await fs.rm(dirtySource, { recursive: true, force: true });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd client && yarn vitest run test/release/substrate/adopt.test.ts`
+Expected: FAIL with `Cannot find module '../../../scripts/release/substrate-adopt'`
+
+- [ ] **Step 3: Implement substrate-adopt**
+
+```typescript
+// client/scripts/release/substrate-adopt.ts
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { goldPath } from './substrate-paths';
+import type { Manifest } from './types';
+import { ManifestSchema } from './types';
+
+const EXCLUDE_DIRS = new Set(['engine']);
+const EXCLUDE_PATTERNS: RegExp[] = [
+  /^jinn\.db\.bak/,
+  /^config\.before/,
+  /^config\.json\.pre/,
+  /^daemon-/,
+  /\.log$/,
+  /^run-/,
+];
+
+export interface AdoptOptions {
+  sourceDir: string;            // path to the existing .jinn-client/ dir
+  opName: string;               // "op-a", "op-b", etc.
+  role: Manifest['role'];
+  shape: Manifest['shape'];
+  apiPort: number;
+  substrateRoot?: string;
+}
+
+async function copyTreeWithExcludes(srcDir: string, dstDir: string): Promise<void> {
+  await fs.mkdir(dstDir, { recursive: true });
+  const entries = await fs.readdir(srcDir, { withFileTypes: true });
+  for (const ent of entries) {
+    if (EXCLUDE_DIRS.has(ent.name)) continue;
+    if (EXCLUDE_PATTERNS.some((re) => re.test(ent.name))) continue;
+    const srcPath = path.join(srcDir, ent.name);
+    const dstPath = path.join(dstDir, ent.name);
+    if (ent.isDirectory()) {
+      await copyTreeWithExcludes(srcPath, dstPath);
+    } else if (ent.isFile()) {
+      await fs.copyFile(srcPath, dstPath);
+      // preserve mode (keystore-password should remain chmod 600)
+      const stat = await fs.stat(srcPath);
+      await fs.chmod(dstPath, stat.mode);
+    }
+  }
+}
+
+async function readJsonOrNull<T>(p: string): Promise<T | null> {
+  try {
+    return JSON.parse(await fs.readFile(p, 'utf-8')) as T;
+  } catch {
+    return null;
+  }
+}
+
+interface SourceEarningState {
+  master_address: string;
+  chain: string;
+  fleet_agent_id?: string;
+  fleet_safe_address?: string;
+  fleet_identity_registry?: string;
+  fleet_stage?: string;
+  services?: Array<{
+    agent_address: string;
+    safe_address: string;
+    service_id: number;
+    mech_address?: string;
+    staking_address?: string;
+    identity_registry_address?: string;
+    step?: string;
+  }>;
+}
+
+interface SourceConfig {
+  rpcUrl?: string;
+  apiPort?: number;
+  joinedSolverNets?: Record<string, unknown>;
+}
+
+export async function adoptOperator(opts: AdoptOptions): Promise<void> {
+  const gold = goldPath(opts.opName, opts.substrateRoot);
+  const goldJinn = path.join(gold, '.jinn-client');
+
+  // 1. Clear any existing gold for this op
+  await fs.rm(gold, { recursive: true, force: true });
+  await fs.mkdir(goldJinn, { recursive: true });
+
+  // 2. Copy the source dir with excludes
+  await copyTreeWithExcludes(opts.sourceDir, goldJinn);
+
+  // 3. Rewrite apiPort in the copied config.json
+  const cfgPath = path.join(goldJinn, 'config.json');
+  const cfg = await readJsonOrNull<SourceConfig>(cfgPath);
+  if (cfg) {
+    cfg.apiPort = opts.apiPort;
+    await fs.writeFile(cfgPath, JSON.stringify(cfg, null, 2) + '\n');
+  }
+
+  // 4. Read earning_state.json to populate manifest
+  const statePath = path.join(goldJinn, 'earning', 'earning_state.json');
+  const state = await readJsonOrNull<SourceEarningState>(statePath);
+  if (!state) {
+    throw new Error(`source operator at ${opts.sourceDir} has no earning/earning_state.json`);
+  }
+  const svc = state.services?.[0];
+
+  // 5. Build manifest
+  const manifest: Manifest = {
+    substrateVersion: '1',
+    createdAt: new Date().toISOString(),
+    adoptedFrom: opts.sourceDir,
+    name: opts.opName,
+    shape: opts.shape,
+    role: opts.role,
+    network: state.chain === 'base-sepolia' ? 'base-sepolia' : 'base',
+    operator: {
+      masterAddress: state.master_address,
+      fleetAgentId: state.fleet_agent_id ?? null,
+      fleetSafeAddress: state.fleet_safe_address ?? null,
+      fleetStage: state.fleet_stage ?? null,
+      serviceId: svc?.service_id ?? 0,
+      serviceStep: svc?.step ?? 'unknown',
+      agentEoa: svc?.agent_address ?? '0x0000000000000000000000000000000000000000',
+      safeAddress: svc?.safe_address ?? '0x0000000000000000000000000000000000000000',
+      mechAddress: svc?.mech_address ?? '0x0000000000000000000000000000000000000000',
+      stakingAddress: svc?.staking_address ?? '0x0000000000000000000000000000000000000000',
+      identityRegistry: svc?.identity_registry_address ?? state.fleet_identity_registry ?? '0x0000000000000000000000000000000000000000',
+    },
+    config: {
+      apiPort: opts.apiPort,
+      rpcUrl: cfg?.rpcUrl ?? 'https://base-sepolia.example/unknown',
+      joinedSolverNets: cfg?.joinedSolverNets ? Object.keys(cfg.joinedSolverNets) : [],
+    },
+  };
+
+  // 6. Validate manifest before writing
+  ManifestSchema.parse(manifest);
+
+  // 7. Write manifest
+  await fs.writeFile(path.join(gold, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n');
+}
+
+async function cliMain(): Promise<void> {
+  // Parse --from <dir> --as <name> --role <role> --shape <shape> --apiPort <port>
+  // (one set of args; for multiple ops, invoke multiple times)
+  const args = process.argv.slice(2);
+  const argMap: Record<string, string> = {};
+  for (let i = 0; i < args.length; i++) {
+    if (args[i].startsWith('--')) {
+      const key = args[i].slice(2);
+      const val = args[i + 1];
+      if (!val) { console.error(`missing value for --${key}`); process.exit(2); }
+      argMap[key] = val;
+      i++;
+    }
+  }
+  const { from, as: opName, role, shape, apiPort } = argMap;
+  if (!from || !opName || !role || !shape || !apiPort) {
+    console.error('usage: substrate-adopt --from <.jinn-client-dir> --as <op-name> --role <launcher|participant|legacy-backup> --shape <current|pre-fleet> --apiPort <port>');
+    process.exit(2);
+  }
+  await adoptOperator({
+    sourceDir: from,
+    opName,
+    role: role as Manifest['role'],
+    shape: shape as Manifest['shape'],
+    apiPort: parseInt(apiPort, 10),
+  });
+  console.log(`adopted ${opName} from ${from}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  cliMain().catch((err) => {
+    console.error(err);
+    process.exit(2);
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd client && yarn vitest run test/release/substrate/adopt.test.ts`
+Expected: PASS, 4 tests passing
+
+- [ ] **Step 5: Run substrate-verify on the adopted result as a sanity check**
+
+```typescript
+// append to client/test/release/substrate/adopt.test.ts
+import { verifySubstrate } from '../../../scripts/release/substrate-verify';
+
+it('adopted op-a passes substrate-verify (skip on-chain)', async () => {
+  await adoptOperator({
+    sourceDir: fixtureDir,
+    opName: 'op-a',
+    role: 'launcher',
+    shape: 'current',
+    apiPort: 7332,
+    substrateRoot: tmpRoot,
+  });
+  const result = await verifySubstrate('op-a', { substrateRoot: tmpRoot, skipOnChain: true });
+  expect(result.ok).toBe(true);
+  expect(result.failures).toEqual([]);
+});
+```
+
+Run: `cd client && yarn vitest run test/release/substrate/adopt.test.ts`
+Expected: PASS, 5 tests passing
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/scripts/release/substrate-adopt.ts client/test/release/substrate/adopt.test.ts
+git commit -m "feat(substrate): add substrate-adopt for copying existing operator state into gold"
+```
+
+---
+
+## Task 7: substrate-copy — workspace creation
+
+**Files:**
+- Create: `client/scripts/release/substrate-copy.ts`
+- Test: `client/test/release/substrate/copy.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// client/test/release/substrate/copy.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { adoptOperator } from '../../../scripts/release/substrate-adopt';
+import { copyWorkspace } from '../../../scripts/release/substrate-copy';
+
+describe('substrate-copy', () => {
+  let tmpRoot: string;
+  const opAFixture = path.resolve(__dirname, 'fixtures', 'op-a-fixture', '.jinn-client');
+  const opBFixture = path.resolve(__dirname, 'fixtures', 'op-b-fixture', '.jinn-client');
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'substrate-copy-'));
+    await adoptOperator({ sourceDir: opAFixture, opName: 'op-a', role: 'launcher', shape: 'current', apiPort: 7332, substrateRoot: tmpRoot });
+    await adoptOperator({ sourceDir: opBFixture, opName: 'op-b', role: 'participant', shape: 'current', apiPort: 7333, substrateRoot: tmpRoot });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('creates per-run workspace from gold', async () => {
+    const handle = await copyWorkspace({ ops: ['op-a', 'op-b'], substrateRoot: tmpRoot });
+    expect(handle.runId).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-/);
+
+    for (const opName of ['op-a', 'op-b']) {
+      const wsOp = path.join(handle.workspaceRoot, opName);
+      await expect(fs.access(path.join(wsOp, 'manifest.json'))).resolves.toBeUndefined();
+      await expect(fs.access(path.join(wsOp, '.jinn-client', 'config.json'))).resolves.toBeUndefined();
+    }
+  });
+
+  it('teardown removes the workspace dir', async () => {
+    const handle = await copyWorkspace({ ops: ['op-a'], substrateRoot: tmpRoot });
+    expect(handle.workspaceRoot).toContain('workspaces');
+    await fs.access(handle.workspaceRoot);
+    await handle.teardown();
+    await expect(fs.access(handle.workspaceRoot)).rejects.toThrow();
+  });
+
+  it('teardown is idempotent', async () => {
+    const handle = await copyWorkspace({ ops: ['op-a'], substrateRoot: tmpRoot });
+    await handle.teardown();
+    await expect(handle.teardown()).resolves.toBeUndefined();
+  });
+
+  it('returns per-op paths for ergonomic use', async () => {
+    const handle = await copyWorkspace({ ops: ['op-a', 'op-b'], substrateRoot: tmpRoot });
+    expect(handle.opPaths['op-a']).toContain('op-a');
+    expect(handle.opPaths['op-b']).toContain('op-b');
+    expect(handle.opPaths['op-a']).not.toContain('op-b');
+  });
+
+  it('throws if requested op is not in gold', async () => {
+    await expect(copyWorkspace({ ops: ['op-z'], substrateRoot: tmpRoot })).rejects.toThrow(/op-z/);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd client && yarn vitest run test/release/substrate/copy.test.ts`
+Expected: FAIL with `Cannot find module '../../../scripts/release/substrate-copy'`
+
+- [ ] **Step 3: Implement substrate-copy**
+
+```typescript
+// client/scripts/release/substrate-copy.ts
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { goldPath, workspacePath, generateRunId } from './substrate-paths';
+
+export interface CopyWorkspaceOptions {
+  ops: string[];                    // names of gold ops to include
+  substrateRoot?: string;
+  runId?: string;                   // override the generated run-id
+}
+
+export interface WorkspaceHandle {
+  runId: string;
+  workspaceRoot: string;            // ~/jinn-dev/workspaces/<run-id>/
+  opPaths: Record<string, string>;  // opName → ~/jinn-dev/workspaces/<run-id>/<opName>/
+  teardown: () => Promise<void>;
+}
+
+async function copyDir(src: string, dst: string): Promise<void> {
+  await fs.mkdir(dst, { recursive: true });
+  const entries = await fs.readdir(src, { withFileTypes: true });
+  for (const ent of entries) {
+    const s = path.join(src, ent.name);
+    const d = path.join(dst, ent.name);
+    if (ent.isDirectory()) {
+      await copyDir(s, d);
+    } else if (ent.isFile()) {
+      await fs.copyFile(s, d);
+      const stat = await fs.stat(s);
+      await fs.chmod(d, stat.mode);
+    }
+  }
+}
+
+export async function copyWorkspace(opts: CopyWorkspaceOptions): Promise<WorkspaceHandle> {
+  const runId = opts.runId ?? generateRunId();
+  const opPaths: Record<string, string> = {};
+
+  // Validate every requested op exists in gold first
+  for (const opName of opts.ops) {
+    const src = goldPath(opName, opts.substrateRoot);
+    try {
+      await fs.access(src);
+    } catch {
+      throw new Error(`gold operator ${opName} not found at ${src}`);
+    }
+  }
+
+  // Copy each op
+  for (const opName of opts.ops) {
+    const src = goldPath(opName, opts.substrateRoot);
+    const dst = workspacePath(runId, opName, opts.substrateRoot);
+    await copyDir(src, dst);
+    opPaths[opName] = dst;
+  }
+
+  const workspaceRoot = path.dirname(opPaths[opts.ops[0]]);
+
+  // Tag the workspace with provenance
+  await fs.writeFile(
+    path.join(workspaceRoot, '.created-by'),
+    JSON.stringify({ runId, createdAt: new Date().toISOString(), ops: opts.ops }, null, 2) + '\n',
+  );
+
+  return {
+    runId,
+    workspaceRoot,
+    opPaths,
+    teardown: async () => {
+      await fs.rm(workspaceRoot, { recursive: true, force: true });
+    },
+  };
+}
+
+async function cliMain(): Promise<void> {
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    console.error('usage: substrate-copy <op-name> [<op-name> ...]');
+    process.exit(2);
+  }
+  const handle = await copyWorkspace({ ops: args });
+  console.log(JSON.stringify({ runId: handle.runId, workspaceRoot: handle.workspaceRoot, opPaths: handle.opPaths }, null, 2));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  cliMain().catch((err) => {
+    console.error(err);
+    process.exit(2);
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd client && yarn vitest run test/release/substrate/copy.test.ts`
+Expected: PASS, 5 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/scripts/release/substrate-copy.ts client/test/release/substrate/copy.test.ts
+git commit -m "feat(substrate): add substrate-copy for per-run workspace creation"
+```
+
+---
+
+## Task 8: substrate-topup — balance check and gap surfacing
+
+**Files:**
+- Create: `client/scripts/release/substrate-topup.ts`
+- Test: `client/test/release/substrate/topup.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// client/test/release/substrate/topup.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { adoptOperator } from '../../../scripts/release/substrate-adopt';
+import { checkSubstrateTopup } from '../../../scripts/release/substrate-topup';
+import { spawnAnvilFork, type AnvilForkHandle } from './helpers/anvil-fork';
+
+describe('substrate-topup', () => {
+  let tmpRoot: string;
+  let anvil: AnvilForkHandle;
+  const opAFixture = path.resolve(__dirname, 'fixtures', 'op-a-fixture', '.jinn-client');
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'substrate-topup-'));
+    anvil = await spawnAnvilFork();
+    await adoptOperator({ sourceDir: opAFixture, opName: 'op-a', role: 'launcher', shape: 'current', apiPort: 7332, substrateRoot: tmpRoot });
+    // Override the manifest's rpcUrl to the local Anvil for the test
+    const manifestPath = path.join(tmpRoot, 'operators', 'op-a', 'manifest.json');
+    const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf-8'));
+    manifest.config.rpcUrl = anvil.rpcUrl;
+    await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+  });
+
+  afterEach(async () => {
+    await anvil.stop();
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('reports ok=false when master ETH balance is zero', async () => {
+    const result = await checkSubstrateTopup('op-a', { substrateRoot: tmpRoot });
+    expect(result.ok).toBe(false);
+    expect(result.needs.some((n) => n.resource === 'ETH' && n.have === 0n)).toBe(true);
+  });
+
+  it('reports the ETH delta to topup', async () => {
+    const result = await checkSubstrateTopup('op-a', { substrateRoot: tmpRoot });
+    const ethNeed = result.needs.find((n) => n.resource === 'ETH');
+    expect(ethNeed).toBeDefined();
+    expect(ethNeed!.want).toBeGreaterThan(ethNeed!.have);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd client && yarn vitest run test/release/substrate/topup.test.ts`
+Expected: FAIL with `Cannot find module '../../../scripts/release/substrate-topup'`
+
+- [ ] **Step 3: Implement substrate-topup**
+
+```typescript
+// client/scripts/release/substrate-topup.ts
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { createPublicClient, http, parseAbi, type Address } from 'viem';
+import { baseSepolia } from 'viem/chains';
+import { ManifestSchema, type TopupResult, type Manifest } from './types';
+import { goldPath } from './substrate-paths';
+
+const TARGET_ETH_WEI = 5_000_000_000_000_000n;       // 0.005 ETH
+const TARGET_USDC_UNITS = 1_000_000n;                // 1.00 USDC (6 decimals)
+const USDC_BASE_SEPOLIA: Address = '0x036CbD53842c5426634e7929541eC2318f3dCF7e';
+const ERC20_ABI = parseAbi(['function balanceOf(address) view returns (uint256)']);
+
+export interface TopupOptions {
+  substrateRoot?: string;
+}
+
+export async function checkSubstrateTopup(opName: string, opts: TopupOptions = {}): Promise<TopupResult> {
+  const opDir = goldPath(opName, opts.substrateRoot);
+  const manifestRaw = await fs.readFile(path.join(opDir, 'manifest.json'), 'utf-8');
+  const manifest: Manifest = ManifestSchema.parse(JSON.parse(manifestRaw));
+
+  const client = createPublicClient({ chain: baseSepolia, transport: http(manifest.config.rpcUrl) });
+  const needs: TopupResult['needs'] = [];
+
+  // ETH on master EOA (for posting txs from substrate ops)
+  const ethBalance = await client.getBalance({ address: manifest.operator.masterAddress as Address });
+  if (ethBalance < TARGET_ETH_WEI) {
+    needs.push({ resource: 'ETH', have: ethBalance, want: TARGET_ETH_WEI });
+  }
+
+  // USDC on Safe (for x402 payments — only if op participates in donation scenarios)
+  try {
+    const usdcBalance = await client.readContract({
+      address: USDC_BASE_SEPOLIA,
+      abi: ERC20_ABI,
+      functionName: 'balanceOf',
+      args: [manifest.operator.safeAddress as Address],
+    });
+    if (usdcBalance < TARGET_USDC_UNITS) {
+      needs.push({ resource: 'USDC', have: usdcBalance, want: TARGET_USDC_UNITS });
+    }
+  } catch {
+    // USDC token might not be deployed on the local fork; treat as zero
+    needs.push({ resource: 'USDC', have: 0n, want: TARGET_USDC_UNITS });
+  }
+
+  return { opName, needs, ok: needs.length === 0 };
+}
+
+async function cliMain(): Promise<void> {
+  const opName = process.argv[2];
+  if (!opName) {
+    console.error('usage: substrate-topup <op-name>');
+    process.exit(2);
+  }
+  const result = await checkSubstrateTopup(opName);
+  console.log(JSON.stringify(
+    {
+      opName: result.opName,
+      ok: result.ok,
+      needs: result.needs.map((n) => ({ ...n, have: n.have.toString(), want: n.want.toString() })),
+    },
+    null,
+    2,
+  ));
+  if (!result.ok) {
+    console.error('\nSubstrate op has low balances. Fund manually or via release-bot wallet:');
+    for (const n of result.needs) {
+      console.error(`  - ${n.resource}: have ${n.have.toString()}, want ${n.want.toString()}`);
+    }
+    process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  cliMain().catch((err) => {
+    console.error(err);
+    process.exit(2);
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd client && yarn vitest run test/release/substrate/topup.test.ts`
+Expected: PASS, 2 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/scripts/release/substrate-topup.ts client/test/release/substrate/topup.test.ts
+git commit -m "feat(substrate): add substrate-topup balance check (surface gaps, no auto-drip)"
+```
+
+---
+
+## Task 9: substrate-reap — workspace age-based pruning
+
+**Files:**
+- Create: `client/scripts/release/substrate-reap.ts`
+- Test: `client/test/release/substrate/reap.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// client/test/release/substrate/reap.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { reapWorkspaces } from '../../../scripts/release/substrate-reap';
+
+describe('substrate-reap', () => {
+  let tmpRoot: string;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'substrate-reap-'));
+    await fs.mkdir(path.join(tmpRoot, 'workspaces'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  async function seedWorkspace(name: string, ageDays: number): Promise<void> {
+    const wsDir = path.join(tmpRoot, 'workspaces', name);
+    await fs.mkdir(wsDir, { recursive: true });
+    await fs.writeFile(path.join(wsDir, '.created-by'), JSON.stringify({ runId: name }));
+    const ageMs = Date.now() - ageDays * 24 * 60 * 60 * 1000;
+    const time = new Date(ageMs);
+    await fs.utimes(wsDir, time, time);
+  }
+
+  it('removes workspaces older than 7 days', async () => {
+    await seedWorkspace('old-workspace', 10);
+    await seedWorkspace('fresh-workspace', 1);
+
+    const result = await reapWorkspaces({ substrateRoot: tmpRoot, maxAgeDays: 7 });
+
+    expect(result.reaped).toEqual(['old-workspace']);
+    await expect(fs.access(path.join(tmpRoot, 'workspaces', 'old-workspace'))).rejects.toThrow();
+    await expect(fs.access(path.join(tmpRoot, 'workspaces', 'fresh-workspace'))).resolves.toBeUndefined();
+  });
+
+  it('returns empty list when nothing is old enough', async () => {
+    await seedWorkspace('fresh-1', 2);
+    await seedWorkspace('fresh-2', 5);
+
+    const result = await reapWorkspaces({ substrateRoot: tmpRoot, maxAgeDays: 7 });
+
+    expect(result.reaped).toEqual([]);
+    expect(result.kept).toHaveLength(2);
+  });
+
+  it('handles empty workspaces dir gracefully', async () => {
+    const result = await reapWorkspaces({ substrateRoot: tmpRoot, maxAgeDays: 7 });
+    expect(result.reaped).toEqual([]);
+    expect(result.kept).toEqual([]);
+  });
+
+  it('skips non-directory entries', async () => {
+    await fs.writeFile(path.join(tmpRoot, 'workspaces', 'a-file.txt'), 'not a dir');
+    const result = await reapWorkspaces({ substrateRoot: tmpRoot, maxAgeDays: 7 });
+    expect(result.reaped).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd client && yarn vitest run test/release/substrate/reap.test.ts`
+Expected: FAIL with `Cannot find module '../../../scripts/release/substrate-reap'`
+
+- [ ] **Step 3: Implement substrate-reap**
+
+```typescript
+// client/scripts/release/substrate-reap.ts
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { workspacesRoot } from './substrate-paths';
+
+export interface ReapOptions {
+  substrateRoot?: string;
+  maxAgeDays?: number;             // default 7
+}
+
+export interface ReapResult {
+  reaped: string[];                // workspace dir names removed
+  kept: string[];                  // workspace dir names retained
+}
+
+export async function reapWorkspaces(opts: ReapOptions = {}): Promise<ReapResult> {
+  const maxAgeDays = opts.maxAgeDays ?? 7;
+  const root = workspacesRoot(opts.substrateRoot);
+  const cutoffMs = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
+
+  const reaped: string[] = [];
+  const kept: string[] = [];
+
+  let entries: Awaited<ReturnType<typeof fs.readdir>>;
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { reaped, kept };
+    }
+    throw err;
+  }
+
+  for (const ent of entries) {
+    if (!ent.isDirectory()) continue;
+    const fullPath = path.join(root, ent.name);
+    const stat = await fs.stat(fullPath);
+    if (stat.mtimeMs < cutoffMs) {
+      await fs.rm(fullPath, { recursive: true, force: true });
+      reaped.push(ent.name);
+    } else {
+      kept.push(ent.name);
+    }
+  }
+
+  return { reaped, kept };
+}
+
+async function cliMain(): Promise<void> {
+  const result = await reapWorkspaces();
+  console.log(JSON.stringify(result, null, 2));
+  if (result.reaped.length > 0) {
+    console.error(`reaped ${result.reaped.length} workspace(s) older than 7 days`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  cliMain().catch((err) => {
+    console.error(err);
+    process.exit(2);
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd client && yarn vitest run test/release/substrate/reap.test.ts`
+Expected: PASS, 4 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/scripts/release/substrate-reap.ts client/test/release/substrate/reap.test.ts
+git commit -m "feat(substrate): add substrate-reap for workspace age-based pruning"
+```
+
+---
+
+## Task 10: Wire yarn scripts in package.json
+
+**Files:**
+- Modify: `client/package.json`
+
+- [ ] **Step 1: Read the current package.json scripts section**
+
+Run: `cd client && cat package.json | head -50`
+Expected output shows existing `scripts:` block.
+
+- [ ] **Step 2: Add the substrate-related yarn scripts**
+
+Open `client/package.json` and add these entries inside the `"scripts"` object (preserve existing entries; add alphabetically near other release/staking scripts):
+
+```json
+{
+  "scripts": {
+    "substrate:adopt": "tsx scripts/release/substrate-adopt.ts",
+    "substrate:copy": "tsx scripts/release/substrate-copy.ts",
+    "substrate:verify": "tsx scripts/release/substrate-verify.ts",
+    "substrate:topup": "tsx scripts/release/substrate-topup.ts",
+    "substrate:reap": "tsx scripts/release/substrate-reap.ts"
+  }
+}
+```
+
+(If `tsx` isn't already a devDependency, check by running `cd client && yarn list --pattern tsx | head -3`. If absent, this task should not add it — surface as a follow-up. If present, the entries above work directly.)
+
+- [ ] **Step 3: Verify yarn scripts run (smoke test the help paths)**
+
+Run: `cd client && yarn substrate:adopt 2>&1 | head -5`
+Expected output: `usage: substrate-adopt --from <.jinn-client-dir> --as <op-name> ...` (and exit code 2)
+
+Run: `cd client && yarn substrate:verify 2>&1 | head -5`
+Expected output: `usage: substrate-verify <op-name> [--skip-on-chain]`
+
+Run: `cd client && yarn substrate:copy 2>&1 | head -5`
+Expected output: `usage: substrate-copy <op-name> [<op-name> ...]`
+
+Run: `cd client && yarn substrate:topup 2>&1 | head -5`
+Expected output: `usage: substrate-topup <op-name>`
+
+Run: `cd client && yarn substrate:reap 2>&1 | tail -5`
+Expected output: `{ "reaped": [], "kept": [...] }` (exit 0 if substrate exists; ENOENT-handled if not)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/package.json
+git commit -m "chore(substrate): wire yarn scripts for substrate lifecycle ops"
+```
+
+---
+
+## Task 11: README for substrate scripts
+
+**Files:**
+- Create: `client/scripts/release/README.md`
+
+- [ ] **Step 1: Write the README**
+
+```markdown
+# Substrate scripts
+
+Lifecycle scripts for the test-operator substrate at `~/jinn-dev/operators/`.
+Spec: `docs/superpowers/specs/2026-05-19-release-readiness-and-substrate-design.md`.
+
+## Operations
+
+### substrate-adopt
+
+Copy an existing operator state dir into the gold substrate. One operator at a time.
+
+```bash
+yarn substrate:adopt \
+  --from ~/.jinn-client/ \
+  --as op-a \
+  --role launcher \
+  --shape current \
+  --apiPort 7332
+```
+
+Excludes `engine/`, `*.log`, `jinn.db.bak*`, `config.before*`, `config.json.pre*`, `daemon-*`, `run-*` from the copy. Writes `manifest.json` with identity captured from `earning/earning_state.json`.
+
+### substrate-copy
+
+Per-run workspace copy from gold. Returns a JSON handle with `runId`, `workspaceRoot`, and `opPaths`.
+
+```bash
+yarn substrate:copy op-a op-b
+```
+
+The workspace lives at `~/jinn-dev/workspaces/<run-id>/`. Caller is responsible for teardown (`rm -rf $workspaceRoot`) — or use `reapWorkspaces()` to garbage-collect.
+
+### substrate-verify
+
+Manifest schema check plus on-chain identity verification.
+
+```bash
+yarn substrate:verify op-a
+yarn substrate:verify op-a --skip-on-chain
+```
+
+Exits non-zero on any failure. JSON result on stdout includes `failures`, `warnings`, and `onChain` snapshot.
+
+### substrate-topup
+
+Reports low balances on substrate operators. Does not auto-drip; surfaces gaps for manual top-up via faucet or release-bot wallet.
+
+```bash
+yarn substrate:topup op-a
+```
+
+Targets: 0.005 ETH master, 1.00 USDC safe. Exits non-zero if any below threshold.
+
+### substrate-reap
+
+Garbage-collects workspaces older than 7 days under `~/jinn-dev/workspaces/`.
+
+```bash
+yarn substrate:reap
+```
+
+Safe to run any time. JSON result on stdout shows `reaped` and `kept` workspace names.
+
+## Programmatic API
+
+Each script exports its core function for use from other scripts or skills:
+
+```typescript
+import { adoptOperator } from 'client/scripts/release/substrate-adopt';
+import { copyWorkspace } from 'client/scripts/release/substrate-copy';
+import { verifySubstrate } from 'client/scripts/release/substrate-verify';
+import { checkSubstrateTopup } from 'client/scripts/release/substrate-topup';
+import { reapWorkspaces } from 'client/scripts/release/substrate-reap';
+```
+
+## Manifest schema
+
+See `types.ts` for the Zod schema and `Manifest` TypeScript type.
+
+## Failure modes
+
+| Operation | Failure | Recovery |
+|---|---|---|
+| adopt | source dir missing earning_state.json | fix source state or pick a different source |
+| verify | manifest schema mismatch | re-adopt (substrate may have changed shape) |
+| verify | on-chain agentId doesn't match safeAddress | substrate is stale; investigate |
+| verify | master ETH balance too low | run substrate-topup; fund manually |
+| copy | requested op not in gold | run substrate-adopt for that op first |
+| topup | low balance | fund manually from release-bot wallet |
+| reap | none expected — idempotent | n/a |
+```
+
+Save as `client/scripts/release/README.md`.
+
+- [ ] **Step 2: Verify the file**
+
+Run: `cd client && cat scripts/release/README.md | head -20`
+Expected: README content shown.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/scripts/release/README.md
+git commit -m "docs(substrate): add README for substrate lifecycle scripts"
+```
+
+---
+
+## Task 12: Re-adopt the current on-disk substrate using the new scripts
+
+**Files:**
+- None modified; this is an integration sanity check.
+
+This task validates that the scripts can reproduce the manual adoption we performed during the spec brainstorm. The existing on-disk substrate at `~/jinn-dev/operators/op-{a,b,c-legacy}/` was created manually with python; this task confirms `substrate-adopt.ts` produces equivalent state.
+
+- [ ] **Step 1: Verify the current substrate exists and passes verify**
+
+Run:
+```bash
+cd client
+yarn substrate:verify op-a --skip-on-chain
+yarn substrate:verify op-b --skip-on-chain
+yarn substrate:verify op-c-legacy --skip-on-chain
+```
+
+Expected: all three return `"ok": true` (manifests written during brainstorm should pass schema).
+
+- [ ] **Step 2: Snapshot the current manifests for comparison**
+
+Run:
+```bash
+mkdir -p /tmp/substrate-snapshot-baseline
+cp ~/jinn-dev/operators/op-a/manifest.json /tmp/substrate-snapshot-baseline/op-a.json
+cp ~/jinn-dev/operators/op-b/manifest.json /tmp/substrate-snapshot-baseline/op-b.json
+cp ~/jinn-dev/operators/op-c-legacy/manifest.json /tmp/substrate-snapshot-baseline/op-c-legacy.json
+```
+
+- [ ] **Step 3: Re-adopt op-a via the new script into a tmp substrate root**
+
+Run:
+```bash
+cd client
+TMP_ROOT=$(mktemp -d)
+yarn substrate:adopt \
+  --from ~/.jinn-client/ \
+  --as op-a \
+  --role launcher \
+  --shape current \
+  --apiPort 7332
+# (the above writes to $HOME/jinn-dev/operators/op-a — replacing the manual one;
+#  if you want to keep both, override substrateRoot via env or use the API directly)
+```
+
+For a non-destructive check, use the programmatic API in a one-off script:
+```bash
+cd client
+node -e "
+  require('tsx/cjs');
+  require('./scripts/release/substrate-adopt').adoptOperator({
+    sourceDir: process.env.HOME + '/.jinn-client',
+    opName: 'op-a',
+    role: 'launcher',
+    shape: 'current',
+    apiPort: 7332,
+    substrateRoot: '$TMP_ROOT',
+  }).then(() => console.log('done'));
+"
+```
+
+- [ ] **Step 4: Compare manifests (excluding createdAt timestamp which legitimately differs)**
+
+Run:
+```bash
+jq 'del(.createdAt)' /tmp/substrate-snapshot-baseline/op-a.json > /tmp/baseline-no-ts.json
+jq 'del(.createdAt)' $TMP_ROOT/operators/op-a/manifest.json > /tmp/new-no-ts.json
+diff /tmp/baseline-no-ts.json /tmp/new-no-ts.json
+```
+
+Expected: no diff (or only ordering differences within objects, which are semantically equivalent).
+
+If there's a real diff, investigate which field drifted and fix `substrate-adopt.ts` to match the manual adoption.
+
+- [ ] **Step 5: Tear down the tmp substrate**
+
+```bash
+rm -rf $TMP_ROOT /tmp/substrate-snapshot-baseline /tmp/baseline-no-ts.json /tmp/new-no-ts.json
+```
+
+- [ ] **Step 6: Commit a small fix if needed, otherwise mark task complete**
+
+If a fix was needed, commit it:
+```bash
+git add client/scripts/release/substrate-adopt.ts
+git commit -m "fix(substrate): align substrate-adopt with manual-adoption output"
+```
+
+Otherwise no commit is needed — this task is a validation gate.
+
+---
+
+## Self-review
+
+### Spec coverage
+
+| Spec requirement | Covered by | Status |
+|---|---|---|
+| §2 path layout | Task 2 (paths) | ✓ |
+| §2 manifest schema | Task 1 (types) | ✓ |
+| §2 substrate-adopt | Task 6 | ✓ |
+| §2 substrate-copy | Task 7 | ✓ |
+| §2 substrate-verify | Tasks 4, 5 | ✓ |
+| §2 substrate-topup | Task 8 | ✓ |
+| §2 workspace reaper | Task 9 | ✓ |
+| §7 funding maintenance | Task 8 (surfaces gaps) | ✓ (no auto-drip in v1, as specified) |
+| §7 substrate-snapshot (bootstrap fresh) | deferred per spec | ✓ (intentionally out of scope) |
+
+### Placeholder scan
+
+No TBDs, TODOs, "add appropriate error handling", or "similar to Task N" — each task contains complete code and exact commands.
+
+### Type consistency
+
+Confirmed:
+- `Manifest` type matches across types.ts, substrate-adopt, substrate-verify, substrate-topup, substrate-copy.
+- `verifySubstrate(opName, opts)` signature consistent across Task 4 and Task 5.
+- `WorkspaceHandle` interface defined in Task 7 used as the contract for downstream consumers (release-prep, future plans).
+- `goldPath(opName, substrateRoot?)` signature consistent.
+
+### Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-19-substrate-foundation-plan.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. Uses `superpowers:subagent-driven-development`.
+
+2. **Inline Execution** — Execute tasks in this session using `superpowers:executing-plans`, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/plans/2026-05-19-testing-jinn-app-multi-op-plan.md
+++ b/docs/superpowers/plans/2026-05-19-testing-jinn-app-multi-op-plan.md
@@ -1,0 +1,1661 @@
+# testing-jinn-app multi-op extension implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the existing `testing-jinn-app` skill at `.claude/skills/testing-jinn-app/SKILL.md` to cover multi-operator scenarios. Ships documentation (skill extension + 7 reference docs) plus minimal helper code (multi-op daemon spawn helper + handshake URL capture) that the scenario implementations in Plans C/D consume. Existing single-op recipes stay unchanged.
+
+**Architecture:** Skill is the library; release-prep is the gate runner; release-readiness is the audit. This plan delivers the library. Reference docs describe scenarios at the level of detail Plans C/D's implementation tasks need; minimal helpers (`multi-op-daemon.ts`, `handshake-url.ts`) live in `client/test/helpers/` so Plans C/D import them. The scenario recipes (`scenario-*.md`) are the contract between Plans B (recipe writer) and Plans C/D (recipe consumer).
+
+**Tech Stack:** Markdown for skill + reference docs. TypeScript + Vitest + `child_process` for the spawn helper. Helpers test against a real daemon spawn using a dedicated tmp HOME (no substrate dependency — uses the existing single-op `HOME=$tmpdir` pattern from the current skill).
+
+**Dependencies:**
+- **Plan A (substrate foundation)** — required for runtime of T2.x scenarios in Plans C/D, but NOT for any task in Plan B. Plan B's helpers operate on arbitrary HOME dirs and don't import substrate scripts. The scenario reference docs *describe* how to use substrate-derived workspaces, but the descriptions are static.
+- **No other plans** — Plan B can be written and executed independently.
+
+---
+
+## File structure
+
+**Source files (all new under `client/test/helpers/`):**
+
+| Path | Responsibility |
+|---|---|
+| `client/test/helpers/handshake-url.ts` | Parse handshake URL from a daemon's stdout stream |
+| `client/test/helpers/multi-op-daemon.ts` | Spawn N concurrent daemons with distinct HOMEs and ports; return handles |
+
+**Test files:**
+
+| Path | Covers |
+|---|---|
+| `client/test/helpers/handshake-url.test.ts` | URL parsing for various stdout shapes |
+| `client/test/helpers/multi-op-daemon.test.ts` | Spawn lifecycle: start, ready, teardown |
+
+**Skill files (under `.claude/skills/testing-jinn-app/`):**
+
+| Path | New / modified | Responsibility |
+|---|---|---|
+| `.claude/skills/testing-jinn-app/SKILL.md` | modified | Add "Multi-operator scenarios" section + extend "Things to watch for" |
+| `.claude/skills/testing-jinn-app/references/multi-op-spawn.md` | new | Bash + TypeScript spawn recipes |
+| `.claude/skills/testing-jinn-app/references/multi-op-chrome-devtools.md` | new | Multi-page chrome-devtools driving pattern |
+| `.claude/skills/testing-jinn-app/references/multi-op-playwright.md` | new | Playwright two-daemon test template |
+| `.claude/skills/testing-jinn-app/references/scenario-spa-route-smoke.md` | new | T1.4 recipe (single-op, route smoke) |
+| `.claude/skills/testing-jinn-app/references/scenario-cross-op-donation.md` | new | T2.1 recipe |
+| `.claude/skills/testing-jinn-app/references/scenario-producer-evaluator.md` | new | T2.2 recipe |
+| `.claude/skills/testing-jinn-app/references/scenario-multi-op-spa-flow.md` | new | T2.3 recipe |
+
+No modifications to `client/package.json` or `playwright.config.ts` in this plan — Plans C/D do those.
+
+---
+
+## Task 1: Handshake URL parser
+
+**Files:**
+- Create: `client/test/helpers/handshake-url.ts`
+- Test: `client/test/helpers/handshake-url.test.ts`
+
+The daemon emits a one-time-use handshake URL on stdout/stderr at startup like `UI handshake URL: http://127.0.0.1:7332/auth?token=abc`. This helper extracts it from a stream of stdout lines.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// client/test/helpers/handshake-url.test.ts
+import { describe, it, expect } from 'vitest';
+import { extractHandshakeUrl, makeHandshakeCollector } from './handshake-url';
+
+describe('extractHandshakeUrl', () => {
+  it('extracts URL from a typical daemon line', () => {
+    const line = '[server] UI handshake URL: http://127.0.0.1:7332/auth/handshake?token=abc123';
+    expect(extractHandshakeUrl(line)).toBe('http://127.0.0.1:7332/auth/handshake?token=abc123');
+  });
+
+  it('returns null on non-matching lines', () => {
+    expect(extractHandshakeUrl('some unrelated log line')).toBeNull();
+    expect(extractHandshakeUrl('')).toBeNull();
+  });
+
+  it('handles whitespace variation between label and URL', () => {
+    const line = 'UI handshake URL:       http://localhost:7332/x';
+    expect(extractHandshakeUrl(line)).toBe('http://localhost:7332/x');
+  });
+
+  it('does not match if URL is missing', () => {
+    expect(extractHandshakeUrl('UI handshake URL:')).toBeNull();
+  });
+});
+
+describe('makeHandshakeCollector', () => {
+  it('resolves when URL appears in a chunk', async () => {
+    const collector = makeHandshakeCollector(5000);
+    collector.feed('startup line\n');
+    collector.feed('UI handshake URL: http://127.0.0.1:7332/auth?t=xyz\n');
+    const url = await collector.promise;
+    expect(url).toBe('http://127.0.0.1:7332/auth?t=xyz');
+  });
+
+  it('handles URL split across two feed calls', async () => {
+    const collector = makeHandshakeCollector(5000);
+    collector.feed('UI handshake URL: http://12');
+    collector.feed('7.0.0.1:7332/auth?t=split\n');
+    const url = await collector.promise;
+    expect(url).toBe('http://127.0.0.1:7332/auth?t=split');
+  });
+
+  it('rejects after timeout if URL never arrives', async () => {
+    const collector = makeHandshakeCollector(50);
+    collector.feed('only unrelated lines\n');
+    await expect(collector.promise).rejects.toThrow(/timed out/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd client && yarn vitest run test/helpers/handshake-url.test.ts`
+Expected: FAIL with `Cannot find module './handshake-url'`
+
+- [ ] **Step 3: Implement handshake-url.ts**
+
+```typescript
+// client/test/helpers/handshake-url.ts
+
+const HANDSHAKE_RE = /UI handshake URL:\s+(\S+)/;
+
+export function extractHandshakeUrl(line: string): string | null {
+  const m = line.match(HANDSHAKE_RE);
+  return m ? m[1] : null;
+}
+
+export interface HandshakeCollector {
+  feed: (chunk: string) => void;
+  promise: Promise<string>;
+}
+
+export function makeHandshakeCollector(timeoutMs: number): HandshakeCollector {
+  let buffer = '';
+  let resolve!: (url: string) => void;
+  let reject!: (err: Error) => void;
+  const promise = new Promise<string>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  const timer = setTimeout(() => {
+    reject(new Error(`handshake URL collector timed out after ${timeoutMs}ms; buffered: ${buffer.slice(0, 200)}`));
+  }, timeoutMs);
+  return {
+    feed(chunk: string) {
+      buffer += chunk;
+      const url = extractHandshakeUrl(buffer);
+      if (url) {
+        clearTimeout(timer);
+        resolve(url);
+      }
+    },
+    promise,
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd client && yarn vitest run test/helpers/handshake-url.test.ts`
+Expected: PASS, 7 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/test/helpers/handshake-url.ts client/test/helpers/handshake-url.test.ts
+git commit -m "test(helpers): add handshake URL parser for daemon spawn helpers"
+```
+
+---
+
+## Task 2: Multi-op daemon spawn helper
+
+**Files:**
+- Create: `client/test/helpers/multi-op-daemon.ts`
+- Test: `client/test/helpers/multi-op-daemon.test.ts`
+
+The helper spawns N daemon processes, each with its own HOME (substrate-derived or fresh tmp) and apiPort. Returns handles that include the handshake URL and a teardown function.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// client/test/helpers/multi-op-daemon.test.ts
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { spawnMultiOpDaemons, type MultiOpHandle } from './multi-op-daemon';
+
+describe('spawnMultiOpDaemons', () => {
+  let tmpRoot: string;
+  let opAHome: string;
+  let opBHome: string;
+
+  beforeAll(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'multi-op-helper-'));
+    opAHome = path.join(tmpRoot, 'op-a');
+    opBHome = path.join(tmpRoot, 'op-b');
+    await fs.mkdir(path.join(opAHome, '.jinn-client'), { recursive: true });
+    await fs.mkdir(path.join(opBHome, '.jinn-client'), { recursive: true });
+    // Seed minimal config so the daemon doesn't error out on missing fields.
+    // (Real tests will use substrate-copy workspaces; this test just exercises the helper.)
+    const minimalCfg = (port: number) => JSON.stringify({
+      network: 'testnet',
+      apiPort: port,
+      rpcUrl: 'https://base-sepolia.example/dummy',
+      pollIntervalMs: 5000,
+    });
+    await fs.writeFile(path.join(opAHome, '.jinn-client', 'config.json'), minimalCfg(7732));
+    await fs.writeFile(path.join(opBHome, '.jinn-client', 'config.json'), minimalCfg(7733));
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('spawns N daemons with distinct ports and returns handles', async () => {
+    // NOTE: this test requires `yarn build` has been run (dist/bin/jinn.js exists).
+    // If dist is missing, it should skip rather than fail.
+    const distPath = path.resolve(__dirname, '..', '..', 'dist', 'bin', 'jinn.js');
+    try { await fs.access(distPath); } catch {
+      // dist not built; skip
+      return;
+    }
+
+    let handle: MultiOpHandle | undefined;
+    try {
+      handle = await spawnMultiOpDaemons({
+        ops: [
+          { name: 'op-a', home: opAHome, apiPort: 7732 },
+          { name: 'op-b', home: opBHome, apiPort: 7733 },
+        ],
+        readyTimeoutMs: 30000,
+      });
+      expect(Object.keys(handle.daemons).sort()).toEqual(['op-a', 'op-b']);
+      // handshakeUrl may be present only if the daemon emits it; bootstrap-incomplete daemons may not.
+      // The contract: each daemon has a pid and an apiPort.
+      expect(handle.daemons['op-a'].apiPort).toBe(7732);
+      expect(handle.daemons['op-b'].apiPort).toBe(7733);
+      expect(handle.daemons['op-a'].pid).toBeGreaterThan(0);
+      expect(handle.daemons['op-b'].pid).toBeGreaterThan(0);
+    } finally {
+      if (handle) await handle.teardown();
+    }
+  }, 60000);
+
+  it('teardown is idempotent', async () => {
+    const distPath = path.resolve(__dirname, '..', '..', 'dist', 'bin', 'jinn.js');
+    try { await fs.access(distPath); } catch { return; }
+
+    const handle = await spawnMultiOpDaemons({
+      ops: [{ name: 'op-a', home: opAHome, apiPort: 7734 }],
+      readyTimeoutMs: 30000,
+    });
+    await handle.teardown();
+    await expect(handle.teardown()).resolves.toBeUndefined();
+  }, 60000);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd client && yarn vitest run test/helpers/multi-op-daemon.test.ts`
+Expected: FAIL with `Cannot find module './multi-op-daemon'`
+
+- [ ] **Step 3: Implement multi-op-daemon.ts**
+
+```typescript
+// client/test/helpers/multi-op-daemon.ts
+import { spawn, type ChildProcess } from 'node:child_process';
+import * as path from 'node:path';
+import { makeHandshakeCollector } from './handshake-url';
+
+export interface OpSpec {
+  name: string;
+  home: string;                 // HOME directory containing .jinn-client/
+  apiPort: number;
+}
+
+export interface DaemonHandle {
+  name: string;
+  pid: number;
+  apiPort: number;
+  handshakeUrl: string | null;  // null if not emitted within readyTimeoutMs
+  process: ChildProcess;
+}
+
+export interface MultiOpHandle {
+  daemons: Record<string, DaemonHandle>;
+  teardown: () => Promise<void>;
+}
+
+export interface SpawnMultiOpOptions {
+  ops: OpSpec[];
+  readyTimeoutMs?: number;      // default 30s
+  jinnBinPath?: string;         // default: resolve from cwd / dist/bin/jinn.js
+  extraEnv?: NodeJS.ProcessEnv;
+}
+
+async function waitForBootstrap(apiPort: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${apiPort}/v1/bootstrap`, { method: 'GET' });
+      if (res.status === 200 || res.status === 401) return;
+    } catch {
+      // not yet
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`daemon on port ${apiPort} did not become reachable within ${timeoutMs}ms`);
+}
+
+export async function spawnMultiOpDaemons(opts: SpawnMultiOpOptions): Promise<MultiOpHandle> {
+  const readyTimeoutMs = opts.readyTimeoutMs ?? 30000;
+  const jinnBin = opts.jinnBinPath ?? path.resolve(process.cwd(), 'dist', 'bin', 'jinn.js');
+
+  const daemons: Record<string, DaemonHandle> = {};
+  const processes: ChildProcess[] = [];
+
+  async function killAll(): Promise<void> {
+    for (const proc of processes) {
+      if (!proc.killed && proc.pid) {
+        try { proc.kill('SIGTERM'); } catch {}
+      }
+    }
+    await new Promise((r) => setTimeout(r, 200));
+    for (const proc of processes) {
+      if (!proc.killed && proc.pid) {
+        try { proc.kill('SIGKILL'); } catch {}
+      }
+    }
+  }
+
+  try {
+    for (const op of opts.ops) {
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        ...opts.extraEnv,
+        HOME: op.home,
+        JINN_API_PORT: op.apiPort.toString(),
+      };
+      const proc = spawn('node', [jinnBin, 'run', '--no-ui'], {
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      processes.push(proc);
+
+      const collector = makeHandshakeCollector(readyTimeoutMs);
+      proc.stdout?.on('data', (chunk) => collector.feed(chunk.toString()));
+      proc.stderr?.on('data', (chunk) => collector.feed(chunk.toString()));
+
+      // Wait for bootstrap to be reachable
+      await waitForBootstrap(op.apiPort, readyTimeoutMs);
+
+      // Best-effort handshake URL capture (may not emit if daemon is in non-running mode)
+      let handshakeUrl: string | null = null;
+      try {
+        handshakeUrl = await Promise.race([
+          collector.promise,
+          new Promise<string>((_, rej) => setTimeout(() => rej(new Error('handshake not emitted')), 2000)),
+        ]);
+      } catch {
+        handshakeUrl = null;
+      }
+
+      daemons[op.name] = {
+        name: op.name,
+        pid: proc.pid ?? -1,
+        apiPort: op.apiPort,
+        handshakeUrl,
+        process: proc,
+      };
+    }
+  } catch (err) {
+    await killAll();
+    throw err;
+  }
+
+  let torn = false;
+  return {
+    daemons,
+    teardown: async () => {
+      if (torn) return;
+      torn = true;
+      await killAll();
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Build the client and run the test**
+
+Run: `cd client && yarn build && yarn vitest run test/helpers/multi-op-daemon.test.ts`
+Expected: PASS, 2 tests passing (or skipping if `dist/bin/jinn.js` somehow missing after build)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/test/helpers/multi-op-daemon.ts client/test/helpers/multi-op-daemon.test.ts
+git commit -m "test(helpers): add multi-op daemon spawn helper"
+```
+
+---
+
+## Task 3: Update testing-jinn-app SKILL.md — multi-operator section header
+
+**Files:**
+- Modify: `.claude/skills/testing-jinn-app/SKILL.md`
+
+Add a new top-level section to the existing SKILL.md, immediately after the "Automated E2E (Playwright)" section. Existing single-op recipes stay unchanged.
+
+- [ ] **Step 1: Read the current SKILL.md to find the insertion point**
+
+Run: `cat .claude/skills/testing-jinn-app/SKILL.md | grep -n "^## " | head -20`
+Expected output: section headers with line numbers. Find the section just before "Quick reference" (the manual smoke + Playwright recipes end before that summary section).
+
+- [ ] **Step 2: Insert the multi-operator section**
+
+Open `.claude/skills/testing-jinn-app/SKILL.md` and insert the following new section AFTER the "Automated E2E (Playwright)" section and BEFORE "Quick reference":
+
+```markdown
+## Multi-operator scenarios
+
+The single-op recipes above (manual smoke, automated E2E) cover testing one operator in isolation. Multi-operator scenarios — where two daemons interact via the chain and via the operator app — require additional infrastructure that this section documents. Reference docs in `references/` cover each pattern in detail.
+
+Spawn pattern: two (or more) daemons run concurrently against distinct HOMEs (substrate-derived workspaces from Plan A's `substrate-copy`, or fresh tmp HOMEs for clean-state E2Es). Each daemon gets a distinct `JINN_API_PORT`. Helpers in `client/test/helpers/multi-op-daemon.ts` wrap the spawn + teardown lifecycle.
+
+Three method-pattern reference docs cover the mechanics:
+
+- [`references/multi-op-spawn.md`](references/multi-op-spawn.md) — bash + TypeScript spawn recipes; port management; teardown.
+- [`references/multi-op-chrome-devtools.md`](references/multi-op-chrome-devtools.md) — multi-page chrome-devtools driving for cross-op manual smoke.
+- [`references/multi-op-playwright.md`](references/multi-op-playwright.md) — Playwright template for two-daemon automated tests.
+
+Four scenario reference docs are the contracts release-prep's gate runner consumes. Each describes one scenario at the level of detail an implementer needs:
+
+- [`references/scenario-spa-route-smoke.md`](references/scenario-spa-route-smoke.md) — T1.4: load every SPA route against a mocked daemon, assert clean.
+- [`references/scenario-cross-op-donation.md`](references/scenario-cross-op-donation.md) — T2.1: op-a produces corpus artifact, op-b consumes via x402.
+- [`references/scenario-producer-evaluator.md`](references/scenario-producer-evaluator.md) — T2.2: op-a solves task on Anvil-fork, op-b evaluates.
+- [`references/scenario-multi-op-spa-flow.md`](references/scenario-multi-op-spa-flow.md) — T2.3: op-a launches SolverNet via SPA, op-b joins via SPA, both observe each other.
+
+### Things to watch for (multi-op specific)
+
+In addition to the single-op concerns listed earlier:
+
+- **Cross-operator visibility lag** — op-b sees op-a's actions only after the indexer has caught up (~2 indexer-poll-intervals). Wait, don't assume instant.
+- **Identity collisions** — spawning two daemons with the same HOME means both fight for the same agentId/Safe/nonce. Always verify *both* apiPort AND source HOME directory are distinct before spawning.
+- **Workspace bleed** — substrate-derived workspaces under `~/jinn-dev/workspaces/` are auto-pruned at 7 days by `substrate-reap`. Don't leave a workspace assumed to be there between test runs; either own its lifecycle or use a fresh one each test.
+- **Substrate staleness** — if `substrate-verify` reports drift, all multi-op scenarios using substrate workspaces will fail in non-obvious ways. Run verify before any multi-op session.
+- **RPC saturation under concurrent load** — substrate ops currently share one Tenderly key (per spec §2). If both daemons hammer the RPC simultaneously, expect HTTP 429. Tracked as `jinn-mono-lrey`; for now, add jittered delays in scenarios where both daemons are RPC-active.
+```
+
+Save the file.
+
+- [ ] **Step 3: Sanity-check the insertion**
+
+Run: `grep -A 2 "## Multi-operator scenarios" .claude/skills/testing-jinn-app/SKILL.md | head -5`
+Expected output: the section header and its intro line.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/testing-jinn-app/SKILL.md
+git commit -m "docs(testing-jinn-app): add multi-operator scenarios section"
+```
+
+---
+
+## Task 4: Reference doc — multi-op-spawn.md
+
+**Files:**
+- Create: `.claude/skills/testing-jinn-app/references/multi-op-spawn.md`
+
+- [ ] **Step 1: Create the reference doc**
+
+Save the following as `.claude/skills/testing-jinn-app/references/multi-op-spawn.md`:
+
+```markdown
+# Multi-op daemon spawn
+
+How to spawn two or more `jinn` daemons concurrently for cross-operator testing. Two recipes — bash for ad-hoc use, TypeScript for automated tests.
+
+## Source of HOMEs
+
+Two flavors:
+
+1. **Substrate-derived workspaces** — use Plan A's `substrate-copy.ts` to create per-run isolated copies of `op-a` / `op-b` from gold. Best for scenarios that need pre-bootstrapped identity (most T2.x scenarios).
+
+   ```typescript
+   import { copyWorkspace } from '@/scripts/release/substrate-copy';
+
+   const handle = await copyWorkspace({ ops: ['op-a', 'op-b'] });
+   // handle.opPaths['op-a'] → '/Users/.../jinn-dev/workspaces/<run-id>/op-a/'
+   // teardown via handle.teardown() at end of test
+   ```
+
+2. **Fresh tmp HOMEs** — for clean-state E2E tests that don't need an existing identity (e.g. fresh-bootstrap scenarios). Each daemon gets its own `HOME=$tmpdir`.
+
+   ```typescript
+   const opAHome = await fs.mkdtemp(path.join(os.tmpdir(), 'fresh-op-a-'));
+   const opBHome = await fs.mkdtemp(path.join(os.tmpdir(), 'fresh-op-b-'));
+   // (Seed minimal config under <home>/.jinn-client/config.json as needed)
+   ```
+
+## Bash recipe (ad-hoc)
+
+```bash
+# Set up substrate workspace
+RUN_ID="$(date -u +%Y-%m-%dT%H-%M-%S)-$RANDOM"
+yarn substrate:copy op-a op-b
+# (parse runId from stdout; or skip and use fixed paths in dev)
+
+# Spawn op-a (apiPort 7332, persistent identity from substrate)
+HOME=~/jinn-dev/workspaces/$RUN_ID/op-a JINN_API_PORT=7332 \
+  node dist/bin/jinn.js run --no-ui > /tmp/op-a.log 2>&1 &
+OP_A_PID=$!
+
+# Spawn op-b (apiPort 7333)
+HOME=~/jinn-dev/workspaces/$RUN_ID/op-b JINN_API_PORT=7333 \
+  node dist/bin/jinn.js run --no-ui > /tmp/op-b.log 2>&1 &
+OP_B_PID=$!
+
+# Wait for both /v1/bootstrap to be reachable
+for port in 7332 7333; do
+  until curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:$port/v1/bootstrap | grep -qE "200|401"; do
+    sleep 0.25
+  done
+done
+
+# Capture handshake URLs from logs
+OP_A_URL="$(grep -m1 'UI handshake URL:' /tmp/op-a.log | sed 's/.*UI handshake URL:\s*//')"
+OP_B_URL="$(grep -m1 'UI handshake URL:' /tmp/op-b.log | sed 's/.*UI handshake URL:\s*//')"
+
+echo "op-a: $OP_A_URL"
+echo "op-b: $OP_B_URL"
+
+# Teardown
+trap "kill $OP_A_PID $OP_B_PID 2>/dev/null; rm -rf ~/jinn-dev/workspaces/$RUN_ID" EXIT
+```
+
+## TypeScript recipe (automated tests)
+
+Use the helper at `client/test/helpers/multi-op-daemon.ts`:
+
+```typescript
+import { spawnMultiOpDaemons, type MultiOpHandle } from '../helpers/multi-op-daemon';
+import { copyWorkspace } from '../../scripts/release/substrate-copy';
+
+let workspace: Awaited<ReturnType<typeof copyWorkspace>>;
+let daemons: MultiOpHandle;
+
+beforeAll(async () => {
+  workspace = await copyWorkspace({ ops: ['op-a', 'op-b'] });
+  daemons = await spawnMultiOpDaemons({
+    ops: [
+      { name: 'op-a', home: workspace.opPaths['op-a'], apiPort: 7732 },
+      { name: 'op-b', home: workspace.opPaths['op-b'], apiPort: 7733 },
+    ],
+    readyTimeoutMs: 30000,
+  });
+});
+
+afterAll(async () => {
+  await daemons.teardown();
+  await workspace.teardown();
+});
+
+it('does cross-op thing', async () => {
+  // daemons.daemons['op-a'].apiPort, .handshakeUrl, etc.
+});
+```
+
+## Port selection
+
+Substrate ops are pre-configured with apiPorts (op-a=7332, op-b=7333, op-c-legacy=7334). For tests that need different ports (e.g. avoiding collision with the daily-driver daemon at 7332), override via the `apiPort` option in the helper. The helper passes it as `JINN_API_PORT` env var; the daemon's config-resolution prefers env over config file.
+
+For parallel test files (separate Vitest workers), pick non-overlapping port ranges (e.g. 7332-7333 for one file, 7732-7733 for another).
+
+## Teardown contract
+
+- `daemons.teardown()` sends SIGTERM to all spawned processes, waits 200ms, then SIGKILL if still alive.
+- `daemons.teardown()` is idempotent — safe to call multiple times.
+- Use a `try { ... } finally { await daemons.teardown(); }` pattern in tests. Don't rely on `afterAll` alone — if `beforeAll` partially succeeded (op-a started, op-b failed), the partial spawn must still be cleaned up.
+
+## Common failure modes
+
+| Failure | Likely cause | Fix |
+|---|---|---|
+| `daemon on port X did not become reachable within Yms` | port collision with another process | check `lsof -i :X` |
+| `daemon on port X did not become reachable within Yms` | misconfigured HOME (config.json absent or malformed) | verify HOME/.jinn-client/config.json exists |
+| handshake URL is null | daemon never reached "running" mode (bootstrap incomplete in HOME) | substrate-verify the HOME; or use substrate-derived HOME |
+| teardown hangs | child process refusing SIGTERM | helper escalates to SIGKILL after 200ms; if test still hangs, increase the wait |
+```
+
+- [ ] **Step 2: Verify file readable**
+
+Run: `head -15 .claude/skills/testing-jinn-app/references/multi-op-spawn.md`
+Expected: first ~15 lines of the doc.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/testing-jinn-app/references/multi-op-spawn.md
+git commit -m "docs(testing-jinn-app): add multi-op-spawn reference"
+```
+
+---
+
+## Task 5: Reference doc — multi-op-chrome-devtools.md
+
+**Files:**
+- Create: `.claude/skills/testing-jinn-app/references/multi-op-chrome-devtools.md`
+
+- [ ] **Step 1: Create the reference doc**
+
+Save the following as `.claude/skills/testing-jinn-app/references/multi-op-chrome-devtools.md`:
+
+```markdown
+# Multi-op chrome-devtools driving
+
+For manual smoke tests where you drive two operator apps side by side. Uses the `chrome-devtools` MCP server's multi-page support.
+
+## Prereqs
+
+- Both daemons spawned (see [multi-op-spawn.md](multi-op-spawn.md)). Capture both handshake URLs.
+- `chrome-devtools` MCP loaded in your session. Verify with `ToolSearch query="chrome devtools navigate"` — if `mcp__chrome-devtools__new_page` and `mcp__chrome-devtools__select_page` don't surface, this MCP isn't loaded and the recipe below won't work; fall back to manual two-browser-window driving.
+
+## Recipe
+
+```typescript
+// 1. Open a page per operator
+const opAPage = await mcp__chrome_devtools__new_page({ url: opAHandshakeUrl });
+const opBPage = await mcp__chrome_devtools__new_page({ url: opBHandshakeUrl });
+
+// 2. Drive op-a — explicitly select before each action
+await mcp__chrome_devtools__select_page({ pageId: opAPage });
+await mcp__chrome_devtools__click({ selector: 'button:has-text("Create SolverNet")' });
+// ... wizard steps ...
+
+// 3. Drive op-b — explicitly select again
+await mcp__chrome_devtools__select_page({ pageId: opBPage });
+await mcp__chrome_devtools__navigate_page({ url: opBHandshakeUrl + '/operator/join' });
+await mcp__chrome_devtools__take_screenshot({});
+
+// 4. Cross-verify: switch back to op-a and check op-a sees op-b's action
+await mcp__chrome_devtools__select_page({ pageId: opAPage });
+await mcp__chrome_devtools__navigate_page({ url: opAHandshakeUrl + '/launcher/launched/<id>' });
+```
+
+## Critical rule: always select before acting
+
+chrome-devtools MCP maintains an "active page" pointer. Every click / type / navigate operates on the currently-selected page. If you fan out across two pages without explicit `select_page` calls, you'll drive whichever happened to be selected last — often the wrong one.
+
+**Pattern:**
+```typescript
+async function driveOnPage(pageId: string, action: () => Promise<void>): Promise<void> {
+  await mcp__chrome_devtools__select_page({ pageId });
+  await action();
+}
+```
+
+Wrap every cross-page operation in this pattern.
+
+## Cross-op visibility lag
+
+When op-a performs an action that op-b should see (e.g. op-a launches a SolverNet, op-b should see it in the catalog), there's a delay equal to:
+
+- One indexer poll interval (~5 sec for the Ponder indexer at default config)
+- Plus one SPA poll interval (~1.5 sec for useQuery defaults)
+
+**Don't assert op-b's view immediately after op-a's action.** Wait at least 10 seconds for indexer + SPA polls. Use `wait_for` with the expected DOM state, not a fixed sleep:
+
+```typescript
+await mcp__chrome_devtools__select_page({ pageId: opBPage });
+await mcp__chrome_devtools__wait_for({
+  text: 'my-new-solvernet',
+  timeout: 30000,                  // generous; indexer can lag
+});
+```
+
+## Screenshot conventions
+
+When reporting a multi-op smoke result, take screenshots of both pages at each critical state, named consistently:
+
+```typescript
+await mcp__chrome_devtools__select_page({ pageId: opAPage });
+await mcp__chrome_devtools__take_screenshot({ name: '01-op-a-after-create' });
+
+await mcp__chrome_devtools__select_page({ pageId: opBPage });
+await mcp__chrome_devtools__take_screenshot({ name: '02-op-b-catalog-shows-new' });
+```
+
+Screenshot pairs at each step make cross-op state comparison readable.
+
+## Common failure modes
+
+| Failure | Likely cause | Fix |
+|---|---|---|
+| Action happens on wrong page | forgot to `select_page` before action | wrap in `driveOnPage` helper |
+| op-b doesn't see op-a's change | not waiting for indexer/SPA poll | use `wait_for` with expected text, not sleep |
+| Stale screenshot | took screenshot before page actually updated | wait for the indicator DOM change first |
+| MCP not loaded | session doesn't have chrome-devtools MCP | check `ToolSearch query="chrome devtools navigate"`; fall back to Playwright recipe |
+```
+
+- [ ] **Step 2: Verify file readable**
+
+Run: `head -10 .claude/skills/testing-jinn-app/references/multi-op-chrome-devtools.md`
+Expected: first ~10 lines of the doc.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/testing-jinn-app/references/multi-op-chrome-devtools.md
+git commit -m "docs(testing-jinn-app): add multi-op chrome-devtools reference"
+```
+
+---
+
+## Task 6: Reference doc — multi-op-playwright.md
+
+**Files:**
+- Create: `.claude/skills/testing-jinn-app/references/multi-op-playwright.md`
+
+- [ ] **Step 1: Create the reference doc**
+
+Save the following as `.claude/skills/testing-jinn-app/references/multi-op-playwright.md`:
+
+```markdown
+# Multi-op Playwright template
+
+For automated regression coverage of two-operator flows. Tests live under `client/test/dashboard/multi-op/`. Pattern below mirrors the existing single-op `client/test/dashboard/spa-config.e2e.test.ts` but with two daemons + two Playwright pages.
+
+## Template
+
+```typescript
+// client/test/dashboard/multi-op/<scenario>.e2e.test.ts
+import { test, expect, type Page } from '@playwright/test';
+import { spawnMultiOpDaemons, type MultiOpHandle } from '../../helpers/multi-op-daemon';
+import { copyWorkspace } from '../../../scripts/release/substrate-copy';
+import { mockDaemonApi } from '../helpers/mock-daemon-api';   // existing single-op mock helper
+
+let workspace: Awaited<ReturnType<typeof copyWorkspace>>;
+let daemons: MultiOpHandle;
+let opAUrl: string;
+let opBUrl: string;
+
+test.beforeAll(async () => {
+  workspace = await copyWorkspace({ ops: ['op-a', 'op-b'] });
+  daemons = await spawnMultiOpDaemons({
+    ops: [
+      { name: 'op-a', home: workspace.opPaths['op-a'], apiPort: 7732 },
+      { name: 'op-b', home: workspace.opPaths['op-b'], apiPort: 7733 },
+    ],
+    readyTimeoutMs: 30000,
+  });
+  opAUrl = daemons.daemons['op-a'].handshakeUrl ?? `http://127.0.0.1:7732/`;
+  opBUrl = daemons.daemons['op-b'].handshakeUrl ?? `http://127.0.0.1:7733/`;
+});
+
+test.afterAll(async () => {
+  await daemons?.teardown();
+  await workspace?.teardown();
+});
+
+test('op-a launches SolverNet → op-b sees it within 30s', async ({ browser }) => {
+  // Create two isolated contexts — separate cookies, separate state per op
+  const opACtx = await browser.newContext();
+  const opBCtx = await browser.newContext();
+  const opAPage = await opACtx.newPage();
+  const opBPage = await opBCtx.newPage();
+
+  // Optional: mock daemon API per page (matches the single-op pattern)
+  await mockDaemonApi(opAPage, { port: 7732 });
+  await mockDaemonApi(opBPage, { port: 7733 });
+
+  await opAPage.goto(opAUrl);
+  await opBPage.goto(opBUrl);
+
+  // Drive op-a (Launcher Create wizard)
+  await opAPage.getByRole('link', { name: /launcher/i }).click();
+  await opAPage.getByRole('button', { name: /create solvernet/i }).click();
+  // ... wizard steps ...
+  await opAPage.getByRole('button', { name: /launch/i }).click();
+  await expect(opAPage.getByText(/launched/i)).toBeVisible({ timeout: 60000 });
+
+  // Verify op-b sees the new SolverNet within 30s of launch
+  await opBPage.goto(opBUrl + '/operator/join');
+  await expect(opBPage.getByText(/new-solvernet-name/i)).toBeVisible({ timeout: 30000 });
+
+  await opACtx.close();
+  await opBCtx.close();
+});
+```
+
+## Two pages, two contexts
+
+Use **separate Playwright `BrowserContext`** instances per operator. Each context has its own cookies, localStorage, and session. If you reuse one context with two pages, the second page's auth state will collide with the first.
+
+```typescript
+const opACtx = await browser.newContext();
+const opAPage = await opACtx.newPage();
+
+const opBCtx = await browser.newContext();
+const opBPage = await opBCtx.newPage();
+```
+
+## Mock vs real daemon
+
+Two modes, choose per scenario:
+
+### Mocked (T1.4 SPA route smoke, T2.3 multi-op SPA flow lite variant)
+
+Each Playwright page gets its own `mockDaemonApi(page, { port })` call. Reuses the existing single-op mock helper. Fast, deterministic, doesn't need real daemons running — but doesn't catch bugs that only surface with real daemon state.
+
+### Real (T2.1, T2.2, T2.3 full variant)
+
+No `mockDaemonApi` call. Pages talk to the real daemons started by `spawnMultiOpDaemons`. Slower, requires substrate, exercises real RPC + indexer integration. Catches real integration bugs.
+
+## Helper conventions
+
+For tests that recur, lift the daemon spawn into a fixture file under `client/test/dashboard/multi-op/fixtures/`. Example:
+
+```typescript
+// fixtures/two-substrate-ops.ts
+import { test as base } from '@playwright/test';
+import { spawnMultiOpDaemons, type MultiOpHandle } from '../../../helpers/multi-op-daemon';
+import { copyWorkspace } from '../../../../scripts/release/substrate-copy';
+
+export const test = base.extend<{ daemons: MultiOpHandle; opAUrl: string; opBUrl: string }>({
+  daemons: async ({}, use) => {
+    const workspace = await copyWorkspace({ ops: ['op-a', 'op-b'] });
+    const daemons = await spawnMultiOpDaemons({
+      ops: [
+        { name: 'op-a', home: workspace.opPaths['op-a'], apiPort: 7732 },
+        { name: 'op-b', home: workspace.opPaths['op-b'], apiPort: 7733 },
+      ],
+    });
+    try {
+      await use(daemons);
+    } finally {
+      await daemons.teardown();
+      await workspace.teardown();
+    }
+  },
+  opAUrl: async ({ daemons }, use) => {
+    await use(daemons.daemons['op-a'].handshakeUrl ?? 'http://127.0.0.1:7732/');
+  },
+  opBUrl: async ({ daemons }, use) => {
+    await use(daemons.daemons['op-b'].handshakeUrl ?? 'http://127.0.0.1:7733/');
+  },
+});
+```
+
+## Common failure modes
+
+| Failure | Likely cause | Fix |
+|---|---|---|
+| op-b sees stale op-a state | indexer hasn't caught up | use `expect(...).toBeVisible({ timeout: 30000 })`, not `await page.waitForSelector(...)` |
+| Auth/cookie collision | reused single context for two operators | always two `browser.newContext()` calls |
+| Daemon spawn timeout | dist/bin/jinn.js missing or stale | `yarn build` before running |
+| Tests pass locally, flake in CI | RPC saturation or test parallelism | run multi-op tests with `workers: 1` for now (see jinn-mono-lrey) |
+| `mockDaemonApi` doesn't intercept | wrong port arg | helper takes port; verify the page's daemon URL matches |
+
+## Running the tests
+
+Single multi-op file:
+```bash
+cd client && yarn build && yarn playwright test --config=playwright.config.ts test/dashboard/multi-op/<scenario>.e2e.test.ts
+```
+
+All multi-op:
+```bash
+cd client && yarn build && yarn playwright test --config=playwright.config.ts test/dashboard/multi-op/
+```
+
+Sequential (avoid RPC saturation):
+```bash
+cd client && yarn playwright test --config=playwright.config.ts --workers=1 test/dashboard/multi-op/
+```
+```
+
+- [ ] **Step 2: Verify file readable**
+
+Run: `head -10 .claude/skills/testing-jinn-app/references/multi-op-playwright.md`
+Expected: first ~10 lines.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/testing-jinn-app/references/multi-op-playwright.md
+git commit -m "docs(testing-jinn-app): add multi-op Playwright template reference"
+```
+
+---
+
+## Task 7: Scenario doc — scenario-spa-route-smoke.md (T1.4)
+
+**Files:**
+- Create: `.claude/skills/testing-jinn-app/references/scenario-spa-route-smoke.md`
+
+- [ ] **Step 1: Create the doc**
+
+Save the following as `.claude/skills/testing-jinn-app/references/scenario-spa-route-smoke.md`:
+
+```markdown
+# Scenario T1.4 — SPA route smoke
+
+**Tier:** 1 (single-op, route-mocked, runs on every push)
+**Wall-clock budget:** 30s
+**Catches:** broken routes, missing endpoint mocks, JS errors introduced by new SPA code, React error boundary firings.
+
+## Goal
+
+Load every SPA route against a mocked daemon API. For each route, assert:
+1. No JS error in `page.on('pageerror', ...)`.
+2. No React error boundary visible (no `[data-error-boundary]` element).
+3. No "endpoint not mocked" console error from missing route intercepts.
+4. The page renders past the initial spinner (some recognizable DOM element appears within 5s).
+
+## Implementation location
+
+`client/test/dashboard/release-prep/spa-route-smoke.e2e.test.ts`
+
+## Inputs
+
+- Routes list: extracted from `client/src/dashboard/spa/src/App.tsx` (the React Router config). The test imports the route table from a single source of truth.
+- Mocked daemon API: reuses the existing `mockDaemonApi(page)` helper from single-op tests (e.g. `client/test/dashboard/spa-config.e2e.test.ts`).
+
+## Setup
+
+```typescript
+import { test, expect, type Page } from '@playwright/test';
+import { mockDaemonApi } from '../helpers/mock-daemon-api';
+import { ROUTES } from '../../../src/dashboard/spa/src/routes';   // exported list of route paths
+
+let consoleErrors: string[] = [];
+let pageErrors: Error[] = [];
+
+test.beforeEach(async ({ page }) => {
+  consoleErrors = [];
+  pageErrors = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+  page.on('pageerror', (err) => pageErrors.push(err));
+  await mockDaemonApi(page);
+});
+
+for (const route of ROUTES) {
+  test(`SPA renders clean at ${route}`, async ({ page }) => {
+    await page.goto(`http://127.0.0.1:7332${route}`);
+    await page.waitForSelector('main, [data-page-loaded], [data-app-shell]', { timeout: 5000 });
+    expect(pageErrors).toHaveLength(0);
+    expect(consoleErrors.filter((e) => !e.includes('expected harmless pattern'))).toHaveLength(0);
+    await expect(page.locator('[data-error-boundary]')).toHaveCount(0);
+  });
+}
+```
+
+## Routes to cover (initial)
+
+Derived from the existing SPA routes; the actual implementation should import a shared `ROUTES` constant rather than hardcoding here:
+
+- `/` (root → overview redirect)
+- `/overview`
+- `/configuration`
+- `/configuration#network`
+- `/configuration#security`
+- `/launcher`
+- `/launcher/create`
+- `/launcher/launched/:placeholder-id`  (with a known mock id)
+- `/operator/join/:placeholder-cid` (with a known mock cid)
+- `/network`
+- `/build`
+
+The test parameterizes over this list; one test per route.
+
+## Failure semantics
+
+- `pageerror` array non-empty → fail with the captured error stack
+- React error boundary visible → fail with the boundary's text content (helps debugging)
+- Console errors non-empty (after filtering known harmless patterns) → fail with all error messages
+- Route doesn't reach the "rendered" sentinel within 5s → fail with "route did not render"
+
+The "known harmless" filter list lives in the test file (e.g. ResizeObserver loop warnings). It starts empty and gets entries added when needed, each with a comment explaining why.
+
+## What this scenario does NOT catch
+
+- Real-daemon behavior (uses mocks)
+- Cross-operator state synchronization
+- Integration bugs between SPA and real daemon API
+- Visual regressions (no screenshot comparison)
+
+These belong in T2.x (cross-op) and Tier 3 (real testnet) scenarios.
+
+## Wall-clock
+
+~30 seconds total: ~3 seconds per route × ~11 routes. Runs in parallel within Playwright's default worker count.
+
+## Dependencies
+
+- The SPA must export a `ROUTES` constant from a single module so this test parameterizes correctly. If `ROUTES` doesn't exist yet, Plan C/D's implementation should add it (small refactor — extract route table from App.tsx).
+- `mockDaemonApi` helper from single-op tests (already exists).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/skills/testing-jinn-app/references/scenario-spa-route-smoke.md
+git commit -m "docs(testing-jinn-app): add T1.4 SPA route smoke scenario reference"
+```
+
+---
+
+## Task 8: Scenario doc — scenario-cross-op-donation.md (T2.1)
+
+**Files:**
+- Create: `.claude/skills/testing-jinn-app/references/scenario-cross-op-donation.md`
+
+- [ ] **Step 1: Create the doc**
+
+Save the following as `.claude/skills/testing-jinn-app/references/scenario-cross-op-donation.md`:
+
+```markdown
+# Scenario T2.1 — Cross-operator donation
+
+**Tier:** 2 (substrate-derived workspace, runs in release-prep)
+**Wall-clock budget:** 5 minutes
+**Catches:** x402 + ERC-8128 handshake regressions, corpus indexer attribution bugs, payment-gated artifact access bugs.
+
+## Goal
+
+op-a produces a corpus artifact, indexer picks it up, op-b queries Discovery API for the artifact, op-b pays x402 USDC, op-b retrieves the artifact, signature + payload validate end-to-end.
+
+This is the gate that should have caught the #310 silent breakage (donation-consumption gate was passing because Op A wasn't producing, so consumption couldn't verify).
+
+## Implementation location
+
+`client/test/release/tier-2/T2.1-cross-op-donation.ts`
+
+## Setup
+
+- substrate workspace via `copyWorkspace({ ops: ['op-a', 'op-b'] })`
+- both daemons spawned with substrate-derived HOMEs, distinct apiPorts (7732, 7733)
+- Anvil-fork RPC (forks Base Sepolia); both daemons' configs point at this fork URL
+- op-a config: `solverNets.<name>.roles = ['solving']` for the chosen SolverNet
+- op-b config: joined to the same SolverNet via `joinedSolverNets[<manifestCid>]`
+
+## Steps
+
+```typescript
+// 1. Spawn daemons + workspace (see multi-op-playwright.md template)
+const workspace = await copyWorkspace({ ops: ['op-a', 'op-b'] });
+const daemons = await spawnMultiOpDaemons({
+  ops: [
+    { name: 'op-a', home: workspace.opPaths['op-a'], apiPort: 7732 },
+    { name: 'op-b', home: workspace.opPaths['op-b'], apiPort: 7733 },
+  ],
+});
+
+// 2. op-a produces a corpus artifact
+//    Either: trigger via daemon API (POST /v1/corpus/produce) or wait for natural production tick
+const opARes = await fetch(`http://127.0.0.1:7732/v1/corpus/produce`, {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ solverNetManifestCid: KNOWN_MANIFEST_CID, payload: SAMPLE_PAYLOAD }),
+});
+const { artifactCid } = await opARes.json();
+
+// 3. Wait for indexer to pick it up (poll Discovery API)
+const indexedCid = await waitFor(async () => {
+  const res = await fetch(`http://127.0.0.1:7733/v1/discovery/corpus?cid=${artifactCid}`);
+  if (!res.ok) return null;
+  const body = await res.json();
+  return body.cid === artifactCid ? body : null;
+}, { timeoutMs: 60000, intervalMs: 2000 });
+expect(indexedCid).toBeTruthy();
+
+// 4. op-b queries Discovery API for the artifact (no payment yet — gated)
+const previewRes = await fetch(`http://127.0.0.1:7733/v1/corpus/${artifactCid}`);
+expect(previewRes.status).toBe(402);   // Payment required
+
+// 5. op-b initiates x402 payment
+const paymentRes = await fetch(`http://127.0.0.1:7733/v1/corpus/${artifactCid}/pay`, {
+  method: 'POST',
+});
+const { paymentTx } = await paymentRes.json();
+expect(paymentTx).toMatch(/^0x[a-fA-F0-9]{64}$/);
+
+// 6. op-b retrieves the artifact (with payment proof)
+const retrievedRes = await fetch(`http://127.0.0.1:7733/v1/corpus/${artifactCid}`, {
+  headers: { 'x-x402-payment': paymentTx },
+});
+expect(retrievedRes.status).toBe(200);
+const retrieved = await retrievedRes.json();
+expect(retrieved.payload).toEqual(SAMPLE_PAYLOAD);
+
+// 7. Verify the ERC-8128 signature on the artifact
+const sigValid = await verifyErc8128Signature(retrieved);
+expect(sigValid).toBe(true);
+
+// 8. Cleanup
+await daemons.teardown();
+await workspace.teardown();
+```
+
+## Assertions (summary)
+
+| # | Assertion | Why |
+|---|---|---|
+| A1 | op-a produces an artifact with a valid CID | producer side works |
+| A2 | indexer attributes the artifact to op-a within 60s | indexer cross-op visibility |
+| A3 | op-b's unpaid query returns 402 | gating works |
+| A4 | op-b's payment tx is mined | x402 payment side works |
+| A5 | op-b's paid retrieval returns 200 + correct payload | gating releases after payment |
+| A6 | ERC-8128 signature on retrieved artifact validates | end-to-end provenance |
+
+## Failure modes
+
+| Failure | Class | Triage |
+|---|---|---|
+| op-a never produces artifact | real-bug | BLOCKING — producer side broken |
+| indexer never sees artifact within 60s | flake-timing first attempt; real-bug on second | retry; if persistent, blocking |
+| op-b's preview returns 200 (no gate) | real-bug | BLOCKING — gate bypass |
+| Payment tx fails | flake-infra or real-bug | retry; if persistent, check x402 contract |
+| Paid retrieval returns 402 | real-bug | BLOCKING — payment not honored |
+| Signature mismatch | real-bug | BLOCKING — provenance broken |
+| RPC saturation mid-test | flake-infra | retry once with jittered delay |
+
+## Wall-clock
+
+~5 minutes:
+- 30s daemon spawn
+- 60s artifact production + indexer
+- 60s payment + retrieval
+- 30s signature verification
+- ~30s setup/teardown overhead
+
+## Dependencies
+
+- Substrate workspace via Plan A's `substrate-copy`
+- Daemon HTTP API endpoints: `/v1/corpus/produce`, `/v1/corpus/:cid`, `/v1/corpus/:cid/pay`, `/v1/discovery/corpus` (these mostly exist in v0.1.6; verify shape at implementation time)
+- Anvil-fork-of-Base-Sepolia RPC (existing pattern in client/test/e2e/)
+- KNOWN_MANIFEST_CID — the substrate-pinned SolverNet manifest that both ops are joined to (read from op-a's manifest.json or config.json)
+- Existing helper: `verifyErc8128Signature` (or implement inline using the existing ERC-8128 module)
+
+## What this scenario does NOT catch
+
+- Real-network token economics (use Tier 3 for that)
+- Indexer behavior under high write load (this scenario is one writer, one reader)
+- Cross-chain donation scenarios
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/skills/testing-jinn-app/references/scenario-cross-op-donation.md
+git commit -m "docs(testing-jinn-app): add T2.1 cross-op donation scenario reference"
+```
+
+---
+
+## Task 9: Scenario doc — scenario-producer-evaluator.md (T2.2)
+
+**Files:**
+- Create: `.claude/skills/testing-jinn-app/references/scenario-producer-evaluator.md`
+
+- [ ] **Step 1: Create the doc**
+
+Save the following as `.claude/skills/testing-jinn-app/references/scenario-producer-evaluator.md`:
+
+```markdown
+# Scenario T2.2 — Producer/evaluator (Anvil-fork)
+
+**Tier:** 2 (substrate-derived workspace, Anvil-fork, runs in release-prep)
+**Wall-clock budget:** 5 minutes
+**Catches:** claim → solve → deliver → evaluate loop regressions; activity-counter increments; verdict pipeline end-to-end mechanically.
+
+## Goal
+
+op-a posts a known-solvable SWE-rebench v2 task, claims it, solves it via a *stubbed harness* (deterministic cached solution), delivers; op-b claims the verdict request, evaluates via real evaluator Docker image, posts verdict. Assert verdictCode matches expected.
+
+This is the Anvil-fork mechanical counterpart to Tier 3's real-testnet variant. Same loop, but stubbed harness (no real OpenRouter spend) and forked chain.
+
+## Implementation location
+
+`client/test/release/tier-2/T2.2-producer-evaluator-fork.ts`
+
+## Setup
+
+- substrate workspace via `copyWorkspace({ ops: ['op-a', 'op-b'] })`
+- Anvil fork of Base Sepolia at the substrate's last-known-good block; impersonate proxy owner; upgrade JinnRouter to V3 inline (existing pattern in `client/test/e2e/task-first-helpers.ts`)
+- op-a config: `roles: ['solving']` for swe-rebench-v2 SolverNet
+- op-b config: `roles: ['evaluating']` for same SolverNet
+- Harness stub: register a fake harness that returns a canned solution for the known-instance task (so no real OpenRouter call happens)
+
+## Steps
+
+```typescript
+const workspace = await copyWorkspace({ ops: ['op-a', 'op-b'] });
+const anvil = await spawnAnvilForkOfBaseSepolia();    // existing helper, returns rpcUrl + cleanup
+const daemons = await spawnMultiOpDaemons({
+  ops: [
+    { name: 'op-a', home: workspace.opPaths['op-a'], apiPort: 7732 },
+    { name: 'op-b', home: workspace.opPaths['op-b'], apiPort: 7733 },
+  ],
+  extraEnv: { BASE_RPC_URL: anvil.rpcUrl, JINN_HARNESS_STUB_INSTANCE: KNOWN_INSTANCE_ID },
+});
+
+// 1. op-a posts a known-solvable task
+const postRes = await fetch(`http://127.0.0.1:7732/v1/tasks`, {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({
+    solverType: 'swe-rebench-v2.v1',
+    spec: { instanceId: KNOWN_INSTANCE_ID, repo: KNOWN_REPO, commit: KNOWN_COMMIT },
+  }),
+});
+const { taskId, requestId } = await postRes.json();
+
+// 2. Wait for op-a to claim + solve + deliver (auto via solving role)
+const delivered = await waitFor(async () => {
+  const res = await fetch(`http://127.0.0.1:7732/v1/tasks/${taskId}`);
+  const body = await res.json();
+  return body.state === 'DELIVERED' ? body : null;
+}, { timeoutMs: 90000, intervalMs: 2000 });
+expect(delivered.deliveryTxHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
+
+// 3. Wait for op-b to claim verdict request + run evaluator + post verdict
+const verdict = await waitFor(async () => {
+  const res = await fetch(`http://127.0.0.1:7733/v1/verdicts?taskId=${taskId}`);
+  const body = await res.json();
+  return body.verdicts?.length > 0 ? body.verdicts[0] : null;
+}, { timeoutMs: 120000, intervalMs: 2000 });
+
+// 4. Assertions
+expect(verdict.verdictCode).toBe(KNOWN_EXPECTED_VERDICT);   // 1 if patch applies + tests pass
+expect(verdict.verdictTxHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
+
+// 5. Activity counters incremented
+const opAActivity = await fetch(`http://127.0.0.1:7732/v1/activity`).then(r => r.json());
+expect(opAActivity.deliveriesCount).toBeGreaterThan(0);
+const opBActivity = await fetch(`http://127.0.0.1:7733/v1/activity`).then(r => r.json());
+expect(opBActivity.verdictsCount).toBeGreaterThan(0);
+
+// 6. Cleanup
+await daemons.teardown();
+await anvil.stop();
+await workspace.teardown();
+```
+
+## Assertions (summary)
+
+| # | Assertion | Why |
+|---|---|---|
+| A1 | Task post returns valid taskId + requestId | task admission works |
+| A2 | op-a delivers within 90s | producer side: claim + stubbed solve + deliver loop closes |
+| A3 | delivery has a valid tx hash | on-chain delivery succeeded |
+| A4 | op-b posts verdict within 120s of delivery | evaluator side: claim + eval + verdict loop closes |
+| A5 | verdictCode matches KNOWN_EXPECTED_VERDICT | substrate recheck + scoring is correct |
+| A6 | op-a deliveriesCount incremented | activity-counter accounting works |
+| A7 | op-b verdictsCount incremented | activity-counter accounting works |
+
+## Stubbed harness
+
+Activated via `JINN_HARNESS_STUB_INSTANCE=<instance-id>` env var. The stub:
+- Pattern-matches on instance ID; only stubs the one we're testing.
+- Returns a canned patch from `client/test/release/tier-2/fixtures/<instance-id>.patch`.
+- Logs that it stubbed (so a real-harness-still-invoked regression would show absent stub logs).
+
+This avoids the ~$0.10 API call per run while exercising the rest of the loop.
+
+## Failure modes
+
+| Failure | Class | Triage |
+|---|---|---|
+| Task post returns 4xx | real-bug | BLOCKING — admission gate broken |
+| op-a never delivers within 90s | could be: harness stub not picked up; daemon misconfig; chain stall | inspect logs; flake on first, real-bug on retry |
+| Delivery tx revert | real-bug | BLOCKING — JinnRouter regression |
+| op-b never picks up verdict request | real-bug | BLOCKING — evaluator role inactive |
+| Evaluator Docker fails to run | flake-infra (Docker daemon) or real-bug (image broken) | check `docker ps`; retry |
+| verdictCode mismatches expected | real-bug | BLOCKING — substrate/scoring regression |
+| Activity counter not incremented | real-bug | BLOCKING — accounting regression |
+
+## Wall-clock
+
+~5 minutes:
+- 30s daemon spawn + Anvil fork
+- 90s producer loop
+- 120s evaluator loop
+- 30s setup/teardown
+
+## Dependencies
+
+- Substrate workspace from Plan A
+- Existing `spawnAnvilForkOfBaseSepolia` helper (from `client/test/e2e/task-first-helpers.ts`)
+- Existing JinnRouter V3 fork-upgrade pattern (same file)
+- Stubbed harness registration mechanism — to be added or extended in Plan C/D if not present
+- KNOWN_INSTANCE_ID, KNOWN_REPO, KNOWN_COMMIT, KNOWN_EXPECTED_VERDICT — fixture constants for a known-solvable SWE-rebench instance (existing pattern in `client/test/release/tier-2/fixtures/`)
+
+## What this scenario does NOT catch
+
+- Real OpenRouter API behavior (Tier 3 covers that)
+- Real RPC behavior under load (this uses Anvil; Tier 3 uses real testnet)
+- Cross-chain verdict flows
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/skills/testing-jinn-app/references/scenario-producer-evaluator.md
+git commit -m "docs(testing-jinn-app): add T2.2 producer/evaluator Anvil-fork scenario reference"
+```
+
+---
+
+## Task 10: Scenario doc — scenario-multi-op-spa-flow.md (T2.3)
+
+**Files:**
+- Create: `.claude/skills/testing-jinn-app/references/scenario-multi-op-spa-flow.md`
+
+- [ ] **Step 1: Create the doc**
+
+Save the following as `.claude/skills/testing-jinn-app/references/scenario-multi-op-spa-flow.md`:
+
+```markdown
+# Scenario T2.3 — Multi-op SPA flow
+
+**Tier:** 2 (substrate-derived workspace, Anvil-fork, runs in release-prep)
+**Wall-clock budget:** 5 minutes
+**Catches:** cross-op UI flows that pass with mocks but break with real daemons; SPA-side state synchronization; Launcher → Operator catalog visibility.
+
+## Goal
+
+op-a launches a SolverNet via the SPA Launcher Create wizard. op-b sees it appear in the Operator catalog. op-b joins via the SPA. op-a's launched-SolverNet dashboard shows op-b's join.
+
+This catches a class of bug invisible to single-op tests and to mocked multi-op tests: real-daemon state propagation through the SPA.
+
+## Implementation location
+
+`client/test/dashboard/multi-op/launcher-join-flow.e2e.test.ts`
+
+## Setup
+
+- substrate workspace via `copyWorkspace({ ops: ['op-a', 'op-b'] })`
+- both daemons spawned via `spawnMultiOpDaemons` against Anvil-fork RPC
+- Playwright with two contexts (one per operator) — see [multi-op-playwright.md](multi-op-playwright.md)
+
+## Steps
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { spawnMultiOpDaemons } from '../../helpers/multi-op-daemon';
+import { copyWorkspace } from '../../../scripts/release/substrate-copy';
+import { spawnAnvilForkOfBaseSepolia } from '../../e2e/task-first-helpers';
+
+let workspace, daemons, anvil, opAUrl, opBUrl;
+
+test.beforeAll(async () => {
+  workspace = await copyWorkspace({ ops: ['op-a', 'op-b'] });
+  anvil = await spawnAnvilForkOfBaseSepolia();
+  daemons = await spawnMultiOpDaemons({
+    ops: [
+      { name: 'op-a', home: workspace.opPaths['op-a'], apiPort: 7732 },
+      { name: 'op-b', home: workspace.opPaths['op-b'], apiPort: 7733 },
+    ],
+    extraEnv: { BASE_RPC_URL: anvil.rpcUrl },
+  });
+  opAUrl = daemons.daemons['op-a'].handshakeUrl ?? `http://127.0.0.1:7732/`;
+  opBUrl = daemons.daemons['op-b'].handshakeUrl ?? `http://127.0.0.1:7733/`;
+});
+
+test.afterAll(async () => {
+  await daemons?.teardown();
+  await anvil?.stop();
+  await workspace?.teardown();
+});
+
+test('op-a launches → op-b sees → op-b joins → op-a sees join', async ({ browser }) => {
+  const opACtx = await browser.newContext();
+  const opBCtx = await browser.newContext();
+  const opAPage = await opACtx.newPage();
+  const opBPage = await opBCtx.newPage();
+
+  // === op-a: Launcher Create wizard ===
+  await opAPage.goto(opAUrl);
+  await opAPage.getByRole('link', { name: /launcher/i }).click();
+  await opAPage.getByRole('button', { name: /create solvernet/i }).click();
+
+  // Step 1: Define
+  const solverNetName = `t23-test-${Date.now()}`;
+  await opAPage.getByLabel(/name/i).fill(solverNetName);
+  await opAPage.getByLabel(/description/i).fill('T2.3 e2e test SolverNet');
+  await opAPage.getByRole('button', { name: /next/i }).click();
+
+  // Step 2: Review Contract
+  await opAPage.getByRole('button', { name: /next/i }).click();
+
+  // Step 3: Configure Generator
+  await opAPage.getByLabel(/cadence/i).fill('60000');   // 60s
+  await opAPage.getByRole('button', { name: /next/i }).click();
+
+  // Step 4: Configure Pricing
+  await opAPage.getByLabel(/price/i).fill('100');
+  await opAPage.getByRole('button', { name: /next/i }).click();
+
+  // Step 5: Review and Launch
+  await opAPage.getByRole('button', { name: /launch/i }).click();
+
+  // Wait for launch state machine to reach 'launched'
+  await expect(opAPage.getByText(/launched/i)).toBeVisible({ timeout: 120000 });
+  const manifestCid = await opAPage.getByTestId('manifest-cid').textContent();
+  expect(manifestCid).toMatch(/^bafkrei/);
+
+  // === op-b: Operator catalog sees op-a's SolverNet ===
+  await opBPage.goto(opBUrl);
+  await opBPage.getByRole('link', { name: /operator/i }).click();
+  await opBPage.getByRole('button', { name: /browse catalog/i }).click();
+  await expect(opBPage.getByText(solverNetName)).toBeVisible({ timeout: 30000 });
+
+  // === op-b joins via SPA ===
+  await opBPage.getByText(solverNetName).click();
+  await opBPage.getByRole('button', { name: /join/i }).click();
+  // Restart banner should appear (operator.join writes config; daemon doesn't hot-reload SolverNet config)
+  await expect(opBPage.getByText(/restart required/i)).toBeVisible({ timeout: 10000 });
+
+  // === op-a's launched dashboard reflects op-b's join ===
+  await opAPage.goto(opAUrl + '/launcher/launched');
+  await opAPage.getByText(solverNetName).click();
+  // Operator join is on-chain; SPA should poll and reflect within 30s
+  await expect(opAPage.getByText(/1 operator joined/i)).toBeVisible({ timeout: 30000 });
+
+  await opACtx.close();
+  await opBCtx.close();
+});
+```
+
+## Assertions (summary)
+
+| # | Assertion | Why |
+|---|---|---|
+| A1 | op-a wizard launch reaches `launched` state within 120s | Launcher state machine end-to-end |
+| A2 | manifest CID matches `bafkrei...` shape | pinning + on-chain registry write succeeded |
+| A3 | op-b's catalog shows the new SolverNet within 30s | global registry indexing works |
+| A4 | op-b's join writes operator-side config | operator.join RPC + restart banner |
+| A5 | op-a's launched dashboard shows "1 operator joined" within 30s | cross-op SPA polling correctness |
+
+## Failure modes
+
+| Failure | Class | Triage |
+|---|---|---|
+| Wizard wizard step doesn't advance | real-bug | BLOCKING — wizard UI regression |
+| Launch state machine times out before `launched` | could be: pinning hang, broadcast fail, indexer fail | inspect launch-progress record; flake on first |
+| op-b's catalog doesn't show within 30s | indexer slow OR catalog query broken | check Discovery API directly; if working, SPA-side bug |
+| op-b's join doesn't write config | real-bug | BLOCKING — operator.join broken |
+| Restart banner missing | real-bug | BLOCKING — restart semantics regression |
+| op-a's "1 operator joined" never appears | could be: on-chain operator-join missed, indexer lag, SPA polling broken | check on-chain first, then indexer, then SPA |
+
+## Wall-clock
+
+~5 minutes:
+- 30s daemon spawn + Anvil fork
+- 120s op-a launch
+- 30s op-b catalog lookup
+- 60s op-b join + restart banner
+- 30s op-a sees join
+- 30s setup/teardown
+
+## Dependencies
+
+- Substrate workspace from Plan A
+- spawnAnvilForkOfBaseSepolia helper (existing)
+- The SPA Launcher Create wizard's data-testid attributes (`manifest-cid` etc.) — may need to be added to the SPA in Plan C/D if missing
+- The Operator catalog page at `/operator/...` (existing in v0.1.6)
+- The launched-SolverNet dashboard at `/launcher/launched/:id` (existing in v0.1.6)
+
+## What this scenario does NOT catch
+
+- UX paper cuts (Tier 3 manual walkthrough covers these)
+- Real-network economics
+- Visual regressions
+- Operator's actual claim/solve flow (T2.2 covers that)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/skills/testing-jinn-app/references/scenario-multi-op-spa-flow.md
+git commit -m "docs(testing-jinn-app): add T2.3 multi-op SPA flow scenario reference"
+```
+
+---
+
+## Task 11: Final SKILL.md polish — Quick reference table update
+
+**Files:**
+- Modify: `.claude/skills/testing-jinn-app/SKILL.md`
+
+The existing skill has a "Quick reference" table near the bottom. Extend it with multi-op entries.
+
+- [ ] **Step 1: Read the current Quick reference table**
+
+Run: `awk '/## Quick reference/,/## Common mistakes/' .claude/skills/testing-jinn-app/SKILL.md`
+Expected output: the table.
+
+- [ ] **Step 2: Extend the table**
+
+Open `.claude/skills/testing-jinn-app/SKILL.md`. Find the existing Quick reference table:
+
+```markdown
+| Goal | Approach |
+|------|----------|
+| Spot a UX/layout bug | Manual + chrome-devtools, take screenshots |
+| Reproduce a reported issue | Manual + chrome-devtools, follow user's exact path |
+| Add regression coverage | Playwright E2E with `page.route` mocks |
+| Verify hash deep-links | Navigate to `/configuration#network` etc. |
+| Test against real chain state | Reuse a bootstrapped HOME, no mocks |
+| Test pure SPA wiring | Fresh HOME + mock all `/v1/*` endpoints |
+```
+
+Add these rows below the existing ones (before the next section):
+
+```markdown
+| Spot a cross-op visibility bug | Multi-op chrome-devtools — drive two pages, [`references/multi-op-chrome-devtools.md`](references/multi-op-chrome-devtools.md) |
+| Add cross-op regression coverage | Multi-op Playwright — [`references/multi-op-playwright.md`](references/multi-op-playwright.md) |
+| Test SPA route surface (T1.4) | [`references/scenario-spa-route-smoke.md`](references/scenario-spa-route-smoke.md) |
+| Test cross-op donation (T2.1) | [`references/scenario-cross-op-donation.md`](references/scenario-cross-op-donation.md) |
+| Test producer/evaluator on Anvil-fork (T2.2) | [`references/scenario-producer-evaluator.md`](references/scenario-producer-evaluator.md) |
+| Test multi-op SPA flow (T2.3) | [`references/scenario-multi-op-spa-flow.md`](references/scenario-multi-op-spa-flow.md) |
+```
+
+Save the file.
+
+- [ ] **Step 3: Sanity check**
+
+Run: `grep -c "T2\." .claude/skills/testing-jinn-app/SKILL.md`
+Expected: at least 5 (the new table rows + the references section).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/testing-jinn-app/SKILL.md
+git commit -m "docs(testing-jinn-app): extend Quick reference table with multi-op scenarios"
+```
+
+---
+
+## Task 12: README cross-reference + final verification
+
+**Files:**
+- None modified. This task is a final verification gate.
+
+- [ ] **Step 1: Verify all reference docs exist**
+
+Run:
+```bash
+ls .claude/skills/testing-jinn-app/references/
+```
+
+Expected output (alphabetical):
+```
+multi-op-chrome-devtools.md
+multi-op-playwright.md
+multi-op-spawn.md
+scenario-cross-op-donation.md
+scenario-multi-op-spa-flow.md
+scenario-producer-evaluator.md
+scenario-spa-route-smoke.md
+```
+
+(7 files)
+
+- [ ] **Step 2: Verify SKILL.md has the multi-op section**
+
+Run: `grep -c "Multi-operator scenarios" .claude/skills/testing-jinn-app/SKILL.md`
+Expected: at least 1 occurrence.
+
+- [ ] **Step 3: Verify helper files exist with tests**
+
+Run:
+```bash
+ls client/test/helpers/multi-op-daemon.ts client/test/helpers/multi-op-daemon.test.ts client/test/helpers/handshake-url.ts client/test/helpers/handshake-url.test.ts
+```
+
+Expected: all four files present.
+
+- [ ] **Step 4: Run all helper tests**
+
+Run: `cd client && yarn vitest run test/helpers/handshake-url.test.ts test/helpers/multi-op-daemon.test.ts`
+Expected: all tests pass (multi-op-daemon tests may auto-skip if dist is missing — that's fine for this verification step).
+
+- [ ] **Step 5: Verify cross-references in SKILL.md actually resolve**
+
+Run:
+```bash
+grep -oE 'references/[a-z-]+\.md' .claude/skills/testing-jinn-app/SKILL.md | sort -u | while read ref; do
+  if [ -f ".claude/skills/testing-jinn-app/$ref" ]; then
+    echo "OK   $ref"
+  else
+    echo "MISS $ref"
+  fi
+done
+```
+
+Expected: every line `OK <ref>`, no `MISS`.
+
+- [ ] **Step 6: Final commit (no-op if nothing to add)**
+
+If any verification step revealed a missing/broken reference, fix inline and commit. Otherwise this task is a validation gate with no commit required.
+
+---
+
+## Self-review
+
+### Spec coverage
+
+| Spec requirement | Covered by | Status |
+|---|---|---|
+| §5 SKILL.md multi-op section | Task 3 + Task 11 | ✓ |
+| §5 multi-op-spawn reference | Task 4 | ✓ |
+| §5 multi-op-chrome-devtools reference | Task 5 | ✓ |
+| §5 multi-op-playwright reference | Task 6 | ✓ |
+| §5 scenario-spa-route-smoke (T1.4) | Task 7 | ✓ |
+| §5 scenario-cross-op-donation (T2.1) | Task 8 | ✓ |
+| §5 scenario-producer-evaluator (T2.2) | Task 9 | ✓ |
+| §5 scenario-multi-op-spa-flow (T2.3) | Task 10 | ✓ |
+| §5 "Things to watch for" multi-op entries | Task 3 (embedded in SKILL.md section) | ✓ |
+| §5 minimal helper code (handshake URL + multi-op-daemon) | Tasks 1, 2 | ✓ |
+
+### Placeholder scan
+
+No "TBD" / "TODO" / "fill in details" in any task. Each task contains complete file content or complete code blocks. References to "Plan A's substrate-copy" and "Plan C/D's implementation" are intentional cross-plan references, not placeholders — the imports resolve once Plan A lands; the scenario recipes are intentionally consumed by Plans C/D.
+
+### Type consistency
+
+- `MultiOpHandle`, `DaemonHandle`, `OpSpec`, `SpawnMultiOpOptions` signatures consistent between Task 2 implementation and Task 6 multi-op-playwright reference doc.
+- `extractHandshakeUrl`, `makeHandshakeCollector` API consistent between Task 1 implementation and Task 2 consumer.
+- `copyWorkspace` reference (from Plan A) consistent across Tasks 6, 8, 9, 10 — signature matches Plan A's substrate-copy.
+
+### Cross-plan contract check
+
+This plan promises Plans C/D the following inputs:
+- `client/test/helpers/multi-op-daemon.ts` exports `spawnMultiOpDaemons(opts): Promise<MultiOpHandle>` (Task 2 delivers)
+- `client/test/helpers/handshake-url.ts` exports `extractHandshakeUrl`, `makeHandshakeCollector` (Task 1 delivers)
+- Seven reference docs at known paths (Tasks 3-10 deliver)
+
+Plans C/D's tasks should import these by exact path and consume the reference docs by reading them as authoritative scenario specs.
+
+### Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-19-testing-jinn-app-multi-op-plan.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven (recommended)** — Dispatch a fresh subagent per task, review between tasks. Uses `superpowers:subagent-driven-development`. This plan is mostly doc-writing; subagent dispatch is fast and parallelizes well.
+
+2. **Inline Execution** — Execute tasks in this session using `superpowers:executing-plans`, batch execution with checkpoints.
+
+Plan B has no runtime dependency on Plan A (the imports resolve once Plan A lands; the writing can happen in parallel). Plan A is currently being implemented by a separate background `claude` session — Plan B can be implemented in parallel by a different session, or sequentially after Plan A lands.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-19-release-readiness-and-substrate-design.md
+++ b/docs/superpowers/specs/2026-05-19-release-readiness-and-substrate-design.md
@@ -1,0 +1,736 @@
+# Release-readiness and test-operator substrate
+
+**Version:** v0.1
+**Date:** 2026-05-19
+**Authors:** Adriano Bradley, Claude Opus 4.7
+**Status:** draft
+
+## Why
+
+The v0.1.6 cut on 2026-05-19 spent roughly three hours fighting four distinct CI gate failures (Tenderly rate-limit on public RPC fallback, a `transcript-watcher` test flake, an Anvil stake-stall, a Tenderly rate-limit on the high-quota key after multi-bootstrap saturation). None of the gates caught a real release bug. The ship decision was carried by independent evidence — a manual A3 verification on real Base Sepolia producing `verdictCode=1` on a real `sympy__sympy-27510` solve.
+
+That pattern is structural, not incidental. The current release gates do three things wrong:
+
+1. **They catch their own infrastructure flakes, not release bugs.** The bugs that bit v0.1.6 (Hermes provider routing #293/#298, MCP launcher path #294/#299, ghost-task class #300, eval-substrate silently broken for three weeks before fufn) were all caught by humans and agents *using the app on testnet*, not by CI gates.
+2. **They re-bootstrap from scratch on every run.** Each `bootstrapBaseSepoliaForkOperator` call hammers the fork-source RPC for storage and code fetches. By the third call in one job, even the high-quota Tenderly key returns HTTP errors. This is `jinn-mono-lrey`.
+3. **They don't audit the app.** Operator-app surfaces (the dashboard SPA) are what users actually see and use. The current gates verify chain mechanics and never load a page.
+
+There's also a deeper gap: there is no codified path from "we think this is ready to ship" to "it actually is ready." The current Monday-cut flow draws a draft and asks a human to decide. The human decision is good, but it relies on memory of what changed and trust in unstated checks — both of which decay.
+
+This spec proposes a substrate-anchored test infrastructure plus two new skills that compose into a reliable, advisory release-readiness process. The goal is to make the v0.1.6 outcome (ship-on-independent-evidence with full audit trail) the default, not the exception.
+
+## §1 Architecture overview
+
+Two new skills sit on a shared on-disk substrate. The existing `testing-jinn-app` skill extends to cover multi-operator scenarios.
+
+```
+                       ┌─────────────────────────────────────────┐
+                       │      release-readiness  (meta-skill)    │
+                       │  audit canon → triage gaps → drive      │
+                       │  closure → invoke release-prep → invoke │
+                       │  Tier 3 → emit handoff doc              │
+                       └────────────────┬────────────────────────┘
+                                        │ invokes
+                                        ▼
+                       ┌─────────────────────────────────────────┐
+                       │      release-prep  (mechanical skill)   │
+                       │  copy substrate → run Tier 1 + Tier 2   │
+                       │  → emit jinn-release-evidence marker    │
+                       └────────────────┬────────────────────────┘
+                                        │ uses
+                                        ▼
+   ┌──────────────────────────────────────────────────────────────────┐
+   │   Persistent test-operator substrate                             │
+   │   ~/jinn-dev/operators/op-{a,b,c-legacy}/  (gold copy)           │
+   │   ~/jinn-dev/workspaces/<run-id>/op-{a,b}/  (per-run, ephemeral) │
+   └──────────────────────────────────────────────────────────────────┘
+                                        ▲
+                                        │ uses
+                       ┌─────────────────────────────────────────┐
+                       │   testing-jinn-app  (existing, extended)│
+                       │   spawn daemon(s) → drive via Playwright│
+                       │   / chrome-devtools → assert            │
+                       └─────────────────────────────────────────┘
+```
+
+### Three tiers of evidence
+
+- **Tier 1** — single-operator mechanics on Anvil. Runs on every push to `next` (canary cadence). ~4 min budget. Catches bootstrap-reliability, harness-readiness, indexer-schema, and SPA-route regressions.
+- **Tier 2** — cross-operator scenarios against substrate-derived workspaces (Anvil-fork). Runs in `release-prep`. ~15 min budget. Catches donation-handshake, producer/evaluator-loop, and multi-op SPA bugs.
+- **Tier 3** — real Base Sepolia testnet, real Hermes, real verdict. Runs in `release-readiness` (human-invoked mode only). ~10 min, ~$0.10 API spend. **The only required gate for a named cut.**
+
+### Architectural backbone
+
+The substrate gets *copied* into a workspace at the start of each Tier 2 run. The gate never bootstraps. This single decision dissolves the failure modes that bit v0.1.6 — no Tenderly saturation, no Anvil stake-stalls, no Stage-1 timeouts under multi-bootstrap load.
+
+### New artifacts on disk
+
+- `~/jinn-dev/operators/op-{a,b,c-legacy}/` — gold-copy substrate (slow-changing, manually refreshed when contracts or schemas drift). **Adopted 2026-05-19 from existing fully-bootstrapped operators; details in §2.**
+- `docs/release/<version>/release-prep-evidence.md` — gate output, marker-ready
+- `docs/release/<version>/handoff.md` — release-readiness output, structured for human review
+
+### Files this spec creates or modifies
+
+| Path | New / modified | Purpose |
+|---|---|---|
+| `.claude/skills/testing-jinn-app/SKILL.md` | modified | Extend with multi-operator section |
+| `.claude/skills/testing-jinn-app/references/*` | new | Multi-op recipes + scenario reference docs |
+| `.claude/skills/release-prep/SKILL.md` | new | Mechanical gate-runner skill |
+| `.claude/skills/release-prep/references/*` | new | Tier-1, Tier-2, evidence format, failure classification |
+| `.claude/skills/release-readiness/SKILL.md` | new | Meta audit + triage + closure skill |
+| `.claude/skills/release-readiness/references/*` | new | Static checklist, canon prompts, triage taxonomy, handoff template |
+| `client/scripts/release/substrate-{adopt,copy,verify,topup}.ts` | new | Substrate lifecycle scripts |
+| `client/test/release/tier-1/*.ts` | new | T1.1–T1.4 implementations |
+| `client/test/release/tier-2/*.ts` | new | T2.1–T2.3 implementations |
+| `client/test/release/tier-3/*.ts` | new | T3.1 implementation |
+| `.github/workflows/npm-publish.yml` | modified | Replace `operator-gate` with Tier 1 scenarios |
+
+## §2 Test-operator substrate
+
+### Path layout
+
+```
+~/jinn-dev/
+├── operators/                              # GOLD COPY — slow-changing, read-mostly
+│   ├── op-a/                               # Launcher; adopted from ~/.jinn-client/
+│   │   ├── manifest.json                   # identity, role, on-chain addresses
+│   │   └── .jinn-client/
+│   │       ├── config.json                 # apiPort=7332
+│   │       ├── earning/                    # state + master keystore + launched SolverNet records
+│   │       ├── keystore-password           # chmod 600
+│   │       ├── disclaimer-acknowledged
+│   │       ├── installed-harnesses.json
+│   │       └── operator-mcp-config.json
+│   ├── op-b/                               # Participant; adopted from ~/jinn-canary-test/home/.jinn-client/
+│   │   ├── manifest.json
+│   │   └── .jinn-client/                   # apiPort=7333
+│   └── op-c-legacy/                        # Legacy-backup; adopted from ~/.jinn-testnet-acceptance/
+│       ├── manifest.json
+│       └── .jinn-client/                   # apiPort=7334, pre-fleet bootstrap shape
+└── workspaces/                             # PER-RUN — copied from gold, torn down after
+    └── <run-id>/
+        ├── op-a/
+        └── op-b/
+```
+
+The substrate lives outside any git checkout (survives worktree deletes). Each operator has a `manifest.json` capturing its identity, role, on-chain bindings, and the substrate-version it was generated under.
+
+### Manifest schema
+
+```json
+{
+  "substrateVersion": "1",
+  "createdAt": "2026-05-19T14:47:19Z",
+  "adoptedFrom": "~/.jinn-client/",
+  "name": "op-a",
+  "shape": "current",                       // "current" | "pre-fleet"
+  "role": "launcher",                       // "launcher" | "participant" | "legacy-backup"
+  "network": "base-sepolia",
+  "operator": {
+    "masterAddress": "0xE64bAf00...",
+    "fleetAgentId": "5474",
+    "fleetSafeAddress": "0x0e767E28...",
+    "fleetStage": "stage1_and_2",
+    "serviceId": 46,
+    "serviceStep": "complete",
+    "agentEoa": "0x63192d38...",
+    "safeAddress": "0x0e767E28...",
+    "mechAddress": "0x9c415369...",
+    "stakingAddress": "0x24e34E50...",
+    "identityRegistry": "0x8004A818..."
+  },
+  "config": {
+    "apiPort": 7332,
+    "rpcUrl": "https://base-sepolia.gateway.tenderly.co/...",
+    "joinedSolverNets": ["bafkrei..."]
+  }
+}
+```
+
+### Adopted substrate (as of 2026-05-19)
+
+The substrate exists. Adoption was performed during this spec's brainstorm and committed before writing the doc.
+
+| Op | Source | Master | AgentId | Service | Shape | Role | apiPort |
+|---|---|---|---|---|---|---|---|
+| op-a | `~/.jinn-client/` | `0xE64bAf00...` | 5474 | 46 | current | launcher | 7332 |
+| op-b | `~/jinn-canary-test/home/.jinn-client/` | `0x09040a87...` | 5941 | 56 | current | participant | 7333 |
+| op-c-legacy | `~/.jinn-testnet-acceptance/.jinn-client/` | `0xC1494C7F...` | — | 26 | pre-fleet | legacy-backup | 7334 |
+
+Total disk cost: 88KB across all three (no `engine/work/` cache included). Each op holds only the minimum to spawn a daemon at the right identity: config, earning state, keystores, password, and the lightweight acknowledgement files.
+
+### Lifecycle operations
+
+| Script | Purpose | When |
+|---|---|---|
+| `substrate-adopt.ts` | Copy from existing operator dirs into gold | One-time per substrate refresh |
+| `substrate-copy.ts` | Per-run workspace copy from gold | Start of every Tier 2 run |
+| `substrate-verify.ts` | Manifest + on-chain health check | Start of every release-prep / release-readiness run |
+| `substrate-topup.ts` | Top up Tier 3 funding (ETH + USDC) | Pre-Tier-3 check |
+| `substrate-snapshot.ts` | Bootstrap fresh from scratch (rare) | Deferred — only when adopt + upgrade can't recover |
+
+### Workspace lifecycle
+
+Each Tier 2 run gets `<run-id> = YYYY-MM-DDTHH-MM-SS-<rand4>`. `substrate-copy.ts` copies op-a and op-b into `~/jinn-dev/workspaces/<run-id>/`. Scenarios run against the workspace; gold copy is never touched. At end of run, the workspace is `rm -rf`'d. A background reaper auto-prunes workspaces older than 7 days at the start of every release-prep run.
+
+### Tier 3 substrate use
+
+Tier 3 (real testnet) does **not** copy. It runs daemons directly against the gold copy because the on-chain identity in the gold copy *is* the real-Base-Sepolia identity. Mutations are limited to append operations (task post, solve, verdict). Funding drains and is replenished by `substrate-topup.ts`.
+
+### Mutual exclusion with daily-driver daemon
+
+Substrate operators share their on-chain identity with the daily-driver operator at `~/.jinn-client/` (op-a's source) and `~/jinn-canary-test/...` (op-b's source). Running a substrate daemon on real Base Sepolia while the daily driver is also running results in two daemons fighting for the same nonce/claim/Safe. Rules:
+
+- **Tier 3 (real testnet):** human-invoked mode SIGTERMs daily-driver daemons before Phase 5, restarts after. Autonomous mode skips Tier 3 if daily drivers running.
+- **Tier 2 (Anvil-fork):** safe to run alongside daily driver. Fork is sandboxed.
+- **Tier 1:** no substrate, no conflict.
+
+Detection: `release-readiness` Phase 1 checks ports 7331/7332 on localhost.
+
+### Refresh policy
+
+The gold copy is regenerated when `substrate-verify` reports drift: contracts moved, schema changed, or substrate operator lost staking status. Regeneration is deliberate (manual or scripted via `substrate-snapshot`), not automatic — a fresh substrate burns testnet OLAS bond and shifts agentIds.
+
+## §3 release-prep skill
+
+### Skill location
+
+```
+.claude/skills/release-prep/
+├── SKILL.md
+└── references/
+    ├── tier-1-scenarios.md
+    ├── tier-2-scenarios.md
+    ├── evidence-format.md
+    └── failure-classification.md
+```
+
+### Input contract
+
+```typescript
+interface ReleasePrepInput {
+  branchSha: string;
+  candidateVersion: string;
+  substrateRoot?: string;               // default: ~/jinn-dev/operators/
+  scenarios?: ScenarioId[];             // optional override; default: all enabled
+  outputDir?: string;                   // default: docs/release/<candidateVersion>/
+  parallelism?: number;                 // default: 4
+}
+```
+
+Invocable three ways: from `release-readiness` (subagent dispatch), from a human (`Skill release-prep ...`), or from a future cron. Same contract.
+
+### Five-phase process
+
+```
+1. Preflight
+   ├─ checkout branchSha into a worktree
+   ├─ build the client (yarn build)
+   ├─ verify substrate health
+   │  └─ FAIL: emit "substrate stale, re-adopt" and stop
+   └─ allocate run-id
+
+2. Tier 1 — fan out (parallel, no substrate, ~90s wall-clock)
+   ├─ subagent: T1.1 bootstrap-fresh-anvil (90s budget)
+   ├─ subagent: T1.2 harness-readiness-contract (30s budget)
+   ├─ subagent: T1.3 indexer-round-trip (60s budget)
+   ├─ subagent: T1.4 SPA route smoke (30s budget)
+   └─ collect verdicts
+
+3. Tier 2 — fan out (parallel, substrate-derived workspaces, ~5min wall-clock)
+   ├─ substrate-copy op-a + op-b into per-scenario workspaces
+   ├─ subagent: T2.1 cross-operator-donation (5min budget)
+   ├─ subagent: T2.2 producer-evaluator-anvil-fork (5min budget)
+   ├─ subagent: T2.3 multi-op SPA flow (5min budget)
+   └─ collect verdicts; tear down workspaces
+
+4. Synthesis
+   ├─ aggregate verdicts (pass / skip:<reason> / fail:<class>)
+   ├─ classify each fail: real-bug | flake-infra | flake-timing | agent-crash
+   ├─ write evidence doc: docs/release/<candidateVersion>/release-prep-evidence.md
+   └─ emit marker block to stdout
+
+5. Cleanup
+   └─ remove worktree, reap any orphaned workspaces
+```
+
+### Subagent dispatch model
+
+Each scenario runs as a separate subagent. Per-scenario workspace isolation (each scenario gets its own copy of the substrate) so parallel scenarios don't share daemon state. Subagent receives worktree path, scenario reference doc, workspace path, output path. Reports back a structured verdict:
+
+```json
+{
+  "scenarioId": "T2.1",
+  "verdict": "pass" | "skip:<reason>" | "fail:<class>",
+  "wallClockMs": 312000,
+  "evidencePath": "docs/release/v0.1.7/release-prep-evidence/T2.1.log",
+  "failClass": null | "real-bug" | "flake-infra" | "flake-timing" | "agent-crash",
+  "failNotes": "..."
+}
+```
+
+### Failure classification
+
+| Class | Detection | Action |
+|---|---|---|
+| substrate stale | substrate-verify before fan-out | block run, instruct re-adopt |
+| scenario timeout | wall-clock budget exceeded | mark `fail:flake-timing`, save evidence |
+| scenario RPC error | error message regex (HTTP / network / timeout) | retry once; mark `fail:flake-infra` if second fails |
+| scenario assertion fail | non-flake error | mark `fail:real-bug`, save evidence |
+| workspace teardown fails | rm error | log to reaper, don't block run |
+| subagent crashes | Agent tool error | mark `fail:agent-crash`, save partial evidence |
+
+`flake-*` and `agent-crash` verdicts pass through informationally; they don't block ship by themselves. `real-bug` blocks. `release-readiness` has final say.
+
+### Evidence output
+
+`docs/release/<candidateVersion>/release-prep-evidence.md` plus per-scenario log files under `release-prep-evidence/`. The summary doc embeds a marker block (extends the current `jinn-release-evidence:v1` schema) with per-scenario keys ready to paste into the GitHub Release body.
+
+### Explicit non-goals
+
+- Tier 3 (real testnet) — owned by release-readiness.
+- Triage (blocking-vs-deferrable classification of findings) — owned by release-readiness.
+- Gap closure — owned by release-readiness.
+- Human handoff — owned by release-readiness.
+
+## §4 release-readiness skill
+
+### Skill location
+
+```
+.claude/skills/release-readiness/
+├── SKILL.md
+└── references/
+    ├── static-checklist.md
+    ├── canon-audit-prompts.md
+    ├── triage-taxonomy.md
+    ├── handoff-doc-template.md
+    ├── tier-3-scenario.md
+    └── autonomous-vs-invoked.md
+```
+
+### Input contract
+
+```typescript
+interface ReleaseReadinessInput {
+  candidateVersion: string;
+  branchSha: string;
+  lastReleasedSha?: string;             // diff anchor; defaults to v<prev> tag
+  mode: "human-invoked" | "autonomous";
+  substrateRoot?: string;
+  outputDir?: string;
+  forceShip?: boolean;                  // emergency override, logged in handoff
+}
+```
+
+### Subagent-first design principle
+
+Main agent is a thin coordinator. Anything requiring non-trivial context (canon doc, code section, PR diff, daemon log) runs as a subagent. Main agent only sees structured verdicts. Per-run subagent count: ~6-9 fixed plus one per blocking gap. Main agent's working context stays ~50K tokens regardless of release size.
+
+| Operation | Where | Why |
+|---|---|---|
+| Phase 1 setup (git diff, gh issue queries, substrate-verify) | main | Pure command output |
+| Phase 2 mechanical checks (C2, C5, C6, C9 — grep/AST) | main | No context loading |
+| Phase 2 judgmental + canon pass (C1, C3, C4, C7, C8, C10, C11 + all canon docs) | **1 subagent** | Cross-cutting findings benefit from unified reasoning |
+| Phase 3 triage (classify all gaps) | **1 subagent** | Relative priority across gaps requires unified view |
+| Phase 4 closure (fix + PR) | **1 subagent per gap** | Inherently independent work |
+| Phase 4 PR review per closure | **1 subagent per PR** | Loads PR diff |
+| Phase 5 release-prep | **subagent (the skill itself)** | Already its own skill |
+| Phase 5 Tier 3 scenario | **1 subagent** | Long-running |
+| Phase 6 handoff doc drafting | **1 subagent** | Composes output |
+| Phase 6 SHIP/DEFER/BLOCK decision | main | Terminal judgment stays in main |
+| Phase 7 terminal | main | One-shot notification |
+
+### Seven-phase process
+
+```
+Phase 1: Setup
+  ├─ resolve diff: git log lastReleasedSha..branchSha
+  ├─ load canon: PRINCIPLES.md, SPEC.md, BRAND.md, GROWTH.md, GLOSSARY.md
+  ├─ load operational memory (file-based memory directory)
+  ├─ query open release-blocker issues: gh issue list --label release-blocker
+  └─ verify substrate health
+
+Phase 2: Audit
+  ├─ main runs mechanical checks: C2 / C5 / C6 / C9 (grep/AST)
+  ├─ dispatch judgmental audit subagent (full diff + all canon + check items)
+  └─ collect unified findings list
+
+Phase 3: Triage
+  ├─ dispatch triage subagent
+  ├─ subagent classifies each gap; surfaces cross-cutting concerns
+  ├─ ALREADY-MET: link to evidence
+  ├─ DEFERRABLE: emit gh issue create shell with proposed labels/milestone
+  └─ BLOCKING: queue for Phase 4
+
+Phase 4: Closure (skipped if no BLOCKING)
+  ├─ For each BLOCKING gap, dispatch closure subagent in parallel
+  ├─ Subagent reports: PR URL or escalate=true with reason
+  ├─ For each PR: dispatch PR-review subagent
+  ├─ Main: cross-account merge via dual-account flow if approved
+  └─ After 3 failed close attempts on same gap: BLOCKING-ESCALATED
+       gap remains BLOCKING; recommendation shifts to DEFER
+
+Phase 5: Validate
+  ├─ Invoke release-prep skill with branchSha
+  ├─ Invoke Tier 3 scenario subagent
+  └─ Aggregate
+
+Phase 6: Synthesize
+  ├─ Dispatch handoff-doc-drafting subagent
+  ├─ Main determines recommendation:
+  │    SHIP   if all BLOCKING closed AND Tier 3 passed
+  │    DEFER  if BLOCKING escalated OR Tier 3 failed AND independent evidence weak
+  │    BLOCK  if Tier 3 produced a clear regression
+  ├─ Write final handoff to docs/release/<candidateVersion>/handoff.md
+  ├─ Emit final marker block
+  └─ Append one-line entry to log/decisions/release-readiness-runs.md
+
+Phase 7: Terminal
+  ├─ human-invoked: emit "handoff at <path>; recommendation: SHIP/DEFER/BLOCK"
+  └─ autonomous: gh issue create --label release-ready ...
+```
+
+### Static checklist (C1-C11)
+
+| # | Concern | Triggers when… | Where it runs |
+|---|---|---|---|
+| C1 | operator-app-principle | diff touches `client/src/dashboard/` or operator-facing copy | judgmental subagent |
+| C2 | bootstrap-phase change | diff touches `client/src/earning/bootstrap.ts` | main (grep) |
+| C3 | per-harness readiness | new harness or auth flow change | judgmental subagent |
+| C4 | eval admission / verdict recheck | diff touches eval admission or substrate hashing | judgmental subagent |
+| C5 | task admission filter | diff touches floor / DiscoveryAPI filter / claim eligibility | main (grep) |
+| C6 | canon doc movement | diff touches PRINCIPLES.md / SPEC.md / BRAND.md / GROWTH.md / GLOSSARY.md | main (grep) |
+| C7 | memory invariant violation | diff contradicts stored memory file | judgmental subagent |
+| C8 | wiring-seam coverage | value computed in 2+ modules without single-source helper | judgmental subagent |
+| C9 | release-evidence marker schema | diff touches `.github/workflows/npm-publish.yml` marker check | main (grep) |
+| C10 | spec freshness | spec referenced in code no longer matches code | judgmental subagent |
+| C11 | skill currency | diff touches operator-facing UI / CLI verbs / public surfaces | judgmental subagent |
+
+C11 is the recursion that keeps the system honest. Every release sweeps `.claude/skills/*/SKILL.md` against the diff. Drift is BLOCKING if the skill makes false claims about changed surface (operator hits a wall), DEFERRABLE otherwise.
+
+### Triage taxonomy
+
+**BLOCKING:** PRINCIPLES.md violation introduced by branch, operator-app-principle violation in new UI copy, canon doc moved without ratification, bootstrap/auth/eval substrate regression, wiring-seam drift introduced, Tier 3 regression, skill makes false claims about changed surface.
+
+**DEFERRABLE:** Spec-drift in unreferenced area, pre-existing open issue, quality-of-life concerns, Tier 1/2 flake-class failures, skill doesn't yet cover new surface but existing surface accurate, anything previously triaged as "next release."
+
+**ALREADY-MET:** Static check passed without finding, concern covered by existing test/spec, concern resolved by a commit in window.
+
+### Closure flow
+
+For each BLOCKING gap, dispatch subagent: "investigate, propose fix, implement on a worktree branch off `next`, add regression test, push, file PR." Main agent reads PR-review subagent's report and cross-account approves. Three escalations on same gap shifts recommendation to DEFER.
+
+Cross-account flow: closure subagent pushes as `ritsuKai2000`; main agent does cross-account approve via `ritsukai`. Author can't self-approve in GitHub.
+
+**All issue tracking uses `gh issue` with structured labels and milestones. bd is not used in this skill.**
+
+### Tier 3 scenario
+
+The load-bearing real-testnet evidence — codified A3 verification.
+
+Pre-conditions: daily-driver daemons SIGTERM'd, substrate-topup verified, API key available.
+
+Execution: spawn op-a + op-b daemons from gold substrate, op-a posts a small SWE-rebench v2 task, op-a claims and solves via real Hermes (real OpenRouter API, ~$0.05-$0.10), op-a delivers, op-b claims verdict request, runs real evaluator Docker image, scores, asserts verdictCode matches expected.
+
+Output: tx hashes, IPFS CIDs, wall-clock time, cost, verdict, evidence path under `docs/release/<version>/tier-3-evidence/`.
+
+Budgets: 10 min hard wall-clock, $0.25 API + 0.001 ETH cost cap.
+
+Failure modes: daemon won't start → BLOCK with stderr; task post fails → BLOCK; solve times out → flake first attempt, BLOCK on second; verdict mismatches → REAL REGRESSION (recommendation = BLOCK).
+
+### Handoff doc structure
+
+```
+# Release-readiness handoff — v0.1.7
+Generated: <timestamp>
+Branch SHA: <sha>
+Mode: human-invoked | autonomous
+Audited against last released: v0.1.6 @ <sha>
+Run-id: <run-id>
+
+## Recommendation: SHIP / DEFER / BLOCK
+[reasoning]
+
+## Diff under audit
+[PRs in window, LOC, surfaces touched]
+
+## Gap log
+### Blocking — CLOSED
+### Deferrable — FILED (GitHub issues with milestones)
+### Already met
+
+## release-prep evidence
+[embedded marker block]
+
+## Tier 3 evidence
+[scenario, harness, verdict, tx hashes, IPFS CIDs, cost, wall-clock]
+
+## Walk-through script for human pass
+[diff-derived must-checks by surface]
+
+## Open questions for human
+
+## Independent evidence
+[any out-of-band signal]
+
+## Marker block (final)
+[extends jinn-release-evidence:v1 with tier-3-* and release-readiness-* keys]
+```
+
+### Marker schema extension
+
+The current `jinn-release-evidence:v1` marker gains new keys:
+
+- `tier-1-bootstrap=passed|skipped:#<issue>|failed`
+- `tier-1-harness-readiness=...`
+- `tier-1-indexer-roundtrip=...`
+- `tier-1-spa-route-smoke=...`
+- `tier-2-cross-op-donation=...`
+- `tier-2-producer-evaluator=...`
+- `tier-2-multi-op-spa-flow=...`
+- `tier-3-producer-evaluator-real=...`
+- `release-readiness-recommendation=SHIP|DEFER|BLOCK`
+- `release-readiness-handoff=docs/release/v0.1.7/handoff.md`
+- `release-readiness-run=<run-id>`
+
+The current keys (`release-client-prepare`, `donation-consumption`, `app-first-testnet-acceptance`) are superseded by the per-scenario keys. Migration is one workflow edit + one decision-log entry.
+
+### GitHub labels
+
+Three new labels needed on the repo:
+- `release-readiness` — issues filed by the skill (informational, tracks runs)
+- `release-blocker` — gaps blocking the current cut
+- `skill-drift` — C11 findings on SKILL.md outdatedness
+
+GitHub Milestones (`v0.1.8`, `v0.1.9`, etc.) supply target-release semantics for deferrable gaps.
+
+### Autonomous vs human-invoked
+
+**Human-invoked mode:** Daily-driver daemons SIGTERM'd before Tier 3, restarted after. Tier 3 runs. Cost budget permissive. Phase 7 ends with "handoff ready at `<path>`."
+
+**Autonomous mode:** Daily-driver daemons not touched. Tier 3 SKIPPED if daily drivers running. If skipped, recommendation is `INSUFFICIENT-EVIDENCE-FOR-SHIP; needs human-invoked re-run`. Cost budget tighter. Phase 7 ends with a GitHub issue.
+
+### Integration with existing release cadence
+
+Current state (no cron yet):
+
+```
+Friday evening (manual):
+  human invokes: Skill release-readiness --candidateVersion v0.1.7 --mode autonomous
+  skill runs over weekend (audit + closure + release-prep; Tier 3 SKIPPED)
+  Saturday/Sunday: GH issue filed when complete
+  handoff doc lands at docs/release/v0.1.7/handoff.md
+
+Monday morning:
+  human reads handoff
+  if all looks good: re-invoke with --mode human-invoked for Tier 3
+  Tier 3 runs (~10 min)
+  handoff doc updates with verdict
+  human decides SHIP/DEFER/BLOCK
+  human publishes (or doesn't)
+```
+
+Future (cron, follow-up GH issue):
+
+```
+Friday 23:00 UTC: GH Actions cron fires autonomous mode
+  workflow runs the skill against next HEAD
+  posts handoff doc as a comment on the existing Monday-draft GH Release
+Monday: human picks up, runs human-invoked for Tier 3, decides
+```
+
+### Explicit non-goals
+
+- Publishing the release (always advisory)
+- Modifying canon docs unilaterally
+- Re-running release-prep gates when they already ran against the same SHA
+- Killing operator daemons in autonomous mode
+- Running Tier 3 in autonomous mode
+- Using bd (all issue tracking via `gh issue`)
+
+## §5 testing-jinn-app extension
+
+The existing skill at `.claude/skills/testing-jinn-app/SKILL.md` covers single-operator dashboard testing. It stays unchanged for those use cases. This section adds a multi-operator section and reference docs.
+
+### New section in SKILL.md: "Multi-operator scenarios"
+
+Covers the substrate-anchored spawn pattern, port management, chrome-devtools multi-page driving, Playwright multi-op test templates.
+
+### New reference docs
+
+```
+.claude/skills/testing-jinn-app/references/
+├── multi-op-spawn.md
+├── multi-op-chrome-devtools.md
+├── multi-op-playwright.md
+├── scenario-cross-op-donation.md            # T2.1 recipe
+├── scenario-producer-evaluator.md           # T2.2 recipe
+├── scenario-spa-route-smoke.md              # T1.4 recipe
+└── scenario-multi-op-spa-flow.md            # T2.3 recipe
+```
+
+### Multi-operator spawn pattern
+
+Substrate-derived workspaces, distinct ports per op (7332/7333/7334), per-daemon handshake URL capture, trap-based teardown.
+
+### Failure modes added to "Things to watch for"
+
+- Cross-operator visibility lag (op-b sees op-a's actions only after indexer catch-up)
+- Identity collisions (two daemons with same HOME = same on-chain identity = nonce conflict)
+- Workspace bleed (workspaces auto-pruned at 7 days; don't assume persistence between runs)
+- Substrate staleness (run substrate-verify before any multi-op session)
+- RPC saturation under concurrent load (one shared Tenderly key; add jittered delays in RPC-heavy multi-op scenarios)
+
+### What stays unchanged
+
+Single-op manual smoke (chrome-devtools), single-op Playwright E2E (route-mocked), "rebuild before test," `/v1/bootstrap` readiness wait, handshake-URL-per-spawn, mocking taxonomy.
+
+### Relationship to release-prep and release-readiness
+
+```
+testing-jinn-app          provides the building blocks (recipes)
+       │
+       │ scenarios consumed by
+       ▼
+release-prep              runs scenarios as gates, emits marker
+       │
+       │ marker consumed by
+       ▼
+release-readiness         audits, triages, runs Tier 3, hands off
+```
+
+testing-jinn-app is the **library**. release-prep is the **gate runner**. release-readiness is the **audit + decision skill**. Scenarios are written once in testing-jinn-app and consumed by release-prep — no duplication.
+
+## §6 Scenario inventory (consolidated)
+
+| ID | Tier | Name | Substrate | Lives in | Catches | Wall-clock |
+|---|---|---|---|---|---|---|
+| T1.1 | 1 | bootstrap-fresh-anvil | no | `client/test/release/tier-1/T1.1.ts` | u34i / h74p / k1ng bootstrap reliability | 90s |
+| T1.2 | 1 | harness-readiness-contract | no | `client/test/release/tier-1/T1.2.ts` | vh74 per-harness auth regressions | 30s |
+| T1.3 | 1 | indexer-round-trip | no | `client/test/release/tier-1/T1.3.ts` | fufn eval-substrate, indexer schema drift | 60s |
+| T1.4 | 1 | SPA route smoke | no | `client/test/dashboard/release-prep/spa-route-smoke.e2e.test.ts` | broken routes, missing mocks, JS errors | 30s |
+| T2.1 | 2 | cross-operator-donation | yes | `client/test/release/tier-2/T2.1.ts` | x402 + ERC-8128 handshake regressions | 5m |
+| T2.2 | 2 | producer-evaluator-anvil-fork | yes | `client/test/release/tier-2/T2.2.ts` | claim → solve → deliver → evaluate loop | 5m |
+| T2.3 | 2 | multi-op SPA flow | yes | `client/test/dashboard/multi-op/launcher-join-flow.e2e.test.ts` | cross-op UI bugs invisible under mocks | 5m |
+| T3.1 | 3 | producer-evaluator real-testnet | yes (gold, no copy) | `client/test/release/tier-3/T3.1.ts` | load-bearing real-network verdict | 10m |
+
+**Budget vs expected wall-clock.** Scenarios within a tier run in parallel (each in its own subagent + workspace), so wall-clock for a tier is the *max* of its scenarios, not the sum. Budget is the cap (timeout) per scenario.
+
+- Tier 1 — budget per scenario: 90s; tier wall-clock (parallel max): ~90s
+- Tier 2 — budget per scenario: 5min; tier wall-clock (parallel max): ~5min
+- Tier 3 — single scenario, sequential: ~10min
+
+release-prep wall-clock (Tier 1 + Tier 2 parallel) ≈ 6-7 min. release-readiness end-to-end (release-prep + Tier 3 + audit + closure for a clean release) ≈ 25-35 min.
+
+## §7 Lifecycle, error handling, edge cases
+
+### Substrate funding maintenance (Tier 3)
+
+| Resource | Per op | Top-up trigger | Source |
+|---|---|---|---|
+| ETH | 0.005 | < 0.002 | Base Sepolia faucet / release-bot wallet |
+| USDC | 1.00 | < 0.10 | manual seed, then x402 cycles |
+| OLAS bond | constant | never drains | staked once at substrate creation |
+
+`substrate-topup.ts` runs at start of Tier 3. If balances below threshold, attempts faucet drip; if drained, blocks with operator-app-principle-style escalation.
+
+### Recovery from interrupted runs
+
+No resume. If interrupted, restart from Phase 1. Phases 1-3 are cheap (~5 min). Phase 4 PRs left mid-air can be picked up manually; agent re-audits. Phase 5 is idempotent. Phase 6/7 is a function of inputs.
+
+### API key budget for Tier 3
+
+Per-run cost ~$0.05-$0.10. Weekly cadence ~$0.40-$0.80 / month autonomous + ~$0.20-$0.40 human-invoked. Per-run cap: $0.25 in Tier 3 scenario; abort if exceeded.
+
+### Workspace garbage collection
+
+Trap-handler teardown at end of every run. Background reaper auto-deletes workspaces older than 7 days at start of every release-prep run. Workspaces tagged with `.created-by` for orphan detection.
+
+### Skill-self-update recursion
+
+When release-readiness audits a diff touching its own SKILL.md or references, C11 fires. The skill audits itself. Closure flow dispatches subagent to update the SKILL.md in the same PR.
+
+### Cron not yet wired
+
+Captured as follow-up GitHub issue: "Wire release-readiness autonomous-mode to a Friday 23:00 UTC GitHub Actions schedule." Until that lands, weekend invocation is manual.
+
+## §8 Testing the meta-system
+
+### Unit-ish tests for the skill's own functions
+
+- `client/test/release-skill/audit.test.ts` — known diff + canon corpus, assert findings match expected.
+- `client/test/release-skill/triage.test.ts` — known findings, assert classifications.
+- `client/test/release-skill/handoff-doc.test.ts` — known inputs, assert doc structure.
+
+### Mock canon + diff fixtures
+
+`client/test/release-skill/fixtures/` — one fixture per checklist item plus cross-cutting cases.
+
+### Smoke run against known-good release
+
+Retrospectively run the skill against `v0.1.6`. Expected: recommendation = SHIP, deferrable gaps match what we actually filed (#320, etc.). Catches regressions in the skill itself.
+
+### What's hard to test
+
+The judgmental subagent's reasoning. Fixtures assert *structure* (right number of findings, right severity buckets), not specific reasoning text. Regression-on-known-good catches signal degradation.
+
+## §9 Open questions and acknowledged limitations
+
+### Open questions (resolve in implementation or later)
+
+1. **PRINCIPLES.md vs memory conflict resolution.** PRINCIPLES.md is privileged canon; memory is operational guidance below. Edge cases will emerge.
+2. **What counts as "blocking" for skill-drift.** Clear cases at the extremes; middle ground needs judgment captured in `references/triage-taxonomy.md`.
+3. **How long to keep handoff docs.** Forever, probably. Archive policy deferred until volume justifies.
+4. **Migration path for older releases.** No retroactive migration; forward only.
+5. **Hotfix flow integration.** Tentative: hotfixes skip release-readiness; post-incident GH issue files "audit this hotfix against canon retroactively."
+
+### Acknowledged limitations
+
+- Auto-trigger via cron not wired in v1 (follow-up GH issue).
+- One shared Tenderly RPC key (jinn-mono-lrey tracks fix).
+- Tier 3 cost accumulates ~$0.40-$0.80 / month.
+- engine/work/ cleanup unresolved (#320).
+- Substrate can drift silently between runs (`substrate-verify` catches at start).
+- No concurrent release-candidate support in v1.
+
+### What's *not* an acknowledged limitation
+
+- Subagent reasoning fidelity — property of underlying tools; §8 catches signal degradation.
+- "Gate caught a flake" failure mode — addressed by failure classification.
+- "Ship without Tier 3 evidence" emergency case — handled by `forceShip` with audit log.
+
+## Implementation notes
+
+### Out of scope for this spec
+
+- Cron wiring for autonomous-mode auto-trigger (separate GH issue).
+- jinn-mono-lrey architectural fix (separate work).
+- Engine/work/ cleanup #320 (separate work).
+- Multi-version-in-flight support (defer until needed).
+- Mainnet release-readiness flow (v0.1.x is testnet only; mainnet has different evidence requirements).
+
+### Build sequence
+
+A `writing-plans`-produced plan will sequence the implementation. Rough ordering by dependency:
+
+1. Substrate lifecycle scripts (`substrate-adopt`, `substrate-copy`, `substrate-verify`, `substrate-topup`) — foundation for everything else.
+2. testing-jinn-app extension (multi-op recipes, scenario reference docs) — building blocks release-prep consumes.
+3. Tier 1 + Tier 2 scenario implementations (T1.1–T1.4, T2.1–T2.3).
+4. release-prep skill + its SKILL.md and references.
+5. Tier 3 scenario (T3.1).
+6. release-readiness skill + its SKILL.md and references.
+7. Workflow migration (`.github/workflows/npm-publish.yml` Tier 1 integration, marker schema extension).
+8. Smoke run against v0.1.6 retrospectively.
+9. First production use on v0.1.7.
+
+Substrate adoption itself (the on-disk artifacts) was performed during this spec's brainstorm and is committed before doc finalization. See §2 inventory table.
+
+## References
+
+- `log/decisions/2026-05-19-v0.1.6-stewardship.md` — the v0.1.6 stewardship log that produced the empirical evidence motivating this design.
+- `PRINCIPLES.md` — canon source of truth audited by release-readiness.
+- `docs/engineering/handbook.md` §Cadence — two-train release cadence this skill integrates into.
+- `spec/2026-04-28-canonical-docs.md` — canonical-docs policy referenced by C6.
+- `docs/superpowers/specs/2026-04-24-test-architecture-design.md` — broader test architecture this spec composes with.
+- GitHub issues: `jinn-mono-lrey` (RPC architecture), `#320` (engine/work cleanup), `#310` (donation-consumption), `#312`/`#313` (marker relaxation pattern), `#295`/`#296`/`#297`/`#300`/`#302`/`#304`/`#307`/`#308`/`#309` (v0.1.6 follow-ups).


### PR DESCRIPTION
Implements Plan B from `docs/superpowers/plans/2026-05-19-testing-jinn-app-multi-op-plan.md`.

## Summary

12 tasks shipped:

- **2 TDD code helpers** under `client/test/helpers/`:
  - `handshake-url.ts` — parses the daemon's UI-handshake URL from a stdout stream (7 vitest cases passing).
  - `multi-op-daemon.ts` — spawns N concurrent daemons against distinct HOMEs/ports, returns handles, idempotent teardown (2 vitest cases passing).
- **SKILL.md extension** — new "Multi-operator scenarios" section + 6 new Quick reference rows in `.claude/skills/testing-jinn-app/SKILL.md`.
- **7 reference docs** under `.claude/skills/testing-jinn-app/references/`:
  - Method patterns: `multi-op-spawn.md`, `multi-op-chrome-devtools.md`, `multi-op-playwright.md`
  - Scenarios: `scenario-spa-route-smoke.md` (T1.4), `scenario-cross-op-donation.md` (T2.1), `scenario-producer-evaluator.md` (T2.2), `scenario-multi-op-spa-flow.md` (T2.3)

## Design context

- Spec: `docs/superpowers/specs/2026-05-19-release-readiness-and-substrate-design.md`
- Sibling PR #324 carries the design context.
- Parallel to `feat/substrate-foundation` (Plan A) — no runtime dependency. Plans C/D will consume these contracts.

## Deviations from the verbatim plan

Two deviations the plan author should fold back into the source plan:

1. `makeHandshakeCollector` in `handshake-url.ts` line-splits on `\r?\n` before calling `extractHandshakeUrl`. The plan's verbatim impl would resolve early with partial URLs (e.g. `http://12`) because `\S+` matches greedily; the test for cross-chunk URL assembly would have failed.
2. `spawnMultiOpDaemons` in `multi-op-daemon.ts` injects a `JINN_RPC_URL` fallback so the daemon's RPC preflight passes against a dummy seed config. The fallback chain consults `extraEnv.JINN_RPC_URL`, then `extraEnv.BASE_RPC_URL`, then host env, then the public Tenderly gateway (matching `client/src/config.ts:986`). Without this, T2.2/T2.3 scenarios would silently run against real Sepolia rather than an Anvil fork (caught in post-implementation review).

## Test plan

- [x] `cd client && yarn vitest run test/helpers/handshake-url.test.ts test/helpers/multi-op-daemon.test.ts` — 9/9 pass.
- [x] `cd client && yarn build` — clean.
- [x] `grep -oE 'references/[a-z-]+\.md' .claude/skills/testing-jinn-app/SKILL.md | sort -u` — all 7 cross-references resolve.
- [ ] Plans C/D will exercise the contracts when they consume `spawnMultiOpDaemons` and the scenario recipes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
Closes #370
