### PR TITLE
fix(336): gas top-up requires explicit click; no auto-fire

### DIFF
--- a/client/src/api/setup-endpoints.ts
+++ b/client/src/api/setup-endpoints.ts
@@ -165,10 +165,16 @@ export function addSetupRoutes(app: Hono, config: SetupRoutesConfig = {}): void 
   });
 
   // POST /v1/setup/drip — user-triggered Base Sepolia faucet funding for the
-  // master EOA. One click drains the tiny CDP drip repeatedly until the wallet
-  // reaches the bootstrap floor, the faucet rate-limits, or the safety cap is
-  // hit. Mainnet rejects.
+  // master EOA. By default ("?singleDrip" absent) one click drains the tiny
+  // CDP drip repeatedly until the wallet reaches the bootstrap floor, the
+  // faucet rate-limits, or the safety cap is hit — this is the bootstrap
+  // funding gate (AwaitingFundingCard). With `?singleDrip=true` the endpoint
+  // fires the faucet EXACTLY ONCE and returns immediately with txHash +
+  // deltaWei — this is the running-mode Dashboard "Top up" button, which must
+  // require an explicit click and never auto-fire (jinn-mono #336). Mainnet
+  // rejects.
   app.post('/v1/setup/drip', async (c) => {
+    const singleDrip = c.req.query('singleDrip') === 'true';
     const earningDir =
       config.earningDir ??
       process.env['JINN_EARNING_DIR'] ??
@@ -250,6 +256,53 @@ export function addSetupRoutes(app: Hono, config: SetupRoutesConfig = {}): void 
           balanceWei: balanceWei.toString(),
           targetWei: targetWei.toString(),
         });
