### PR TITLE
fix(332): wire per-harness readiness into JoinFlow harness selector

### DIFF
--- a/client/src/dashboard/spa/src/api/client.ts
+++ b/client/src/dashboard/spa/src/api/client.ts
@@ -27,6 +27,7 @@ import type {
   DiscoveryPluginPublicationsResponse,
   DiscoveryBuilderArtifactsResponse,
   DiscoveryPluginScoresResponse,
+  HarnessReadinessEntry,
 } from './types.js';
 
 interface JsonErrorPayload {
@@ -193,6 +194,18 @@ export const api = {
   hermesDoctor: () =>
     jfetch<{ installed: boolean; exitCode: number | null; stdout: string; stderr: string }>(
       '/api/hermes/doctor',
+    ),
+
+  /**
+   * Per-harness readiness snapshot (vh74.2 Stage A — #248 / #332).
+   * `GET /v1/harnesses/:name/readiness` keys by the daemon's `Harness.name`,
+   * which is the canonical harness name the join form already carries in
+   * `form.harness`. A 404 (`harness_not_found`) propagates as a thrown Error
+   * with `code === 'harness_not_found'`.
+   */
+  harnessReadiness: (name: string) =>
+    jfetch<HarnessReadinessEntry>(
+      `/v1/harnesses/${encodeURIComponent(name)}/readiness`,
     ),
 
   // ---- Launcher mode (spec/2026-05-05-launcher-role-and-mode.md §5.3) ----

--- a/client/src/dashboard/spa/src/api/types.ts
+++ b/client/src/dashboard/spa/src/api/types.ts
@@ -754,3 +754,23 @@ export interface DiscoveryBuilderArtifactsResponse {
 export interface DiscoveryPluginScoresResponse {
   scores: PluginScoreHistoryRowDto[];
 }
+
+// ── Per-harness readiness (vh74.2 Stage A — #248 / #332) ─────────────────────
+// Mirrors the daemon's `HarnessReadinessSnapshot` entry shape exposed at
+// `GET /v1/harnesses/:name/readiness`. The join form consults this to disable
+// harness options whose external dependencies (CLI install, provider key)
+// are unsatisfied.
+
+export interface HarnessReadinessNextStep {
+  description: string;
+  cli?: string;
+  url?: string;
+}
+
+export interface HarnessReadinessEntry {
+  harnessName: string;
+  manifestCids: string[];
+  ready: boolean;
+  reason?: string;
+  nextStep?: HarnessReadinessNextStep;
+}

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
@@ -26,6 +26,7 @@ const apiMock = vi.hoisted(() => ({
   operatorJoin: vi.fn(),
   operatorLeave: vi.fn(),
   hermesDoctor: vi.fn(),
+  harnessReadiness: vi.fn(),
 }));
 
 vi.mock('../../api/client.js', () => ({
@@ -39,6 +40,7 @@ vi.mock('../../api/client.js', () => ({
       leave: (cid: string) => apiMock.operatorLeave(cid),
     },
     hermesDoctor: () => apiMock.hermesDoctor(),
+    harnessReadiness: (name: string) => apiMock.harnessReadiness(name),
   },
 }));
 
@@ -143,6 +145,15 @@ beforeEach(() => {
   apiMock.operatorJoin.mockReset();
   apiMock.operatorLeave.mockReset();
   apiMock.hermesDoctor.mockReset();
+  apiMock.harnessReadiness.mockReset();
+
+  // Default: every probed harness reports ready. Tests that exercise the
+  // not-ready path override this per harness name.
+  apiMock.harnessReadiness.mockImplementation(async (name: string) => ({
+    harnessName: name,
+    manifestCids: [],
+    ready: true,
+  }));
 
   apiMock.getManifest.mockResolvedValue({
     manifest: baseManifest,
@@ -389,6 +400,174 @@ describe('JoinFlow — harness options', () => {
     const chipPlugins = chips.map((c) => c.getAttribute('data-plugin'));
     expect(chipPlugins).not.toContain('claude-code-learner');
     expect(chipPlugins).toContain('network-tools');
+  });
+});
+
+describe('JoinFlow — per-harness readiness gate (#332)', () => {
+  /** Catalog with Claude Code + Codex, both compatible. */
+  const twoHarnessCatalog = {
+    ...baseCatalog,
+    nets: [
+      {
+        ...baseCatalog.nets[0]!,
+        compatibleHarnesses: [
+          { name: 'claude-code-learner', version: '0.1.0', supportsRoles: ['solving' as const] },
+          { name: 'codex-code-learner', version: '0.1.0', supportsRoles: ['solving' as const] },
+        ],
+      },
+    ],
+  };
+
+  it('disables the harness option for a not-ready harness', async () => {
+    apiMock.getSolverNets.mockResolvedValue(twoHarnessCatalog);
+    apiMock.harnessReadiness.mockImplementation(async (name: string) => {
+      if (name === 'codex') {
+        return {
+          harnessName: 'codex',
+          manifestCids: [],
+          ready: false,
+          reason: 'codex CLI not installed',
+          nextStep: { description: 'Install Codex CLI', cli: 'npm i -g @openai/codex' },
+        };
+      }
+      return { harnessName: name, manifestCids: [], ready: true };
+    });
+
+    wrap(<JoinFlow />);
+    await waitFor(() => expect(screen.getByTestId('join-flow-summary')).toBeTruthy());
+    fireEvent.click(screen.getByLabelText('Solver'));
+
+    await waitFor(() => {
+      const codexOption = screen
+        .getAllByTestId('join-harness-option')
+        .find((o) => o.getAttribute('data-harness') === 'codex') as HTMLOptionElement;
+      expect(codexOption.disabled).toBe(true);
+    });
+    const codexOption = screen
+      .getAllByTestId('join-harness-option')
+      .find((o) => o.getAttribute('data-harness') === 'codex') as HTMLOptionElement;
+    expect(codexOption.textContent).toMatch(/setup required/i);
+
+    // Claude Code is ready — its option stays selectable.
+    const claudeOption = screen
+      .getAllByTestId('join-harness-option')
+      .find((o) => o.getAttribute('data-harness') === 'claude-code') as HTMLOptionElement;
+    expect(claudeOption.disabled).toBe(false);
+  });
+
+  it('shows the nextStep caption when the selected harness is not ready', async () => {
+    apiMock.getSolverNets.mockResolvedValue(twoHarnessCatalog);
+    // Claude Code (the default selection) is not ready.
+    apiMock.harnessReadiness.mockImplementation(async (name: string) => {
+      if (name === 'claude-code') {
+        return {
+          harnessName: 'claude-code',
+          manifestCids: [],
+          ready: false,
+          reason: 'not signed in',
+          nextStep: { description: 'Sign in to Claude Code', cli: 'claude login' },
+        };
+      }
+      return { harnessName: name, manifestCids: [], ready: true };
+    });
+
+    wrap(<JoinFlow />);
+    await waitFor(() => expect(screen.getByTestId('join-flow-summary')).toBeTruthy());
+    fireEvent.click(screen.getByLabelText('Solver'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('join-harness-not-ready')).toBeTruthy(),
+    );
+    const banner = screen.getByTestId('join-harness-not-ready');
+    expect(banner.textContent).toMatch(/not ready/i);
+    expect(banner.textContent).toMatch(/not signed in/);
+    expect(screen.getByTestId('join-harness-not-ready-next-step').textContent).toMatch(
+      /Sign in to Claude Code/,
+    );
+    expect(screen.getByTestId('join-harness-not-ready-next-step').textContent).toMatch(
+      /claude login/,
+    );
+  });
+
+  it('gates Save & Join when the selected solver harness is not ready', async () => {
+    apiMock.getSolverNets.mockResolvedValue(twoHarnessCatalog);
+    apiMock.harnessReadiness.mockImplementation(async (name: string) => {
+      if (name === 'claude-code') {
+        return {
+          harnessName: 'claude-code',
+          manifestCids: [],
+          ready: false,
+          reason: 'not signed in',
+          nextStep: { description: 'Sign in to Claude Code' },
+        };
+      }
+      return { harnessName: name, manifestCids: [], ready: true };
+    });
+
+    wrap(<JoinFlow />);
+    await waitFor(() => expect(screen.getByTestId('join-flow-summary')).toBeTruthy());
+    fireEvent.click(screen.getByLabelText('Solver'));
+
+    // Default harness (claude-code) is not ready — submit must be disabled.
+    await waitFor(() => {
+      const submit = screen.getByTestId('join-flow-submit') as HTMLButtonElement;
+      expect(submit.disabled).toBe(true);
+    });
+  });
+
+  it('does NOT gate Save & Join when the selected harness is ready', async () => {
+    apiMock.getSolverNets.mockResolvedValue(twoHarnessCatalog);
+    // Default mock: all ready.
+    wrap(<JoinFlow />);
+    await waitFor(() => expect(screen.getByTestId('join-flow-summary')).toBeTruthy());
+    fireEvent.click(screen.getByLabelText('Solver'));
+
+    await waitFor(() => expect(apiMock.harnessReadiness).toHaveBeenCalled());
+    const submit = screen.getByTestId('join-flow-submit') as HTMLButtonElement;
+    expect(submit.disabled).toBe(false);
+    expect(screen.queryByTestId('join-harness-not-ready')).toBeNull();
+  });
+
+  it('does NOT gate Save & Join on harness readiness when only evaluator is selected', async () => {
+    apiMock.getSolverNets.mockResolvedValue(twoHarnessCatalog);
+    // Even if a solver harness probe came back not-ready, the evaluator-only
+    // path binds harness from the manifest and must not be readiness-gated.
+    apiMock.harnessReadiness.mockImplementation(async (name: string) => ({
+      harnessName: name,
+      manifestCids: [],
+      ready: false,
+      reason: 'not signed in',
+    }));
+
+    wrap(<JoinFlow />);
+    await waitFor(() => expect(screen.getByTestId('join-flow-summary')).toBeTruthy());
+    fireEvent.click(screen.getByLabelText('Evaluator'));
+
+    const submit = screen.getByTestId('join-flow-submit') as HTMLButtonElement;
+    expect(submit.disabled).toBe(false);
+    // The solver-only not-ready banner is not rendered without solver fields.
+    expect(screen.queryByTestId('join-harness-not-ready')).toBeNull();
+  });
+
+  it('does not crash when a harness is absent from the readiness snapshot (404)', async () => {
+    apiMock.getSolverNets.mockResolvedValue(twoHarnessCatalog);
+    apiMock.harnessReadiness.mockImplementation(async (name: string) => {
+      const err = new Error('404 Not Found') as Error & { code?: string };
+      err.code = 'harness_not_found';
+      throw err;
+    });
+
+    wrap(<JoinFlow />);
+    await waitFor(() => expect(screen.getByTestId('join-flow-summary')).toBeTruthy());
+    fireEvent.click(screen.getByLabelText('Solver'));
+
+    await waitFor(() => expect(apiMock.harnessReadiness).toHaveBeenCalled());
+    // Unknown readiness → not blocked, no not-ready banner, options enabled.
+    const submit = screen.getByTestId('join-flow-submit') as HTMLButtonElement;
+    expect(submit.disabled).toBe(false);
+    expect(screen.queryByTestId('join-harness-not-ready')).toBeNull();
+    const options = screen.getAllByTestId('join-harness-option') as HTMLOptionElement[];
+    expect(options.every((o) => !o.disabled)).toBe(true);
   });
 });
 

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
@@ -551,7 +551,7 @@ describe('JoinFlow — per-harness readiness gate (#332)', () => {
 
   it('does not crash when a harness is absent from the readiness snapshot (404)', async () => {
     apiMock.getSolverNets.mockResolvedValue(twoHarnessCatalog);
-    apiMock.harnessReadiness.mockImplementation(async (name: string) => {
+    apiMock.harnessReadiness.mockImplementation(async (_name: string) => {
       const err = new Error('404 Not Found') as Error & { code?: string };
       err.code = 'harness_not_found';
       throw err;

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
@@ -4,6 +4,7 @@ import { useLocation, useParams } from 'wouter';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api } from '../../api/client.js';
 import type {
+  HarnessReadinessEntry,
   RegistryManifestResponse,
   SolverNetCatalogEntry,
   SolverNetsCatalogResponse,
@@ -83,6 +84,51 @@ function truncateAddress(address: string): string {
   return `${address.slice(0, 6)}…${address.slice(-4)}`;
 }
 
+/**
+ * Readiness lookup keyed by harness name. `undefined` for a name means the
+ * probe is still in flight or the harness is absent from the daemon's
+ * readiness snapshot (404 — treated as not-yet-known, not a hard failure).
+ */
+type ReadinessMap = Map<string, HarnessReadinessEntry | undefined>;
+
+/**
+ * Probes `GET /v1/harnesses/:name/readiness` for each candidate harness so
+ * the join form (#332) can disable harness options whose external
+ * dependencies (CLI install, provider API key) are unsatisfied — and gate
+ * Save & Join on the selected harness reporting ready.
+ *
+ * The daemon's readiness snapshot covers every registered harness (not just
+ * joined ones — see `readiness-registry.ts` `_doRefresh`), so an unjoined
+ * harness still resolves here. A 404 is swallowed to `undefined` rather than
+ * thrown: a harness the daemon does not know about should not crash the form.
+ */
+function useReadiness(harnessNames: string[]): { readiness: ReadinessMap } {
+  // Sort + dedupe for a stable query key regardless of catalog ordering.
+  const sortedNames = [...new Set(harnessNames)].sort();
+  const query = useQuery<ReadinessMap>({
+    queryKey: ['harness-readiness', sortedNames.join(',')],
+    enabled: sortedNames.length > 0,
+    // Re-probe periodically so an operator who installs a CLI / adds a key
+    // in another window sees the option un-disable without a full reload.
+    refetchInterval: 5_000,
+    queryFn: async () => {
+      const entries = await Promise.all(
+        sortedNames.map(async (name): Promise<[string, HarnessReadinessEntry | undefined]> => {
+          try {
+            return [name, await api.harnessReadiness(name)];
+          } catch (err) {
+            const code = (err as { code?: string }).code;
+            if (code === 'harness_not_found') return [name, undefined];
+            throw err;
+          }
+        }),
+      );
+      return new Map(entries);
+    },
+  });
+  return { readiness: query.data ?? new Map() };
+}
+
 export function JoinFlow({
   manifestCid: manifestCidOverride,
   navigateTo,
@@ -157,6 +203,15 @@ export function JoinFlow({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [catalogPreferredHarness]);
   const modelOptions = modelOptionsForHarness(form.harness);
+
+  // Per-harness readiness (#332). Probe every solver-compatible harness so
+  // not-ready options render disabled, and Save & Join can gate on the
+  // selected harness reporting ready. The daemon keys the readiness endpoint
+  // by `Harness.name` — the same canonical name `form.harness` carries.
+  const { readiness } = useReadiness(
+    solverCompatibleHarnesses.map((h) => h.name),
+  );
+  const selectedHarnessReadiness = readiness.get(form.harness);
 
   const submitMutation = useMutation({
     mutationFn: () =>
@@ -248,8 +303,19 @@ export function JoinFlow({
   const requiresCostConfirmation = showSolverFields && costDecision.requiresConfirmation;
   const costGateBlocked = requiresCostConfirmation && !highCostAcknowledged;
 
+  // Readiness gate (#332): block Save & Join when the selected solver harness
+  // reports a definitive `ready: false`. A still-loading or unknown probe
+  // (`undefined`) does NOT block — the not-ready *options* are disabled in
+  // the select, so an operator cannot land on a known-not-ready harness, and
+  // we avoid flashing a disabled button before the first probe resolves.
+  const harnessReadinessBlocked =
+    showSolverFields && selectedHarnessReadiness?.ready === false;
+
   const canSubmit =
-    form.roles.length > 0 && !submitMutation.isPending && !costGateBlocked;
+    form.roles.length > 0 &&
+    !submitMutation.isPending &&
+    !costGateBlocked &&
+    !harnessReadinessBlocked;
 
   return (
     <main data-testid="join-flow" data-manifest-cid={cid} style={pageStyle}>
@@ -424,11 +490,25 @@ export function JoinFlow({
                 }}
                 style={selectStyle}
               >
-                {solverCompatibleHarnesses.map((h) => (
-                  <option key={h.name} value={h.name}>
-                    {harnessOptionLabel(h.name, h.version)}
-                  </option>
-                ))}
+                {solverCompatibleHarnesses.map((h) => {
+                  const entry = readiness.get(h.name);
+                  const notReady = entry?.ready === false;
+                  return (
+                    <option
+                      key={h.name}
+                      value={h.name}
+                      disabled={notReady}
+                      data-testid="join-harness-option"
+                      data-harness={h.name}
+                      data-harness-ready={
+                        entry === undefined ? 'unknown' : entry.ready ? 'true' : 'false'
+                      }
+                    >
+                      {harnessOptionLabel(h.name, h.version)}
+                      {notReady ? ' — setup required' : ''}
+                    </option>
+                  );
+                })}
                 {(!catalogEntry || solverCompatibleHarnesses.length === 0) && (
                   <option value={form.harness}>{harnessDisplayName(form.harness)}</option>
                 )}
@@ -444,6 +524,54 @@ export function JoinFlow({
                 >
                   {HERMES_AGENT_DESCRIPTION}
                 </span>
+              )}
+              {selectedHarnessReadiness?.ready === false && (
+                <div
+                  data-testid="join-harness-not-ready"
+                  data-harness={form.harness}
+                  role="status"
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: '4px',
+                    padding: '10px 12px',
+                    border: '1px solid var(--break-red)',
+                    borderRadius: 'var(--radius-2)',
+                    background: 'var(--bg)',
+                    fontFamily: "'JetBrains Mono', monospace",
+                    fontSize: '11px',
+                    color: 'var(--fg)',
+                  }}
+                >
+                  <span style={{ color: 'var(--break-red)' }}>
+                    {harnessDisplayName(form.harness)} is not ready
+                    {selectedHarnessReadiness.reason
+                      ? `: ${selectedHarnessReadiness.reason}`
+                      : ''}
+                  </span>
+                  {selectedHarnessReadiness.nextStep && (
+                    <span
+                      data-testid="join-harness-not-ready-next-step"
+                      style={{ color: 'var(--fg-muted)' }}
+                    >
+                      {selectedHarnessReadiness.nextStep.description}
+                      {selectedHarnessReadiness.nextStep.cli
+                        ? ` (${selectedHarnessReadiness.nextStep.cli})`
+                        : ''}
+                    </span>
+                  )}
+                  {selectedHarnessReadiness.nextStep?.url && (
+                    <a
+                      href={selectedHarnessReadiness.nextStep.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      data-testid="join-harness-not-ready-url"
+                      style={{ color: 'var(--accent-sky)' }}
+                    >
+                      {selectedHarnessReadiness.nextStep.url}
+                    </a>
+                  )}
+                </div>
               )}
             </div>
 

--- a/client/src/harnesses/readiness-registry.ts
+++ b/client/src/harnesses/readiness-registry.ts
@@ -105,8 +105,16 @@ export class HarnessReadinessRegistry {
   }
 
   private async _doRefresh(): Promise<void> {
-    // Group joined entries by harnessName so we only call isReady() once per harness.
+    // Group joined entries by harnessName so we only call isReady() once per
+    // harness. Seed the map with EVERY registered harness — not just joined
+    // ones — so the snapshot covers harnesses the operator could pick but
+    // has not joined yet. The SPA join form (#332) consults this snapshot to
+    // disable not-ready harness options before any join exists, so an
+    // unjoined harness must still appear (with an empty `manifestCids`).
     const harnessToCids = new Map<string, string[]>();
+    for (const name of Object.keys(this.opts.harnessesByName)) {
+      harnessToCids.set(name, []);
+    }
     for (const [cid, joined] of Object.entries(this.opts.joinedHarnessesByCid)) {
       const list = harnessToCids.get(joined.harnessName) ?? [];
       list.push(cid);

--- a/client/test/harnesses/readiness-registry.test.ts
+++ b/client/test/harnesses/readiness-registry.test.ts
@@ -35,6 +35,36 @@ describe('HarnessReadinessRegistry', () => {
     ]);
   });
 
+  it('snapshots every registered harness, even those not joined to any SolverNet (#332)', async () => {
+    // The join form consults the readiness snapshot BEFORE any join exists,
+    // so a harness the operator could pick must appear with empty manifestCids.
+    const claude = fakeHarness('claude-code', { ready: true, reason: 'ok' });
+    const codex = fakeHarness('codex', {
+      ready: false,
+      reason: 'codex CLI not installed',
+      nextStep: { description: 'Install Codex CLI', cli: 'npm i -g @openai/codex' },
+    });
+    const registry = new HarnessReadinessRegistry({
+      harnessesByName: { 'claude-code': claude, codex },
+      // claude-code is joined; codex is registered but NOT joined.
+      joinedHarnessesByCid: {
+        'bafkrei.claude': { harnessName: 'claude-code', roles: ['solver'] },
+      },
+      tickIntervalMs: 4000,
+    });
+    await registry.refreshNow();
+    const snapshot = registry.getSnapshot();
+    const byName = new Map(snapshot.harnesses.map((h) => [h.harnessName, h]));
+    expect(byName.get('claude-code')).toEqual(
+      expect.objectContaining({ ready: true, manifestCids: ['bafkrei.claude'] }),
+    );
+    // Unjoined harness still snapshotted, with an empty manifestCids list.
+    expect(byName.get('codex')).toEqual(
+      expect.objectContaining({ ready: false, manifestCids: [] }),
+    );
+    expect(byName.get('codex')?.nextStep?.description).toBe('Install Codex CLI');
+  });
+
   it('isReadyForClaim returns ready=false for unknown manifestCid', async () => {
     const registry = new HarnessReadinessRegistry({
       harnessesByName: {},


### PR DESCRIPTION
## Summary

The SolverNet join form let operators select harnesses that are not installed/authed — Codex with no CLI, Hermes with no provider key, paid-API models with no surfaced auth dependency. Both Oak and rvx hit this in the v0.1.6 dogfood (rvx joined with Codex he had no auth for → 17/17 failures). PR #248 (vh74.2 Stage A) shipped the per-harness readiness primitive; this is the minimum-viable subset that wires it into the join form, ahead of the larger vh74.3 Stage B generalisation.

- **readiness-registry** — seed `harnessToCids` from `Object.keys(harnessesByName)` so every *registered* harness appears in the snapshot, not just *joined* ones (the join form probes readiness before any join exists; unjoined harnesses resolve with an empty `manifestCids`).
- **SPA api client** — add `harnessReadiness(name)` + `HarnessReadinessEntry` type for `GET /v1/harnesses/:name/readiness`. The endpoint keys by `Harness.name`, which is the canonical name `form.harness` already carries — no name translation needed.
- **JoinFlow** — add a `useReadiness` hook (probes every solver-compatible harness, re-polls every 5s); render not-ready harness `<option>`s `disabled` with a "setup required" suffix; surface the readiness `nextStep` caption (description + CLI + URL) for the selected harness; gate Save & Join on the selected solver harness reporting a definitive `ready: false`. Evaluator-only joins bypass the gate (harness bound by the manifest). A 404 (`harness_not_found`) is swallowed to unknown — an unknown harness does not crash or block the form.

Composes cleanly with vh74.3 Stage B.

## Test plan

- [x] `yarn typecheck` — clean
- [x] `yarn test --run` — 3578 passed, 7 skipped, 0 failures
- [x] New `readiness-registry.test.ts` case: unjoined registered harness is snapshotted with empty `manifestCids`
- [x] New `JoinFlow.test.tsx` describe block (6 cases): not-ready option disabled, nextStep caption rendered, Save & Join gated when selected harness not ready, ungated when ready, ungated for evaluator-only joins, no crash on 404

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)