### PR TITLE
fix(309): document permissions + graceful PR-creation fallback in changelog-mirror

### DIFF
--- a/.github/workflows/changelog-mirror.yml
+++ b/.github/workflows/changelog-mirror.yml
@@ -8,6 +8,20 @@
 # Reference:
 # - docs/engineering/handbook.md §Building in public — substrate
 # - client/CHANGELOG.md (current hand-maintained state)
+#
+# Permissions note (issue #309):
+# The `permissions:` block below grants `pull-requests: write` to the
+# workflow-scoped GITHUB_TOKEN, which is the workflow-level half of the
+# Actions PR-creation contract. The repo-level half — Settings > Actions >
+# General > Workflow permissions > "Allow GitHub Actions to create and
+# approve pull requests" — must also be enabled, otherwise `gh pr create`
+# fails with "GitHub Actions is not permitted to create or approve pull
+# requests (createPullRequest)" regardless of this block.
+#
+# When the repo setting is off, this workflow still pushes the mirror branch
+# (`changelog/mirror-<tag>`) and surfaces a clear `::warning::` with the
+# manual recovery command, then exits 0 so the failure does not block the
+# release pipeline (the workflow is informational, not a publish gate).
 
 name: CHANGELOG mirror
 
@@ -75,5 +89,26 @@ jobs:
           if gh pr view "$BRANCH" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh pr edit "$BRANCH" --repo "$GITHUB_REPOSITORY" --title "$TITLE" --body "$BODY"
           else
-            gh pr create --repo "$GITHUB_REPOSITORY" --base main --head "$BRANCH" --title "$TITLE" --body "$BODY"
+            # `gh pr create` with the workflow GITHUB_TOKEN is gated behind the
+            # repo-level setting "Allow GitHub Actions to create and approve
+            # pull requests" (see the permissions note in the header + issue
+            # #309). When that toggle is off, GitHub rejects creation with a
+            # recognisable error. Degrade gracefully rather than failing the
+            # release pipeline: the mirror branch is already pushed, so a
+            # maintainer can open the PR by hand from the warning below.
+            CREATE_ERR="$(mktemp)"
+            if gh pr create --repo "$GITHUB_REPOSITORY" --base main --head "$BRANCH" --title "$TITLE" --body "$BODY" 2>"$CREATE_ERR"; then
+              cat "$CREATE_ERR" >&2 || true
+              rm -f "$CREATE_ERR"
+            else
+              cat "$CREATE_ERR" >&2 || true
+              if grep -qi 'not permitted to create or approve pull requests' "$CREATE_ERR"; then
+                echo "::warning title=CHANGELOG mirror PR not created::GitHub Actions is not permitted to create pull requests. A Captain must enable Settings > Actions > General > Workflow permissions > 'Allow GitHub Actions to create and approve pull requests' (issue #309). The mirror branch '${BRANCH}' has been pushed; open the PR manually with: gh pr create --repo ${GITHUB_REPOSITORY} --base main --head ${BRANCH} --title \"${TITLE}\""
+                rm -f "$CREATE_ERR"
+                exit 0
+              fi
+              # Any other failure is a genuine error — surface it and fail.
+              rm -f "$CREATE_ERR"
+              exit 1
+            fi
           fi


### PR DESCRIPTION
## Summary

Closes #309.

The CHANGELOG mirror workflow (`.github/workflows/changelog-mirror.yml`) fails at the `gh pr create` step. The issue premise was partly wrong: the workflow already declares `permissions: { contents: write, pull-requests: write }`. The real root cause is the **repo-level** setting "Allow GitHub Actions to create and approve pull requests" being **OFF**.

The workflow-scoped `pull-requests: write` permission is necessary-but-not-sufficient: GitHub additionally gates PR *creation* by the built-in `GITHUB_TOKEN` behind that org/repo toggle. With the toggle off, `gh pr create` fails with `GitHub Actions is not permitted to create or approve pull requests (createPullRequest)` regardless of the `permissions:` block.

This PR makes the workflow **fail gracefully** until the setting is enabled:

- **Header note** — documents the repo-setting requirement in the workflow header, making the necessary-not-sufficient relationship explicit at the point of use (references issue #309).
- **Graceful fallback** — the `gh pr create` step now captures stderr, detects the "not permitted to create or approve pull requests" error, emits a `::warning::` with a copy-paste manual recovery command, and `exit 0` so a missing toggle never blocks the release pipeline. The mirror branch is already pushed at that point, so a maintainer can open the PR by hand. Any *other* `gh pr create` failure still fails loud (`exit 1`).

## Captain action required for full resolution

This PR makes the workflow degrade gracefully but does **not** by itself restore automatic mirror-PR creation. A Captain must enable the repo setting:

> **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"**

Until that toggle is on, the workflow will push the mirror branch and surface a `::warning::` with the manual `gh pr create` command instead of failing the run.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses
- [ ] After the repo setting is enabled, confirm a published Release triggers automatic mirror-PR creation
- [ ] With the setting off, confirm the workflow run completes green and emits the `::warning::` with the manual recovery command

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)