### PR TITLE
chore(326): hide embedded agent surface until more robust

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### Embedded agent surface hidden by default (issue #326)
+
+- **The embedded Claude agent chat surface no longer renders in the operator
+  app by default.** The right-rail agent panel (running mode) and the
+  "Ask Claude" panel (onboarding) are hidden. The 2026-05-19 v0.1.6 dogfood
+  found the surface isn't robust enough for first-time operators — it is the
+  only daemon-side surface that strictly requires Claude auth, and its
+  action-authority / plugin-scope shape is still in design (#177 / #178).
+- **Feature flag: `JINN_ENABLE_EMBEDDED_AGENT`.** Set
+  `JINN_ENABLE_EMBEDDED_AGENT=1` (also accepts `true`) to re-enable the
+  surface for development. Default is off. When off, the daemon does not
+  mount the `/api/agent/ws` bridge and the SPA renders no agent panel; when
+  on, the dev-time path works end-to-end as before.
+- **Claude-Code-as-a-solver-harness is unaffected.** Operators can still pick
+  Claude Code as their SolverNet harness — that path is independent of the
+  embedded chat surface and its WebSocket bridge.
+
 ### SWE-rebench v2 admission
 
 - **Admission semantics bumped from `'2'` → `'3'`.** Operators running the

--- a/client/src/api/bootstrap-endpoint.ts
+++ b/client/src/api/bootstrap-endpoint.ts
@@ -26,6 +26,27 @@ export interface BootstrapEndpointConfig {
     solverNets?: Record<string, unknown>;
     joinedSolverNets?: Record<string, unknown>;
   };
+  /**
+   * Feature flag for the embedded Claude agent chat surface in the operator
+   * SPA. Defaults to false; set via `JINN_ENABLE_EMBEDDED_AGENT=1` for
+   * development. When false, the SPA hides the agent rail / "Ask Claude"
+   * onboarding panel and the daemon does not mount the `/api/agent/ws`
+   * bridge. The Claude-Code-as-solver-harness path is unaffected. See
+   * GitHub issue #326.
+   */
+  embeddedAgentEnabled?: boolean;
+}
+
+/**
+ * Resolves the JINN_ENABLE_EMBEDDED_AGENT env var. Default off. Anything
+ * other than '1' / 'true' (case-insensitive) is treated as off so a stray
+ * value can't accidentally re-enable the surface.
+ */
+export function isEmbeddedAgentEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env['JINN_ENABLE_EMBEDDED_AGENT'];
+  if (raw === undefined) return false;
+  const normalized = raw.trim().toLowerCase();
+  return normalized === '1' || normalized === 'true';
 }
 
 const STEPS = [
@@ -131,6 +152,7 @@ function fundingTargetWei(fundingGate: FundingGateOnDisk): string | undefined {
 
 export function addBootstrapRoutes(app: Hono, config: BootstrapEndpointConfig): void {
   app.get('/v1/bootstrap', (c) => {
+    const embeddedAgentEnabled = config.embeddedAgentEnabled ?? false;
     const path = join(config.earningDir, 'earning_state.json');
     if (!existsSync(path)) {
       return c.json({
@@ -139,6 +161,7 @@ export function addBootstrapRoutes(app: Hono, config: BootstrapEndpointConfig): 
         steps: STEPS,
         currentStep: STEPS[0],
         services: [],
+        embeddedAgentEnabled,
       });
     }
 
@@ -204,6 +227,7 @@ export function addBootstrapRoutes(app: Hono, config: BootstrapEndpointConfig): 
       steps: STEPS,
       currentStep,
       services,
+      embeddedAgentEnabled,
       master_address: parsed.master_address,
       chain: parsed.chain,
       ...(parsed.fleet_agent_id ? { fleet_agent_id: parsed.fleet_agent_id } : {}),

--- a/client/src/dashboard/spa/src/App.tsx
+++ b/client/src/dashboard/spa/src/App.tsx
@@ -53,6 +53,9 @@ export default function App(): JSX.Element {
 
   const network = (data.chain === 'base' ? 'mainnet' : 'testnet') as 'testnet' | 'mainnet';
   const masterAddress = data.master_address ?? '';
+  // Issue #326: the embedded agent rail renders only when the daemon reports
+  // the surface is enabled (JINN_ENABLE_EMBEDDED_AGENT=1). Default-off.
+  const embeddedAgentEnabled = data.embeddedAgentEnabled === true;
 
   return (
     <Router>
@@ -66,7 +69,7 @@ export default function App(): JSX.Element {
       <AppShell
         header={<Header network={network} rpcHealthy={true} masterAddress={masterAddress} />}
         tabs={<TopTabs />}
-        rail={<AgentRail />}
+        rail={embeddedAgentEnabled ? <AgentRail /> : undefined}
       >
         <Switch>
           <Route path="/overview/activity"><OverviewActivityPage /></Route>

--- a/client/src/dashboard/spa/src/api/types.ts
+++ b/client/src/dashboard/spa/src/api/types.ts
@@ -80,6 +80,14 @@ export interface BootstrapState {
   }>;
   /** Persisted from the last fatal bootstrap exit. Absent on healthy state. */
   error?: BootstrapErrorEnvelope;
+  /**
+   * Issue #326: whether the embedded Claude agent chat surface should render.
+   * Driven by the daemon's `JINN_ENABLE_EMBEDDED_AGENT` env var; false by
+   * default. When false the SPA hides the agent rail and the onboarding
+   * "Ask Claude" panel, and the daemon does not mount `/api/agent/ws`.
+   * Absent on responses from older daemons — treat absent as false.
+   */
+  embeddedAgentEnabled?: boolean;
 }
 
 export interface ClaudeAuthState {

--- a/client/src/dashboard/spa/src/regions/Onboarding.test.tsx
+++ b/client/src/dashboard/spa/src/regions/Onboarding.test.tsx
@@ -1,10 +1,14 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Onboarding, statusFor } from './Onboarding.js';
 import type { BootstrapState } from '../api/types.js';
 
 // Mock the API client so we control what bootstrap + status data returns.
+// `bootstrapOverride` lets individual tests tweak the returned bootstrap state
+// (e.g. the issue #326 embedded-agent flag) without re-mocking the module.
+let bootstrapOverride: Partial<BootstrapState> = {};
+
 vi.mock('../api/client.js', () => ({
   api: {
     getBootstrap: async (): Promise<BootstrapState> => ({
@@ -14,9 +18,20 @@ vi.mock('../api/client.js', () => ({
       currentStep: 'wallet',
       services: [],
       chain: 'base-sepolia',
+      ...bootstrapOverride,
     }),
   },
 }));
+
+// The embedded agent panel mounts an xterm.js terminal; stub it so the
+// onboarding tests stay free of the WebSocket / xterm setup.
+vi.mock('./Agent.js', () => ({
+  Agent: () => <div data-testid="agent-stub">agent</div>,
+}));
+
+afterEach(() => {
+  bootstrapOverride = {};
+});
 
 function withQueryClient(node: JSX.Element): JSX.Element {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -40,6 +55,31 @@ describe('Onboarding (3-phase post-vh74.2)', () => {
     render(withQueryClient(<Onboarding />));
     await screen.findByText(/Provisioning your wallet/i);
     expect(screen.queryByText(/Sign in to Claude/i)).toBeNull();
+  });
+
+  // Issue #326: the embedded "Ask Claude" panel is hidden by default. It only
+  // renders when the daemon reports embeddedAgentEnabled === true.
+  it('hides the "Ask Claude" panel when embeddedAgentEnabled is absent', async () => {
+    render(withQueryClient(<Onboarding />));
+    await screen.findByText(/Provisioning your wallet/i);
+    expect(screen.queryByText(/Ask Claude/i)).toBeNull();
+    expect(screen.queryByTestId('agent-stub')).toBeNull();
+  });
+
+  it('hides the "Ask Claude" panel when embeddedAgentEnabled is false', async () => {
+    bootstrapOverride = { embeddedAgentEnabled: false };
+    render(withQueryClient(<Onboarding />));
+    await screen.findByText(/Provisioning your wallet/i);
+    expect(screen.queryByText(/Ask Claude/i)).toBeNull();
+    expect(screen.queryByTestId('agent-stub')).toBeNull();
+  });
+
+  it('renders the "Ask Claude" panel when embeddedAgentEnabled is true', async () => {
+    bootstrapOverride = { embeddedAgentEnabled: true };
+    render(withQueryClient(<Onboarding />));
+    await screen.findByText(/Provisioning your wallet/i);
+    expect(screen.getByText(/Ask Claude/i)).toBeTruthy();
+    expect(screen.getByTestId('agent-stub')).toBeTruthy();
   });
 });
 

--- a/client/src/dashboard/spa/src/regions/Onboarding.tsx
+++ b/client/src/dashboard/spa/src/regions/Onboarding.tsx
@@ -116,6 +116,10 @@ export function Onboarding(): JSX.Element {
   // momentary drip that briefly crossed the threshold doesn't flip the row
   // to DONE before the bootstrapper advances past awaiting_funding on-chain.
   const fundingTargetMet = bootstrap.funding?.targetMet;
+  // Issue #326: the embedded "Ask Claude" panel renders only when the daemon
+  // reports the surface is enabled (JINN_ENABLE_EMBEDDED_AGENT=1). When off,
+  // the bootstrap-progress column spans the full width.
+  const embeddedAgentEnabled = bootstrap.embeddedAgentEnabled === true;
   return (
     <div
       className="min-h-screen w-full"
@@ -124,7 +128,9 @@ export function Onboarding(): JSX.Element {
       <style>{ANIMATIONS}</style>
 
       <div className="max-w-[1280px] mx-auto px-10 py-10 grid grid-cols-12 gap-10">
-        <section className="col-span-12 lg:col-span-7 flex flex-col gap-8">
+        <section
+          className={`col-span-12 ${embeddedAgentEnabled ? 'lg:col-span-7' : ''} flex flex-col gap-8`}
+        >
           <header className="flex items-baseline justify-between">
             <span className="j-label" style={{ color: 'var(--accent-gold)' }}>
               Jinn · Onboarding
@@ -171,15 +177,17 @@ export function Onboarding(): JSX.Element {
           </ol>
         </section>
 
-        <aside className="col-span-12 lg:col-span-5 flex flex-col gap-3">
-          <span className="j-label">Ask Claude</span>
-          <div
-            className="j-card overflow-hidden"
-            style={{ height: 'calc(100vh - 220px)', minHeight: '520px' }}
-          >
-            <Agent agentGated={false} />
-          </div>
-        </aside>
+        {embeddedAgentEnabled && (
+          <aside className="col-span-12 lg:col-span-5 flex flex-col gap-3">
+            <span className="j-label">Ask Claude</span>
+            <div
+              className="j-card overflow-hidden"
+              style={{ height: 'calc(100vh - 220px)', minHeight: '520px' }}
+            >
+              <Agent agentGated={false} />
+            </div>
+          </aside>
+        )}
       </div>
     </div>
   );

--- a/client/src/dashboard/spa/src/shell/AppShell.test.tsx
+++ b/client/src/dashboard/spa/src/shell/AppShell.test.tsx
@@ -18,4 +18,20 @@ describe('AppShell', () => {
     expect(screen.getByTestId('rail')).toBeTruthy();
     expect(screen.getByTestId('main')).toBeTruthy();
   });
+
+  // Issue #326: when the embedded agent surface is hidden the rail prop is
+  // omitted; the shell renders no aside and collapses to a single column.
+  it('renders no rail aside when the rail prop is omitted', () => {
+    render(
+      <AppShell
+        header={<div data-testid="header">H</div>}
+        tabs={<div data-testid="tabs">T</div>}
+      >
+        <div data-testid="main">M</div>
+      </AppShell>,
+    );
+    expect(screen.getByTestId('header')).toBeTruthy();
+    expect(screen.getByTestId('main')).toBeTruthy();
+    expect(screen.queryByTestId('rail')).toBeNull();
+  });
 });

--- a/client/src/dashboard/spa/src/shell/AppShell.tsx
+++ b/client/src/dashboard/spa/src/shell/AppShell.tsx
@@ -9,11 +9,17 @@ import type { ReactNode } from 'react';
 export interface AppShellProps {
   header: ReactNode;
   tabs: ReactNode;
-  rail: ReactNode;
+  /**
+   * Right-rail content (the embedded agent panel). Optional — when omitted
+   * (issue #326: embedded agent surface hidden by default) the shell
+   * collapses to a single column and renders no aside.
+   */
+  rail?: ReactNode;
   children: ReactNode;
 }
 
 export function AppShell({ header, tabs, rail, children }: AppShellProps): JSX.Element {
+  const showRail = rail != null;
   return (
     <div
       className="w-full"
@@ -22,7 +28,7 @@ export function AppShell({ header, tabs, rail, children }: AppShellProps): JSX.E
         color: 'var(--fg)',
         display: 'grid',
         gridTemplateRows: 'auto auto minmax(0, 1fr)',
-        gridTemplateColumns: '1fr 320px',
+        gridTemplateColumns: showRail ? '1fr 320px' : '1fr',
         // Lock the outer shell to the viewport so internal regions (main,
         // aside) can scroll independently. Without this, the agent rail's
         // xterm scrollback expands the document height past 800kpx and the
@@ -38,16 +44,18 @@ export function AppShell({ header, tabs, rail, children }: AppShellProps): JSX.E
         {tabs}
       </div>
       <main style={{ overflowY: 'auto', minHeight: 0 }}>{children}</main>
-      <aside
-        style={{
-          borderLeft: '1px solid var(--border)',
-          overflowY: 'auto',
-          minHeight: 0,
-          height: '100%',
-        }}
-      >
-        {rail}
-      </aside>
+      {showRail && (
+        <aside
+          style={{
+            borderLeft: '1px solid var(--border)',
+            overflowY: 'auto',
+            minHeight: 0,
+            height: '100%',
+          }}
+        >
+          {rail}
+        </aside>
+      )}
     </div>
   );
 }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -36,6 +36,7 @@ import { ensureUiToken } from './api/ui-token.js';
 import { hashImplStateDir } from './harnesses/freeze.js';
 import { readModeState } from './harnesses/mode-state.js';
 import { attachAgentWs, updateAgentClaudePath } from './agent/agent-ws.js';
+import { isEmbeddedAgentEnabled } from './api/bootstrap-endpoint.js';
 import { createSetupModeController } from './setup-mode.js';
 import { formatBootstrapOperatorMessage } from './operator-errors.js';
 import { requestDaemonRestart } from './restart-daemon.js';
@@ -171,6 +172,13 @@ if (config.network === 'mainnet' && process.env['JINN_ENABLE_MAINNET'] !== '1') 
   config.network = 'testnet';
   config.rpcUrl = 'https://base-sepolia.gateway.tenderly.co/75tyLMQuD8EHpXxMwINIKu';
 }
+// Issue #326: the embedded Claude agent chat surface (right rail + onboarding
+// "Ask Claude" panel + /api/agent/ws bridge) is hidden by default while its
+// action-authority / plugin-scope shape is still in design. Set
+// `JINN_ENABLE_EMBEDDED_AGENT=1` to re-enable it for development. This does
+// NOT affect Claude-Code-as-a-solver-harness — that path is independent.
+const embeddedAgentEnabled = isEmbeddedAgentEnabled();
+
 let activeClaudePath = config.claudePath ?? 'claude';
 const selectClaudePath = (claudePath: string): void => {
   activeClaudePath = claudePath;
@@ -1036,6 +1044,9 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
           solverNets: config.solverNets as Record<string, unknown> | undefined,
           joinedSolverNets: config.joinedSolverNets as Record<string, unknown> | undefined,
         }),
+        // Issue #326: gate the embedded agent chat surface. Off by default;
+        // `JINN_ENABLE_EMBEDDED_AGENT=1` re-enables it for development.
+        embeddedAgentEnabled: embeddedAgentEnabled,
       },
       // SolverNet catalog. Stubbed to the bundled `prediction` net for v1.
       // Once the daemon's harness/plugin registry is loaded, swap this for a
@@ -1342,38 +1353,52 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
   // can attach to a long-lived embedded `claude` subprocess. The embedded
   // session reads MCP config we materialise to disk so it can reach the
   // operator MCP server (`jinn mcp`) for tool calls.
-  const operatorMcpConfigPath = join(homedir(), '.jinn-client', 'operator-mcp-config.json');
-  try {
-    mkdirSync(dirname(operatorMcpConfigPath), { recursive: true });
-    writeFileSyncMain(
-      operatorMcpConfigPath,
-      JSON.stringify(
-        {
-          mcpServers: {
-            'jinn-operator': {
-              command: 'jinn',
-              args: ['mcp'],
+  //
+  // Issue #326: the embedded agent chat surface is hidden by default. The WS
+  // bridge mounts only when `JINN_ENABLE_EMBEDDED_AGENT=1` so the dev-time
+  // path stays end-to-end; with the flag off there is no /api/agent/ws route
+  // and the SPA never renders the chat panel. Claude-Code-as-solver-harness
+  // is independent of this bridge and unaffected.
+  if (embeddedAgentEnabled) {
+    const operatorMcpConfigPath = join(homedir(), '.jinn-client', 'operator-mcp-config.json');
+    try {
+      mkdirSync(dirname(operatorMcpConfigPath), { recursive: true });
+      writeFileSyncMain(
+        operatorMcpConfigPath,
+        JSON.stringify(
+          {
+            mcpServers: {
+              'jinn-operator': {
+                command: 'jinn',
+                args: ['mcp'],
+              },
             },
           },
-        },
-        null,
-        2,
-      ),
+          null,
+          2,
+        ),
+      );
+    } catch (err) {
+      console.warn(
+        `[main] Failed to write operator MCP config at ${operatorMcpConfigPath}: ` +
+          (err instanceof Error ? err.message : String(err)),
+      );
+    }
+    attachAgentWs({
+      httpServer: setupApiServer.server,
+      uiToken,
+      claudePath: activeClaudePath,
+      cwd: process.cwd(),
+      mcpConfigPath: operatorMcpConfigPath,
+    });
+    console.log(
+      `[main] Agent WS bridge mounted at ws://127.0.0.1:${setupApiServer.port}/api/agent/ws`,
     );
-  } catch (err) {
-    console.warn(
-      `[main] Failed to write operator MCP config at ${operatorMcpConfigPath}: ` +
-        (err instanceof Error ? err.message : String(err)),
+  } else {
+    console.log(
+      '[main] Embedded agent surface disabled (set JINN_ENABLE_EMBEDDED_AGENT=1 to enable).',
     );
   }
-  attachAgentWs({
-    httpServer: setupApiServer.server,
-    uiToken,
-    claudePath: activeClaudePath,
-    cwd: process.cwd(),
-    mcpConfigPath: operatorMcpConfigPath,
-  });
-  console.log(`[main] Agent WS bridge mounted at ws://127.0.0.1:${setupApiServer.port}/api/agent/ws`);
 
   // ── Init-if-missing ──────────────────────────────────────────────────────
   // If the keystore is missing but we have a password, run `jinn init` now so

--- a/client/test/api/bootstrap-endpoint.test.ts
+++ b/client/test/api/bootstrap-endpoint.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { Hono } from 'hono';
-import { addBootstrapRoutes } from '../../src/api/bootstrap-endpoint.js';
+import {
+  addBootstrapRoutes,
+  isEmbeddedAgentEnabled,
+} from '../../src/api/bootstrap-endpoint.js';
 import { buildEnvelope } from '../../src/errors/envelope.js';
 import { persistBootstrapError } from '../../src/errors/persisted-bootstrap-error.js';
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
@@ -305,5 +308,68 @@ describe('GET /v1/bootstrap', () => {
     const res = await app.request('/v1/bootstrap');
     const body = await res.json() as { retire_failed?: unknown };
     expect(body.retire_failed).toBeUndefined();
+  });
+});
+
+// Issue #326: the embedded agent chat surface is gated behind
+// JINN_ENABLE_EMBEDDED_AGENT. The endpoint surfaces the resolved flag so the
+// SPA can hide the agent rail / onboarding panel; the daemon also uses it to
+// decide whether to mount /api/agent/ws.
+describe('isEmbeddedAgentEnabled', () => {
+  it('defaults to false when the env var is unset', () => {
+    expect(isEmbeddedAgentEnabled({})).toBe(false);
+  });
+
+  it('is true for "1"', () => {
+    expect(isEmbeddedAgentEnabled({ JINN_ENABLE_EMBEDDED_AGENT: '1' })).toBe(true);
+  });
+
+  it('is true for "true" (case-insensitive, trimmed)', () => {
+    expect(isEmbeddedAgentEnabled({ JINN_ENABLE_EMBEDDED_AGENT: 'true' })).toBe(true);
+    expect(isEmbeddedAgentEnabled({ JINN_ENABLE_EMBEDDED_AGENT: ' TRUE ' })).toBe(true);
+  });
+
+  it('is false for any other value', () => {
+    expect(isEmbeddedAgentEnabled({ JINN_ENABLE_EMBEDDED_AGENT: '0' })).toBe(false);
+    expect(isEmbeddedAgentEnabled({ JINN_ENABLE_EMBEDDED_AGENT: 'yes' })).toBe(false);
+    expect(isEmbeddedAgentEnabled({ JINN_ENABLE_EMBEDDED_AGENT: '' })).toBe(false);
+  });
+});
+
+describe('GET /v1/bootstrap — embeddedAgentEnabled flag (issue #326)', () => {
+  it('reports embeddedAgentEnabled=false by default', async () => {
+    const earningDir = makeFixtureEarningDir({
+      master_address: '0xabc',
+      chain: 'base-sepolia',
+      services: [{ index: 0, step: 'complete', safe_address: '0xsafe' }],
+    });
+    const app = new Hono();
+    addBootstrapRoutes(app, { earningDir });
+    const res = await app.request('/v1/bootstrap');
+    const body = await res.json() as { embeddedAgentEnabled?: boolean };
+    expect(body.embeddedAgentEnabled).toBe(false);
+  });
+
+  it('reports embeddedAgentEnabled=true when the flag is set on the config', async () => {
+    const earningDir = makeFixtureEarningDir({
+      master_address: '0xabc',
+      chain: 'base-sepolia',
+      services: [{ index: 0, step: 'complete', safe_address: '0xsafe' }],
+    });
+    const app = new Hono();
+    addBootstrapRoutes(app, { earningDir, embeddedAgentEnabled: true });
+    const res = await app.request('/v1/bootstrap');
+    const body = await res.json() as { embeddedAgentEnabled?: boolean };
+    expect(body.embeddedAgentEnabled).toBe(true);
+  });
+
+  it('reports embeddedAgentEnabled=false on the uninitialized branch', async () => {
+    const earningDir = mkdtempSync(join(tmpdir(), 'jinn-bootstrap-empty-326-'));
+    const app = new Hono();
+    addBootstrapRoutes(app, { earningDir });
+    const res = await app.request('/v1/bootstrap');
+    const body = await res.json() as { mode: string; embeddedAgentEnabled?: boolean };
+    expect(body.mode).toBe('uninitialized');
+    expect(body.embeddedAgentEnabled).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #326.

## Summary

Hides the embedded Claude agent chat surface from the operator app's default rendering, behind a new feature flag. Per the 2026-05-19 v0.1.6 dogfood, the surface isn't robust enough for first-time operators: it strictly requires Claude auth (#236) and its action-authority / plugin-scope shape is still in design (#177 / #178). The backend agent-WS code and Claude-Code-as-a-solver-harness path stay intact.

## What changed

- **Feature flag `JINN_ENABLE_EMBEDDED_AGENT`** (env var, off by default; accepts `1` or `true`). New `isEmbeddedAgentEnabled()` helper in `client/src/api/bootstrap-endpoint.ts`.
- **Daemon (`main.ts`)** — `/api/agent/ws` bridge mounts only when the flag is set. With the flag off the daemon logs that the surface is disabled. The operator-MCP-config write moved inside the gated block (only needed by the bridge).
- **`/v1/bootstrap`** — surfaces `embeddedAgentEnabled` so the SPA can gate rendering without a rebuild (runtime flag).
- **SPA** — `App.tsx` passes the agent rail to `AppShell` only when enabled; `AppShell` `rail` is now optional and collapses to a single column when omitted. `Onboarding.tsx` renders the "Ask Claude" panel only when enabled, spanning the bootstrap column full-width otherwise.
- **CHANGELOG** — documents the flag, default, and that Claude-Code-as-harness is unaffected (`client/CHANGELOG.md` Unreleased).
- **Tests** — `isEmbeddedAgentEnabled` unit tests + `/v1/bootstrap` flag assertions; `AppShell` no-rail test; `Onboarding` shows/hides "Ask Claude" by flag.

Out of scope (kept per the issue): `client/src/agent/agent-ws.ts`, the xterm dependency, the `Agent` / `AgentRail` components — they remain for the in-design future home (#177).

## Test plan

- [x] `yarn typecheck` — 0 errors.
- [x] `yarn vitest run` — 3707 passed; 1 pre-existing flake (`test/trajectory/transcript-watcher.test.ts`, timing-sensitive, unrelated to this change, passes in isolation).
- [x] SPA suite — 396 passed including new `AppShell` / `Onboarding` flag tests.
- [ ] Playwright SPA suite — not run locally (needs built daemon + browser); no Playwright test references the agent rail/panel.
- [ ] Manual: with flag unset, `/operator` renders no right rail and onboarding shows no "Ask Claude" panel; with `JINN_ENABLE_EMBEDDED_AGENT=1`, both render and `/api/agent/ws` works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)