### PR TITLE
fix(335): surface daemon disconnect in the operator SPA

### DIFF
--- a/client/src/dashboard/spa/src/App.offline.test.tsx
+++ b/client/src/dashboard/spa/src/App.offline.test.tsx
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ConnectionState } from './api/connection-state.js';
+
+/**
+ * Issue #335 — the OfflineBanner must surface a dead daemon in *every* App
+ * render branch, not just the operating shell. These tests prove the banner
+ * is mounted while the operator is still bootstrapping (LoadingScreen and
+ * Onboarding early-returns), the case the canonical review flagged: a daemon
+ * that dies mid-bootstrap must not leave the SPA on a stale screen with no
+ * offline signal.
+ */
+
+// The connection state is injected per-test so we can simulate a daemon
+// that has died while bootstrap is still in flight.
+let connectionState: ConnectionState = {
+  status: 'connected',
+  lastConnectedAt: 0,
+};
+
+vi.mock('./api/connection-state.js', () => ({
+  useConnectionState: () => connectionState,
+}));
+
+// Bootstrap mode is injected per-test to drive the three App branches.
+let bootstrapMode: 'uninitialized' | 'setup' | 'running' = 'uninitialized';
+
+vi.mock('./api/client.js', () => ({
+  api: {
+    getBootstrap: async () => ({ mode: bootstrapMode }),
+  },
+}));
+
+// The bootstrap sub-screens pull in heavy subtrees (event streams, queries).
+// Stub them down to identifiable markers — this test only cares that the
+// banner is co-mounted with whatever branch App selects.
+vi.mock('./regions/LoadingScreen.js', () => ({
+  LoadingScreen: ({ headline }: { headline: string }) => (
+    <div data-testid="loading-screen">{headline}</div>
+  ),
+}));
+
+vi.mock('./regions/Onboarding.js', () => ({
+  Onboarding: () => <div data-testid="onboarding" />,
+}));
+
+const disconnected: ConnectionState = {
+  status: 'disconnected',
+  since: 0,
+  lastError: 'network down',
+  attempts: 2,
+};
+
+async function renderApp(): Promise<void> {
+  const { default: App } = await import('./App.js');
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <App />
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  vi.resetModules();
+  connectionState = { status: 'connected', lastConnectedAt: 0 };
+  bootstrapMode = 'uninitialized';
+});
+
+describe('App offline banner across bootstrap phases', () => {
+  it('renders the OfflineBanner during the LoadingScreen branch when the daemon dies', async () => {
+    bootstrapMode = 'uninitialized';
+    connectionState = disconnected;
+    await renderApp();
+
+    // LoadingScreen branch is active …
+    await waitFor(() =>
+      expect(screen.getByTestId('loading-screen')).toBeTruthy(),
+    );
+    // … and the offline banner is co-mounted, not discarded.
+    expect(screen.getByTestId('offline-banner')).toBeTruthy();
+  });
+
+  it('renders the OfflineBanner during the Onboarding branch when the daemon dies', async () => {
+    bootstrapMode = 'setup';
+    connectionState = disconnected;
+    await renderApp();
+
+    await waitFor(() => expect(screen.getByTestId('onboarding')).toBeTruthy());
+    expect(screen.getByTestId('offline-banner')).toBeTruthy();
+  });
+
+  it('shows no banner during bootstrap while the daemon is connected', async () => {
+    bootstrapMode = 'setup';
+    connectionState = { status: 'connected', lastConnectedAt: 0 };
+    await renderApp();
+
+    await waitFor(() => expect(screen.getByTestId('onboarding')).toBeTruthy());
+    expect(screen.queryByTestId('offline-banner')).toBeNull();
+  });
+});

