### PR TITLE
fix(333): SolverNet join success affordance + banner consistency

### DIFF
--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -202,7 +202,11 @@ export function OverviewPage(): JSX.Element {
   const jinnClaimable = formatEth(status?.rewards?.pendingStakingRewardsWei);
   const gasBalanceEth = formatEth(status?.masterGas?.balanceWei);
   const gasRunwayDays = status?.masterGas?.runwayDaysExcess ?? '—';
-  const liveNow = deriveLiveNow(status);
+  // Gate the LiveNow attention banner on the freshly-polled join map so a
+  // stale `prediction_solvernet_missing` diagnostic (the daemon only
+  // re-reads `joinedSolverNets` on restart) does not contradict the joined
+  // SolverNet shown below (#333).
+  const liveNow = deriveLiveNow(status, bootstrap?.joinedSolverNets);
   const waitingMessage = operatorWaitingMessage(joined, taskRunTotals, operator?.nextAction?.description);
   // Auto-clear timer for transient success notices (e.g. the gas top-up
   // confirmation, which should surface the amount + tx hash for ~5s then

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
@@ -733,7 +733,7 @@ describe('JoinFlow — role selection', () => {
 });
 
 describe('JoinFlow — submission', () => {
-  it('calls api.operator.join with the chosen roles + solver fields and navigates on success', async () => {
+  it('calls api.operator.join with the chosen roles + solver fields and shows the success affordance', async () => {
     const { nav } = wrap(<JoinFlow />);
     await waitFor(() =>
       expect(screen.getByTestId('join-flow-summary')).toBeTruthy(),
@@ -765,9 +765,58 @@ describe('JoinFlow — submission', () => {
         disabledDefaultPlugins: [],
       }),
     );
+    // #333: a successful join shows an explicit success state ON the join
+    // page — it must NOT silently redirect to /operator.
     await waitFor(() =>
-      expect(nav.history.at(-1)).toBe('/operator#solvernets'),
+      expect(screen.getByTestId('join-flow-success')).toBeTruthy(),
     );
+    expect(nav.history.at(-1)).toBe('/operator/join/bafybeiaaa');
+  });
+
+  it('renders a success card naming the joined SolverNet and a restart hint (#333)', async () => {
+    apiMock.operatorJoin.mockResolvedValue({
+      ok: true,
+      restartRequired: true,
+      manifestCid: 'bafybeiaaa',
+      config: {
+        manifestCid: 'bafybeiaaa',
+        name: 'Prediction Markets',
+        roles: ['solver'],
+      },
+    });
+    wrap(<JoinFlow />);
+    await waitFor(() =>
+      expect(screen.getByTestId('join-flow-summary')).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByLabelText('Solver'));
+    fireEvent.click(screen.getByTestId('join-flow-submit'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('join-flow-success-card')).toBeTruthy(),
+    );
+    expect(screen.getByTestId('join-flow-success-name').textContent).toMatch(
+      /Prediction Markets/,
+    );
+    expect(screen.getByTestId('join-flow-success-restart')).toBeTruthy();
+    // The form is gone — the operator is on a confirmation, not the picker.
+    expect(screen.queryByTestId('join-flow-submit')).toBeNull();
+  });
+
+  it('success-card CTA navigates into the joined SolverNet (#333)', async () => {
+    const { nav } = wrap(<JoinFlow />);
+    await waitFor(() =>
+      expect(screen.getByTestId('join-flow-summary')).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByLabelText('Solver'));
+    fireEvent.click(screen.getByTestId('join-flow-submit'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('join-flow-success-view')).toBeTruthy(),
+    );
+    fireEvent.click(screen.getByTestId('join-flow-success-view'));
+    expect(nav.history.at(-1)).toBe('/operator#solvernets/bafybeiaaa');
   });
 
   it('omits solver-only fields when only evaluator is selected', async () => {

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
@@ -72,6 +72,19 @@ interface JoinFormState {
 }
 
 /**
+ * Result of a successful join, retained so the flow can render an explicit
+ * success affordance on the join page rather than redirecting silently to
+ * `/operator` — the v0.1.6 dogfood paper cut where rvx couldn't tell the join
+ * had succeeded (#333).
+ */
+interface JoinSuccess {
+  manifestCid: string;
+  name: string;
+  roles: Role[];
+  restartRequired: boolean;
+}
+
+/**
  * Match a manifest's contract to a catalog entry by the canonical
  * `{id, version}` pair. Replaces the predecessor concatenated-solverType
  * string match (PRs d4491879 / 26548969 removed the `solverType` concept
@@ -182,6 +195,7 @@ export function JoinFlow({
     model: defaultModel,
   });
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [joinSuccess, setJoinSuccess] = useState<JoinSuccess | null>(null);
   const [showHermesPrecheck, setShowHermesPrecheck] = useState(false);
   // Tracks whether the operator has explicitly picked a harness in this
   // session. Once true, the catalog-arrival effect below MUST NOT stomp
@@ -239,11 +253,21 @@ export function JoinFlow({
             }
           : {}),
       }),
-    onSuccess: () => {
-      // Invalidate so the catalog's joined-indicator badge appears on the
+    onSuccess: (result) => {
+      // Invalidate so the catalog's joined-indicator badge and the Operator
+      // page's joined list / LiveNow banner pick the new entry up on the
       // next tick instead of waiting up to 30s for the next refetch.
       void queryClient.invalidateQueries({ queryKey: ['operator', 'joined'] });
-      navigate('/operator#solvernets');
+      void queryClient.invalidateQueries({ queryKey: ['bootstrap'] });
+      // Render an explicit success state on this page rather than a silent
+      // redirect to /operator — the v0.1.6 dogfood paper cut (#333). The
+      // operator confirms the join landed, then chooses where to go next.
+      setJoinSuccess({
+        manifestCid: result.manifestCid,
+        name: result.config.name ?? manifest?.name ?? result.manifestCid,
+        roles: result.config.roles,
+        restartRequired: result.restartRequired,
+      });
     },
     onError: (err) => {
       setSubmitError(err instanceof Error ? err.message : String(err));
@@ -283,6 +307,17 @@ export function JoinFlow({
             void manifestQuery.refetch();
           }}
         />
+      </main>
+    );
+  }
+
+  // Successful join — show an explicit confirmation on this page instead of
+  // a silent redirect to /operator (#333). The operator sees the SolverNet
+  // they just joined, the restart hint, and clear next-step CTAs.
+  if (joinSuccess) {
+    return (
+      <main data-testid="join-flow-success" style={pageStyle}>
+        <JoinSuccessCard success={joinSuccess} navigate={navigate} />
       </main>
     );
   }
@@ -913,6 +948,124 @@ function ErrorBanner({
         </button>
       </div>
     </div>
+  );
+}
+
+/**
+ * Post-join success affordance (#333). Renders in place of the form once the
+ * join config write succeeds: a green-bordered confirmation naming the
+ * SolverNet just joined, the restart hint when the daemon needs a restart to
+ * pick the config up, and explicit CTAs into the joined list / catalog. This
+ * replaces the silent redirect to `/operator` that left v0.1.6 operators
+ * unsure whether their join had landed.
+ */
+function JoinSuccessCard({
+  success,
+  navigate,
+}: {
+  success: JoinSuccess;
+  navigate: (path: string) => void;
+}): JSX.Element {
+  const roleLabel = success.roles
+    .map((r) => (r === 'solver' ? 'Solver' : 'Evaluator'))
+    .join(' + ');
+  return (
+    <>
+      <div
+        data-testid="join-flow-success-card"
+        role="status"
+        style={{
+          background: 'var(--bg-elevated)',
+          border: '1px solid var(--vow-green)',
+          borderRadius: 'var(--radius-3)',
+          padding: '20px 24px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '10px',
+        }}
+      >
+        <span
+          style={{
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '11px',
+            fontWeight: 500,
+            letterSpacing: '0.14em',
+            textTransform: 'uppercase',
+            color: 'var(--vow-green)',
+          }}
+        >
+          Joined
+        </span>
+        <span
+          data-testid="join-flow-success-name"
+          style={{
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '18px',
+            fontWeight: 500,
+            color: 'var(--fg)',
+          }}
+        >
+          You joined {success.name}
+        </span>
+        <span
+          style={{
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '12px',
+            color: 'var(--fg-muted)',
+            lineHeight: 1.5,
+          }}
+        >
+          You're in as {roleLabel || 'an operator'}. This SolverNet now shows in
+          your joined list.
+        </span>
+        {success.restartRequired && (
+          <span
+            data-testid="join-flow-success-restart"
+            style={{
+              fontFamily: "'JetBrains Mono', monospace",
+              fontSize: '12px',
+              color: 'var(--accent-gold)',
+              lineHeight: 1.5,
+            }}
+          >
+            Restart the node to start participating — the daemon picks up
+            SolverNet config on restart.
+          </span>
+        )}
+      </div>
+      <footer
+        style={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          alignItems: 'center',
+          gap: '12px',
+        }}
+      >
+        <button
+          type="button"
+          data-testid="join-flow-success-browse"
+          onClick={() => navigate('/operator#solvernets')}
+          style={ghostButtonStyle}
+        >
+          Browse SolverNets
+        </button>
+        <button
+          type="button"
+          data-testid="join-flow-success-view"
+          onClick={() =>
+            navigate(`/operator#solvernets/${success.manifestCid}`)
+          }
+          style={{
+            ...ghostButtonStyle,
+            background: 'var(--accent-sky)',
+            color: 'var(--bg-sunken)',
+            border: '1px solid var(--accent-sky)',
+          }}
+        >
+          View joined SolverNet
+        </button>
+      </footer>
+    </>
   );
 }
 

--- a/client/src/dashboard/spa/src/pages/overview/LiveNowBand.test.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/LiveNowBand.test.tsx
@@ -9,6 +9,7 @@ import { api } from '../../api/client.js';
 vi.mock('../../api/client.js', () => ({
   api: {
     getStatus: vi.fn(),
+    getBootstrap: vi.fn(),
   },
 }));
 
@@ -26,6 +27,9 @@ function wrap(ui: JSX.Element): void {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Default: no joined SolverNets. Tests that exercise the joined-gating
+  // path override this with a populated map.
+  vi.mocked(api.getBootstrap).mockResolvedValue({} as never);
 });
 
 afterEach(() => {
@@ -142,6 +146,88 @@ describe('deriveLiveNow', () => {
       label: 'Configure SolverNet',
       href: '/operator#solvernets',
     });
+  });
+
+  it('suppresses the "No active SolverNet" banner when joinedSolverNets is non-empty (#333)', () => {
+    // The daemon only re-reads joinedSolverNets on restart, so the live
+    // status payload can still carry a stale `prediction_solvernet_missing`
+    // diagnostic after a successful join. Gating on the freshly-polled join
+    // map keeps the banner from contradicting the joined list.
+    const result = deriveLiveNow(
+      {
+        fleet: { services: [{ index: 0, step: 'complete' }] },
+        activity: { recent: [{ ts: '2026-05-19T10:00:00.000Z', kind: 'startup' }] },
+        predictionV1: {
+          totals: { activeTaskRuns: 0 },
+          operator: {
+            diagnostics: [
+              {
+                code: 'prediction_solvernet_missing',
+                severity: 'error',
+                message: 'No active SolverNet configured.',
+                configField: 'solverNets',
+              },
+            ],
+          },
+        },
+      },
+      { bafybeiaaa: { name: 'Prediction Markets', roles: ['solver'] } },
+    );
+
+    // No attention — the join map proves a SolverNet is configured.
+    expect(result.state).not.toBe('attention');
+    expect(result.line).not.toContain('No active SolverNet');
+  });
+
+  it('still surfaces non-missing diagnostics when joinedSolverNets is non-empty (#333)', () => {
+    // The join-map gate is scoped to `prediction_solvernet_missing` only —
+    // a real harness diagnostic must still raise the attention banner.
+    const result = deriveLiveNow(
+      {
+        fleet: { services: [{ index: 0, step: 'complete' }] },
+        predictionV1: {
+          totals: { activeTaskRuns: 0 },
+          operator: {
+            diagnostics: [
+              {
+                code: 'harness_mismatch',
+                severity: 'error',
+                message: 'Selected Harness does not support prediction.v1 restoration Tasks.',
+              },
+            ],
+          },
+        },
+      },
+      { bafybeiaaa: { name: 'Prediction Markets', roles: ['solver'] } },
+    );
+
+    expect(result.state).toBe('attention');
+    expect(result.line).toContain('does not support prediction.v1');
+  });
+
+  it('still surfaces the "No active SolverNet" banner when joinedSolverNets is empty (#333)', () => {
+    const result = deriveLiveNow(
+      {
+        fleet: { services: [{ index: 0, step: 'complete' }] },
+        predictionV1: {
+          totals: { activeTaskRuns: 0 },
+          operator: {
+            diagnostics: [
+              {
+                code: 'prediction_solvernet_missing',
+                severity: 'error',
+                message: 'No active SolverNet configured.',
+                configField: 'solverNets',
+              },
+            ],
+          },
+        },
+      },
+      {},
+    );
+
+    expect(result.state).toBe('attention');
+    expect(result.line).toBe('No active SolverNet configured.');
   });
 
   it('excludes prediction_solvernet_disabled from attention triggers', () => {
@@ -290,6 +376,74 @@ describe('<LiveNowBand />', () => {
     expect(screen.getByTestId('live-now-cta').textContent).toMatch(/Configure SolverNet/);
     expect(screen.getByTestId('live-now-cta').getAttribute('style')).toContain(
       'border: 1px solid var(--accent-sky)',
+    );
+  });
+
+  it('does not render the "No active SolverNet" attention banner when a SolverNet is joined (#333)', async () => {
+    // Stale daemon diagnostic + a fresh joined-SolverNets map: the banner
+    // must defer to the join map and not contradict the joined list.
+    const status: LiveNowStatusInput = {
+      fleet: { services: [{ index: 0, step: 'complete' }] },
+      predictionV1: {
+        totals: { activeTaskRuns: 0 },
+        operator: {
+          diagnostics: [
+            {
+              code: 'prediction_solvernet_missing',
+              severity: 'error',
+              message: 'No active SolverNet configured.',
+              configField: 'solverNets',
+            },
+          ],
+        },
+      },
+    };
+    vi.mocked(api.getStatus).mockResolvedValue(status);
+    vi.mocked(api.getBootstrap).mockResolvedValue({
+      joinedSolverNets: {
+        bafybeiaaa: { name: 'Prediction Markets', roles: ['solver'] },
+      },
+    } as never);
+
+    wrap(<LiveNowBand />);
+
+    await waitFor(() => {
+      const band = screen.getByTestId('live-now-band');
+      expect(band.getAttribute('data-state')).not.toBe('attention');
+    });
+    expect(screen.getByTestId('live-now-line').textContent).not.toContain(
+      'No active SolverNet',
+    );
+  });
+
+  it('still renders the "No active SolverNet" attention banner when no SolverNet is joined (#333)', async () => {
+    const status: LiveNowStatusInput = {
+      fleet: { services: [{ index: 0, step: 'complete' }] },
+      predictionV1: {
+        totals: { activeTaskRuns: 0 },
+        operator: {
+          diagnostics: [
+            {
+              code: 'prediction_solvernet_missing',
+              severity: 'error',
+              message: 'No active SolverNet configured.',
+              configField: 'solverNets',
+            },
+          ],
+        },
+      },
+    };
+    vi.mocked(api.getStatus).mockResolvedValue(status);
+    vi.mocked(api.getBootstrap).mockResolvedValue({ joinedSolverNets: {} } as never);
+
+    wrap(<LiveNowBand />);
+
+    await waitFor(() => {
+      const band = screen.getByTestId('live-now-band');
+      expect(band.getAttribute('data-state')).toBe('attention');
+    });
+    expect(screen.getByTestId('live-now-line').textContent).toContain(
+      'No active SolverNet',
     );
   });
 

--- a/client/src/dashboard/spa/src/pages/overview/LiveNowBand.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/LiveNowBand.tsx
@@ -139,7 +139,25 @@ function summarizeStages(tasks: readonly LiveTaskRun[] | undefined): { line: str
   return { line, longestMs };
 }
 
-export function deriveLiveNow(status: LiveNowStatusInput | undefined): LiveNowDerived {
+/**
+ * `true` when the operator has at least one joined SolverNet. The daemon's
+ * diagnostic pipeline already gates `prediction_solvernet_missing` on this
+ * (#239), but the daemon only re-reads `joinedSolverNets` on restart — so a
+ * stale `prediction_solvernet_missing` diagnostic survives in the live status
+ * payload between a successful join and the next restart. `deriveLiveNow`
+ * gates the banner on the SPA's freshly-polled `joinedSolverNets` map so the
+ * attention banner clears the moment the join lands (#333).
+ */
+function hasJoinedSolverNet(
+  joinedSolverNets: Record<string, unknown> | undefined,
+): boolean {
+  return Boolean(joinedSolverNets) && Object.keys(joinedSolverNets!).length > 0;
+}
+
+export function deriveLiveNow(
+  status: LiveNowStatusInput | undefined,
+  joinedSolverNets?: Record<string, unknown>,
+): LiveNowDerived {
   const viewActivityCta = { label: 'View activity', href: VIEW_ACTIVITY_HREF };
 
   // Bootstrapping: any service not at a complete-equivalent step.
@@ -162,8 +180,18 @@ export function deriveLiveNow(status: LiveNowStatusInput | undefined): LiveNowDe
   // `Configure prediction`, etc.) — the operator goes there to resolve, not
   // to /overview/activity. The `N more` pill (when set) handles "see all
   // current attentions" by linking into the activity page.
+  //
+  // `prediction_solvernet_missing` is additionally suppressed once the
+  // operator has a joined SolverNet — the live status payload can carry a
+  // stale copy until the daemon restarts and re-reads `joinedSolverNets`
+  // (#333). Gating on the SPA's freshly-polled join map keeps the "No active
+  // SolverNet configured" banner from contradicting the joined list.
+  const operatorHasJoined = hasJoinedSolverNet(joinedSolverNets);
   const diagnostics = (status?.predictionV1?.operator?.diagnostics ?? []).filter(
-    (d) => d.severity === 'error' && d.code !== 'prediction_solvernet_disabled',
+    (d) =>
+      d.severity === 'error' &&
+      d.code !== 'prediction_solvernet_disabled' &&
+      !(d.code === 'prediction_solvernet_missing' && operatorHasJoined),
   );
   if (diagnostics.length > 0) {
     const first = diagnostics[0]!;
@@ -219,13 +247,26 @@ export const LIVE_NOW_STATE_LABEL: Record<LiveNowState, string> = {
   idle: 'IDLE',
 };
 
+interface BootstrapWithJoined {
+  joinedSolverNets?: Record<string, unknown>;
+}
+
 export function LiveNowBand(): JSX.Element {
   const { data } = useQuery<LiveNowStatusInput>({
     queryKey: ['status'],
     queryFn: () => api.getStatus() as Promise<LiveNowStatusInput>,
     refetchInterval: 5_000,
   });
-  const derived = deriveLiveNow(data);
+  // Bootstrap carries the operator's joined-SolverNet map. Sharing the
+  // ['bootstrap'] query key with Overview/Operator avoids a double-poll;
+  // the join flow invalidates ['operator', 'joined'] but the bootstrap
+  // refetch interval picks the map change up within 30s either way.
+  const { data: bootstrap } = useQuery<BootstrapWithJoined>({
+    queryKey: ['bootstrap'],
+    queryFn: () => api.getBootstrap() as Promise<BootstrapWithJoined>,
+    refetchInterval: 30_000,
+  });
+  const derived = deriveLiveNow(data, bootstrap?.joinedSolverNets);
   const tone = LIVE_NOW_TONE[derived.state];
   const stateLabel = LIVE_NOW_STATE_LABEL[derived.state];
 


### PR DESCRIPTION
Closes #333.

## Problem

From the 2026-05-19 v0.1.6 dogfood (first-time operator rvx):

1. Clicking **Save & Join** on a SolverNet silently redirected to `/operator` with no success affordance — rvx: "quite unclear that it was a success."
2. The top-of-dashboard **"No active SolverNet configured"** attention banner persisted even after a join succeeded and the SolverNet showed in the joined list. Oak had to leave + re-join to clear it.

## Changes

Builds on #239 (which fixed the daemon-side diagnostic pipeline to read `joinedSolverNets`). This is the remaining **SPA-side** work.

- **`JoinFlow.tsx`** — a successful Save & Join now renders an explicit success state *on the join page* instead of a silent redirect: a green-bordered confirmation naming the joined SolverNet, the restart-required hint, and CTAs (`View joined SolverNet` deep-links to `/operator#solvernets/<cid>`; `Browse SolverNets` to `/operator#solvernets`). The `['operator','joined']` and `['bootstrap']` queries are invalidated so the joined list / banner refresh immediately.
- **`LiveNowBand.tsx`** — `deriveLiveNow` now takes the freshly-polled `joinedSolverNets` map and suppresses the `prediction_solvernet_missing` diagnostic when the map is non-empty. The daemon only re-reads `joinedSolverNets` on restart, so a stale `prediction_solvernet_missing` could survive in the live status payload between a join and the next restart — gating on the SPA's join map keeps the banner from contradicting the joined list. `LiveNowBand` fetches bootstrap (shared `['bootstrap']` query key — no double-poll). Other diagnostics are unaffected.
- **`Overview.tsx`** — passes `bootstrap?.joinedSolverNets` into its `deriveLiveNow` call (same gate as above).

## Test plan

- [x] `yarn typecheck` — clean
- [x] `yarn build` — passes (SPA `tsc -b` exits 0)
- [x] `yarn test --run` SPA suite — 403/403 pass, including new regression coverage:
  - `JoinFlow.test.tsx` — post-join success card renders, names the joined SolverNet, shows the restart hint, does NOT redirect; success CTA navigates into the joined SolverNet
  - `LiveNowBand.test.tsx` — `deriveLiveNow` suppresses the "No active SolverNet" banner when `joinedSolverNets` is non-empty; still surfaces it when empty; non-missing diagnostics still raise attention; component-level test on `<LiveNowBand />` for both states

🤖 Generated with [Claude Code](https://claude.com/claude-code)