### PR TITLE
feat(launcher): surface operator-join count on launched dashboard (#351)

### DIFF
--- a/client/src/api/discovery-endpoint.ts
+++ b/client/src/api/discovery-endpoint.ts
@@ -6,6 +6,7 @@
  *   GET /v1/discovery/plugin-publications?solverType&builderAgentId&includeRevoked
  *   GET /v1/discovery/builder-artifacts?builderAgentId&limit
  *   GET /v1/discovery/plugin-scores?cid&limit
+ *   GET /v1/discovery/solvernet-operator-count?cid
  *
  * Used by the /build SPA route (hfmf) to render published plug-ins, the
  * local operator's published plug-ins, and per-plug-in score history.
@@ -80,6 +81,34 @@ export function addDiscoveryRoutes(app: Hono, config: DiscoveryEndpointConfig): 
         ...(limit !== undefined && Number.isFinite(limit) ? { limit } : {}),
       });
       return c.json({ artifacts });
+    } catch (err) {
+      if (err instanceof DiscoveryUnavailableError) {
+        return c.json({ error: 'discovery_unavailable' }, 503);
+      }
+      return c.json({ error: 'internal_error', detail: (err as Error).message }, 503);
+    }
+  });
+
+  // GET /v1/discovery/solvernet-operator-count?cid=<manifestCid>
+  //
+  // Returns the count of distinct operators with on-chain activity (claimed
+  // tasks) on the SolverNet identified by `cid`. Backs the operator-count
+  // surface on the launched-SolverNet dashboard (issue #351). See
+  // `DiscoveryAPI.getSolverNetOperatorCount` for why this counts
+  // *participating* operators rather than config-level "joins".
+  app.get('/v1/discovery/solvernet-operator-count', async (c) => {
+    const discovery = getDiscovery();
+    if (!discovery) {
+      return c.json(
+        { error: 'subsystem_not_ready', message: 'DiscoveryAPI still initialising' },
+        503,
+      );
+    }
+    const cid = c.req.query('cid');
+    if (!cid) return c.json({ error: 'cid is required' }, 400);
+    try {
+      const operatorCount = await discovery.getSolverNetOperatorCount(cid);
+      return c.json({ manifestCid: cid, operatorCount });
     } catch (err) {
       if (err instanceof DiscoveryUnavailableError) {
         return c.json({ error: 'discovery_unavailable' }, 503);

--- a/client/src/dashboard/spa/src/api/client.ts
+++ b/client/src/dashboard/spa/src/api/client.ts
@@ -27,6 +27,7 @@ import type {
   DiscoveryPluginPublicationsResponse,
   DiscoveryBuilderArtifactsResponse,
   DiscoveryPluginScoresResponse,
+  DiscoverySolverNetOperatorCountResponse,
   HarnessReadinessEntry,
 } from './types.js';
 
@@ -472,6 +473,13 @@ export const api = {
       if (limit !== undefined) q.set('limit', String(limit));
       return jfetch<DiscoveryPluginScoresResponse>(
         `/v1/discovery/plugin-scores?${q.toString()}`,
+      );
+    },
+    // Distinct operators with on-chain activity on a SolverNet (issue #351).
+    getSolverNetOperatorCount: (cid: string) => {
+      const q = new URLSearchParams({ cid });
+      return jfetch<DiscoverySolverNetOperatorCountResponse>(
+        `/v1/discovery/solvernet-operator-count?${q.toString()}`,
       );
     },
   },

--- a/client/src/dashboard/spa/src/api/types.ts
+++ b/client/src/dashboard/spa/src/api/types.ts
@@ -763,6 +763,18 @@ export interface DiscoveryPluginScoresResponse {
   scores: PluginScoreHistoryRowDto[];
 }
 
+/**
+ * Response from `GET /v1/discovery/solvernet-operator-count?cid=<manifestCid>`.
+ * `operatorCount` is the number of distinct operators with on-chain activity
+ * (claimed tasks) on the SolverNet — see the daemon's
+ * `DiscoveryAPI.getSolverNetOperatorCount` for why this counts participating
+ * operators rather than config-level joins. Issue #351.
+ */
+export interface DiscoverySolverNetOperatorCountResponse {
+  manifestCid: string;
+  operatorCount: number;
+}
+
 // ── Per-harness readiness (vh74.2 Stage A — #248 / #332) ─────────────────────
 // Mirrors the daemon's `HarnessReadinessSnapshot` entry shape exposed at
 // `GET /v1/harnesses/:name/readiness`. The join form consults this to disable

--- a/client/src/dashboard/spa/src/pages/LauncherLaunched.test.tsx
+++ b/client/src/dashboard/spa/src/pages/LauncherLaunched.test.tsx
@@ -29,6 +29,9 @@ vi.mock('../api/client.js', () => ({
       transitionLifecycle: vi.fn(),
       updateGeneratorConfig: vi.fn(),
     },
+    discovery: {
+      getSolverNetOperatorCount: vi.fn(),
+    },
   },
 }));
 
@@ -149,6 +152,11 @@ beforeEach(() => {
     generatedAt: '',
     nets: [],
   } satisfies LauncherStatusResponse);
+  // Default: 0 participating operators. Per-test overrides set a real count.
+  vi.mocked(api.discovery.getSolverNetOperatorCount).mockResolvedValue({
+    manifestCid: 'bafybeigtest1234567890',
+    operatorCount: 0,
+  });
 });
 
 afterEach(() => {
@@ -186,6 +194,35 @@ describe('LauncherLaunchedPage', () => {
     await waitFor(() =>
       expect(screen.getByTestId('launcher-launched-name').textContent).toBe('Polymarket'),
     );
+  });
+
+  it('surfaces the operator-join count from the discovery API (issue #351)', async () => {
+    vi.mocked(api.solvernets.get).mockResolvedValue(buildRecord());
+    vi.mocked(api.solvernets.getManifest).mockResolvedValue(buildManifestResponse());
+    vi.mocked(api.discovery.getSolverNetOperatorCount).mockResolvedValue({
+      manifestCid: 'bafybeigtest1234567890',
+      operatorCount: 2,
+    });
+    wrap(<LauncherLaunchedPage solverNetId="sn-1" pollIntervalMs={1000} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('operator-count').textContent).toBe('2'),
+    );
+    expect(api.discovery.getSolverNetOperatorCount).toHaveBeenCalledWith(
+      'bafybeigtest1234567890',
+    );
+  });
+
+  it('omits the operator-count field when the discovery query fails', async () => {
+    vi.mocked(api.solvernets.get).mockResolvedValue(buildRecord());
+    vi.mocked(api.solvernets.getManifest).mockResolvedValue(buildManifestResponse());
+    vi.mocked(api.discovery.getSolverNetOperatorCount).mockRejectedValue(
+      new Error('discovery_unavailable'),
+    );
+    wrap(<LauncherLaunchedPage solverNetId="sn-1" pollIntervalMs={1000} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('launcher-launched-status-header')).toBeTruthy(),
+    );
+    expect(screen.queryByTestId('operator-count')).toBeNull();
   });
 
   it('still renders panels when manifest fetch fails (degrades gracefully)', async () => {

--- a/client/src/dashboard/spa/src/pages/LauncherLaunched.tsx
+++ b/client/src/dashboard/spa/src/pages/LauncherLaunched.tsx
@@ -73,6 +73,20 @@ export function LauncherLaunchedPage({
     staleTime: Infinity,
   });
 
+  // Distinct operators with on-chain activity on this SolverNet (issue #351).
+  // Polls alongside the record so the header reflects new participants without
+  // a manual reload. A discovery outage / pre-bootstrap 503 leaves the query
+  // in error; StatusHeader renders nothing in that case rather than a stale 0.
+  const operatorCountQuery = useQuery<number>({
+    queryKey: ['solvernets', 'operator-count', manifestCid],
+    queryFn: async () => {
+      const res = await api.discovery.getSolverNetOperatorCount(manifestCid!);
+      return res.operatorCount;
+    },
+    enabled: Boolean(manifestCid),
+    refetchInterval: pollIntervalMs,
+  });
+
   const [dialogTarget, setDialogTarget] = useState<LifecycleTarget | null>(null);
   const [dialogError, setDialogError] = useState<string | null>(null);
 
@@ -163,6 +177,7 @@ export function LauncherLaunchedPage({
       <StatusHeader
         record={record}
         manifest={manifest}
+        operatorCount={operatorCountQuery.data}
         onAction={(target) => {
           setDialogError(null);
           setDialogTarget(target);

--- a/client/src/dashboard/spa/src/pages/LauncherLaunched.tsx
+++ b/client/src/dashboard/spa/src/pages/LauncherLaunched.tsx
@@ -38,6 +38,13 @@ import {
 
 const POLL_INTERVAL_MS = 2_500;
 
+/**
+ * Operator count changes slowly (a new operator appears only when one claims a
+ * task) and each poll fans out to a paginated discovery scan, so it polls far
+ * less often than the 2.5s record poll. Tests override it via `pollIntervalMs`.
+ */
+const OPERATOR_COUNT_POLL_INTERVAL_MS = 30_000;
+
 export interface LauncherLaunchedPageProps {
   /** Override poll interval (tests). */
   pollIntervalMs?: number;
@@ -74,9 +81,11 @@ export function LauncherLaunchedPage({
   });
 
   // Distinct operators with on-chain activity on this SolverNet (issue #351).
-  // Polls alongside the record so the header reflects new participants without
-  // a manual reload. A discovery outage / pre-bootstrap 503 leaves the query
-  // in error; StatusHeader renders nothing in that case rather than a stale 0.
+  // Polls on its own slower cadence (OPERATOR_COUNT_POLL_INTERVAL_MS) rather
+  // than the 2.5s record poll: the count changes only when an operator claims
+  // a task, and each poll fans out to a paginated discovery scan. A discovery
+  // outage / pre-bootstrap 503 leaves the query in error; StatusHeader renders
+  // nothing in that case rather than a stale 0.
   const operatorCountQuery = useQuery<number>({
     queryKey: ['solvernets', 'operator-count', manifestCid],
     queryFn: async () => {
@@ -84,7 +93,7 @@ export function LauncherLaunchedPage({
       return res.operatorCount;
     },
     enabled: Boolean(manifestCid),
-    refetchInterval: pollIntervalMs,
+    refetchInterval: OPERATOR_COUNT_POLL_INTERVAL_MS,
   });
 
   const [dialogTarget, setDialogTarget] = useState<LifecycleTarget | null>(null);

--- a/client/src/dashboard/spa/src/pages/launcher-launched/StatusHeader.test.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher-launched/StatusHeader.test.tsx
@@ -261,4 +261,45 @@ describe('StatusHeader', () => {
     // Truncated cid: first 8 chars + ellipsis + last 6 chars.
     expect(screen.getByTestId('launcher-launched-manifest-cid').textContent).toMatch(/bafybeig…/);
   });
+
+  // ── operator-count (issue #351) ───────────────────────────────────────────
+
+  it('renders the operator count when supplied', () => {
+    render(
+      <StatusHeader
+        record={buildRecord()}
+        manifest={buildManifest()}
+        operatorCount={3}
+        onAction={() => undefined}
+      />,
+    );
+    expect(screen.getByTestId('launcher-launched-operator-count').textContent).toMatch(/3/);
+    // The aliased `operator-count` test-id (the T2.3 selector) carries the
+    // same value via a hidden span — mirrors the `manifest-cid` aliasing.
+    expect(screen.getByTestId('operator-count').textContent).toBe('3');
+  });
+
+  it('renders an operator count of 0 when no operator has participated yet', () => {
+    render(
+      <StatusHeader
+        record={buildRecord()}
+        manifest={buildManifest()}
+        operatorCount={0}
+        onAction={() => undefined}
+      />,
+    );
+    expect(screen.getByTestId('operator-count').textContent).toBe('0');
+  });
+
+  it('omits the operator-count field when the count is undefined', () => {
+    render(
+      <StatusHeader
+        record={buildRecord()}
+        manifest={buildManifest()}
+        onAction={() => undefined}
+      />,
+    );
+    expect(screen.queryByTestId('launcher-launched-operator-count')).toBeNull();
+    expect(screen.queryByTestId('operator-count')).toBeNull();
+  });
 });

--- a/client/src/dashboard/spa/src/pages/launcher-launched/StatusHeader.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher-launched/StatusHeader.tsx
@@ -32,12 +32,14 @@ export interface StatusHeaderProps {
   record: LaunchedSolverNetRecord;
   manifest?: SolverNetManifestV1;
   /**
-   * Number of distinct operators with on-chain activity on this SolverNet
-   * (issue #351). `undefined` while the discovery query is loading or after
-   * a discovery outage — the Operators field is omitted rather than showing a
-   * misleading 0. The count reflects operators who have *claimed a task*: an
-   * operator "join" in the app is a local config write with no on-chain
-   * footprint (see `spec/2026-05-05-solvernet-creation-and-launch.md` §12).
+   * Number of distinct operators that have *ever* claimed a task on this
+   * SolverNet (issue #351) — an all-time ever-participated count, including
+   * tasks now finalized or refunded. `undefined` while the discovery query is
+   * loading or after a discovery outage — the Operators field is omitted
+   * rather than showing a misleading 0. The count reflects operators who have
+   * *claimed a task*: an operator "join" in the app is a local config write
+   * with no on-chain footprint (see
+   * `spec/2026-05-05-solvernet-creation-and-launch.md` §12).
    */
   operatorCount?: number;
   /** Triggered when the operator clicks Pause / Resume / Retire. */
@@ -186,7 +188,7 @@ export function StatusHeader({
             testid="launcher-launched-operator-count"
             additionalTestIds={['operator-count']}
             mono
-            title="Distinct operators that have claimed a task on this SolverNet"
+            title="Distinct operators that have ever claimed a task on this SolverNet, including on finalized or refunded tasks"
           />
         )}
       </dl>

--- a/client/src/dashboard/spa/src/pages/launcher-launched/StatusHeader.tsx
+++ b/client/src/dashboard/spa/src/pages/launcher-launched/StatusHeader.tsx
@@ -31,6 +31,15 @@ import {
 export interface StatusHeaderProps {
   record: LaunchedSolverNetRecord;
   manifest?: SolverNetManifestV1;
+  /**
+   * Number of distinct operators with on-chain activity on this SolverNet
+   * (issue #351). `undefined` while the discovery query is loading or after
+   * a discovery outage — the Operators field is omitted rather than showing a
+   * misleading 0. The count reflects operators who have *claimed a task*: an
+   * operator "join" in the app is a local config write with no on-chain
+   * footprint (see `spec/2026-05-05-solvernet-creation-and-launch.md` §12).
+   */
+  operatorCount?: number;
   /** Triggered when the operator clicks Pause / Resume / Retire. */
   onAction: (target: LifecycleTarget) => void;
   /** When a lifecycle transition is in flight, disable buttons + show pill. */
@@ -46,6 +55,7 @@ const ACTION_LABELS: Record<LifecycleTarget, string> = {
 export function StatusHeader({
   record,
   manifest,
+  operatorCount,
   onAction,
   pending,
 }: StatusHeaderProps): JSX.Element {
@@ -169,6 +179,16 @@ export function StatusHeader({
           testid="launcher-launched-agent"
           mono
         />
+        {operatorCount !== undefined && (
+          <IdentityField
+            label="Operators"
+            value={String(operatorCount)}
+            testid="launcher-launched-operator-count"
+            additionalTestIds={['operator-count']}
+            mono
+            title="Distinct operators that have claimed a task on this SolverNet"
+          />
+        )}
       </dl>
     </header>
   );

--- a/client/src/discovery/http.ts
+++ b/client/src/discovery/http.ts
@@ -90,6 +90,15 @@ query Tasks(
  */
 const ATTEMPTS_PAGE_LIMIT = 1000;
 
+/**
+ * Hard cap on `OPERATOR_COUNT_TASKS_QUERY` pages (leg 1 of the operator-count
+ * query). At `ATTEMPTS_PAGE_LIMIT` rows per page that is 50_000 tasks — far
+ * beyond any realistic SolverNet — and bounds the scan so the dashboard's
+ * recurring poll cannot trigger an unbounded walk. On a SolverNet past the cap
+ * the resulting count is a lower bound; see `getSolverNetOperatorCount`.
+ */
+const MAX_OPERATOR_COUNT_TASK_PAGES = 50;
+
 const ATTEMPTS_FOR_TASKS_QUERY = `
 query AttemptsForTasks($taskIds: [String!]!, $chainId: Int!, $limit: Int!, $after: String) {
   attempts(
@@ -161,6 +170,12 @@ query GetLifecycleStatus($manifestCid: String!) {
  * so this runs in two legs: first `OPERATOR_COUNT_TASKS_QUERY` (task ids for
  * the digest), then `OPERATOR_COUNT_ATTEMPTS_QUERY` batched over those ids via
  * the `_in` operator — the same pattern `findClaimableTasks` already uses.
+ *
+ * The task query intentionally does NOT filter `finalized` / `refunded`: the
+ * on-chain backing reads raw `TaskAttemptCreated` logs and cannot see lifecycle
+ * state, so adding the filter here would make HTTP and on-chain disagree. The
+ * count is an *ever-participated* signal across all task lifecycle states — see
+ * `DiscoveryAPI.getSolverNetOperatorCount`.
  */
 const OPERATOR_COUNT_TASKS_QUERY = `
 query OperatorCountTasks($manifestDigest: String!, $limit: Int!, $after: String) {
@@ -720,16 +735,18 @@ export function createHttpDiscoveryAPI(opts: HttpDiscoveryAPIOptions): Discovery
     const manifestDigest = manifestDigestForCid(manifestCid).toLowerCase();
 
     // Leg 1: page every task id for this SolverNet. Single-chain query, so all
-    // rows share a chainId — captured for the leg-2 attempt filter.
+    // rows share a chainId — captured for the leg-2 attempt filter. Capped at
+    // MAX_OPERATOR_COUNT_TASK_PAGES so the dashboard's recurring poll cannot
+    // trigger an unbounded scan.
     const taskIds: string[] = [];
     let chainId: number | undefined;
     let taskCursor: string | null = null;
-    for (;;) {
+    for (let page = 0; page < MAX_OPERATOR_COUNT_TASK_PAGES; page++) {
       const data: OperatorCountTasksPage = await postGql<OperatorCountTasksPage>(
         gqlUrl,
         fetchImpl,
         OPERATOR_COUNT_TASKS_QUERY,
-        { manifestDigest, limit: 1000, after: taskCursor },
+        { manifestDigest, limit: ATTEMPTS_PAGE_LIMIT, after: taskCursor },
       );
       const items = data.tasks?.items ?? [];
       for (const row of items) {

--- a/client/src/discovery/http.ts
+++ b/client/src/discovery/http.ts
@@ -25,6 +25,7 @@ import type {
   PublishedArtifact,
 } from './types.js';
 import { DiscoveryUnavailableError } from './types.js';
+import { manifestDigestForCid } from '../adapters/mech/digest.js';
 
 // ── GraphQL query strings ─────────────────────────────────────────────────────
 
@@ -150,6 +151,58 @@ query GetLifecycleStatus($manifestCid: String!) {
 }
 `;
 
+/**
+ * Per-SolverNet attempt fetch for the operator-count query. Pages through every
+ * `attempt` row whose `taskId` belongs to a task with the given
+ * `manifestDigest`. The caller de-duplicates `operator` client-side to derive
+ * the distinct-operator count.
+ *
+ * There is no single GraphQL field joining `attempt` to `task.manifestDigest`,
+ * so this runs in two legs: first `OPERATOR_COUNT_TASKS_QUERY` (task ids for
+ * the digest), then `OPERATOR_COUNT_ATTEMPTS_QUERY` batched over those ids via
+ * the `_in` operator — the same pattern `findClaimableTasks` already uses.
+ */
+const OPERATOR_COUNT_TASKS_QUERY = `
+query OperatorCountTasks($manifestDigest: String!, $limit: Int!, $after: String) {
+  tasks(
+    where: { manifestDigest: $manifestDigest },
+    limit: $limit,
+    after: $after,
+    orderBy: "id",
+    orderDirection: "asc"
+  ) {
+    items {
+      id
+      chainId
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+`;
+
+const OPERATOR_COUNT_ATTEMPTS_QUERY = `
+query OperatorCountAttempts($taskIds: [String!]!, $chainId: Int!, $limit: Int!, $after: String) {
+  attempts(
+    where: { taskId_in: $taskIds, chainId: $chainId },
+    limit: $limit,
+    after: $after,
+    orderBy: "attemptIndex",
+    orderDirection: "asc"
+  ) {
+    items {
+      operator
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+`;
+
 const QUERY_ENVELOPES_QUERY = `
 query QueryEnvelopes($where: envelopeFilter, $limit: Int!) {
   envelopes(
@@ -241,6 +294,22 @@ interface EnvelopeRow {
 
 interface EnvelopePage {
   envelopes: { items: EnvelopeRow[] };
+}
+
+// ── Operator-count query response types (issue #351) ─────────────────────────
+
+interface OperatorCountTasksPage {
+  tasks: {
+    items: Array<{ id: string; chainId: number }>;
+    pageInfo?: { hasNextPage: boolean; endCursor: string | null };
+  };
+}
+
+interface OperatorCountAttemptsPage {
+  attempts: {
+    items: Array<{ operator: string }>;
+    pageInfo?: { hasNextPage: boolean; endCursor: string | null };
+  };
 }
 
 // ── Plug-in publication queries (attd) ───────────────────────────────────────
@@ -641,6 +710,65 @@ export function createHttpDiscoveryAPI(opts: HttpDiscoveryAPIOptions): Discovery
     };
   }
 
+  // ── getSolverNetOperatorCount ─────────────────────────────────────────────
+
+  async function getSolverNetOperatorCount(manifestCid: string): Promise<number> {
+    await ensureReady();
+
+    // The indexer keys tasks by `manifestDigest = keccak256(toBytes(cid))`,
+    // not by the cid string. Compute the digest so the task filter matches.
+    const manifestDigest = manifestDigestForCid(manifestCid).toLowerCase();
+
+    // Leg 1: page every task id for this SolverNet. Single-chain query, so all
+    // rows share a chainId — captured for the leg-2 attempt filter.
+    const taskIds: string[] = [];
+    let chainId: number | undefined;
+    let taskCursor: string | null = null;
+    for (;;) {
+      const data: OperatorCountTasksPage = await postGql<OperatorCountTasksPage>(
+        gqlUrl,
+        fetchImpl,
+        OPERATOR_COUNT_TASKS_QUERY,
+        { manifestDigest, limit: 1000, after: taskCursor },
+      );
+      const items = data.tasks?.items ?? [];
+      for (const row of items) {
+        taskIds.push(row.id);
+        if (chainId === undefined) chainId = row.chainId;
+      }
+      const pageInfo: OperatorCountTasksPage['tasks']['pageInfo'] = data.tasks?.pageInfo;
+      if (!pageInfo?.hasNextPage || !pageInfo.endCursor) break;
+      taskCursor = pageInfo.endCursor;
+    }
+
+    // No tasks → no attempts → no participating operators.
+    if (taskIds.length === 0 || chainId === undefined) return 0;
+
+    // Leg 2: page every attempt for those task ids, collecting distinct
+    // operators. Batched over the id set via the `_in` operator (Ponder caps
+    // plural-query limit at 1000, hence ATTEMPTS_PAGE_LIMIT paging).
+    const operators = new Set<string>();
+    let attemptCursor: string | null = null;
+    for (;;) {
+      const data: OperatorCountAttemptsPage = await postGql<OperatorCountAttemptsPage>(
+        gqlUrl,
+        fetchImpl,
+        OPERATOR_COUNT_ATTEMPTS_QUERY,
+        { taskIds, chainId, limit: ATTEMPTS_PAGE_LIMIT, after: attemptCursor },
+      );
+      for (const row of data.attempts?.items ?? []) {
+        if (typeof row.operator === 'string' && row.operator.length > 0) {
+          operators.add(row.operator.toLowerCase());
+        }
+      }
+      const pageInfo: OperatorCountAttemptsPage['attempts']['pageInfo'] = data.attempts?.pageInfo;
+      if (!pageInfo?.hasNextPage || !pageInfo.endCursor) break;
+      attemptCursor = pageInfo.endCursor;
+    }
+
+    return operators.size;
+  }
+
   // ── queryEnvelopes ────────────────────────────────────────────────────────
 
   async function queryEnvelopes(query: CorpusQuery): Promise<EnvelopeRef[]> {
@@ -792,6 +920,7 @@ export function createHttpDiscoveryAPI(opts: HttpDiscoveryAPIOptions): Discovery
     findClaimableTasks,
     listLaunchedSolverNets,
     getLifecycleStatus,
+    getSolverNetOperatorCount,
     queryEnvelopes,
     listPluginPublications,
     getPluginScores,

--- a/client/src/discovery/onchain.ts
+++ b/client/src/discovery/onchain.ts
@@ -949,6 +949,121 @@ export function createOnchainDiscoveryAPI(opts: OnchainDiscoveryAPIOptions): Dis
     };
   }
 
+  // ── getSolverNetOperatorCount ──────────────────────────────────────────────
+
+  async function getSolverNetOperatorCount(manifestCid: string): Promise<number> {
+    if (!routerAddress) {
+      throw new DiscoveryUnavailableError(
+        `OnchainDiscoveryAPI: no routerAddress configured for chainId=${opts.chainId}`,
+      );
+    }
+
+    const client = getClient();
+    let currentBlock: bigint;
+    try {
+      currentBlock = await (client as PublicClient).getBlockNumber();
+    } catch (err) {
+      throw new DiscoveryUnavailableError(
+        `OnchainDiscoveryAPI.getSolverNetOperatorCount: failed to get block number`,
+        err,
+      );
+    }
+
+    // Scan from the execution-discovery floor (not the cursor cache): like
+    // listPluginPublications this is a complete-recount call with no
+    // accumulator, so it must always see every TaskCreated / TaskAttemptCreated
+    // event for the SolverNet.
+    const fromBlock = resolveScanFromBlock(opts, currentBlock);
+    const targetDigest = manifestDigestForCid(manifestCid).toLowerCase() as Hex;
+
+    // Pass 1: TaskCreated → the set of task ids belonging to this SolverNet.
+    let solverNetTaskIds: Set<string>;
+    try {
+      const taskIdLists = await scanLogsInChunks(
+        async (start, end) => {
+          const logs = await (client as PublicClient).getLogs({
+            address: routerAddress,
+            fromBlock: start,
+            toBlock: end,
+          });
+          const decoded: string[] = [];
+          for (const log of logs) {
+            try {
+              const event = decodeEventLog({
+                abi: JINN_ROUTER_ABI,
+                data: log.data,
+                topics: log.topics,
+              });
+              if (event.eventName !== 'TaskCreated') continue;
+              const evArgs = event.args as { taskId: bigint; manifestDigest: Hex };
+              if ((evArgs.manifestDigest as string).toLowerCase() !== targetDigest) continue;
+              decoded.push(String(evArgs.taskId));
+            } catch {
+              // Not a TaskCreated event — skip.
+            }
+          }
+          return decoded;
+        },
+        fromBlock,
+        currentBlock,
+        chunk,
+      );
+      solverNetTaskIds = new Set(taskIdLists);
+    } catch (err) {
+      if (err instanceof DiscoveryUnavailableError) throw err;
+      throw new DiscoveryUnavailableError(
+        `OnchainDiscoveryAPI.getSolverNetOperatorCount: getLogs for TaskCreated failed`,
+        err,
+      );
+    }
+
+    // No tasks → no attempts → no participating operators.
+    if (solverNetTaskIds.size === 0) return 0;
+
+    // Pass 2: TaskAttemptCreated → distinct operators across those tasks.
+    let operators: Set<string>;
+    try {
+      const operatorLists = await scanLogsInChunks(
+        async (start, end) => {
+          const logs = await (client as PublicClient).getLogs({
+            address: routerAddress,
+            fromBlock: start,
+            toBlock: end,
+          });
+          const decoded: string[] = [];
+          for (const log of logs) {
+            try {
+              const event = decodeEventLog({
+                abi: JINN_ROUTER_ABI,
+                data: log.data,
+                topics: log.topics,
+              });
+              if (event.eventName !== 'TaskAttemptCreated') continue;
+              const evArgs = event.args as { taskId: bigint; operator: Address };
+              if (!solverNetTaskIds.has(String(evArgs.taskId))) continue;
+              decoded.push(evArgs.operator.toLowerCase());
+            } catch {
+              // Not a TaskAttemptCreated event — skip.
+            }
+          }
+          return decoded;
+        },
+        fromBlock,
+        currentBlock,
+        chunk,
+      );
+      operators = new Set(operatorLists);
+    } catch (err) {
+      if (err instanceof DiscoveryUnavailableError) throw err;
+      throw new DiscoveryUnavailableError(
+        `OnchainDiscoveryAPI.getSolverNetOperatorCount: getLogs for TaskAttemptCreated failed`,
+        err,
+      );
+    }
+
+    return operators.size;
+  }
+
   // ── queryEnvelopes ─────────────────────────────────────────────────────────
 
   async function queryEnvelopes(query: CorpusQuery): Promise<EnvelopeRef[]> {
@@ -1121,6 +1236,7 @@ export function createOnchainDiscoveryAPI(opts: OnchainDiscoveryAPIOptions): Dis
     findClaimableTasks,
     listLaunchedSolverNets,
     getLifecycleStatus,
+    getSolverNetOperatorCount,
     queryEnvelopes,
     listPluginPublications,
     getPluginScores,

--- a/client/src/discovery/onchain.ts
+++ b/client/src/discovery/onchain.ts
@@ -70,6 +70,15 @@ const DEFAULT_ROUTER_BY_CHAIN_ID: Record<number, Address> = {
 /** Concurrency cap for parallel canClaimTask calls. */
 const CLAIM_CHECK_CONCURRENCY = 8;
 
+/**
+ * Hard cap on the number of getLogs chunks `getSolverNetOperatorCount` scans
+ * per pass. Bounds the dashboard's recurring operator-count poll so it cannot
+ * walk unbounded chain history; past the cap the count is a lower bound. See
+ * `DiscoveryAPI.getSolverNetOperatorCount`. The HTTP backing's sibling cap is
+ * `MAX_OPERATOR_COUNT_TASK_PAGES` in `http.ts`.
+ */
+const MAX_OPERATOR_COUNT_TASK_PAGES = 50;
+
 const SOLVERNET_MANIFEST_KEY_PREFIX = 'solvernet-manifest:';
 
 // ── ABI fragments ─────────────────────────────────────────────────────────────
@@ -448,6 +457,11 @@ function foldPluginPublications(events: PluginMetadataEvent[]): {
  * items have been accumulated — avoiding scanning the entire history when
  * only a bounded result set is needed. Without `maxResults`, scans
  * oldest-first (standard order).
+ *
+ * When `maxChunks` is provided, the oldest-first scan stops after at most
+ * `maxChunks` getLogs round-trips. This bounds a recurring caller (e.g. the
+ * dashboard's operator-count poll) so it cannot walk unbounded history; past
+ * the cap the result set is a prefix of the full range.
  */
 async function scanLogsInChunks<T>(
   getLogs: (fromBlock: bigint, toBlock: bigint) => Promise<T[]>,
@@ -455,6 +469,7 @@ async function scanLogsInChunks<T>(
   toBlock: bigint,
   chunkBlocks: bigint,
   maxResults?: number,
+  maxChunks?: number,
 ): Promise<T[]> {
   const results: T[] = [];
 
@@ -477,10 +492,13 @@ async function scanLogsInChunks<T>(
     // Oldest-first scan. Each chunk is [start, start + chunkBlocks] inclusive,
     // and the next iteration starts at `start + chunkBlocks + 1n` — no overlap,
     // no gap.
+    let chunksScanned = 0;
     for (let start = fromBlock; start <= toBlock; start += chunkBlocks + 1n) {
+      if (maxChunks !== undefined && chunksScanned >= maxChunks) break;
       const end = start + chunkBlocks > toBlock ? toBlock : start + chunkBlocks;
       const chunk = await getLogs(start, end);
       results.push(...chunk);
+      chunksScanned += 1;
     }
   }
 
@@ -972,7 +990,9 @@ export function createOnchainDiscoveryAPI(opts: OnchainDiscoveryAPIOptions): Dis
     // Scan from the execution-discovery floor (not the cursor cache): like
     // listPluginPublications this is a complete-recount call with no
     // accumulator, so it must always see every TaskCreated / TaskAttemptCreated
-    // event for the SolverNet.
+    // event for the SolverNet. Both passes are capped at
+    // MAX_OPERATOR_COUNT_TASK_PAGES getLogs chunks so this recurring poll
+    // cannot walk unbounded history; past the cap the count is a lower bound.
     const fromBlock = resolveScanFromBlock(opts, currentBlock);
     const targetDigest = manifestDigestForCid(manifestCid).toLowerCase() as Hex;
 
@@ -1007,6 +1027,8 @@ export function createOnchainDiscoveryAPI(opts: OnchainDiscoveryAPIOptions): Dis
         fromBlock,
         currentBlock,
         chunk,
+        undefined,
+        MAX_OPERATOR_COUNT_TASK_PAGES,
       );
       solverNetTaskIds = new Set(taskIdLists);
     } catch (err) {
@@ -1051,6 +1073,8 @@ export function createOnchainDiscoveryAPI(opts: OnchainDiscoveryAPIOptions): Dis
         fromBlock,
         currentBlock,
         chunk,
+        undefined,
+        MAX_OPERATOR_COUNT_TASK_PAGES,
       );
       operators = new Set(operatorLists);
     } catch (err) {

--- a/client/src/discovery/types.ts
+++ b/client/src/discovery/types.ts
@@ -182,12 +182,20 @@ export interface DiscoveryAPI {
   getLifecycleStatus(manifestCid: string): Promise<SolverNetLifecycleStatus | undefined>;
 
   /**
-   * Returns the number of distinct operators that have on-chain activity on
-   * the SolverNet identified by `manifestCid` — i.e. the count of unique
+   * Returns the number of distinct operators that have *ever* claimed a task
+   * on the SolverNet identified by `manifestCid` — i.e. the count of unique
    * `attempt.operator` Safe addresses across every task whose
-   * `manifestDigest === keccak256(manifestCid)`.
+   * `manifestDigest === keccak256(manifestCid)`, **including tasks that are
+   * now finalized or refunded**.
    *
-   * This is the protocol-observable participation signal: a "join" in the
+   * This is an *ever-participated* signal, not a "currently active" one. The
+   * count never filters on task lifecycle state: the on-chain backing reads
+   * raw `TaskAttemptCreated` logs, which carry no finalized/refunded flag, so
+   * the only count consistent across all three backings (HTTP / embedded /
+   * on-chain) is the all-time distinct-operator total. Treat it as "operators
+   * who have participated at least once", not "operators participating today".
+   *
+   * It is the protocol-observable participation signal: a "join" in the
    * operator app is purely a local config write (`joinedSolverNets[<cid>]`,
    * see `spec/2026-05-05-solvernet-creation-and-launch.md` §12) and leaves no
    * on-chain footprint. An operator only becomes visible to the network once
@@ -195,6 +203,10 @@ export interface DiscoveryAPI {
    * to (operator, SolverNet). This method therefore counts *participating*
    * operators (operators who have claimed at least one task), which is the
    * only honest cross-operator count derivable from the indexer / chain.
+   *
+   * Task pagination is hard-capped (`MAX_OPERATOR_COUNT_TASK_PAGES` in each
+   * backing) so a pathological task volume cannot turn this into an unbounded
+   * scan; on a SolverNet beyond the cap the count is a lower bound.
    *
    * Returns `0` when no operator has attempted a task on the SolverNet yet.
    */

--- a/client/src/discovery/types.ts
+++ b/client/src/discovery/types.ts
@@ -182,6 +182,25 @@ export interface DiscoveryAPI {
   getLifecycleStatus(manifestCid: string): Promise<SolverNetLifecycleStatus | undefined>;
 
   /**
+   * Returns the number of distinct operators that have on-chain activity on
+   * the SolverNet identified by `manifestCid` — i.e. the count of unique
+   * `attempt.operator` Safe addresses across every task whose
+   * `manifestDigest === keccak256(manifestCid)`.
+   *
+   * This is the protocol-observable participation signal: a "join" in the
+   * operator app is purely a local config write (`joinedSolverNets[<cid>]`,
+   * see `spec/2026-05-05-solvernet-creation-and-launch.md` §12) and leaves no
+   * on-chain footprint. An operator only becomes visible to the network once
+   * they claim a task — `TaskAttemptCreated` is the first on-chain event tied
+   * to (operator, SolverNet). This method therefore counts *participating*
+   * operators (operators who have claimed at least one task), which is the
+   * only honest cross-operator count derivable from the indexer / chain.
+   *
+   * Returns `0` when no operator has attempted a task on the SolverNet yet.
+   */
+  getSolverNetOperatorCount(manifestCid: string): Promise<number>;
+
+  /**
    * Returns envelope refs matching the query. Refs only — byte retrieval is
    * done by the corpus library on demand.
    *

--- a/client/src/discovery/with-fallback.ts
+++ b/client/src/discovery/with-fallback.ts
@@ -202,6 +202,13 @@ export function withFallback(
       );
     },
 
+    getSolverNetOperatorCount(manifestCid) {
+      return dispatch(
+        () => primary.getSolverNetOperatorCount(manifestCid),
+        () => floor.getSolverNetOperatorCount(manifestCid),
+      );
+    },
+
     queryEnvelopes(query) {
       return dispatch(
         () => primary.queryEnvelopes(query),

--- a/client/test/api/discovery-endpoint.test.ts
+++ b/client/test/api/discovery-endpoint.test.ts
@@ -9,6 +9,7 @@ function stubDiscovery(partial: Partial<DiscoveryAPI>): DiscoveryAPI {
     findClaimableTasks: vi.fn(),
     listLaunchedSolverNets: vi.fn(),
     getLifecycleStatus: vi.fn(),
+    getSolverNetOperatorCount: vi.fn().mockResolvedValue(0),
     queryEnvelopes: vi.fn(),
     listPluginPublications: vi.fn().mockResolvedValue([]),
     getPluginScores: vi.fn().mockResolvedValue([]),
@@ -98,6 +99,42 @@ describe('discovery-endpoint (hfmf)', () => {
     const app = new Hono();
     addDiscoveryRoutes(app, { discovery: () => discovery });
     const res = await app.request('/v1/discovery/plugin-publications');
+    expect(res.status).toBe(503);
+  });
+
+  it('GET /v1/discovery/solvernet-operator-count?cid= returns the count (#351)', async () => {
+    const discovery = stubDiscovery({
+      getSolverNetOperatorCount: vi.fn().mockResolvedValue(3),
+    });
+    const app = new Hono();
+    addDiscoveryRoutes(app, { discovery: () => discovery });
+    const res = await app.request(
+      '/v1/discovery/solvernet-operator-count?cid=bafkreitest',
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.manifestCid).toBe('bafkreitest');
+    expect(body.operatorCount).toBe(3);
+    expect(discovery.getSolverNetOperatorCount).toHaveBeenCalledWith('bafkreitest');
+  });
+
+  it('GET /v1/discovery/solvernet-operator-count without cid returns 400', async () => {
+    const discovery = stubDiscovery({});
+    const app = new Hono();
+    addDiscoveryRoutes(app, { discovery: () => discovery });
+    const res = await app.request('/v1/discovery/solvernet-operator-count');
+    expect(res.status).toBe(400);
+  });
+
+  it('GET /v1/discovery/solvernet-operator-count 503s on discovery outage', async () => {
+    const discovery = stubDiscovery({
+      getSolverNetOperatorCount: vi.fn().mockRejectedValue(new Error('indexer down')),
+    });
+    const app = new Hono();
+    addDiscoveryRoutes(app, { discovery: () => discovery });
+    const res = await app.request(
+      '/v1/discovery/solvernet-operator-count?cid=bafkreitest',
+    );
     expect(res.status).toBe(503);
   });
 });

--- a/client/test/api/discovery-endpoint.test.ts
+++ b/client/test/api/discovery-endpoint.test.ts
@@ -167,12 +167,13 @@ describe('discovery-endpoint — auth gating (jinn-mono-0nih)', () => {
     expect(res.status).toBe(200);
   });
 
-  it('gates all three discovery sub-paths', async () => {
+  it('gates every discovery sub-path', async () => {
     const app = gatedApp(stubDiscovery({}));
     for (const path of [
       '/v1/discovery/plugin-publications?solverType=foo',
       '/v1/discovery/builder-artifacts?builderAgentId=1',
       '/v1/discovery/plugin-scores?cid=bafy',
+      '/v1/discovery/solvernet-operator-count?cid=bafytest',
     ]) {
       const res = await app.request(path);
       expect(res.status, `${path} should require auth`).toBe(401);

--- a/client/test/dashboard/multi-op/launcher-join-flow.e2e.test.ts
+++ b/client/test/dashboard/multi-op/launcher-join-flow.e2e.test.ts
@@ -57,23 +57,40 @@ test('T2.3 — op-a launches, op-b joins, both observe each other', async ({ bro
     // ===== op-a sees op-b's join =====
     await opAPage.goto(`${opAUrl}/launcher/launched`);
     await opAPage.getByText(solverNetName).click();
-    // The assertion below is known-broken: the SPA does not yet surface operator
-    // join counts. `LaunchedSolverNetRecord`
-    // (client/src/dashboard/spa/src/api/types.ts:466) has no operatorsJoined field
-    // and the launched dashboard has no element with data-testid="operator-count".
-    // A daemon endpoint + SPA surface must land first.
-    // Tracked in: https://github.com/Jinn-Network/mono/issues/351
-    // See docs/superpowers/plans/2026-05-19-tier-2-scenarios-plan.md Task 9.
+
+    // The launched dashboard now surfaces an `operator-count` element
+    // (issue #351 — StatusHeader "Operators" field, fed by
+    // `GET /v1/discovery/solvernet-operator-count`). The element exists and
+    // renders a real, indexer-derived number — so this assertion is now live:
+    // T2.3 verifies the surface unconditionally.
+    await expect(opAPage.getByTestId('operator-count')).toHaveText(/\d+/, {
+      timeout: 60000,
+    });
+
+    // The "exactly 1 operator joined" magnitude assertion stays gated.
+    // #351 surfaced that an operator "join" is purely a local config write to
+    // `joinedSolverNets[<cid>]` on the joining operator's daemon
+    // (spec/2026-05-05-solvernet-creation-and-launch.md §12) — it leaves NO
+    // on-chain footprint. The only protocol-observable signal is
+    // `TaskAttemptCreated`: an operator becomes visible network-wide once they
+    // *claim a task*. So `operator-count` counts *participating* operators, and
+    // in this scenario op-b joins but never claims a task — the honest count is
+    // 0, not 1.
     //
-    // Until #351 ships, this assertion is gated behind JINN_T23_OPERATOR_COUNT_READY
-    // so the rest of T2.3 can pass and run-tier-2 does not exit 1 every run. Set
-    // JINN_T23_OPERATOR_COUNT_READY=1 once the SPA surface exists to re-enable it.
+    // Asserting `/1/` unconditionally requires either (a) extending this
+    // scenario so op-b restarts + claims a task, or (b) a new on-chain
+    // operator-registration event + indexer entity so config-level joins
+    // become observable. Both are out of scope for #351; tracked as follow-up.
+    // Set JINN_T23_OPERATOR_COUNT_READY=1 once op-b also produces an on-chain
+    // operator footprint.
     if (process.env['JINN_T23_OPERATOR_COUNT_READY'] === '1') {
       await expect(opAPage.getByTestId('operator-count')).toHaveText(/1/, { timeout: 60000 });
     } else {
       console.warn(
-        'T2.3: skipping operator-count assertion — SPA does not yet surface operator ' +
-          'join counts (GH #351). Set JINN_T23_OPERATOR_COUNT_READY=1 once it ships.',
+        'T2.3: operator-count element is present and indexer-wired (GH #351); the ' +
+          '"1 operator joined" magnitude assertion stays gated — a config-level join has no ' +
+          'on-chain footprint, so a join-only scenario yields 0. Set ' +
+          'JINN_T23_OPERATOR_COUNT_READY=1 once op-b also claims a task on-chain.',
       );
     }
   } finally {

--- a/client/test/discovery/http.test.ts
+++ b/client/test/discovery/http.test.ts
@@ -643,6 +643,117 @@ describe('getLifecycleStatus', () => {
   });
 });
 
+// ── getSolverNetOperatorCount (#351) ──────────────────────────────────────────
+
+describe('getSolverNetOperatorCount', () => {
+  /**
+   * Mock a two-leg GraphQL exchange: `OperatorCountTasks` returns the task
+   * page, `OperatorCountAttempts` returns the attempts page. `/ready` probes
+   * resolve 200 so the GraphQL path is reached.
+   */
+  function mockTwoLeg(tasksData: unknown, attemptsData: unknown) {
+    const queries: string[] = [];
+    const impl = vi.fn(async (url: string, init?: RequestInit) => {
+      if (isReadyProbe(url)) return new Response(null, { status: 200 });
+      const body = JSON.parse(init?.body as string) as { query: string };
+      queries.push(body.query);
+      const payload = body.query.includes('query OperatorCountTasks(')
+        ? tasksData
+        : attemptsData;
+      return new Response(JSON.stringify({ data: payload }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    return { impl, queries };
+  }
+
+  it('counts distinct operators across the SolverNet attempts', async () => {
+    const { impl } = mockTwoLeg(
+      {
+        tasks: {
+          items: [
+            { id: '1', chainId: 84532 },
+            { id: '2', chainId: 84532 },
+          ],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+      {
+        attempts: {
+          items: [
+            // op-a attempts twice, op-b once → 2 distinct operators.
+            { operator: '0xAAAA000000000000000000000000000000000000' },
+            { operator: '0xaaaa000000000000000000000000000000000000' },
+            { operator: '0xBBBB000000000000000000000000000000000000' },
+          ],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+    );
+    const client = createHttpDiscoveryAPI({ url: BASE_URL, fetchImpl: impl as unknown as typeof fetch });
+    const count = await client.getSolverNetOperatorCount('bafkreitestcid');
+    expect(count).toBe(2);
+  });
+
+  it('returns 0 when the SolverNet has no tasks', async () => {
+    const { impl, queries } = mockTwoLeg(
+      { tasks: { items: [], pageInfo: { hasNextPage: false, endCursor: null } } },
+      { attempts: { items: [], pageInfo: { hasNextPage: false, endCursor: null } } },
+    );
+    const client = createHttpDiscoveryAPI({ url: BASE_URL, fetchImpl: impl as unknown as typeof fetch });
+    const count = await client.getSolverNetOperatorCount('bafkreiempty');
+    expect(count).toBe(0);
+    // Short-circuit: no attempt query is issued when there are no tasks.
+    expect(queries.some((q) => q.includes('query OperatorCountAttempts('))).toBe(false);
+  });
+
+  it('returns 0 when tasks exist but no operator has attempted any', async () => {
+    const { impl } = mockTwoLeg(
+      {
+        tasks: {
+          items: [{ id: '1', chainId: 84532 }],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+      { attempts: { items: [], pageInfo: { hasNextPage: false, endCursor: null } } },
+    );
+    const client = createHttpDiscoveryAPI({ url: BASE_URL, fetchImpl: impl as unknown as typeof fetch });
+    const count = await client.getSolverNetOperatorCount('bafkreinoattempts');
+    expect(count).toBe(0);
+  });
+
+  it('filters tasks by the keccak256 manifest digest of the cid', async () => {
+    const { impl, queries } = mockTwoLeg(
+      { tasks: { items: [], pageInfo: { hasNextPage: false, endCursor: null } } },
+      { attempts: { items: [], pageInfo: { hasNextPage: false, endCursor: null } } },
+    );
+    const client = createHttpDiscoveryAPI({ url: BASE_URL, fetchImpl: impl as unknown as typeof fetch });
+    await client.getSolverNetOperatorCount('bafkreitestcid');
+    // The tasks query is keyed by manifestDigest (a 0x-prefixed keccak hash),
+    // not by the raw cid string.
+    expect(queries[0]).toContain('query OperatorCountTasks(');
+  });
+
+  it('throws DiscoveryUnavailableError on GraphQL errors', async () => {
+    const { impl } = mockFetch({ errors: [{ message: 'indexer 500' }] });
+    const client = createHttpDiscoveryAPI({ url: BASE_URL, fetchImpl: impl as unknown as typeof fetch });
+    await expect(
+      client.getSolverNetOperatorCount('bafkreitestcid'),
+    ).rejects.toThrow(DiscoveryUnavailableError);
+  });
+
+  it('throws DiscoveryUnavailableError on network failure', async () => {
+    const client = createHttpDiscoveryAPI({
+      url: BASE_URL,
+      fetchImpl: networkErrorFetch() as unknown as typeof fetch,
+    });
+    await expect(
+      client.getSolverNetOperatorCount('bafkreitestcid'),
+    ).rejects.toThrow(DiscoveryUnavailableError);
+  });
+});
+
 // ── queryEnvelopes ────────────────────────────────────────────────────────────
 
 describe('queryEnvelopes', () => {

--- a/client/test/discovery/with-fallback.test.ts
+++ b/client/test/discovery/with-fallback.test.ts
@@ -79,8 +79,9 @@ function makeStub(overrides?: Partial<Record<MethodName, DiscoveryAPI[MethodName
     findClaimableTasks: vi.fn(async () => [TASK_CANDIDATE]),
     listLaunchedSolverNets: vi.fn(async () => [SOLVER_NET_SUMMARY]),
     getLifecycleStatus: vi.fn(async () => LIFECYCLE_STATUS),
+    getSolverNetOperatorCount: vi.fn(async () => 1),
     queryEnvelopes: vi.fn(async () => [ENVELOPE_REF]),
-  };
+  } as unknown as DiscoveryAPI;
   return { ...defaults, ...(overrides ?? {}) };
 }
 
@@ -92,8 +93,9 @@ function makeThrowingStub(error: Error): DiscoveryAPI {
     findClaimableTasks: vi.fn(async () => { throw error; }),
     listLaunchedSolverNets: vi.fn(async () => { throw error; }),
     getLifecycleStatus: vi.fn(async () => { throw error; }),
+    getSolverNetOperatorCount: vi.fn(async () => { throw error; }),
     queryEnvelopes: vi.fn(async () => { throw error; }),
-  };
+  } as unknown as DiscoveryAPI;
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -364,6 +366,17 @@ describe('withFallback — all four methods', () => {
 
     expect(result).toEqual([ENVELOPE_REF]);
     expect(floor.queryEnvelopes).toHaveBeenCalledOnce();
+  });
+
+  it('getSolverNetOperatorCount routes to floor on DiscoveryUnavailableError', async () => {
+    const primary = makeThrowingStub(ERROR);
+    const floor = makeStub();
+    const api = makeWrapper(primary, floor);
+
+    const result = await api.getSolverNetOperatorCount('bafkreitest');
+
+    expect(result).toBe(1);
+    expect(floor.getSolverNetOperatorCount).toHaveBeenCalledOnce();
   });
 });
 


### PR DESCRIPTION
## Summary

Wires an indexer-backed operator count end-to-end onto the launched-SolverNet dashboard, so a launcher can see how many operators participate in their SolverNet.

- **DiscoveryAPI** gains `getSolverNetOperatorCount(manifestCid)` — implemented in the HTTP (GraphQL) and on-chain (RPC floor) backings, threaded through the `withFallback` wrapper. It counts distinct `attempt.operator` Safe addresses across every task whose `manifestDigest === keccak256(toBytes(cid))`. No indexer schema or handler change — it's a pure read-side aggregation over the existing `task` + `attempt` entities, so no re-sync.
- New daemon route `GET /v1/discovery/solvernet-operator-count?cid=`.
- `LauncherLaunchedPage` polls it; `StatusHeader` renders an **Operators** field with `data-testid="operator-count"` (aliased as a hidden span, mirroring the existing `manifest-cid` pattern). The field is omitted — not shown as a misleading `0` — while the discovery query is loading or after an outage.

## Investigation finding (why T2.3's gate stays — partly)

An operator "join" in the app is **purely a local config write** to `joinedSolverNets[<cid>]` on the joining operator's own daemon (`spec/2026-05-05-solvernet-creation-and-launch.md` §12; `POST /v1/operator/join/:cid` in `setup-endpoints.ts`). It leaves **no on-chain footprint** — no event, no tx, no indexer entity. The launcher's daemon has no way to observe it.

The only protocol-observable signal tying an operator to a SolverNet is `TaskAttemptCreated` (the `attempt` indexer entity) — an operator becomes visible network-wide once they **claim a task**. So `getSolverNetOperatorCount` honestly counts *participating* operators, not config-level joins. This is the same shape as the explorer's existing `countDistinct(attempt.operator)`.

A true "operators *joined*" count would need a contract change (an on-chain operator-registration event + new indexer entity/handler) — too large for this PR, and arguably a design question.

## T2.3 status

- The `operator-count` **element-presence** assertion is now **live and unconditional** — T2.3 asserts `getByTestId('operator-count')` renders a real number, catching any regression that drops the surface.
- The **"exactly 1 operator joined"** magnitude assertion **stays gated** behind `JINN_T23_OPERATOR_COUNT_READY`. T2.3's op-b joins but never claims a task, so the honest on-chain count is `0`, not `1`. Removing the gate entirely would make T2.3 fail. Closing the gap needs either op-b claiming a task in-scenario, or the on-chain operator-registration event above — tracked as follow-up.

## Test plan

- [x] `yarn typecheck` clean (client src)
- [x] SPA `tsc -b && vite build` clean
- [x] `test/discovery/http.test.ts` — new `getSolverNetOperatorCount` suite (distinct-operator count, 0-task / 0-attempt cases, GraphQL-error + network-error → `DiscoveryUnavailableError`)
- [x] `test/discovery/with-fallback.test.ts` — new routing test
- [x] `test/api/discovery-endpoint.test.ts` — new route tests (200 / 400 missing-cid / 503 outage)
- [x] `StatusHeader.test.tsx` + `LauncherLaunched.test.tsx` — operator-count rendered / 0 / omitted-on-undefined / omitted-on-query-error
- [ ] T2.3 Playwright run (`run-tier-2`) — requires `BASE_SEPOLIA_RPC_URL`; the `operator-count` element-presence assertion now runs unconditionally

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)