### PR TITLE
fix(308): deep-fetch tag ancestry in promote-main workflow

### DIFF
--- a/.github/workflows/promote-main.yml
+++ b/.github/workflows/promote-main.yml
@@ -34,7 +34,14 @@ jobs:
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          git fetch --tags --depth=1 origin "$RELEASE_TAG"
+          # Fetch the tag deeply (no --depth=1). A shallow tag fetch creates a
+          # shallow graft at the tag commit; subsequent `git fetch origin next`
+          # does NOT auto-unshallow that graft, so the line-75 ancestry check
+          # (`git merge-base --is-ancestor main <tag>`) fails when walking
+          # across the boundary. Tag fetches are cheap (no large objects); the
+          # deep fetch pulls only the ancestry needed to resolve ancestry from
+          # main to the tag commit. See #308.
+          git fetch --tags origin "$RELEASE_TAG"
           SHA="$(git rev-parse "$RELEASE_TAG^{commit}")"
           echo "release_sha=$SHA" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- `promote-main.yml`'s release-event ancestry check failed v0.1.6's promotion ("main is not an ancestor of release SHA 92ba5361...") even though main IS an ancestor.
- Root cause: the tag fetch ran with `--depth=1`, which writes the tag commit's SHA into `.git/shallow`, creating a shallow graft. The subsequent `git fetch origin next` does NOT auto-unshallow existing grafts, so the `git merge-base --is-ancestor main <tag>` check failed walking across the shallow boundary.
- Fix: drop `--depth=1` from the tag fetch so no shallow graft is created. Tag fetches are cheap (no large objects); the deep fetch pulls only the ancestry needed between the tag commit and the existing local history rooted at main (already fetched with `fetch-depth: 0` by `actions/checkout@v5`).

## Test plan
- [ ] Confirm the next Monday named cut triggers `promote-main.yml` and the ancestry check passes
- [ ] Verify the hotfix early-exit path (`Skip if main already at release SHA`) still short-circuits when `MAIN_SHA == RELEASE_SHA`

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>