### PR TITLE
feat(334): inline decision-context help in SolverNet join form

### DIFF
--- a/client/docs/operator/join-form-context.md
+++ b/client/docs/operator/join-form-context.md
@@ -1,0 +1,148 @@
+# Joining a SolverNet — decision context
+
+This page is the long-form companion to the operator-side join form
+(`/operator/join/:cid` in the dashboard). The form asks you to make a few
+consequential choices — which roles to take, which harness and model to run,
+which plug-ins to load. The inline help next to each field carries the short
+answer; this page carries the full one.
+
+Most of these choices are reversible. You can leave a SolverNet and re-join
+with different settings; nothing here locks you in. But the choices do affect
+what you spend and what you earn, so it is worth reading once.
+
+## Solver vs Evaluator
+
+A SolverNet runs the Jinn loop: tasks are created, **solvers** attempt them,
+**evaluators** verify the solutions, and the verified result becomes knowledge.
+You can take either role, or both, on any SolverNet that lists them as open.
+
+**Solver** — your daemon claims open tasks, runs the harness against them, and
+submits solutions on-chain.
+
+- *Token use.* This is the spending role. Every task attempt runs your harness
+  — that is model inference (your API key or subscription) plus the gas to
+  submit the solution. A solver that claims aggressively spends more.
+- *Reward profile.* Solvers earn from the SolverNet's solution rewards when
+  their submitted solution is accepted. Upside scales with how well your
+  harness performs against the evaluation function — a better forecaster on a
+  prediction SolverNet, for example, earns more per task.
+- *In the loop.* Solvers are the supply side of attempts. The corpus of
+  verified solutions you contribute to also feeds back: your agent learns from
+  what worked, which compounds over time. That compounding is the part most
+  first-run operators are not yet thinking about — it is the reason to pick a
+  SolverNet you intend to stay on.
+
+**Evaluator** — your daemon claims submitted solutions and runs the
+SolverNet's evaluation function to produce a verdict.
+
+- *Token use.* Usually lower than solving. The evaluation function is fixed by
+  the SolverNet's contract — for many SolverNets it is deterministic (a Brier
+  score, a test-suite pass/fail) and does not call a model at all. When it
+  does, the cost is bounded by that function, not by an open-ended harness run.
+- *Reward profile.* Evaluators earn from the SolverNet's verdict rewards for
+  producing verdicts. The work is more uniform than solving — you are not
+  competing on cleverness, you are competing on availability and correctness.
+- *In the loop.* Evaluators are the trust layer. Without verdicts, no solution
+  becomes knowledge. It is a lower-variance role: steadier, less spend, less
+  per-task upside, but it is not a lesser role.
+
+**Both.** Taking both roles is allowed and common — your daemon will claim
+both tasks and solutions. It is more total work and more total spend, but it
+also means you are not idle when one side of the loop is quiet.
+
+**If you are unsure:** start as a solver on one SolverNet whose outcomes you
+understand, with a model you already pay for. Add the evaluator role, or a
+second SolverNet, once the loop is running and you have seen the spend.
+
+## Harness and model
+
+The **harness** is the runtime that actually executes a task — it takes the
+task, drives a model (and any plug-ins), and produces a solution. The
+**model** is the LLM the harness drives.
+
+The harness picker only appears for the **solver** role. The evaluator role
+binds its harness from the SolverNet's manifest — see "Why the Evaluator role
+has no model selector" below.
+
+### Do I need subscriptions to both?
+
+No — you need credentials for **one** of them, not both, and it depends on the
+harness:
+
+- **Claude Code harness** — runs the `claude` CLI as a subprocess. It uses
+  whatever authentication the CLI is already configured with on the machine:
+  either a Claude subscription (Pro / Max) signed in to the CLI, or an
+  Anthropic API key. You do not need a separate harness subscription.
+- **Hermes Agent harness** — a self-improving agent by Nous Research with a
+  built-in learning loop. It is a separate package; the join form runs an
+  install precheck before it lets you join with Hermes selected. Its model
+  authentication is the harness's own — follow the precheck panel's
+  instructions.
+
+The default the form shows you (harness + model) is the SolverNet's first
+compatible option, not a recommendation that you must pay for two things. Pick
+the harness whose credentials you already have. If neither is set up, the
+Claude Code harness with an Anthropic API key is the lowest-friction start.
+
+### Can I combine any harness with any model?
+
+Not freely. The model list is filtered to the models the selected harness
+supports — when you change the harness, the model resets to that harness's
+default. If a SolverNet's manifest constrains the harness, the picker only
+shows compatible options.
+
+### Install and auth
+
+- Claude Code: install the `claude` CLI and sign in (subscription) or export
+  `ANTHROPIC_API_KEY` (raw API). See the daemon's setup runbook.
+- Hermes Agent: the join form's precheck panel walks you through the install
+  command if it is missing. Do not reinstall if the precheck reports a network
+  error — that means the daemon is unreachable, not that Hermes is absent.
+
+## Plug-ins
+
+Plug-ins are optional. **On a first run you almost certainly do not need to
+touch this section** — leave the defaults and join.
+
+A SolverPlugin is normal AI tooling — MCP servers, Claude Code or Gemini
+extensions, skills, prompts, local docs or examples — that a harness can load
+while it solves tasks. They do not execute tasks themselves and they are not
+SolverNet authority; they are reusable substrate that can help a harness do
+better on a particular kind of task.
+
+When you *would* think about plug-ins:
+
+- A SolverNet ships a bundled plug-in tailored to its task type (for example,
+  `jinn-prediction-plugin` for prediction SolverNets). These are usually
+  enabled by default — you are mostly choosing whether to keep them.
+- You have built or installed a SolverPlugin of your own and want this
+  SolverNet's harness to load it.
+
+If you have neither, skip the section. You can always re-join later with
+plug-ins added once you know what you want from them. See the SolverPlugin
+quickstart for how plug-ins are built and installed.
+
+## Why the Evaluator role has no model selector
+
+When you select the evaluator role and not the solver role, the form shows no
+harness or model picker — just a line naming the bound evaluation function.
+This is not a sign that the evaluator role is underdeveloped or
+uninteresting.
+
+The evaluator's harness is **bound by the SolverNet's manifest**, specifically
+by `contract.evaluationFunction.implementation`. The whole point of an
+evaluator is to be a predictable, agreed-upon check — every evaluator on a
+SolverNet runs the *same* evaluation function so that verdicts are comparable
+and trustworthy. If each operator picked their own model, verdicts would not
+agree, and the trust layer would not be a layer.
+
+So there is nothing for you to configure: the SolverNet already decided what
+the evaluator runs. For many SolverNets that function is deterministic and
+does not call a model at all. The empty selector means "this is fixed", not
+"this is unfinished".
+
+## See also
+
+- SolverPlugin quickstart — `client/docs/solver-plugins.md`
+- Launching a SolverNet (the other side of the join) — `client/docs/launch-solvernet.md`
+- Harness SDK — `client/docs/path-2/README.md`

