### PR TITLE
fix(330): claim loop gates on hermes harness readiness

### DIFF
--- a/client/src/api/hermes-doctor-endpoint.ts
+++ b/client/src/api/hermes-doctor-endpoint.ts
@@ -11,6 +11,10 @@
  * `installed: false` means the binary was not found (ENOENT or equivalent).
  * `exitCode !== 0` (with `installed: true`) means the binary exists but
  * reports a config problem.
+ *
+ * The probe logic is exported as `probeHermesDoctor` so the Hermes harness
+ * can reuse it from `isReady()` — same source of truth for the SPA
+ * precheck panel and the daemon's claim-readiness gate (#330).
  */
 import type { Hono } from 'hono';
 import { spawnSync } from 'node:child_process';
@@ -27,35 +31,42 @@ export interface HermesDoctorConfig {
   hermesDoctorTimeoutMs?: number;
 }
 
+/**
+ * Synchronously runs `hermes doctor` and classifies the result. Pure (no
+ * Hono dependency) so the harness layer can call it without pulling the API
+ * server in.
+ */
+export function probeHermesDoctor(config: HermesDoctorConfig = {}): HermesDoctorResponse {
+  const hermesBin = config.hermesPath ?? 'hermes';
+  const timeoutMs = config.hermesDoctorTimeoutMs ?? 30_000;
+
+  const result = spawnSync(hermesBin, ['doctor'], {
+    timeout: timeoutMs,
+    encoding: 'utf8',
+  });
+
+  const errorCode = (result.error as NodeJS.ErrnoException | undefined)?.code;
+  // installed=true means we found the binary on disk. ENOENT is the only
+  // definitive not-installed signal. Other errors (EACCES = wrong
+  // permissions; ETIMEDOUT = ran but didn't finish in time) indicate the
+  // binary exists but couldn't be exercised cleanly — surface those as
+  // config-issue, not missing.
+  const notFound = errorCode === 'ENOENT';
+  const installed = !notFound && (
+    result.status !== null
+    || result.signal !== null
+    || (errorCode != null && errorCode !== 'ENOENT')
+  );
+  return {
+    installed,
+    exitCode: result.status,
+    stdout: (result.stdout ?? '').slice(0, 4000),
+    stderr: (result.stderr ?? '').slice(0, 4000),
+  };
+}
+
 export function addHermesDoctorRoutes(app: Hono, config: HermesDoctorConfig = {}): void {
   app.get('/api/hermes/doctor', (c) => {
-    const hermesBin = config.hermesPath ?? 'hermes';
-    const timeoutMs = config.hermesDoctorTimeoutMs ?? 30_000;
-
-    const result = spawnSync(hermesBin, ['doctor'], {
-      timeout: timeoutMs,
-      encoding: 'utf8',
-    });
-
-    const errorCode = (result.error as NodeJS.ErrnoException | undefined)?.code;
-    // installed=true means we found the binary on disk. ENOENT is the only
-    // definitive not-installed signal. Other errors (EACCES = wrong
-    // permissions; ETIMEDOUT = ran but didn't finish in time) indicate the
-    // binary exists but couldn't be exercised cleanly — surface those as
-    // config-issue, not missing.
-    const notFound = errorCode === 'ENOENT';
-    const installed = !notFound && (
-      result.status !== null
-      || result.signal !== null
-      || (errorCode != null && errorCode !== 'ENOENT')
-    );
-    const body: HermesDoctorResponse = {
-      installed,
-      exitCode: result.status,
-      stdout: (result.stdout ?? '').slice(0, 4000),
-      stderr: (result.stderr ?? '').slice(0, 4000),
-    };
-
-    return c.json(body);
+    return c.json(probeHermesDoctor(config));
   });
 }

--- a/client/src/harnesses/impls/hermes-agent/harness.ts
+++ b/client/src/harnesses/impls/hermes-agent/harness.ts
@@ -1,12 +1,17 @@
 // client/src/harnesses/impls/hermes-agent/harness.ts
-import type { Harness, HarnessContext, Solution } from '../../types.js';
+import type { Harness, HarnessContext, ReadyStatus, Solution } from '../../types.js';
 import { HERMES_AGENT_HARNESS } from '../../names.js';
 import type { HermesHarnessAdapter } from './adapter.js';
 import { harvestOutput } from '../learner/harvest.js';
