### PR TITLE
fix(289): in-process respawn on operator-triggered restart

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -38,6 +38,7 @@ import { readModeState } from './harnesses/mode-state.js';
 import { attachAgentWs, updateAgentClaudePath } from './agent/agent-ws.js';
 import { createSetupModeController } from './setup-mode.js';
 import { formatBootstrapOperatorMessage } from './operator-errors.js';
+import { requestDaemonRestart } from './restart-daemon.js';
 import { buildEnvelope, emitEnvelope, type ErrorCode, type ErrorEnvelope } from './errors/envelope.js';
 import {
   clearBootstrapError,
@@ -944,10 +945,12 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
         hermesDoctorTimeoutMs: config.hermesDoctorTimeoutMs,
       },
       admin: {
-        onRestartRequested: () => {
-          console.log('[main] Restart requested via operator MCP. Exiting...');
-          process.exit(0);
-        },
+        // jinn-mono #289: in interactive mode (the dashboard SPA case),
+        // spawn a detached replacement before exiting so the panel reconnects
+        // to a live daemon instead of seeing a 502 + terminal prompt. In
+        // headless mode (`JINN_NO_UI=1`), exit without respawning so the
+        // supervisor / systemd / docker entrypoint decides what to do.
+        onRestartRequested: () => requestDaemonRestart(),
       },
       harnessStatus: {
         getStatus: async () => {

--- a/client/src/restart-daemon.ts
+++ b/client/src/restart-daemon.ts
@@ -1,0 +1,120 @@
+/**
+ * In-process respawn helper for operator-triggered daemon restarts.
+ *
+ * Issue #289: clicking "Restart node" in the operator panel previously called
+ * `process.exit(0)`, which killed the daemon and stranded the operator outside
+ * the app (the panel went 502, the terminal got a shell prompt). Every
+ * restart-required config change funnelled through the same handler:
+ *
+ *   - POST /v1/setup/network              — RPC URL change
+ *   - POST /v1/setup/change-password      — keystore password rotation
+ *   - POST /v1/setup/solvernets/:name     — SolverNet enable/disable
+ *   - POST /v1/operator/join/:cid         — SolverNet join
+ *
+ * The fix is the smallest thing that makes the button mean what it says:
+ * before the parent exits, spawn a detached copy of the current process,
+ * inheriting argv (sans node binary), env, and stdio. The child takes over
+ * the port; the panel reconnects within a couple of seconds.
+ *
+ * Headless gate: `JINN_NO_UI=1` (already the established headless flag in
+ * main.ts) skips the respawn — operators running `jinn run --no-ui` from a
+ * supervisor / systemd unit / docker entrypoint want the supervisor to
+ * decide whether to restart, not the daemon.
+ *
+ * The helper is split out from main.ts so it's unit-testable without
+ * touching the entry-point bootstrap path.
+ */
+
+import { spawn, type SpawnOptions } from 'node:child_process';
+
+/**
+ * Options for `requestDaemonRestart`. All optional in production; the helper
+ * defaults to `process` / `node:child_process`. Tests inject doubles.
+ */
+export interface RequestDaemonRestartOptions {
+  /** Defaults to `process.env`. */
+  env?: NodeJS.ProcessEnv;
+  /** Defaults to `process.argv` (`[node, scriptPath, ...args]`). */
+  argv?: readonly string[];
+  /** Defaults to `process.execPath` (the node binary). */
+  execPath?: string;
+  /**
+   * Defaults to `node:child_process.spawn`. Injected for tests so we can
+   * assert what was spawned without actually forking node.
+   */
+  spawnFn?: typeof spawn;
+  /** Defaults to `(code) => process.exit(code)`. Injected for tests. */
+  exitFn?: (code: number) => void;
+  /** Defaults to `console.log`. Injected for tests to capture output. */
+  log?: (message: string) => void;
+  /**
+   * Delay (ms) between spawning the child and exiting the parent. Gives the
+   * child a moment to bind the API port before the parent vacates it.
+   * Defaults to 250ms per the issue body. Tests can pass 0 for synchrony.
+   */
+  exitDelayMs?: number;
+}
+
+/**
+ * Pure predicate: true when the current env is headless and respawn should
+ * be skipped. Exposed so callers and tests can share the same check.
+ */
+export function isHeadless(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env['JINN_NO_UI'] === '1';
+}
+
+/**
+ * Handle an operator-triggered restart request.
+ *
+ * - In **interactive** mode (default), spawn a detached child that re-runs
+ *   the current node invocation, then exit after a short delay so the child
+ *   can bind the API port.
+ * - In **headless** mode (`JINN_NO_UI=1`), exit without respawning. The
+ *   supervisor is responsible for relaunching the daemon if it wants to.
+ *
+ * Returns the action taken (for tests). Production callers ignore the return.
+ */
+export function requestDaemonRestart(
+  opts: RequestDaemonRestartOptions = {},
+): 'respawned' | 'headless-exit' {
+  const env = opts.env ?? process.env;
+  const argv = opts.argv ?? process.argv;
+  const execPath = opts.execPath ?? process.execPath;
+  const spawnFn = opts.spawnFn ?? spawn;
+  const exitFn = opts.exitFn ?? ((code: number) => process.exit(code));
+  const log = opts.log ?? ((message: string) => console.log(message));
+  const exitDelayMs = opts.exitDelayMs ?? 250;
+
+  if (isHeadless(env)) {
+    log(
+      '[main] Restart requested via operator MCP, but JINN_NO_UI=1 — exiting without respawn (let the supervisor decide).',
+    );
+    exitFn(0);
+    return 'headless-exit';
+  }
+
+  log('[main] Restart requested via operator MCP. Spawning replacement and exiting...');
+
+  // argv[0] is the node binary; argv[1..] are the script + flags. The child
+  // re-runs the same script with the same flags, under the same node binary.
+  const childArgs = argv.slice(1);
+  const spawnOptions: SpawnOptions = {
+    detached: true,
+    stdio: 'inherit',
+    env,
+  };
+  const child = spawnFn(execPath, childArgs, spawnOptions);
+  // Detach so the parent can exit without taking the child with it.
+  child.unref();
+
+  // Give the child a moment to bind the API port before we vacate it.
+  // The 250ms default matches the issue body's empirical measurement; tests
+  // pass 0 for synchrony.
+  if (exitDelayMs <= 0) {
+    exitFn(0);
+  } else {
+    setTimeout(() => exitFn(0), exitDelayMs);
+  }
+
+  return 'respawned';
+}

--- a/client/test/main/restart-daemon-respawn.test.ts
+++ b/client/test/main/restart-daemon-respawn.test.ts
@@ -1,0 +1,160 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+import { isHeadless, requestDaemonRestart } from '../../src/restart-daemon.js';
+
+/**
+ * Regression test for #289 — `'Restart node' button kills the daemon`.
+ *
+ * Before this fix, the operator-MCP restart handler in main.ts called
+ * `process.exit(0)` directly. That stranded the operator: the panel went
+ * 502-on-localhost, the terminal returned to a shell prompt, and the only
+ * path back was a manual `jinn run` re-invocation.
+ *
+ * The fix replaces the bare exit with an in-process respawn: spawn a
+ * detached copy of the current process inheriting argv + env, then exit
+ * after a short delay so the child can bind the API port.
+ *
+ * Test surface:
+ *  - In interactive mode (default), respawn IS invoked, child inherits
+ *    argv[1..] and env, child is detached + unref'd, parent exits 0.
+ *  - In headless mode (`JINN_NO_UI=1`), respawn is NOT invoked — the
+ *    supervisor decides whether to restart.
+ *  - Source-textual: main.ts no longer contains the bare-exit pattern in
+ *    `onRestartRequested`. Catches future-regression-via-revert.
+ */
+
+function makeFakeChild() {
+  return {
+    unref: vi.fn(),
+  };
+}
+
+describe('#289 — operator-triggered restart respawn', () => {
+  describe('isHeadless predicate', () => {
+    it('returns true when JINN_NO_UI=1', () => {
+      expect(isHeadless({ JINN_NO_UI: '1' })).toBe(true);
+    });
+
+    it('returns false when JINN_NO_UI is unset', () => {
+      expect(isHeadless({})).toBe(false);
+    });
+
+    it('returns false when JINN_NO_UI is any other value', () => {
+      expect(isHeadless({ JINN_NO_UI: '0' })).toBe(false);
+      expect(isHeadless({ JINN_NO_UI: 'true' })).toBe(false);
+    });
+  });
+
+  describe('interactive mode (default)', () => {
+    it('spawns a detached replacement with the same argv[1..] and env, then exits 0', () => {
+      const fakeChild = makeFakeChild();
+      const spawnFn = vi.fn(() => fakeChild as never);
+      const exitFn = vi.fn();
+      const log = vi.fn();
+
+      const env = { HOME: '/tmp/test-home', JINN_PASSWORD: 'secret' };
+      const argv = ['/usr/bin/node', '/opt/jinn/dist/main.js', 'run', '--config', '/tmp/c.json'];
+
+      const result = requestDaemonRestart({
+        env,
+        argv,
+        execPath: '/usr/bin/node',
+        spawnFn: spawnFn as unknown as typeof import('node:child_process').spawn,
+        exitFn,
+        log,
+        exitDelayMs: 0,
+      });
+
+      expect(result).toBe('respawned');
+
+      // Spawn was called exactly once, with the node binary + argv[1..].
+      expect(spawnFn).toHaveBeenCalledTimes(1);
+      const [execPathArg, argsArg, optionsArg] = spawnFn.mock.calls[0]!;
+      expect(execPathArg).toBe('/usr/bin/node');
+      expect(argsArg).toEqual(['/opt/jinn/dist/main.js', 'run', '--config', '/tmp/c.json']);
+
+      // Spawned detached + stdio inherit + env passed through.
+      expect(optionsArg).toMatchObject({
+        detached: true,
+        stdio: 'inherit',
+        env,
+      });
+
+      // Child was unref'd so the parent's exit doesn't take it down.
+      expect(fakeChild.unref).toHaveBeenCalledTimes(1);
+
+      // Parent exited 0.
+      expect(exitFn).toHaveBeenCalledWith(0);
+    });
+
+    it('logs that it is respawning', () => {
+      const log = vi.fn();
+      requestDaemonRestart({
+        env: {},
+        argv: ['/usr/bin/node', '/main.js'],
+        execPath: '/usr/bin/node',
+        spawnFn: vi.fn(() => makeFakeChild() as never) as unknown as typeof import('node:child_process').spawn,
+        exitFn: vi.fn(),
+        log,
+        exitDelayMs: 0,
+      });
+      const joined = log.mock.calls.map((c) => c[0]).join('\n');
+      expect(joined).toMatch(/Restart requested/i);
+      expect(joined).toMatch(/[Ss]pawning|[Rr]espawn/);
+    });
+  });
+
+  describe('headless mode (JINN_NO_UI=1)', () => {
+    it('does NOT spawn a replacement; exits 0', () => {
+      const spawnFn = vi.fn();
+      const exitFn = vi.fn();
+      const log = vi.fn();
+
+      const result = requestDaemonRestart({
+        env: { JINN_NO_UI: '1' },
+        argv: ['/usr/bin/node', '/main.js', 'run'],
+        execPath: '/usr/bin/node',
+        spawnFn: spawnFn as unknown as typeof import('node:child_process').spawn,
+        exitFn,
+        log,
+        exitDelayMs: 0,
+      });
+
+      expect(result).toBe('headless-exit');
+      expect(spawnFn).not.toHaveBeenCalled();
+      expect(exitFn).toHaveBeenCalledWith(0);
+
+      // The log should make it obvious why we exited without respawning,
+      // so an operator inspecting logs after a supervisor doesn't restart
+      // the daemon understands what happened.
+      const joined = log.mock.calls.map((c) => c[0]).join('\n');
+      expect(joined).toMatch(/JINN_NO_UI/);
+    });
+  });
+
+  describe('main.ts wiring', () => {
+    const MAIN_PATH = join(__dirname, '../../src/main.ts');
+
+    it('no longer contains the bare process.exit(0) in onRestartRequested', () => {
+      const source = readFileSync(MAIN_PATH, 'utf8');
+      // The exact pre-fix shape: an arrow function whose body is just the log
+      // line + `process.exit(0)`. We assert the source no longer matches the
+      // bare-exit pattern under onRestartRequested.
+      const onRestartIdx = source.indexOf('onRestartRequested');
+      expect(onRestartIdx).toBeGreaterThan(-1);
+      const handlerWindow = source.slice(onRestartIdx, onRestartIdx + 500);
+      expect(handlerWindow).not.toMatch(/process\.exit\(\s*0\s*\)/);
+    });
+
+    it('routes onRestartRequested through requestDaemonRestart', () => {
+      const source = readFileSync(MAIN_PATH, 'utf8');
+      expect(source).toMatch(/from\s+['"]\.\/restart-daemon\.js['"]/);
+      // Handler body invokes requestDaemonRestart.
+      const onRestartIdx = source.indexOf('onRestartRequested');
+      const handlerWindow = source.slice(onRestartIdx, onRestartIdx + 500);
+      expect(handlerWindow).toMatch(/requestDaemonRestart\s*\(/);
+    });
+  });
+});


### PR DESCRIPTION
Closes #289.

## What changed

Replaced the bare `process.exit(0)` in the restart handler with a spawn-then-exit pattern: spawn a detached copy of the current process inheriting env/argv/stdio, then exit. The new child takes over the port; the operator sees the dashboard reconnect rather than a dead panel + terminal prompt.

Specifically:

- New helper `client/src/restart-daemon.ts` exporting `requestDaemonRestart()` — does the spawn-then-exit, with a `JINN_NO_UI=1` headless gate that skips respawn (lets the supervisor decide).
- `client/src/main.ts` `onRestartRequested` now calls `requestDaemonRestart()` instead of `process.exit(0)`.

## Why

Per #289: clicking "Restart node" in the operator app was supposed to actually restart. With the old pattern, it killed the daemon and stranded the operator. Every restart-required config change funnelled through this — RPC URL, password rotation, SolverNet enable/disable, SolverNet join. The operator-never-leaves-the-app principle (PRINCIPLES.md / CLAUDE.md) was breached on the most-clicked restart surface in the panel.

## Test plan

Regression tests at `client/test/main/restart-daemon-respawn.test.ts` (8 tests, all pass):

- [x] `isHeadless` predicate true on `JINN_NO_UI=1`, false otherwise
- [x] Interactive mode: spawn invoked once with `execPath` + `argv.slice(1)`, options include `detached: true`, `stdio: 'inherit'`, `env` passed through, child `unref()`'d, parent exits 0
- [x] Interactive mode: log line announces respawn
- [x] Headless mode: spawn NOT invoked, parent exits 0, log line mentions `JINN_NO_UI`
- [x] main.ts wiring: `onRestartRequested` no longer contains bare `process.exit(0)`; routes through `requestDaemonRestart`

Full client vitest suite green: **3574 passed / 7 skipped / 0 failed** (24.8s).

Typecheck (`tsc --noEmit`): zero errors.

Manual smoke (recommended pre-merge):
- [ ] Click a restart-required UI action in the dashboard SPA, observe daemon respawn and panel reconnect.
- [ ] Run `JINN_NO_UI=1 jinn run`, hit `POST /api/admin/restart` with the admin token, confirm daemon exits without respawning.

## Headless gate

`JINN_NO_UI=1` is the existing headless flag in `main.ts` (line 721, `keepSetupUiOnBootstrapError`). Reusing it keeps the env surface flat — no new flag invented.

## Out of scope

- Hot-reload of RPC URL (~30-50 call sites; needs its own spec).
- Packaged-app wrapper handling respawn (future work; helper is easy to gate behind `JINN_INPROCESS_RESPAWN=0` if needed).
- Port-7331 race tuning beyond the 250ms default (issue body flagged Linux may want longer; can iterate based on field reports).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>