--- a/client/src/dashboard/spa/src/components/InlineHelp.test.tsx
+++ b/client/src/dashboard/spa/src/components/InlineHelp.test.tsx
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { InlineHelp } from './InlineHelp.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('InlineHelp', () => {
+  it('renders the trigger collapsed by default', () => {
+    render(<InlineHelp label="Roles help">Decision context.</InlineHelp>);
+    const trigger = screen.getByTestId('inline-help-trigger');
+    expect(trigger.getAttribute('aria-label')).toBe('Roles help');
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByTestId('inline-help-panel')).toBeNull();
+  });
+
+  it('expands the panel when the trigger is clicked', () => {
+    render(<InlineHelp label="Roles help">Decision context.</InlineHelp>);
+    fireEvent.click(screen.getByTestId('inline-help-trigger'));
+    const panel = screen.getByTestId('inline-help-panel');
+    expect(panel).toBeTruthy();
+    expect(panel.textContent).toMatch(/decision context/i);
+    expect(
+      screen.getByTestId('inline-help-trigger').getAttribute('aria-expanded'),
+    ).toBe('true');
+  });
+
+  it('collapses again on a second click', () => {
+    render(<InlineHelp label="Roles help">Decision context.</InlineHelp>);
+    const trigger = screen.getByTestId('inline-help-trigger');
+    fireEvent.click(trigger);
+    expect(screen.getByTestId('inline-help-panel')).toBeTruthy();
+    fireEvent.click(trigger);
+    expect(screen.queryByTestId('inline-help-panel')).toBeNull();
+  });
+
+  it('renders a doc link inside the panel when docHref is supplied', () => {
+    render(
+      <InlineHelp
+        label="Roles help"
+        docHref="https://example.com/docs#roles"
+        docLabel="Full guide"
+      >
+        Short copy.
+      </InlineHelp>,
+    );
+    fireEvent.click(screen.getByTestId('inline-help-trigger'));
+    const link = screen.getByTestId('inline-help-doc-link');
+    expect(link.getAttribute('href')).toBe('https://example.com/docs#roles');
+    expect(link.textContent).toBe('Full guide');
+  });
+
+  it('omits the doc link when docHref is not supplied', () => {
+    render(<InlineHelp label="Roles help">Short copy.</InlineHelp>);
+    fireEvent.click(screen.getByTestId('inline-help-trigger'));
+    expect(screen.queryByTestId('inline-help-doc-link')).toBeNull();
+  });
+});