+      }
+
+      // Single-drip mode (jinn-mono #336): the running-mode Dashboard "Top up"
+      // button must fire the faucet EXACTLY ONCE per click — never loop. The
+      // multi-drip loop below is for the one-time bootstrap funding gate
+      // (AwaitingFundingCard), where the wallet has to clear the entire
+      // bootstrap floor. On the running dashboard the operator just wants a
+      // single, explicit top-up they can see confirmed (amount + tx hash).
+      if (singleDrip) {
+        const balanceBefore = balanceWei;
+        const result = await requestFunding(address, 'base-sepolia');
+        if (!result.ok) {
+          return c.json(
+            {
+              ok: false,
+              address,
+              txHashes,
+              attempts: 0,
+              balanceWei: balanceWei?.toString(),
+              targetWei: targetWei?.toString(),
+              reason: result.reason,
+              rateLimited: result.rateLimited,
+            },
+            200,
+          );
+        }
+        if (result.txHash) txHashes.push(result.txHash);
+        balanceWei = await getBalance();
+        persistFundingGate(balanceWei);
+        const deltaWei =
+          balanceBefore !== null && balanceWei !== null && balanceWei > balanceBefore
+            ? balanceWei - balanceBefore
+            : null;
+        return c.json(
+          {
+            ok: txHashes.length > 0,
+            address,
+            txHash: result.txHash,
+            txHashes,
+            attempts: txHashes.length,
+            balanceWei: balanceWei?.toString(),
+            targetWei: targetWei?.toString(),
+            deltaWei: deltaWei !== null ? deltaWei.toString() : undefined,
+            reason: txHashes.length > 0 ? undefined : 'faucet_did_not_send',
+          },
+          txHashes.length > 0 ? 202 : 200,
+        );
       }
 
       const maxFaucetIters = computeFaucetDripCap({

--- a/client/src/dashboard/spa/src/api/client.ts
+++ b/client/src/dashboard/spa/src/api/client.ts
@@ -94,7 +94,18 @@ export const api = {
     jfetch<{ ok: boolean; reason?: string }>('/v1/auth/claude/spawn', {
       method: 'POST',
     }),
-  triggerDrip: () =>
+  /**
+   * Trigger a Base Sepolia faucet drip for the master EOA.
+   *
+   * - Default (bootstrap funding gate): the daemon loops the tiny CDP drip
+   *   until the wallet clears the entire bootstrap floor.
+   * - `{ singleDrip: true }` (running-mode Dashboard "Top up"): the daemon
+   *   fires the faucet EXACTLY ONCE and returns immediately with a `deltaWei`
+   *   reporting how much the balance moved. This is what makes the Dashboard
+   *   Gas top-up an explicit, one-shot action with no re-firing loop
+   *   (jinn-mono #336).
+   */
+  triggerDrip: (opts?: { singleDrip?: boolean }) =>
     jfetch<{
       ok: boolean;
       address?: string;
@@ -103,10 +114,11 @@ export const api = {
       attempts?: number;
       balanceWei?: string;
       targetWei?: string;
+      deltaWei?: string;
       reason?: string;
       rateLimited?: boolean;
     }>(
-      '/v1/setup/drip',
+      opts?.singleDrip ? '/v1/setup/drip?singleDrip=true' : '/v1/setup/drip',
       { method: 'POST' },
     ),
   changeKeystorePassword: (current: string, next: string) =>

--- a/client/src/dashboard/spa/src/pages/Overview.test.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.test.tsx
@@ -27,7 +27,7 @@ vi.mock('../api/client.js', () => ({
     getStatus: () => getStatusMock(),
     getBootstrap: () => getBootstrapMock(),
     claimRewards: () => claimRewardsMock(),
-    triggerDrip: () => triggerDripMock(),
+    triggerDrip: (opts?: { singleDrip?: boolean }) => triggerDripMock(opts),
     restartDaemon: () => restartDaemonMock(),
   },
 }));
@@ -533,5 +533,140 @@ describe('OverviewPage empty-state gating', () => {
     fireEvent.click(screen.getByRole('button', { name: /restart/i }));
     await waitFor(() => expect(restartDaemonMock).toHaveBeenCalledOnce());
     expect(history.at(-1)).toBe('/overview');
+  });
+});
+
+// ── Gas top-up: explicit click, no auto-fire (jinn-mono #336) ───────────────
+//
+// rvx in the v0.1.6 dogfood: "I hit the button 'Top up' and it just magically
+// increases the number ... can't seem to stop it." The Dashboard Gas top-up
+// must be a single, explicit action: one click → exactly one faucet call, no
+// re-firing while the Dashboard stays mounted, a one-line amount + tx-hash
+// confirmation, and the button disabled while the request is in flight.
+describe('OverviewPage gas top-up (jinn-mono #336)', () => {
+  const gasStatus = {
+    rewards: { pendingStakingRewardsWei: '1000000000000000000' },
+    masterGas: { balanceWei: '23000000000000000', runwayDaysExcess: 4 },
+    fleet: { services: [] },
+    predictionV1: {
+      operator: { ok: true, solverNet: { name: 'prediction', enabled: false }, diagnostics: [] },
+      totals: { observedTasks: 1, activeTaskRuns: 0, solutions: 0, verdicts: 0, failed: 0 },
+    },
+  };
+
+  it('fires the faucet exactly once per click, in single-drip mode', async () => {
+    getStatusMock.mockResolvedValue(gasStatus);
+    getBootstrapMock.mockResolvedValue({ solverNets: {} });
+    triggerDripMock.mockResolvedValue({
+      ok: true,
+      txHash: '0xabc0000000000000000000000000000000000000000000000000000000001234',
+      txHashes: ['0xabc0000000000000000000000000000000000000000000000000000000001234'],
+      deltaWei: '5000000000000000',
+      attempts: 1,
+    });
+    render(withProviders(<OverviewPage />));
+
+    const topUpButton = await screen.findByRole('button', { name: /top up/i });
+    fireEvent.click(topUpButton);
+
+    await waitFor(() => expect(triggerDripMock).toHaveBeenCalledOnce());
+    // Single-drip is the contract that prevents the server-side loop: the
+    // page must ask for the one-shot path, never the bootstrap loop.
+    expect(triggerDripMock).toHaveBeenCalledWith({ singleDrip: true });
+  });
+
+  it('does not re-fire the faucet while the Dashboard stays mounted', async () => {
+    getStatusMock.mockResolvedValue(gasStatus);
+    getBootstrapMock.mockResolvedValue({ solverNets: {} });
+    triggerDripMock.mockResolvedValue({
+      ok: true,
+      txHash: '0xabc0000000000000000000000000000000000000000000000000000000001234',
+      txHashes: ['0xabc0000000000000000000000000000000000000000000000000000000001234'],
+      deltaWei: '5000000000000000',
+      attempts: 1,
+    });
+    const { rerender } = render(withProviders(<OverviewPage />));
+
+    const topUpButton = await screen.findByRole('button', { name: /top up/i });
+    fireEvent.click(topUpButton);
+    await waitFor(() => expect(triggerDripMock).toHaveBeenCalledOnce());
+
+    // Status polling re-renders the page repeatedly; none of those re-renders
+    // may re-invoke the faucet. Force several re-renders and assert the call
+    // count is still 1.
+    for (let i = 0; i < 5; i++) {
+      rerender(withProviders(<OverviewPage />));
+    }
+    await new Promise((r) => setTimeout(r, 50));
+    expect(triggerDripMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces a one-line confirmation with the amount and tx hash', async () => {
+    getStatusMock.mockResolvedValue(gasStatus);
+    getBootstrapMock.mockResolvedValue({ solverNets: {} });
+    triggerDripMock.mockResolvedValue({
+      ok: true,
+      txHash: '0xabc0000000000000000000000000000000000000000000000000000000001234',
+      txHashes: ['0xabc0000000000000000000000000000000000000000000000000000000001234'],
+      deltaWei: '5000000000000000', // 0.005 ETH
+      attempts: 1,
+    });
+    render(withProviders(<OverviewPage />));
+
+    fireEvent.click(await screen.findByRole('button', { name: /top up/i }));
+
+    const notice = await screen.findByTestId('dashboard-action-notice');
+    expect(notice.textContent).toMatch(/0\.005000 ETH/);
+    expect(notice.textContent).toMatch(/0xabc0…1234/);
+  });
+
+  it('disables the Top up button while the request is in flight', async () => {
+    getStatusMock.mockResolvedValue(gasStatus);
+    getBootstrapMock.mockResolvedValue({ solverNets: {} });
+    let resolveDrip: (v: unknown) => void = () => undefined;
+    triggerDripMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveDrip = resolve;
+      }),
+    );
+    render(withProviders(<OverviewPage />));
+
+    const topUpButton = await screen.findByRole('button', { name: /top up/i });
+    fireEvent.click(topUpButton);
+
+    // While the faucet call is unresolved the button must be disabled.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /working/i })).toHaveProperty('disabled', true),
+    );
+
+    resolveDrip({
+      ok: true,
+      txHash: '0xabc0000000000000000000000000000000000000000000000000000000001234',
+      txHashes: ['0xabc0000000000000000000000000000000000000000000000000000000001234'],
+      deltaWei: '5000000000000000',
+      attempts: 1,
+    });
+
+    // After resolution the button re-enables and the confirmation shows.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /top up/i })).toHaveProperty('disabled', false),
+    );
+    expect((await screen.findByTestId('dashboard-action-notice')).textContent).toMatch(/tx 0xabc0…1234/);
+  });
+
+  it('surfaces a faucet failure as an error notice', async () => {
+    getStatusMock.mockResolvedValue(gasStatus);
+    getBootstrapMock.mockResolvedValue({ solverNets: {} });
+    triggerDripMock.mockResolvedValue({
+      ok: false,
+      rateLimited: true,
+      reason: 'Faucet rate limited (1 claim per 24 hours per address).',
+    });
+    render(withProviders(<OverviewPage />));
+
+    fireEvent.click(await screen.findByRole('button', { name: /top up/i }));
+
+    const notice = await screen.findByRole('alert');
+    expect(notice.textContent).toMatch(/rate limited/i);
   });
 });

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import { HeroStats } from './overview/HeroStats.js';
 import { AlertBand } from './overview/AlertBand.js';
