### PR TITLE
fix(290): wire PluginPublication indexing for plugin:* MetadataSet events

### DIFF
--- a/client/src/discovery/onchain.ts
+++ b/client/src/discovery/onchain.ts
@@ -16,6 +16,11 @@
  *   from IdentityRegistry (key prefix `solvernet-manifest:`) and fold via the
  *   existing `resolveMostRecentWins` helper.
  *
+ * - `listPluginPublications` / `listBuilderArtifacts` read `MetadataSet` events
+ *   (key prefix `plugin:`), decode the on-chain PLUGIN_PAYLOAD_TUPLE /
+ *   REVOCATION_PAYLOAD_TUPLE, and fold most-recent-wins so the operator app's
+ *   /build registry panels keep rendering during an indexer outage (gh#290).
+ *
  * - `queryEnvelopes` delegates to the existing `runOnchainCorpusQuery`.
  *
  * - `cursorCache` is an optional injection point: when provided, the start
@@ -27,6 +32,7 @@
 
 import {
   createPublicClient,
+  decodeAbiParameters,
   decodeEventLog,
   http,
   type Address,
@@ -42,6 +48,8 @@ import { JINN_ROUTER_ABI } from '../adapters/mech/types.js';
 import { canClaimTask } from '../adapters/mech/contracts.js';
 import { manifestDigestForCid } from '../adapters/mech/digest.js';
 import { resolveMostRecentWins, type SetMetadataEvent, type SetMetadataLifecyclePayload } from '../solvernets/most-recent-wins.js';
+import { PLUGIN_PAYLOAD_TUPLE, REVOCATION_PAYLOAD_TUPLE } from '../erc8004/abis.js';
+import { PLUGIN_METADATA_KEY_PREFIX } from '../erc8004/plugin-registry.js';
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -198,6 +206,194 @@ function decodeSolvernetMetadataLog(log: {
     blockNumber: Number(log.blockNumber ?? 0n),
     transactionIndex: log.transactionIndex ?? 0,
   };
+}
+
+// ── Plug-in publication on-chain floor ────────────────────────────────────────
+//
+// The on-chain floor enumerates `plugin:<cid>` MetadataSet events directly so
+// the operator app's /build registry panels keep rendering during an indexer
+// outage. The indexer's `pluginPublication` entity is the rich source (it also
+// IPFS-enriches); this floor decodes the same on-chain payload tuples
+// (PLUGIN_PAYLOAD_TUPLE / REVOCATION_PAYLOAD_TUPLE) without the IPFS hop, then
+// folds most-recent-wins by (blockNumber, transactionIndex, logIndex).
+
+/**
+ * A decoded `plugin:<cid>` MetadataSet event. `kind` discriminates a v1
+ * publish (carries the full payload) from a v2 revocation (carries only the
+ * reason). Provenance fields drive the most-recent-wins fold.
+ */
+interface PluginMetadataEvent {
+  agentId: string;
+  pluginCid: string;
+  blockNumber: bigint;
+  transactionIndex: number;
+  logIndex: number;
+  kind: 'publish' | 'revoke';
+  /** v1-publish fields — present only when kind === 'publish'. */
+  publish?: {
+    pluginName: string;
+    pluginVersion: string;
+    pluginSha256: `0x${string}`;
+    supports: readonly string[];
+    publishedAt: number;
+  };
+  /** v2-revocation reason — present only when kind === 'revoke'. */
+  revokedReason?: string;
+}
+
+/**
+ * Decode a MetadataSet log into a PluginMetadataEvent, or null if the key is
+ * not a `plugin:` key or the payload decodes to neither a v1-publish nor a
+ * v2-revocation tuple. Mirrors `decodeSolvernetMetadataLog`.
+ */
+function decodePluginMetadataLog(log: {
+  data: Hex;
+  topics: readonly Hex[];
+  blockNumber: bigint | null;
+  transactionIndex: number | null;
+  logIndex: number | null;
+}): PluginMetadataEvent | null {
+  let decoded: {
+    eventName: 'MetadataSet';
+    args: { agentId: bigint; metadataKey: string; metadataValue: Hex };
+  };
+  try {
+    decoded = decodeEventLog({
+      abi: IDENTITY_METADATA_ABI,
+      data: log.data,
+      topics: log.topics as [`0x${string}`, ...`0x${string}`[]],
+    }) as typeof decoded;
+  } catch {
+    return null;
+  }
+
+  if (decoded.eventName !== 'MetadataSet') return null;
+  if (!decoded.args.metadataKey.startsWith(PLUGIN_METADATA_KEY_PREFIX)) return null;
+
+  const pluginCid = decoded.args.metadataKey.slice(PLUGIN_METADATA_KEY_PREFIX.length);
+  if (pluginCid.length === 0) return null;
+
+  const base = {
+    agentId: decoded.args.agentId.toString(),
+    pluginCid,
+    blockNumber: log.blockNumber ?? 0n,
+    transactionIndex: log.transactionIndex ?? 0,
+    logIndex: log.logIndex ?? 0,
+  };
+
+  // Try v1 publish first; on failure fall back to v2 revocation. Garbage
+  // payloads decode to neither and are dropped (return null).
+  try {
+    const d = decodeAbiParameters(PLUGIN_PAYLOAD_TUPLE, decoded.args.metadataValue);
+    if (Number(d[0]) === 1) {
+      return {
+        ...base,
+        kind: 'publish',
+        publish: {
+          pluginName: d[1],
+          pluginVersion: d[2],
+          pluginSha256: d[3],
+          supports: d[4],
+          publishedAt: Number(d[5]),
+        },
+      };
+    }
+  } catch {
+    // not a v1 payload — try v2 below
+  }
+  try {
+    const d = decodeAbiParameters(REVOCATION_PAYLOAD_TUPLE, decoded.args.metadataValue);
+    if (Number(d[0]) === 2 && d[1] === true) {
+      return { ...base, kind: 'revoke', revokedReason: d[2] };
+    }
+  } catch {
+    // not a v2 payload either
+  }
+  return null;
+}
+
+/**
+ * Fold a stream of plug-in MetadataSet events into the latest state per
+ * `<agentId>:<pluginCid>` key, most-recent-wins by
+ * (blockNumber, transactionIndex, logIndex). A v2 revocation only mutates the
+ * `revoked` / `revokedReason` fields of an existing publish; a revocation with
+ * no prior publish is meaningless and dropped (no row materialised).
+ */
+function foldPluginPublications(events: PluginMetadataEvent[]): PluginPublication[] {
+  interface Folded {
+    agentId: string;
+    pluginCid: string;
+    blockNumber: bigint;
+    transactionIndex: number;
+    logIndex: number;
+    pluginName: string;
+    pluginVersion: string;
+    pluginSha256: `0x${string}`;
+    supports: readonly string[];
+    publishedAt: number;
+    revoked: boolean;
+    revokedReason?: string;
+  }
+  const byKey = new Map<string, Folded>();
+
+  const isNewer = (e: PluginMetadataEvent, row: Folded): boolean =>
+    e.blockNumber > row.blockNumber ||
+    (e.blockNumber === row.blockNumber && e.transactionIndex > row.transactionIndex) ||
+    (e.blockNumber === row.blockNumber &&
+      e.transactionIndex === row.transactionIndex &&
+      e.logIndex > row.logIndex);
+
+  for (const e of events) {
+    const key = `${e.agentId}:${e.pluginCid}`;
+    const existing = byKey.get(key);
+
+    if (e.kind === 'publish' && e.publish) {
+      // A republish un-revokes (revoked resets to false), matching the
+      // indexer's handleMetadataSet v1 path.
+      if (!existing || isNewer(e, existing)) {
+        byKey.set(key, {
+          agentId: e.agentId,
+          pluginCid: e.pluginCid,
+          blockNumber: e.blockNumber,
+          transactionIndex: e.transactionIndex,
+          logIndex: e.logIndex,
+          pluginName: e.publish.pluginName,
+          pluginVersion: e.publish.pluginVersion,
+          pluginSha256: e.publish.pluginSha256,
+          supports: e.publish.supports,
+          publishedAt: e.publish.publishedAt,
+          revoked: false,
+          revokedReason: undefined,
+        });
+      }
+      continue;
+    }
+
+    // revoke — only valid against an existing publish, and only if newer.
+    if (e.kind === 'revoke' && existing && isNewer(e, existing)) {
+      existing.revoked = true;
+      existing.revokedReason = e.revokedReason;
+      existing.blockNumber = e.blockNumber;
+      existing.transactionIndex = e.transactionIndex;
+      existing.logIndex = e.logIndex;
+    }
+  }
+
+  return [...byKey.values()].map((row) => {
+    const out: PluginPublication = {
+      artifactType: 'plugin',
+      builderAgentId: row.agentId,
+      cid: row.pluginCid,
+      name: row.pluginName,
+      version: row.pluginVersion,
+      supports: row.supports,
+      publishedAt: row.publishedAt,
+      pluginSha256: row.pluginSha256,
+      revoked: row.revoked,
+    };
+    if (row.revokedReason !== undefined) out.revokedReason = row.revokedReason;
+    return out;
+  });
 }
 
 /**
@@ -728,15 +924,129 @@ export function createOnchainDiscoveryAPI(opts: OnchainDiscoveryAPIOptions): Dis
     }
   }
 
-  // ── Builder discovery stubs (attd) ────────────────────────────────────────
-  // Builder discovery requires the indexer's `pluginPublication` entity; the
-  // on-chain RPC floor does not enumerate it (would require a getLogs sweep +
-  // payload decode that the floor is not designed for). When falling back to the
-  // on-chain floor, builder browsing is unavailable until the indexer recovers.
+  // ── listPluginPublications (gh#290) ───────────────────────────────────────
+  // The on-chain floor enumerates `plugin:<cid>` MetadataSet events directly so
+  // the operator app's /build registry panels keep rendering during an indexer
+  // outage. Unlike the indexer's `pluginPublication` entity, the floor does NOT
+  // IPFS-enrich — but the rich fields (name, version, supports, sha256,
+  // publishedAt) are all in the on-chain PLUGIN_PAYLOAD_TUPLE, so the floor
+  // serves complete rows without an IPFS hop.
 
-  async function listPluginPublications(): Promise<PluginPublication[]> { return []; }
+  async function scanPluginMetadataEvents(): Promise<PluginMetadataEvent[]> {
+    if (!identityRegistryAddress) return [];
+
+    const client = getClient();
+    let currentBlock: bigint;
+    try {
+      currentBlock = await (client as PublicClient).getBlockNumber();
+    } catch (err) {
+      throw new DiscoveryUnavailableError(
+        `OnchainDiscoveryAPI.listPluginPublications: failed to get block number`,
+        err,
+      );
+    }
+
+    const fromBlock = resolveFromBlock(opts, 'plugins', currentBlock);
+
+    let events: PluginMetadataEvent[];
+    try {
+      events = await scanLogsInChunks(
+        async (start, end) => {
+          const logs = await (client as PublicClient).getLogs({
+            address: identityRegistryAddress,
+            fromBlock: start,
+            toBlock: end,
+          });
+          const decoded: PluginMetadataEvent[] = [];
+          for (const log of logs) {
+            const event = decodePluginMetadataLog(log as {
+              data: Hex;
+              topics: readonly Hex[];
+              blockNumber: bigint | null;
+              transactionIndex: number | null;
+              logIndex: number | null;
+            });
+            if (event) decoded.push(event);
+          }
+          return decoded;
+        },
+        fromBlock,
+        currentBlock,
+        chunk,
+      );
+    } catch (err) {
+      if (err instanceof DiscoveryUnavailableError) throw err;
+      throw new DiscoveryUnavailableError(
+        `OnchainDiscoveryAPI.listPluginPublications: getLogs for MetadataSet failed`,
+        err,
+      );
+    }
+
+    if (currentBlock > 0n) opts.cursorCache?.write('plugins', currentBlock);
+    return events;
+  }
+
+  async function listPluginPublications(args?: {
+    solverType?: string;
+    builderAgentId?: string;
+    includeRevoked?: boolean;
+    limit?: number;
+  }): Promise<PluginPublication[]> {
+    let events: PluginMetadataEvent[];
+    try {
+      events = await scanPluginMetadataEvents();
+    } catch (err) {
+      if (err instanceof DiscoveryUnavailableError) throw err;
+      throw new DiscoveryUnavailableError(
+        `OnchainDiscoveryAPI.listPluginPublications: scan failed`,
+        err,
+      );
+    }
+
+    let rows = foldPluginPublications(events);
+
+    // Apply the same filters the HTTP layer pushes into its `where` clause.
+    if (args?.builderAgentId !== undefined) {
+      rows = rows.filter((r) => r.builderAgentId === args.builderAgentId);
+    }
+    if (args?.solverType !== undefined) {
+      rows = rows.filter((r) => r.supports.includes(args.solverType as string));
+    }
+    // Revoked rows are included by default; drop them only when asked.
+    if (args?.includeRevoked === false) {
+      rows = rows.filter((r) => !r.revoked);
+    }
+
+    // Newest-first by publishedAt, mirroring the HTTP layer's
+    // `orderBy: "blockNumber", orderDirection: "desc"`.
+    rows.sort((a, b) => b.publishedAt - a.publishedAt);
+
+    if (args?.limit !== undefined && args.limit >= 0) {
+      rows = rows.slice(0, args.limit);
+    }
+    return rows;
+  }
+
+  // ── listBuilderArtifacts (gh#290) ─────────────────────────────────────────
+  // Today only plug-ins are published; mirror the HTTP layer and delegate to
+  // listPluginPublications so the "Your published plug-ins" panel populates on
+  // the floor too. The harness variant is added when Path 2 ships.
+
+  async function listBuilderArtifacts(args: {
+    builderAgentId: string;
+    limit?: number;
+  }): Promise<PublishedArtifact[]> {
+    return listPluginPublications({
+      builderAgentId: args.builderAgentId,
+      limit: args.limit,
+    });
+  }
+
+  // ── getPluginScores stub (ebu7 dependency) ────────────────────────────────
+  // Score history needs the indexer's `attemptEnvelopeMeta` + `verdict`
+  // enrichment join, which the on-chain floor cannot reconstruct. Stays a stub.
+
   async function getPluginScores(): Promise<PluginScoreHistoryRow[]> { return []; }
-  async function listBuilderArtifacts(): Promise<PublishedArtifact[]> { return []; }
 
   return {
     findClaimableTasks,

--- a/client/src/discovery/onchain.ts
+++ b/client/src/discovery/onchain.ts
@@ -159,6 +159,25 @@ function resolveFromBlock(
   return toBigInt(opts.taskDiscoveryFromBlock, defaultFromBlock);
 }
 
+/**
+ * Resolve the start block for a scan that must always see full history,
+ * deliberately ignoring `cursorCache`. Used by `scanPluginMetadataEvents`:
+ * `foldPluginPublications` re-folds from scratch each call, so a cursor would
+ * cause latent data-loss (every publication before the cursor would vanish).
+ * Priority order:
+ *  1. opts.taskDiscoveryFromBlock — explicit override
+ *  2. DEFAULT_EXECUTION_DISCOVERY_FROM_BLOCK[chainId] — chain default
+ *  3. currentBlock (no history)
+ */
+function resolveScanFromBlock(
+  opts: OnchainDiscoveryAPIOptions,
+  currentBlock: bigint,
+): bigint {
+  const defaultFromBlock =
+    DEFAULT_EXECUTION_DISCOVERY_FROM_BLOCK[opts.chainId] ?? currentBlock;
+  return toBigInt(opts.taskDiscoveryFromBlock, defaultFromBlock);
+}
+
 /** Decode a MetadataSet log into a SetMetadataEvent or null if not a solvernet-manifest event. */
 function decodeSolvernetMetadataLog(log: {
   data: Hex;
@@ -313,13 +332,32 @@ function decodePluginMetadataLog(log: {
 }
 
 /**
+ * The chain-attested provenance anchor for a folded publication. Carried
+ * alongside the public `PluginPublication` shape so `listPluginPublications`
+ * can sort by `(blockNumber, transactionIndex, logIndex) desc` for true
+ * parity with the HTTP layer's `orderBy: blockNumber` without widening the
+ * public result type.
+ */
+interface PluginPublicationAnchor {
+  blockNumber: bigint;
+  transactionIndex: number;
+  logIndex: number;
+}
+
+/**
  * Fold a stream of plug-in MetadataSet events into the latest state per
  * `<agentId>:<pluginCid>` key, most-recent-wins by
  * (blockNumber, transactionIndex, logIndex). A v2 revocation only mutates the
  * `revoked` / `revokedReason` fields of an existing publish; a revocation with
  * no prior publish is meaningless and dropped (no row materialised).
+ *
+ * Returns the materialised rows plus an `anchors` map keyed by row identity,
+ * so callers can sort by the chain-attested anchor.
  */
-function foldPluginPublications(events: PluginMetadataEvent[]): PluginPublication[] {
+function foldPluginPublications(events: PluginMetadataEvent[]): {
+  rows: PluginPublication[];
+  anchors: Map<PluginPublication, PluginPublicationAnchor>;
+} {
   interface Folded {
     agentId: string;
     pluginCid: string;
@@ -379,7 +417,9 @@ function foldPluginPublications(events: PluginMetadataEvent[]): PluginPublicatio
     }
   }
 
-  return [...byKey.values()].map((row) => {
+  const rows: PluginPublication[] = [];
+  const anchors = new Map<PluginPublication, PluginPublicationAnchor>();
+  for (const row of byKey.values()) {
     const out: PluginPublication = {
       artifactType: 'plugin',
       builderAgentId: row.agentId,
@@ -392,8 +432,14 @@ function foldPluginPublications(events: PluginMetadataEvent[]): PluginPublicatio
       revoked: row.revoked,
     };
     if (row.revokedReason !== undefined) out.revokedReason = row.revokedReason;
-    return out;
-  });
+    rows.push(out);
+    anchors.set(out, {
+      blockNumber: row.blockNumber,
+      transactionIndex: row.transactionIndex,
+      logIndex: row.logIndex,
+    });
+  }
+  return { rows, anchors };
 }
 
 /**
@@ -946,7 +992,14 @@ export function createOnchainDiscoveryAPI(opts: OnchainDiscoveryAPIOptions): Dis
       );
     }
 
-    const fromBlock = resolveFromBlock(opts, 'plugins', currentBlock);
+    // No cursor here. `listPluginPublications` must return the *complete*
+    // catalog from a single call: `foldPluginPublications` re-folds from
+    // scratch every call, so it must see *all* events. A cursor would scan
+    // only `[cachedBlock, head]` on the second call and silently drop every
+    // publication before the cursor — unlike `findClaimableTasks`, whose
+    // caller accumulates across calls, this method has no accumulator.
+    // Always scan from the chain default, ignoring any injected cursorCache.
+    const fromBlock = resolveScanFromBlock(opts, currentBlock);
 
     let events: PluginMetadataEvent[];
     try {
@@ -982,7 +1035,7 @@ export function createOnchainDiscoveryAPI(opts: OnchainDiscoveryAPIOptions): Dis
       );
     }
 
-    if (currentBlock > 0n) opts.cursorCache?.write('plugins', currentBlock);
+    // Intentionally no cursorCache.write here — see resolveScanFromBlock.
     return events;
   }
 
@@ -1003,7 +1056,8 @@ export function createOnchainDiscoveryAPI(opts: OnchainDiscoveryAPIOptions): Dis
       );
     }
 
-    let rows = foldPluginPublications(events);
+    const { rows: foldedRows, anchors: foldedAnchors } = foldPluginPublications(events);
+    let rows = foldedRows;
 
     // Apply the same filters the HTTP layer pushes into its `where` clause.
     if (args?.builderAgentId !== undefined) {
@@ -1017,14 +1071,29 @@ export function createOnchainDiscoveryAPI(opts: OnchainDiscoveryAPIOptions): Dis
       rows = rows.filter((r) => !r.revoked);
     }
 
-    // Newest-first by publishedAt, mirroring the HTTP layer's
-    // `orderBy: "blockNumber", orderDirection: "desc"`.
-    rows.sort((a, b) => b.publishedAt - a.publishedAt);
+    // Newest-first by the fold's chain-attested anchor
+    // (blockNumber, transactionIndex, logIndex) desc — true parity with the
+    // HTTP layer's `orderBy: "blockNumber", orderDirection: "desc"`. Sorting
+    // by the builder-supplied `publishedAt` would diverge: that value is not
+    // chain-attested. `foldedAnchors` carries the anchor alongside each row so
+    // the public `PluginPublication` shape stays unchanged.
+    rows.sort((a, b) => {
+      const aa = foldedAnchors.get(a);
+      const ba = foldedAnchors.get(b);
+      if (!aa || !ba) return 0;
+      if (aa.blockNumber !== ba.blockNumber) {
+        return aa.blockNumber > ba.blockNumber ? -1 : 1;
+      }
+      if (aa.transactionIndex !== ba.transactionIndex) {
+        return ba.transactionIndex - aa.transactionIndex;
+      }
+      return ba.logIndex - aa.logIndex;
+    });
 
-    if (args?.limit !== undefined && args.limit >= 0) {
-      rows = rows.slice(0, args.limit);
-    }
-    return rows;
+    // Clamp `limit` to `[1, 500]` (default 100), mirroring the HTTP layer for
+    // drop-in `with-fallback` parity.
+    const limit = Math.min(500, Math.max(1, args?.limit ?? 100));
+    return rows.slice(0, limit);
   }
 
   // ── listBuilderArtifacts (gh#290) ─────────────────────────────────────────

--- a/client/test/discovery/onchain.test.ts
+++ b/client/test/discovery/onchain.test.ts
@@ -206,6 +206,106 @@ function buildSolvernetMetadataLog(
   } as unknown as Log;
 }
 
+// ── Plug-in publication ABI tuples + log builders (gh#290) ────────────────────
+
+const PLUGIN_PAYLOAD_TUPLE = [
+  { name: 'version', type: 'uint8' },
+  { name: 'pluginName', type: 'string' },
+  { name: 'pluginVersion', type: 'string' },
+  { name: 'pluginSha256', type: 'bytes32' },
+  { name: 'supports', type: 'string[]' },
+  { name: 'publishedAt', type: 'uint64' },
+] as const;
+
+const REVOCATION_PAYLOAD_TUPLE = [
+  { name: 'version', type: 'uint8' },
+  { name: 'revoked', type: 'bool' },
+  { name: 'reason', type: 'string' },
+] as const;
+
+/** Build a MetadataSet log for a `plugin:<cid>` v1 publish payload. */
+function buildPluginPublishLog(args: {
+  agentId: bigint;
+  pluginCid: string;
+  pluginName: string;
+  pluginVersion: string;
+  pluginSha256: Hex;
+  supports: string[];
+  publishedAt: bigint;
+  blockNumber: bigint;
+  transactionIndex?: number;
+  logIndex?: number;
+}): Log {
+  const metadataKey = `plugin:${args.pluginCid}`;
+  const valueHex = encodeAbiParameters(PLUGIN_PAYLOAD_TUPLE, [
+    1,
+    args.pluginName,
+    args.pluginVersion,
+    args.pluginSha256,
+    args.supports,
+    args.publishedAt,
+  ]);
+  const topics = encodeEventTopics({
+    abi: METADATA_ABI,
+    eventName: 'MetadataSet',
+    args: { agentId: args.agentId, indexedMetadataKey: metadataKey },
+  });
+  const data = encodeAbiParameters(
+    [
+      { name: 'metadataKey', type: 'string' },
+      { name: 'metadataValue', type: 'bytes' },
+    ],
+    [metadataKey, valueHex],
+  );
+  return {
+    address: IDENTITY_REGISTRY,
+    data,
+    topics,
+    blockNumber: args.blockNumber,
+    blockHash: `0x${'00'.repeat(32)}` as Hex,
+    transactionHash: `0x${'44'.repeat(32)}` as Hex,
+    transactionIndex: args.transactionIndex ?? 0,
+    logIndex: args.logIndex ?? 0,
+    removed: false,
+  } as unknown as Log;
+}
+
+/** Build a MetadataSet log for a `plugin:<cid>` v2 revocation payload. */
+function buildPluginRevokeLog(args: {
+  agentId: bigint;
+  pluginCid: string;
+  reason: string;
+  blockNumber: bigint;
+  transactionIndex?: number;
+  logIndex?: number;
+}): Log {
+  const metadataKey = `plugin:${args.pluginCid}`;
+  const valueHex = encodeAbiParameters(REVOCATION_PAYLOAD_TUPLE, [2, true, args.reason]);
+  const topics = encodeEventTopics({
+    abi: METADATA_ABI,
+    eventName: 'MetadataSet',
+    args: { agentId: args.agentId, indexedMetadataKey: metadataKey },
+  });
+  const data = encodeAbiParameters(
+    [
+      { name: 'metadataKey', type: 'string' },
+      { name: 'metadataValue', type: 'bytes' },
+    ],
+    [metadataKey, valueHex],
+  );
+  return {
+    address: IDENTITY_REGISTRY,
+    data,
+    topics,
+    blockNumber: args.blockNumber,
+    blockHash: `0x${'00'.repeat(32)}` as Hex,
+    transactionHash: `0x${'55'.repeat(32)}` as Hex,
+    transactionIndex: args.transactionIndex ?? 0,
+    logIndex: args.logIndex ?? 0,
+    removed: false,
+  } as unknown as Log;
+}
+
 // ── Mock client builder ───────────────────────────────────────────────────────
 
 /** Build a mock PublicClient with a queue of log batches per getLogs call. */
@@ -753,6 +853,283 @@ describe('OnchainDiscoveryAPI — cursorCache', () => {
 
     await api.getLifecycleStatus('unknown-cid');
     expect(cache.write).toHaveBeenCalledWith('solvernets', CURRENT_BLOCK);
+  });
+});
+
+describe('OnchainDiscoveryAPI — listPluginPublications (gh#290)', () => {
+  const SHA_1 = `0x${'aa'.repeat(32)}` as Hex;
+  const SHA_2 = `0x${'bb'.repeat(32)}` as Hex;
+
+  it('decodes a v1 publish MetadataSet log into a PluginPublication row', async () => {
+    const log = buildPluginPublishLog({
+      agentId: 42n,
+      pluginCid: 'bafyPluginOne',
+      pluginName: '@builder/swe-skill',
+      pluginVersion: '0.1.0',
+      pluginSha256: SHA_1,
+      supports: ['swe-rebench-v2.v1'],
+      publishedAt: 1_715_700_000n,
+      blockNumber: 5_000n,
+    });
+    const mockClient = buildMockClient([[log]]);
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      identityRegistryAddress: IDENTITY_REGISTRY,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+
+    const rows = await api.listPluginPublications();
+    expect(rows).toEqual([
+      {
+        artifactType: 'plugin',
+        builderAgentId: '42',
+        cid: 'bafyPluginOne',
+        name: '@builder/swe-skill',
+        version: '0.1.0',
+        supports: ['swe-rebench-v2.v1'],
+        publishedAt: 1_715_700_000,
+        pluginSha256: SHA_1,
+        revoked: false,
+      },
+    ]);
+  });
+
+  it('returns an empty array when no plugin: MetadataSet events are found', async () => {
+    const mockClient = buildMockClient([[]]);
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      identityRegistryAddress: IDENTITY_REGISTRY,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+    expect(await api.listPluginPublications()).toEqual([]);
+  });
+
+  it('ignores non-plugin MetadataSet keys (solvernet-manifest:)', async () => {
+    const solvernetLog = buildSolvernetMetadataLog(7n, 'bafyManifest', 'launched', 4_000n);
+    const mockClient = buildMockClient([[solvernetLog]]);
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      identityRegistryAddress: IDENTITY_REGISTRY,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+    expect(await api.listPluginPublications()).toEqual([]);
+  });
+
+  it('a v2 revocation flips revoked=true and carries the reason', async () => {
+    const publish = buildPluginPublishLog({
+      agentId: 42n,
+      pluginCid: 'bafyPluginOne',
+      pluginName: '@builder/swe-skill',
+      pluginVersion: '0.1.0',
+      pluginSha256: SHA_1,
+      supports: ['swe-rebench-v2.v1'],
+      publishedAt: 1_715_700_000n,
+      blockNumber: 5_000n,
+    });
+    const revoke = buildPluginRevokeLog({
+      agentId: 42n,
+      pluginCid: 'bafyPluginOne',
+      reason: 'cve-2026-xxxx',
+      blockNumber: 6_000n,
+    });
+    const mockClient = buildMockClient([[publish, revoke]]);
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      identityRegistryAddress: IDENTITY_REGISTRY,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+
+    const rows = await api.listPluginPublications();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ revoked: true, revokedReason: 'cve-2026-xxxx' });
+  });
+
+  it('excludes revoked rows when includeRevoked is false', async () => {
+    const publish = buildPluginPublishLog({
+      agentId: 42n,
+      pluginCid: 'bafyPluginOne',
+      pluginName: '@builder/swe-skill',
+      pluginVersion: '0.1.0',
+      pluginSha256: SHA_1,
+      supports: ['swe-rebench-v2.v1'],
+      publishedAt: 1_715_700_000n,
+      blockNumber: 5_000n,
+    });
+    const revoke = buildPluginRevokeLog({
+      agentId: 42n,
+      pluginCid: 'bafyPluginOne',
+      reason: 'mistake',
+      blockNumber: 6_000n,
+    });
+    const mockClient = buildMockClient([[publish, revoke]]);
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      identityRegistryAddress: IDENTITY_REGISTRY,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+    expect(await api.listPluginPublications({ includeRevoked: false })).toEqual([]);
+  });
+
+  it('a v1 republish after a revocation un-revokes the row', async () => {
+    const publish = buildPluginPublishLog({
+      agentId: 42n,
+      pluginCid: 'bafyPluginOne',
+      pluginName: '@builder/swe-skill',
+      pluginVersion: '0.1.0',
+      pluginSha256: SHA_1,
+      supports: ['swe-rebench-v2.v1'],
+      publishedAt: 1_715_700_000n,
+      blockNumber: 5_000n,
+    });
+    const revoke = buildPluginRevokeLog({
+      agentId: 42n,
+      pluginCid: 'bafyPluginOne',
+      reason: 'mistake',
+      blockNumber: 6_000n,
+    });
+    const republish = buildPluginPublishLog({
+      agentId: 42n,
+      pluginCid: 'bafyPluginOne',
+      pluginName: '@builder/swe-skill',
+      pluginVersion: '0.2.0',
+      pluginSha256: SHA_2,
+      supports: ['swe-rebench-v2.v1'],
+      publishedAt: 1_715_800_000n,
+      blockNumber: 7_000n,
+    });
+    const mockClient = buildMockClient([[publish, revoke, republish]]);
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      identityRegistryAddress: IDENTITY_REGISTRY,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+    const rows = await api.listPluginPublications();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ revoked: false, version: '0.2.0' });
+    expect(rows[0]?.revokedReason).toBeUndefined();
+  });
+
+  it('filters by builderAgentId and solverType', async () => {
+    const logs = (): Log[] => [
+      buildPluginPublishLog({
+        agentId: 1n,
+        pluginCid: 'bafyA',
+        pluginName: '@a/plugin',
+        pluginVersion: '1.0.0',
+        pluginSha256: SHA_1,
+        supports: ['swe-rebench-v2.v1'],
+        publishedAt: 100n,
+        blockNumber: 1_000n,
+      }),
+      buildPluginPublishLog({
+        agentId: 2n,
+        pluginCid: 'bafyB',
+        pluginName: '@b/plugin',
+        pluginVersion: '1.0.0',
+        pluginSha256: SHA_2,
+        supports: ['other-type.v1'],
+        publishedAt: 200n,
+        blockNumber: 2_000n,
+      }),
+    ];
+    const mkApi = () =>
+      createOnchainDiscoveryAPI({
+        chainId: CHAIN_ID,
+        identityRegistryAddress: IDENTITY_REGISTRY,
+        taskDiscoveryFromBlock: 0,
+        // Fresh mock client per call — buildMockClient's batch queue is consumed.
+        publicClient: buildMockClient([logs()]) as never,
+      });
+
+    const byBuilder = await mkApi().listPluginPublications({ builderAgentId: '2' });
+    expect(byBuilder.map((r) => r.cid)).toEqual(['bafyB']);
+
+    const bySolverType = await mkApi().listPluginPublications({
+      solverType: 'swe-rebench-v2.v1',
+    });
+    expect(bySolverType.map((r) => r.cid)).toEqual(['bafyA']);
+  });
+
+  it('ignores garbage payloads on a plugin: key without throwing', async () => {
+    // Hand-craft a MetadataSet log with a non-decodable value.
+    const metadataKey = 'plugin:bafyGarbage';
+    const topics = encodeEventTopics({
+      abi: METADATA_ABI,
+      eventName: 'MetadataSet',
+      args: { agentId: 9n, indexedMetadataKey: metadataKey },
+    });
+    const data = encodeAbiParameters(
+      [
+        { name: 'metadataKey', type: 'string' },
+        { name: 'metadataValue', type: 'bytes' },
+      ],
+      [metadataKey, '0xdeadbeef'],
+    );
+    const garbage = {
+      address: IDENTITY_REGISTRY,
+      data,
+      topics,
+      blockNumber: 3_000n,
+      blockHash: `0x${'00'.repeat(32)}` as Hex,
+      transactionHash: `0x${'66'.repeat(32)}` as Hex,
+      transactionIndex: 0,
+      logIndex: 0,
+      removed: false,
+    } as unknown as Log;
+    const mockClient = buildMockClient([[garbage]]);
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      identityRegistryAddress: IDENTITY_REGISTRY,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+    expect(await api.listPluginPublications()).toEqual([]);
+  });
+
+  it('listBuilderArtifacts delegates to listPluginPublications', async () => {
+    const log = buildPluginPublishLog({
+      agentId: 42n,
+      pluginCid: 'bafyPluginOne',
+      pluginName: '@builder/swe-skill',
+      pluginVersion: '0.1.0',
+      pluginSha256: SHA_1,
+      supports: ['swe-rebench-v2.v1'],
+      publishedAt: 1_715_700_000n,
+      blockNumber: 5_000n,
+    });
+    const mockClient = buildMockClient([[log]]);
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      identityRegistryAddress: IDENTITY_REGISTRY,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+    const artifacts = await api.listBuilderArtifacts({ builderAgentId: '42' });
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]).toMatchObject({ artifactType: 'plugin', cid: 'bafyPluginOne' });
+  });
+
+  it('throws DiscoveryUnavailableError when getLogs fails', async () => {
+    const mockClient = {
+      getBlockNumber: vi.fn(async () => CURRENT_BLOCK),
+      getLogs: vi.fn(async () => {
+        throw new Error('rpc down');
+      }),
+      simulateContract: vi.fn(),
+    };
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      identityRegistryAddress: IDENTITY_REGISTRY,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+    await expect(api.listPluginPublications()).rejects.toBeInstanceOf(DiscoveryUnavailableError);
   });
 });
 