--- a/client/src/dashboard/spa/src/components/InlineHelp.tsx
+++ b/client/src/dashboard/spa/src/components/InlineHelp.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react';
+
+/**
+ * Expandable inline help. A small "i" trigger sits next to a field label;
+ * clicking it reveals a short decision-context panel below the label without
+ * leaving the form (Issue #334 — operators were choosing roles / harnesses /
+ * plug-ins with no trade-off context).
+ *
+ * The panel carries the *short* answer. The full long-form copy lives in
+ * `client/docs/operator/join-form-context.md`; `docHref` points the operator
+ * there when they want the complete picture.
+ */
+export interface InlineHelpProps {
+  /** Accessible label for the trigger, e.g. "Roles help". */
+  label: string;
+  /** Short decision-context copy shown in the expandable panel. */
+  children: React.ReactNode;
+  /** Optional link to the long-form doc section. */
+  docHref?: string;
+  /** Visible text for the doc link. Defaults to "Read more". */
+  docLabel?: string;
+}
+
+export function InlineHelp({
+  label,
+  children,
+  docHref,
+  docLabel = 'Read more',
+}: InlineHelpProps): JSX.Element {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <span style={{ display: 'inline-flex', flexDirection: 'column', gap: '6px' }}>
+      <button
+        type="button"
+        data-testid="inline-help-trigger"
+        aria-label={label}
+        aria-expanded={open}
+        onClick={() => setOpen((prev) => !prev)}
+        style={{
+          width: '14px',
+          height: '14px',
+          lineHeight: '12px',
+          padding: 0,
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontFamily: "'JetBrains Mono', monospace",
+          fontSize: '10px',
+          fontWeight: 600,
+          fontStyle: 'italic',
+          color: 'var(--fg-muted)',
+          background: 'var(--bg-elevated)',
+          border: '1px solid var(--fg-muted)',
+          borderRadius: 'var(--radius-2)',
+          cursor: 'pointer',
+        }}
+      >
+        i
+      </button>
+      {open && (
+        <span
+          data-testid="inline-help-panel"
+          role="note"
+          style={{
+            display: 'block',
+            background: 'var(--bg-elevated)',
+            border: '1px solid var(--border)',
+            borderRadius: 'var(--radius-2)',
+            padding: '10px 12px',
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '11px',
+            lineHeight: 1.6,
+            fontWeight: 400,
+            letterSpacing: 'normal',
+            textTransform: 'none',
+            color: 'var(--fg-muted)',
+            maxWidth: '420px',
+          }}
+        >
+          {children}
+          {docHref && (
+            <>
+              {' '}
+              <a
+                data-testid="inline-help-doc-link"
+                href={docHref}
+                target="_blank"
+                rel="noreferrer"
+                style={{ color: 'var(--accent-sky)' }}
+              >
+                {docLabel}
+              </a>
+            </>
+          )}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
@@ -940,3 +940,107 @@ describe('JoinFlow — cost surfacing + confirmation gate (Issue #331 P0)', () =
     expect(submit.disabled).toBe(true);
   });
 });
