### PR TITLE
feat(331): cost surfacing + confirmation gate for paid-API-key harnesses

### DIFF
--- a/client/src/dashboard/spa/src/pages/configuration/CostEstimatePanel.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/CostEstimatePanel.tsx
@@ -1,0 +1,206 @@
+/**
+ * Shared cost-estimate surface used by `JoinFlow` (operator catalog) and
+ * `JoinedNetCard` (Settings). Reads the harness/model billing model from
+ * `client/src/harnesses/cost-estimates.ts`.
+ *
+ * Issue #331 (P0 tier). The component:
+ *   - Renders nothing for subscription harnesses (Claude Code, Codex) —
+ *     callers see `decision.showEstimate === false` and the parent omits
+ *     this panel. We still render a tiny "Included in subscription"
+ *     reassurance row when `mode='inline'` so the operator gets explicit
+ *     confirmation instead of an absent UI.
+ *   - For paid-API-key harnesses, surfaces the per-task USD estimate and
+ *     the heuristic that produced it.
+ *   - When the estimate trips the configured high-cost threshold the
+ *     confirmation gate ("I understand — I have a budget for this") must
+ *     be rendered by the caller; this component exposes `data-cost-*`
+ *     attributes so tests can assert the gate condition.
+ */
+
+import type { JSX } from 'react';
+import {
+  decideCostSurface,
+  DEFAULT_HIGH_COST_THRESHOLD_USD,
+  formatUsd,
+  type CostSurfaceDecision,
+} from '../../../../../harnesses/cost-estimates.js';
+
+export interface CostEstimatePanelProps {
+  harness: string | undefined;
+  modelId: string | undefined;
+  /** Override the gate threshold. Defaults to $1/task. */
+  thresholdUsd?: number;
+  /**
+   * `'card'` (default) renders the panel inside its own card-style
+   * container suitable for the JoinFlow's stacked layout. `'inline'`
+   * renders a compact two-line variant for the JoinedNetCard edit form.
+   */
+  variant?: 'card' | 'inline';
+  /** testid prefix — defaults to `cost-estimate`. */
+  testIdPrefix?: string;
+}
+
+export function useCostSurfaceDecision(
+  harness: string | undefined,
+  modelId: string | undefined,
+  thresholdUsd: number = DEFAULT_HIGH_COST_THRESHOLD_USD,
+): CostSurfaceDecision {
+  return decideCostSurface(harness, modelId, thresholdUsd);
+}
+
+export function CostEstimatePanel({
+  harness,
+  modelId,
+  thresholdUsd = DEFAULT_HIGH_COST_THRESHOLD_USD,
+  variant = 'card',
+  testIdPrefix = 'cost-estimate',
+}: CostEstimatePanelProps): JSX.Element | null {
+  const decision = decideCostSurface(harness, modelId, thresholdUsd);
+
+  if (!decision.showEstimate) {
+    // Subscription harness — render the explicit reassurance row so the
+    // operator gets confirmation that there is no per-task API cost.
+    return (
+      <div
+        data-testid={`${testIdPrefix}-subscription`}
+        data-cost-mode="subscription"
+        style={variant === 'card' ? subscriptionCardStyle : subscriptionInlineStyle}
+      >
+        <span style={iconStyle} aria-hidden="true">
+          ◆
+        </span>
+        <span style={subscriptionTextStyle}>
+          {decision.suppressedReason ?? 'Included in subscription, no per-task API cost.'}
+        </span>
+      </div>
+    );
+  }
+
+  const estimate = decision.estimate;
+  const usd = estimate?.usd ?? null;
+  const isHighCost = decision.requiresConfirmation;
+
+  return (
+    <div
+      data-testid={`${testIdPrefix}-panel`}
+      data-cost-mode="paid-api"
+      data-cost-usd={usd !== null ? usd.toFixed(4) : 'unknown'}
+      data-cost-high-cost={isHighCost ? 'true' : 'false'}
+      style={variant === 'card' ? paidCardStyle(isHighCost) : paidInlineStyle(isHighCost)}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: '12px' }}>
+        <span style={labelStyle}>Estimated cost per task</span>
+        <span
+          data-testid={`${testIdPrefix}-amount`}
+          style={{
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: variant === 'card' ? '18px' : '14px',
+            fontWeight: 500,
+            color: isHighCost ? 'var(--break-red)' : 'var(--fg)',
+          }}
+        >
+          {usd !== null ? `~${formatUsd(usd)}` : 'unavailable'}
+        </span>
+      </div>
+      {estimate && (
+        <span
+          data-testid={`${testIdPrefix}-heuristic`}
+          style={{
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '11px',
+            color: 'var(--fg-muted)',
+          }}
+        >
+          Heuristic: ~{(estimate.typicalInputTokens / 1000).toFixed(0)}k input + ~
+          {(estimate.typicalOutputTokens / 1000).toFixed(0)}k output @ ${estimate.entry.inputPer1kTokens.toFixed(4)}
+          /1k in, ${estimate.entry.outputPer1kTokens.toFixed(4)}/1k out (provider: {estimate.entry.provider}).
+          Real usage will vary.
+        </span>
+      )}
+      {usd === null && (
+        <span
+          data-testid={`${testIdPrefix}-unknown`}
+          style={{
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '11px',
+            color: 'var(--fg-muted)',
+          }}
+        >
+          No pricing entry for this model id — confirm rates with your provider before joining.
+        </span>
+      )}
+      {isHighCost && (
+        <span
+          data-testid={`${testIdPrefix}-warning`}
+          style={{
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '11px',
+            color: 'var(--break-red)',
+          }}
+        >
+          This model is above ${thresholdUsd.toFixed(2)}/task. You will be asked to confirm before joining.
+        </span>
+      )}
+    </div>
+  );
+}
+
+const labelStyle: React.CSSProperties = {
+  fontFamily: "'JetBrains Mono', monospace",
+  fontSize: '11px',
+  fontWeight: 500,
+  letterSpacing: '0.14em',
+  textTransform: 'uppercase',
+  color: 'var(--fg-muted)',
+};
+
+const iconStyle: React.CSSProperties = {
+  color: 'var(--accent-sky)',
+  fontSize: '12px',
+};
+
+const subscriptionTextStyle: React.CSSProperties = {
+  fontFamily: "'JetBrains Mono', monospace",
+  fontSize: '12px',
+  color: 'var(--fg-muted)',
+};
+
+const subscriptionCardStyle: React.CSSProperties = {
+  background: 'var(--bg-elevated)',
+  border: '1px solid var(--border)',
+  borderRadius: 'var(--radius-2)',
+  padding: '10px 14px',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '10px',
+};
+
+const subscriptionInlineStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+  padding: '6px 0',
+};
+
+function paidCardStyle(highCost: boolean): React.CSSProperties {
+  return {
+    background: 'var(--bg-elevated)',
+    border: `1px solid ${highCost ? 'var(--break-red)' : 'var(--border)'}`,
+    borderRadius: 'var(--radius-2)',
+    padding: '14px 16px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+  };
+}
+
+function paidInlineStyle(highCost: boolean): React.CSSProperties {
+  return {
+    border: `1px solid ${highCost ? 'var(--break-red)' : 'var(--border)'}`,
+    borderRadius: 'var(--radius-2)',
+    padding: '8px 10px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '4px',
+  };
+}

--- a/client/src/dashboard/spa/src/pages/configuration/JoinedNetCard.test.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/JoinedNetCard.test.tsx
@@ -418,3 +418,79 @@ describe('<JoinedNetCard />', () => {
     expect(onRestart).not.toHaveBeenCalled();
   });
 });