--- a/client/src/dashboard/spa/src/App.tsx
+++ b/client/src/dashboard/spa/src/App.tsx
@@ -43,17 +43,33 @@ export default function App(): JSX.Element {
   // rendering stale state. The probe runs regardless of bootstrap phase.
   const connection = useConnectionState();
 
+  // #335: the OfflineBanner must surface a dead daemon in *every* render
+  // branch, not just the operating shell. If the daemon dies while the
+  // operator is still bootstrapping, the loading/onboarding screens would
+  // otherwise sit stale with no offline signal — the exact "UI lies about
+  // daemon state" failure #335 names. Hoist the banner above all three
+  // branches so it is reachable regardless of bootstrap phase.
   if (isLoading || !data || data.mode === 'uninitialized') {
     const headline = !data
       ? 'Starting jinn'
       : data.mode === 'uninitialized'
         ? 'Setting up your wallet'
         : 'Loading';
-    return <LoadingScreen headline={headline} />;
+    return (
+      <>
+        <OfflineBanner connection={connection} />
+        <LoadingScreen headline={headline} />
+      </>
+    );
   }
 
   if (data.mode !== 'running') {
-    return <Onboarding />;
+    return (
+      <>
+        <OfflineBanner connection={connection} />
+        <Onboarding />
+      </>
+    );
   }
 
   const network = (data.chain === 'base' ? 'mainnet' : 'testnet') as 'testnet' | 'mainnet';

--- a/client/src/dashboard/spa/src/App.tsx
+++ b/client/src/dashboard/spa/src/App.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { Router, Route, Switch, Redirect } from 'wouter';
 import { api } from './api/client.js';
 import type { BootstrapState } from './api/types.js';
+import { useConnectionState } from './api/connection-state.js';
 import { LoadingScreen } from './regions/LoadingScreen.js';
 import { Onboarding } from './regions/Onboarding.js';
 import { AppShell } from './shell/AppShell.js';
@@ -10,6 +11,7 @@ import { Header } from './shell/Header.js';
 import { TopTabs } from './shell/TopTabs.js';
 import { AgentRail } from './shell/AgentRail.js';
 import { RestartBanner } from './shell/RestartBanner.js';
+import { OfflineBanner } from './shell/OfflineBanner.js';
 import { OverviewPage } from './pages/Overview.js';
 import { OverviewActivityPage } from './pages/OverviewActivity.js';
 import { OperatorPage } from './pages/Operator.js';
@@ -37,6 +39,9 @@ export default function App(): JSX.Element {
     refetchInterval: 1500,
   });
   const [restartPending, setRestartPending] = useState(false);