+
+describe('JoinFlow — inline decision-context help (#334)', () => {
+  it('renders a help trigger next to the Roles label', async () => {
+    wrap(<JoinFlow />);
+    await waitFor(() =>
+      expect(screen.getByTestId('join-flow-summary')).toBeTruthy(),
+    );
+
+    expect(screen.getByRole('button', { name: 'Roles help' })).toBeTruthy();
+  });
+
+  it('expands Roles help with solver-vs-evaluator trade-off copy', async () => {
+    wrap(<JoinFlow />);
+    await waitFor(() =>
+      expect(screen.getByTestId('join-flow-summary')).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Roles help' }));
+
+    const panels = screen.getAllByTestId('inline-help-panel');
+    expect(panels.length).toBeGreaterThan(0);
+    const rolesPanel = panels.find((p) =>
+      /spending role/i.test(p.textContent ?? ''),
+    );
+    expect(rolesPanel).toBeTruthy();
+    expect(rolesPanel?.textContent).toMatch(/evaluator/i);
+  });
+
+  it('shows Harness, Model and Plugins help triggers once the solver role is selected', async () => {
+    wrap(<JoinFlow />);
+    await waitFor(() =>
+      expect(screen.getByTestId('join-flow-summary')).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByLabelText('Solver'));
+
+    expect(screen.getByRole('button', { name: 'Harness help' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Model help' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Plugins help' })).toBeTruthy();
+  });
+
+  it('Harness help explains harnesses need credentials for one, not both', async () => {
+    wrap(<JoinFlow />);
+    await waitFor(() =>
+      expect(screen.getByTestId('join-flow-summary')).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByLabelText('Solver'));
+    fireEvent.click(screen.getByRole('button', { name: 'Harness help' }));
+
+    const panels = screen.getAllByTestId('inline-help-panel');
+    const harnessPanel = panels.find((p) =>
+      /credentials for one harness/i.test(p.textContent ?? ''),
+    );
+    expect(harnessPanel).toBeTruthy();
+  });
+
+  it('Plugins help tells first-run operators they can skip the section', async () => {
+    wrap(<JoinFlow />);
+    await waitFor(() =>
+      expect(screen.getByTestId('join-flow-summary')).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByLabelText('Solver'));
+    fireEvent.click(screen.getByRole('button', { name: 'Plugins help' }));
+
+    const panels = screen.getAllByTestId('inline-help-panel');
+    const pluginsPanel = panels.find((p) =>
+      /do not need to touch/i.test(p.textContent ?? ''),
+    );
+    expect(pluginsPanel).toBeTruthy();
+  });
+
+  it('Evaluator-info help explains the empty model selector is by design', async () => {
+    wrap(<JoinFlow />);
+    await waitFor(() =>
+      expect(screen.getByTestId('join-flow-summary')).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByLabelText('Evaluator'));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Evaluator configuration help' }),
+    );
+
+    const panels = screen.getAllByTestId('inline-help-panel');
+    const evalPanel = panels.find((p) =>
+      /by design/i.test(p.textContent ?? ''),
+    );
+    expect(evalPanel).toBeTruthy();
+    expect(evalPanel?.textContent).toMatch(/same evaluation function/i);
+  });
+
+  it('inline help links out to the join-form-context doc', async () => {
+    wrap(<JoinFlow />);
+    await waitFor(() =>
+      expect(screen.getByTestId('join-flow-summary')).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Roles help' }));
+
+    const link = screen.getByTestId('inline-help-doc-link');
+    expect(link.getAttribute('href')).toMatch(/join-form-context\.md/);
+  });
+});

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
@@ -23,9 +23,18 @@ import {
 import { PluginPicker } from '../configuration/PluginPicker.js';
 import { CostEstimatePanel, useCostSurfaceDecision } from '../configuration/CostEstimatePanel.js';
 import { formatWeiAmount } from '../launcher-launched/helpers.js';
+import { InlineHelp } from '../../components/InlineHelp.js';
 
 const HERMES_AGENT_DESCRIPTION =
   'Self-improving agent by Nous Research. Built-in learning loop.';
+
+/**
+ * Long-form decision context for the join form lives in
+ * `client/docs/operator/join-form-context.md`. Inline help points operators
+ * there for the full picture (Issue #334).
+ */
+const JOIN_FORM_CONTEXT_DOC =
+  'https://github.com/Jinn-Network/mono/blob/main/cargo/client/docs/operator/join-form-context.md';
 
 /**
  * Operator participation flow keyed by `manifestCid`.
@@ -328,7 +337,19 @@ export function JoinFlow({
       </section>
 
       <section style={cardStyle}>
-        <span style={cardLabelStyle}>Roles</span>
+        <span style={labelRowStyle}>
+          <span style={cardLabelStyle}>Roles</span>
+          <InlineHelp
+            label="Roles help"
+            docHref={`${JOIN_FORM_CONTEXT_DOC}#solver-vs-evaluator`}
+          >
+            Solver attempts tasks and submits solutions — this is the
+            spending role (model inference + gas) and the one with the most
+            per-task upside. Evaluator verifies others' solutions — lower spend,
+            steadier, lower variance. You can take either or both. Unsure? Start
+            as a solver on one SolverNet with a model you already pay for.
+          </InlineHelp>
+        </span>
         <div
           style={{
             display: 'grid',
@@ -404,7 +425,22 @@ export function JoinFlow({
             }}
           >
             <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
-              <span style={fieldLabelStyle}>Harness</span>
+              <span style={labelRowStyle}>
+                <span style={fieldLabelStyle}>Harness</span>
+                <InlineHelp
+                  label="Harness help"
+                  docHref={`${JOIN_FORM_CONTEXT_DOC}#harness-and-model`}
+                >
+                  The harness is the runtime that executes a task. You need
+                  credentials for one harness, not for the harness and the
+                  model both. Claude Code uses whatever the `claude` CLI is
+                  signed in with — a Claude subscription or an Anthropic API
+                  key. Hermes Agent is a separate package; the join form runs an
+                  install precheck for it. The default shown is the SolverNet's
+                  first compatible option, not a recommendation to pay for two
+                  things.
+                </InlineHelp>
+              </span>
               <select
                 aria-label="Harness"
                 data-testid="join-harness-select"
@@ -448,7 +484,20 @@ export function JoinFlow({
             </div>
 
             <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
-              <span style={fieldLabelStyle}>Model</span>
+              <span style={labelRowStyle}>
+                <span style={fieldLabelStyle}>Model</span>
+                <InlineHelp
+                  label="Model help"
+                  docHref={`${JOIN_FORM_CONTEXT_DOC}#harness-and-model`}
+                >
+                  The model is the LLM the harness drives. The list is filtered
+                  to the models the selected harness supports — changing the
+                  harness resets the model to that harness's default. You pay
+                  for the model through the harness's credentials; there is no
+                  separate model subscription on top of that. See the cost
+                  estimate below before you commit.
+                </InlineHelp>
+              </span>
               <select
                 aria-label="Model"
                 data-testid="join-model-select"
@@ -519,7 +568,20 @@ export function JoinFlow({
           )}
 
           <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-            <span style={fieldLabelStyle}>Plugins</span>
+            <span style={labelRowStyle}>
+              <span style={fieldLabelStyle}>Plugins</span>
+              <InlineHelp
+                label="Plugins help"
+                docHref={`${JOIN_FORM_CONTEXT_DOC}#plug-ins`}
+              >
+                Plug-ins are optional — on a first run you almost certainly do
+                not need to touch this. A SolverPlugin is reusable AI tooling
+                (MCP servers, skills, extensions) a harness can load while it
+                solves. SolverNets ship task-specific plug-ins enabled by
+                default; you would only add your own here if you have built one.
+                You can re-join later with plug-ins added.
+              </InlineHelp>
+            </span>
             <PluginPicker
               available={catalogEntry?.compatiblePlugins ?? []}
               selected={form.plugins}
@@ -537,7 +599,20 @@ export function JoinFlow({
 
       {showEvaluatorInfo && !showSolverFields && (
         <section data-testid="join-flow-evaluator-info" style={cardStyle}>
-          <span style={cardLabelStyle}>Evaluator configuration</span>
+          <span style={labelRowStyle}>
+            <span style={cardLabelStyle}>Evaluator configuration</span>
+            <InlineHelp
+              label="Evaluator configuration help"
+              docHref={`${JOIN_FORM_CONTEXT_DOC}#why-the-evaluator-role-has-no-model-selector`}
+            >
+              There is no harness or model picker for the evaluator role — and
+              that is by design, not a sign the role is underdeveloped. Every
+              evaluator on a SolverNet must run the same evaluation function so
+              verdicts are comparable, so the SolverNet's manifest binds it for
+              you. For many SolverNets that function is deterministic and calls
+              no model at all.
+            </InlineHelp>
+          </span>
           <p
             style={{
               fontFamily: "'JetBrains Mono', monospace",
@@ -557,7 +632,18 @@ export function JoinFlow({
 
       {showEvaluatorInfo && showSolverFields && (
         <section data-testid="join-flow-evaluator-info" style={cardStyle}>
-          <span style={cardLabelStyle}>Evaluator binding</span>
+          <span style={labelRowStyle}>
+            <span style={cardLabelStyle}>Evaluator binding</span>
+            <InlineHelp
+              label="Evaluator binding help"
+              docHref={`${JOIN_FORM_CONTEXT_DOC}#why-the-evaluator-role-has-no-model-selector`}
+            >
+              The evaluator harness is bound by the SolverNet's manifest so
+              every evaluator runs the same evaluation function — verdicts have
+              to be comparable to be trustworthy. The harness and model fields
+              above configure only the solver role.
+            </InlineHelp>
+          </span>
           <p
             style={{
               fontFamily: "'JetBrains Mono', monospace",
@@ -744,6 +830,13 @@ const fieldLabelStyle: React.CSSProperties = {
   letterSpacing: '0.14em',
   textTransform: 'uppercase',
   color: 'var(--fg-muted)',
+};
+
+// Row that pairs a section / field label with its InlineHelp trigger.
+const labelRowStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: '8px',
 };
 
 const selectStyle: React.CSSProperties = {


### PR DESCRIPTION
## Summary

- The SolverNet join form (`/operator/join/:cid`) left first-time operators making consequential choices — role selection, harness install dependency, model spend — with no trade-off context. Surfaced by rvx, the first public v0.1.6 operator, in his first 5 minutes (#334, parent #328).
- Adds an expandable `InlineHelp` affordance (a small "i" trigger that opens a short panel in-form) next to the **Roles**, **Harness**, **Model**, **Plugins**, and **Evaluator-info** section labels. Operators never leave the form to read it — the chosen affordance over tooltips or a side panel.
- Each panel carries the short answer; the new long-form doc `client/docs/operator/join-form-context.md` carries the full one, linked from every panel.

## What each panel answers

- **Roles** — solver vs evaluator: token use (solver is the spending role), reward profile, what each does in the loop, the compounding-corpus angle, and a "start as a solver on one SolverNet" recommendation for the unsure.
- **Harness** — you need credentials for *one* harness, not the harness and the model both; Claude Code uses the `claude` CLI's existing auth (subscription or API key), Hermes Agent is a separate package with its own precheck; the shown default is not a "pay for two things" recommendation.
- **Model** — the list is filtered to the harness's supported models; you pay through the harness's credentials; points at the cost-estimate panel.
- **Plugins** — optional; first-run operators can skip it entirely; what a SolverPlugin is and when you'd add your own.
- **Evaluator-info** — the empty model selector is *by design*: every evaluator runs the manifest-bound evaluation function so verdicts are comparable; it is not a sign the role is underdeveloped.

## Test plan

- [x] `yarn typecheck` — zero errors
- [x] `yarn test --run` — 3709 passed, 7 skipped (full suite)
- [x] New `InlineHelp.test.tsx` — 5 tests (collapsed-by-default, expand/collapse, doc-link rendering)
- [x] New JoinFlow help assertions — 7 tests covering each panel's copy + the doc link

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)