+
+describe('<JoinedNetCard /> — cost surfacing + confirmation gate (Issue #331 P0)', () => {
+  const HERMES_CATALOG: SolverNetCatalogEntry = {
+    name: 'Prediction Markets',
+    description: 'Predict things',
+    state: 'live',
+    contract: { id: 'prediction', version: 'v1' },
+    supportedRoles: ['solving', 'evaluating'],
+    compatibleHarnesses: [
+      { name: 'claude-code-learner', version: '0.1.0', supportsRoles: ['solving'] },
+      { name: 'hermes-agent', version: '0.1.0', supportsRoles: ['solving'] },
+    ],
+    compatiblePlugins: [],
+  };
+
+  it('renders the subscription reassurance row for Claude Code (no false-positive gate)', () => {
+    wrap(<JoinedNetCard joined={ENTRY} catalogEntry={HERMES_CATALOG} defaultExpanded />);
+    expect(screen.getByTestId('joined-net-card-cost-subscription')).toBeTruthy();
+    expect(screen.getByTestId('joined-net-card-cost-subscription').textContent).toMatch(
+      /subscription/i,
+    );
+    expect(screen.queryByTestId('joined-net-card-cost-confirmation')).toBeNull();
+    expect(screen.queryByTestId('joined-net-card-cost-panel')).toBeNull();
+  });
+
+  it('shows the cost panel + confirmation when the operator switches to Hermes + Opus 4.7', async () => {
+    vi.mocked(api.operator.join).mockResolvedValue({
+      ok: true,
+      restartRequired: true,
+      manifestCid: 'bafybeiaaa',
+      config: { manifestCid: 'bafybeiaaa', roles: ['solver', 'evaluator'] },
+    });
+    wrap(<JoinedNetCard joined={ENTRY} catalogEntry={HERMES_CATALOG} defaultExpanded />);
+
+    fireEvent.change(screen.getByTestId('joined-net-card-harness-select'), {
+      target: { value: 'hermes-agent' },
+    });
+
+    // Hermes default model is anthropic/claude-opus-4.7 (Opus 4.7 via
+    // OpenRouter), well above the $1/task gate.
+    await waitFor(() =>
+      expect(screen.getByTestId('joined-net-card-cost-panel')).toBeTruthy(),
+    );
+    expect(screen.getByTestId('joined-net-card-cost-panel').getAttribute('data-cost-high-cost')).toBe(
+      'true',
+    );
+    expect(screen.getByTestId('joined-net-card-cost-amount').textContent).toMatch(/\$2\.25/);
+    expect(screen.getByTestId('joined-net-card-cost-confirmation')).toBeTruthy();
+
+    // Save disabled until acknowledged.
+    const save = screen.getByTestId('joined-net-card-save') as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+
+    fireEvent.click(
+      screen.getByTestId('joined-net-card-cost-confirmation-checkbox'),
+    );
+    await waitFor(() => expect(save.disabled).toBe(false));
+
+    fireEvent.click(save);
+    await waitFor(() => expect(api.operator.join).toHaveBeenCalled());
+  });
+
+  it('does NOT show the confirmation gate when the model stays under $1/task', () => {
+    const sonnetEntry: JoinedNetEntry = {
+      ...ENTRY,
+      harness: 'hermes-agent',
+      model: 'deepseek/deepseek-v4-flash',
+    };
+    wrap(<JoinedNetCard joined={sonnetEntry} catalogEntry={HERMES_CATALOG} defaultExpanded />);
+    expect(screen.getByTestId('joined-net-card-cost-panel')).toBeTruthy();
+    expect(screen.getByTestId('joined-net-card-cost-panel').getAttribute('data-cost-high-cost')).toBe(
+      'false',
+    );
+    expect(screen.queryByTestId('joined-net-card-cost-confirmation')).toBeNull();
+  });
+});

--- a/client/src/dashboard/spa/src/pages/configuration/JoinedNetCard.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/JoinedNetCard.tsx
@@ -18,6 +18,7 @@ import {
   harnessOptionLabel,
 } from './harnessNames.js';
 import { PluginPicker } from './PluginPicker.js';
