### PR TITLE
fix(engine): clean up engine/work task dirs after terminal state (#320)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -77,6 +77,7 @@
     "release:testnet-acceptance:docker": "node scripts/testnet-acceptance-docker.mjs",
     "release:testnet-acceptance:host": "node scripts/testnet-acceptance.mjs",
     "status": "tsx scripts/status.ts",
+    "cleanup:engine-work": "tsx scripts/cleanup-engine-work.ts",
     "e2e": "tsx test/e2e/validate.ts",
     "e2e:task-first-local": "tsx test/e2e/task-first-local.ts",
     "e2e:claude-code-learner": "tsx test/e2e/claude-code-learner-portfolio-v0.ts",

--- a/client/scripts/cleanup-engine-work.ts
+++ b/client/scripts/cleanup-engine-work.ts
@@ -191,10 +191,12 @@ function main(): void {
     }
   }
 
-  const reclaimable = candidates.reduce(
-    (sum, name) => sum + dirSizeBytes(join(workingDirRoot, name)),
-    0,
+  // Size each candidate once, up front. The dry run reports this as the
+  // reclaimable estimate; the --apply path sums the subset actually removed.
+  const candidateSizes = new Map(
+    candidates.map((name) => [name, dirSizeBytes(join(workingDirRoot, name))]),
   );
+  const reclaimable = [...candidateSizes.values()].reduce((a, b) => a + b, 0);
 
   console.log(
     `  scanned ${entries.length} dir(s); ${candidates.length} removable ` +
@@ -221,7 +223,11 @@ function main(): void {
     orphanMaxAgeMs,
   });
 
-  console.log(`  removed ${report.removed.length} dir(s); ~${humanBytes(reclaimable)} freed.`);
+  const freed = report.removed.reduce(
+    (sum, name) => sum + (candidateSizes.get(name) ?? 0),
+    0,
+  );
+  console.log(`  removed ${report.removed.length} dir(s); ${humanBytes(freed)} freed.`);
   if (report.errors.length > 0) {
     console.log(`  ${report.errors.length} dir(s) could not be removed:`);
     for (const e of report.errors) console.log(`    - ${e.requestId}: ${e.error}`);

--- a/client/scripts/cleanup-engine-work.ts
+++ b/client/scripts/cleanup-engine-work.ts
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+/**
+ * One-shot engine working-directory cleanup (issue #320).
+ *
+ * The daemon provisions a heavy scratch directory per task under
+ * `engine.workingDirRoot` (default `~/.jinn-client/engine/work/<requestId>/`).
+ * Until the work-dir reaper shipped, nothing removed these — operators
+ * accumulated hundreds of dirs / tens of GB.
+ *
+ * This script clears the existing backlog. It is SAFE TO RUN ON A LIVE
+ * OPERATOR: it opens the daemon's SQLite store read-only, and removes a
+ * directory only when it is provably safe:
+ *
+ *   - the matching task run is in a terminal state (COMPLETE / FAILED), or
+ *   - the directory has no DB row at all AND is older than --orphan-age
+ *     (default 24h) — i.e. it cannot be a task the daemon is mid-claim on.
+ *
+ * A directory whose task is still in-flight is NEVER removed.
+ *
+ * The daemon's own reaper makes this script unnecessary going forward; it
+ * exists to drain the pre-fix backlog in one pass.
+ *
+ * Usage:
+ *   yarn cleanup:engine-work                     # dry run — prints what would go
+ *   yarn cleanup:engine-work -- --apply          # actually delete
+ *   yarn cleanup:engine-work -- --apply --orphan-age 168h
+ *   yarn cleanup:engine-work -- --config ./my-config.json --apply
+ *
+ * Flags:
+ *   --apply            Perform deletions. Without it the script is a dry run.
+ *   --orphan-age <dur> Age threshold for dirs with no DB row. Accepts `30m`,
+ *                      `24h`, `7d`, or a raw millisecond count. Default 24h.
+ *   --config <path>    Config file path (same resolution as the daemon).
+ */
+
+import { config as dotenvConfig } from 'dotenv';
+import Database from 'better-sqlite3';
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadConfig, getConfigPathFromArgs } from '../src/config.js';
+import {
+  reapWorkDirs,
+  DEFAULT_ORPHAN_MAX_AGE_MS,
+} from '../src/harnesses/engine/work-dir-reaper.js';
+
+dotenvConfig({ path: join(dirname(fileURLToPath(import.meta.url)), '..', '.env') });
+
+// ── Arg parsing ───────────────────────────────────────────────────────────────
+
+function parseDuration(raw: string): number {
+  const m = /^(\d+(?:\.\d+)?)(ms|s|m|h|d)?$/.exec(raw.trim());
+  if (!m) throw new Error(`invalid --orphan-age value: ${raw}`);
+  const n = Number(m[1]);
+  switch (m[2]) {
+    case 'd': return n * 24 * 60 * 60 * 1000;
+    case 'h': return n * 60 * 60 * 1000;
+    case 'm': return n * 60 * 1000;
+    case 's': return n * 1000;
+    default:  return n; // bare number → milliseconds
+  }
+}
+
+function getFlagValue(argv: string[], flag: string): string | undefined {
+  const i = argv.indexOf(flag);
+  return i >= 0 && i + 1 < argv.length ? argv[i + 1] : undefined;
+}
+
+// ── Terminal-set extraction ───────────────────────────────────────────────────
+
+/**
+ * Read the task_runs table read-only and split request IDs into terminal vs
+ * in-flight. Returns null when the DB file does not exist (fresh operator) so
+ * the caller can fall back to age-only reaping.
+ */
+function loadIdSets(dbPath: string): {
+  terminal: Set<string>;
+  inFlight: Set<string>;
+} | null {
+  if (!existsSync(dbPath)) return null;
+  const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+  try {
+    const hasTable = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='task_runs'`)
+      .get();
+    if (!hasTable) return { terminal: new Set(), inFlight: new Set() };
+    const rows = db
+      .prepare(`SELECT request_id, state FROM task_runs`)
+      .all() as Array<{ request_id: string; state: string }>;
+    const terminal = new Set<string>();
+    const inFlight = new Set<string>();
+    for (const r of rows) {
+      if (r.state === 'COMPLETE' || r.state === 'FAILED') terminal.add(r.request_id);
+      else inFlight.add(r.request_id);
+    }
+    return { terminal, inFlight };
+  } finally {
+    db.close();
+  }
+}
+
+// ── Disk-usage helper (best effort, for the human-readable summary) ───────────
+
+function dirSizeBytes(dir: string): number {
+  let total = 0;
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return 0;
+  }
+  for (const name of entries) {
+    const p = join(dir, name);
+    try {
+      const st = statSync(p);
+      total += st.isDirectory() ? dirSizeBytes(p) : st.size;
+    } catch {
+      /* vanished — ignore */
+    }
+  }
+  return total;
+}
+
+function humanBytes(n: number): string {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let v = n;
+  let u = 0;
+  while (v >= 1024 && u < units.length - 1) {
+    v /= 1024;
+    u += 1;
+  }
+  return `${v.toFixed(v < 10 && u > 0 ? 1 : 0)}${units[u]}`;
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+function main(): void {
+  const argv = process.argv.slice(2);
+  const apply = argv.includes('--apply');
+  const orphanAgeRaw = getFlagValue(argv, '--orphan-age');
+  const orphanMaxAgeMs = orphanAgeRaw
+    ? parseDuration(orphanAgeRaw)
+    : DEFAULT_ORPHAN_MAX_AGE_MS;
+
+  const configPath = getConfigPathFromArgs(argv);
+  const config = loadConfig(configPath);
+  const workingDirRoot = config.engine.workingDirRoot;
+  const dbPath = config.dbPath;
+
+  console.log('Jinn engine work-dir cleanup (#320)');
+  console.log(`  working dir root: ${workingDirRoot}`);
+  console.log(`  daemon DB:        ${dbPath}`);
+  console.log(`  orphan max age:   ${(orphanMaxAgeMs / 3_600_000).toFixed(1)}h`);
+  console.log(`  mode:             ${apply ? 'APPLY (will delete)' : 'dry run (no deletions)'}`);
+
+  if (!existsSync(workingDirRoot)) {
+    console.log('  → working dir root does not exist; nothing to do.');
+    return;
+  }
+
+  const idSets = loadIdSets(dbPath);
+  if (!idSets) {
+    console.log('  → no daemon DB found; treating every dir as an orphan (age-gated only).');
+  }
+  const terminal = idSets?.terminal ?? new Set<string>();
+  const inFlight = idSets?.inFlight ?? new Set<string>();
+
+  // Pre-compute the would-remove set so the dry run reports sizes accurately.
+  const entries = readdirSync(workingDirRoot).filter((name) => {
+    try {
+      return statSync(join(workingDirRoot, name)).isDirectory();
+    } catch {
+      return false;
+    }
+  });
+  const now = Date.now();
+  const candidates: string[] = [];
+  for (const name of entries) {
+    if (inFlight.has(name)) continue;
+    const isTerminal = terminal.has(name);
+    if (isTerminal) {
+      candidates.push(name);
+      continue;
+    }
+    // Orphan — age-gate it.
+    try {
+      const mtimeMs = statSync(join(workingDirRoot, name)).mtimeMs;
+      if (now - mtimeMs >= orphanMaxAgeMs) candidates.push(name);
+    } catch {
+      /* vanished — skip */
+    }
+  }
+
+  const reclaimable = candidates.reduce(
+    (sum, name) => sum + dirSizeBytes(join(workingDirRoot, name)),
+    0,
+  );
+
+  console.log(
+    `  scanned ${entries.length} dir(s); ${candidates.length} removable ` +
+    `(~${humanBytes(reclaimable)} reclaimable); ${inFlight.size} in-flight protected.`,
+  );
+
+  if (candidates.length === 0) {
+    console.log('  → nothing to remove.');
+    return;
+  }
+
+  if (!apply) {
+    console.log('  Would remove:');
+    for (const name of candidates.slice(0, 50)) console.log(`    - ${name}`);
+    if (candidates.length > 50) console.log(`    … and ${candidates.length - 50} more`);
+    console.log('  Re-run with --apply to delete.');
+    return;
+  }
+
+  const report = reapWorkDirs({
+    workingDirRoot,
+    terminalRequestIds: terminal,
+    inFlightRequestIds: inFlight,
+    orphanMaxAgeMs,
+  });
+
+  console.log(`  removed ${report.removed.length} dir(s); ~${humanBytes(reclaimable)} freed.`);
+  if (report.errors.length > 0) {
+    console.log(`  ${report.errors.length} dir(s) could not be removed:`);
+    for (const e of report.errors) console.log(`    - ${e.requestId}: ${e.error}`);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/client/scripts/cleanup-engine-work.ts
+++ b/client/scripts/cleanup-engine-work.ts
@@ -43,6 +43,7 @@ import {
   reapWorkDirs,
   DEFAULT_ORPHAN_MAX_AGE_MS,
 } from '../src/harnesses/engine/work-dir-reaper.js';
+import { TERMINAL_STATES, type TaskRunState } from '../src/harnesses/engine/state.js';
 
 dotenvConfig({ path: join(dirname(fileURLToPath(import.meta.url)), '..', '.env') });
 
@@ -90,7 +91,7 @@ function loadIdSets(dbPath: string): {
     const terminal = new Set<string>();
     const inFlight = new Set<string>();
     for (const r of rows) {
-      if (r.state === 'COMPLETE' || r.state === 'FAILED') terminal.add(r.request_id);
+      if (TERMINAL_STATES.has(r.state as TaskRunState)) terminal.add(r.request_id);
       else inFlight.add(r.request_id);
     }
     return { terminal, inFlight };

--- a/client/scripts/cleanup-engine-work.ts
+++ b/client/scripts/cleanup-engine-work.ts
@@ -182,10 +182,14 @@ function main(): void {
       candidates.push(name);
       continue;
     }
-    // Orphan — age-gate it.
+    // Orphan — age-gate it. Prefer birthtime (creation) over mtime so a
+    // continuously-written orphan still ages out; fall back to mtime where
+    // the platform does not record birthtime (birthtimeMs === 0). Matches
+    // the daemon reaper in work-dir-reaper.ts.
     try {
-      const mtimeMs = statSync(join(workingDirRoot, name)).mtimeMs;
-      if (now - mtimeMs >= orphanMaxAgeMs) candidates.push(name);
+      const st = statSync(join(workingDirRoot, name));
+      const ageRefMs = st.birthtimeMs > 0 ? st.birthtimeMs : st.mtimeMs;
+      if (now - ageRefMs >= orphanMaxAgeMs) candidates.push(name);
     } catch {
       /* vanished — skip */
     }

--- a/client/scripts/cleanup-engine-work.ts
+++ b/client/scripts/cleanup-engine-work.ts
@@ -183,14 +183,11 @@ function main(): void {
       candidates.push(name);
       continue;
     }
-    // Orphan — age-gate it. Prefer birthtime (creation) over mtime so a
-    // continuously-written orphan still ages out; fall back to mtime where
-    // the platform does not record birthtime (birthtimeMs === 0). Matches
-    // the daemon reaper in work-dir-reaper.ts.
+    // Orphan — age-gate it off mtime (matches the daemon reaper in
+    // work-dir-reaper.ts; see the comment there on why not birthtime).
     try {
-      const st = statSync(join(workingDirRoot, name));
-      const ageRefMs = st.birthtimeMs > 0 ? st.birthtimeMs : st.mtimeMs;
-      if (now - ageRefMs >= orphanMaxAgeMs) candidates.push(name);
+      const mtimeMs = statSync(join(workingDirRoot, name)).mtimeMs;
+      if (now - mtimeMs >= orphanMaxAgeMs) candidates.push(name);
     } catch {
       /* vanished — skip */
     }

--- a/client/src/harnesses/engine/engine.ts
+++ b/client/src/harnesses/engine/engine.ts
@@ -15,6 +15,11 @@ import { TaskRunPersistence, type PersistedTaskRun, type PersistedTaskRunInput }
 import { TaskRunState, MissingEvidenceHashError } from './state.js';
 import type { Store } from '../../store/store.js';
 import {
+  reapWorkDirs,
+  DEFAULT_ORPHAN_MAX_AGE_MS,
+  type ReapWorkDirsReport,
+} from './work-dir-reaper.js';
+import {
   provisionWorkingDir,
   provisionImplStateDir,
   walkArtifacts,
@@ -308,6 +313,28 @@ export interface TaskEngineOptions {
    * Spec: docs/superpowers/specs/2026-05-06-agent-harness-solvernet-design.md §6.3
    */
   harnessMode?: 'train' | 'frozen';
+  /**
+   * Working-directory reaper tuning (issue #320). Each task run provisions a
+   * heavy scratch directory under `paths.workingDirRoot`; without cleanup an
+   * operator accumulates hundreds of dirs / tens of GB. The engine reaps a
+   * task's directory once it reaches a terminal state (COMPLETE / FAILED),
+   * and periodically sweeps the root for crash-orphaned dirs.
+   *
+   * Optional — sensible defaults apply when absent.
+   */
+  workDirReaper?: {
+    /**
+     * Age above which a directory with no DB row (orphaned by a crash or an
+     * older daemon) is removed. Defaults to {@link DEFAULT_ORPHAN_MAX_AGE_MS}
+     * (24h). Set to a large value to keep orphans for forensic inspection.
+     */
+    orphanMaxAgeMs?: number;
+    /**
+     * Disable the reaper entirely (escape hatch for debugging a stuck task).
+     * Defaults to false — the reaper runs.
+     */
+    disabled?: boolean;
+  };
 }
 
 // ── Recovery report ───────────────────────────────────────────────────────────
@@ -393,6 +420,9 @@ export class TaskEngine {
     this.stopResolve = resolve;
   });
 
+  /** Working-dir reaper tuning (issue #320). */
+  protected readonly workDirReaperOpts: { orphanMaxAgeMs: number; disabled: boolean };
+
   constructor(opts: TaskEngineOptions) {
     this.persistence = new TaskRunPersistence(opts.store.db);
     this.store = opts.store;
@@ -408,6 +438,10 @@ export class TaskEngine {
     this.reputationFeedback = opts.reputationFeedback;
     this.operatorConfig = opts.operatorConfig;
     this.harnessMode = opts.harnessMode ?? 'train';
+    this.workDirReaperOpts = {
+      orphanMaxAgeMs: opts.workDirReaper?.orphanMaxAgeMs ?? DEFAULT_ORPHAN_MAX_AGE_MS,
+      disabled: opts.workDirReaper?.disabled ?? false,
+    };
   }
 
   // ── Public API ──────────────────────────────────────────────────────────────
@@ -483,12 +517,54 @@ export class TaskEngine {
       }
     }
 
+    // Reap the working directories of tasks that have reached a terminal
+    // state. Cheap (one readdir + a few rmSync) and idempotent, so it runs
+    // every tick — there is no separate reaper loop to keep alive or crash.
+    this.reapWorkDirsNow();
+
     if (!wait) return;
 
     const reports = await Promise.all(scheduled);
     for (const report of reports) {
       this.logProcessReport('tick', report);
     }
+  }
+
+  /**
+   * Reap on-disk per-task working directories (issue #320).
+   *
+   * Removes the scratch directory of every task in a terminal state
+   * (COMPLETE / FAILED) and any crash-orphaned directory older than the
+   * configured max age. In-flight tasks are never touched. Safe to call at
+   * any time; never throws (filesystem errors are collected into the report).
+   *
+   * Called automatically every `tick()`; also exposed for the one-shot
+   * cleanup script and for tests.
+   */
+  reapWorkDirsNow(): ReapWorkDirsReport {
+    const empty: ReapWorkDirsReport = { removed: [], protected: [], scanned: 0, errors: [] };
+    if (this.workDirReaperOpts.disabled) return empty;
+
+    const inFlightRequestIds = new Set(this.persistence.getInFlight().map((t) => t.requestId));
+    const terminalRequestIds = new Set(this.persistence.getTerminal().map((t) => t.requestId));
+
+    const report = reapWorkDirs({
+      workingDirRoot: this.paths.workingDirRoot,
+      terminalRequestIds,
+      inFlightRequestIds,
+      orphanMaxAgeMs: this.workDirReaperOpts.orphanMaxAgeMs,
+    });
+
+    if (report.removed.length > 0) {
+      console.log(
+        `[harness-engine] work-dir reaper removed ${report.removed.length} ` +
+        `terminal/orphaned task dir(s) under ${this.paths.workingDirRoot}`,
+      );
+    }
+    for (const e of report.errors) {
+      console.warn(`[harness-engine] work-dir reaper failed to remove ${e.requestId}: ${e.error}`);
+    }
+    return report;
   }
 
   /**

--- a/client/src/harnesses/engine/engine.ts
+++ b/client/src/harnesses/engine/engine.ts
@@ -545,8 +545,12 @@ export class TaskEngine {
     const empty: ReapWorkDirsReport = { removed: [], protected: [], scanned: 0, errors: [] };
     if (this.workDirReaperOpts.disabled) return empty;
 
-    const inFlightRequestIds = new Set(this.persistence.getInFlight().map((t) => t.requestId));
-    const terminalRequestIds = new Set(this.persistence.getTerminal().map((t) => t.requestId));
+    // Read the in-flight / terminal partition as a single atomic snapshot.
+    // Two separate queries would leave a TOCTOU window: a task transitioning
+    // DELIVERING → COMPLETE between the reads could be classified terminal and
+    // have its working directory deleted while deliver() still needs it.
+    const { terminal: terminalRequestIds, inFlight: inFlightRequestIds } =
+      this.persistence.getReaperPartition();
 
     const report = reapWorkDirs({
       workingDirRoot: this.paths.workingDirRoot,

--- a/client/src/harnesses/engine/persistence.ts
+++ b/client/src/harnesses/engine/persistence.ts
@@ -587,6 +587,33 @@ export class TaskRunPersistence {
     return rows.map(rowToTaskRun);
   }
 
+  /**
+   * Atomic snapshot for the working-dir reaper (issue #320): every task run's
+   * request ID partitioned into terminal (COMPLETE / FAILED) vs in-flight.
+   *
+   * The reaper must NOT read in-flight and terminal sets as two separate
+   * queries — a task transitioning DELIVERING → COMPLETE between the two reads
+   * could be seen by neither (or, worse, classified terminal) and have its
+   * working directory deleted while `deliver()` still references files in it.
+   * A single `SELECT` is a single statement, so the snapshot is internally
+   * consistent: every row is observed at exactly one state.
+   */
+  getReaperPartition(): { terminal: Set<string>; inFlight: Set<string> } {
+    const rows = this.db
+      .prepare('SELECT request_id, state FROM task_runs')
+      .all() as Array<{ request_id: string; state: string }>;
+    const terminal = new Set<string>();
+    const inFlight = new Set<string>();
+    for (const r of rows) {
+      if (TERMINAL_STATES.has(r.state as TaskRunState)) {
+        terminal.add(r.request_id);
+      } else {
+        inFlight.add(r.request_id);
+      }
+    }
+    return { terminal, inFlight };
+  }
+
   hasInFlightFor(args: {
     solverType: string;
     taskRole: 'restoration' | 'evaluation';

--- a/client/src/harnesses/engine/persistence.ts
+++ b/client/src/harnesses/engine/persistence.ts
@@ -574,6 +574,19 @@ export class TaskRunPersistence {
     return rows.map(rowToTaskRun);
   }
 
+  /**
+   * Fetch all terminal tasks (COMPLETE or FAILED).
+   * Used by the working-dir reaper (issue #320) to decide which on-disk
+   * scratch directories are safe to delete.
+   */
+  getTerminal(): PersistedTaskRun[] {
+    const terminalList = [...TERMINAL_STATES];
+    const placeholders = terminalList.map(() => '?').join(', ');
+    const sql = `SELECT * FROM task_runs WHERE state IN (${placeholders}) ORDER BY state_updated_at ASC`;
+    const rows = this.db.prepare(sql).all(...terminalList) as RawRow[];
+    return rows.map(rowToTaskRun);
+  }
+
   hasInFlightFor(args: {
     solverType: string;
     taskRole: 'restoration' | 'evaluation';

--- a/client/src/harnesses/engine/work-dir-reaper.ts
+++ b/client/src/harnesses/engine/work-dir-reaper.ts
@@ -87,11 +87,16 @@ export function reapWorkDirs(opts: ReapWorkDirsOptions): ReapWorkDirsReport {
   for (const requestId of entries) {
     const dir = join(opts.workingDirRoot, requestId);
     let isDir = false;
-    let mtimeMs = 0;
+    // Age the orphan off its creation time where the platform records it
+    // (birthtimeMs > 0, e.g. APFS / ext4). Writing a file into an orphan dir
+    // bumps mtime, so an mtime-only TTL would keep a continuously-written
+    // orphan alive forever. Fall back to mtime where birthtime is unavailable
+    // (returns 0), which is the conservative, never-too-aggressive choice.
+    let ageRefMs = 0;
     try {
       const st = statSync(dir);
       isDir = st.isDirectory();
-      mtimeMs = st.mtimeMs;
+      ageRefMs = st.birthtimeMs > 0 ? st.birthtimeMs : st.mtimeMs;
     } catch {
       continue; // vanished between readdir and stat — fine.
     }
@@ -108,7 +113,7 @@ export function reapWorkDirs(opts: ReapWorkDirsOptions): ReapWorkDirsReport {
     // (3) Orphan (no DB row) — remove only once past the max age.
     const isTerminal = opts.terminalRequestIds.has(requestId);
     const isOrphan = !isTerminal; // not in-flight, not terminal → no row
-    if (isOrphan && now() - mtimeMs < orphanMaxAgeMs) {
+    if (isOrphan && now() - ageRefMs < orphanMaxAgeMs) {
       continue; // young orphan — give the DB a chance to catch up.
     }
 

--- a/client/src/harnesses/engine/work-dir-reaper.ts
+++ b/client/src/harnesses/engine/work-dir-reaper.ts
@@ -87,16 +87,15 @@ export function reapWorkDirs(opts: ReapWorkDirsOptions): ReapWorkDirsReport {
   for (const requestId of entries) {
     const dir = join(opts.workingDirRoot, requestId);
     let isDir = false;
-    // Age the orphan off its creation time where the platform records it
-    // (birthtimeMs > 0, e.g. APFS / ext4). Writing a file into an orphan dir
-    // bumps mtime, so an mtime-only TTL would keep a continuously-written
-    // orphan alive forever. Fall back to mtime where birthtime is unavailable
-    // (returns 0), which is the conservative, never-too-aggressive choice.
-    let ageRefMs = 0;
+    // Age orphans off mtime, not birthtime: a dir with a live writer keeps
+    // bumping mtime, so it stays "fresh" and is never reaped — which is what
+    // we want, since a continuously-written orphan has a running task whose
+    // DB row was lost. birthtime would reap it out from under that task.
+    let mtimeMs = 0;
     try {
       const st = statSync(dir);
       isDir = st.isDirectory();
-      ageRefMs = st.birthtimeMs > 0 ? st.birthtimeMs : st.mtimeMs;
+      mtimeMs = st.mtimeMs;
     } catch {
       continue; // vanished between readdir and stat — fine.
     }
@@ -113,7 +112,7 @@ export function reapWorkDirs(opts: ReapWorkDirsOptions): ReapWorkDirsReport {
     // (3) Orphan (no DB row) — remove only once past the max age.
     const isTerminal = opts.terminalRequestIds.has(requestId);
     const isOrphan = !isTerminal; // not in-flight, not terminal → no row
-    if (isOrphan && now() - ageRefMs < orphanMaxAgeMs) {
+    if (isOrphan && now() - mtimeMs < orphanMaxAgeMs) {
       continue; // young orphan — give the DB a chance to catch up.
     }
 

--- a/client/src/harnesses/engine/work-dir-reaper.ts
+++ b/client/src/harnesses/engine/work-dir-reaper.ts
@@ -1,0 +1,127 @@
+/**
+ * Working-directory reaper.
+ *
+ * The TaskEngine provisions a per-task working directory under
+ * `engine.workingDirRoot` (default `~/.jinn-client/engine/work/<requestId>/`).
+ * Each one holds heavy scratch — a cloned repo, a per-task plugins copy, a
+ * `system_snapshot.tar.gz`, session transcripts and an env directory.
+ *
+ * Historically nothing ever removed these. A long-lived operator accumulated
+ * 412 work dirs / 49 GB with no cleanup (issue #320). The snapshot tarball is
+ * uploaded to IPFS at delivery time, so once a task reaches a terminal state
+ * (COMPLETE / FAILED) the on-disk working directory is pure dead weight.
+ *
+ * This module is the single place that decides what may be deleted. It is
+ * deliberately conservative:
+ *
+ *   1. A directory whose requestId is currently in-flight is NEVER removed,
+ *      regardless of age — the engine still needs it.
+ *   2. A directory whose requestId is in a terminal state is removed
+ *      immediately (its evidence already lives on-chain / on IPFS).
+ *   3. A directory with no matching persistence row at all ("orphan" — left
+ *      by a crash, an older daemon version, or a wiped DB) is removed only
+ *      once it is older than `orphanMaxAgeMs`, so we never race a task the
+ *      DB has not observed yet.
+ *
+ * It is pure I/O over the filesystem plus two caller-supplied id sets, which
+ * makes it trivially testable and equally usable from the one-shot cleanup
+ * script (`scripts/cleanup-engine-work.ts`).
+ */
+
+import { readdirSync, statSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** Default age before an orphaned (no DB row) work dir is reaped: 24 hours. */
+export const DEFAULT_ORPHAN_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+export interface ReapWorkDirsOptions {
+  /** Root that holds per-task working directories (`engine.workingDirRoot`). */
+  workingDirRoot: string;
+  /** Request IDs whose task run is in a terminal state (COMPLETE / FAILED). */
+  terminalRequestIds: ReadonlySet<string>;
+  /** Request IDs whose task run is still in-flight — never reaped. */
+  inFlightRequestIds: ReadonlySet<string>;
+  /**
+   * Age above which a directory with no DB row (orphan) is reaped.
+   * Defaults to {@link DEFAULT_ORPHAN_MAX_AGE_MS}.
+   */
+  orphanMaxAgeMs?: number;
+  /** Injectable clock for tests. Defaults to `Date.now`. */
+  now?: () => number;
+}
+
+export interface ReapWorkDirsReport {
+  /** Request IDs whose working directory was removed this pass. */
+  removed: string[];
+  /** Request IDs skipped because the task is still in-flight. */
+  protected: string[];
+  /** Bytes-freed is not computed (would require a recursive walk); count only. */
+  scanned: number;
+  /** Non-fatal errors keyed by requestId (e.g. permission denied on rm). */
+  errors: Array<{ requestId: string; error: string }>;
+}
+
+/**
+ * Sweep `workingDirRoot` once and remove every working directory that is safe
+ * to delete. Never throws for a missing root or an individual failed removal —
+ * the daemon must keep running even if the disk is wedged.
+ */
+export function reapWorkDirs(opts: ReapWorkDirsOptions): ReapWorkDirsReport {
+  const now = opts.now ?? Date.now;
+  const orphanMaxAgeMs = opts.orphanMaxAgeMs ?? DEFAULT_ORPHAN_MAX_AGE_MS;
+  const report: ReapWorkDirsReport = {
+    removed: [],
+    protected: [],
+    scanned: 0,
+    errors: [],
+  };
+
+  let entries: string[];
+  try {
+    entries = readdirSync(opts.workingDirRoot);
+  } catch {
+    // Root does not exist yet (no task ever ran) — nothing to do.
+    return report;
+  }
+
+  for (const requestId of entries) {
+    const dir = join(opts.workingDirRoot, requestId);
+    let isDir = false;
+    let mtimeMs = 0;
+    try {
+      const st = statSync(dir);
+      isDir = st.isDirectory();
+      mtimeMs = st.mtimeMs;
+    } catch {
+      continue; // vanished between readdir and stat — fine.
+    }
+    if (!isDir) continue;
+    report.scanned += 1;
+
+    // (1) Never touch an in-flight task's directory.
+    if (opts.inFlightRequestIds.has(requestId)) {
+      report.protected.push(requestId);
+      continue;
+    }
+
+    // (2) Terminal task — safe to remove immediately.
+    // (3) Orphan (no DB row) — remove only once past the max age.
+    const isTerminal = opts.terminalRequestIds.has(requestId);
+    const isOrphan = !isTerminal; // not in-flight, not terminal → no row
+    if (isOrphan && now() - mtimeMs < orphanMaxAgeMs) {
+      continue; // young orphan — give the DB a chance to catch up.
+    }
+
+    try {
+      rmSync(dir, { recursive: true, force: true });
+      report.removed.push(requestId);
+    } catch (err) {
+      report.errors.push({
+        requestId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return report;
+}

--- a/client/test/harnesses/engine/engine-work-dir-cleanup.test.ts
+++ b/client/test/harnesses/engine/engine-work-dir-cleanup.test.ts
@@ -127,4 +127,64 @@ describe('TaskEngine work-dir cleanup (#320)', () => {
 
     expect(existsSync(doneDir)).toBe(false);
   });
+
+  // ── TOCTOU race regression (PR #377 review) ──────────────────────────────
+  //
+  // reapWorkDirsNow() must read the in-flight / terminal partition as a single
+  // atomic snapshot. Two separate queries (getInFlight() + getTerminal()) left
+  // a window where a task transitioning DELIVERING → COMPLETE between the reads
+  // could be classified terminal and have its working dir deleted while
+  // deliver() still referenced files in it — a data-loss vector.
+
+  it('getReaperPartition: a DELIVERING task is classified in-flight, never terminal', () => {
+    persistence.insertDiscovered(makeInput('0xdelivering'));
+    persistence.transition('0xdelivering', TaskRunState.CLAIMED);
+    persistence.transition('0xdelivering', TaskRunState.WAITING);
+    persistence.transition('0xdelivering', TaskRunState.PRE_SNAPSHOT);
+    persistence.transition('0xdelivering', TaskRunState.RUNNING);
+    persistence.transition('0xdelivering', TaskRunState.POST_SNAPSHOT);
+    persistence.transition('0xdelivering', TaskRunState.PACKAGING);
+    persistence.transition('0xdelivering', TaskRunState.DELIVERING);
+
+    const { terminal, inFlight } = persistence.getReaperPartition();
+
+    expect(inFlight.has('0xdelivering')).toBe(true);
+    expect(terminal.has('0xdelivering')).toBe(false);
+  });
+
+  it('getReaperPartition: every row lands in exactly one set (consistent snapshot)', () => {
+    persistence.insertDiscovered(makeInput('0xterminal'));
+    driveToComplete(persistence, '0xterminal');
+    persistence.insertDiscovered(makeInput('0xinflight'));
+    persistence.transition('0xinflight', TaskRunState.CLAIMED);
+    persistence.insertDiscovered(makeInput('0xdiscovered')); // still DISCOVERED
+
+    const { terminal, inFlight } = persistence.getReaperPartition();
+
+    // No request ID appears in both sets, and none is lost.
+    const overlap = [...terminal].filter((id) => inFlight.has(id));
+    expect(overlap).toHaveLength(0);
+    expect(terminal.size + inFlight.size).toBe(3);
+    expect(terminal.has('0xterminal')).toBe(true);
+    expect(inFlight.has('0xinflight')).toBe(true);
+    expect(inFlight.has('0xdiscovered')).toBe(true);
+  });
+
+  it('reapWorkDirsNow never deletes the work dir of a task still DELIVERING', () => {
+    persistence.insertDiscovered(makeInput('0xdelivering'));
+    persistence.transition('0xdelivering', TaskRunState.CLAIMED);
+    persistence.transition('0xdelivering', TaskRunState.WAITING);
+    persistence.transition('0xdelivering', TaskRunState.PRE_SNAPSHOT);
+    persistence.transition('0xdelivering', TaskRunState.RUNNING);
+    persistence.transition('0xdelivering', TaskRunState.POST_SNAPSHOT);
+    persistence.transition('0xdelivering', TaskRunState.PACKAGING);
+    persistence.transition('0xdelivering', TaskRunState.DELIVERING);
+    const dir = makeWorkDir(workRoot, '0xdelivering');
+
+    const report = engine.reapWorkDirsNow();
+
+    expect(existsSync(dir)).toBe(true);
+    expect(report.protected).toContain('0xdelivering');
+    expect(report.removed).not.toContain('0xdelivering');
+  });
 });

--- a/client/test/harnesses/engine/engine-work-dir-cleanup.test.ts
+++ b/client/test/harnesses/engine/engine-work-dir-cleanup.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, existsSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { Store } from '../../../src/store/store.js';
+import { TaskEngine, type TaskEngineOptions } from '../../../src/harnesses/engine/engine.js';
+import { TaskRunPersistence, type PersistedTaskRunInput } from '../../../src/harnesses/engine/persistence.js';
+import { TaskRunState } from '../../../src/harnesses/engine/state.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeInput(requestId: string): PersistedTaskRunInput {
+  const now = Date.now();
+  return {
+    requestId,
+    taskCid: 'bafyabc123',
+    onchainCreationTx: '0xdeadbeef',
+    onchainCreationBlock: 1000,
+    solverType: 'portfolio.v0',
+    windowStartTs: now + 60_000,
+    windowEndTs: now + 60_000 + 86_400_000,
+    task: { id: requestId, description: 'test', solverType: 'portfolio.v0', role: 'restoration' },
+  };
+}
+
+/** Drive a persisted row all the way to a terminal state via valid transitions. */
+function driveToComplete(p: TaskRunPersistence, requestId: string): void {
+  p.transition(requestId, TaskRunState.CLAIMED);
+  p.transition(requestId, TaskRunState.WAITING);
+  p.transition(requestId, TaskRunState.PRE_SNAPSHOT);
+  p.transition(requestId, TaskRunState.RUNNING);
+  p.transition(requestId, TaskRunState.POST_SNAPSHOT);
+  p.transition(requestId, TaskRunState.PACKAGING);
+  p.transition(requestId, TaskRunState.DELIVERING);
+  p.transition(requestId, TaskRunState.COMPLETE);
+}
+
+function makeWorkDir(root: string, requestId: string): string {
+  const dir = join(root, requestId);
+  mkdirSync(join(dir, 'repo'), { recursive: true });
+  writeFileSync(join(dir, 'task.json'), '{}', 'utf-8');
+  writeFileSync(join(dir, 'system_snapshot.tar.gz'), 'x'.repeat(128), 'utf-8');
+  return dir;
+}
+
+describe('TaskEngine work-dir cleanup (#320)', () => {
+  let workRoot: string;
+  let implRoot: string;
+  let store: Store;
+  let engine: TaskEngine;
+  let persistence: TaskRunPersistence;
+
+  beforeEach(() => {
+    workRoot = mkdtempSync(join(tmpdir(), 'jinn-engine-work-'));
+    implRoot = mkdtempSync(join(tmpdir(), 'jinn-engine-impl-'));
+    store = new Store(':memory:');
+    persistence = new TaskRunPersistence(store.db);
+    const opts: TaskEngineOptions = {
+      store,
+      paths: { workingDirRoot: workRoot, implStateDirRoot: implRoot },
+    };
+    engine = new TaskEngine(opts);
+  });
+
+  afterEach(() => {
+    rmSync(workRoot, { recursive: true, force: true });
+    rmSync(implRoot, { recursive: true, force: true });
+  });
+
+  it('reapWorkDirsNow removes the work dir of a COMPLETE task', () => {
+    persistence.insertDiscovered(makeInput('0xdone'));
+    const dir = makeWorkDir(workRoot, '0xdone');
+    driveToComplete(persistence, '0xdone');
+
+    const report = engine.reapWorkDirsNow();
+
+    expect(existsSync(dir)).toBe(false);
+    expect(report.removed).toContain('0xdone');
+  });
+
+  it('reapWorkDirsNow removes the work dir of a FAILED task', () => {
+    persistence.insertDiscovered(makeInput('0xbroke'));
+    const dir = makeWorkDir(workRoot, '0xbroke');
+    persistence.markFailed('0xbroke', 'harness blew up');
+
+    const report = engine.reapWorkDirsNow();
+
+    expect(existsSync(dir)).toBe(false);
+    expect(report.removed).toContain('0xbroke');
+  });
+
+  it('reapWorkDirsNow never removes the work dir of an in-flight task', () => {
+    persistence.insertDiscovered(makeInput('0xrunning'));
+    persistence.transition('0xrunning', TaskRunState.CLAIMED);
+    persistence.transition('0xrunning', TaskRunState.WAITING);
+    persistence.transition('0xrunning', TaskRunState.PRE_SNAPSHOT);
+    persistence.transition('0xrunning', TaskRunState.RUNNING);
+    const dir = makeWorkDir(workRoot, '0xrunning');
+
+    const report = engine.reapWorkDirsNow();
+
+    expect(existsSync(dir)).toBe(true);
+    expect(report.removed).not.toContain('0xrunning');
+    expect(report.protected).toContain('0xrunning');
+  });
+
+  it('reapWorkDirsNow clears a backlog of completed dirs in one pass', () => {
+    const ids = Array.from({ length: 8 }, (_, i) => `0xbacklog-${i}`);
+    for (const id of ids) {
+      persistence.insertDiscovered(makeInput(id));
+      makeWorkDir(workRoot, id);
+      driveToComplete(persistence, id);
+    }
+
+    const report = engine.reapWorkDirsNow();
+
+    for (const id of ids) expect(existsSync(join(workRoot, id))).toBe(false);
+    expect(report.removed.sort()).toEqual([...ids].sort());
+  });
+
+  it('tick() reaps terminal work dirs alongside advancing in-flight tasks', async () => {
+    persistence.insertDiscovered(makeInput('0xdone'));
+    const doneDir = makeWorkDir(workRoot, '0xdone');
+    driveToComplete(persistence, '0xdone');
+
+    await engine.tick();
+
+    expect(existsSync(doneDir)).toBe(false);
+  });
+});

--- a/client/test/harnesses/engine/work-dir-reaper.test.ts
+++ b/client/test/harnesses/engine/work-dir-reaper.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, existsSync, writeFileSync, utimesSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { reapWorkDirs } from '../../../src/harnesses/engine/work-dir-reaper.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Create a fake per-task working directory with some scratch content. */
+function makeWorkDir(root: string, requestId: string, ageMs = 0): string {
+  const dir = join(root, requestId);
+  mkdirSync(join(dir, 'repo'), { recursive: true });
+  mkdirSync(join(dir, 'env'), { recursive: true });
+  writeFileSync(join(dir, 'task.json'), '{}', 'utf-8');
+  writeFileSync(join(dir, 'system_snapshot.tar.gz'), 'x'.repeat(64), 'utf-8');
+  if (ageMs > 0) {
+    const when = (Date.now() - ageMs) / 1000;
+    // Backdate the directory mtime so the reaper sees it as old.
+    utimesSync(dir, when, when);
+  }
+  return dir;
+}
+
+describe('reapWorkDirs', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'jinn-reaper-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('removes a work dir whose request is in the terminal set', () => {
+    const dir = makeWorkDir(root, '0xterminal');
+    makeWorkDir(root, '0xinflight');
+
+    const report = reapWorkDirs({
+      workingDirRoot: root,
+      terminalRequestIds: new Set(['0xterminal']),
+      inFlightRequestIds: new Set(['0xinflight']),
+    });
+
+    expect(existsSync(dir)).toBe(false);
+    expect(existsSync(join(root, '0xinflight'))).toBe(true);
+    expect(report.removed).toContain('0xterminal');
+    expect(report.removed).toHaveLength(1);
+  });
+
+  it('never removes a work dir for an in-flight request', () => {
+    const dir = makeWorkDir(root, '0xinflight', 30 * 24 * 60 * 60 * 1000); // 30 days old
+
+    const report = reapWorkDirs({
+      workingDirRoot: root,
+      terminalRequestIds: new Set(),
+      inFlightRequestIds: new Set(['0xinflight']),
+    });
+
+    expect(existsSync(dir)).toBe(true);
+    expect(report.removed).toHaveLength(0);
+    expect(report.protected).toContain('0xinflight');
+  });
+
+  it('removes an orphaned work dir older than the max age', () => {
+    const old = makeWorkDir(root, '0xorphan-old', 2 * 24 * 60 * 60 * 1000); // 2 days old
+    const fresh = makeWorkDir(root, '0xorphan-fresh', 60 * 1000); // 1 minute old
+
+    const report = reapWorkDirs({
+      workingDirRoot: root,
+      terminalRequestIds: new Set(),
+      inFlightRequestIds: new Set(),
+      orphanMaxAgeMs: 24 * 60 * 60 * 1000, // 24h
+    });
+
+    expect(existsSync(old)).toBe(false);
+    expect(existsSync(fresh)).toBe(true);
+    expect(report.removed).toContain('0xorphan-old');
+    expect(report.removed).not.toContain('0xorphan-fresh');
+  });
+
+  it('keeps a recent orphan that is not yet past the max age', () => {
+    const dir = makeWorkDir(root, '0xorphan-fresh', 60 * 1000);
+
+    const report = reapWorkDirs({
+      workingDirRoot: root,
+      terminalRequestIds: new Set(),
+      inFlightRequestIds: new Set(),
+      orphanMaxAgeMs: 24 * 60 * 60 * 1000,
+    });
+
+    expect(existsSync(dir)).toBe(true);
+    expect(report.removed).toHaveLength(0);
+  });
+
+  it('is a no-op when the working dir root does not exist', () => {
+    const report = reapWorkDirs({
+      workingDirRoot: join(root, 'does-not-exist'),
+      terminalRequestIds: new Set(['0xany']),
+      inFlightRequestIds: new Set(),
+    });
+    expect(report.removed).toHaveLength(0);
+  });
+
+  it('reclaims disk: clears a backlog of terminal dirs in one pass', () => {
+    const ids = Array.from({ length: 12 }, (_, i) => `0xbacklog-${i}`);
+    for (const id of ids) makeWorkDir(root, id);
+
+    const report = reapWorkDirs({
+      workingDirRoot: root,
+      terminalRequestIds: new Set(ids),
+      inFlightRequestIds: new Set(),
+    });
+
+    expect(report.removed.sort()).toEqual([...ids].sort());
+    for (const id of ids) expect(existsSync(join(root, id))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The TaskEngine provisions a heavy per-task scratch directory under `engine.workingDirRoot` (default `~/.jinn-client/engine/work/<requestId>/`) — a cloned repo, a per-task plugins copy, a `system_snapshot.tar.gz`, session transcripts and an env dir. **Nothing ever removed them.** A long-lived operator hit 412 dirs / 49 GB (#320).

### Root cause

`TaskEngine.process()`'s `COMPLETE` / `FAILED` cases are a literal `// Terminal — nothing to do.` no-op. There is no cleanup-after-delivery hook, no periodic reaper, no max-age/size policy anywhere in the engine, harness or runner code. The `work-archives/` directory observed on the operator is a leftover from an older daemon version — `work-archive` appears nowhere in the current codebase, so archive rotation isn't "broken", it simply doesn't exist. The `system_snapshot.tar.gz` is itself written *inside* the workingDir at `pack()` time and is uploaded to IPFS at delivery — so once a task is terminal the entire on-disk directory is dead weight.

### The fix

- **`work-dir-reaper.ts`** — single decision point for what may be deleted. Conservative by design: an in-flight task's dir is **never** removed regardless of age; a terminal task's dir (evidence already on-chain / on IPFS) is removed immediately; a directory with no DB row at all (crash-orphan, older daemon, wiped DB) is removed only once older than a 24h TTL so we never race a task the DB hasn't observed yet. Never throws — filesystem errors are collected into the report.
- **`TaskRunPersistence.getTerminal()`** — enumerates COMPLETE/FAILED runs.
- **`TaskEngine.reapWorkDirsNow()`** — runs every `tick()`. No separate loop to keep alive or crash; idempotent and cheap (one `readdir` + a few `rmSync`). Tunable via the new optional `workDirReaper` engine option (`orphanMaxAgeMs`, `disabled`).
- **`scripts/cleanup-engine-work.ts`** (`yarn cleanup:engine-work`) — one-shot backlog drainer to clear the existing 412-dir / 49 GB backlog. **Safe on a live operator**: opens the daemon's SQLite store *read-only*, dry-run by default (prints what would go + reclaimable size), `--apply` to delete, `--orphan-age` tunable. Same in-flight protection as the reaper.

### Retention default

Terminal dirs are reaped immediately (snapshot already on IPFS); orphans get a 24h TTL. A time-based `work-archives/` rotation was considered and rejected — the snapshot tarball is already pinned, so archiving it again to local disk just re-leaks disk more slowly.

## Test plan

- [x] `work-dir-reaper.test.ts` — terminal / in-flight / orphan-age matrix, missing-root no-op, 12-dir backlog drain (6 tests)
- [x] `engine-work-dir-cleanup.test.ts` — `reapWorkDirsNow()` + `tick()` integration against a real `Store` DB and real temp dirs, including the in-flight-protection invariant (5 tests)
- [x] Full engine suite green (337 tests); persistence + recovery green
- [x] `yarn typecheck` clean
- [x] Cleanup script manually exercised: dry-run + `--apply` against a synthetic work root — removed the COMPLETE dir, protected the RUNNING dir, kept the young orphan
- [ ] Operator runs `yarn cleanup:engine-work -- --apply` once to drain the 49 GB backlog

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)