### PR TITLE
chore(367): converge client feature flags onto window.__JINN_FEATURES__

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -14,7 +14,9 @@
   `JINN_ENABLE_EMBEDDED_AGENT=1` (also accepts `true`) to re-enable the
   surface for development. Default is off. When off, the daemon does not
   mount the `/api/agent/ws` bridge and the SPA renders no agent panel; when
-  on, the dev-time path works end-to-end as before.
+  on, the dev-time path works end-to-end as before. (Issue #367: the SPA now
+  reads this flag through the injected `window.__JINN_FEATURES__`, the same
+  channel as the plug-in builder UI flag — no behaviour change for operators.)
 - **Claude-Code-as-a-solver-harness is unaffected.** Operators can still pick
   Claude Code as their SolverNet harness — that path is independent of the
   embedded chat surface and its WebSocket bridge.

--- a/client/src/api/bootstrap-endpoint.ts
+++ b/client/src/api/bootstrap-endpoint.ts
@@ -26,27 +26,6 @@ export interface BootstrapEndpointConfig {
     solverNets?: Record<string, unknown>;
     joinedSolverNets?: Record<string, unknown>;
   };
-  /**
-   * Feature flag for the embedded Claude agent chat surface in the operator
-   * SPA. Defaults to false; set via `JINN_ENABLE_EMBEDDED_AGENT=1` for
-   * development. When false, the SPA hides the agent rail / "Ask Claude"
-   * onboarding panel and the daemon does not mount the `/api/agent/ws`
-   * bridge. The Claude-Code-as-solver-harness path is unaffected. See
-   * GitHub issue #326.
-   */
-  embeddedAgentEnabled?: boolean;
-}
-
-/**
- * Resolves the JINN_ENABLE_EMBEDDED_AGENT env var. Default off. Anything
- * other than '1' / 'true' (case-insensitive) is treated as off so a stray
- * value can't accidentally re-enable the surface.
- */
-export function isEmbeddedAgentEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
-  const raw = env['JINN_ENABLE_EMBEDDED_AGENT'];
-  if (raw === undefined) return false;
-  const normalized = raw.trim().toLowerCase();
-  return normalized === '1' || normalized === 'true';
 }
 
 const STEPS = [
@@ -152,7 +131,6 @@ function fundingTargetWei(fundingGate: FundingGateOnDisk): string | undefined {
 
 export function addBootstrapRoutes(app: Hono, config: BootstrapEndpointConfig): void {
   app.get('/v1/bootstrap', (c) => {
-    const embeddedAgentEnabled = config.embeddedAgentEnabled ?? false;
     const path = join(config.earningDir, 'earning_state.json');
     if (!existsSync(path)) {
       return c.json({
@@ -161,7 +139,6 @@ export function addBootstrapRoutes(app: Hono, config: BootstrapEndpointConfig): 
         steps: STEPS,
         currentStep: STEPS[0],
         services: [],
-        embeddedAgentEnabled,
       });
     }
 
@@ -227,7 +204,6 @@ export function addBootstrapRoutes(app: Hono, config: BootstrapEndpointConfig): 
       steps: STEPS,
       currentStep,
       services,
-      embeddedAgentEnabled,
       master_address: parsed.master_address,
       chain: parsed.chain,
       ...(parsed.fleet_agent_id ? { fleet_agent_id: parsed.fleet_agent_id } : {}),

--- a/client/src/api/server.ts
+++ b/client/src/api/server.ts
@@ -227,6 +227,22 @@ const dashboardDir = resolveDashboardDir() ?? join(__dirname, '..', 'dashboard')
 const assetsDir = join(dashboardDir, 'assets');
 
 /**
+ * Resolve the `JINN_ENABLE_EMBEDDED_AGENT` env var. Default off. Anything
+ * other than `1` / `true` (case-insensitive) is treated as off so a stray
+ * value can't accidentally re-enable the surface.
+ *
+ * Issue #367: this also has a daemon-side consumer (`main.ts` gates the
+ * `/api/agent/ws` bridge on it), so it stays a standalone helper rather than
+ * being inlined into `resolveFeatureFlags`.
+ */
+export function isEmbeddedAgentEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env['JINN_ENABLE_EMBEDDED_AGENT'];
+  if (raw === undefined) return false;
+  const normalized = raw.trim().toLowerCase();
+  return normalized === '1' || normalized === 'true';
+}
+
+/**
  * Resolve the operator-app feature flags from the daemon environment.
  *
  * Each flag is derived from a `JINN_ENABLE_*` env var ("1" enables). The SPA
@@ -238,10 +254,16 @@ const assetsDir = join(dashboardDir, 'assets');
  * (`/build` route + Build top-tab). Default-off until the first-run UX is
  * solid; the plug-in substrate (CLI verbs, indexer, Discovery API, docs)
  * stays live regardless.
+ *
+ * Issue #326 / #367: `embeddedAgent` gates the embedded Claude agent chat
+ * surface (operating-shell rail + onboarding "Ask Claude" panel). Migrated
+ * here from the `/v1/bootstrap` JSON response so the operator app has a single
+ * feature-flag channel — see #367.
  */
 function resolveFeatureFlags(): Record<string, boolean> {
   return {
     pluginBuilderUi: process.env['JINN_ENABLE_PLUGIN_BUILDER_UI'] === '1',
+    embeddedAgent: isEmbeddedAgentEnabled(),
   };
 }
 

--- a/client/src/dashboard/spa/src/App.rail.test.tsx
+++ b/client/src/dashboard/spa/src/App.rail.test.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -34,7 +35,7 @@ vi.mock('./regions/LoadingScreen.js', () => ({
 // flag, so this is the precise gating behaviour under test. Stubbing here
 // also avoids pulling in the heavy page subtrees the real shell mounts.
 vi.mock('./shell/AppShell.js', () => ({
-  AppShell: ({ rail }: { rail?: unknown }) => (
+  AppShell: ({ rail }: { rail?: ReactNode }) => (
     <div data-testid="app-shell">{rail ?? null}</div>
   ),
 }));

--- a/client/src/dashboard/spa/src/App.rail.test.tsx
+++ b/client/src/dashboard/spa/src/App.rail.test.tsx
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+/**
+ * Issue #326 / #367 — the operating-shell embedded agent rail renders only
+ * when the `embeddedAgent` feature flag is injected via
+ * `window.__JINN_FEATURES__`. The Onboarding "Ask Claude" panel path is
+ * covered in `regions/Onboarding.test.tsx`; these tests cover the running-mode
+ * rail, which `App.tsx` gates on the same converged flag channel.
+ */
+
+vi.mock('./api/connection-state.js', () => ({
+  useConnectionState: () => ({ status: 'connected', lastConnectedAt: 0 }),
+}));
+
+// Drive App into the running branch so the operating shell (and its rail)
+// mounts.
+vi.mock('./api/client.js', () => ({
+  api: {
+    getBootstrap: async () => ({ mode: 'running', chain: 'base-sepolia' }),
+  },
+}));
+
+// The pre-running `LoadingScreen` branch opens a `/v1/events` EventSource,
+// which jsdom does not provide. Stub it to a marker — this test only cares
+// about the running-mode operating shell.
+vi.mock('./regions/LoadingScreen.js', () => ({
+  LoadingScreen: () => <div data-testid="loading-screen" />,
+}));
+
+// Stub AppShell down to a marker that just renders whatever `rail` it was
+// handed — App.tsx passes `<AgentRail />` or `undefined` depending on the
+// flag, so this is the precise gating behaviour under test. Stubbing here
+// also avoids pulling in the heavy page subtrees the real shell mounts.
+vi.mock('./shell/AppShell.js', () => ({
+  AppShell: ({ rail }: { rail?: unknown }) => (
+    <div data-testid="app-shell">{rail ?? null}</div>
+  ),
+}));
+
+vi.mock('./shell/AgentRail.js', () => ({
+  AgentRail: () => <div data-testid="agent-rail" />,
+}));
+
+async function renderApp(): Promise<void> {
+  const { default: App } = await import('./App.js');
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <App />
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  vi.resetModules();
+  delete (window as { __JINN_FEATURES__?: unknown }).__JINN_FEATURES__;
+});
+
+describe('App operating-shell agent rail (issue #367 converged flag)', () => {
+  it('hides the agent rail when no feature flags are injected', async () => {
+    await renderApp();
+    await waitFor(() => expect(screen.getByTestId('app-shell')).toBeTruthy());
+    expect(screen.queryByTestId('agent-rail')).toBeNull();
+  });
+
+  it('hides the agent rail when embeddedAgent is false', async () => {
+    window.__JINN_FEATURES__ = { embeddedAgent: false };
+    await renderApp();
+    await waitFor(() => expect(screen.getByTestId('app-shell')).toBeTruthy());
+    expect(screen.queryByTestId('agent-rail')).toBeNull();
+  });
+
+  it('renders the agent rail when embeddedAgent is true', async () => {
+    window.__JINN_FEATURES__ = { embeddedAgent: true };
+    await renderApp();
+    await waitFor(() => expect(screen.getByTestId('agent-rail')).toBeTruthy());
+  });
+});

--- a/client/src/dashboard/spa/src/App.tsx
+++ b/client/src/dashboard/spa/src/App.tsx
@@ -78,15 +78,16 @@ export default function App(): JSX.Element {
 
   const network = (data.chain === 'base' ? 'mainnet' : 'testnet') as 'testnet' | 'mainnet';
   const masterAddress = data.master_address ?? '';
-  // Issue #326: the embedded agent rail renders only when the daemon reports
-  // the surface is enabled (JINN_ENABLE_EMBEDDED_AGENT=1). Default-off.
-  const embeddedAgentEnabled = data.embeddedAgentEnabled === true;
 
   // Issue #327: the builder surfaces (/build route + Build top-tab) are hidden
   // until the operator-app first-run UX is solid. The plug-in substrate stays
   // live for direct-CLI builders; only the operator-app promotion is gated.
   // Set JINN_ENABLE_PLUGIN_BUILDER_UI=1 on the daemon to re-enable.
-  const pluginBuilderUi = getFeatures().pluginBuilderUi;
+  //
+  // Issue #326 / #367: the embedded agent rail renders only when the daemon
+  // reports the surface is enabled (JINN_ENABLE_EMBEDDED_AGENT=1). Default-off.
+  // Read via the same `window.__JINN_FEATURES__` channel as every other flag.
+  const { pluginBuilderUi, embeddedAgent } = getFeatures();
 
   return (
     <Router>
@@ -101,7 +102,7 @@ export default function App(): JSX.Element {
       <AppShell
         header={<Header network={network} rpcHealthy={true} masterAddress={masterAddress} />}
         tabs={<TopTabs />}
-        rail={embeddedAgentEnabled ? <AgentRail /> : undefined}
+        rail={embeddedAgent ? <AgentRail /> : undefined}
       >
         <Switch>
           <Route path="/overview/activity"><OverviewActivityPage /></Route>

--- a/client/src/dashboard/spa/src/api/types.ts
+++ b/client/src/dashboard/spa/src/api/types.ts
@@ -80,14 +80,9 @@ export interface BootstrapState {
   }>;
   /** Persisted from the last fatal bootstrap exit. Absent on healthy state. */
   error?: BootstrapErrorEnvelope;
-  /**
-   * Issue #326: whether the embedded Claude agent chat surface should render.
-   * Driven by the daemon's `JINN_ENABLE_EMBEDDED_AGENT` env var; false by
-   * default. When false the SPA hides the agent rail and the onboarding
-   * "Ask Claude" panel, and the daemon does not mount `/api/agent/ws`.
-   * Absent on responses from older daemons — treat absent as false.
-   */
-  embeddedAgentEnabled?: boolean;
+  // Issue #367: the embedded-agent feature flag is no longer carried in this
+  // response. The operator app reads it (and every other feature flag) via the
+  // injected `window.__JINN_FEATURES__` — see `lib/features.ts` `getFeatures()`.
 }
 
 export interface ClaudeAuthState {

--- a/client/src/dashboard/spa/src/lib/features.test.ts
+++ b/client/src/dashboard/spa/src/lib/features.test.ts
@@ -13,7 +13,7 @@ afterEach(() => {
 
 describe('getFeatures', () => {
   it('defaults every flag off when window.__JINN_FEATURES__ is absent', () => {
-    expect(getFeatures()).toEqual({ pluginBuilderUi: false });
+    expect(getFeatures()).toEqual({ pluginBuilderUi: false, embeddedAgent: false });
   });
 
   it('reads pluginBuilderUi true when injected as true', () => {
@@ -38,6 +38,32 @@ describe('getFeatures', () => {
 
   it('treats a non-object injection as all-off', () => {
     window.__JINN_FEATURES__ = 'enabled' as unknown as Record<string, unknown>;
-    expect(getFeatures()).toEqual({ pluginBuilderUi: false });
+    expect(getFeatures()).toEqual({ pluginBuilderUi: false, embeddedAgent: false });
+  });
+
+  // Issue #367: the embedded-agent flag converged onto this same channel.
+  it('reads embeddedAgent true when injected as true', () => {
+    window.__JINN_FEATURES__ = { embeddedAgent: true };
+    expect(getFeatures().embeddedAgent).toBe(true);
+  });
+
+  it('treats embeddedAgent false as off', () => {
+    window.__JINN_FEATURES__ = { embeddedAgent: false };
+    expect(getFeatures().embeddedAgent).toBe(false);
+  });
+
+  it('coerces a non-boolean embeddedAgent to off', () => {
+    window.__JINN_FEATURES__ = { embeddedAgent: 'true' as unknown };
+    expect(getFeatures().embeddedAgent).toBe(false);
+  });
+
+  it('treats a missing embeddedAgent key as off', () => {
+    window.__JINN_FEATURES__ = { pluginBuilderUi: true };
+    expect(getFeatures().embeddedAgent).toBe(false);
+  });
+
+  it('reads both flags independently', () => {
+    window.__JINN_FEATURES__ = { pluginBuilderUi: true, embeddedAgent: true };
+    expect(getFeatures()).toEqual({ pluginBuilderUi: true, embeddedAgent: true });
   });
 });

--- a/client/src/dashboard/spa/src/lib/features.ts
+++ b/client/src/dashboard/spa/src/lib/features.ts
@@ -16,14 +16,24 @@
  * only the operator-app promotion of `/build` is hidden until the
  * first-run UX is solid. Set `JINN_ENABLE_PLUGIN_BUILDER_UI=1` on the daemon
  * to re-enable the full surface for development and design work.
+ *
+ * Issue #326 / #367: `embeddedAgent` gates the embedded Claude agent chat
+ * surface (the operating-shell right rail + the onboarding "Ask Claude"
+ * panel). Driven by `JINN_ENABLE_EMBEDDED_AGENT`; off by default while the
+ * surface's action-authority / plugin-scope shape is still in design. This
+ * flag migrated here from the `/v1/bootstrap` response — see #367 (converge
+ * the two client feature-flag channels onto `window.__JINN_FEATURES__`).
  */
 export interface JinnFeatures {
   /** Builder UI surfaces: the `/build` route + the Build top-tab. */
   pluginBuilderUi: boolean;
+  /** Embedded Claude agent chat surface: operating-shell rail + onboarding panel. */
+  embeddedAgent: boolean;
 }
 
 const DEFAULT_FEATURES: JinnFeatures = {
   pluginBuilderUi: false,
+  embeddedAgent: false,
 };
 
 declare global {
@@ -46,5 +56,6 @@ export function getFeatures(): JinnFeatures {
   }
   return {
     pluginBuilderUi: injected['pluginBuilderUi'] === true,
+    embeddedAgent: injected['embeddedAgent'] === true,
   };
 }

--- a/client/src/dashboard/spa/src/regions/Onboarding.test.tsx
+++ b/client/src/dashboard/spa/src/regions/Onboarding.test.tsx
@@ -6,7 +6,7 @@ import type { BootstrapState } from '../api/types.js';
 
 // Mock the API client so we control what bootstrap + status data returns.
 // `bootstrapOverride` lets individual tests tweak the returned bootstrap state
-// (e.g. the issue #326 embedded-agent flag) without re-mocking the module.
+// without re-mocking the module.
 let bootstrapOverride: Partial<BootstrapState> = {};
 
 vi.mock('../api/client.js', () => ({
@@ -31,6 +31,7 @@ vi.mock('./Agent.js', () => ({
 
 afterEach(() => {
   bootstrapOverride = {};
+  delete (window as { __JINN_FEATURES__?: unknown }).__JINN_FEATURES__;
 });
 
 function withQueryClient(node: JSX.Element): JSX.Element {
@@ -57,25 +58,26 @@ describe('Onboarding (3-phase post-vh74.2)', () => {
     expect(screen.queryByText(/Sign in to Claude/i)).toBeNull();
   });
 
-  // Issue #326: the embedded "Ask Claude" panel is hidden by default. It only
-  // renders when the daemon reports embeddedAgentEnabled === true.
-  it('hides the "Ask Claude" panel when embeddedAgentEnabled is absent', async () => {
+  // Issue #326 / #367: the embedded "Ask Claude" panel is hidden by default.
+  // It renders only when the `embeddedAgent` feature flag is injected via
+  // `window.__JINN_FEATURES__` (converged channel — see #367).
+  it('hides the "Ask Claude" panel when no feature flags are injected', async () => {
     render(withQueryClient(<Onboarding />));
     await screen.findByText(/Provisioning your wallet/i);
     expect(screen.queryByText(/Ask Claude/i)).toBeNull();
     expect(screen.queryByTestId('agent-stub')).toBeNull();
   });
 
-  it('hides the "Ask Claude" panel when embeddedAgentEnabled is false', async () => {
-    bootstrapOverride = { embeddedAgentEnabled: false };
+  it('hides the "Ask Claude" panel when embeddedAgent is false', async () => {
+    window.__JINN_FEATURES__ = { embeddedAgent: false };
     render(withQueryClient(<Onboarding />));
     await screen.findByText(/Provisioning your wallet/i);
     expect(screen.queryByText(/Ask Claude/i)).toBeNull();
     expect(screen.queryByTestId('agent-stub')).toBeNull();
   });
 
-  it('renders the "Ask Claude" panel when embeddedAgentEnabled is true', async () => {
-    bootstrapOverride = { embeddedAgentEnabled: true };
+  it('renders the "Ask Claude" panel when embeddedAgent is true', async () => {
+    window.__JINN_FEATURES__ = { embeddedAgent: true };
     render(withQueryClient(<Onboarding />));
     await screen.findByText(/Provisioning your wallet/i);
     expect(screen.getByText(/Ask Claude/i)).toBeTruthy();

--- a/client/src/dashboard/spa/src/regions/Onboarding.tsx
+++ b/client/src/dashboard/spa/src/regions/Onboarding.tsx
@@ -28,6 +28,7 @@ import type {
 } from '../api/types.js';
 import { AwaitingFundingCard } from './AwaitingFundingCard.js';
 import { Agent } from './Agent.js';
+import { getFeatures } from '../lib/features.js';
 
 type Phase = 1 | 2 | 3;
 type PhaseStatus = 'done' | 'active' | 'queued' | 'error';
@@ -116,10 +117,11 @@ export function Onboarding(): JSX.Element {
   // momentary drip that briefly crossed the threshold doesn't flip the row
   // to DONE before the bootstrapper advances past awaiting_funding on-chain.
   const fundingTargetMet = bootstrap.funding?.targetMet;
-  // Issue #326: the embedded "Ask Claude" panel renders only when the daemon
-  // reports the surface is enabled (JINN_ENABLE_EMBEDDED_AGENT=1). When off,
-  // the bootstrap-progress column spans the full width.
-  const embeddedAgentEnabled = bootstrap.embeddedAgentEnabled === true;
+  // Issue #326 / #367: the embedded "Ask Claude" panel renders only when the
+  // daemon reports the surface is enabled (JINN_ENABLE_EMBEDDED_AGENT=1). When
+  // off, the bootstrap-progress column spans the full width. Read via the
+  // `window.__JINN_FEATURES__` channel like every other operator-app flag.
+  const embeddedAgentEnabled = getFeatures().embeddedAgent;
   return (
     <div
       className="min-h-screen w-full"

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -27,7 +27,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { loadConfig, getConfigPathFromArgs, DEFAULT_CONFIG_PATH } from './config.js';
 import { Store } from './store/store.js';
-import { startApiServer, type ApiServer } from './api/server.js';
+import { startApiServer, isEmbeddedAgentEnabled, type ApiServer } from './api/server.js';
 // addHarnessReadinessRoutes is wired through startApiServer's holder ref now
 // (jinn-mono-u34i). No direct import needed.
 import { CapturePublishUnavailableError } from './api/captures.js';
@@ -36,7 +36,6 @@ import { ensureUiToken } from './api/ui-token.js';
 import { hashImplStateDir } from './harnesses/freeze.js';
 import { readModeState } from './harnesses/mode-state.js';
 import { attachAgentWs, updateAgentClaudePath } from './agent/agent-ws.js';
-import { isEmbeddedAgentEnabled } from './api/bootstrap-endpoint.js';
 import { createSetupModeController } from './setup-mode.js';
 import { formatBootstrapOperatorMessage } from './operator-errors.js';
 import { requestDaemonRestart } from './restart-daemon.js';
@@ -177,6 +176,11 @@ if (config.network === 'mainnet' && process.env['JINN_ENABLE_MAINNET'] !== '1') 
 // action-authority / plugin-scope shape is still in design. Set
 // `JINN_ENABLE_EMBEDDED_AGENT=1` to re-enable it for development. This does
 // NOT affect Claude-Code-as-a-solver-harness — that path is independent.
+//
+// Issue #367: the SPA reads this flag via the injected `window.__JINN_FEATURES__`
+// (`resolveFeatureFlags` in api/server.ts) like every other operator-app flag.
+// This `embeddedAgentEnabled` const is the daemon-side consumer only — it gates
+// whether the `/api/agent/ws` bridge is mounted below.
 const embeddedAgentEnabled = isEmbeddedAgentEnabled();
 
 let activeClaudePath = config.claudePath ?? 'claude';
@@ -1048,9 +1052,6 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
           solverNets: config.solverNets as Record<string, unknown> | undefined,
           joinedSolverNets: config.joinedSolverNets as Record<string, unknown> | undefined,
         }),
-        // Issue #326: gate the embedded agent chat surface. Off by default;
-        // `JINN_ENABLE_EMBEDDED_AGENT=1` re-enables it for development.
-        embeddedAgentEnabled: embeddedAgentEnabled,
       },
       // SolverNet catalog. Stubbed to the bundled `prediction` net for v1.
       // Once the daemon's harness/plugin registry is loaded, swap this for a

--- a/client/test/api/bootstrap-endpoint.test.ts
+++ b/client/test/api/bootstrap-endpoint.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { Hono } from 'hono';
-import {
-  addBootstrapRoutes,
-  isEmbeddedAgentEnabled,
-} from '../../src/api/bootstrap-endpoint.js';
+import { addBootstrapRoutes } from '../../src/api/bootstrap-endpoint.js';
 import { buildEnvelope } from '../../src/errors/envelope.js';
 import { persistBootstrapError } from '../../src/errors/persisted-bootstrap-error.js';
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
@@ -311,33 +308,13 @@ describe('GET /v1/bootstrap', () => {
   });
 });
 
-// Issue #326: the embedded agent chat surface is gated behind
-// JINN_ENABLE_EMBEDDED_AGENT. The endpoint surfaces the resolved flag so the
-// SPA can hide the agent rail / onboarding panel; the daemon also uses it to
-// decide whether to mount /api/agent/ws.
-describe('isEmbeddedAgentEnabled', () => {
-  it('defaults to false when the env var is unset', () => {
-    expect(isEmbeddedAgentEnabled({})).toBe(false);
-  });
-
-  it('is true for "1"', () => {
-    expect(isEmbeddedAgentEnabled({ JINN_ENABLE_EMBEDDED_AGENT: '1' })).toBe(true);
-  });
-
-  it('is true for "true" (case-insensitive, trimmed)', () => {
-    expect(isEmbeddedAgentEnabled({ JINN_ENABLE_EMBEDDED_AGENT: 'true' })).toBe(true);
-    expect(isEmbeddedAgentEnabled({ JINN_ENABLE_EMBEDDED_AGENT: ' TRUE ' })).toBe(true);
-  });
-
-  it('is false for any other value', () => {
-    expect(isEmbeddedAgentEnabled({ JINN_ENABLE_EMBEDDED_AGENT: '0' })).toBe(false);
-    expect(isEmbeddedAgentEnabled({ JINN_ENABLE_EMBEDDED_AGENT: 'yes' })).toBe(false);
-    expect(isEmbeddedAgentEnabled({ JINN_ENABLE_EMBEDDED_AGENT: '' })).toBe(false);
-  });
-});
-
-describe('GET /v1/bootstrap — embeddedAgentEnabled flag (issue #326)', () => {
-  it('reports embeddedAgentEnabled=false by default', async () => {
+// Issue #367: `/v1/bootstrap` no longer carries the embedded-agent feature
+// flag. The operator app reads it (and every feature flag) via the injected
+// `window.__JINN_FEATURES__` — see `test/api/feature-flags-inject.test.ts`
+// (`isEmbeddedAgentEnabled` + `resolveFeatureFlags`) and the SPA's
+// `lib/features.test.ts`.
+describe('GET /v1/bootstrap — no feature-flag fields (issue #367)', () => {
+  it('does not include embeddedAgentEnabled in the response', async () => {
     const earningDir = makeFixtureEarningDir({
       master_address: '0xabc',
       chain: 'base-sepolia',
@@ -346,30 +323,17 @@ describe('GET /v1/bootstrap — embeddedAgentEnabled flag (issue #326)', () => {
     const app = new Hono();
     addBootstrapRoutes(app, { earningDir });
     const res = await app.request('/v1/bootstrap');
-    const body = await res.json() as { embeddedAgentEnabled?: boolean };
-    expect(body.embeddedAgentEnabled).toBe(false);
+    const body = await res.json() as Record<string, unknown>;
+    expect('embeddedAgentEnabled' in body).toBe(false);
   });
 
-  it('reports embeddedAgentEnabled=true when the flag is set on the config', async () => {
-    const earningDir = makeFixtureEarningDir({
-      master_address: '0xabc',
-      chain: 'base-sepolia',
-      services: [{ index: 0, step: 'complete', safe_address: '0xsafe' }],
-    });
-    const app = new Hono();
-    addBootstrapRoutes(app, { earningDir, embeddedAgentEnabled: true });
-    const res = await app.request('/v1/bootstrap');
-    const body = await res.json() as { embeddedAgentEnabled?: boolean };
-    expect(body.embeddedAgentEnabled).toBe(true);
-  });
-
-  it('reports embeddedAgentEnabled=false on the uninitialized branch', async () => {
-    const earningDir = mkdtempSync(join(tmpdir(), 'jinn-bootstrap-empty-326-'));
+  it('does not include embeddedAgentEnabled on the uninitialized branch', async () => {
+    const earningDir = mkdtempSync(join(tmpdir(), 'jinn-bootstrap-empty-367-'));
     const app = new Hono();
     addBootstrapRoutes(app, { earningDir });
     const res = await app.request('/v1/bootstrap');
-    const body = await res.json() as { mode: string; embeddedAgentEnabled?: boolean };
-    expect(body.mode).toBe('uninitialized');
-    expect(body.embeddedAgentEnabled).toBe(false);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body['mode']).toBe('uninitialized');
+    expect('embeddedAgentEnabled' in body).toBe(false);
   });
 });

--- a/client/test/api/feature-flags-inject.test.ts
+++ b/client/test/api/feature-flags-inject.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { injectFeatureFlags } from '../../src/api/server.js';
+import { injectFeatureFlags, isEmbeddedAgentEnabled } from '../../src/api/server.js';
 
 /**
  * Issue #327: the daemon injects `window.__JINN_FEATURES__` into the served
@@ -56,5 +56,34 @@ describe('injectFeatureFlags', () => {
     const out = injectFeatureFlags(noHead, { pluginBuilderUi: false });
     expect(out).toContain('__JINN_FEATURES__');
     expect(out.indexOf('__JINN_FEATURES__')).toBeLessThan(out.indexOf('</body>'));
+  });
+});
+
+/**
+ * Issue #326 / #367: the embedded Claude agent chat surface is gated behind
+ * `JINN_ENABLE_EMBEDDED_AGENT`. Per #367 this flag converged onto the same
+ * `window.__JINN_FEATURES__` channel as the builder UI flag — `resolveFeatureFlags`
+ * derives `embeddedAgent` from it. `isEmbeddedAgentEnabled` stays a standalone
+ * helper because the daemon also reads it directly to gate the `/api/agent/ws`
+ * bridge.
+ */
+describe('isEmbeddedAgentEnabled', () => {
+  it('defaults to false when the env var is unset', () => {
+    expect(isEmbeddedAgentEnabled({})).toBe(false);
+  });
+
+  it('is true for "1"', () => {
+    expect(isEmbeddedAgentEnabled({ JINN_ENABLE_EMBEDDED_AGENT: '1' })).toBe(true);
+  });
+
+  it('is true for "true" (case-insensitive, trimmed)', () => {
+    expect(isEmbeddedAgentEnabled({ JINN_ENABLE_EMBEDDED_AGENT: 'true' })).toBe(true);
+    expect(isEmbeddedAgentEnabled({ JINN_ENABLE_EMBEDDED_AGENT: ' TRUE ' })).toBe(true);
+  });
+
+  it('is false for any other value', () => {
+    expect(isEmbeddedAgentEnabled({ JINN_ENABLE_EMBEDDED_AGENT: '0' })).toBe(false);
+    expect(isEmbeddedAgentEnabled({ JINN_ENABLE_EMBEDDED_AGENT: 'yes' })).toBe(false);
+    expect(isEmbeddedAgentEnabled({ JINN_ENABLE_EMBEDDED_AGENT: '' })).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #367.

## Summary

Two client-side feature-flag channels landed in the 2026-05-19/20 release-feedback batch by different mechanisms:

- **#354** — `embeddedAgentEnabled` carried in the `/v1/bootstrap` JSON response, read by the SPA at runtime (first-render flash, extra API round-trip).
- **#364** — `window.__JINN_FEATURES__` injected into the served HTML, read via `lib/features.ts` `getFeatures()` (no flash, all-off-by-default, strict boolean coercion).

This converges onto `window.__JINN_FEATURES__` — the cleaner mechanism — so every future operator-app flag has one home.

## What changed

- **`lib/features.ts`** — `JinnFeatures` / `getFeatures()` gain an `embeddedAgent` flag, strict-coerced and default-off alongside `pluginBuilderUi`.
- **`api/server.ts`** — `resolveFeatureFlags()` derives `embeddedAgent` from `JINN_ENABLE_EMBEDDED_AGENT`. `isEmbeddedAgentEnabled` moved here from `bootstrap-endpoint.ts` — the daemon still reads it directly to gate the `/api/agent/ws` bridge, a legitimate non-flag consumer, so it stays a standalone helper.
- **`bootstrap-endpoint.ts`** — `embeddedAgentEnabled` config field removed; the field is gone from both `/v1/bootstrap` responses (uninitialized + normal). Every reader was traced first — only the SPA consumed it.
- **SPA** — `App.tsx` and `Onboarding.tsx` read `getFeatures().embeddedAgent`; `api/types.ts` `BootstrapState` drops the field.
- **`main.ts`** — imports `isEmbeddedAgentEnabled` from `api/server.js`; the bootstrap-config wiring of the flag is removed. The daemon-side WS-bridge gate is unchanged.
- **Tests** — `isEmbeddedAgentEnabled` unit tests moved to `feature-flags-inject.test.ts`; `bootstrap-endpoint.test.ts` now asserts the field is absent from the response; `features.test.ts` and `Onboarding.test.tsx` cover the converged `embeddedAgent` channel.

No behaviour change for operators — both surfaces (embedded agent, plug-in builder UI) stay gated-off by default.

## Test plan

- [x] `yarn typecheck` — 0 errors.
- [x] `yarn test` — 3896 passed, 8 skipped, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)