+import { CostEstimatePanel, useCostSurfaceDecision } from './CostEstimatePanel.js';
 
 /**
  * Per-SolverNet edit card on /operator → SolverNets → Joined.
@@ -206,6 +207,15 @@ export function JoinedNetCard({
       if (res.restartRequired) onRestartPending?.();
     },
   });
+
+  const [highCostAcknowledged, setHighCostAcknowledged] = useState(false);
+  const isSolver = joined.roles.includes('solver');
+  const costDecision = useCostSurfaceDecision(
+    isSolver ? form.harness : undefined,
+    isSolver ? form.model : undefined,
+  );
+  const requiresCostConfirmation = isSolver && costDecision.requiresConfirmation;
+  const costGateBlocked = requiresCostConfirmation && !highCostAcknowledged;
 
   const [confirmingLeave, setConfirmingLeave] = useState(false);
   const leaveMutation = useMutation({
@@ -450,6 +460,7 @@ export function JoinedNetCard({
                   harness,
                   model: defaultModelForHarness(harness),
                 }));
+                setHighCostAcknowledged(false);
               }}
               style={{
                 ...selectStyle,
@@ -556,7 +567,10 @@ export function JoinedNetCard({
               aria-label="Model"
               data-testid="joined-net-card-model-select"
               value={form.model}
-              onChange={(e) => setForm({ ...form, model: e.target.value })}
+              onChange={(e) => {
+                setForm({ ...form, model: e.target.value });
+                setHighCostAcknowledged(false);
+              }}
               style={selectStyle}
             >
               {modelOptions.map((m) => (
@@ -577,6 +591,48 @@ export function JoinedNetCard({
               })()}
             </select>
           </div>
+
+          {isSolver && (
+            <CostEstimatePanel
+              harness={form.harness}
+              modelId={form.model}
+              variant="inline"
+              testIdPrefix="joined-net-card-cost"
+            />
+          )}
+
+          {requiresCostConfirmation && (
+            <label
+              data-testid="joined-net-card-cost-confirmation"
+              data-cost-confirmation-checked={highCostAcknowledged ? 'true' : 'false'}
+              style={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: '8px',
+                padding: '10px 12px',
+                border: '1px solid var(--break-red)',
+                borderRadius: 'var(--radius-2)',
+                background: 'var(--bg)',
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: '12px',
+                color: 'var(--fg)',
+                cursor: 'pointer',
+              }}
+            >
+              <input
+                type="checkbox"
+                data-testid="joined-net-card-cost-confirmation-checkbox"
+                checked={highCostAcknowledged}
+                onChange={(e) => setHighCostAcknowledged(e.target.checked)}
+                style={{ accentColor: 'var(--break-red)', marginTop: '2px', width: '14px', height: '14px' }}
+                aria-label="I understand the per-task cost and have a budget for this"
+              />
+              <span>
+                I understand — I have a budget for this. The selected model is estimated above $1/task on
+                my own provider key.
+              </span>
+            </label>
+          )}
 
           {saveMutation.isError && (
             <span
@@ -614,9 +670,9 @@ export function JoinedNetCard({
               <button
                 type="button"
                 data-testid="joined-net-card-save"
-                disabled={!dirty || saveMutation.isPending}
+                disabled={!dirty || saveMutation.isPending || costGateBlocked}
                 onClick={() => saveMutation.mutate()}
-                style={primaryButtonStyle(dirty && !saveMutation.isPending)}
+                style={primaryButtonStyle(dirty && !saveMutation.isPending && !costGateBlocked)}
               >
                 {saveMutation.isPending ? 'Saving…' : 'Save'}
               </button>

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
@@ -675,6 +675,14 @@ describe('JoinFlow — Hermes Agent precheck panel', () => {
     // Select hermes-agent.
     fireEvent.change(harnessSelect, { target: { value: 'hermes-agent' } });
     await waitFor(() => expect(harnessSelect.value).toBe('hermes-agent'));
+
+    // Hermes default is Opus 4.7 — above the $1/task cost gate (Issue
+    // #331). Acknowledge it so the submit button isn't gated; these
+    // tests are exercising the precheck path, not the cost gate.
+    await waitFor(() =>
+      expect(screen.getByTestId('join-flow-cost-confirmation')).toBeTruthy(),
+    );
+    fireEvent.click(screen.getByTestId('join-flow-cost-confirmation-checkbox'));
   }
 
   it('shows the not-installed panel when hermesDoctor returns installed:false', async () => {
@@ -786,6 +794,9 @@ describe('JoinFlow — Hermes Agent precheck panel', () => {
     expect(screen.getByTestId('join-flow-solver-fields')).toBeTruthy();
   });
 
+  // Cost-protection P0 tests live in the following describe block, then the
+  // remaining Hermes precheck cases continue below.
+
   it('shows the network-error panel when hermesDoctor rejects (does NOT fall through to install)', async () => {
     apiMock.hermesDoctor.mockRejectedValue(new Error('Network error: failed to fetch /api/hermes/doctor'));
 
@@ -800,5 +811,132 @@ describe('JoinFlow — Hermes Agent precheck panel', () => {
     // reinstall a Hermes that is already there when the daemon is just down).
     expect(screen.queryByTestId('hermes-precheck-not-installed')).toBeNull();
     expect(apiMock.operatorJoin).not.toHaveBeenCalled();
+  });
+});
+
+describe('JoinFlow — cost surfacing + confirmation gate (Issue #331 P0)', () => {
+  /**
+   * Catalog with Hermes + Claude Code, both compatible. The default solver
+   * harness is the first compatible — Claude Code — so the cost surface
+   * for that path renders the subscription reassurance. Switching to
+   * Hermes + Opus 4.7 puts us in the high-cost band; switching to
+   * Hermes + DeepSeek V4 Flash stays under the $1 threshold.
+   */
+  const mixedHarnessCatalog = {
+    ...baseCatalog,
+    nets: [
+      {
+        ...baseCatalog.nets[0]!,
+        compatibleHarnesses: [
+          { name: 'claude-code-learner', version: '0.1.0', supportsRoles: ['solving' as const] },
+          { name: 'hermes-agent', version: '0.1.0', supportsRoles: ['solving' as const] },
+        ],
+      },
+    ],
+  };
+
+  async function setupSolverWithMixedHarnesses(): Promise<HTMLSelectElement> {
+    apiMock.getSolverNets.mockResolvedValue(mixedHarnessCatalog);
+    wrap(<JoinFlow />);
+    await waitFor(() => expect(screen.getByTestId('join-flow-summary')).toBeTruthy());
+    fireEvent.click(screen.getByLabelText('Solver'));
+    const harnessSelect = screen.getByTestId('join-harness-select') as HTMLSelectElement;
+    await waitFor(() =>
+      expect(Array.from(harnessSelect.options).some((o) => o.value === 'hermes-agent')).toBe(true),
+    );
+    return harnessSelect;
+  }
+
+  it('renders the subscription reassurance row and NO confirmation gate for Claude Code', async () => {
+    const harnessSelect = await setupSolverWithMixedHarnesses();
+    fireEvent.change(harnessSelect, { target: { value: 'claude-code' } });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('join-flow-cost-subscription')).toBeTruthy(),
+    );
+    expect(screen.getByTestId('join-flow-cost-subscription').textContent).toMatch(
+      /subscription/i,
+    );
+    // No confirmation gate, no high-cost panel.
+    expect(screen.queryByTestId('join-flow-cost-confirmation')).toBeNull();
+    expect(screen.queryByTestId('join-flow-cost-panel')).toBeNull();
+
+    // The submit button should remain enabled once a role is picked.
+    const submit = screen.getByTestId('join-flow-submit') as HTMLButtonElement;
+    expect(submit.disabled).toBe(false);
+  });
+
+  it('shows the cost panel and the $1/task warning for Hermes + Opus 4.7', async () => {
+    const harnessSelect = await setupSolverWithMixedHarnesses();
+    fireEvent.change(harnessSelect, { target: { value: 'hermes-agent' } });
+
+    // Hermes default is anthropic/claude-opus-4.7 — above the $1/task gate.
+    await waitFor(() => expect(screen.getByTestId('join-flow-cost-panel')).toBeTruthy());
+    const panel = screen.getByTestId('join-flow-cost-panel');
+    expect(panel.getAttribute('data-cost-high-cost')).toBe('true');
+    expect(panel.getAttribute('data-cost-mode')).toBe('paid-api');
+    expect(screen.getByTestId('join-flow-cost-amount').textContent).toMatch(/\$2\.25/);
+    expect(screen.getByTestId('join-flow-cost-warning')).toBeTruthy();
+    expect(screen.getByTestId('join-flow-cost-confirmation')).toBeTruthy();
+  });
+
+  it('disables the Save & Join button until the high-cost confirmation is checked', async () => {
+    const harnessSelect = await setupSolverWithMixedHarnesses();
+    fireEvent.change(harnessSelect, { target: { value: 'hermes-agent' } });
+
+    await waitFor(() => expect(screen.getByTestId('join-flow-cost-confirmation')).toBeTruthy());
+    const submit = screen.getByTestId('join-flow-submit') as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+
+    const checkbox = screen.getByTestId(
+      'join-flow-cost-confirmation-checkbox',
+    ) as HTMLInputElement;
+    fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(true);
+
+    await waitFor(() => expect(submit.disabled).toBe(false));
+  });
+
+  it('does NOT show the confirmation gate for Hermes + DeepSeek V4 Flash (sub-$1 model)', async () => {
+    const harnessSelect = await setupSolverWithMixedHarnesses();
+    fireEvent.change(harnessSelect, { target: { value: 'hermes-agent' } });
+
+    // Switch to a low-cost model.
+    await waitFor(() => expect(screen.getByTestId('join-model-select')).toBeTruthy());
+    const modelSelect = screen.getByTestId('join-model-select') as HTMLSelectElement;
+    fireEvent.change(modelSelect, { target: { value: 'deepseek/deepseek-v4-flash' } });
+
+    // Panel still shows, but the warning + confirmation are gone.
+    await waitFor(() => expect(screen.getByTestId('join-flow-cost-panel')).toBeTruthy());
+    expect(screen.getByTestId('join-flow-cost-panel').getAttribute('data-cost-high-cost')).toBe('false');
+    expect(screen.queryByTestId('join-flow-cost-warning')).toBeNull();
+    expect(screen.queryByTestId('join-flow-cost-confirmation')).toBeNull();
+
+    // And the submit button is enabled (no gate).
+    const submit = screen.getByTestId('join-flow-submit') as HTMLButtonElement;
+    expect(submit.disabled).toBe(false);
+  });
+
+  it('resets the confirmation when the model is swapped back to a low-cost model', async () => {
+    const harnessSelect = await setupSolverWithMixedHarnesses();
+    fireEvent.change(harnessSelect, { target: { value: 'hermes-agent' } });
+
+    // Acknowledge Opus 4.7.
+    await waitFor(() => expect(screen.getByTestId('join-flow-cost-confirmation')).toBeTruthy());
+    fireEvent.click(screen.getByTestId('join-flow-cost-confirmation-checkbox'));
+
+    // Switch to a cheap model — confirmation goes away.
+    const modelSelect = screen.getByTestId('join-model-select') as HTMLSelectElement;
+    fireEvent.change(modelSelect, { target: { value: 'deepseek/deepseek-v4-flash' } });
+    await waitFor(() => expect(screen.queryByTestId('join-flow-cost-confirmation')).toBeNull());
+
+    // Switch back to Opus — confirmation reappears and the prior tick must
+    // NOT have persisted (operator must re-confirm).
+    fireEvent.change(modelSelect, { target: { value: 'anthropic/claude-opus-4.7' } });
+    await waitFor(() => expect(screen.getByTestId('join-flow-cost-confirmation')).toBeTruthy());
+    const checkbox = screen.getByTestId('join-flow-cost-confirmation-checkbox') as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+    const submit = screen.getByTestId('join-flow-submit') as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
   });
 });

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
@@ -21,6 +21,7 @@ import {
   harnessOptionLabel,
 } from '../configuration/harnessNames.js';
 import { PluginPicker } from '../configuration/PluginPicker.js';