@@ -102,6 +102,27 @@ function formatEth(wei?: string): string {
   }
 }
 
+/**
+ * Format a wei amount for a one-line top-up confirmation. Drips are tiny, so
+ * show enough precision to be meaningful (6 dp) without a trailing wall of
+ * zeros.
+ */
+function formatDripEth(wei?: string): string | null {
+  if (!wei || !/^\d+$/.test(wei)) return null;
+  try {
+    const eth = Number(BigInt(wei)) / 1e18;
+    return `${eth.toFixed(6)} ETH`;
+  } catch {
+    return null;
+  }
+}
+
+/** Shorten a tx hash for inline display (0x1234…abcd). */
+function truncTx(hash?: string): string | null {
+  if (!hash || hash.length < 12) return hash ?? null;
+  return `${hash.slice(0, 6)}…${hash.slice(-4)}`;
+}
+
 export function OverviewPage(): JSX.Element {
   const [activeAction, setActiveAction] = useState<string | null>(null);
   const [notice, setNotice] = useState<{ tone: 'success' | 'error'; text: string } | null>(null);
@@ -183,12 +204,28 @@ export function OverviewPage(): JSX.Element {
   const gasRunwayDays = status?.masterGas?.runwayDaysExcess ?? '—';
   const liveNow = deriveLiveNow(status);
   const waitingMessage = operatorWaitingMessage(joined, taskRunTotals, operator?.nextAction?.description);
+  // Auto-clear timer for transient success notices (e.g. the gas top-up
+  // confirmation, which should surface the amount + tx hash for ~5s then
+  // fade — issue #336).
+  const noticeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (noticeTimerRef.current) clearTimeout(noticeTimerRef.current);
+    },
+    [],
+  );
+
   const runAction = (
     label: string,
     action: () => Promise<{ message?: string } | void> | { message?: string } | void,
+    opts?: { autoClearMs?: number },
   ): void => {
     setActiveAction(label);
     setNotice(null);
+    if (noticeTimerRef.current) {
+      clearTimeout(noticeTimerRef.current);
+      noticeTimerRef.current = null;
+    }
     Promise.resolve()
       .then(action)
       .then((result) => {
@@ -196,6 +233,12 @@ export function OverviewPage(): JSX.Element {
           tone: 'success',
           text: result?.message ?? `${label} requested.`,
         });
+        if (opts?.autoClearMs) {
+          noticeTimerRef.current = setTimeout(() => {
+            setNotice(null);
+            noticeTimerRef.current = null;
+          }, opts.autoClearMs);
+        }
       })
       .catch((err) => {
         setNotice({
@@ -228,20 +271,32 @@ export function OverviewPage(): JSX.Element {
             return { message: 'JINN claim command completed.' };
           })}
         onTopUp={() =>
-          runAction('Top up gas', async () => {
-            const res = await api.triggerDrip();
-            if (!res.ok) {
-              throw new Error(res.reason ?? 'Gas top-up failed.');
-            }
-            const txCount = res.txHashes?.length ?? (res.txHash ? 1 : 0);
-            if (txCount > 0) {
-              return { message: `Gas top-up requested (${txCount} ${txCount === 1 ? 'transaction' : 'transactions'}).` };
-            }
-            if (res.attempts === 0) {
-              return { message: 'Gas balance is already above the testnet top-up target.' };
-            }
-            return { message: 'Gas top-up checked; no additional funding was needed.' };
-          })}
+          runAction(
+            'Top up gas',
+            async () => {
+              // Issue #336: one explicit click → exactly one faucet drip.
+              // `singleDrip: true` makes the daemon fire the faucet once and
+              // return immediately — no server-side loop, so the gas number
+              // never "magically" keeps climbing while the Dashboard is open.
+              const res = await api.triggerDrip({ singleDrip: true });
+              if (!res.ok) {
+                throw new Error(res.reason ?? 'Gas top-up failed.');
+              }
+              const txHash = res.txHash ?? res.txHashes?.at(-1);
+              if (!txHash) {
+                return { message: 'Gas top-up checked; the faucet sent no funds.' };
+              }
+              const amount = formatDripEth(res.deltaWei);
+              const txLabel = truncTx(txHash);
+              return {
+                message: amount
+                  ? `Gas topped up: +${amount} · tx ${txLabel}`
+                  : `Gas top-up sent · tx ${txLabel}`,
+              };
+            },
+            // Confirmation is transient — surface it, then fade after ~5s.
+            { autoClearMs: 5_000 },
+          )}
         onRestart={() =>
           runAction('Restart node', async () => {
             const res = await api.restartDaemon();

--- a/client/test/api/setup-endpoints.test.ts
+++ b/client/test/api/setup-endpoints.test.ts
@@ -463,6 +463,125 @@ describe('POST /v1/setup/drip', () => {
   // than a special reason code. The drip-cap-test that PR #84 added
   // upstream (`runs the user-triggered faucet loop for the persisted Base
   // Sepolia master wallet`, above) covers the new behaviour.
+
+  // ── Single-drip mode (jinn-mono #336) ────────────────────────────────────
+  //
+  // The running-mode Dashboard "Top up" button must fire the faucet EXACTLY
+  // ONCE per click — never loop. `?singleDrip=true` selects that path. These
+  // tests lock the invariant: one request → one `requestFunding` call, even
+  // when the multi-drip cap would otherwise loop dozens of times.
+  it('fires the faucet exactly once with ?singleDrip=true (jinn-mono #336)', async () => {
+    const earningDir = mkdtempSync(join(tmpdir(), 'jinn-drip-single-'));
+    const store = new FleetStateStore(earningDir);
+    const state = await store.load('base-sepolia');
+    await store.save({
+      ...state,
+      master_address: '0x5555555555555555555555555555555555555555',
+    });
+
+    const requestFunding = vi.fn(async () => ({
+      ok: true,
+      txHash: '0x' + '5a'.repeat(32),
+    }));
+    const app = new Hono();
+    addSetupRoutes(app, {
+      earningDir,
+      chain: 'base-sepolia',
+      requestFunding,
+      // A target that the multi-drip loop would chase for dozens of
+      // iterations — singleDrip must ignore the cap entirely.
+      minEoaGasWei: '10000000000000000',
+      interDripPauseMs: 0,
+    });
+
+    const res = await app.request('/v1/setup/drip?singleDrip=true', {
+      method: 'POST',
+    });
+
+    expect(res.status).toBe(202);
+    expect(requestFunding).toHaveBeenCalledTimes(1);
+    expect(requestFunding).toHaveBeenCalledWith(
+      '0x5555555555555555555555555555555555555555',
+      'base-sepolia',
+    );
+    const body = (await res.json()) as {
+      ok: boolean;
+      txHash?: string;
+      txHashes: string[];
+      attempts: number;
+    };
+    expect(body.ok).toBe(true);
+    expect(body.attempts).toBe(1);
+    expect(body.txHashes).toHaveLength(1);
+    expect(body.txHash).toBe('0x' + '5a'.repeat(32));
+  });
+
+  it('still runs the multi-drip loop when ?singleDrip is absent (jinn-mono #336 regression guard)', async () => {
+    const earningDir = mkdtempSync(join(tmpdir(), 'jinn-drip-multi-'));
+    const store = new FleetStateStore(earningDir);
+    const state = await store.load('base-sepolia');
+    await store.save({
+      ...state,
+      master_address: '0x6666666666666666666666666666666666666666',
+    });
+
+    const requestFunding = vi.fn(async () => ({
+      ok: true,
+      txHash: '0x' + '6b'.repeat(32),
+    }));
+    const app = new Hono();
+    addSetupRoutes(app, {
+      earningDir,
+      chain: 'base-sepolia',
+      requestFunding,
+      maxFaucetIters: 3,
+      interDripPauseMs: 0,
+    });
+
+    const res = await app.request('/v1/setup/drip', { method: 'POST' });
+
+    expect(res.status).toBe(202);
+    // The bootstrap funding gate keeps looping — singleDrip did not regress it.
+    expect(requestFunding).toHaveBeenCalledTimes(3);
+  });
+
+  it('surfaces a faucet failure on the single-drip path without looping (jinn-mono #336)', async () => {
+    const earningDir = mkdtempSync(join(tmpdir(), 'jinn-drip-single-fail-'));
+    const store = new FleetStateStore(earningDir);
+    const state = await store.load('base-sepolia');
+    await store.save({
+      ...state,
+      master_address: '0x7777777777777777777777777777777777777777',
+    });
+
+    const requestFunding = vi.fn(async () => ({
+      ok: false,
+      rateLimited: true,
+      reason: 'Faucet rate limited (1 claim per 24 hours per address).',
+    }));
+    const app = new Hono();
+    addSetupRoutes(app, {
+      earningDir,
+      chain: 'base-sepolia',
+      requestFunding,
+      minEoaGasWei: '10000000000000000',
+      interDripPauseMs: 0,
+    });
+
+    const res = await app.request('/v1/setup/drip?singleDrip=true', {
+      method: 'POST',
+    });
+
+    expect(res.status).toBe(200);
+    expect(requestFunding).toHaveBeenCalledTimes(1);
+    const body = (await res.json()) as {
+      ok: boolean;
+      rateLimited?: boolean;
+      reason?: string;
+    };
+    expect(body.ok).toBe(false);
+    expect(body.rateLimited).toBe(true);
+  });
 });
 
 describe('POST /v1/setup/solvernets/:name', () => {


### PR DESCRIPTION
## Summary

- The running-mode Dashboard Gas **Top up** button silently re-fired the faucet while the Dashboard stayed open — the gas balance crept up on its own and the operator could not stop it without navigating away (rvx, v0.1.6 dogfood). Root cause: the dashboard reused the bootstrap funding endpoint, whose server-side loop drips the faucet repeatedly until the wallet clears the entire bootstrap floor. From the running dashboard that reads as a runaway auto-fire; on mainnet it would be a real bug.
- Added `?singleDrip=true` to `POST /v1/setup/drip` — one request fires the faucet **exactly once** and returns immediately with the tx hash and the balance delta (`deltaWei`). The bootstrap funding gate (`AwaitingFundingCard`) keeps the multi-drip loop it genuinely needs.
- Dashboard `onTopUp` now calls `triggerDrip({ singleDrip: true })`, surfaces a one-line amount + tx-hash confirmation that auto-clears after ~5s, and the button is disabled (`activeAction`) while the request is in flight.

## Acceptance criteria

- [x] Clicking Top up fires the faucet **exactly once** (`?singleDrip=true`; one `requestFunding` call).
- [x] No polling / re-firing loop while the Dashboard is open (verified by re-render test).
- [x] One-line confirmation of amount + tx hash (`Gas topped up: +0.005000 ETH · tx 0xabc0…1234`).
- [x] Button disabled while top-up in-flight.

## Test plan

- [x] `client/test/api/setup-endpoints.test.ts` — single-drip fires once; multi-drip loop unchanged when flag absent; faucet failure surfaced without looping.
- [x] `client/src/dashboard/spa/src/pages/Overview.test.tsx` — click fires once with `{ singleDrip: true }`; no re-fire across forced re-renders; confirmation shows amount + tx hash; button disabled in-flight then re-enabled; faucet failure renders an error notice.
- [x] `cd client && yarn typecheck` — clean.
- [x] `cd client && yarn test --run` — 3705 passed, 7 skipped.

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)