### PR TITLE
fix(329): Claude Code harness dropdown selects on click

### DIFF
--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
@@ -289,6 +289,56 @@ describe('JoinFlow — harness options', () => {
     );
   });
 
+  it('selecting Claude Code in the dropdown sticks even when the catalog default is Hermes (issue #329)', async () => {
+    // Issue #329 regression. Production SWE-rebench v2 catalog
+    // (`client/src/main.ts`) lists Hermes first; selecting Claude Code from
+    // the dropdown silently reverted to Hermes on every render because a
+    // render-time `setForm` was bouncing form.harness back to the catalog
+    // default whenever it equalled the seed `claude-code`. Cover the full
+    // sequence: catalog default Hermes -> operator picks Claude Code -> value
+    // sticks across re-renders -> submit carries claude-code.
+    apiMock.getSolverNets.mockResolvedValue({
+      ...baseCatalog,
+      nets: [
+        {
+          ...baseCatalog.nets[0]!,
+          compatibleHarnesses: [
+            { name: 'hermes-agent', version: '0.1.0', supportsRoles: ['solving' as const] },
+            { name: 'claude-code-learner', version: '0.1.0', supportsRoles: ['solving' as const] },
+            { name: 'codex-code-learner', version: '0.1.0', supportsRoles: ['solving' as const] },
+          ],
+        },
+      ],
+    });
+
+    wrap(<JoinFlow />);
+    await waitFor(() => expect(screen.getByTestId('join-flow-summary')).toBeTruthy());
+    fireEvent.click(screen.getByLabelText('Solver'));
+
+    const harnessSelect = screen.getByTestId('join-harness-select') as HTMLSelectElement;
+    // Catalog-arrival effect picks Hermes as the seed.
+    await waitFor(() => expect(harnessSelect.value).toBe('hermes-agent'));
+
+    // Operator selects Claude Code.
+    fireEvent.change(harnessSelect, { target: { value: 'claude-code' } });
+
+    // The pick must stick — not silently revert to Hermes on re-render.
+    await waitFor(() => expect(harnessSelect.value).toBe('claude-code'));
+    // Force several re-renders (toggle Evaluator on and off) to exercise the
+    // catalog-arrival effect's dependency tracking — Claude Code must remain.
+    fireEvent.click(screen.getByLabelText('Evaluator'));
+    fireEvent.click(screen.getByLabelText('Evaluator'));
+    expect(harnessSelect.value).toBe('claude-code');
+
+    // Submit carries the operator's choice.
+    fireEvent.click(screen.getByTestId('join-flow-submit'));
+    await waitFor(() => expect(apiMock.operatorJoin).toHaveBeenCalled());
+    expect(apiMock.operatorJoin).toHaveBeenCalledWith(
+      'bafybeiaaa',
+      expect.objectContaining({ harness: 'claude-code', roles: ['solver'] }),
+    );
+  });
+
   it('drops claude-code-learner from default plugins when Hermes Agent is selected', async () => {
     // Hermes owns its own learning loop (skill self-improvement, memory
     // curation, FTS5 session search — see harnesses/impls/hermes-agent/

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { HermesPrecheckPanel } from './HermesPrecheckPanel.js';
 import { useLocation, useParams } from 'wouter';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -127,25 +127,33 @@ export function JoinFlow({
   });
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [showHermesPrecheck, setShowHermesPrecheck] = useState(false);
+  // Tracks whether the operator has explicitly picked a harness in this
+  // session. Once true, the catalog-arrival effect below MUST NOT stomp
+  // their choice — that was the cause of issue #329, where SWE-rebench v2
+  // (whose catalog default is Hermes) re-overrode every Claude Code click.
+  const operatorPickedHarness = useRef(false);
 
   // The catalog loads independently of the manifest — when it arrives, if
-  // the operator hasn't picked a harness yet (`form.harness` still equal to
-  // the seed default) and the catalog's first compatible option differs,
-  // shift to that. This is render-time-safe because we only call setForm
-  // when the values are unequal — React queues the re-render and bails out
-  // from infinite loops automatically.
+  // the operator hasn't picked a harness yet, shift the seed default to the
+  // catalog's first compatible option. Once-per-catalog-load via useEffect
+  // (NOT a render-time setState) so subsequent dropdown selections don't
+  // get reverted on every re-render.
   const catalogPreferredHarness = solverCompatibleHarnesses[0]?.name;
-  if (
-    catalogPreferredHarness &&
-    form.harness === DEFAULT_HARNESS &&
-    catalogPreferredHarness !== DEFAULT_HARNESS
-  ) {
-    setForm({
-      ...form,
+  useEffect(() => {
+    if (operatorPickedHarness.current) return;
+    if (!catalogPreferredHarness) return;
+    if (catalogPreferredHarness === form.harness) return;
+    setForm((prev) => ({
+      ...prev,
       harness: catalogPreferredHarness,
       model: defaultModelForHarness(catalogPreferredHarness),
-    });
-  }
+    }));
+    // form.harness intentionally omitted: we only react to the catalog
+    // value changing (initial load / contract switch). Including form.harness
+    // would re-fire this effect after the operator picks something and
+    // bounce them back to the catalog default.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [catalogPreferredHarness]);
   const modelOptions = modelOptionsForHarness(form.harness);
 
   const submitMutation = useMutation({
@@ -389,6 +397,10 @@ export function JoinFlow({
                 value={form.harness}
                 onChange={(e) => {
                   const harness = e.target.value;
+                  // Mark the choice as operator-driven so the catalog-arrival
+                  // effect above doesn't bounce them back to the catalog
+                  // default on the next render (issue #329).
+                  operatorPickedHarness.current = true;
                   setForm({
                     ...form,
                     harness,


### PR DESCRIPTION
## Summary

Fixes #329 — operators on the SolverNet join form (notably SWE-rebench v2) could select Codex and Hermes, but every click on **Claude Code** silently reverted to Hermes. Two operators hit this in the 2026-05-19 v0.1.6 dogfood (Oak + rvx).

## Root cause

`JoinFlow.tsx` had a render-time `setForm` guard intended to seed the harness from the catalog once it loaded:

```tsx
if (catalogPreferredHarness && form.harness === DEFAULT_HARNESS &&
    catalogPreferredHarness !== DEFAULT_HARNESS) {
  setForm({ ...form, harness: catalogPreferredHarness, ... });
}
```

`DEFAULT_HARNESS === 'claude-code'`. For SWE-rebench v2 the catalog (`client/src/main.ts`) lists `hermes-agent` first, so `catalogPreferredHarness === 'hermes-agent'`. The guard runs on every render — including the render that fires right after `onChange` sets `form.harness` to `'claude-code'`. It immediately overwrites the operator's pick. Codex stuck because picking Codex moved `form.harness` off the seed default and the guard skipped; Hermes stuck because no change was needed.

## Fix

- Replace the render-time `setForm` with a `useEffect` keyed on `catalogPreferredHarness`.
- Add an `operatorPickedHarness` ref that the select's `onChange` flips to `true` — once flipped, the catalog-arrival effect short-circuits so later catalog re-arrivals (contract switch, refetch) don't bounce the operator's choice.
- Documented the dependency-list choice in a comment so future contributors don't re-add `form.harness` and reintroduce the bug.

## Files modified

- `client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx` — the fix.
- `client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx` — regression test mirroring production SWE-rebench v2 catalog ordering (`hermes-agent`, `claude-code`, `codex`), asserting the dropdown sticks across forced re-renders and the submitted body carries `claude-code`.

## Test plan

- [x] Regression test fails on unpatched source (verified by stashing the fix and rerunning — `Expected: "claude-code" / Received: "hermes-agent"`).
- [x] Regression test passes on patched source.
- [x] `vitest run src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx` — 24 / 24 pass.
- [x] `yarn run -T -B vitest run` (full client suite) — 3567 passed, 7 skipped, 0 failed.
- [x] `tsc --noEmit` — clean.
- [ ] Reviewer: ad-hoc smoke against a built daemon on the SWE-rebench v2 join form.

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)