### PR TITLE
fix(338): clarify Leave SolverNet copy — explain immediate vs deferred effects

### DIFF
--- a/client/src/dashboard/spa/src/pages/configuration/JoinedNetCard.test.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/JoinedNetCard.test.tsx
@@ -342,6 +342,36 @@ describe('<JoinedNetCard />', () => {
     expect(screen.queryByTestId('joined-net-card-orphaned')).toBeNull();
   });
 
+  // Regression for #338: rvx in the v0.1.6 dogfood asked "what does 'stops
+  // claims' mean? and 'on the next restart' — does this mean it'll keep going
+  // until I restart?" The pre-fix copy said only "Leaving stops claims for
+  // this SolverNet on the next daemon restart." which was ambiguous on three
+  // axes: (a) what happens right now to the config, (b) what the running
+  // daemon does in the meantime, (c) what happens to in-flight tasks. The
+  // copy must now say all three explicitly.
+  it('Leave explainer covers immediate config removal, the until-restart behaviour, and the in-flight caveat (#338)', () => {
+    wrap(<JoinedNetCard joined={ENTRY} catalogEntry={CATALOG} defaultExpanded />);
+    const explainer = screen.getByTestId('joined-net-card-leave-explainer');
+    const text = explainer.textContent ?? '';
+    // (a) immediate effect on config.
+    expect(text).toMatch(/removes this SolverNet from your config right away/i);
+    // (b) running daemon keeps going until restart.
+    expect(text).toMatch(/keeps? .*loaded copy in memory/i);
+    expect(text).toMatch(/until you restart/i);
+    // (c) in-flight task caveat.
+    expect(text).toMatch(/already in flight/i);
+  });
+
+  it('Retired-banner copy explains the post-leave restart step (#338)', async () => {
+    wrap(<JoinedNetCard joined={ENTRY} defaultExpanded />);
+    const banner = await waitFor(() =>
+      screen.getByTestId('joined-net-card-orphaned'),
+    );
+    const text = banner.textContent ?? '';
+    expect(text).toMatch(/removes the entry from your config/i);
+    expect(text).toMatch(/restart the daemon/i);
+  });
+
   describe('orphaned state (manifest fetch fails)', () => {
     it('shows the RETIRED banner and a Leave button, no edit form, when manifest fetch fails', async () => {
       // Card resolves internally; the suite-level mock makes both queries fail.

--- a/client/src/dashboard/spa/src/pages/configuration/JoinedNetCard.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/JoinedNetCard.tsx
@@ -359,7 +359,7 @@ export function JoinedNetCard({
           <span style={{ color: 'var(--wane)', textTransform: 'uppercase', letterSpacing: '0.14em', fontSize: '10px', marginRight: '8px' }}>
             Retired
           </span>
-          Manifest no longer in the registry. This SolverNet is not claiming on-chain anymore — leaving it cleans up your config.
+          Manifest no longer in the registry. This SolverNet is not claiming on-chain anymore — leaving it removes the entry from your config. Restart the daemon afterwards so it stops looking for this manifest at startup.
           {leaveMutation.isError && (
             <div role="alert" style={{ marginTop: '6px', color: 'var(--break-red)', fontSize: '11px' }}>
               {leaveMutation.error instanceof Error ? leaveMutation.error.message : 'Leave failed.'}
@@ -687,21 +687,27 @@ export function JoinedNetCard({
               borderTop: '1px dashed var(--border)',
               display: 'flex',
               justifyContent: 'space-between',
-              alignItems: 'center',
+              alignItems: 'flex-start',
               gap: '12px',
               flexWrap: 'wrap',
             }}
           >
             <span
+              data-testid="joined-net-card-leave-explainer"
               style={{
                 fontFamily: "'JetBrains Mono', monospace",
                 fontSize: '11px',
                 color: 'var(--fg-dim)',
                 lineHeight: 1.5,
+                maxWidth: '440px',
               }}
             >
-              Leaving stops claims for this SolverNet on the next daemon
-              restart. You can re-join from the Discover catalog later.
+              Leave removes this SolverNet from your config right away. The
+              running daemon keeps its loaded copy in memory, so it will go on
+              claiming and finishing tasks for this SolverNet until you restart
+              it — restart to actually stop new claims. Tasks already in flight
+              run to completion either way. You can re-join from the Discover
+              catalog later.
             </span>
             {!confirmingLeave ? (
               <button


### PR DESCRIPTION
## Summary

The Leave SolverNet affordance's copy was ambiguous. It said only:

> Leaving stops claims for this SolverNet on the next daemon restart.

A v0.1.6 dogfood operator (rvx) read this as: "does it stop *now* or keep going until I restart?" — and then observed the daemon was *still solving* after they left. The behaviour is correct (`joinedSolverNets` is loaded into the TaskEngine at startup and not hot-reloaded — confirmed by `joinedSolverNetsViewFromConfig` wiring in `main.ts` and the `restartRequired: true` leave-endpoint response), but the copy never explained it.

This PR rewrites both Leave explainers (`JoinedNetCard.tsx`) to state the three facts plainly:

- The config entry is **removed immediately** on Leave.
- The **running daemon keeps claiming and finishing tasks** for this SolverNet until restarted — restart is what actually stops new claims.
- **In-flight tasks always run to completion** — Leave does not kill running tasks.

Drops the metaphor on a behaviour-with-consequences surface, per `BRAND.md` (plain speech where operator effort/cost is on the line).

The retired-banner copy gets a matching one-line clarification about the post-leave restart step.

### Restart-required path: kept, not dropped

Issue #338 floated dropping the restart-required path *if* the claim loop can re-read `joinedSolverNets` without restart. It cannot — CLAUDE.md states "the daemon does not hot-reload SolverNet config" and the engine reads the config snapshot once at startup. Making the daemon hot-reload would be a daemon-side refactor (out of scope for a copy fix). The fix instead makes the restart requirement explicit and unambiguous. #289 (restart-button respawn) is the right follow-up to simplify this UX once it lands.

## Test plan

- [x] `cd client && tsc --noEmit` — zero errors
- [x] `vitest run` — full suite: 3699 passed, 7 skipped, 0 failed
- [x] Two new component tests on `JoinedNetCard.test.tsx` assert the active-card explainer covers (a) immediate config removal, (b) until-restart behaviour, (c) in-flight caveat, and the retired banner covers the post-leave restart step

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)