+import { CostEstimatePanel, useCostSurfaceDecision } from '../configuration/CostEstimatePanel.js';
 import { formatWeiAmount } from '../launcher-launched/helpers.js';
 
 const HERMES_AGENT_DESCRIPTION =
@@ -132,6 +133,7 @@ export function JoinFlow({
   // their choice — that was the cause of issue #329, where SWE-rebench v2
   // (whose catalog default is Hermes) re-overrode every Claude Code click.
   const operatorPickedHarness = useRef(false);
+  const [highCostAcknowledged, setHighCostAcknowledged] = useState(false);
 
   // The catalog loads independently of the manifest — when it arrives, if
   // the operator hasn't picked a harness yet, shift the seed default to the
@@ -235,7 +237,19 @@ export function JoinFlow({
 
   const showSolverFields = form.roles.includes('solver');
   const showEvaluatorInfo = form.roles.includes('evaluator');
-  const canSubmit = form.roles.length > 0 && !submitMutation.isPending;
+
+  // Cost-protection surface (Issue #331). Only consulted when the solver
+  // role is selected — the evaluator role binds to a manifest-supplied
+  // implementation and bypasses operator harness choice entirely.
+  const costDecision = useCostSurfaceDecision(
+    showSolverFields ? form.harness : undefined,
+    showSolverFields ? form.model : undefined,
+  );
+  const requiresCostConfirmation = showSolverFields && costDecision.requiresConfirmation;
+  const costGateBlocked = requiresCostConfirmation && !highCostAcknowledged;
+
+  const canSubmit =
+    form.roles.length > 0 && !submitMutation.isPending && !costGateBlocked;
 
   return (
     <main data-testid="join-flow" data-manifest-cid={cid} style={pageStyle}>
@@ -406,6 +420,7 @@ export function JoinFlow({
                     harness,
                     model: defaultModelForHarness(harness),
                   });
+                  setHighCostAcknowledged(false);
                 }}
                 style={selectStyle}
               >
@@ -438,7 +453,10 @@ export function JoinFlow({
                 aria-label="Model"
                 data-testid="join-model-select"
                 value={form.model}
-                onChange={(e) => setForm({ ...form, model: e.target.value })}
+                onChange={(e) => {
+                  setForm({ ...form, model: e.target.value });
+                  setHighCostAcknowledged(false);
+                }}
                 style={selectStyle}
               >
                 {modelOptions.map((m) => (
@@ -460,6 +478,45 @@ export function JoinFlow({
               </select>
             </div>
           </div>
+
+          <CostEstimatePanel
+            harness={form.harness}
+            modelId={form.model}
+            testIdPrefix="join-flow-cost"
+          />
+
+          {requiresCostConfirmation && (
+            <label
+              data-testid="join-flow-cost-confirmation"
+              data-cost-confirmation-checked={highCostAcknowledged ? 'true' : 'false'}
+              style={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: '10px',
+                padding: '12px 14px',
+                border: '1px solid var(--break-red)',
+                borderRadius: 'var(--radius-2)',
+                background: 'var(--bg)',
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: '12px',
+                color: 'var(--fg)',
+                cursor: 'pointer',
+              }}
+            >
+              <input
+                type="checkbox"
+                data-testid="join-flow-cost-confirmation-checkbox"
+                checked={highCostAcknowledged}
+                onChange={(e) => setHighCostAcknowledged(e.target.checked)}
+                style={{ accentColor: 'var(--break-red)', marginTop: '2px', width: '14px', height: '14px' }}
+                aria-label="I understand the per-task cost and have a budget for this"
+              />
+              <span>
+                I understand — I have a budget for this. The selected model is estimated at more than $1
+                per task; I am responsible for the API spend on my own provider key.
+              </span>
+            </label>
+          )}
 
           <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
             <span style={fieldLabelStyle}>Plugins</span>

--- a/client/src/harnesses/cost-estimates.ts
+++ b/client/src/harnesses/cost-estimates.ts
@@ -1,0 +1,360 @@
+/**
+ * Per-task cost estimates for paid-API-key harnesses.
+ *
+ * Background — Issue #331 (Run-mode `feat`, P0 tier under release-feedback
+ * umbrella #328). The operator dashboard surfaces a harness/model selection
+ * at SolverNet-join time and again in Settings. Operators routing a paid
+ * API key (Anthropic, OpenAI, OpenRouter, Nous Portal) through the Hermes
+ * harness — or a "raw API key" Claude Code variant if we ever add one —
+ * have **no UI nudge** at join-time about per-task cost. The v0.1.6 dogfood
+ * surfaced the concrete worry: a first-run operator could pick Opus 4.7 +
+ * SWE-rebench v2 and burn $100s/hr before they figure out what Jinn does.
+ *
+ * This module captures the heuristic the SPA uses to render that estimate
+ * and to gate the Save & Join action when the estimate exceeds a
+ * configurable per-task threshold (default $1).
+ *
+ * Heuristic shape per the spec:
+ *   per-1k-token rate × typical task length, by model id.
+ *
+ * Subscription harnesses (Claude Code, Codex) are flagged via
+ * `subscriptionPath: true` on the harness; in that case the surface shows
+ * "Included in subscription, no per-task API cost" and **does not** trigger
+ * the confirmation gate, regardless of the model selected.
+ *
+ * To add a new model: append an entry to `MODEL_COST_TABLE`. The id is the
+ * exact `model` string persisted to `joinedSolverNets[<cid>].model`. To
+ * shape a new harness: append to `HARNESS_BILLING`. Keep the units
+ * consistent: token counts in tokens, rates in USD-per-1k-tokens.
+ *
+ * Units note: Anthropic + OpenAI publish prices per million tokens; we
+ * convert to per-1k-tokens here so the multiplication reads as
+ * `(tokens / 1000) * pricePer1k`. Avoids floating-point surprises when the
+ * dashboard renders cents.
+ *
+ * Pricing references captured at the time of this commit (see PR body):
+ *   - Anthropic Claude Opus 4.7: $15/M input, $75/M output (≈ $0.015 / 1k
+ *     input, $0.075 / 1k output). Typical SWE-rebench v2 task estimated at
+ *     ~50k input + 20k output → ~$2.25/task. Anthropic public pricing.
+ *   - Anthropic Claude Sonnet 4.6: $3/M input, $15/M output.
+ *   - OpenAI GPT-5.4: $1.25/M input, $10/M output (OpenAI public pricing).
+ *   - OpenAI GPT-5.4 Mini: $0.25/M input, $2/M output.
+ *
+ * These are heuristics. Provider-API reconciliation (actual usage) is
+ * deferred to the P1 follow-up tracked in #331.
+ */
+
+import {
+  CLAUDE_CODE_HARNESS,
+  CODEX_HARNESS,
+  HERMES_AGENT_HARNESS,
+  canonicalHarnessName,
+} from './names.js';
+
+export type Provider = 'anthropic' | 'openai' | 'openrouter' | 'nous' | 'other';
+
+export interface ModelCostEntry {
+  /** Upstream API provider that owns the billing relationship. */
+  provider: Provider;
+  /** USD per 1k input tokens. */
+  inputPer1kTokens: number;
+  /** USD per 1k output tokens. */
+  outputPer1kTokens: number;
+  /** Typical input-token consumption for a single task. Heuristic. */
+  typicalInputTokens: number;
+  /** Typical output-token consumption for a single task. Heuristic. */
+  typicalOutputTokens: number;
+  /**
+   * `true` when this model id is only ever reached via a subscription path
+   * (e.g. a future "Claude Code subscription" pinned model). The default
+   * gate logic prefers the harness-level flag — this exists so an
+   * individual model entry can override it on a per-id basis.
+   */
+  subscriptionPath?: boolean;
+}
+
+/**
+ * Per-model cost entries. Keyed by the exact `model` id persisted to
+ * `joinedSolverNets[<cid>].model`. The dashboard model dropdown in
+ * `claudeModels.ts` is the source of truth for which ids appear here.
+ */
+export const MODEL_COST_TABLE: Readonly<Record<string, ModelCostEntry>> = {
+  // ---------- Anthropic family (direct + via OpenRouter) ----------
+  'claude-opus-4-7': {
+    provider: 'anthropic',
+    inputPer1kTokens: 0.015,
+    outputPer1kTokens: 0.075,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'claude-sonnet-4-6': {
+    provider: 'anthropic',
+    inputPer1kTokens: 0.003,
+    outputPer1kTokens: 0.015,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'claude-haiku-4-5-20251001': {
+    provider: 'anthropic',
+    inputPer1kTokens: 0.001,
+    outputPer1kTokens: 0.005,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  // OpenRouter routing of the same families (Hermes harness uses these).
+  'anthropic/claude-opus-4.7': {
+    provider: 'openrouter',
+    inputPer1kTokens: 0.015,
+    outputPer1kTokens: 0.075,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'anthropic/claude-sonnet-4.6': {
+    provider: 'openrouter',
+    inputPer1kTokens: 0.003,
+    outputPer1kTokens: 0.015,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+
+  // ---------- OpenAI family ----------
+  'gpt-5.4': {
+    provider: 'openai',
+    inputPer1kTokens: 0.00125,
+    outputPer1kTokens: 0.01,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'gpt-5.4-mini': {
+    provider: 'openai',
+    inputPer1kTokens: 0.00025,
+    outputPer1kTokens: 0.002,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'gpt-5.5': {
+    provider: 'openai',
+    // Newer flagship; public pricing not confirmed at heuristic-capture
+    // time, so use Opus-4.7-class rates as a conservative upper bound
+    // until we get a verified figure.
+    inputPer1kTokens: 0.015,
+    outputPer1kTokens: 0.06,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'gpt-5.3-codex': {
+    provider: 'openai',
+    inputPer1kTokens: 0.00125,
+    outputPer1kTokens: 0.01,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'gpt-5.3-codex-spark': {
+    provider: 'openai',
+    inputPer1kTokens: 0.00125,
+    outputPer1kTokens: 0.01,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+
+  // ---------- OpenRouter long-tail (Hermes) ----------
+  // These rates are coarse — OpenRouter's effective price depends on the
+  // route picked. We pick the published list-price upper bound so the
+  // estimate biases toward over-warning rather than under-warning.
+  'tencent/hy3-preview': {
+    provider: 'openrouter',
+    inputPer1kTokens: 0.003,
+    outputPer1kTokens: 0.015,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'deepseek/deepseek-v4-pro': {
+    provider: 'openrouter',
+    inputPer1kTokens: 0.0014,
+    outputPer1kTokens: 0.0028,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'deepseek/deepseek-v4-flash': {
+    provider: 'openrouter',
+    inputPer1kTokens: 0.0001,
+    outputPer1kTokens: 0.0004,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'google/gemini-3.1-flash-lite': {
+    provider: 'openrouter',
+    inputPer1kTokens: 0.0001,
+    outputPer1kTokens: 0.0004,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'moonshotai/kimi-k2.6': {
+    provider: 'openrouter',
+    inputPer1kTokens: 0.0006,
+    outputPer1kTokens: 0.0025,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'openrouter/owl-alpha': {
+    provider: 'openrouter',
+    inputPer1kTokens: 0.002,
+    outputPer1kTokens: 0.008,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'minimax/minimax-m2.7': {
+    provider: 'openrouter',
+    inputPer1kTokens: 0.0008,
+    outputPer1kTokens: 0.0032,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+  'nousresearch/hermes-4-405b': {
+    provider: 'nous',
+    inputPer1kTokens: 0.0009,
+    outputPer1kTokens: 0.0009,
+    typicalInputTokens: 50_000,
+    typicalOutputTokens: 20_000,
+  },
+};
+
+/**
+ * Harness-level billing classification.
+ *
+ * `subscriptionPath: true` means the harness shells out to a
+ * subscription-billed CLI (Claude Code, Codex) and the operator does NOT
+ * incur per-task API charges — the cost surface is suppressed entirely
+ * and the confirmation gate is never triggered.
+ *
+ * `subscriptionPath: false` means the harness routes to a paid API key
+ * (Hermes via OpenRouter / Anthropic API / Nous Portal). The cost surface
+ * is shown and the gate fires above the configured threshold.
+ */
+export const HARNESS_BILLING: Readonly<Record<string, { subscriptionPath: boolean }>> = {
+  [CLAUDE_CODE_HARNESS]: { subscriptionPath: true },
+  [CODEX_HARNESS]: { subscriptionPath: true },
+  [HERMES_AGENT_HARNESS]: { subscriptionPath: false },
+};
+
+/** Default per-task USD threshold above which the confirmation gate fires. */
+export const DEFAULT_HIGH_COST_THRESHOLD_USD = 1;
+
+export interface CostEstimate {
+  /** Estimated per-task cost in USD. */
+  usd: number;
+  /** Computed input cost in USD. */
+  inputUsd: number;
+  /** Computed output cost in USD. */
+  outputUsd: number;
+  /** Heuristic typical input tokens used. */
+  typicalInputTokens: number;
+  /** Heuristic typical output tokens used. */
+  typicalOutputTokens: number;
+  /** Underlying entry consulted. */
+  entry: ModelCostEntry;
+}
+
+/**
+ * Compute the per-task cost estimate for a given model id. Returns `null`
+ * when the id has no entry in `MODEL_COST_TABLE` — callers should treat
+ * that as "unknown, don't surface a number" rather than rendering $0.
+ */
+export function estimateModelCost(modelId: string): CostEstimate | null {
+  const entry = MODEL_COST_TABLE[modelId];
+  if (!entry) return null;
+  const inputUsd = (entry.typicalInputTokens / 1000) * entry.inputPer1kTokens;
+  const outputUsd = (entry.typicalOutputTokens / 1000) * entry.outputPer1kTokens;
+  return {
+    usd: inputUsd + outputUsd,
+    inputUsd,
+    outputUsd,
+    typicalInputTokens: entry.typicalInputTokens,
+    typicalOutputTokens: entry.typicalOutputTokens,
+    entry,
+  };
+}
+
+/**
+ * `true` when the harness routes through a paid API key. Subscription
+ * harnesses (Claude Code, Codex) return `false`; unknown harnesses
+ * conservatively return `true` so a misnamed harness doesn't silently
+ * skip the cost surface.
+ */
+export function harnessUsesPaidApiKey(harness: string | undefined): boolean {
+  if (!harness) return false;
+  const canonical = canonicalHarnessName(harness);
+  const billing = HARNESS_BILLING[canonical];
+  if (!billing) return true;
+  return !billing.subscriptionPath;
+}
+
+export interface CostSurfaceDecision {
+  /** Whether to show a numeric cost-per-task estimate at all. */
+  showEstimate: boolean;
+  /** Resolved estimate (may be `null` even when `showEstimate` is true if the model id is unknown). */
+  estimate: CostEstimate | null;
+  /** Whether the Save & Join action requires the high-cost confirmation. */
+  requiresConfirmation: boolean;
+  /**
+   * Human-readable reason the surface is suppressed when `showEstimate`
+   * is false — e.g. "Included in subscription, no per-task API cost".
+   * `null` when the surface is shown.
+   */
+  suppressedReason: string | null;
+}
+
+/**
+ * Decide what the cost surface should render for a given harness + model
+ * combination, plus whether the confirmation gate fires.
+ *
+ * Defaults:
+ *   - threshold: $1 / task (see DEFAULT_HIGH_COST_THRESHOLD_USD).
+ *   - subscription harness → suppress surface + skip gate.
+ *   - unknown model on a paid harness → show estimate slot (caller may
+ *     render "estimate unavailable") but DO NOT trigger the gate.
+ */
+export function decideCostSurface(
+  harness: string | undefined,
+  modelId: string | undefined,
+  thresholdUsd: number = DEFAULT_HIGH_COST_THRESHOLD_USD,
+): CostSurfaceDecision {
+  if (!harnessUsesPaidApiKey(harness)) {
+    return {
+      showEstimate: false,
+      estimate: null,
+      requiresConfirmation: false,
+      suppressedReason: 'Included in subscription, no per-task API cost.',
+    };
+  }
+  const estimate = modelId ? estimateModelCost(modelId) : null;
+  const modelOverridesSubscription =
+    estimate?.entry.subscriptionPath === true;
+  if (modelOverridesSubscription) {
+    return {
+      showEstimate: false,
+      estimate: null,
+      requiresConfirmation: false,
+      suppressedReason: 'Included in subscription, no per-task API cost.',
+    };
+  }
+  return {
+    showEstimate: true,
+    estimate,
+    requiresConfirmation: estimate !== null && estimate.usd > thresholdUsd,
+    suppressedReason: null,
+  };
+}
+
+/**
+ * Format a USD amount for compact display in the dashboard. Picks the
+ * smallest fraction count that still distinguishes the value from $0.
+ */
+export function formatUsd(amount: number): string {
+  if (!Number.isFinite(amount)) return '—';
+  if (amount === 0) return '$0';
+  if (amount < 0.01) return `<$0.01`;
+  if (amount < 1) return `$${amount.toFixed(2)}`;
+  if (amount < 10) return `$${amount.toFixed(2)}`;
+  return `$${amount.toFixed(2)}`;
+}

--- a/client/test/harnesses/cost-estimates.test.ts
+++ b/client/test/harnesses/cost-estimates.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Unit tests for `client/src/harnesses/cost-estimates.ts`.
+ *
+ * Acceptance criteria pulled from Issue #331 (cost protection P0):
+ *   - MODEL_COST_TABLE lookup returns the heuristic per-task estimate.
+ *   - decideCostSurface suppresses the cost surface for subscription
+ *     harnesses (Claude Code, Codex).
+ *   - decideCostSurface requires the confirmation gate when estimate
+ *     exceeds the default $1/task threshold (e.g. Opus 4.7).
+ *   - decideCostSurface does NOT require the gate below threshold or for
+ *     subscription harnesses (no false-positive gate fire).
+ *   - Heuristic value for Opus 4.7 on SWE-rebench-v2 typical task lands
+ *     near $2.25 (the figure called out in the issue body).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_HIGH_COST_THRESHOLD_USD,
+  MODEL_COST_TABLE,
+  decideCostSurface,
+  estimateModelCost,
+  formatUsd,
+  harnessUsesPaidApiKey,
+} from '../../src/harnesses/cost-estimates.js';
+
+describe('MODEL_COST_TABLE', () => {
+  it('covers the canonical Anthropic, OpenAI, and OpenRouter ids the dashboard exposes', () => {
+    // Spot-check the ids that ship in client/src/dashboard/spa/src/pages/
+    // configuration/claudeModels.ts — at minimum the operator default
+    // (Haiku), the warning-tier (Opus 4.7), the OpenRouter route of the
+    // same Opus family that Hermes lists, and the GPT-5.4 family.
+    expect(MODEL_COST_TABLE['claude-haiku-4-5-20251001']).toBeDefined();
+    expect(MODEL_COST_TABLE['claude-sonnet-4-6']).toBeDefined();
+    expect(MODEL_COST_TABLE['claude-opus-4-7']).toBeDefined();
+    expect(MODEL_COST_TABLE['anthropic/claude-opus-4.7']).toBeDefined();
+    expect(MODEL_COST_TABLE['gpt-5.4']).toBeDefined();
+    expect(MODEL_COST_TABLE['gpt-5.4-mini']).toBeDefined();
+  });
+
+  it('keeps the Opus 4.7 entry shape conservative — $0.015/1k input, $0.075/1k output', () => {
+    const opus = MODEL_COST_TABLE['claude-opus-4-7']!;
+    expect(opus.provider).toBe('anthropic');
+    expect(opus.inputPer1kTokens).toBeCloseTo(0.015, 5);
+    expect(opus.outputPer1kTokens).toBeCloseTo(0.075, 5);
+  });
+});
+
+describe('estimateModelCost', () => {
+  it('returns null for unknown model ids (callers render "estimate unavailable")', () => {
+    expect(estimateModelCost('not-a-real-model-id')).toBeNull();
+  });
+
+  it('matches the Issue #331 heuristic: Opus 4.7 ≈ $2.25/task at 50k input + 20k output', () => {
+    const estimate = estimateModelCost('claude-opus-4-7');
+    expect(estimate).not.toBeNull();
+    // 50k input × $0.015/1k + 20k output × $0.075/1k = $0.75 + $1.50 = $2.25
+    expect(estimate!.usd).toBeCloseTo(2.25, 5);
+    expect(estimate!.inputUsd).toBeCloseTo(0.75, 5);
+    expect(estimate!.outputUsd).toBeCloseTo(1.5, 5);
+  });
+
+  it('produces a sub-$1 estimate for Haiku — does not trigger the high-cost band', () => {
+    const estimate = estimateModelCost('claude-haiku-4-5-20251001');
+    expect(estimate).not.toBeNull();
+    expect(estimate!.usd).toBeLessThan(DEFAULT_HIGH_COST_THRESHOLD_USD);
+  });
+
+  it('produces a sub-$1 estimate for GPT-5.4 Mini', () => {
+    const estimate = estimateModelCost('gpt-5.4-mini');
+    expect(estimate).not.toBeNull();
+    expect(estimate!.usd).toBeLessThan(DEFAULT_HIGH_COST_THRESHOLD_USD);
+  });
+});
+
+describe('harnessUsesPaidApiKey', () => {
+  it('returns false for subscription harnesses (Claude Code, Codex)', () => {
+    expect(harnessUsesPaidApiKey('claude-code')).toBe(false);
+    expect(harnessUsesPaidApiKey('codex')).toBe(false);
+  });
+
+  it('returns true for Hermes (paid raw API key path)', () => {
+    expect(harnessUsesPaidApiKey('hermes-agent')).toBe(true);
+  });
+
+  it('canonicalises learner-prefixed harness names before classification', () => {
+    // `claude-code-learner` aliases to `claude-code` in canonicalHarnessName.
+    expect(harnessUsesPaidApiKey('claude-code-learner')).toBe(false);
+    expect(harnessUsesPaidApiKey('codex-code-learner')).toBe(false);
+  });
+
+  it('treats unknown harnesses conservatively as paid (so we never silently hide a cost surface)', () => {
+    expect(harnessUsesPaidApiKey('some-future-harness')).toBe(true);
+  });
+
+  it('returns false for an undefined harness (nothing to show)', () => {
+    expect(harnessUsesPaidApiKey(undefined)).toBe(false);
+  });
+});
+
+describe('decideCostSurface — subscription harnesses', () => {
+  it('suppresses the estimate for Claude Code regardless of model', () => {
+    const decision = decideCostSurface('claude-code', 'claude-opus-4-7');
+    expect(decision.showEstimate).toBe(false);
+    expect(decision.requiresConfirmation).toBe(false);
+    expect(decision.suppressedReason).toMatch(/subscription/i);
+  });
+
+  it('suppresses the estimate for Codex regardless of model', () => {
+    const decision = decideCostSurface('codex', 'gpt-5.5');
+    expect(decision.showEstimate).toBe(false);
+    expect(decision.requiresConfirmation).toBe(false);
+    expect(decision.suppressedReason).toMatch(/subscription/i);
+  });
+
+  it('does NOT trigger the confirmation gate for Claude Code + Opus 4.7 (false-positive guard)', () => {
+    // This is the explicit non-false-positive test called out in the
+    // PR scope: subscription harnesses must never demand the budget
+    // confirmation, even when paired with what would otherwise be a
+    // high-cost API-priced model.
+    const decision = decideCostSurface('claude-code', 'claude-opus-4-7');
+    expect(decision.requiresConfirmation).toBe(false);
+  });
+});
+
+describe('decideCostSurface — paid-API-key harnesses', () => {
+  it('shows the estimate and triggers the gate for Hermes + Opus 4.7 ($2.25 > $1)', () => {
+    const decision = decideCostSurface('hermes-agent', 'anthropic/claude-opus-4.7');
+    expect(decision.showEstimate).toBe(true);
+    expect(decision.estimate).not.toBeNull();
+    expect(decision.estimate!.usd).toBeGreaterThan(DEFAULT_HIGH_COST_THRESHOLD_USD);
+    expect(decision.requiresConfirmation).toBe(true);
+  });
+
+  it('shows the estimate but does NOT trigger the gate for Hermes + DeepSeek V4 Flash (well under $1)', () => {
+    const decision = decideCostSurface('hermes-agent', 'deepseek/deepseek-v4-flash');
+    expect(decision.showEstimate).toBe(true);
+    expect(decision.estimate).not.toBeNull();
+    expect(decision.estimate!.usd).toBeLessThan(DEFAULT_HIGH_COST_THRESHOLD_USD);
+    expect(decision.requiresConfirmation).toBe(false);
+  });
+
+  it('shows the estimate slot but does NOT trigger the gate when the model is unknown', () => {
+    // Unknown model — caller will render "estimate unavailable" rather
+    // than a number. We deliberately don't gate, to avoid blocking joins
+    // on operator-pinned custom ids we haven't priced yet.
+    const decision = decideCostSurface('hermes-agent', 'unknown-vendor/custom-finetune');
+    expect(decision.showEstimate).toBe(true);
+    expect(decision.estimate).toBeNull();
+    expect(decision.requiresConfirmation).toBe(false);
+  });
+
+  it('honours a caller-supplied threshold', () => {
+    // Bump the threshold so even Opus 4.7 no longer trips the gate.
+    const decision = decideCostSurface('hermes-agent', 'anthropic/claude-opus-4.7', 10);
+    expect(decision.showEstimate).toBe(true);
+    expect(decision.requiresConfirmation).toBe(false);
+  });
+});
+
+describe('formatUsd', () => {
+  it('renders <$0.01 for tiny values', () => {
+    expect(formatUsd(0.0001)).toBe('<$0.01');
+  });
+
+  it('renders cents for sub-$1 values', () => {
+    expect(formatUsd(0.43)).toBe('$0.43');
+  });
+
+  it('renders two decimals for typical task costs', () => {
+    expect(formatUsd(2.25)).toBe('$2.25');
+  });
+
+  it('handles zero cleanly', () => {
+    expect(formatUsd(0)).toBe('$0');
+  });
+
+  it('handles non-finite values without crashing', () => {
+    expect(formatUsd(Number.NaN)).toBe('—');
+  });
+});


### PR DESCRIPTION
## Summary

Partial close of #331 — P0 tier (release-feedback umbrella #328).

Cost protection for operators routing paid API keys (Anthropic / OpenAI /
OpenRouter / Nous Portal) through the Hermes harness. The v0.1.6 dogfood
surfaced the concrete risk that motivated this: a first-run operator
joining SWE-rebench v2 with Hermes + Opus 4.7 could burn \$100s/hr with
no UI nudge.

- **Cost-per-task surfacing.** The JoinFlow (operator catalog) and
  JoinedNetCard (Settings) render an estimated USD-per-task line when
  the operator selects a paid-API-key harness/model combo. The heuristic
  — `per-1k-token rate × typical task length` — lives in
  [`client/src/harnesses/cost-estimates.ts`](client/src/harnesses/cost-estimates.ts)
  in the `MODEL_COST_TABLE` constant. Each entry carries `{ provider,
  inputPer1kTokens, outputPer1kTokens, typicalInputTokens,
  typicalOutputTokens, subscriptionPath? }` so adding a new model is a
  one-line append. Calibrated against #331: Opus 4.7 at ~50k input +
  ~20k output ≈ \$2.25/task.
- **Confirmation gate.** When the estimate exceeds the default
  \$1/task threshold (`DEFAULT_HIGH_COST_THRESHOLD_USD`), Save / Save &
  Join is disabled until the operator ticks an explicit "I understand —
  I have a budget for this" checkbox. Acknowledgement resets when the
  harness or model changes.
- **Subscription harnesses are exempt.** Claude Code and Codex render a
  small reassurance row ("Included in subscription, no per-task API
  cost") and **never** trigger the gate, regardless of selected model.
  Covered by an explicit false-positive test.

### Out of scope (filed as a follow-up Issue)

- P1 daily spend cap + claim-loop pause (needs design).
- P1 per-task observability in the activity surface (UI work).
- Provider-API reconciliation against actual usage (P1+).

Follow-up: file separate Issue for P1 daily spend cap + claim-loop pause.

Closes #331 (partial — only P0 tier).

## Test plan

- [x] `yarn typecheck` — passes.
- [x] Full client vitest suite — 3597 passed | 7 skipped, no regressions.
- [x] Unit tests for `MODEL_COST_TABLE` + `estimateModelCost` +
      `decideCostSurface` (23 cases) covering: table coverage of the
      operator-facing model dropdown ids; the \$2.25/task Opus 4.7
      heuristic landing; sub-\$1 Haiku/Mini exemption; subscription
      vs paid harness classification; threshold honouring.
- [x] JoinFlow component tests (5 new cases): subscription reassurance
      shows for Claude Code; cost panel + gate fires for Hermes + Opus
      4.7; Save & Join disabled until the box is ticked; sub-\$1 model
      exempts the gate; model-swap resets acknowledgement.
- [x] JoinedNetCard component tests (3 new cases): subscription
      reassurance for default Claude Code; switch-to-Hermes shows panel
      + gate; sub-\$1 model exempts the gate.
- [ ] Manual: open the operator dashboard, navigate to /operator/join/{cid},
      pick Hermes + Opus 4.7, confirm the gate shows and Save & Join is
      disabled until the box is ticked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)