### PR TITLE
fix(366): codex readiness probe validates auth liveness

### DIFF
--- a/client/src/api/codex-doctor-endpoint.ts
+++ b/client/src/api/codex-doctor-endpoint.ts
@@ -6,35 +6,52 @@
  * before the operator saves a Codex harness selection.
  *
  * Response shape:
- *   { installed: boolean, authenticated: boolean, exitCode: number | null,
- *     stdout: string, stderr: string }
+ *   { installed: boolean, authenticated: boolean,
+ *     authStatus: 'ok' | 'expired' | 'not_configured',
+ *     exitCode: number | null, stdout: string, stderr: string }
  *
  * `installed: false` means the binary was not found (ENOENT or equivalent).
  * `exitCode !== 0` (with `installed: true`) means the binary exists but
  * `codex --version` itself failed.
- * `authenticated: false` (with `installed: true`, `exitCode === 0`) means the
- * binary is present and runnable but no credentials are configured — Codex
- * authenticates via the `OPENAI_API_KEY` env var or a `codex login` session
- * persisted under `CODEX_HOME` / `~/.codex/auth.json`.
+ *
+ * `authStatus` (with `installed: true`, `exitCode === 0`) classifies the
+ * Codex credentials:
+ *   - `'ok'`             — usable credentials: an `OPENAI_API_KEY` (env or in
+ *                          `auth.json`), or a non-expired `codex login` OAuth
+ *                          session.
+ *   - `'expired'`        — an `auth.json` is present but its OAuth tokens have
+ *                          expired, or the file is malformed/unreadable. A
+ *                          logged-out operator with a leftover file lands here
+ *                          instead of false-`ok` (#366).
+ *   - `'not_configured'` — no `OPENAI_API_KEY` and no `auth.json` at all.
+ * `authenticated` is kept as a convenience alias for `authStatus === 'ok'`.
+ *
+ * Codex (unlike Hermes) has no `codex doctor` subcommand, so install
+ * detection shells `codex --version`. Codex also exposes no auth-status
+ * subcommand, so liveness is derived by parsing + expiry-checking the
+ * `auth.json` it persists — existence alone is not enough: a stale OAuth
+ * session reads as logged-in to a naive existence check (#366).
  *
  * The probe logic is exported as `probeCodexDoctor` so the Codex variant of
  * the `LearnerHarness` can reuse it from `isReady()` — same source of truth
  * for the SPA precheck panel and the daemon's claim-readiness gate (#348,
- * same-shape bug as #330).
- *
- * Codex (unlike Hermes) has no `codex doctor` subcommand, so install
- * detection shells `codex --version` and auth detection is a separate
- * filesystem / env check rather than a probe exit code.
+ * same-shape bug as #330; liveness tightening from #366).
  */
 import type { Hono } from 'hono';
 import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
+/** Classification of Codex credentials. */
+export type CodexAuthStatus = 'ok' | 'expired' | 'not_configured';
+
 export interface CodexDoctorResponse {
   installed: boolean;
+  /** Convenience alias — true iff `authStatus === 'ok'`. */
   authenticated: boolean;
+  /** Live/expired/absent classification of Codex credentials. */
+  authStatus: CodexAuthStatus;
   exitCode: number | null;
   stdout: string;
   stderr: string;
@@ -45,26 +62,126 @@ export interface CodexDoctorConfig {
   codexDoctorTimeoutMs?: number;
   /** Inject env for testing (defaults to process.env). */
   env?: NodeJS.ProcessEnv;
-  /** Override the auth-file existence check (for testing). */
-  authFileExists?: boolean;
+  /**
+   * Override the auth-file read (for testing). Returns the raw `auth.json`
+   * contents, or `undefined` when no file exists. When supplied, the real
+   * filesystem is not touched.
+   */
+  readAuthFile?: () => string | undefined;
+  /** Override the clock for deterministic expiry tests (epoch ms). */
+  now?: number;
+}
+
+/** Shape of the relevant fields of a Codex `auth.json`. */
+interface CodexAuthFile {
+  auth_mode?: string;
+  OPENAI_API_KEY?: string | null;
+  tokens?: {
+    id_token?: string | null;
+    access_token?: string | null;
+    refresh_token?: string | null;
+  } | null;
 }
 
 /**
- * Whether Codex has usable credentials. Codex authenticates either via the
- * `OPENAI_API_KEY` env var or via a `codex login` session persisted to
- * `auth.json` under `CODEX_HOME` (falling back to `~/.codex`).
+ * Decodes a JWT's payload and returns its `exp` claim (epoch seconds), or
+ * `undefined` when the token is absent, malformed, or carries no `exp`.
+ * Defensive: never throws.
  */
-function detectCodexAuth(config: CodexDoctorConfig): boolean {
-  if (config.authFileExists !== undefined) {
-    return config.authFileExists || hasApiKey(config);
+function jwtExpiry(token: string | null | undefined): number | undefined {
+  if (typeof token !== 'string' || token.length === 0) return undefined;
+  const parts = token.split('.');
+  if (parts.length !== 3) return undefined;
+  try {
+    const payloadJson = Buffer.from(parts[1], 'base64url').toString('utf8');
+    const payload = JSON.parse(payloadJson) as { exp?: unknown };
+    return typeof payload.exp === 'number' ? payload.exp : undefined;
+  } catch {
+    return undefined;
   }
-  if (hasApiKey(config)) return true;
+}
+
+/**
+ * Classifies the credentials inside a parsed `auth.json`.
+ *
+ *   - A non-empty `OPENAI_API_KEY` in the file is API-key mode — there is no
+ *     expiry, so presence is acceptable (`'ok'`).
+ *   - Otherwise it is OAuth (`codex login`) mode: expiry-check the JWT `exp`
+ *     of `id_token` (falling back to `access_token`). An expired token, or
+ *     tokens we cannot expiry-check at all (no JWT / no `exp`), is treated as
+ *     `'expired'` — the safe direction for a claim gate: a logged-out operator
+ *     with a leftover file must not read as live (#366).
+ */
+function classifyAuthFile(auth: CodexAuthFile, nowMs: number): CodexAuthStatus {
+  const fileApiKey = auth.OPENAI_API_KEY;
+  if (typeof fileApiKey === 'string' && fileApiKey.trim().length > 0) {
+    return 'ok';
+  }
+  const tokens = auth.tokens;
+  if (!tokens || typeof tokens !== 'object') {
+    // A file with neither an API key nor a tokens object carries no usable
+    // credential — treat as stale rather than live.
+    return 'expired';
+  }
+  const exp = jwtExpiry(tokens.id_token) ?? jwtExpiry(tokens.access_token);
+  if (exp === undefined) {
+    // Tokens present but not expiry-checkable — cannot prove liveness.
+    return 'expired';
+  }
+  return exp * 1000 > nowMs ? 'ok' : 'expired';
+}
+
+/**
+ * Reads `auth.json` (from `CODEX_HOME` or `~/.codex`) and returns its raw
+ * contents, or `undefined` when the file does not exist. A read error other
+ * than "not found" (e.g. EACCES) is reported as an empty string so the caller
+ * classifies it as `expired` rather than `not_configured`.
+ */
+function readCodexAuthFile(config: CodexDoctorConfig): string | undefined {
+  if (config.readAuthFile) return config.readAuthFile();
   const env = config.env ?? process.env;
   const codexHome = env['CODEX_HOME']?.trim();
   const authPath = codexHome
     ? join(codexHome, 'auth.json')
     : join(homedir(), '.codex', 'auth.json');
-  return existsSync(authPath);
+  try {
+    return readFileSync(authPath, 'utf8');
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === 'ENOENT') return undefined;
+    // File exists but is unreadable — surface as a present-but-broken file so
+    // it classifies as `expired`, never `not_configured`.
+    return '';
+  }
+}
+
+/**
+ * Classifies Codex credential state. Codex authenticates either via the
+ * `OPENAI_API_KEY` env var (no expiry) or via a `codex login` session
+ * persisted to `auth.json` under `CODEX_HOME` (falling back to `~/.codex`).
+ *
+ * Liveness, not mere existence: a malformed file or an expired OAuth session
+ * classifies as `'expired'`, distinct from `'not_configured'` (no file and no
+ * env key). Never throws — a corrupt file degrades to `'expired'`.
+ */
+function detectCodexAuthStatus(config: CodexDoctorConfig): CodexAuthStatus {
+  if (hasApiKey(config)) return 'ok';
+
+  const raw = readCodexAuthFile(config);
+  if (raw === undefined) return 'not_configured';
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Malformed / truncated auth.json — a logged-out operator with a corrupt
+    // leftover file. Stale-class, never a false `ok` (#366).
+    return 'expired';
+  }
+  if (!parsed || typeof parsed !== 'object') return 'expired';
+
+  const nowMs = config.now ?? Date.now();
+  return classifyAuthFile(parsed as CodexAuthFile, nowMs);
 }
 
 function hasApiKey(config: CodexDoctorConfig): boolean {
@@ -100,11 +217,15 @@ export function probeCodexDoctor(config: CodexDoctorConfig = {}): CodexDoctorRes
   );
 
   // Auth is only meaningful once the binary is present and runnable.
-  const authenticated = installed && result.status === 0 && detectCodexAuth(config);
+  const runnable = installed && result.status === 0;
+  const authStatus: CodexAuthStatus = runnable
+    ? detectCodexAuthStatus(config)
+    : 'not_configured';
 
   return {
     installed,
-    authenticated,
+    authenticated: authStatus === 'ok',
+    authStatus,
     exitCode: result.status,
     stdout: (result.stdout ?? '').slice(0, 4000),
     stderr: (result.stderr ?? '').slice(0, 4000),

--- a/client/src/api/codex-doctor-endpoint.ts
+++ b/client/src/api/codex-doctor-endpoint.ts
@@ -87,6 +87,10 @@ interface CodexAuthFile {
  * Decodes a JWT's payload and returns its `exp` claim (epoch seconds), or
  * `undefined` when the token is absent, malformed, or carries no `exp`.
  * Defensive: never throws.
+ *
+ * Note: the JWT signature is intentionally NOT verified — this is not a
+ * security gap. The daemon only needs the `exp` claim for a liveness hint;
+ * Codex itself verifies signatures when the token is actually used.
  */
 function jwtExpiry(token: string | null | undefined): number | undefined {
   if (typeof token !== 'string' || token.length === 0) return undefined;

--- a/client/src/harnesses/impls/learner/harness.ts
+++ b/client/src/harnesses/impls/learner/harness.ts
@@ -80,8 +80,12 @@ export class LearnerHarness implements Harness {
    *     failed claims (#348).
    *   - `exitCode !== 0` → binary exists but `codex --version` failed →
    *     ready=false pointing at the Codex precheck panel.
-   *   - `authenticated: false` → binary runs but no `OPENAI_API_KEY` /
-   *     `codex login` session → ready=false with a sign-in nextStep.
+   *   - `authStatus: 'not_configured'` → binary runs but no `OPENAI_API_KEY`
+   *     and no `codex login` session → ready=false with a sign-in nextStep.
+   *   - `authStatus: 'expired'` → an `auth.json` is present but its OAuth
+   *     session has expired (or the file is malformed) → ready=false with a
+   *     re-login nextStep. Distinct from `not_configured` so a logged-out
+   *     operator with a leftover file is not treated as ready (#366).
    *   - otherwise → ready=true.
    */
   private codexIsReady(): ReadyStatus {
@@ -116,7 +120,18 @@ export class LearnerHarness implements Harness {
         },
       };
     }
-    if (!result.authenticated) {
+    if (result.authStatus === 'expired') {
+      return {
+        ready: false,
+        reason: 'codex auth expired',
+        nextStep: {
+          description:
+            'Codex sign-in has expired — run `codex login` to refresh the session (or set OPENAI_API_KEY), then re-check the Codex precheck panel in the operator dashboard.',
+          url: '/api/codex/doctor',
+        },
+      };
+    }
+    if (result.authStatus !== 'ok') {
       return {
         ready: false,
         reason: 'codex auth not configured',

--- a/client/test/api/codex-doctor-endpoint.test.ts
+++ b/client/test/api/codex-doctor-endpoint.test.ts
@@ -4,8 +4,12 @@
  * Unit tests for GET /api/codex/doctor and the exported `probeCodexDoctor`.
  *
  * Codex has no `codex doctor` subcommand, so install detection shells
- * `codex --version` and auth detection is a separate filesystem / env check.
- * We mock spawnSync (install probe) and existsSync (auth-file probe) so the
+ * `codex --version`. Codex also exposes no auth-status subcommand, so auth
+ * liveness is derived by parsing + expiry-checking the `auth.json` it
+ * persists — existence alone is not enough (#366): a stale OAuth session
+ * reads as logged-in to a naive existence check, false-gating the daemon.
+ *
+ * We mock spawnSync (install probe) and readFileSync (auth-file read) so the
  * tests run without a real codex binary or a real `~/.codex/auth.json`.
  */
 import { describe, expect, it, vi, beforeEach } from 'vitest';
@@ -14,23 +18,26 @@ import { Hono } from 'hono';
 // Mock node:child_process and node:fs before importing the module under test
 // so vi.mock hoisting applies correctly.
 const spawnSyncMock = vi.fn();
-const existsSyncMock = vi.fn();
+const readFileSyncMock = vi.fn();
 
 vi.mock('node:child_process', () => ({
   spawnSync: (...args: unknown[]) => spawnSyncMock(...args),
 }));
 
 vi.mock('node:fs', () => ({
-  existsSync: (...args: unknown[]) => existsSyncMock(...args),
+  readFileSync: (...args: unknown[]) => readFileSyncMock(...args),
 }));
 
 const { addCodexDoctorRoutes, probeCodexDoctor } = await import(
   '../../src/api/codex-doctor-endpoint.js'
 );
 
+type CodexAuthStatus = 'ok' | 'expired' | 'not_configured';
+
 interface CodexDoctorBody {
   installed: boolean;
   authenticated: boolean;
+  authStatus: CodexAuthStatus;
   exitCode: number | null;
   stdout: string;
   stderr: string;
@@ -40,7 +47,8 @@ interface CodexDoctorConfig {
   codexPath?: string;
   codexDoctorTimeoutMs?: number;
   env?: NodeJS.ProcessEnv;
-  authFileExists?: boolean;
+  readAuthFile?: () => string | undefined;
+  now?: number;
 }
 
 function buildApp(config: CodexDoctorConfig = {}) {
@@ -49,11 +57,39 @@ function buildApp(config: CodexDoctorConfig = {}) {
   return app;
 }
 
+/** Builds a JWT-shaped token whose payload carries the given `exp` (seconds). */
+function jwtWithExp(expSeconds: number | undefined): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString(
+    'base64url',
+  );
+  const payload = Buffer.from(
+    JSON.stringify(expSeconds === undefined ? { sub: 'u' } : { sub: 'u', exp: expSeconds }),
+  ).toString('base64url');
+  return `${header}.${payload}.signature`;
+}
+
+/** A well-formed OAuth (`chatgpt`-mode) auth.json whose id_token expires at `expSeconds`. */
+function oauthAuthJson(expSeconds: number): string {
+  return JSON.stringify({
+    auth_mode: 'chatgpt',
+    OPENAI_API_KEY: null,
+    tokens: {
+      id_token: jwtWithExp(expSeconds),
+      access_token: jwtWithExp(expSeconds),
+      refresh_token: 'rt_xxx',
+      account_id: 'acct_xxx',
+    },
+    last_refresh: '2026-05-20T11:57:52.936277Z',
+  });
+}
+
 beforeEach(() => {
   spawnSyncMock.mockReset();
-  existsSyncMock.mockReset();
-  // Default: no auth file on disk unless a test opts in.
-  existsSyncMock.mockReturnValue(false);
+  readFileSyncMock.mockReset();
+  // Default: no auth file on disk (ENOENT) unless a test opts in.
+  readFileSyncMock.mockImplementation(() => {
+    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  });
 });
 
 describe('GET /api/codex/doctor — install detection', () => {
@@ -73,6 +109,7 @@ describe('GET /api/codex/doctor — install detection', () => {
     const body = (await res.json()) as CodexDoctorBody;
     expect(body.installed).toBe(false);
     expect(body.authenticated).toBe(false);
+    expect(body.authStatus).toBe('not_configured');
     expect(body.exitCode).toBeNull();
     expect(body.stdout).toBe('');
     expect(body.stderr).toBe('');
@@ -117,6 +154,7 @@ describe('GET /api/codex/doctor — install detection', () => {
     expect(body.exitCode).toBe(1);
     // Non-zero exit means auth is not meaningful even if credentials exist.
     expect(body.authenticated).toBe(false);
+    expect(body.authStatus).toBe('not_configured');
     expect(body.stdout).toBe('');
     expect(body.stderr).toBe(diagnosticMsg);
   });
@@ -214,7 +252,7 @@ describe('GET /api/codex/doctor — install detection', () => {
   });
 });
 
-describe('probeCodexDoctor — auth detection', () => {
+describe('probeCodexDoctor — auth detection (presence)', () => {
   function okSpawn() {
     spawnSyncMock.mockReturnValue({
       status: 0,
@@ -225,90 +263,99 @@ describe('probeCodexDoctor — auth detection', () => {
     });
   }
 
-  it('authenticated:true when OPENAI_API_KEY env var is present', () => {
+  it('authStatus:ok when OPENAI_API_KEY env var is present', () => {
     okSpawn();
-    existsSyncMock.mockReturnValue(false);
 
     const result = probeCodexDoctor({ env: { OPENAI_API_KEY: 'sk-test-123' } });
     expect(result.installed).toBe(true);
     expect(result.authenticated).toBe(true);
+    expect(result.authStatus).toBe('ok');
     // env-based auth short-circuits the filesystem probe.
-    expect(existsSyncMock).not.toHaveBeenCalled();
+    expect(readFileSyncMock).not.toHaveBeenCalled();
   });
 
-  it('authenticated:false when OPENAI_API_KEY is absent and no auth file exists', () => {
+  it('authStatus:not_configured when OPENAI_API_KEY is absent and no auth file exists', () => {
     okSpawn();
-    existsSyncMock.mockReturnValue(false);
 
     const result = probeCodexDoctor({ env: {} });
     expect(result.installed).toBe(true);
     expect(result.authenticated).toBe(false);
+    expect(result.authStatus).toBe('not_configured');
   });
 
   it('treats an empty/whitespace OPENAI_API_KEY as absent', () => {
     okSpawn();
-    existsSyncMock.mockReturnValue(false);
 
     const result = probeCodexDoctor({ env: { OPENAI_API_KEY: '   ' } });
-    expect(result.authenticated).toBe(false);
+    expect(result.authStatus).toBe('not_configured');
   });
 
-  it('authenticated:true when ~/.codex/auth.json exists', () => {
+  it('reads ~/.codex/auth.json when CODEX_HOME is unset', () => {
     okSpawn();
-    existsSyncMock.mockImplementation((p: string) => p.endsWith('/.codex/auth.json'));
+    readFileSyncMock.mockImplementation((p: string) => {
+      if (typeof p === 'string' && p.endsWith('/.codex/auth.json')) {
+        return oauthAuthJson(Math.floor(Date.now() / 1000) + 3600);
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
 
     const result = probeCodexDoctor({ env: {} });
-    expect(result.authenticated).toBe(true);
+    expect(result.authStatus).toBe('ok');
   });
 
-  it('checks $CODEX_HOME/auth.json when CODEX_HOME is set', () => {
+  it('reads $CODEX_HOME/auth.json when CODEX_HOME is set', () => {
     okSpawn();
-    existsSyncMock.mockImplementation(
-      (p: string) => p === '/custom/codex/auth.json',
-    );
+    readFileSyncMock.mockImplementation((p: string) => {
+      if (p === '/custom/codex/auth.json') {
+        return oauthAuthJson(Math.floor(Date.now() / 1000) + 3600);
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
 
     const result = probeCodexDoctor({ env: { CODEX_HOME: '/custom/codex' } });
-    expect(result.authenticated).toBe(true);
-    expect(existsSyncMock).toHaveBeenCalledWith('/custom/codex/auth.json');
+    expect(result.authStatus).toBe('ok');
+    expect(readFileSyncMock).toHaveBeenCalledWith('/custom/codex/auth.json', 'utf8');
   });
 
-  it('authenticated:false when CODEX_HOME is set but its auth.json is absent', () => {
+  it('authStatus:not_configured when CODEX_HOME is set but its auth.json is absent', () => {
     okSpawn();
-    existsSyncMock.mockReturnValue(false);
 
     const result = probeCodexDoctor({ env: { CODEX_HOME: '/custom/codex' } });
-    expect(result.authenticated).toBe(false);
-    expect(existsSyncMock).toHaveBeenCalledWith('/custom/codex/auth.json');
+    expect(result.authStatus).toBe('not_configured');
+    expect(readFileSyncMock).toHaveBeenCalledWith('/custom/codex/auth.json', 'utf8');
   });
 
-  it('honours the authFileExists test-override branch (true)', () => {
+  it('authStatus:ok via the readAuthFile override (api-key-mode file)', () => {
     okSpawn();
 
-    const result = probeCodexDoctor({ env: {}, authFileExists: true });
-    expect(result.authenticated).toBe(true);
+    const result = probeCodexDoctor({
+      env: {},
+      readAuthFile: () => JSON.stringify({ auth_mode: 'apikey', OPENAI_API_KEY: 'sk-file-123' }),
+    });
+    expect(result.authStatus).toBe('ok');
     // Override skips the real filesystem probe.
-    expect(existsSyncMock).not.toHaveBeenCalled();
+    expect(readFileSyncMock).not.toHaveBeenCalled();
   });
 
-  it('honours the authFileExists test-override branch (false, no api key)', () => {
+  it('authStatus:not_configured via the readAuthFile override (no file, no api key)', () => {
     okSpawn();
 
-    const result = probeCodexDoctor({ env: {}, authFileExists: false });
-    expect(result.authenticated).toBe(false);
-    expect(existsSyncMock).not.toHaveBeenCalled();
+    const result = probeCodexDoctor({ env: {}, readAuthFile: () => undefined });
+    expect(result.authStatus).toBe('not_configured');
+    expect(readFileSyncMock).not.toHaveBeenCalled();
   });
 
-  it('authFileExists:false still authenticates when OPENAI_API_KEY is present', () => {
+  it('OPENAI_API_KEY env still authenticates even when readAuthFile returns nothing', () => {
     okSpawn();
 
     const result = probeCodexDoctor({
       env: { OPENAI_API_KEY: 'sk-test-123' },
-      authFileExists: false,
+      readAuthFile: () => undefined,
     });
-    expect(result.authenticated).toBe(true);
+    expect(result.authStatus).toBe('ok');
   });
 
-  it('authenticated:false when binary is not installed even if credentials exist', () => {
+  it('authStatus:not_configured when binary is not installed even if credentials exist', () => {
     spawnSyncMock.mockReturnValue({
       status: null,
       signal: null,
@@ -319,6 +366,132 @@ describe('probeCodexDoctor — auth detection', () => {
 
     const result = probeCodexDoctor({ env: { OPENAI_API_KEY: 'sk-test-123' } });
     expect(result.installed).toBe(false);
+    expect(result.authStatus).toBe('not_configured');
+  });
+});
+
+describe('probeCodexDoctor — auth liveness (#366)', () => {
+  function okSpawn() {
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      signal: null,
+      error: undefined,
+      stdout: 'codex 1.2.3\n',
+      stderr: '',
+    });
+  }
+
+  const NOW_MS = Date.UTC(2026, 4, 20, 12, 0, 0);
+
+  it('authStatus:ok for a non-expired OAuth (chatgpt-mode) auth.json', () => {
+    okSpawn();
+    const futureExp = Math.floor(NOW_MS / 1000) + 3600;
+
+    const result = probeCodexDoctor({
+      env: {},
+      now: NOW_MS,
+      readAuthFile: () => oauthAuthJson(futureExp),
+    });
+    expect(result.authenticated).toBe(true);
+    expect(result.authStatus).toBe('ok');
+  });
+
+  it('authStatus:expired for a stale OAuth auth.json whose id_token has expired', () => {
+    okSpawn();
+    const pastExp = Math.floor(NOW_MS / 1000) - 3600; // expired an hour ago
+
+    const result = probeCodexDoctor({
+      env: {},
+      now: NOW_MS,
+      readAuthFile: () => oauthAuthJson(pastExp),
+    });
+    // The bug: existence-only detection read this as authenticated:true.
     expect(result.authenticated).toBe(false);
+    expect(result.authStatus).toBe('expired');
+  });
+
+  it('authStatus:expired for a malformed (unparseable) auth.json — never crashes', () => {
+    okSpawn();
+
+    const result = probeCodexDoctor({
+      env: {},
+      now: NOW_MS,
+      readAuthFile: () => '{ "auth_mode": "chatgpt", "tokens": {',
+    });
+    expect(result.authenticated).toBe(false);
+    expect(result.authStatus).toBe('expired');
+  });
+
+  it('authStatus:expired for an auth.json with no tokens and no api key', () => {
+    okSpawn();
+
+    const result = probeCodexDoctor({
+      env: {},
+      now: NOW_MS,
+      readAuthFile: () => JSON.stringify({ auth_mode: 'chatgpt', OPENAI_API_KEY: null }),
+    });
+    expect(result.authStatus).toBe('expired');
+  });
+
+  it('authStatus:expired for an auth.json whose tokens are not JWTs (no exp claim)', () => {
+    okSpawn();
+
+    const result = probeCodexDoctor({
+      env: {},
+      now: NOW_MS,
+      readAuthFile: () =>
+        JSON.stringify({
+          auth_mode: 'chatgpt',
+          OPENAI_API_KEY: null,
+          tokens: { id_token: 'not-a-jwt', access_token: 'also-not-a-jwt' },
+        }),
+    });
+    expect(result.authStatus).toBe('expired');
+  });
+
+  it('falls back to access_token expiry when id_token carries no exp', () => {
+    okSpawn();
+    const header = Buffer.from('{}').toString('base64url');
+    const noExpPayload = Buffer.from(JSON.stringify({ sub: 'u' })).toString('base64url');
+    const idTokenNoExp = `${header}.${noExpPayload}.sig`;
+    const futureExp = Math.floor(NOW_MS / 1000) + 3600;
+    const accessPayload = Buffer.from(
+      JSON.stringify({ sub: 'u', exp: futureExp }),
+    ).toString('base64url');
+    const accessToken = `${header}.${accessPayload}.sig`;
+
+    const result = probeCodexDoctor({
+      env: {},
+      now: NOW_MS,
+      readAuthFile: () =>
+        JSON.stringify({
+          auth_mode: 'chatgpt',
+          OPENAI_API_KEY: null,
+          tokens: { id_token: idTokenNoExp, access_token: accessToken },
+        }),
+    });
+    expect(result.authStatus).toBe('ok');
+  });
+
+  it('authStatus:ok for an api-key-mode auth.json (no expiry to check)', () => {
+    okSpawn();
+
+    const result = probeCodexDoctor({
+      env: {},
+      now: NOW_MS,
+      readAuthFile: () =>
+        JSON.stringify({ auth_mode: 'apikey', OPENAI_API_KEY: 'sk-file-key' }),
+    });
+    expect(result.authStatus).toBe('ok');
+  });
+
+  it('treats an unreadable (EACCES) auth.json as expired, not not_configured', () => {
+    okSpawn();
+    readFileSyncMock.mockImplementation(() => {
+      throw Object.assign(new Error('EACCES'), { code: 'EACCES' });
+    });
+
+    const result = probeCodexDoctor({ env: {}, now: NOW_MS });
+    expect(result.authStatus).toBe('expired');
   });
 });

--- a/client/test/api/codex-doctor-endpoint.test.ts
+++ b/client/test/api/codex-doctor-endpoint.test.ts
@@ -451,14 +451,7 @@ describe('probeCodexDoctor — auth liveness (#366)', () => {
 
   it('falls back to access_token expiry when id_token carries no exp', () => {
     okSpawn();
-    const header = Buffer.from('{}').toString('base64url');
-    const noExpPayload = Buffer.from(JSON.stringify({ sub: 'u' })).toString('base64url');
-    const idTokenNoExp = `${header}.${noExpPayload}.sig`;
     const futureExp = Math.floor(NOW_MS / 1000) + 3600;
-    const accessPayload = Buffer.from(
-      JSON.stringify({ sub: 'u', exp: futureExp }),
-    ).toString('base64url');
-    const accessToken = `${header}.${accessPayload}.sig`;
 
     const result = probeCodexDoctor({
       env: {},
@@ -467,7 +460,7 @@ describe('probeCodexDoctor — auth liveness (#366)', () => {
         JSON.stringify({
           auth_mode: 'chatgpt',
           OPENAI_API_KEY: null,
-          tokens: { id_token: idTokenNoExp, access_token: accessToken },
+          tokens: { id_token: jwtWithExp(undefined), access_token: jwtWithExp(futureExp) },
         }),
     });
     expect(result.authStatus).toBe('ok');

--- a/client/test/harnesses/impls/learner/codex-is-ready.test.ts
+++ b/client/test/harnesses/impls/learner/codex-is-ready.test.ts
@@ -36,6 +36,7 @@ describe('LearnerHarness.isReady — Codex variant (#348)', () => {
     vi.mocked(probeCodexDoctor).mockReturnValue({
       installed: true,
       authenticated: true,
+      authStatus: 'ok',
       exitCode: 0,
       stdout: 'codex 1.2.3',
       stderr: '',
@@ -50,6 +51,7 @@ describe('LearnerHarness.isReady — Codex variant (#348)', () => {
     vi.mocked(probeCodexDoctor).mockReturnValue({
       installed: false,
       authenticated: false,
+      authStatus: 'not_configured',
       exitCode: null,
       stdout: '',
       stderr: '',
@@ -66,6 +68,7 @@ describe('LearnerHarness.isReady — Codex variant (#348)', () => {
     vi.mocked(probeCodexDoctor).mockReturnValue({
       installed: true,
       authenticated: false,
+      authStatus: 'not_configured',
       exitCode: 0,
       stdout: 'codex 1.2.3',
       stderr: '',
@@ -73,7 +76,29 @@ describe('LearnerHarness.isReady — Codex variant (#348)', () => {
     const harness = new LearnerHarness({ name: CODEX_HARNESS, adapter: new NoOpAdapter() });
     const result = await harness.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
     expect(result.ready).toBe(false);
-    expect(result.reason).toMatch(/auth/i);
+    expect(result.reason).toMatch(/not configured/i);
     expect(result.nextStep?.description).toMatch(/sign in|OPENAI_API_KEY|codex login/i);
+  });
+
+  // #366: a stale/expired auth.json must not read as ready. The reason MUST
+  // be distinct from the not-configured case so the operator sees a
+  // re-login hint rather than a first-time sign-in hint.
+  it('returns ready=false with a distinct re-login reason when codex auth is expired', async () => {
+    vi.mocked(probeCodexDoctor).mockReturnValue({
+      installed: true,
+      authenticated: false,
+      authStatus: 'expired',
+      exitCode: 0,
+      stdout: 'codex 1.2.3',
+      stderr: '',
+    });
+    const harness = new LearnerHarness({ name: CODEX_HARNESS, adapter: new NoOpAdapter() });
+    const result = await harness.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+    expect(result.ready).toBe(false);
+    expect(result.reason).toMatch(/expired/i);
+    // Distinct from the not-configured reason.
+    expect(result.reason).not.toMatch(/not configured/i);
+    expect(result.nextStep?.description).toMatch(/codex login|expired/i);
+    expect(result.nextStep?.url).toBe('/api/codex/doctor');
   });
 });


### PR DESCRIPTION
## Summary

Closes #366.

`probeCodexDoctor` (in `client/src/api/codex-doctor-endpoint.ts`) detected Codex auth by the **existence** of `OPENAI_API_KEY` in env OR an `auth.json` (`~/.codex/auth.json`, or `$CODEX_HOME`). Codex has no `doctor` subcommand, so existence was the available proxy — but it is existence-only: a stale, expired, or malformed `auth.json` read as `authenticated: true`. A logged-out operator with a leftover file got a false-ready claim gate, and the daemon claimed tasks the codex harness then failed to execute (residual of the failed-claim cascade #344/#363 fixed).

## What changed

`probeCodexDoctor` now parses `auth.json` and expiry-checks it instead of trusting mere presence:

- **API-key mode** — `OPENAI_API_KEY` in env, or a non-empty `OPENAI_API_KEY` inside the file (`auth_mode: "apikey"`) — has no expiry, so presence is acceptable -> `ok`.
- **OAuth mode** (`codex login`, `auth_mode: "chatgpt"`) — expiry-checks the JWT `exp` claim of `tokens.id_token`, falling back to `tokens.access_token`. An expired token, a non-JWT token, or tokens with no `exp` -> `expired` (the safe direction for a claim gate: a logged-out operator with a leftover file must not read as live).
- **Malformed / unreadable `auth.json`** -> `expired`. Parsing is fully defensive — a corrupt or truncated file degrades to `expired`, never throws.
- **No file and no env key** -> `not_configured`.

`CodexDoctorResponse` gains `authStatus: 'ok' | 'expired' | 'not_configured'`; `authenticated` is kept as a back-compat alias for `authStatus === 'ok'`. The Codex variant of `LearnerHarness.isReady` maps `authStatus: 'expired'` to a distinct `codex auth expired` reason with a `codex login` re-login nextStep — separate from `codex auth not configured` so the operator sees a refresh-session hint rather than a first-time sign-in hint.

The schema was confirmed against a real `~/.codex/auth.json` on a Codex-logged-in machine: `{ auth_mode, OPENAI_API_KEY: string|null, tokens: { id_token, access_token, refresh_token, account_id }, last_refresh }`, where `id_token`/`access_token` are JWTs carrying an `exp` claim.

The test-only `authFileExists` config override is replaced with a `readAuthFile` injection (returns raw file content, since liveness needs the content, not just existence) plus an optional `now` clock override for deterministic expiry tests.

## Files

- `client/src/api/codex-doctor-endpoint.ts` — JWT expiry parsing + `authStatus` classification; `readAuthFile`/`now` injection.
- `client/src/harnesses/impls/learner/harness.ts` — `codexIsReady` distinguishes `auth_expired` from `auth_not_configured`.
- `client/test/api/codex-doctor-endpoint.test.ts` — migrated to `readFileSync`/`readAuthFile` mocking; new auth-liveness block.
- `client/test/harnesses/impls/learner/codex-is-ready.test.ts` — new expired-auth case with a distinct-reason assertion.

## Test plan

- [x] `yarn typecheck` (`build:sdk && tsc --noEmit`) — zero errors.
- [x] Full client suite: 480 files passed / 5 skipped, 3901 tests passed / 8 skipped.
- [x] Unit (`codex-doctor-endpoint.test.ts`, auth-liveness block): `authStatus: 'expired'` for a stale OAuth `auth.json` whose `id_token` has expired (the bug — existence-only read this as `authenticated: true`); `authStatus: 'expired'` for a malformed/unparseable `auth.json` without crashing; plus non-JWT tokens, tokens with no `exp`, `access_token` expiry fallback, api-key-mode files, an unreadable (EACCES) file, and the non-expired OAuth happy path.
- [x] Unit (`codex-is-ready.test.ts`): the Codex harness returns `ready: false` with an `expired`-flavoured reason distinct from `not configured` and a `codex login` nextStep.
- [x] Daemon regression (`claim-readiness-gate.test.ts`) — unchanged, still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)