### PR TITLE
fix(348): codex variant of claim-loop readiness gate

### DIFF
--- a/client/src/api/codex-doctor-endpoint.ts
+++ b/client/src/api/codex-doctor-endpoint.ts
@@ -1,0 +1,118 @@
+/**
+ * GET /api/codex/doctor
+ *
+ * Runs `codex --version` via spawnSync and inspects the auth configuration so
+ * the operator dashboard can show an install-required / sign-in-required panel
+ * before the operator saves a Codex harness selection.
+ *
+ * Response shape:
+ *   { installed: boolean, authenticated: boolean, exitCode: number | null,
+ *     stdout: string, stderr: string }
+ *
+ * `installed: false` means the binary was not found (ENOENT or equivalent).
+ * `exitCode !== 0` (with `installed: true`) means the binary exists but
+ * `codex --version` itself failed.
+ * `authenticated: false` (with `installed: true`, `exitCode === 0`) means the
+ * binary is present and runnable but no credentials are configured — Codex
+ * authenticates via the `OPENAI_API_KEY` env var or a `codex login` session
+ * persisted under `CODEX_HOME` / `~/.codex/auth.json`.
+ *
+ * The probe logic is exported as `probeCodexDoctor` so the Codex variant of
+ * the `LearnerHarness` can reuse it from `isReady()` — same source of truth
+ * for the SPA precheck panel and the daemon's claim-readiness gate (#348,
+ * same-shape bug as #330).
+ *
+ * Codex (unlike Hermes) has no `codex doctor` subcommand, so install
+ * detection shells `codex --version` and auth detection is a separate
+ * filesystem / env check rather than a probe exit code.
+ */
+import type { Hono } from 'hono';
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export interface CodexDoctorResponse {
+  installed: boolean;
+  authenticated: boolean;
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+export interface CodexDoctorConfig {
+  codexPath?: string;
+  codexDoctorTimeoutMs?: number;
+  /** Inject env for testing (defaults to process.env). */
+  env?: NodeJS.ProcessEnv;
+  /** Override the auth-file existence check (for testing). */
+  authFileExists?: boolean;
+}
+
+/**
+ * Whether Codex has usable credentials. Codex authenticates either via the
+ * `OPENAI_API_KEY` env var or via a `codex login` session persisted to
+ * `auth.json` under `CODEX_HOME` (falling back to `~/.codex`).
+ */
+function detectCodexAuth(config: CodexDoctorConfig): boolean {
+  if (config.authFileExists !== undefined) {
+    return config.authFileExists || hasApiKey(config);
+  }
+  if (hasApiKey(config)) return true;
+  const env = config.env ?? process.env;
+  const codexHome = env['CODEX_HOME']?.trim();
+  const authPath = codexHome
+    ? join(codexHome, 'auth.json')
+    : join(homedir(), '.codex', 'auth.json');
+  return existsSync(authPath);
+}
+
+function hasApiKey(config: CodexDoctorConfig): boolean {
+  const env = config.env ?? process.env;
+  return Boolean(env['OPENAI_API_KEY']?.trim());
+}
+
+/**
+ * Synchronously runs `codex --version` and classifies install + auth state.
+ * Pure (no Hono dependency) so the harness layer can call it without pulling
+ * the API server in.
+ */
+export function probeCodexDoctor(config: CodexDoctorConfig = {}): CodexDoctorResponse {
+  const codexBin = config.codexPath ?? 'codex';
+  const timeoutMs = config.codexDoctorTimeoutMs ?? 30_000;
+
+  const result = spawnSync(codexBin, ['--version'], {
+    timeout: timeoutMs,
+    encoding: 'utf8',
+  });
+
+  const errorCode = (result.error as NodeJS.ErrnoException | undefined)?.code;
+  // installed=true means we found the binary on disk. ENOENT is the only
+  // definitive not-installed signal. Other errors (EACCES = wrong
+  // permissions; ETIMEDOUT = ran but didn't finish in time) indicate the
+  // binary exists but couldn't be exercised cleanly — surface those as
+  // config-issue, not missing.
+  const notFound = errorCode === 'ENOENT';
+  const installed = !notFound && (
+    result.status !== null
+    || result.signal !== null
+    || (errorCode != null && errorCode !== 'ENOENT')
+  );
+
+  // Auth is only meaningful once the binary is present and runnable.
+  const authenticated = installed && result.status === 0 && detectCodexAuth(config);
+
+  return {
+    installed,
+    authenticated,
+    exitCode: result.status,
+    stdout: (result.stdout ?? '').slice(0, 4000),
+    stderr: (result.stderr ?? '').slice(0, 4000),
+  };
+}
+
+export function addCodexDoctorRoutes(app: Hono, config: CodexDoctorConfig = {}): void {
+  app.get('/api/codex/doctor', (c) => {
+    return c.json(probeCodexDoctor(config));
+  });
+}

--- a/client/src/api/server.ts
+++ b/client/src/api/server.ts
@@ -45,6 +45,7 @@ import { addHarnessStatusRoutes, type HarnessStatusDeps } from './harness-status
 import { addHarnessReadinessRoutes } from './harness-readiness-endpoint.js';
 import type { HarnessReadinessRegistry } from '../harnesses/readiness-registry.js';
 import { addHermesDoctorRoutes, type HermesDoctorConfig } from './hermes-doctor-endpoint.js';
+import { addCodexDoctorRoutes, type CodexDoctorConfig } from './codex-doctor-endpoint.js';
 import { addLauncherRoutes, type LauncherRoutesDeps } from './launcher-endpoints.js';
 import {
   addOperatorArtifactsRoutes,
@@ -150,6 +151,11 @@ export interface ApiServerConfig {
    * Powers the dashboard's Hermes install precheck panel in the join flow.
    */
   hermesDoctor?: HermesDoctorConfig;
+  /**
+   * When set, mounts `GET /api/codex/doctor` under the UI token gate.
+   * Powers the dashboard's Codex install precheck panel in the join flow.
+   */
+  codexDoctor?: CodexDoctorConfig;
   /** Operator-local artifact inventory + future-artifact pricing controls. */
   operatorArtifacts?: Omit<OperatorArtifactsRoutesConfig, 'store'>;
   /** Path D local session-end hook endpoint. */
@@ -469,6 +475,7 @@ export async function startApiServer(config: ApiServerConfig): Promise<ApiServer
 
   if (config.ui) {
     addHermesDoctorRoutes(app, config.hermesDoctor ?? {});
+    addCodexDoctorRoutes(app, config.codexDoctor ?? {});
   }
 
   if (config.ui) {

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -151,6 +151,15 @@ export const JinnConfigSchema = z.object({
    */
   hermesDoctorTimeoutMs: z.number().int().positive().default(30_000),
 
+  /** Path to the `codex` executable. Defaults to `codex` when unset. */
+  codexPath: z.string().optional(),
+
+  /**
+   * Timeout in ms for `codex --version` health-check runs.
+   * Default 30 000 ms. Env: JINN_CODEX_DOCTOR_TIMEOUT_MS.
+   */
+  codexDoctorTimeoutMs: z.number().int().positive().default(30_000),
+
   /**
    * How the operator runs the daemon. Set once by app-guided setup or the
    * legacy `jinn auth` compatibility command, then read by every command that
@@ -759,6 +768,10 @@ export function loadConfig(configPath?: string): JinnConfig {
   if (env['JINN_HERMES_PROVIDER'])   merged.hermesProvider = env['JINN_HERMES_PROVIDER'];
   if (env['JINN_HERMES_DOCTOR_TIMEOUT_MS']) {
     merged.hermesDoctorTimeoutMs = parseInt(env['JINN_HERMES_DOCTOR_TIMEOUT_MS'], 10);
+  }
+  if (env['JINN_CODEX_PATH'])        merged.codexPath = env['JINN_CODEX_PATH'];
+  if (env['JINN_CODEX_DOCTOR_TIMEOUT_MS']) {
+    merged.codexDoctorTimeoutMs = parseInt(env['JINN_CODEX_DOCTOR_TIMEOUT_MS'], 10);
   }
   if (env['JINN_RUNTIME_MODE'])      merged.runtimeMode = env['JINN_RUNTIME_MODE'];
   if (env['JINN_PEERS'])             merged.peers = env['JINN_PEERS'];

--- a/client/src/harnesses/impls/index.ts
+++ b/client/src/harnesses/impls/index.ts
@@ -68,6 +68,11 @@ export interface HarnessEnv {
   codexPath?: string;
   /** Default Codex model when a SolverNet does not specify one. */
   codexModel?: string;
+  /**
+   * Timeout (ms) for the `codex --version` probe in the Codex variant of
+   * `LearnerHarness.isReady`.
+   */
+  codexDoctorTimeoutMs?: number;
   /** Optional Polymarket Gamma API override for acceptance or private mirrors. */
   polymarketGammaBaseUrl?: string;
   /** Optional Polymarket CLOB API override for acceptance or private mirrors. */
@@ -249,6 +254,10 @@ export function buildHarnesses(env: HarnessEnv): Harness[] {
     name: CODEX_HARNESS,
     adapter: codexLearnerAdapter,
     claudePath: env.claudePath,
+    ...(env.codexPath !== undefined ? { codexPath: env.codexPath } : {}),
+    ...(env.codexDoctorTimeoutMs !== undefined
+      ? { codexDoctorTimeoutMs: env.codexDoctorTimeoutMs }
+      : {}),
   }));
 
   const hermesAdapter = new HermesHarnessAdapter({

--- a/client/src/harnesses/impls/learner/harness.ts
+++ b/client/src/harnesses/impls/learner/harness.ts
@@ -1,9 +1,10 @@
 import type {
   Harness,
   HarnessContext,
+  ReadyStatus,
   Solution,
 } from '../../types.js';
-import { CLAUDE_CODE_HARNESS } from '../../names.js';
+import { CLAUDE_CODE_HARNESS, CODEX_HARNESS, canonicalHarnessName } from '../../names.js';
 import type {
   HarnessAdapter,
   TaskSessionInputs,
@@ -12,6 +13,7 @@ import type {
 import { resolvePluginRoot } from './plugin-path.js';
 import { harvestOutput } from './harvest.js';
 import { buildClaudeIsReady } from '../../../preflight/claude-auth.js';
+import { probeCodexDoctor } from '../../../api/codex-doctor-endpoint.js';
 
 /**
  * `Harness` shell. Bridges the engine's dispatch contract
@@ -27,6 +29,8 @@ export class LearnerHarness implements Harness {
   private readonly adapter: HarnessAdapter;
   private readonly pluginRoot: string;
   private readonly claudePath: string;
+  private readonly codexPath: string | undefined;
+  private readonly codexDoctorTimeoutMs: number | undefined;
   private readonly runtimeMode: 'bare' | 'container' | 'docker-compose';
 
   constructor(config: LearnerHarnessConfig) {
@@ -35,13 +39,96 @@ export class LearnerHarness implements Harness {
     this.version = config.version ?? '0.1.0-shim';
     this.pluginRoot = config.pluginRoot ?? resolvePluginRoot();
     this.claudePath = config.claudePath ?? 'claude';
+    this.codexPath = config.codexPath;
+    this.codexDoctorTimeoutMs = config.codexDoctorTimeoutMs;
     this.runtimeMode = config.runtimeMode ?? 'bare';
   }
 
-  isReady = buildClaudeIsReady({
+  private readonly claudeIsReady = buildClaudeIsReady({
     getClaudePath: () => this.claudePath,
     getContext: () => this.runtimeMode,
   });
+
+  /**
+   * Readiness probe.
+   *
+   * The `LearnerHarness` shell backs two distinct CLIs: claude-code (the
+   * default) and Codex (`name === CODEX_HARNESS`). The probe MUST match the
+   * CLI actually invoked — delegating the Codex variant to the claude auth
+   * probe makes a missing/unconfigured `codex` install look always-ready and
+   * burns N/N failed claims (#348, the same-shape bug as #330).
+   *
+   *   - claude-code → `buildClaudeIsReady` (shells `claude auth status`).
+   *   - Codex       → `probeCodexDoctor` (shells `codex --version`, then
+   *     checks for `OPENAI_API_KEY` / a `codex login` auth file).
+   */
+  async isReady(
+    ctx?: { solverType: string; role?: 'restoration' | 'evaluation' },
+  ): Promise<ReadyStatus> {
+    if (canonicalHarnessName(this.name) === CODEX_HARNESS) {
+      return this.codexIsReady();
+    }
+    return this.claudeIsReady(ctx);
+  }
+
+  /**
+   * Codex-specific readiness probe. Shells `codex --version` via the shared
+   * `probeCodexDoctor` helper (same logic the SPA precheck endpoint uses).
+   * Reports:
+   *   - `installed: false` → binary not on PATH → ready=false with an install
+   *     nextStep so the operator sees an actionable message instead of N/N
+   *     failed claims (#348).
+   *   - `exitCode !== 0` → binary exists but `codex --version` failed →
+   *     ready=false pointing at the Codex precheck panel.
+   *   - `authenticated: false` → binary runs but no `OPENAI_API_KEY` /
+   *     `codex login` session → ready=false with a sign-in nextStep.
+   *   - otherwise → ready=true.
+   */
+  private codexIsReady(): ReadyStatus {
+    const config: { codexPath?: string; codexDoctorTimeoutMs?: number } = {};
+    if (this.codexPath !== undefined) config.codexPath = this.codexPath;
+    if (this.codexDoctorTimeoutMs !== undefined) {
+      config.codexDoctorTimeoutMs = this.codexDoctorTimeoutMs;
+    }
+    const result = probeCodexDoctor(config);
+    if (!result.installed) {
+      return {
+        ready: false,
+        reason: 'codex binary not installed',
+        nextStep: {
+          description:
+            'Install the Codex CLI — see the Codex precheck panel in the operator dashboard for the install command.',
+          url: '/api/codex/doctor',
+        },
+      };
+    }
+    if (result.exitCode !== 0) {
+      const stderr = result.stderr.trim();
+      const stdout = result.stdout.trim();
+      const detail = stderr.length > 0 ? stderr : stdout;
+      return {
+        ready: false,
+        reason: `codex --version exit ${result.exitCode}${detail ? `: ${detail}` : ''}`,
+        nextStep: {
+          description:
+            'Run `codex --version` locally to surface the problem, or open the Codex precheck panel in the operator dashboard.',
+          url: '/api/codex/doctor',
+        },
+      };
+    }
+    if (!result.authenticated) {
+      return {
+        ready: false,
+        reason: 'codex auth not configured',
+        nextStep: {
+          description:
+            'Sign in to Codex — set OPENAI_API_KEY or run `codex login`, then re-check the Codex precheck panel in the operator dashboard.',
+          url: '/api/codex/doctor',
+        },
+      };
+    }
+    return { ready: true };
+  }
 
   supports(spec: { solverType: string; role?: 'restoration' | 'evaluation' }): boolean {
     if (spec.role === 'evaluation') return false;

--- a/client/src/harnesses/impls/learner/types.ts
+++ b/client/src/harnesses/impls/learner/types.ts
@@ -124,4 +124,15 @@ export interface LearnerHarnessConfig {
    * Defaults to 'bare'.
    */
   runtimeMode?: 'bare' | 'container' | 'docker-compose';
+  /**
+   * Path to the `codex` executable. Used by `isReady()` when this
+   * `LearnerHarness` is the Codex variant (`name === CODEX_HARNESS`) — it is
+   * passed to `probeCodexDoctor()`. Defaults to 'codex' (from PATH).
+   */
+  codexPath?: string;
+  /**
+   * Timeout (ms) for the `codex --version` probe in the Codex variant's
+   * `isReady()`. Defaults to 30s.
+   */
+  codexDoctorTimeoutMs?: number;
 }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -972,6 +972,10 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
         hermesPath: config.hermesPath,
         hermesDoctorTimeoutMs: config.hermesDoctorTimeoutMs,
       },
+      codexDoctor: {
+        codexPath: config.codexPath,
+        codexDoctorTimeoutMs: config.codexDoctorTimeoutMs,
+      },
       admin: {
         // jinn-mono #289: in interactive mode (the dashboard SPA case),
         // spawn a detached replacement before exiting so the panel reconnects
@@ -1844,6 +1848,8 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     hermesModel: config.hermesModel,
     hermesProvider: config.hermesProvider,
     hermesDoctorTimeoutMs: config.hermesDoctorTimeoutMs,
+    codexPath: config.codexPath,
+    codexDoctorTimeoutMs: config.codexDoctorTimeoutMs,
   })) {
     implRegistry.register(impl);
   }

--- a/client/test/api/codex-doctor-endpoint.test.ts
+++ b/client/test/api/codex-doctor-endpoint.test.ts
@@ -1,0 +1,324 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for GET /api/codex/doctor and the exported `probeCodexDoctor`.
+ *
+ * Codex has no `codex doctor` subcommand, so install detection shells
+ * `codex --version` and auth detection is a separate filesystem / env check.
+ * We mock spawnSync (install probe) and existsSync (auth-file probe) so the
+ * tests run without a real codex binary or a real `~/.codex/auth.json`.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Mock node:child_process and node:fs before importing the module under test
+// so vi.mock hoisting applies correctly.
+const spawnSyncMock = vi.fn();
+const existsSyncMock = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  spawnSync: (...args: unknown[]) => spawnSyncMock(...args),
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: (...args: unknown[]) => existsSyncMock(...args),
+}));
+
+const { addCodexDoctorRoutes, probeCodexDoctor } = await import(
+  '../../src/api/codex-doctor-endpoint.js'
+);
+
+interface CodexDoctorBody {
+  installed: boolean;
+  authenticated: boolean;
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+interface CodexDoctorConfig {
+  codexPath?: string;
+  codexDoctorTimeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+  authFileExists?: boolean;
+}
+
+function buildApp(config: CodexDoctorConfig = {}) {
+  const app = new Hono();
+  addCodexDoctorRoutes(app, config);
+  return app;
+}
+
+beforeEach(() => {
+  spawnSyncMock.mockReset();
+  existsSyncMock.mockReset();
+  // Default: no auth file on disk unless a test opts in.
+  existsSyncMock.mockReturnValue(false);
+});
+
+describe('GET /api/codex/doctor — install detection', () => {
+  it('returns installed:false when codex binary is not found (ENOENT)', async () => {
+    spawnSyncMock.mockReturnValue({
+      status: null,
+      signal: null,
+      error: Object.assign(new Error('spawn codex ENOENT'), { code: 'ENOENT' }),
+      stdout: '',
+      stderr: '',
+    });
+
+    const app = buildApp();
+    const res = await app.request('/api/codex/doctor');
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as CodexDoctorBody;
+    expect(body.installed).toBe(false);
+    expect(body.authenticated).toBe(false);
+    expect(body.exitCode).toBeNull();
+    expect(body.stdout).toBe('');
+    expect(body.stderr).toBe('');
+  });
+
+  it('returns installed:true, exitCode:0 when codex --version succeeds', async () => {
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      signal: null,
+      error: undefined,
+      stdout: 'codex 1.2.3\n',
+      stderr: '',
+    });
+
+    const app = buildApp({ env: {} });
+    const res = await app.request('/api/codex/doctor');
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as CodexDoctorBody;
+    expect(body.installed).toBe(true);
+    expect(body.exitCode).toBe(0);
+    expect(body.stdout).toContain('codex 1.2.3');
+    expect(body.stderr).toBe('');
+  });
+
+  it('returns installed:true, exitCode:1 with stderr when codex --version reports a config issue', async () => {
+    const diagnosticMsg = 'error: failed to load configuration';
+    spawnSyncMock.mockReturnValue({
+      status: 1,
+      signal: null,
+      error: undefined,
+      stdout: '',
+      stderr: diagnosticMsg,
+    });
+
+    const app = buildApp({ env: {} });
+    const res = await app.request('/api/codex/doctor');
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as CodexDoctorBody;
+    expect(body.installed).toBe(true);
+    expect(body.exitCode).toBe(1);
+    // Non-zero exit means auth is not meaningful even if credentials exist.
+    expect(body.authenticated).toBe(false);
+    expect(body.stdout).toBe('');
+    expect(body.stderr).toBe(diagnosticMsg);
+  });
+
+  it('treats EACCES (binary exists but not executable) as installed:true (config-issue, not install prompt)', async () => {
+    spawnSyncMock.mockReturnValue({
+      status: null,
+      signal: null,
+      error: Object.assign(new Error('spawn codex EACCES'), { code: 'EACCES' }),
+      stdout: '',
+      stderr: '',
+    });
+
+    const app = buildApp({ env: {} });
+    const res = await app.request('/api/codex/doctor');
+    const body = (await res.json()) as CodexDoctorBody;
+
+    expect(body.installed).toBe(true);
+    expect(body.authenticated).toBe(false);
+    expect(body.exitCode).toBeNull();
+  });
+
+  it('treats spawnSync timeout (ETIMEDOUT) as installed:true with exitCode null', async () => {
+    spawnSyncMock.mockReturnValue({
+      status: null,
+      signal: 'SIGTERM',
+      error: Object.assign(new Error('ETIMEDOUT'), { code: 'ETIMEDOUT' }),
+      stdout: '',
+      stderr: '',
+    });
+
+    const app = buildApp({ env: {} });
+    const res = await app.request('/api/codex/doctor');
+    const body = (await res.json()) as CodexDoctorBody;
+
+    expect(body.installed).toBe(true);
+    expect(body.authenticated).toBe(false);
+    expect(body.exitCode).toBeNull();
+  });
+
+  it('uses the configured codexPath binary', async () => {
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      signal: null,
+      error: undefined,
+      stdout: '',
+      stderr: '',
+    });
+
+    const app = buildApp({ codexPath: '/opt/codex/bin/codex', env: {} });
+    await app.request('/api/codex/doctor');
+
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      '/opt/codex/bin/codex',
+      ['--version'],
+      expect.objectContaining({ timeout: 30_000 }),
+    );
+  });
+
+  it('uses the configured codexDoctorTimeoutMs', async () => {
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      signal: null,
+      error: undefined,
+      stdout: '',
+      stderr: '',
+    });
+
+    const app = buildApp({ codexDoctorTimeoutMs: 5_000, env: {} });
+    await app.request('/api/codex/doctor');
+
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      'codex',
+      ['--version'],
+      expect.objectContaining({ timeout: 5_000 }),
+    );
+  });
+
+  it('truncates stdout and stderr to 4000 characters', async () => {
+    const longOutput = 'x'.repeat(5000);
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      signal: null,
+      error: undefined,
+      stdout: longOutput,
+      stderr: longOutput,
+    });
+
+    const app = buildApp({ env: {} });
+    const res = await app.request('/api/codex/doctor');
+    const body = (await res.json()) as CodexDoctorBody;
+
+    expect(body.stdout).toHaveLength(4000);
+    expect(body.stderr).toHaveLength(4000);
+  });
+});
+
+describe('probeCodexDoctor — auth detection', () => {
+  function okSpawn() {
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      signal: null,
+      error: undefined,
+      stdout: 'codex 1.2.3\n',
+      stderr: '',
+    });
+  }
+
+  it('authenticated:true when OPENAI_API_KEY env var is present', () => {
+    okSpawn();
+    existsSyncMock.mockReturnValue(false);
+
+    const result = probeCodexDoctor({ env: { OPENAI_API_KEY: 'sk-test-123' } });
+    expect(result.installed).toBe(true);
+    expect(result.authenticated).toBe(true);
+    // env-based auth short-circuits the filesystem probe.
+    expect(existsSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('authenticated:false when OPENAI_API_KEY is absent and no auth file exists', () => {
+    okSpawn();
+    existsSyncMock.mockReturnValue(false);
+
+    const result = probeCodexDoctor({ env: {} });
+    expect(result.installed).toBe(true);
+    expect(result.authenticated).toBe(false);
+  });
+
+  it('treats an empty/whitespace OPENAI_API_KEY as absent', () => {
+    okSpawn();
+    existsSyncMock.mockReturnValue(false);
+
+    const result = probeCodexDoctor({ env: { OPENAI_API_KEY: '   ' } });
+    expect(result.authenticated).toBe(false);
+  });
+
+  it('authenticated:true when ~/.codex/auth.json exists', () => {
+    okSpawn();
+    existsSyncMock.mockImplementation((p: string) => p.endsWith('/.codex/auth.json'));
+
+    const result = probeCodexDoctor({ env: {} });
+    expect(result.authenticated).toBe(true);
+  });
+
+  it('checks $CODEX_HOME/auth.json when CODEX_HOME is set', () => {
+    okSpawn();
+    existsSyncMock.mockImplementation(
+      (p: string) => p === '/custom/codex/auth.json',
+    );
+
+    const result = probeCodexDoctor({ env: { CODEX_HOME: '/custom/codex' } });
+    expect(result.authenticated).toBe(true);
+    expect(existsSyncMock).toHaveBeenCalledWith('/custom/codex/auth.json');
+  });
+
+  it('authenticated:false when CODEX_HOME is set but its auth.json is absent', () => {
+    okSpawn();
+    existsSyncMock.mockReturnValue(false);
+
+    const result = probeCodexDoctor({ env: { CODEX_HOME: '/custom/codex' } });
+    expect(result.authenticated).toBe(false);
+    expect(existsSyncMock).toHaveBeenCalledWith('/custom/codex/auth.json');
+  });
+
+  it('honours the authFileExists test-override branch (true)', () => {
+    okSpawn();
+
+    const result = probeCodexDoctor({ env: {}, authFileExists: true });
+    expect(result.authenticated).toBe(true);
+    // Override skips the real filesystem probe.
+    expect(existsSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('honours the authFileExists test-override branch (false, no api key)', () => {
+    okSpawn();
+
+    const result = probeCodexDoctor({ env: {}, authFileExists: false });
+    expect(result.authenticated).toBe(false);
+    expect(existsSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('authFileExists:false still authenticates when OPENAI_API_KEY is present', () => {
+    okSpawn();
+
+    const result = probeCodexDoctor({
+      env: { OPENAI_API_KEY: 'sk-test-123' },
+      authFileExists: false,
+    });
+    expect(result.authenticated).toBe(true);
+  });
+
+  it('authenticated:false when binary is not installed even if credentials exist', () => {
+    spawnSyncMock.mockReturnValue({
+      status: null,
+      signal: null,
+      error: Object.assign(new Error('spawn codex ENOENT'), { code: 'ENOENT' }),
+      stdout: '',
+      stderr: '',
+    });
+
+    const result = probeCodexDoctor({ env: { OPENAI_API_KEY: 'sk-test-123' } });
+    expect(result.installed).toBe(false);
+    expect(result.authenticated).toBe(false);
+  });
+});

--- a/client/test/daemon/claim-readiness-gate.test.ts
+++ b/client/test/daemon/claim-readiness-gate.test.ts
@@ -133,6 +133,43 @@ describe('Daemon — claim readiness gate (#330)', () => {
     await daemon.stop();
   });
 
+  it('does NOT claim for a Codex SolverNet when the codex harness reports not ready (#348)', async () => {
+    // Same-shape regression as the Hermes case above: a Codex-harness
+    // SolverNet whose `codex` CLI is missing must not have tasks claimed
+    // against it. The gate is harness-agnostic — it reads whatever reason
+    // the registry surfaces — so a codex-flavoured not-ready reason must
+    // block claims exactly as the hermes one does.
+    const adapter = new LocalAdapter();
+    const claimSpy = vi.spyOn(adapter, 'claimTask');
+
+    const registry = controlledRegistry(() => ({
+      ready: false,
+      reason: 'codex binary not installed',
+    }));
+
+    const daemon = new Daemon({
+      adapter,
+      runner: new SimpleRunner(async (d) => `done: ${d}`),
+      taskSources: [],
+      dbPath: ':memory:',
+      restorationEngine: minimalEngineConfig(),
+      harnessReadinessRegistry: registry,
+    });
+    await daemon.start();
+
+    await adapter.postTask({
+      id: 'task-codex-not-ready',
+      description: 'codex SolverNet — gate not ready',
+      solverNetManifestCid: 'bafkrei.codex-cid',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(registry.isReadyForClaim).toHaveBeenCalledWith('bafkrei.codex-cid');
+    expect(claimSpy).not.toHaveBeenCalled();
+
+    await daemon.stop();
+  });
+
   it('surfaces the not-ready reason via a warn log on first transition', async () => {
     const adapter = new LocalAdapter();
 

--- a/client/test/harnesses/impls/learner/codex-is-ready.test.ts
+++ b/client/test/harnesses/impls/learner/codex-is-ready.test.ts
@@ -1,0 +1,79 @@
+// client/test/harnesses/impls/learner/codex-is-ready.test.ts
+//
+// Regression coverage for #348 (same-shape bug as #330): a `LearnerHarness`
+// constructed with `name === CODEX_HARNESS` MUST probe the codex CLI in
+// `isReady()`, not the claude CLI. Pre-fix the Codex variant delegated to
+// `buildClaudeIsReady`, so a Codex-harness SolverNet looked always-ready
+// even with no `codex` install — operators selecting Codex on a fresh
+// machine hit the same N/N failed-claim cascade #330 described.
+import { describe, expect, it, vi } from 'vitest';
+import { LearnerHarness } from '../../../../src/harnesses/impls/learner/index.js';
+import { CODEX_HARNESS } from '../../../../src/harnesses/names.js';
+import { probeCodexDoctor } from '../../../../src/api/codex-doctor-endpoint.js';
+import type {
+  HarnessAdapter,
+  TaskSessionInputs,
+} from '../../../../src/harnesses/impls/learner/types.js';
+
+vi.mock('../../../../src/api/codex-doctor-endpoint.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../../src/api/codex-doctor-endpoint.js')>();
+  return {
+    ...actual,
+    probeCodexDoctor: vi.fn(),
+  };
+});
+
+/** Minimal no-op adapter to satisfy the required `adapter` field. */
+class NoOpAdapter implements HarnessAdapter {
+  readonly name = 'noop';
+  readonly allowsHarnessSelfModification = false;
+  async runTask(_inputs: TaskSessionInputs): Promise<void> {}
+}
+
+describe('LearnerHarness.isReady — Codex variant (#348)', () => {
+  it('returns ready=true when probeCodexDoctor reports installed, exit 0, authenticated', async () => {
+    vi.mocked(probeCodexDoctor).mockReturnValue({
+      installed: true,
+      authenticated: true,
+      exitCode: 0,
+      stdout: 'codex 1.2.3',
+      stderr: '',
+    });
+    const harness = new LearnerHarness({ name: CODEX_HARNESS, adapter: new NoOpAdapter() });
+    const result = await harness.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+    expect(result.ready).toBe(true);
+    expect(probeCodexDoctor).toHaveBeenCalled();
+  });
+
+  it('returns ready=false with install nextStep when codex binary missing', async () => {
+    vi.mocked(probeCodexDoctor).mockReturnValue({
+      installed: false,
+      authenticated: false,
+      exitCode: null,
+      stdout: '',
+      stderr: '',
+    });
+    const harness = new LearnerHarness({ name: CODEX_HARNESS, adapter: new NoOpAdapter() });
+    const result = await harness.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+    expect(result.ready).toBe(false);
+    expect(result.reason).toMatch(/not installed/i);
+    expect(result.nextStep?.description).toMatch(/install/i);
+    expect(result.nextStep?.url).toBe('/api/codex/doctor');
+  });
+
+  it('returns ready=false with sign-in nextStep when codex auth not configured', async () => {
+    vi.mocked(probeCodexDoctor).mockReturnValue({
+      installed: true,
+      authenticated: false,
+      exitCode: 0,
+      stdout: 'codex 1.2.3',
+      stderr: '',
+    });
+    const harness = new LearnerHarness({ name: CODEX_HARNESS, adapter: new NoOpAdapter() });
+    const result = await harness.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+    expect(result.ready).toBe(false);
+    expect(result.reason).toMatch(/auth/i);
+    expect(result.nextStep?.description).toMatch(/sign in|OPENAI_API_KEY|codex login/i);
+  });
+});


### PR DESCRIPTION
## Summary

`LearnerHarness` with `name=CODEX_HARNESS` delegated `isReady()` to `buildClaudeIsReady`, which probes the **claude** CLI — not codex. A Codex-harness SolverNet therefore had an always-ready claim-loop gate even with no working `codex` install, so operators selecting Codex on a fresh machine hit the same N/N failed-claim cascade #330 described. This is the same-shape bug as #344's Hermes fix, surfaced during parity-review on #344.

- Add `probeCodexDoctor` in `client/src/api/codex-doctor-endpoint.ts`, mirroring `hermes-doctor-endpoint.ts`: `codex --version` for install detection, plus an `OPENAI_API_KEY` / `codex login` auth-file check. Detects binary missing, version exit-code != 0, and auth not configured — each returning `{ ok: false, reason, nextStep }` with an operator-actionable hint.
- Branch `LearnerHarness.isReady` on `name === CODEX_HARNESS` → `probeCodexDoctor`; the claude-code variant is unchanged (still `buildClaudeIsReady`).
- Add `codexPath` / `codexDoctorTimeoutMs` to `LearnerHarnessConfig`, wired from `HarnessEnv` in `harnesses/impls/index.ts`.
- Mount `GET /api/codex/doctor` alongside the existing hermes precheck route so the `nextStep` URL resolves.

## Test plan

- [x] New `client/test/harnesses/impls/learner/codex-is-ready.test.ts` — 3 cases: ready (installed + exit 0 + authed), not-ready with install nextStep (binary missing), not-ready with sign-in nextStep (auth not configured).
- [x] Extended `client/test/daemon/claim-readiness-gate.test.ts` with a codex SolverNet case asserting a codex-flavoured not-ready reason blocks claims (daemon-level regression, mirrors #344).
- [x] `tsc --noEmit` — zero errors.
- [x] Full client suite: 454 files passed / 5 skipped, 3701 tests passed / 7 skipped.

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)