### PR TITLE
fix(337): clear all-good indicator after jinn update

### DIFF
--- a/client/src/cli/commands/update.ts
+++ b/client/src/cli/commands/update.ts
@@ -1,5 +1,7 @@
 import { execSync } from 'node:child_process';
 import { copyFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 import type { CommandContext, CommandModule } from '../command.js';
 import { COMMON_FLAGS } from '../command.js';
@@ -19,6 +21,36 @@ class StringWriter {
   private chunks: string[] = [];
   write(s: string): boolean { this.chunks.push(s); return true; }
   toString(): string { return this.chunks.join(''); }
+}
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_JSON_PATH = join(HERE, '..', '..', '..', 'package.json');
+
+function readClientVersion(): string {
+  try {
+    const raw = readFileSync(PACKAGE_JSON_PATH, 'utf-8');
+    const pkg = JSON.parse(raw) as { version?: string };
+    return pkg.version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+/**
+ * Formats the final all-good indicator line for `jinn update`.
+ * Green when stderr is a TTY and NO_COLOR is unset; plain text otherwise.
+ *
+ * Exported for tests; the daemon never imports this directly.
+ */
+export function formatUpdateSuccessLine(
+  version: string,
+  opts: { stderrIsTty: boolean; noColor: boolean },
+): string {
+  const text = `✓ jinn updated to v${version}`;
+  if (opts.stderrIsTty && !opts.noColor) {
+    return `\x1b[32m${text}\x1b[0m`;
+  }
+  return text;
 }
 
 interface IntegrationInstallResultEntry {
@@ -456,6 +488,18 @@ Examples:
           noColor: Boolean(ctx.env['NO_COLOR']),
         },
       );
+
+      // All-good indicator (#337): on happy path, end terminal output with a
+      // clear success line on stderr so it appears last regardless of JSON or
+      // human mode and never pollutes the structured stdout payload. Failure
+      // path is unchanged — existing error lines already make the state legible.
+      if (allOk) {
+        const noColor = Boolean(ctx.env['NO_COLOR']);
+        const stderrIsTty = Boolean(process.stderr.isTTY);
+        console.error(
+          formatUpdateSuccessLine(readClientVersion(), { stderrIsTty, noColor }),
+        );
+      }
     },
   };
 }

--- a/client/test/cli/commands/update.test.ts
+++ b/client/test/cli/commands/update.test.ts
@@ -3,7 +3,7 @@ import Database from 'better-sqlite3';
 import os from 'os';
 import path from 'path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createUpdateCommand } from '@/cli/commands/update.js';
+import { createUpdateCommand, formatUpdateSuccessLine } from '@/cli/commands/update.js';
 import { runCommand } from '@test/cli.js';
 import type { CommandContext } from '@/cli/command.js';
 import { FleetStateStore } from '@/earning/store.js';
@@ -466,5 +466,67 @@ describe('update command', () => {
     expect(earningStep).toMatchObject({ status: 'skipped' });
     expect(earningStep?.detail).toContain('not bootstrapped');
     expect(await new FleetStateStore(earningDir).tryLoadExisting()).toBeNull();
+  });
+
+  // #337 — clear all-good indicator after `jinn update`.
+  describe('all-good success indicator', () => {
+    it('formats a plain success line when stderr is not a TTY', () => {
+      expect(formatUpdateSuccessLine('1.2.3', { stderrIsTty: false, noColor: false }))
+        .toBe('✓ jinn updated to v1.2.3');
+    });
+
+    it('wraps the success line in ANSI green when stderr is a TTY and NO_COLOR is unset', () => {
+      expect(formatUpdateSuccessLine('1.2.3', { stderrIsTty: true, noColor: false }))
+        .toBe('\x1b[32m✓ jinn updated to v1.2.3\x1b[0m');
+    });
+
+    it('drops color when NO_COLOR is set even on a TTY', () => {
+      expect(formatUpdateSuccessLine('1.2.3', { stderrIsTty: true, noColor: true }))
+        .toBe('✓ jinn updated to v1.2.3');
+    });
+
+    it('prints the success line to stderr on the happy path', async () => {
+      const earningDir = await makeEarningDir();
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        const cmd = makeUpdateCommand(earningDir);
+        const { envelopes } = await runCommand(cmd, {
+          argv: ['--json', '--skip-npm', '--skip-plugins'],
+        });
+        const payload = envelopes[envelopes.length - 1] as { ok: boolean };
+        expect(payload.ok).toBe(true);
+
+        const stderrText = errSpy.mock.calls.map((args) => String(args[0])).join('\n');
+        expect(stderrText).toMatch(/✓ jinn updated to v/);
+      } finally {
+        errSpy.mockRestore();
+      }
+    });
+
+    it('does not print the success line when an update step fails', async () => {
+      const earningDir = await makeEarningDir();
+      const store = new FleetStateStore(earningDir);
+      // Trigger a state-integrity error so allOk is false.
+      await store.save({
+        ...createDefaultFleetState('base'),
+        master_address: '0x9999999999999999999999999999999999999999',
+        services: [{ ...completeService(), mech_address: null }],
+      });
+
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        const cmd = makeUpdateCommand(earningDir);
+        const { envelopes } = await runCommand(cmd, {
+          argv: ['--json', '--skip-npm', '--skip-plugins'],
+        });
+        const payload = envelopes[envelopes.length - 1] as { ok: boolean };
+        expect(payload.ok).toBe(false);
+
+        const stderrText = errSpy.mock.calls.map((args) => String(args[0])).join('\n');
+        expect(stderrText).not.toMatch(/✓ jinn updated to v/);
+      } finally {
+        errSpy.mockRestore();
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #337. After a successful `jinn update`, terminal output now ends with a clear all-good indicator (`✓ jinn updated to v<version>`) so operators no longer have to infer success from the absence of error lines.

- Success line printed to **stderr** on the happy path (`allOk`), so it appears last in the terminal regardless of JSON or `--human` mode and never pollutes the structured stdout payload.
- ANSI-green when stderr is a TTY and `NO_COLOR` is unset; plain text otherwise (no color library in the codebase — raw `\x1b[32m…\x1b[0m`).
- Version read from `package.json` with the same pattern as `jinn version`.
- Failure path unchanged — existing error lines already make the state legible.

## Test plan

- [x] `yarn typecheck` — passes
- [x] `yarn test test/cli/commands/update.test.ts` — 14/14 pass (5 new)
  - [x] `formatUpdateSuccessLine` — plain when not TTY
  - [x] `formatUpdateSuccessLine` — ANSI green on TTY
  - [x] `formatUpdateSuccessLine` — drops color when `NO_COLOR` set
  - [x] success line printed to stderr on happy path
  - [x] success line NOT printed when an update step fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>