+import { probeHermesDoctor } from '../../../api/hermes-doctor-endpoint.js';
 
 export interface HermesHarnessConfig {
   adapter: HermesHarnessAdapter;
   version?: string;
+  /** Hermes binary path used by `isReady()`. Defaults to `hermes` (PATH lookup). */
+  hermesPath?: string;
+  /** Timeout for the `hermes doctor` probe. Defaults to 30s. */
+  hermesDoctorTimeoutMs?: number;
 }
 
 /**
@@ -26,10 +31,59 @@ export class HermesHarness implements Harness {
   readonly version: string;
   readonly freezeStateHashIgnore = ['auth', 'auth.json', 'bin/tirith', '.env', 'config.yaml'] as const;
   private readonly adapter: HermesHarnessAdapter;
+  private readonly hermesPath: string | undefined;
+  private readonly hermesDoctorTimeoutMs: number | undefined;
 
   constructor(config: HermesHarnessConfig) {
     this.adapter = config.adapter;
     this.version = config.version ?? '0.1.0';
+    this.hermesPath = config.hermesPath;
+    this.hermesDoctorTimeoutMs = config.hermesDoctorTimeoutMs;
+  }
+
+  /**
+   * Readiness probe — shells out to `hermes doctor` via the shared
+   * `probeHermesDoctor` helper (same logic the SPA precheck endpoint
+   * uses). Reports:
+   *   - `installed: false` → binary not on PATH → ready=false with install
+   *     nextStep so the operator sees an actionable message instead of
+   *     N/N failed claims (#330).
+   *   - `exitCode !== 0` → binary exists but `hermes doctor` reports a
+   *     configuration problem (e.g. provider not signed in) → ready=false
+   *     with a nextStep that points at the SPA precheck panel.
+   *   - `exitCode === 0` → ready=true.
+   */
+  async isReady(_ctx?: { solverType: string; role?: 'restoration' | 'evaluation' }): Promise<ReadyStatus> {
+    const config: { hermesPath?: string; hermesDoctorTimeoutMs?: number } = {};
+    if (this.hermesPath !== undefined) config.hermesPath = this.hermesPath;
+    if (this.hermesDoctorTimeoutMs !== undefined) config.hermesDoctorTimeoutMs = this.hermesDoctorTimeoutMs;
+    const result = probeHermesDoctor(config);
+    if (!result.installed) {
+      return {
+        ready: false,
+        reason: 'hermes binary not installed',
+        nextStep: {
+          description:
+            'Install the Hermes agent runner — see the Hermes precheck panel in the operator dashboard for the install command.',
+          url: '/api/hermes/doctor',
+        },
+      };
+    }
+    if (result.exitCode !== 0) {
+      const stderr = result.stderr.trim();
+      const stdout = result.stdout.trim();
+      const detail = stderr.length > 0 ? stderr : stdout;
+      return {
+        ready: false,
+        reason: `hermes doctor exit ${result.exitCode}${detail ? `: ${detail}` : ''}`,
+        nextStep: {
+          description:
+            'Run `hermes doctor` locally to surface the configuration problem, or open the Hermes precheck panel in the operator dashboard to sign in / select a provider.',
+          url: '/api/hermes/doctor',
+        },
+      };
+    }
+    return { ready: true };
   }
 
   supports(spec: { solverType: string; role?: 'restoration' | 'evaluation' }): boolean {

--- a/client/src/harnesses/impls/index.ts
+++ b/client/src/harnesses/impls/index.ts
@@ -104,6 +104,8 @@ export interface HarnessEnv {
   hermesModel?: string;
   /** Hermes provider (e.g. 'anthropic'). */
   hermesProvider?: string;
+  /** Timeout (ms) for the `hermes doctor` probe in HermesHarness.isReady. */
+  hermesDoctorTimeoutMs?: number;
 }
 
 /**
@@ -258,7 +260,11 @@ export function buildHarnesses(env: HarnessEnv): Harness[] {
     storePath: env.storePath,
     corpusEnv: env.corpusEnv ?? {},
   });
-  out.push(new HermesHarness({ adapter: hermesAdapter }));
+  out.push(new HermesHarness({
+    adapter: hermesAdapter,
+    ...(env.hermesPath !== undefined ? { hermesPath: env.hermesPath } : {}),
+    ...(env.hermesDoctorTimeoutMs !== undefined ? { hermesDoctorTimeoutMs: env.hermesDoctorTimeoutMs } : {}),
+  }));
 
   if (env.disabledNames && env.disabledNames.length > 0) {
     const disabled = canonicalHarnessNameSet(env.disabledNames);

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1697,6 +1697,7 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     hermesPath: config.hermesPath,
     hermesModel: config.hermesModel,
     hermesProvider: config.hermesProvider,
+    hermesDoctorTimeoutMs: config.hermesDoctorTimeoutMs,
   })) {
     implRegistry.register(impl);
   }

--- a/client/test/daemon/claim-readiness-gate.test.ts
+++ b/client/test/daemon/claim-readiness-gate.test.ts
@@ -1,0 +1,172 @@
+// client/test/daemon/claim-readiness-gate.test.ts
+//
+// Regression for #330: the daemon must not claim tasks against a SolverNet
+// whose harness reports not-ready. Pre-fix on v0.1.6, a fresh operator who
+// joined SWE-rebench v2 without installing/authing Hermes burned 26 failed
+// claims in minutes — every claim landed because the gate was wired but
+// `HermesHarness` had no `isReady()` so the registry treated it as
+// always-ready.
+//
+// The test spins up a real `Daemon` against a `LocalAdapter`, posts a task
+// whose `solverNetManifestCid` matches a joined entry, and verifies the
+// claim path observes a not-ready harness and skips. The reverse path
+// (registry transitions to ready → claims resume) is also covered.
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Daemon, type DaemonConfig } from '../../src/daemon/daemon.js';
+import { LocalAdapter } from '../../src/adapters/local/adapter.js';
+import { SimpleRunner } from '../../src/runner/simple.js';
+import { HarnessRegistry } from '../../src/harnesses/engine/registry.js';
+import {
+  _resetReadinessGateMemoForTests,
+} from '../../src/daemon/readiness-gate.js';
+import type { HarnessReadinessRegistry } from '../../src/harnesses/readiness-registry.js';
+
+function minimalEngineConfig(): DaemonConfig['restorationEngine'] {
+  const root = mkdtempSync(join(tmpdir(), 'jinn-daemon-readiness-test-'));
+  const implRegistry = new HarnessRegistry({ default: 'legacy-claude' });
+  return {
+    implRegistry,
+    paths: {
+      workingDirRoot: join(root, 'work'),
+      implStateDirRoot: join(root, 'impl-state'),
+    },
+  };
+}
+
+/** Fake registry that returns whatever the controllable callback says. */
+function controlledRegistry(getReady: () => { ready: boolean; reason?: string }) {
+  return {
+    isReadyForClaim: vi.fn(() => getReady()),
+    getSnapshot: vi.fn(() => ({ lastRefreshedAt: '', harnesses: [] })),
+    refreshNow: vi.fn(async () => {}),
+    start: vi.fn(),
+    stop: vi.fn(),
+  } as unknown as HarnessReadinessRegistry;
+}
+
+beforeEach(() => {
+  _resetReadinessGateMemoForTests();
+});
+
+describe('Daemon — claim readiness gate (#330)', () => {
+  it('does NOT call adapter.claimTask when registry reports the harness not ready', async () => {
+    const adapter = new LocalAdapter();
+    const claimSpy = vi.spyOn(adapter, 'claimTask');
+
+    const registry = controlledRegistry(() => ({
+      ready: false,
+      reason: 'hermes binary not installed',
+    }));
+
+    const daemon = new Daemon({
+      adapter,
+      runner: new SimpleRunner(async (d) => `done: ${d}`),
+      taskSources: [],
+      dbPath: ':memory:',
+      restorationEngine: minimalEngineConfig(),
+      harnessReadinessRegistry: registry,
+    });
+    await daemon.start();
+
+    // Post a task carrying a manifestCid so the gate path activates.
+    await adapter.postTask({
+      id: 'task-not-ready',
+      description: 'should be skipped',
+      solverNetManifestCid: 'bafkrei.fake-cid',
+    });
+
+    // Give the engine-watcher loop a few ticks to observe the announcement.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(registry.isReadyForClaim).toHaveBeenCalledWith('bafkrei.fake-cid');
+    expect(claimSpy).not.toHaveBeenCalled();
+
+    await daemon.stop();
+  });
+
+  it('claims when registry transitions from not-ready to ready', async () => {
+    const adapter = new LocalAdapter();
+    const claimSpy = vi.spyOn(adapter, 'claimTask');
+
+    // Flip from not-ready to ready between announcements.
+    let ready = false;
+    const registry = controlledRegistry(() =>
+      ready
+        ? { ready: true }
+        : { ready: false, reason: 'hermes binary not installed' },
+    );
+
+    const daemon = new Daemon({
+      adapter,
+      runner: new SimpleRunner(async (d) => `done: ${d}`),
+      taskSources: [],
+      dbPath: ':memory:',
+      restorationEngine: minimalEngineConfig(),
+      harnessReadinessRegistry: registry,
+    });
+    await daemon.start();
+
+    // Round 1 — not ready, no claim.
+    await adapter.postTask({
+      id: 'task-skip-1',
+      description: 'first task — gate not ready',
+      solverNetManifestCid: 'bafkrei.fake-cid',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(claimSpy).not.toHaveBeenCalled();
+
+    // Round 2 — flip to ready, post a fresh task, expect a claim.
+    ready = true;
+    await adapter.postTask({
+      id: 'task-claim-2',
+      description: 'second task — gate ready',
+      solverNetManifestCid: 'bafkrei.fake-cid',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(claimSpy).toHaveBeenCalled();
+    const args = claimSpy.mock.calls[0]!;
+    expect(args[0]).toBe('2');  // LocalAdapter assigns sequential string ids
+
+    await daemon.stop();
+  });
+
+  it('surfaces the not-ready reason via a warn log on first transition', async () => {
+    const adapter = new LocalAdapter();
+
+    const registry = controlledRegistry(() => ({
+      ready: false,
+      reason: 'hermes doctor exit 1: provider not configured',
+    }));
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const daemon = new Daemon({
+      adapter,
+      runner: new SimpleRunner(async (d) => `done: ${d}`),
+      taskSources: [],
+      dbPath: ':memory:',
+      restorationEngine: minimalEngineConfig(),
+      harnessReadinessRegistry: registry,
+    });
+    await daemon.start();
+
+    await adapter.postTask({
+      id: 'task-log',
+      description: 'gate skip with operator-visible reason',
+      solverNetManifestCid: 'bafkrei.fake-cid',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const matched = warnSpy.mock.calls.some((call) => {
+      const msg = String(call[0] ?? '');
+      return msg.includes('hermes doctor exit 1') && msg.includes('skipping');
+    });
+    expect(matched).toBe(true);
+
+    warnSpy.mockRestore();
+    await daemon.stop();
+  });
+});

--- a/client/test/harnesses/impls/hermes-agent/is-ready.test.ts
+++ b/client/test/harnesses/impls/hermes-agent/is-ready.test.ts
@@ -1,0 +1,62 @@
+// client/test/harnesses/impls/hermes-agent/is-ready.test.ts
+//
+// Regression coverage for #330: HermesHarness must expose isReady() so the
+// readiness registry can prevent the claim loop from claiming tasks against
+// an uninstalled / mis-configured hermes binary. Pre-fix HermesHarness had
+// no isReady; the registry treated it as always-ready and rvx's fresh
+// install burned 26 failed claims in minutes.
+import { describe, expect, it, vi } from 'vitest';
+import { HermesHarness } from '../../../../src/harnesses/impls/hermes-agent/harness.js';
+import { probeHermesDoctor } from '../../../../src/api/hermes-doctor-endpoint.js';
+
+vi.mock('../../../../src/api/hermes-doctor-endpoint.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../src/api/hermes-doctor-endpoint.js')>();
+  return {
+    ...actual,
+    probeHermesDoctor: vi.fn(),
+  };
+});
+
+const fakeAdapter = { name: 'hermes-agent', runTask: vi.fn() };
+
+describe('HermesHarness.isReady', () => {
+  it('returns ready=true when probeHermesDoctor reports installed and exit 0', async () => {
+    vi.mocked(probeHermesDoctor).mockReturnValue({
+      installed: true,
+      exitCode: 0,
+      stdout: 'ok',
+      stderr: '',
+    });
+    const h = new HermesHarness({ adapter: fakeAdapter as any });
+    const result = await h.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+    expect(result.ready).toBe(true);
+  });
+
+  it('returns ready=false with install nextStep when hermes binary missing', async () => {
+    vi.mocked(probeHermesDoctor).mockReturnValue({
+      installed: false,
+      exitCode: null,
+      stdout: '',
+      stderr: '',
+    });
+    const h = new HermesHarness({ adapter: fakeAdapter as any });
+    const result = await h.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+    expect(result.ready).toBe(false);
+    expect(result.reason).toMatch(/not installed/i);
+    expect(result.nextStep?.description).toMatch(/install/i);
+  });
+
+  it('returns ready=false with config nextStep when hermes doctor exit != 0', async () => {
+    vi.mocked(probeHermesDoctor).mockReturnValue({
+      installed: true,
+      exitCode: 1,
+      stdout: '',
+      stderr: 'no provider configured',
+    });
+    const h = new HermesHarness({ adapter: fakeAdapter as any });
+    const result = await h.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+    expect(result.ready).toBe(false);
+    expect(result.reason).toMatch(/doctor/i);
+    expect(result.nextStep?.description).toMatch(/sign in|configure|hermes/i);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #330.

The pre-claim readiness gate shipped in PR #248 (`daemon/readiness-gate.ts`) was wired against `HarnessReadinessRegistry`, but `HermesHarness` did not implement `isReady()`. The registry treated harnesses without an `isReady` as always-ready, so fresh operators who joined SWE-rebench v2 (Hermes default) without installing/authing Hermes burned N/N failed claims — rvx saw 17 → 26 failed claims in minutes on v0.1.6.

## Wiring

- Extract `probeHermesDoctor` from `src/api/hermes-doctor-endpoint.ts` into a pure helper (same module). Keeps the `hermes doctor` probe a single source of truth for the SPA precheck panel (`/api/hermes/doctor`) and the daemon's claim gate.
- Add `HermesHarness.isReady()` that delegates to `probeHermesDoctor` and returns `{ ready: false, reason, nextStep }` for the two failure modes:
  - binary missing on PATH → install nextStep
  - `hermes doctor` exit != 0 → config-issue nextStep (with stderr/stdout in `reason`)
- Thread `hermesDoctorTimeoutMs` through `HarnessEnv` → `buildHarnesses` → `HermesHarness` so the existing config knob (already used by the SPA endpoint) also bounds the daemon probe.

The claim-loop call site (`Daemon._runEngineWatcherLoop` → `gateClaimByReadiness`) is unchanged — the registry's tick-cached snapshot picks up the new `isReady` automatically, the log-on-transition discipline already lives in `readiness-gate.ts`, and rvx's case now skips with a clear `[readiness] <cid> not ready (hermes binary not installed); skipping claims` warn on the first transition.

## Files

- `client/src/api/hermes-doctor-endpoint.ts` — extract `probeHermesDoctor`.
- `client/src/harnesses/impls/hermes-agent/harness.ts` — add `isReady`.
- `client/src/harnesses/impls/index.ts` — pass `hermesDoctorTimeoutMs` to `HermesHarness`.
- `client/src/main.ts` — thread `config.hermesDoctorTimeoutMs` to `buildHarnesses`.
- `client/test/harnesses/impls/hermes-agent/is-ready.test.ts` — 3 unit cases.
- `client/test/daemon/claim-readiness-gate.test.ts` — 3 daemon-level regression cases.

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn test` — 3572 passed / 7 skipped (449 files, 6 new tests in 2 new files)
- [x] `yarn lint:no-late-mount` clean
- [x] Unit: `HermesHarness.isReady` returns ready when `hermes doctor` exits 0; returns not-ready with install nextStep when binary missing; returns not-ready with config nextStep on exit != 0.
- [x] Daemon: with a `LocalAdapter` and a fake registry reporting not-ready, `adapter.claimTask` is never called even though the engine-watcher loop observes the announcement.
- [x] Daemon (inverse): when the registry transitions not-ready → ready, the next announcement is claimed.
- [x] Daemon (operator surface): the not-ready reason is logged via `console.warn` on the first transition.

## Out of scope

- SPA banner / per-harness setup card UX — that's #332 / Stage B of `vh74.2`.
- Codex harness's `isReady` currently delegates to the Claude probe (`learner/harness.ts` builds `isReady` from `buildClaudeIsReady` even for the codex variant). Same shape of bug, different harness; filing a follow-up rather than expanding this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)