--- a/client/test/discovery/onchain.test.ts
+++ b/client/test/discovery/onchain.test.ts
@@ -1131,6 +1131,200 @@ describe('OnchainDiscoveryAPI — listPluginPublications (gh#290)', () => {
     });
     await expect(api.listPluginPublications()).rejects.toBeInstanceOf(DiscoveryUnavailableError);
   });
+
+  it('returns the full catalog on every call even when a cursorCache is injected (no data-loss regression)', async () => {
+    // An injected cursorCache must NOT cause the second call to scan only
+    // [cachedBlock, head]. `foldPluginPublications` re-folds from scratch, so
+    // if the scan window narrowed, every publication before the cursor would
+    // vanish from the result. This guards that latent data-loss bug.
+    const pluginA = buildPluginPublishLog({
+      agentId: 1n,
+      pluginCid: 'bafyOldPlugin',
+      pluginName: '@a/old',
+      pluginVersion: '1.0.0',
+      pluginSha256: SHA_1,
+      supports: ['swe-rebench-v2.v1'],
+      publishedAt: 100n,
+      blockNumber: 1_000n,
+    });
+    const pluginB = buildPluginPublishLog({
+      agentId: 2n,
+      pluginCid: 'bafyNewPlugin',
+      pluginName: '@b/new',
+      pluginVersion: '1.0.0',
+      pluginSha256: SHA_2,
+      supports: ['swe-rebench-v2.v1'],
+      publishedAt: 200n,
+      blockNumber: 8_000n,
+    });
+
+    // A cursorCache whose `read` advances to near-head after the first scan —
+    // mimicking the behaviour that previously broke the floor.
+    let cached: bigint | null = null;
+    const cache: OnchainCursorCache = {
+      read: vi.fn((label: string) => (label === 'plugins' ? cached : null)),
+      write: vi.fn((label: string, block: bigint) => {
+        if (label === 'plugins') cached = block;
+      }),
+    };
+
+    // Each call gets a fresh single-batch mock returning BOTH plugins. If the
+    // floor honoured the cursor, the second call's getLogs `fromBlock` would
+    // jump past block 1_000 — but the floor must always scan from the default.
+    const mkApi = () =>
+      createOnchainDiscoveryAPI({
+        chainId: CHAIN_ID,
+        identityRegistryAddress: IDENTITY_REGISTRY,
+        taskDiscoveryFromBlock: 0,
+        chunkBlocks: 100_000,
+        publicClient: buildMockClient([[pluginA, pluginB]]) as never,
+        cursorCache: cache,
+      });
+
+    const first = await mkApi().listPluginPublications();
+    expect(first.map((r) => r.cid).sort()).toEqual(['bafyNewPlugin', 'bafyOldPlugin']);
+
+    // Second call: the catalog must still be complete — the old plugin must
+    // not have vanished behind a cursor.
+    const second = await mkApi().listPluginPublications();
+    expect(second.map((r) => r.cid).sort()).toEqual(['bafyNewPlugin', 'bafyOldPlugin']);
+
+    // The floor never consults nor advances a 'plugins' cursor.
+    expect(cache.write).not.toHaveBeenCalledWith('plugins', expect.anything());
+  });
+
+  it('always scans plugin: events from the chain default, never from an injected cursor', async () => {
+    const cache: OnchainCursorCache = {
+      // Even if a stale 'plugins' cursor is present, the floor must ignore it.
+      read: vi.fn(() => 7_777n),
+      write: vi.fn(),
+    };
+    const mockClient = buildMockClient([[]]);
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      identityRegistryAddress: IDENTITY_REGISTRY,
+      taskDiscoveryFromBlock: 0,
+      chunkBlocks: 100_000,
+      publicClient: mockClient as never,
+      cursorCache: cache,
+    });
+
+    await api.listPluginPublications();
+
+    // getLogs scanned from block 0 (taskDiscoveryFromBlock), not from 7_777.
+    const getLogsCall = mockClient.getLogs.mock.calls[0][0];
+    expect(getLogsCall.fromBlock).toBe(0n);
+  });
+
+  it('clamps limit to [1, 500], mirroring the HTTP layer', async () => {
+    // Six plugins on six distinct blocks.
+    const logs: Log[] = Array.from({ length: 6 }, (_, i) =>
+      buildPluginPublishLog({
+        agentId: BigInt(i + 1),
+        pluginCid: `bafyPlugin${i}`,
+        pluginName: `@p/plugin${i}`,
+        pluginVersion: '1.0.0',
+        pluginSha256: SHA_1,
+        supports: ['swe-rebench-v2.v1'],
+        publishedAt: BigInt(100 + i),
+        blockNumber: BigInt(1_000 + i),
+      }),
+    );
+    const mkApi = () =>
+      createOnchainDiscoveryAPI({
+        chainId: CHAIN_ID,
+        identityRegistryAddress: IDENTITY_REGISTRY,
+        taskDiscoveryFromBlock: 0,
+        publicClient: buildMockClient([logs]) as never,
+      });
+
+    // limit=0 clamps up to 1.
+    expect(await mkApi().listPluginPublications({ limit: 0 })).toHaveLength(1);
+    // Negative limit clamps up to 1.
+    expect(await mkApi().listPluginPublications({ limit: -5 })).toHaveLength(1);
+    // limit above 500 clamps down to 500 (here capped by the 6 available rows).
+    expect(await mkApi().listPluginPublications({ limit: 9_999 })).toHaveLength(6);
+    // A valid in-range limit is honoured exactly.
+    expect(await mkApi().listPluginPublications({ limit: 3 })).toHaveLength(3);
+  });
+
+  it('sorts newest-first by chain anchor (blockNumber desc), not by builder-supplied publishedAt', async () => {
+    // publishedAt is deliberately inverted relative to blockNumber: the older
+    // block carries the larger publishedAt. The floor must order by the
+    // chain-attested blockNumber, matching the HTTP layer's orderBy.
+    const earlyBlockLatePublishedAt = buildPluginPublishLog({
+      agentId: 1n,
+      pluginCid: 'bafyEarlyBlock',
+      pluginName: '@a/early',
+      pluginVersion: '1.0.0',
+      pluginSha256: SHA_1,
+      supports: ['swe-rebench-v2.v1'],
+      publishedAt: 9_000n, // larger publishedAt
+      blockNumber: 1_000n, // smaller blockNumber
+    });
+    const lateBlockEarlyPublishedAt = buildPluginPublishLog({
+      agentId: 2n,
+      pluginCid: 'bafyLateBlock',
+      pluginName: '@b/late',
+      pluginVersion: '1.0.0',
+      pluginSha256: SHA_2,
+      supports: ['swe-rebench-v2.v1'],
+      publishedAt: 100n, // smaller publishedAt
+      blockNumber: 8_000n, // larger blockNumber
+    });
+    const mockClient = buildMockClient([
+      [earlyBlockLatePublishedAt, lateBlockEarlyPublishedAt],
+    ]);
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      identityRegistryAddress: IDENTITY_REGISTRY,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+
+    const rows = await api.listPluginPublications();
+    // blockNumber desc → late-block row first, despite its smaller publishedAt.
+    expect(rows.map((r) => r.cid)).toEqual(['bafyLateBlock', 'bafyEarlyBlock']);
+  });
+
+  it('breaks blockNumber ties by (transactionIndex, logIndex) desc', async () => {
+    const sameBlock = 5_000n;
+    const lowerLog = buildPluginPublishLog({
+      agentId: 1n,
+      pluginCid: 'bafyLowerLog',
+      pluginName: '@a/lower',
+      pluginVersion: '1.0.0',
+      pluginSha256: SHA_1,
+      supports: ['swe-rebench-v2.v1'],
+      publishedAt: 100n,
+      blockNumber: sameBlock,
+      transactionIndex: 0,
+      logIndex: 1,
+    });
+    const higherLog = buildPluginPublishLog({
+      agentId: 2n,
+      pluginCid: 'bafyHigherLog',
+      pluginName: '@b/higher',
+      pluginVersion: '1.0.0',
+      pluginSha256: SHA_2,
+      supports: ['swe-rebench-v2.v1'],
+      publishedAt: 100n,
+      blockNumber: sameBlock,
+      transactionIndex: 0,
+      logIndex: 9,
+    });
+    const mockClient = buildMockClient([[lowerLog, higherLog]]);
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      identityRegistryAddress: IDENTITY_REGISTRY,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+
+    const rows = await api.listPluginPublications();
+    // Same block, same txIndex → higher logIndex sorts first.
+    expect(rows.map((r) => r.cid)).toEqual(['bafyHigherLog', 'bafyLowerLog']);
+  });
 });
 
 describe('limitedConcurrency — partial-failure resilience', () => {


### PR DESCRIPTION
## Summary

- The Ponder indexer's `pluginPublication` entity (schema, `handleMetadataSet` plugin path, REST routes) already shipped in **PR #214**. The remaining gap was the **on-chain RPC floor** — the always-live fallback the daemon routes to during an indexer outage — where `listPluginPublications` / `listBuilderArtifacts` were stubs returning `[]`. With the floor blind to plug-in publications, the operator app's `/build` registry panels render a permanent empty state whenever the indexer is unreachable.
- This implements the floor: scan `IdentityRegistry` `MetadataSet` events for `plugin:<cid>` keys, decode the on-chain `PLUGIN_PAYLOAD_TUPLE` / `REVOCATION_PAYLOAD_TUPLE`, and fold most-recent-wins by `(blockNumber, transactionIndex, logIndex)` — mirroring the indexer's `handleMetadataSet` plugin path and the existing `solvernet-manifest:` floor scan. All rich fields (`name`, `version`, `supports`, `pluginSha256`, `publishedAt`) are in the on-chain payload, so the floor serves complete rows **without an IPFS hop**.
- `listBuilderArtifacts` now delegates to `listPluginPublications`, matching the HTTP layer. `getPluginScores` stays a stub — score history needs the indexer's `attemptEnvelopeMeta` + `verdict` enrichment join, which the floor cannot reconstruct.

## Why this, not an indexer change

Investigation found the indexer code is **already complete** — `packages/indexer/ponder.schema.ts` exports `pluginPublication`, `src/handlers.ts` routes `plugin:<cid>` keys, `src/index.ts` registers the handler, and `src/api/index.ts` exposes REST routes. All 186 indexer tests pass. The issue's reproduction (deployed GraphQL missing `pluginPublications`) is an **operational redeploy** of the Railway instance with a `DATABASE_SCHEMA` bump (see `packages/indexer/deploy/README.md` §"Zero-downtime rolling deploys") — not a code change in this repo.

The actionable code gap was the on-chain floor, which the Issue explicitly calls out as a "Companion issue" and §Constraint Option 1. Fixing it means the `/build` panels populate **even when the indexer is down**.

## Test plan

- [x] `client` typecheck (`tsc --noEmit`) — clean
- [x] `test/discovery/onchain.test.ts` — 34 tests pass, including 10 new `listPluginPublications` cases (v1 decode, v2 revocation, un-revoke on republish, `includeRevoked`/`solverType`/`builderAgentId` filters, garbage-payload resilience, `DiscoveryUnavailableError` on RPC failure, `listBuilderArtifacts` delegation)
- [x] `test/discovery/` — all 94 tests pass
- [x] `packages/indexer` — all 186 tests pass (indexer side already complete)
- [ ] Operational follow-up (not in this PR): redeploy `jinn-indexer-production.up.railway.app` with a `DATABASE_SCHEMA` bump so the indexer's `pluginPublications` GraphQL field goes live.

Closes #290

Generated with Claude Code