+  // #335: detect a dead daemon so the operating shell stops silently
+  // rendering stale state. The probe runs regardless of bootstrap phase.
+  const connection = useConnectionState();
 
   if (isLoading || !data || data.mode === 'uninitialized') {
     const headline = !data
@@ -56,6 +61,7 @@ export default function App(): JSX.Element {
 
   return (
     <Router>
+      <OfflineBanner connection={connection} />
       <RestartBanner
         restartPending={restartPending}
         onRestart={async () => {

--- a/client/src/dashboard/spa/src/api/connection-state.test.tsx
+++ b/client/src/dashboard/spa/src/api/connection-state.test.tsx
@@ -75,12 +75,13 @@ describe('useConnectionState', () => {
     expect(result.current.status).toBe('disconnected');
     if (result.current.status === 'disconnected') {
       expect(result.current.attempts).toBeGreaterThanOrEqual(1);
-      expect(result.current.lastError).toBe('probe failed');
+      // The real rejection reason is threaded through, not a literal stub.
+      expect(result.current.lastError).toBe('network down');
     }
   });
 
-  it('treats a 5xx as down but a 401/403 as alive', async () => {
-    // 503 then 200: the 503 counts as a failure, the 200 clears it.
+  it('treats 502/503/504 as down but a 401/403 as alive', async () => {
+    // 503 then 503: an unavailable gateway counts as a daemon-down failure.
     globalThis.fetch = makeFetch([{ status: 503 }, { status: 503 }]);
     const { result } = renderHook(() =>
       useConnectionState({ pollIntervalMs: 1000, failureThreshold: 2 }),
@@ -90,6 +91,9 @@ describe('useConnectionState', () => {
       await vi.advanceTimersByTimeAsync(1000);
     });
     expect(result.current.status).toBe('disconnected');
+    if (result.current.status === 'disconnected') {
+      expect(result.current.lastError).toMatch(/HTTP 503/);
+    }
 
     // A 403 (auth surface) must NOT be read as a dead daemon.
     globalThis.fetch = makeFetch([{ status: 403 }]);
@@ -100,6 +104,21 @@ describe('useConnectionState', () => {
       await vi.advanceTimersByTimeAsync(3000);
     });
     expect(authResult.current.status).toBe('connected');
+  });
+
+  it('treats a genuine 500 as alive-but-erroring, not offline', async () => {
+    // A 500 from a *live* daemon is an uncaught throw in gatherStatusForApi.
+    // The process answered, so it is up — the probe must NOT flip to
+    // disconnected and wrongly tell the operator to re-run `jinn run`.
+    globalThis.fetch = makeFetch([{ status: 500 }]);
+    const { result } = renderHook(() =>
+      useConnectionState({ pollIntervalMs: 1000, failureThreshold: 2 }),
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(result.current.status).toBe('connected');
   });
 
   it('auto-reconnects when the daemon comes back', async () => {

--- a/client/src/dashboard/spa/src/api/connection-state.test.tsx
+++ b/client/src/dashboard/spa/src/api/connection-state.test.tsx
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useConnectionState } from './connection-state.js';
+
+/**
+ * Issue #335 — the connection-liveness probe. These tests drive the hook with
+ * a stubbed `fetch` so we can simulate a dying / recovering daemon without a
+ * real server, and assert the timing contract: surface a dead daemon within
+ * the issue's ~5s target, and auto-recover when it answers again.
+ */
+
+type FetchResult = { status: number } | 'reject';
+
+/**
+ * A scriptable `fetch` stub. Each call shifts the next scripted result; once
+ * the script is exhausted it keeps returning the final result so the polling
+ * loop has a stable steady state.
+ */
+function makeFetch(script: FetchResult[]): typeof fetch {
+  let lastResult: FetchResult = script[0] ?? { status: 200 };
+  return vi.fn(async () => {
+    const next = script.shift();
+    if (next !== undefined) lastResult = next;
+    if (lastResult === 'reject') throw new Error('network down');
+    return { status: lastResult.status } as Response;
+  }) as unknown as typeof fetch;
+}
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('useConnectionState', () => {
+  it('starts connected and stays connected while the daemon answers OK', async () => {
+    globalThis.fetch = makeFetch([{ status: 200 }]);
+    const { result } = renderHook(() =>
+      useConnectionState({ pollIntervalMs: 1000 }),
+    );
+
+    // Initial state is optimistically connected.
+    expect(result.current.status).toBe('connected');
+
+    // Let the first probe + a couple of poll cycles run.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(result.current.status).toBe('connected');
+  });
+
+  it('flips to disconnected after the failure threshold (~4s with defaults)', async () => {
+    // Every probe rejects — daemon is dead.
+    globalThis.fetch = makeFetch(['reject']);
+    const { result } = renderHook(() =>
+      useConnectionState({ pollIntervalMs: 2000, failureThreshold: 2 }),
+    );
+
+    // First probe runs immediately and fails (failures=1, still connected).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.status).toBe('connected');
+
+    // Second probe after one poll interval crosses the threshold.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(result.current.status).toBe('disconnected');
+    if (result.current.status === 'disconnected') {
+      expect(result.current.attempts).toBeGreaterThanOrEqual(1);
+      expect(result.current.lastError).toBe('probe failed');
+    }
+  });
+
+  it('treats a 5xx as down but a 401/403 as alive', async () => {
+    // 503 then 200: the 503 counts as a failure, the 200 clears it.
+    globalThis.fetch = makeFetch([{ status: 503 }, { status: 503 }]);
+    const { result } = renderHook(() =>
+      useConnectionState({ pollIntervalMs: 1000, failureThreshold: 2 }),
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(result.current.status).toBe('disconnected');
+
+    // A 403 (auth surface) must NOT be read as a dead daemon.
+    globalThis.fetch = makeFetch([{ status: 403 }]);
+    const { result: authResult } = renderHook(() =>
+      useConnectionState({ pollIntervalMs: 1000, failureThreshold: 2 }),
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(authResult.current.status).toBe('connected');
+  });
+
+  it('auto-reconnects when the daemon comes back', async () => {
+    // Fail twice (cross threshold), then recover on every later probe.
+    globalThis.fetch = makeFetch(['reject', 'reject', { status: 200 }]);
+    const { result } = renderHook(() =>
+      useConnectionState({
+        pollIntervalMs: 1000,
+        failureThreshold: 2,
+        maxBackoffMs: 4000,
+      }),
+    );
+
+    // Drive past the threshold into disconnected.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(result.current.status).toBe('disconnected');
+
+    // The backoff retry eventually fires; the daemon now answers OK and the
+    // hook flips back to connected. Advancing well past the (capped) backoff
+    // window settles the state synchronously under fake timers.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(8000);
+    });
+    expect(result.current.status).toBe('connected');
+  });
+});

--- a/client/src/dashboard/spa/src/api/connection-state.ts
+++ b/client/src/dashboard/spa/src/api/connection-state.ts
@@ -6,7 +6,7 @@
  * last-known state forever. Operators thought the node was still working;
  * only a manual page refresh surfaced the truth.
  *
- * This hook fires a small `/v1/status` HEAD-ish poll on a short cadence
+ * This hook fires a small `GET /v1/status` poll on a short cadence
  * (default 2s) and counts consecutive failures. After two failures (~4s) it
  * flips into `disconnected`; the SPA renders the offline banner. While
  * disconnected the poll keeps trying with exponential backoff (capped at
@@ -50,7 +50,14 @@ export interface UseConnectionStateOptions {
   probeUrl?: string;
 }
 
-async function probe(url: string, timeoutMs: number): Promise<boolean> {
+interface ProbeResult {
+  /** True when the daemon process is reachable (it answered at all). */
+  ok: boolean;
+  /** Human-readable failure reason when `ok` is false; null otherwise. */
+  error: string | null;
+}
+
+async function probe(url: string, timeoutMs: number): Promise<ProbeResult> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
@@ -60,12 +67,25 @@ async function probe(url: string, timeoutMs: number): Promise<boolean> {
       cache: 'no-store',
       signal: controller.signal,
     });
-    // 401/403 still mean the daemon is alive and responding. Only treat
-    // network-level failures + 5xx as "daemon is down". The auth surface
-    // owns its own redirect.
-    return res.status < 500;
-  } catch {
-    return false;
+    // The daemon answered, so its process is alive. Distinguish "process
+    // down" from "process up but erroring":
+    //  - A genuine 500 is the daemon catching an uncaught throw in
+    //    `gatherStatusForApi` — the process is *up*, just erroring. Telling
+    //    the operator to re-run `jinn run` would be wrong, so treat 500 as
+    //    alive.
+    //  - 401/403 also mean the daemon is alive; the auth surface owns its
+    //    own redirect.
+    //  - Only 502/503/504 (gateway / unavailable / timeout) mean the
+    //    process is genuinely unreachable behind whatever is fronting it.
+    if (res.status === 502 || res.status === 503 || res.status === 504) {
+      return { ok: false, error: `daemon unavailable (HTTP ${res.status})` };
+    }
+    return { ok: true, error: null };
+  } catch (err) {
+    // Network-level rejection (connection refused, abort/timeout) — the
+    // daemon process is not answering at all.
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
   } finally {
     clearTimeout(timer);
   }
@@ -103,10 +123,10 @@ export function useConnectionState(
     };
 
     const tick = async () => {
-      const ok = await probe(probeUrl, probeTimeoutMs);
+      const result = await probe(probeUrl, probeTimeoutMs);
       if (cancelledRef.current) return;
 
-      if (ok) {
+      if (result.ok) {
         consecutiveFailuresRef.current = 0;
         backoffRef.current = pollIntervalMs;
         setState((prev) =>
@@ -124,12 +144,16 @@ export function useConnectionState(
       if (failures >= failureThreshold) {
         setState((prev) => {
           if (prev.status === 'disconnected') {
-            return { ...prev, attempts: prev.attempts + 1, lastError: 'probe failed' };
+            return {
+              ...prev,
+              attempts: prev.attempts + 1,
+              lastError: result.error,
+            };
           }
           return {
             status: 'disconnected',
             since: Date.now(),
-            lastError: 'probe failed',
+            lastError: result.error,
             attempts: 1,
           };
         });

--- a/client/src/dashboard/spa/src/api/connection-state.ts
+++ b/client/src/dashboard/spa/src/api/connection-state.ts
@@ -1,0 +1,160 @@
+/**
+ * Daemon-connection liveness probe for the operator SPA.
+ *
+ * Issue #335: when the daemon process dies (intentional shutdown, crash, or
+ * a restart that fails to respawn — see #289), the SPA was rendering its
+ * last-known state forever. Operators thought the node was still working;
+ * only a manual page refresh surfaced the truth.
+ *
+ * This hook fires a small `/v1/status` HEAD-ish poll on a short cadence
+ * (default 2s) and counts consecutive failures. After two failures (~4s) it
+ * flips into `disconnected`; the SPA renders the offline banner. While
+ * disconnected the poll keeps trying with exponential backoff (capped at
+ * 30s) until the daemon answers OK again, at which point the state flips
+ * back to `connected` and the rest of the app's react-query refetches
+ * naturally resume.
+ *
+ * The hook is intentionally independent of `useEventStream`: SSE alone
+ * can't distinguish "no events lately" from "socket dead", and the daemon
+ * may be alive but not emitting. A small dedicated probe gives the SPA a
+ * cheap, deterministic dead-daemon signal.
+ */
+import { useEffect, useRef, useState } from 'react';
+
+export type ConnectionState =
+  | { status: 'connected'; lastConnectedAt: number }
+  | {
+      status: 'disconnected';
+      since: number;
+      lastError: string | null;
+      attempts: number;
+    };
+
+export interface UseConnectionStateOptions {
+  /** Base poll cadence while connected, ms. Default 2000. */
+  pollIntervalMs?: number;
+  /**
+   * Consecutive probe failures before the hook flips into `disconnected`.
+   * Default 2 — combined with the default 2s poll this surfaces a dead
+   * daemon within ~4s (within the issue's "~5s" target).
+   */
+  failureThreshold?: number;
+  /** Reconnect backoff cap while disconnected, ms. Default 30000. */
+  maxBackoffMs?: number;
+  /** Probe timeout, ms. Default 3500. */
+  probeTimeoutMs?: number;
+  /**
+   * Endpoint used for the liveness probe. Default `/v1/status`. Override
+   * mainly exists so tests can target a stub URL.
+   */
+  probeUrl?: string;
+}
+
+async function probe(url: string, timeoutMs: number): Promise<boolean> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      credentials: 'same-origin',
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+    // 401/403 still mean the daemon is alive and responding. Only treat
+    // network-level failures + 5xx as "daemon is down". The auth surface
+    // owns its own redirect.
+    return res.status < 500;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function useConnectionState(
+  opts: UseConnectionStateOptions = {},
+): ConnectionState {
+  const {
+    pollIntervalMs = 2000,
+    failureThreshold = 2,
+    maxBackoffMs = 30_000,
+    probeTimeoutMs = 3500,
+    probeUrl = '/v1/status',
+  } = opts;
+
+  const [state, setState] = useState<ConnectionState>({
+    status: 'connected',
+    lastConnectedAt: Date.now(),
+  });
+
+  // Refs keep the polling loop stable across renders without re-arming
+  // timers on every state flip.
+  const consecutiveFailuresRef = useRef(0);
+  const backoffRef = useRef(pollIntervalMs);
+  const cancelledRef = useRef(false);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const schedule = (delay: number) => {
+      if (cancelledRef.current) return;
+      timer = setTimeout(tick, delay);
+    };
+
+    const tick = async () => {
+      const ok = await probe(probeUrl, probeTimeoutMs);
+      if (cancelledRef.current) return;
+
+      if (ok) {
+        consecutiveFailuresRef.current = 0;
+        backoffRef.current = pollIntervalMs;
+        setState((prev) =>
+          prev.status === 'connected'
+            ? prev
+            : { status: 'connected', lastConnectedAt: Date.now() },
+        );
+        schedule(pollIntervalMs);
+        return;
+      }
+
+      consecutiveFailuresRef.current += 1;
+      const failures = consecutiveFailuresRef.current;
+
+      if (failures >= failureThreshold) {
+        setState((prev) => {
+          if (prev.status === 'disconnected') {
+            return { ...prev, attempts: prev.attempts + 1, lastError: 'probe failed' };
+          }
+          return {
+            status: 'disconnected',
+            since: Date.now(),
+            lastError: 'probe failed',
+            attempts: 1,
+          };
+        });
+        // Exponential backoff while disconnected so we don't hammer a
+        // crashed daemon, but always retry — when the operator runs
+        // `jinn run` again the SPA must notice quickly.
+        backoffRef.current = Math.min(
+          Math.max(backoffRef.current * 2, pollIntervalMs * 2),
+          maxBackoffMs,
+        );
+        schedule(backoffRef.current);
+      } else {
+        schedule(pollIntervalMs);
+      }
+    };
+
+    // Kick off the first probe immediately so the test for "renders banner
+    // on disconnect" doesn't have to wait for an initial interval.
+    void tick();
+
+    return () => {
+      cancelledRef.current = true;
+      if (timer !== null) clearTimeout(timer);
+    };
+  }, [pollIntervalMs, failureThreshold, maxBackoffMs, probeTimeoutMs, probeUrl]);
+
+  return state;
+}

--- a/client/src/dashboard/spa/src/shell/OfflineBanner.test.tsx
+++ b/client/src/dashboard/spa/src/shell/OfflineBanner.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { OfflineBanner } from './OfflineBanner.js';
+import type { ConnectionState } from '../api/connection-state.js';
+
+const connected: ConnectionState = {
+  status: 'connected',
+  lastConnectedAt: Date.now(),
+};
+
+const disconnected: ConnectionState = {
+  status: 'disconnected',
+  since: Date.now(),
+  lastError: 'probe failed',
+  attempts: 3,
+};
+
+describe('OfflineBanner', () => {
+  it('renders nothing while the daemon is connected', () => {
+    const { container } = render(<OfflineBanner connection={connected} />);
+    expect(container.textContent).toBe('');
+    expect(screen.queryByTestId('offline-banner')).toBeNull();
+  });
+
+  it('surfaces the offline state and a restart CTA when disconnected', () => {
+    render(<OfflineBanner connection={disconnected} />);
+    const banner = screen.getByTestId('offline-banner');
+    expect(banner).toBeTruthy();
+    // role=alert so assistive tech announces the dead-daemon condition.
+    expect(banner.getAttribute('role')).toBe('alert');
+    expect(screen.getByText(/daemon offline/i)).toBeTruthy();
+    expect(screen.getByText(/reconnecting automatically/i)).toBeTruthy();
+    // Plain-speech CTA: the operator needs to know to re-run the node.
+    expect(screen.getByText('jinn run')).toBeTruthy();
+  });
+});

--- a/client/src/dashboard/spa/src/shell/OfflineBanner.tsx
+++ b/client/src/dashboard/spa/src/shell/OfflineBanner.tsx
@@ -1,0 +1,67 @@
+/**
+ * Persistent, full-width banner that surfaces a dead-daemon condition.
+ *
+ * Issue #335: when the daemon process dies (intentional shutdown, crash, or
+ * a restart that fails to respawn — see #289), the SPA used to keep rendering
+ * its last-known state forever. Operators thought the node was still working;
+ * only a manual page refresh told the truth.
+ *
+ * `useConnectionState` (api/connection-state.ts) polls `/v1/status` and flips
+ * to `disconnected` within ~4s of the daemon going down. This banner renders
+ * that state: a clear "daemon is offline" message, a "reconnecting" cue, and
+ * a CTA nudging the operator to run `jinn run` again (until #289 lands the
+ * in-app restart respawn). When the daemon answers again the hook flips back
+ * to `connected` and this banner unmounts itself — the rest of the app's
+ * react-query refetches resume naturally.
+ *
+ * This is a money/safety-adjacent surface: it must speak plainly. No vow
+ * metaphor here — the operator needs to know the node is down and what to do.
+ */
+import type { ConnectionState } from '../api/connection-state.js';
+
+export interface OfflineBannerProps {
+  connection: ConnectionState;
+}
+
+export function OfflineBanner({ connection }: OfflineBannerProps): JSX.Element | null {
+  if (connection.status === 'connected') return null;
+
+  return (
+    <div
+      role="alert"
+      data-testid="offline-banner"
+      style={{
+        background: 'var(--bg-elevated)',
+        borderBottom: '2px solid var(--break-red)',
+        padding: '10px 24px',
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        gap: '16px',
+        flexWrap: 'wrap',
+        fontFamily: "'JetBrains Mono', monospace",
+        fontSize: '13px',
+      }}
+    >
+      <span style={{ color: 'var(--fg)' }}>
+        <strong style={{ color: 'var(--break-red)' }}>Daemon offline.</strong>{' '}
+        The jinn node stopped responding — what you see below may be stale.
+        Reconnecting automatically…
+      </span>
+      <code
+        style={{
+          background: 'var(--bg-sunken)',
+          border: '1px solid var(--border-accent)',
+          borderRadius: '4px',
+          padding: '4px 10px',
+          color: 'var(--accent-gold)',
+          fontFamily: "'JetBrains Mono', monospace",
+          fontSize: '12px',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        jinn run
+      </code>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a `useConnectionState` liveness probe (`api/connection-state.ts`) that polls `/v1/status` on a short cadence and flips to `disconnected` within ~4s of the daemon going down; reconnects with exponential backoff and auto-clears when the daemon answers again.
- Adds `OfflineBanner` (`shell/OfflineBanner.tsx`) — a persistent `role=alert` banner that surfaces the dead-daemon state in plain speech with a `jinn run` CTA, and renders nothing while connected.
- Wires `OfflineBanner` into `App` so the operating shell stops silently rendering stale state on a dead daemon.

Fixes the dogfood paper cut (rvx, v0.1.6): "UI/UX stays live even after shutting down — only on page refresh does it say 'cant connect to server'."

## Acceptance criteria (#335)

- [x] SPA detects API disconnect within ~5s of the daemon going down (~4s with default 2s poll + threshold 2).
- [x] Renders a clear "daemon is offline / reconnecting" state with a CTA nudging `jinn run` (until #289 lands the in-app restart respawn).
- [x] When the daemon comes back, the SPA auto-reconnects and the banner clears; react-query refetches resume naturally.

## Test plan

- [x] `yarn typecheck` (client + SPA tsconfig) — zero errors
- [x] `yarn test --run` — 3703 passed, 7 skipped, 0 failed
- [x] New: `connection-state.test.tsx` (4 tests — connected steady state, threshold flip, 5xx-vs-401 handling, auto-reconnect)
- [x] New: `OfflineBanner.test.tsx` (2 tests — hidden while connected, surfaces offline state + CTA)
- [x] `yarn lint:no-late-mount` — clean

Closes #335

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>