### PR TITLE
fix: v0.1.6 operator-app dogfood follow-ups (#328)

### DIFF
--- a/.claude/skills/testing-jinn-app/SKILL.md
+++ b/.claude/skills/testing-jinn-app/SKILL.md
@@ -19,10 +19,13 @@ The jinn app is the operator dashboard SPA at `client/src/dashboard/spa/`, serve
 
 ## Daemon spawn (shared by both recipes)
 
-All commands assume cwd = `jinn-mono/cargo/client`.
+All commands assume cwd = `jinn-mono/client`.
 
 1. Build: `yarn build` — produces `dist/bin/jinn.js` and the SPA bundle in `dist/dashboard/`. **Re-run after every SPA source edit** — the daemon serves the bundled SPA from disk.
 2. Spawn: `node dist/bin/jinn.js run --no-ui`. **Against the operator's real `~/.jinn`, that's the whole command** — the daemon auto-reads `~/.jinn-client/keystore-password` (written at first bootstrap) when `JINN_PASSWORD` is unset. Do NOT ask the operator for a password.
+
+   > **CAVEAT — Restart-button / respawn tests must NOT use `--no-ui`.**
+   > `--no-ui` sets `JINN_NO_UI=1`, which puts the daemon into headless/supervised mode. In that mode, `requestDaemonRestart` (see `client/src/restart-daemon.ts`) skips the in-process respawn and calls `process.exit(0)` instead — it expects an external supervisor (systemd, Docker, etc.) to bring the daemon back. If you are testing the operator **Restart** button or any restart-respawn behaviour (issue #289), launch the daemon **without** `--no-ui`; otherwise the restart kills the daemon with no respawn and the test cannot pass.
 
    Env vars only matter when you're deviating from the default setup:
    - `HOME=<tmpdir>` — only set for a *fresh, clean-state* spawn (e.g. E2E test). Omit to attach to the bootstrapped fleet at `~/.jinn` (Base Sepolia master `0xE64bAf0073a71b0Cb2C0558bB16f24b45E1FB5CF`, agent #5474, safe `0x0e767E28C6889CcD0DfB88E631a3702D56Ce24FC`).

--- a/client/src/adapters/mech/adapter.ts
+++ b/client/src/adapters/mech/adapter.ts
@@ -72,36 +72,19 @@ const ROUTER_REQUEST_CURSOR_CONFIG_KEY = 'mech_router_request_block_cursor_v1';
 const PENDING_EVALUATION_SOLUTIONS_CONFIG_KEY = 'mech_pending_evaluation_solutions_v1';
 const DEFAULT_MECH_DELIVER_BACKFILL_LOOKBACK_BLOCKS = 100_000n;
 
-/**
- * Yield to the Node event loop every N evaluation opportunities while draining
- * the retry queue. A real fleet can accumulate a large backlog of pending
- * evaluation solutions; without an explicit yield the synchronous-feeling
- * async loop can starve the HTTP API (the operator SPA reads `/health` and
- * flips its "Daemon offline" banner if a probe round-trip exceeds its window).
- */
+/** Yield to the event loop every N evaluation opportunities so a large retry
+ *  backlog can't starve the HTTP API mid-cycle. */
 const EVALUATION_RETRY_YIELD_EVERY = 10;
 
 /**
  * Decide whether a `canClaimEvaluation` failure reason means the opportunity
- * can NEVER become claimable (terminal) and should be pruned from the working
- * set, versus a reason that could still clear later (transient — keep
- * retrying).
+ * can NEVER become claimable (terminal, prune it) versus one that could still
+ * clear later (transient, keep retrying).
  *
- * `canClaimEvaluation` returns `reason` as either a decoded known revert
- * (`TCAttemptAlreadyFinalized(1, 0)` or the bare `TCAttemptAlreadyFinalized`)
- * or an arbitrary flattened error message. We strip any decoded-argument
- * suffix to recover the bare revert name and defer to
- * `isNonRecoverableInnerRevert` — the module's existing, maintained
- * classification of "permanent failure for this requestId, never worth
- * retrying" (covers TCAttemptAlreadyFinalized / TCEvaluationDeadlinePassed /
- * TCMaxVerdictsReached, etc.).
- *
- * Anything that does not resolve to a known non-recoverable revert name —
- * generic RPC errors, rate-limit messages, "not yet announced" style
- * failures — is treated as transient and left in the working set. A
- * false-keep (re-checking a dead opportunity) only costs one more RPC; a
- * false-prune (dropping a still-claimable opportunity) loses real work, so
- * when in doubt we keep.
+ * A false-keep (re-checking a dead opportunity) only costs one more RPC; a
+ * false-prune (dropping a still-claimable opportunity) loses real work — so
+ * when in doubt we keep. Anything that does not resolve to a known
+ * non-recoverable revert name is treated as transient.
  */
 function isTerminalEvaluationReason(reason: string | undefined): boolean {
   if (!reason) return false;
@@ -833,10 +816,8 @@ export class MechAdapter implements ExecutionAdapter {
         if (announcement) {
           yield announcement;
         }
-        // No announcement does NOT mean "forget". evaluationAnnouncementForSolution
-        // owns pruning: it removes the solution only for terminal reasons and
-        // intentionally leaves transient failures in the working set so they
-        // are retried on the next cycle.
+        // No announcement does NOT mean "forget" — pruning is owned by
+        // evaluationAnnouncementForSolution, which only removes terminal cases.
       } catch (err) {
         console.error(
           `[mech] evaluation opportunity retry failed for ${requestId}:`,

--- a/client/src/adapters/mech/adapter.ts
+++ b/client/src/adapters/mech/adapter.ts
@@ -44,6 +44,7 @@ import {
   type RouterTaskPolicy,
 } from './contracts.js';
 import { type MechAdapterConfig } from './types.js';
+import { isNonRecoverableInnerRevert } from './safe-revert.js';
 import { VerdictCode, verdictCodeFromValue } from './verdict-code.js';
 import { manifestDigestForCid } from './digest.js';
 import type { DiscoveryAPI } from '../../discovery/types.js';
@@ -70,6 +71,44 @@ interface PendingEvaluationSolution {
 const ROUTER_REQUEST_CURSOR_CONFIG_KEY = 'mech_router_request_block_cursor_v1';
 const PENDING_EVALUATION_SOLUTIONS_CONFIG_KEY = 'mech_pending_evaluation_solutions_v1';
 const DEFAULT_MECH_DELIVER_BACKFILL_LOOKBACK_BLOCKS = 100_000n;
+
+/**
+ * Yield to the Node event loop every N evaluation opportunities while draining
+ * the retry queue. A real fleet can accumulate a large backlog of pending
+ * evaluation solutions; without an explicit yield the synchronous-feeling
+ * async loop can starve the HTTP API (the operator SPA reads `/health` and
+ * flips its "Daemon offline" banner if a probe round-trip exceeds its window).
+ */
+const EVALUATION_RETRY_YIELD_EVERY = 10;
+
+/**
+ * Decide whether a `canClaimEvaluation` failure reason means the opportunity
+ * can NEVER become claimable (terminal) and should be pruned from the working
+ * set, versus a reason that could still clear later (transient — keep
+ * retrying).
+ *
+ * `canClaimEvaluation` returns `reason` as either a decoded known revert
+ * (`TCAttemptAlreadyFinalized(1, 0)` or the bare `TCAttemptAlreadyFinalized`)
+ * or an arbitrary flattened error message. We strip any decoded-argument
+ * suffix to recover the bare revert name and defer to
+ * `isNonRecoverableInnerRevert` — the module's existing, maintained
+ * classification of "permanent failure for this requestId, never worth
+ * retrying" (covers TCAttemptAlreadyFinalized / TCEvaluationDeadlinePassed /
+ * TCMaxVerdictsReached, etc.).
+ *
+ * Anything that does not resolve to a known non-recoverable revert name —
+ * generic RPC errors, rate-limit messages, "not yet announced" style
+ * failures — is treated as transient and left in the working set. A
+ * false-keep (re-checking a dead opportunity) only costs one more RPC; a
+ * false-prune (dropping a still-claimable opportunity) loses real work, so
+ * when in doubt we keep.
+ */
+function isTerminalEvaluationReason(reason: string | undefined): boolean {
+  if (!reason) return false;
+  // Strip a decoded-argument suffix, e.g. `TCAttemptAlreadyFinalized(1, 0)`.
+  const bareName = reason.replace(/\(.*$/s, '').trim();
+  return isNonRecoverableInnerRevert(bareName);
+}
 const DEFAULT_ROUTER_LOG_CHUNK_BLOCKS = 9_999n;
 /**
  * Floor block for the on-chain TaskCreated backlog scan, per chain.
@@ -722,7 +761,12 @@ export class MechAdapter implements ExecutionAdapter {
       return undefined;
     }
 
-    const restoration = await this.restorationAnnouncementForTaskId(solution.taskId);
+    // Cheap claimability gate FIRST — before the restoration lookup + IPFS
+    // fetch. A backlog of terminal opportunities (finalized / evaluation
+    // deadline passed / max verdicts reached) must not pay the expensive
+    // restoration-announcement cost on every poll cycle. Terminal reasons are
+    // pruned from the working set so the loop never re-scans on-chain history;
+    // transient reasons are left in place to be retried next cycle.
     const claimable = await canClaimEvaluation(
       this.publicClient,
       this.config.safeAddress,
@@ -732,13 +776,18 @@ export class MechAdapter implements ExecutionAdapter {
       this.config.mechContractAddress,
     );
     if (!claimable.ok) {
+      const terminal = isTerminalEvaluationReason(claimable.reason);
       console.log(
-        `[mech] skipping evaluation opportunity ${solution.requestId} for task ${solution.taskId}/${solution.attemptIndex}: ${claimable.reason}`,
+        `[mech] skipping evaluation opportunity ${solution.requestId} for task ${solution.taskId}/${solution.attemptIndex}: ${claimable.reason}` +
+          (terminal ? ' (terminal — pruned)' : ' (transient — will retry)'),
       );
-      this.forgetPendingEvaluationSolution(solution.requestId);
+      if (terminal) {
+        this.forgetPendingEvaluationSolution(solution.requestId);
+      }
       return undefined;
     }
 
+    const restoration = await this.restorationAnnouncementForTaskId(solution.taskId);
     const solutionEnvelopeCid = await this.deliveryEnvelopeCidForSolution(solution);
     const resultPayload = await fetchFromIpfs(
       this.config.ipfsGatewayUrl,
@@ -771,14 +820,23 @@ export class MechAdapter implements ExecutionAdapter {
   }
 
   private async *retryPendingEvaluationSolutions(): AsyncIterable<TaskAnnouncement> {
+    let processed = 0;
     for (const [requestId, solution] of Array.from(this.pendingEvaluationSolutions)) {
+      // Yield to the event loop periodically so a large backlog of pending
+      // evaluation solutions can't starve the HTTP API mid-cycle.
+      if (processed > 0 && processed % EVALUATION_RETRY_YIELD_EVERY === 0) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
+      processed++;
       try {
         const announcement = await this.evaluationAnnouncementForSolution(solution);
         if (announcement) {
           yield announcement;
-        } else {
-          this.forgetPendingEvaluationSolution(requestId);
         }
+        // No announcement does NOT mean "forget". evaluationAnnouncementForSolution
+        // owns pruning: it removes the solution only for terminal reasons and
+        // intentionally leaves transient failures in the working set so they
+        // are retried on the next cycle.
       } catch (err) {
         console.error(
           `[mech] evaluation opportunity retry failed for ${requestId}:`,

--- a/client/src/api/hermes-doctor-endpoint.ts
+++ b/client/src/api/hermes-doctor-endpoint.ts
@@ -17,6 +17,7 @@
  * precheck panel and the daemon's claim-readiness gate (#330).
  */
 import type { Hono } from 'hono';
+import type { SpawnSyncReturns } from 'node:child_process';
 import { spawnSync } from 'node:child_process';
 
 export interface HermesDoctorResponse {
@@ -32,20 +33,34 @@ export interface HermesDoctorConfig {
 }
 
 /**
- * Synchronously runs `hermes doctor` and classifies the result. Pure (no
- * Hono dependency) so the harness layer can call it without pulling the API
- * server in.
+ * Shared `hermes <args>` spawn scaffolding for both probes: resolves the binary
+ * and timeout from config, runs `spawnSync`, and extracts the spawn-error code.
+ * Each probe applies its own classification/parsing to the returned result.
  */
-export function probeHermesDoctor(config: HermesDoctorConfig = {}): HermesDoctorResponse {
+function runHermes(
+  args: string[],
+  config: HermesDoctorConfig,
+): { result: SpawnSyncReturns<string>; errorCode: string | undefined } {
   const hermesBin = config.hermesPath ?? 'hermes';
   const timeoutMs = config.hermesDoctorTimeoutMs ?? 30_000;
 
-  const result = spawnSync(hermesBin, ['doctor'], {
+  const result = spawnSync(hermesBin, args, {
     timeout: timeoutMs,
     encoding: 'utf8',
   });
 
   const errorCode = (result.error as NodeJS.ErrnoException | undefined)?.code;
+  return { result, errorCode };
+}
+
+/**
+ * Synchronously runs `hermes doctor` and classifies the result. Pure (no
+ * Hono dependency) so the harness layer can call it without pulling the API
+ * server in.
+ */
+export function probeHermesDoctor(config: HermesDoctorConfig = {}): HermesDoctorResponse {
+  const { result, errorCode } = runHermes(['doctor'], config);
+
   // installed=true means we found the binary on disk. ENOENT is the only
   // definitive not-installed signal. Other errors (EACCES = wrong
   // permissions; ETIMEDOUT = ran but didn't finish in time) indicate the
@@ -99,15 +114,7 @@ export function probeHermesAuthStatus(
   provider: string,
   config: HermesDoctorConfig = {},
 ): HermesAuthStatus {
-  const hermesBin = config.hermesPath ?? 'hermes';
-  const timeoutMs = config.hermesDoctorTimeoutMs ?? 30_000;
-
-  const result = spawnSync(hermesBin, ['auth', 'status', provider], {
-    timeout: timeoutMs,
-    encoding: 'utf8',
-  });
-
-  const errorCode = (result.error as NodeJS.ErrnoException | undefined)?.code;
+  const { result, errorCode } = runHermes(['auth', 'status', provider], config);
   const raw = (result.stdout ?? '').trim().slice(0, 4000);
 
   // Binary not found, or any other spawn error, or no output → not authed.

--- a/client/src/api/hermes-doctor-endpoint.ts
+++ b/client/src/api/hermes-doctor-endpoint.ts
@@ -65,6 +65,61 @@ export function probeHermesDoctor(config: HermesDoctorConfig = {}): HermesDoctor
   };
 }
 
+/**
+ * Result of probing a single Hermes model provider's auth state.
+ */
+export interface HermesAuthStatus {
+  /** Provider name probed, e.g. `openrouter`. */
+  provider: string;
+  /** True only when the provider is authenticated (logged in). */
+  authed: boolean;
+  /** Raw `hermes auth status <provider>` stdout (trimmed, truncated). */
+  raw: string;
+}
+
+/**
+ * Synchronously runs `hermes auth status <provider>` and classifies whether
+ * the provider is authenticated.
+ *
+ * CRITICAL: `hermes auth status` ALWAYS exits 0 — it reports state via
+ * stdout, never via exit code. A not-logged-in provider prints e.g.
+ * `openrouter: logged out`. So we cannot rely on `result.status`; we parse
+ * stdout instead:
+ *   - stdout matches /logged out/i → not authed
+ *   - stdout is empty → not authed (binary said nothing definitive)
+ *   - ENOENT / spawn error → not authed (binary not on PATH)
+ *   - otherwise → authed
+ *
+ * Pure (no Hono dependency) so the harness layer can call it without
+ * pulling the API server in. This is the third readiness gate for Hermes:
+ * `hermes doctor` exits 0 even when every provider is logged out (it treats
+ * missing providers as warnings), so the harness must probe auth directly.
+ */
+export function probeHermesAuthStatus(
+  provider: string,
+  config: HermesDoctorConfig = {},
+): HermesAuthStatus {
+  const hermesBin = config.hermesPath ?? 'hermes';
+  const timeoutMs = config.hermesDoctorTimeoutMs ?? 30_000;
+
+  const result = spawnSync(hermesBin, ['auth', 'status', provider], {
+    timeout: timeoutMs,
+    encoding: 'utf8',
+  });
+
+  const errorCode = (result.error as NodeJS.ErrnoException | undefined)?.code;
+  const raw = (result.stdout ?? '').trim().slice(0, 4000);
+
+  // Binary not found, or any other spawn error, or no output → not authed.
+  if (errorCode != null || raw.length === 0) {
+    return { provider, authed: false, raw };
+  }
+  // `hermes auth status` always exits 0; state is in stdout. A "logged out"
+  // line means the provider is not authenticated.
+  const loggedOut = /logged out/i.test(raw);
+  return { provider, authed: !loggedOut, raw };
+}
+
 export function addHermesDoctorRoutes(app: Hono, config: HermesDoctorConfig = {}): void {
   app.get('/api/hermes/doctor', (c) => {
     return c.json(probeHermesDoctor(config));

--- a/client/src/cli/commands/create.ts
+++ b/client/src/cli/commands/create.ts
@@ -43,6 +43,9 @@ const NETWORK_CHAIN_IDS: Record<string, number> = {
   'ethereum-mainnet': 1,
 };
 
+const QUICKSTART_URL =
+  'https://github.com/Jinn-Network/mono/blob/next/client/docs/build/quickstart.md';
+
 export type HarnessPattern = 'forecaster' | 'evaluator' | 'alternative-harness';
 
 export const SUPPORTED_PATTERNS: readonly HarnessPattern[] = [
@@ -241,7 +244,7 @@ Examples:
   jinn create plugin  @example/my-runtime --pattern runtime-plugin
 
 Quickstart:
-  https://github.com/Jinn-Network/mono/blob/next/client/docs/build/quickstart.md
+  ${QUICKSTART_URL}
 `;
 
 async function run(ctx: CommandContext): Promise<void> {
@@ -327,7 +330,7 @@ async function run(ctx: CommandContext): Promise<void> {
   ctx.writer.write(
     `Created ${packageName} at ${target}\n` +
     `Next: cd ${target} && yarn install && yarn test\n` +
-    `Quickstart: https://github.com/Jinn-Network/mono/blob/next/client/docs/build/quickstart.md\n`,
+    `Quickstart: ${QUICKSTART_URL}\n`,
   );
 }
 

--- a/client/src/cli/commands/create.ts
+++ b/client/src/cli/commands/create.ts
@@ -241,7 +241,7 @@ Examples:
   jinn create plugin  @example/my-runtime --pattern runtime-plugin
 
 Quickstart:
-  https://github.com/Jinn-Network/mono/blob/main/client/docs/build/quickstart.md
+  https://github.com/Jinn-Network/mono/blob/next/client/docs/build/quickstart.md
 `;
 
 async function run(ctx: CommandContext): Promise<void> {
@@ -327,7 +327,7 @@ async function run(ctx: CommandContext): Promise<void> {
   ctx.writer.write(
     `Created ${packageName} at ${target}\n` +
     `Next: cd ${target} && yarn install && yarn test\n` +
-    `Quickstart: https://github.com/Jinn-Network/mono/blob/main/client/docs/build/quickstart.md\n`,
+    `Quickstart: https://github.com/Jinn-Network/mono/blob/next/client/docs/build/quickstart.md\n`,
   );
 }
 

--- a/client/src/cli/commands/create.ts
+++ b/client/src/cli/commands/create.ts
@@ -241,7 +241,7 @@ Examples:
   jinn create plugin  @example/my-runtime --pattern runtime-plugin
 
 Quickstart:
-  https://github.com/Jinn-Network/mono/blob/main/cargo/client/docs/build/quickstart.md
+  https://github.com/Jinn-Network/mono/blob/main/client/docs/build/quickstart.md
 `;
 
 async function run(ctx: CommandContext): Promise<void> {
@@ -327,7 +327,7 @@ async function run(ctx: CommandContext): Promise<void> {
   ctx.writer.write(
     `Created ${packageName} at ${target}\n` +
     `Next: cd ${target} && yarn install && yarn test\n` +
-    `Quickstart: https://github.com/Jinn-Network/mono/blob/main/cargo/client/docs/build/quickstart.md\n`,
+    `Quickstart: https://github.com/Jinn-Network/mono/blob/main/client/docs/build/quickstart.md\n`,
   );
 }
 

--- a/client/src/daemon/daemon.ts
+++ b/client/src/daemon/daemon.ts
@@ -462,14 +462,11 @@ export class Daemon {
         if (this.engineStopped) break;
       }
 
-      // Work-skip cache: on a single-slot daemon watchForTasks() re-yields every
-      // pending task each pass. canAcceptTask() resolves manifests, validates
-      // schemas, and probes impl.isReady() — with a large backlog of
-      // persistently-unacceptable tasks that contiguous run blocks the event
-      // loop ~1-2s and starves the HTTP API. If this task was recently skipped
-      // (within SKIP_RECHECK_TTL_MS) fast-skip it without re-running that work.
-      // The TTL is bounded on purpose: once it elapses we fall through and
-      // re-check, so a task that becomes acceptable is still picked up.
+      // canAcceptTask() resolves manifests, validates schemas, and probes
+      // impl.isReady() — expensive enough that re-running it for every
+      // persistently-unacceptable task each pass starves the HTTP API. Fast-skip
+      // tasks skipped within the bounded SKIP_RECHECK_TTL_MS; once the TTL
+      // elapses we fall through so a now-acceptable task is still picked up.
       if (!this.skipLogDeduper.shouldRecheck(taskAnnouncement.taskId)) {
         continue;
       }
@@ -478,22 +475,16 @@ export class Daemon {
       const taskRole = (taskAnnouncement.task.role ?? 'restoration') as 'restoration' | 'evaluation';
       const accept = await engine.canAcceptTask({ solverType, taskRole, task: taskAnnouncement.task });
       if (!accept.ok) {
-        // Record the skip so the next cycle within the TTL fast-skips the work
-        // above instead of re-running canAcceptTask.
         this.skipLogDeduper.recordSkip(taskAnnouncement.taskId, accept.reason);
-        // Dedupe per (taskId, reason): on a single-slot daemon the engine-watcher
-        // re-observes every pending task each pass, so the original `console.log`
-        // here produced hundreds of identical "another … task is already in flight"
-        // lines per minute. We log once per (taskId, reason) and stay quiet until
-        // the reason for skipping changes (jinn-mono-kzan).
+        // Log once per (taskId, reason) — the engine-watcher re-observes every
+        // pending task each pass, so an unguarded log here floods the console.
         if (this.skipLogDeduper.shouldLog(taskAnnouncement.taskId, accept.reason)) {
           console.log(`[daemon] skipping task ${taskAnnouncement.taskId} — ${accept.reason}`);
         }
         continue;
       }
-      // Task is acceptable now; reset dedupe + work-skip state so a future skip
-      // (e.g. after this slot fills again) logs once instead of being silently
-      // swallowed, and is re-checked immediately rather than fast-skipped.
+      // Task is acceptable now; reset skip state so a future skip logs once and
+      // is re-checked immediately rather than fast-skipped.
       this.skipLogDeduper.forget(taskAnnouncement.taskId);
 
       // Readiness gate: if the task's harness is not ready (e.g. claude unauthenticated),

--- a/client/src/daemon/daemon.ts
+++ b/client/src/daemon/daemon.ts
@@ -445,15 +445,42 @@ export class Daemon {
    */
   private async _runEngineWatcherLoop(engine: TaskEngine): Promise<void> {
     const DEFAULT_WINDOW_MS = 24 * 60 * 60 * 1_000; // 24 h
+    // Yield to the macrotask queue every N announcements so even the first full
+    // scan of a large backlog hands control back to the HTTP server (so /health
+    // doesn't spike) instead of running as one uninterruptible contiguous block.
+    const YIELD_EVERY = 10;
+    let scanned = 0;
 
     for await (const taskAnnouncement of this.adapter.watchForTasks()) {
       if (this.engineStopped) break;
       if (!taskAnnouncement.taskId) continue;
 
+      if (++scanned % YIELD_EVERY === 0) {
+        // setImmediate schedules a macrotask: the event loop drains pending I/O
+        // callbacks (HTTP requests) before resuming this loop.
+        await new Promise<void>(resolve => setImmediate(resolve));
+        if (this.engineStopped) break;
+      }
+
+      // Work-skip cache: on a single-slot daemon watchForTasks() re-yields every
+      // pending task each pass. canAcceptTask() resolves manifests, validates
+      // schemas, and probes impl.isReady() — with a large backlog of
+      // persistently-unacceptable tasks that contiguous run blocks the event
+      // loop ~1-2s and starves the HTTP API. If this task was recently skipped
+      // (within SKIP_RECHECK_TTL_MS) fast-skip it without re-running that work.
+      // The TTL is bounded on purpose: once it elapses we fall through and
+      // re-check, so a task that becomes acceptable is still picked up.
+      if (!this.skipLogDeduper.shouldRecheck(taskAnnouncement.taskId)) {
+        continue;
+      }
+
       const solverType = taskAnnouncement.task.solverType ?? undefined;
       const taskRole = (taskAnnouncement.task.role ?? 'restoration') as 'restoration' | 'evaluation';
       const accept = await engine.canAcceptTask({ solverType, taskRole, task: taskAnnouncement.task });
       if (!accept.ok) {
+        // Record the skip so the next cycle within the TTL fast-skips the work
+        // above instead of re-running canAcceptTask.
+        this.skipLogDeduper.recordSkip(taskAnnouncement.taskId, accept.reason);
         // Dedupe per (taskId, reason): on a single-slot daemon the engine-watcher
         // re-observes every pending task each pass, so the original `console.log`
         // here produced hundreds of identical "another … task is already in flight"
@@ -464,8 +491,9 @@ export class Daemon {
         }
         continue;
       }
-      // Task is acceptable now; reset dedupe state so a future skip (e.g. after
-      // this slot fills again) logs once instead of being silently swallowed.
+      // Task is acceptable now; reset dedupe + work-skip state so a future skip
+      // (e.g. after this slot fills again) logs once instead of being silently
+      // swallowed, and is re-checked immediately rather than fast-skipped.
       this.skipLogDeduper.forget(taskAnnouncement.taskId);
 
       // Readiness gate: if the task's harness is not ready (e.g. claude unauthenticated),

--- a/client/src/daemon/skip-log-dedup.ts
+++ b/client/src/daemon/skip-log-dedup.ts
@@ -19,7 +19,7 @@
  * due for re-check, so a task that becomes acceptable (operator enables the
  * harness, a slot frees up) is always picked up within the TTL.
  *
- * See jinn-mono-kzan (log dedup) and dogfood finding #14 (work-skip cache).
+ * See jinn-mono-kzan (log dedup).
  */
 
 /**

--- a/client/src/daemon/skip-log-dedup.ts
+++ b/client/src/daemon/skip-log-dedup.ts
@@ -5,14 +5,81 @@
  * pass; this helper collapses repeat lines down to one per `(taskId, reason)`
  * pair until the reason changes (or the entry is evicted to keep memory bounded).
  *
- * See jinn-mono-kzan.
+ * It additionally maintains a TTL-bounded *work-skip cache*: once `canAcceptTask`
+ * rejects a task, the engine-watcher records the skip here and — for
+ * `SKIP_RECHECK_TTL_MS` afterwards — fast-skips the task without re-running the
+ * (expensive) `canAcceptTask` work at all. With a large backlog of
+ * persistently-unacceptable tasks (e.g. ~40 evaluation tasks whose harness is
+ * not enabled), re-running manifest resolution + schema validation +
+ * `impl.isReady()` for every task every cycle blocks the Node event loop ~1-2s
+ * and starves the HTTP API. The cache makes a repeat cycle a Map lookup.
+ *
+ * SAFETY: the TTL re-check is mandatory and bounded. A task is NEVER skip-cached
+ * forever — once `SKIP_RECHECK_TTL_MS` has elapsed the cache reports the task as
+ * due for re-check, so a task that becomes acceptable (operator enables the
+ * harness, a slot frees up) is always picked up within the TTL.
+ *
+ * See jinn-mono-kzan (log dedup) and dogfood finding #14 (work-skip cache).
  */
-export class SkipLogDeduper {
-  private lastReasonByTaskId = new Map<string, string>();
-  private readonly maxEntries: number;
 
-  constructor(maxEntries = 1024) {
+/**
+ * How long a task that `canAcceptTask` rejected stays in the work-skip cache
+ * before the engine-watcher re-evaluates it. Bounded on purpose: a false
+ * permanent skip (a claimable task that is never picked up) is a serious bug,
+ * so the cache is only ever a short-lived optimization.
+ */
+export const SKIP_RECHECK_TTL_MS = 30_000;
+
+interface SkipEntry {
+  /** The last skip reason recorded for this task (used for log dedup). */
+  reason: string;
+  /** Wall-clock time (`Date.now()`) the skip was recorded — drives the TTL. */
+  checkedAt: number;
+}
+
+export class SkipLogDeduper {
+  private entriesByTaskId = new Map<string, SkipEntry>();
+  private readonly maxEntries: number;
+  private readonly recheckTtlMs: number;
+
+  constructor(maxEntries = 1024, recheckTtlMs = SKIP_RECHECK_TTL_MS) {
     this.maxEntries = Math.max(1, maxEntries);
+    this.recheckTtlMs = Math.max(0, recheckTtlMs);
+  }
+
+  /**
+   * Returns true when the engine-watcher should re-run `canAcceptTask` for
+   * `taskId` — i.e. there is no cached skip, or the cached skip is older than
+   * `recheckTtlMs`. Returns false when a recent skip is still within the TTL,
+   * meaning the caller should fast-skip the task without doing the work.
+   *
+   * `now` is injectable for deterministic tests; defaults to `Date.now()`.
+   */
+  shouldRecheck(taskId: string, now: number = Date.now()): boolean {
+    const entry = this.entriesByTaskId.get(taskId);
+    if (entry === undefined) return true;
+    return now - entry.checkedAt >= this.recheckTtlMs;
+  }
+
+  /**
+   * Records that `canAcceptTask` rejected `taskId` with `reason`, stamping the
+   * skip with the current time so subsequent `shouldRecheck` calls can apply
+   * the TTL. Refreshes recency for the FIFO memory bound.
+   *
+   * `now` is injectable for deterministic tests; defaults to `Date.now()`.
+   */
+  recordSkip(taskId: string, reason: string, now: number = Date.now()): void {
+    // Delete-then-set so the entry moves to the end of insertion order, keeping
+    // actively-skipped tasks away from the FIFO eviction front.
+    this.entriesByTaskId.delete(taskId);
+    this.entriesByTaskId.set(taskId, { reason, checkedAt: now });
+    if (this.entriesByTaskId.size > this.maxEntries) {
+      // Map iteration is insertion-order; evict the oldest entry.
+      const oldestKey = this.entriesByTaskId.keys().next().value;
+      if (oldestKey !== undefined) {
+        this.entriesByTaskId.delete(oldestKey);
+      }
+    }
   }
 
   /**
@@ -20,28 +87,32 @@ export class SkipLogDeduper {
    * (or the previous reason for this `taskId` was different). Returns false
    * when the previous skip for this task had the same reason — operators
    * already saw the line; another copy is noise.
+   *
+   * This only governs log output; it does NOT record a work-skip TTL entry.
+   * Callers that want the work-skip fast path must also call `recordSkip`.
    */
   shouldLog(taskId: string, reason: string): boolean {
-    const previous = this.lastReasonByTaskId.get(taskId);
-    if (previous === reason) {
-      // Refresh recency so we don't evict an actively-skipped task.
-      this.lastReasonByTaskId.delete(taskId);
-      this.lastReasonByTaskId.set(taskId, reason);
+    const previous = this.entriesByTaskId.get(taskId);
+    if (previous?.reason === reason) {
+      // Refresh recency so we don't evict an actively-skipped task, but keep
+      // the original `checkedAt` so the TTL keeps counting from the first skip.
+      this.entriesByTaskId.delete(taskId);
+      this.entriesByTaskId.set(taskId, previous);
       return false;
     }
-    this.lastReasonByTaskId.set(taskId, reason);
-    if (this.lastReasonByTaskId.size > this.maxEntries) {
-      // Map iteration is insertion-order; evict the oldest entry.
-      const oldestKey = this.lastReasonByTaskId.keys().next().value;
-      if (oldestKey !== undefined) {
-        this.lastReasonByTaskId.delete(oldestKey);
-      }
-    }
+    // New or changed reason: this is a fresh skip. Stamp it now so the
+    // work-skip TTL and the log-dedup state stay consistent for a caller that
+    // only calls `shouldLog`.
+    this.recordSkip(taskId, reason);
     return true;
   }
 
-  /** Forget the last-logged reason for `taskId` (e.g. when the task is claimed). */
+  /**
+   * Forget all skip state for `taskId` — both the last-logged reason and the
+   * work-skip TTL entry. Called when the task is accepted/claimed so a future
+   * skip logs once and is re-checked immediately rather than fast-skipped.
+   */
   forget(taskId: string): void {
-    this.lastReasonByTaskId.delete(taskId);
+    this.entriesByTaskId.delete(taskId);
   }
 }

--- a/client/src/dashboard/spa/src/components/InlineHelp.tsx
+++ b/client/src/dashboard/spa/src/components/InlineHelp.tsx
@@ -74,6 +74,10 @@ export function InlineHelp({
             fontWeight: 400,
             letterSpacing: 'normal',
             textTransform: 'none',
+            // `pre-line` collapses runs of spaces but keeps newlines, so help
+            // copy can use blank lines (`\n\n`) to break dense paragraphs
+            // into short, scannable chunks (#328 inline-help polish).
+            whiteSpace: 'pre-line',
             color: 'var(--fg-muted)',
             maxWidth: '420px',
           }}

--- a/client/src/dashboard/spa/src/pages/Overview.test.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.test.tsx
@@ -536,13 +536,13 @@ describe('OverviewPage empty-state gating', () => {
   });
 });
 
-// ── Restart notice auto-clears (jinn-mono #328 fix #6) ──────────────────────
+// ── Restart notice auto-clears ──────────────────────────────────────────────
 //
-// In the v0.1.6 dogfood the restart-requested notice never cleared — it stayed
-// pinned to the dashboard until the operator triggered some other action. The
-// confirmation is transient, so the Restart action must pass `autoClearMs`
-// (like the gas top-up does) and the notice must disappear on its own.
-describe('OverviewPage restart notice (jinn-mono #328 fix #6)', () => {
+// The restart-requested notice must not stay pinned to the dashboard until the
+// operator triggers some other action. The confirmation is transient, so the
+// Restart action must pass `autoClearMs` (like the gas top-up does) and the
+// notice must disappear on its own.
+describe('OverviewPage restart notice', () => {
   const restartStatus = {
     rewards: { pendingStakingRewardsWei: '1000000000000000000' },
     masterGas: { balanceWei: '23000000000000000', runwayDaysExcess: 4 },
@@ -587,14 +587,13 @@ describe('OverviewPage restart notice (jinn-mono #328 fix #6)', () => {
   });
 });
 
-// ── Gas top-up: explicit click, no auto-fire (jinn-mono #336) ───────────────
+// ── Gas top-up: explicit click, no auto-fire ────────────────────────────────
 //
-// rvx in the v0.1.6 dogfood: "I hit the button 'Top up' and it just magically
-// increases the number ... can't seem to stop it." The Dashboard Gas top-up
-// must be a single, explicit action: one click → exactly one faucet call, no
-// re-firing while the Dashboard stays mounted, a one-line amount + tx-hash
-// confirmation, and the button disabled while the request is in flight.
-describe('OverviewPage gas top-up (jinn-mono #336)', () => {
+// The Dashboard Gas top-up must be a single, explicit action: one click →
+// exactly one faucet call, no re-firing while the Dashboard stays mounted, a
+// one-line amount + tx-hash confirmation, and the button disabled while the
+// request is in flight.
+describe('OverviewPage gas top-up', () => {
   const gasStatus = {
     rewards: { pendingStakingRewardsWei: '1000000000000000000' },
     masterGas: { balanceWei: '23000000000000000', runwayDaysExcess: 4 },

--- a/client/src/dashboard/spa/src/pages/Overview.test.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { Router } from 'wouter';
 import { memoryLocation } from 'wouter/memory-location';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -533,6 +533,57 @@ describe('OverviewPage empty-state gating', () => {
     fireEvent.click(screen.getByRole('button', { name: /restart/i }));
     await waitFor(() => expect(restartDaemonMock).toHaveBeenCalledOnce());
     expect(history.at(-1)).toBe('/overview');
+  });
+});
+
+// ── Restart notice auto-clears (jinn-mono #328 fix #6) ──────────────────────
+//
+// In the v0.1.6 dogfood the restart-requested notice never cleared — it stayed
+// pinned to the dashboard until the operator triggered some other action. The
+// confirmation is transient, so the Restart action must pass `autoClearMs`
+// (like the gas top-up does) and the notice must disappear on its own.
+describe('OverviewPage restart notice (jinn-mono #328 fix #6)', () => {
+  const restartStatus = {
+    rewards: { pendingStakingRewardsWei: '1000000000000000000' },
+    masterGas: { balanceWei: '23000000000000000', runwayDaysExcess: 4 },
+    fleet: { services: [] },
+    predictionV1: {
+      operator: { ok: true, solverNet: { name: 'prediction', enabled: false }, diagnostics: [] },
+      totals: { observedTasks: 1, activeTaskRuns: 0, solutions: 0, verdicts: 0, failed: 0 },
+    },
+  };
+
+  it('auto-clears the restart-requested notice after its autoClearMs window', async () => {
+    vi.useFakeTimers();
+    try {
+      getStatusMock.mockResolvedValue(restartStatus);
+      getBootstrapMock.mockResolvedValue({ solverNets: {} });
+      restartDaemonMock.mockResolvedValue({ ok: true });
+      render(withProviders(<OverviewPage />));
+
+      const restartButton = await vi.waitFor(() =>
+        screen.getByRole('button', { name: /restart/i }),
+      );
+      fireEvent.click(restartButton);
+
+      // The confirmation surfaces first.
+      const notice = await vi.waitFor(() => screen.getByTestId('dashboard-action-notice'));
+      expect(notice.textContent).toMatch(/restart requested/i);
+
+      // Before the auto-clear window elapses the notice is still present.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(9_000);
+      });
+      expect(screen.queryByTestId('dashboard-action-notice')).not.toBeNull();
+
+      // Past the 10s window the notice clears itself — no other action needed.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_000);
+      });
+      expect(screen.queryByTestId('dashboard-action-notice')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -263,7 +263,6 @@ export function OverviewPage(): JSX.Element {
         statusLabel={LIVE_NOW_STATE_LABEL[liveNow.state]}
         statusState={liveNow.state}
         statusDot={LIVE_NOW_TONE[liveNow.state].dot}
-        // #328 fix #1: the bare status label ("ATTENTION") gave no reason.
         // `liveNow.line` is the human-readable why — the first error
         // diagnostic's message, "N tasks restoring", "waiting for next task",
         // etc. — surfaced under the label in the STATUS tile.
@@ -316,9 +315,9 @@ export function OverviewPage(): JSX.Element {
               }
               return { message: 'Restart requested. The dashboard will reconnect when the daemon is back.' };
             },
-            // Issue #328 fix #6: the restart confirmation is transient — surface
-            // it, then fade after ~10s so it doesn't linger until the next
-            // action. The dashboard reconnects on its own when the daemon is back.
+            // Restart confirmation is transient — surface it, then fade after
+            // ~10s so it doesn't linger until the next action. The dashboard
+            // reconnects on its own when the daemon is back.
             { autoClearMs: 10_000 },
           )}
         onRestake={async (serviceId) => {

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -263,6 +263,11 @@ export function OverviewPage(): JSX.Element {
         statusLabel={LIVE_NOW_STATE_LABEL[liveNow.state]}
         statusState={liveNow.state}
         statusDot={LIVE_NOW_TONE[liveNow.state].dot}
+        // #328 fix #1: the bare status label ("ATTENTION") gave no reason.
+        // `liveNow.line` is the human-readable why — the first error
+        // diagnostic's message, "N tasks restoring", "waiting for next task",
+        // etc. — surfaced under the label in the STATUS tile.
+        statusReason={liveNow.line}
         activeAction={activeAction}
         evicted={isEvicted}
         evictedServiceId={evictedServiceId}

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -302,13 +302,20 @@ export function OverviewPage(): JSX.Element {
             { autoClearMs: 5_000 },
           )}
         onRestart={() =>
-          runAction('Restart node', async () => {
-            const res = await api.restartDaemon();
-            if (!res.ok) {
-              throw new Error('Restart request failed.');
-            }
-            return { message: 'Restart requested. The dashboard will reconnect when the daemon is back.' };
-          })}
+          runAction(
+            'Restart node',
+            async () => {
+              const res = await api.restartDaemon();
+              if (!res.ok) {
+                throw new Error('Restart request failed.');
+              }
+              return { message: 'Restart requested. The dashboard will reconnect when the daemon is back.' };
+            },
+            // Issue #328 fix #6: the restart confirmation is transient — surface
+            // it, then fade after ~10s so it doesn't linger until the next
+            // action. The dashboard reconnects on its own when the daemon is back.
+            { autoClearMs: 10_000 },
+          )}
         onRestake={async (serviceId) => {
           const res = await api.restake(serviceId);
           if (!res.ok) {

--- a/client/src/dashboard/spa/src/pages/build/IntroCard.tsx
+++ b/client/src/dashboard/spa/src/pages/build/IntroCard.tsx
@@ -6,7 +6,7 @@ import quickstartMd from '../../../../../../docs/build/quickstart.md?raw';
 import { PanelCard } from '../../components/PanelCard.js';
 
 const QUICKSTART_URL =
-  'https://github.com/Jinn-Network/mono/blob/main/cargo/client/docs/build/quickstart.md';
+  'https://github.com/Jinn-Network/mono/blob/main/client/docs/build/quickstart.md';
 
 export function IntroCard(): JSX.Element {
   return (

--- a/client/src/dashboard/spa/src/pages/build/IntroCard.tsx
+++ b/client/src/dashboard/spa/src/pages/build/IntroCard.tsx
@@ -6,7 +6,7 @@ import quickstartMd from '../../../../../../docs/build/quickstart.md?raw';
 import { PanelCard } from '../../components/PanelCard.js';
 
 const QUICKSTART_URL =
-  'https://github.com/Jinn-Network/mono/blob/main/client/docs/build/quickstart.md';
+  'https://github.com/Jinn-Network/mono/blob/next/client/docs/build/quickstart.md';
 
 export function IntroCard(): JSX.Element {
   return (

--- a/client/src/dashboard/spa/src/pages/configuration/CostEstimatePanel.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/CostEstimatePanel.tsx
@@ -111,10 +111,7 @@ export function CostEstimatePanel({
             color: 'var(--fg-muted)',
           }}
         >
-          Heuristic: ~{(estimate.typicalInputTokens / 1000).toFixed(0)}k input + ~
-          {(estimate.typicalOutputTokens / 1000).toFixed(0)}k output @ ${estimate.entry.inputPer1kTokens.toFixed(4)}
-          /1k in, ${estimate.entry.outputPer1kTokens.toFixed(4)}/1k out (provider: {estimate.entry.provider}).
-          Real usage will vary.
+          Rough estimate — actual cost varies.
         </span>
       )}
       {usd === null && (

--- a/client/src/dashboard/spa/src/pages/configuration/claudeModels.ts
+++ b/client/src/dashboard/spa/src/pages/configuration/claudeModels.ts
@@ -31,19 +31,21 @@ export const CODEX_MODELS: readonly LearnerModelOption[] = [
   { label: 'GPT-5.3 Codex Spark', id: 'gpt-5.3-codex-spark' },
 ] as const;
 
-// Hermes routes models through providers (Nous Portal, OpenRouter, …) using
-// `<provider>/<model>` ids. The first entry is the dashboard default.
-// Operators wanting a different provider/model can pick from this list or
-// override via `hermes model` (which the adapter inherits when the join
-// config leaves `model` unset).
+// Hermes routes every model through OpenRouter using `<provider>/<model>`
+// ids — OpenRouter is Hermes's single model provider. The first entry is the
+// dashboard default. Operators wanting a different model can pick from this
+// list or override via `hermes model` (which the adapter inherits when the
+// join config leaves `model` unset).
 //
 // Set sized + ordered for v0: Anthropic flagships first (operator default;
 // historically Hermes's own recommended default), then the OpenRouter
-// programming leaderboard top-10 (token-volume, verified live via
-// /api/v1/models 2026-05-18 — see jinn-mono-u34i thread), then Nous's own
-// Hermes-405B for harness-namesake continuity. Operators pinned to an id
-// outside this list (e.g. `anthropic/claude-opus-4.6` from an older config)
-// still work — `resolveModelOption` surfaces them as `Custom (<id>)`.
+// programming leaderboard top-8 (token-volume, verified live via
+// /api/v1/models 2026-05-18 — see jinn-mono-u34i thread). Single-provider
+// (OpenRouter) by design: `HermesHarness.isReady()` gates on OpenRouter
+// auth, so every surfaced model must route through OpenRouter. Operators
+// pinned to an id outside this list (e.g. `anthropic/claude-opus-4.6` from
+// an older config) still work — `resolveModelOption` surfaces them as
+// `Custom (<id>)`.
 export const HERMES_MODELS: readonly LearnerModelOption[] = [
   { label: 'Claude Opus 4.7 (OpenRouter)',   id: 'anthropic/claude-opus-4.7'    },
   { label: 'Claude Sonnet 4.6 (OpenRouter)', id: 'anthropic/claude-sonnet-4.6'  },
@@ -54,7 +56,6 @@ export const HERMES_MODELS: readonly LearnerModelOption[] = [
   { label: 'Kimi K2.6',                      id: 'moonshotai/kimi-k2.6'         },
   { label: 'Owl Alpha',                      id: 'openrouter/owl-alpha'         },
   { label: 'MiniMax M2.7',                   id: 'minimax/minimax-m2.7'         },
-  { label: 'Hermes 4 405B (Nous)',           id: 'nousresearch/hermes-4-405b'   },
 ] as const;
 
 function isCodexHarness(harness: string | undefined): boolean {

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
@@ -27,6 +27,7 @@ const apiMock = vi.hoisted(() => ({
   operatorLeave: vi.fn(),
   hermesDoctor: vi.fn(),
   harnessReadiness: vi.fn(),
+  restartDaemon: vi.fn(),
 }));
 
 vi.mock('../../api/client.js', () => ({
@@ -41,6 +42,7 @@ vi.mock('../../api/client.js', () => ({
     },
     hermesDoctor: () => apiMock.hermesDoctor(),
     harnessReadiness: (name: string) => apiMock.harnessReadiness(name),
+    restartDaemon: () => apiMock.restartDaemon(),
   },
 }));
 
@@ -146,6 +148,7 @@ beforeEach(() => {
   apiMock.operatorLeave.mockReset();
   apiMock.hermesDoctor.mockReset();
   apiMock.harnessReadiness.mockReset();
+  apiMock.restartDaemon.mockReset();
 
   // Default: every probed harness reports ready. Tests that exercise the
   // not-ready path override this per harness name.
@@ -170,6 +173,7 @@ beforeEach(() => {
     manifestCid: 'bafybeiaaa',
     config: { manifestCid: 'bafybeiaaa', roles: ['solver'] },
   });
+  apiMock.restartDaemon.mockResolvedValue({ ok: true, scheduled: true });
 });
 
 afterEach(() => {
@@ -817,6 +821,52 @@ describe('JoinFlow — submission', () => {
     );
     fireEvent.click(screen.getByTestId('join-flow-success-view'));
     expect(nav.history.at(-1)).toBe('/operator#solvernets/bafybeiaaa');
+  });
+
+  it('success-card restart button restarts the daemon and goes to /overview (#328)', async () => {
+    const { nav } = wrap(<JoinFlow />);
+    await waitFor(() =>
+      expect(screen.getByTestId('join-flow-summary')).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByLabelText('Solver'));
+    fireEvent.click(screen.getByTestId('join-flow-submit'));
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId('join-flow-success-restart-button'),
+      ).toBeTruthy(),
+    );
+    fireEvent.click(screen.getByTestId('join-flow-success-restart-button'));
+
+    await waitFor(() => expect(apiMock.restartDaemon).toHaveBeenCalled());
+    await waitFor(() => expect(nav.history.at(-1)).toBe('/overview'));
+  });
+
+  it('success-card restart button surfaces an error and stays put on failure (#328)', async () => {
+    apiMock.restartDaemon.mockResolvedValue({ ok: false });
+    const { nav } = wrap(<JoinFlow />);
+    await waitFor(() =>
+      expect(screen.getByTestId('join-flow-summary')).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByLabelText('Solver'));
+    fireEvent.click(screen.getByTestId('join-flow-submit'));
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId('join-flow-success-restart-button'),
+      ).toBeTruthy(),
+    );
+    fireEvent.click(screen.getByTestId('join-flow-success-restart-button'));
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId('join-flow-success-restart-error'),
+      ).toBeTruthy(),
+    );
+    // Restart failed — the operator was not redirected away.
+    expect(nav.history.at(-1)).toBe('/operator/join/bafybeiaaa');
   });
 
   it('omits solver-only fields when only evaluator is selected', async () => {

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
@@ -304,14 +304,12 @@ describe('JoinFlow — harness options', () => {
     );
   });
 
-  it('selecting Claude Code in the dropdown sticks even when the catalog default is Hermes (issue #329)', async () => {
-    // Issue #329 regression. Production SWE-rebench v2 catalog
-    // (`client/src/main.ts`) lists Hermes first; selecting Claude Code from
-    // the dropdown silently reverted to Hermes on every render because a
-    // render-time `setForm` was bouncing form.harness back to the catalog
-    // default whenever it equalled the seed `claude-code`. Cover the full
-    // sequence: catalog default Hermes -> operator picks Claude Code -> value
-    // sticks across re-renders -> submit carries claude-code.
+  it('selecting Claude Code in the dropdown sticks even when the catalog default is Hermes', async () => {
+    // A render-time `setForm` was bouncing form.harness back to the catalog
+    // default whenever it equalled the seed `claude-code`, so picking Claude
+    // Code from the dropdown silently reverted to Hermes on every render. Cover
+    // the full sequence: catalog default Hermes -> operator picks Claude Code
+    // -> value sticks across re-renders -> submit carries claude-code.
     apiMock.getSolverNets.mockResolvedValue({
       ...baseCatalog,
       nets: [
@@ -407,7 +405,7 @@ describe('JoinFlow — harness options', () => {
   });
 });
 
-describe('JoinFlow — per-harness readiness gate (#332)', () => {
+describe('JoinFlow — per-harness readiness gate', () => {
   /** Catalog with Claude Code + Codex, both compatible. */
   const twoHarnessCatalog = {
     ...baseCatalog,
@@ -769,15 +767,15 @@ describe('JoinFlow — submission', () => {
         disabledDefaultPlugins: [],
       }),
     );
-    // #333: a successful join shows an explicit success state ON the join
-    // page — it must NOT silently redirect to /operator.
+    // A successful join shows an explicit success state ON the join page — it
+    // must NOT silently redirect to /operator.
     await waitFor(() =>
       expect(screen.getByTestId('join-flow-success')).toBeTruthy(),
     );
     expect(nav.history.at(-1)).toBe('/operator/join/bafybeiaaa');
   });
 
-  it('renders a success card naming the joined SolverNet and a restart hint (#333)', async () => {
+  it('renders a success card naming the joined SolverNet and a restart hint', async () => {
     apiMock.operatorJoin.mockResolvedValue({
       ok: true,
       restartRequired: true,
@@ -807,7 +805,7 @@ describe('JoinFlow — submission', () => {
     expect(screen.queryByTestId('join-flow-submit')).toBeNull();
   });
 
-  it('success-card CTA navigates into the joined SolverNet (#333)', async () => {
+  it('success-card CTA navigates into the joined SolverNet', async () => {
     const { nav } = wrap(<JoinFlow />);
     await waitFor(() =>
       expect(screen.getByTestId('join-flow-summary')).toBeTruthy(),
@@ -823,7 +821,7 @@ describe('JoinFlow — submission', () => {
     expect(nav.history.at(-1)).toBe('/operator#solvernets/bafybeiaaa');
   });
 
-  it('success-card restart button restarts the daemon and goes to /overview (#328)', async () => {
+  it('success-card restart button restarts the daemon and goes to /overview', async () => {
     const { nav } = wrap(<JoinFlow />);
     await waitFor(() =>
       expect(screen.getByTestId('join-flow-summary')).toBeTruthy(),
@@ -843,7 +841,7 @@ describe('JoinFlow — submission', () => {
     await waitFor(() => expect(nav.history.at(-1)).toBe('/overview'));
   });
 
-  it('success-card restart button surfaces an error and stays put on failure (#328)', async () => {
+  it('success-card restart button surfaces an error and stays put on failure', async () => {
     apiMock.restartDaemon.mockResolvedValue({ ok: false });
     const { nav } = wrap(<JoinFlow />);
     await waitFor(() =>
@@ -954,9 +952,9 @@ describe('JoinFlow — Hermes Agent precheck panel', () => {
     fireEvent.change(harnessSelect, { target: { value: 'hermes-agent' } });
     await waitFor(() => expect(harnessSelect.value).toBe('hermes-agent'));
 
-    // Hermes default is Opus 4.7 — above the $1/task cost gate (Issue
-    // #331). Acknowledge it so the submit button isn't gated; these
-    // tests are exercising the precheck path, not the cost gate.
+    // Hermes default is Opus 4.7 — above the $1/task cost gate. Acknowledge it
+    // so the submit button isn't gated; these tests exercise the precheck path,
+    // not the cost gate.
     await waitFor(() =>
       expect(screen.getByTestId('join-flow-cost-confirmation')).toBeTruthy(),
     );
@@ -1092,7 +1090,7 @@ describe('JoinFlow — Hermes Agent precheck panel', () => {
   });
 });
 
-describe('JoinFlow — cost surfacing + confirmation gate (Issue #331 P0)', () => {
+describe('JoinFlow — cost surfacing + confirmation gate', () => {
   /**
    * Catalog with Hermes + Claude Code, both compatible. The default solver
    * harness is the first compatible — Claude Code — so the cost surface
@@ -1219,7 +1217,7 @@ describe('JoinFlow — cost surfacing + confirmation gate (Issue #331 P0)', () =
   });
 });
 
-describe('JoinFlow — inline decision-context help (#334)', () => {
+describe('JoinFlow — inline decision-context help', () => {
   it('renders a help trigger next to the Roles label', async () => {
     wrap(<JoinFlow />);
     await waitFor(() =>
@@ -1320,7 +1318,7 @@ describe('JoinFlow — inline decision-context help (#334)', () => {
 
     const link = screen.getByTestId('inline-help-doc-link');
     // Assert the full path — a filename-only match let a stale
-    // `cargo/client/docs/...` segment (which 404s) slip through (#328).
+    // `cargo/client/docs/...` segment (which 404s) slip through.
     expect(link.getAttribute('href')).toMatch(
       /\/client\/docs\/operator\/join-form-context\.md/,
     );

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.test.tsx
@@ -1269,6 +1269,10 @@ describe('JoinFlow — inline decision-context help (#334)', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Roles help' }));
 
     const link = screen.getByTestId('inline-help-doc-link');
-    expect(link.getAttribute('href')).toMatch(/join-form-context\.md/);
+    // Assert the full path — a filename-only match let a stale
+    // `cargo/client/docs/...` segment (which 404s) slip through (#328).
+    expect(link.getAttribute('href')).toMatch(
+      /\/client\/docs\/operator\/join-form-context\.md/,
+    );
   });
 });

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
@@ -444,11 +444,15 @@ export function JoinFlow({
             label="Roles help"
             docHref={`${JOIN_FORM_CONTEXT_DOC}#solver-vs-evaluator`}
           >
-            Solver attempts tasks and submits solutions — this is the
-            spending role (model inference + gas) and the one with the most
-            per-task upside. Evaluator verifies others' solutions — lower spend,
-            steadier, lower variance. You can take either or both. Unsure? Start
-            as a solver on one SolverNet with a model you already pay for.
+            Solver attempts tasks and submits solutions. It is the spending
+            role: you pay for model inference and gas. It also has the most
+            upside per task.
+            {'\n\n'}
+            Evaluator checks other operators' solutions. Lower spend, steadier
+            returns, less variance.
+            {'\n\n'}
+            You can take either role, or both. New here? Start as a solver on
+            one SolverNet, using a model you already pay for.
           </InlineHelp>
         </span>
         <div
@@ -532,14 +536,17 @@ export function JoinFlow({
                   label="Harness help"
                   docHref={`${JOIN_FORM_CONTEXT_DOC}#harness-and-model`}
                 >
-                  The harness is the runtime that executes a task. You need
-                  credentials for one harness, not for the harness and the
-                  model both. Claude Code uses whatever the `claude` CLI is
-                  signed in with — a Claude subscription or an Anthropic API
-                  key. Hermes Agent is a separate package; the join form runs an
-                  install precheck for it. The default shown is the SolverNet's
-                  first compatible option, not a recommendation to pay for two
-                  things.
+                  The harness is the runtime that runs a task.
+                  {'\n\n'}
+                  You only need credentials for one harness — the harness, not
+                  the harness and the model separately.
+                  {'\n\n'}
+                  Claude Code uses whatever the `claude` CLI is signed in with:
+                  a Claude subscription or an Anthropic API key. Hermes Agent is
+                  a separate package; the join form checks it is installed.
+                  {'\n\n'}
+                  The default is the SolverNet's first compatible harness. Pick
+                  one. You do not need to pay for two.
                 </InlineHelp>
               </span>
               <select
@@ -642,12 +649,16 @@ export function JoinFlow({
                   label="Model help"
                   docHref={`${JOIN_FORM_CONTEXT_DOC}#harness-and-model`}
                 >
-                  The model is the LLM the harness drives. The list is filtered
-                  to the models the selected harness supports — changing the
-                  harness resets the model to that harness's default. You pay
-                  for the model through the harness's credentials; there is no
-                  separate model subscription on top of that. See the cost
-                  estimate below before you commit.
+                  The model is the LLM the harness runs.
+                  {'\n\n'}
+                  This list only shows models the selected harness supports.
+                  Change the harness and the model resets to that harness's
+                  default.
+                  {'\n\n'}
+                  You pay for the model through the harness's credentials. There
+                  is no extra model subscription on top.
+                  {'\n\n'}
+                  Check the cost estimate below before you join.
                 </InlineHelp>
               </span>
               <select
@@ -726,12 +737,16 @@ export function JoinFlow({
                 label="Plugins help"
                 docHref={`${JOIN_FORM_CONTEXT_DOC}#plug-ins`}
               >
-                Plug-ins are optional — on a first run you almost certainly do
-                not need to touch this. A SolverPlugin is reusable AI tooling
-                (MCP servers, skills, extensions) a harness can load while it
-                solves. SolverNets ship task-specific plug-ins enabled by
-                default; you would only add your own here if you have built one.
-                You can re-join later with plug-ins added.
+                Plug-ins are optional. On your first run you do not need to
+                touch this section.
+                {'\n\n'}
+                A plug-in is reusable AI tooling — MCP servers, skills,
+                extensions — that the harness can load while it solves.
+                {'\n\n'}
+                This SolverNet already enables the plug-ins its tasks need. Add
+                your own only if you have built one.
+                {'\n\n'}
+                You can re-join later with more plug-ins.
               </InlineHelp>
             </span>
             <PluginPicker
@@ -757,12 +772,15 @@ export function JoinFlow({
               label="Evaluator configuration help"
               docHref={`${JOIN_FORM_CONTEXT_DOC}#why-the-evaluator-role-has-no-model-selector`}
             >
-              There is no harness or model picker for the evaluator role — and
-              that is by design, not a sign the role is underdeveloped. Every
-              evaluator on a SolverNet must run the same evaluation function so
-              verdicts are comparable, so the SolverNet's manifest binds it for
-              you. For many SolverNets that function is deterministic and calls
-              no model at all.
+              The evaluator role has no harness or model picker. That is by
+              design.
+              {'\n\n'}
+              Every evaluator on a SolverNet must run the same evaluation
+              function, so verdicts can be compared. The SolverNet's manifest
+              sets it for you.
+              {'\n\n'}
+              For many SolverNets that function is deterministic and uses no
+              model at all.
             </InlineHelp>
           </span>
           <p
@@ -790,10 +808,12 @@ export function JoinFlow({
               label="Evaluator binding help"
               docHref={`${JOIN_FORM_CONTEXT_DOC}#why-the-evaluator-role-has-no-model-selector`}
             >
-              The evaluator harness is bound by the SolverNet's manifest so
-              every evaluator runs the same evaluation function — verdicts have
-              to be comparable to be trustworthy. The harness and model fields
-              above configure only the solver role.
+              The SolverNet's manifest sets the evaluator harness for you.
+              {'\n\n'}
+              Every evaluator runs the same evaluation function, so verdicts can
+              be compared and trusted.
+              {'\n\n'}
+              The harness and model fields above apply only to the solver role.
             </InlineHelp>
           </span>
           <p

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
@@ -35,7 +35,7 @@ const HERMES_AGENT_DESCRIPTION =
  * there for the full picture (Issue #334).
  */
 const JOIN_FORM_CONTEXT_DOC =
-  'https://github.com/Jinn-Network/mono/blob/main/client/docs/operator/join-form-context.md';
+  'https://github.com/Jinn-Network/mono/blob/next/client/docs/operator/join-form-context.md';
 
 /**
  * Operator participation flow keyed by `manifestCid`.

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
@@ -35,7 +35,7 @@ const HERMES_AGENT_DESCRIPTION =
  * there for the full picture (Issue #334).
  */
 const JOIN_FORM_CONTEXT_DOC =
-  'https://github.com/Jinn-Network/mono/blob/main/cargo/client/docs/operator/join-form-context.md';
+  'https://github.com/Jinn-Network/mono/blob/main/client/docs/operator/join-form-context.md';
 
 /**
  * Operator participation flow keyed by `manifestCid`.

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
@@ -969,6 +969,26 @@ function JoinSuccessCard({
   const roleLabel = success.roles
     .map((r) => (r === 'solver' ? 'Solver' : 'Evaluator'))
     .join(' + ');
+  const [restarting, setRestarting] = useState(false);
+  const [restartError, setRestartError] = useState<string | null>(null);
+  const handleRestart = async (): Promise<void> => {
+    setRestarting(true);
+    setRestartError(null);
+    try {
+      const res = await api.restartDaemon();
+      if (!res.ok) {
+        throw new Error('Restart request failed.');
+      }
+      // Send the operator to the overview so they can watch the node
+      // come back up after the restart.
+      navigate('/overview');
+    } catch (err) {
+      setRestartError(
+        err instanceof Error ? err.message : 'Restart request failed.',
+      );
+      setRestarting(false);
+    }
+  };
   return (
     <>
       <div
@@ -1033,6 +1053,20 @@ function JoinSuccessCard({
           </span>
         )}
       </div>
+      {restartError && (
+        <div
+          role="alert"
+          data-testid="join-flow-success-restart-error"
+          style={{
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '12px',
+            color: 'var(--break-red)',
+            lineHeight: 1.5,
+          }}
+        >
+          {restartError}
+        </div>
+      )}
       <footer
         style={{
           display: 'flex',
@@ -1055,14 +1089,25 @@ function JoinSuccessCard({
           onClick={() =>
             navigate(`/operator#solvernets/${success.manifestCid}`)
           }
+          style={ghostButtonStyle}
+        >
+          View joined SolverNet
+        </button>
+        <button
+          type="button"
+          data-testid="join-flow-success-restart-button"
+          onClick={handleRestart}
+          disabled={restarting}
           style={{
             ...ghostButtonStyle,
             background: 'var(--accent-sky)',
             color: 'var(--bg-sunken)',
             border: '1px solid var(--accent-sky)',
+            cursor: restarting ? 'wait' : 'pointer',
+            opacity: restarting ? 0.7 : 1,
           }}
         >
-          View joined SolverNet
+          {restarting ? 'Restarting…' : 'Restart node now'}
         </button>
       </footer>
     </>

--- a/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/JoinFlow.tsx
@@ -631,17 +631,6 @@ export function JoinFlow({
                         : ''}
                     </span>
                   )}
-                  {selectedHarnessReadiness.nextStep?.url && (
-                    <a
-                      href={selectedHarnessReadiness.nextStep.url}
-                      target="_blank"
-                      rel="noreferrer"
-                      data-testid="join-harness-not-ready-url"
-                      style={{ color: 'var(--accent-sky)' }}
-                    >
-                      {selectedHarnessReadiness.nextStep.url}
-                    </a>
-                  )}
                 </div>
               )}
             </div>

--- a/client/src/dashboard/spa/src/pages/overview/HeroStats.test.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/HeroStats.test.tsx
@@ -11,6 +11,7 @@ function defaultProps() {
     statusLabel: 'WORKING',
     statusState: 'working' as const,
     statusDot: 'var(--vow-green)',
+    statusReason: '1 task restoring',
     activeAction: null,
     evicted: false,
     onClaim: () => undefined,
@@ -85,5 +86,54 @@ describe('HeroStats', () => {
   it('does not render Re-stake now button when evicted=true but onRestake is not provided (jinn-mono-hjex.3)', () => {
     render(<HeroStats {...defaultProps()} evicted={true} evictedServiceId={42} />);
     expect(screen.queryByTestId('restake-button')).toBeNull();
+  });
+
+  // ── Status tile reason line (jinn-mono #328 fix #1) ───────────────────────
+  //
+  // The STATUS hero tile used to render only the label ("ATTENTION") with no
+  // explanation. `statusReason` (deriveLiveNow().line) is now surfaced as a
+  // small subdued secondary line under the label so the operator sees *why*.
+  it('renders the status reason line under the STATUS label (jinn-mono #328 fix #1)', () => {
+    render(<HeroStats {...defaultProps()} statusReason="1 task restoring" />);
+    const reason = screen.getByTestId('overview-status-reason');
+    expect(reason.textContent).toBe('1 task restoring');
+    // The reason lives inside the STATUS tile, not elsewhere on the page.
+    expect(screen.getByTestId('overview-status-stat').contains(reason)).toBe(true);
+  });
+
+  it('surfaces the attention reason so ATTENTION is never bare (jinn-mono #328 fix #1)', () => {
+    render(
+      <HeroStats
+        {...defaultProps()}
+        statusLabel="ATTENTION"
+        statusState="attention"
+        statusDot="var(--break-red)"
+        statusReason="Harness does not support prediction.v1"
+      />,
+    );
+    expect(screen.getByText('ATTENTION')).toBeTruthy();
+    expect(screen.getByTestId('overview-status-reason').textContent).toBe(
+      'Harness does not support prediction.v1',
+    );
+  });
+
+  it('renders the reason line in non-attention states too (jinn-mono #328 fix #1)', () => {
+    render(
+      <HeroStats
+        {...defaultProps()}
+        statusLabel="IDLE"
+        statusState="idle"
+        statusDot="var(--fg-muted)"
+        statusReason="waiting for next task"
+      />,
+    );
+    expect(screen.getByTestId('overview-status-reason').textContent).toBe(
+      'waiting for next task',
+    );
+  });
+
+  it('omits the reason line when statusReason is empty (jinn-mono #328 fix #1)', () => {
+    render(<HeroStats {...defaultProps()} statusReason="" />);
+    expect(screen.queryByTestId('overview-status-reason')).toBeNull();
   });
 });

--- a/client/src/dashboard/spa/src/pages/overview/HeroStats.test.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/HeroStats.test.tsx
@@ -88,12 +88,12 @@ describe('HeroStats', () => {
     expect(screen.queryByTestId('restake-button')).toBeNull();
   });
 
-  // ── Status tile reason line (jinn-mono #328 fix #1) ───────────────────────
+  // ── Status tile reason line ───────────────────────────────────────────────
   //
-  // The STATUS hero tile used to render only the label ("ATTENTION") with no
-  // explanation. `statusReason` (deriveLiveNow().line) is now surfaced as a
-  // small subdued secondary line under the label so the operator sees *why*.
-  it('renders the status reason line under the STATUS label (jinn-mono #328 fix #1)', () => {
+  // The STATUS hero tile renders `statusReason` (deriveLiveNow().line) as a
+  // small subdued secondary line under the label so the operator sees *why*,
+  // rather than only the bare label ("ATTENTION").
+  it('renders the status reason line under the STATUS label', () => {
     render(<HeroStats {...defaultProps()} statusReason="1 task restoring" />);
     const reason = screen.getByTestId('overview-status-reason');
     expect(reason.textContent).toBe('1 task restoring');
@@ -101,7 +101,7 @@ describe('HeroStats', () => {
     expect(screen.getByTestId('overview-status-stat').contains(reason)).toBe(true);
   });
 
-  it('surfaces the attention reason so ATTENTION is never bare (jinn-mono #328 fix #1)', () => {
+  it('surfaces the attention reason so ATTENTION is never bare', () => {
     render(
       <HeroStats
         {...defaultProps()}
@@ -117,7 +117,7 @@ describe('HeroStats', () => {
     );
   });
 
-  it('renders the reason line in non-attention states too (jinn-mono #328 fix #1)', () => {
+  it('renders the reason line in non-attention states too', () => {
     render(
       <HeroStats
         {...defaultProps()}
@@ -132,7 +132,7 @@ describe('HeroStats', () => {
     );
   });
 
-  it('omits the reason line when statusReason is empty (jinn-mono #328 fix #1)', () => {
+  it('omits the reason line when statusReason is empty', () => {
     render(<HeroStats {...defaultProps()} statusReason="" />);
     expect(screen.queryByTestId('overview-status-reason')).toBeNull();
   });

--- a/client/src/dashboard/spa/src/pages/overview/HeroStats.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/HeroStats.tsx
@@ -14,6 +14,13 @@ export interface HeroStatsProps {
   statusLabel: string;
   statusState: LiveNowState;
   statusDot: string;
+  /**
+   * Human-readable reason for the current status — `deriveLiveNow().line`.
+   * Rendered as a small subdued line under the status label so the operator
+   * sees *why* the node is in this state (e.g. the first error diagnostic's
+   * message for ATTENTION, or "waiting for next task" when idle). #328 fix #1.
+   */
+  statusReason: string;
   activeAction: string | null;
   /** When true, the service has been evicted from the staking proxy. */
   evicted?: boolean;
@@ -207,11 +214,13 @@ function StatusStat({
   label,
   state,
   dot,
+  reason,
   action,
 }: {
   label: string;
   state: LiveNowState;
   dot: string;
+  reason: string;
   action: JSX.Element;
 }): JSX.Element {
   return (
@@ -258,6 +267,22 @@ function StatusStat({
         </span>
         {label}
       </span>
+      {reason && (
+        <span
+          data-testid="overview-status-reason"
+          style={{
+            color: 'var(--fg-muted)',
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '12px',
+            lineHeight: 1.4,
+            marginTop: '6px',
+            display: 'block',
+            wordBreak: 'break-word',
+          }}
+        >
+          {reason}
+        </span>
+      )}
       {action}
     </div>
   );
@@ -271,6 +296,7 @@ export function HeroStats({
   statusLabel,
   statusState,
   statusDot,
+  statusReason,
   activeAction,
   evicted = false,
   evictedServiceId,
@@ -321,6 +347,7 @@ export function HeroStats({
         label={statusLabel}
         state={statusState}
         dot={statusDot}
+        reason={statusReason}
         action={(
           <ActionButton action="Restart node" activeAction={activeAction} onClick={onRestart}>
             Restart

--- a/client/src/dashboard/spa/src/pages/overview/HeroStats.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/HeroStats.tsx
@@ -18,7 +18,7 @@ export interface HeroStatsProps {
    * Human-readable reason for the current status — `deriveLiveNow().line`.
    * Rendered as a small subdued line under the status label so the operator
    * sees *why* the node is in this state (e.g. the first error diagnostic's
-   * message for ATTENTION, or "waiting for next task" when idle). #328 fix #1.
+   * message for ATTENTION, or "waiting for next task" when idle).
    */
   statusReason: string;
   activeAction: string | null;

--- a/client/src/dashboard/spa/src/shell/OfflineBanner.test.tsx
+++ b/client/src/dashboard/spa/src/shell/OfflineBanner.test.tsx
@@ -22,7 +22,7 @@ describe('OfflineBanner', () => {
     expect(screen.queryByTestId('offline-banner')).toBeNull();
   });
 
-  it('surfaces the offline state and a restart CTA when disconnected', () => {
+  it('surfaces the offline state when disconnected', () => {
     render(<OfflineBanner connection={disconnected} />);
     const banner = screen.getByTestId('offline-banner');
     expect(banner).toBeTruthy();
@@ -30,7 +30,7 @@ describe('OfflineBanner', () => {
     expect(banner.getAttribute('role')).toBe('alert');
     expect(screen.getByText(/daemon offline/i)).toBeTruthy();
     expect(screen.getByText(/reconnecting automatically/i)).toBeTruthy();
-    // Plain-speech CTA: the operator needs to know to re-run the node.
-    expect(screen.getByText('jinn run')).toBeTruthy();
+    // No terminal CTA — auto-reconnect and in-app respawn (#289) supersede it.
+    expect(screen.queryByText('jinn run')).toBeNull();
   });
 });

--- a/client/src/dashboard/spa/src/shell/OfflineBanner.tsx
+++ b/client/src/dashboard/spa/src/shell/OfflineBanner.tsx
@@ -8,14 +8,14 @@
  *
  * `useConnectionState` (api/connection-state.ts) polls `/v1/status` and flips
  * to `disconnected` within ~4s of the daemon going down. This banner renders
- * that state: a clear "daemon is offline" message, a "reconnecting" cue, and
- * a CTA nudging the operator to run `jinn run` again (until #289 lands the
- * in-app restart respawn). When the daemon answers again the hook flips back
- * to `connected` and this banner unmounts itself — the rest of the app's
- * react-query refetches resume naturally.
+ * that state: a clear "daemon is offline" message and a "reconnecting" cue.
+ * The in-app restart respawn (#289) and auto-reconnect supersede any terminal
+ * CTA. When the daemon answers again the hook flips back to `connected` and
+ * this banner unmounts itself — the rest of the app's react-query refetches
+ * resume naturally.
  *
  * This is a money/safety-adjacent surface: it must speak plainly. No vow
- * metaphor here — the operator needs to know the node is down and what to do.
+ * metaphor here.
  */
 import type { ConnectionState } from '../api/connection-state.js';
 
@@ -34,11 +34,6 @@ export function OfflineBanner({ connection }: OfflineBannerProps): JSX.Element |
         background: 'var(--bg-elevated)',
         borderBottom: '2px solid var(--break-red)',
         padding: '10px 24px',
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        gap: '16px',
-        flexWrap: 'wrap',
         fontFamily: "'JetBrains Mono', monospace",
         fontSize: '13px',
       }}
@@ -48,20 +43,6 @@ export function OfflineBanner({ connection }: OfflineBannerProps): JSX.Element |
         The jinn node stopped responding — what you see below may be stale.
         Reconnecting automatically…
       </span>
-      <code
-        style={{
-          background: 'var(--bg-sunken)',
-          border: '1px solid var(--border-accent)',
-          borderRadius: '4px',
-          padding: '4px 10px',
-          color: 'var(--accent-gold)',
-          fontFamily: "'JetBrains Mono', monospace",
-          fontSize: '12px',
-          whiteSpace: 'nowrap',
-        }}
-      >
-        jinn run
-      </code>
     </div>
   );
 }

--- a/client/src/harnesses/impls/hermes-agent/harness.ts
+++ b/client/src/harnesses/impls/hermes-agent/harness.ts
@@ -71,7 +71,6 @@ export class HermesHarness implements Harness {
         nextStep: {
           description:
             'Install the Hermes agent runner — see the Hermes precheck panel in the operator dashboard for the install command.',
-          url: '/api/hermes/doctor',
         },
       };
     }
@@ -85,7 +84,6 @@ export class HermesHarness implements Harness {
         nextStep: {
           description:
             'Run `hermes doctor` locally to surface the configuration problem, or open the Hermes precheck panel in the operator dashboard to sign in / select a provider.',
-          url: '/api/hermes/doctor',
         },
       };
     }
@@ -100,7 +98,6 @@ export class HermesHarness implements Harness {
         nextStep: {
           description:
             'Connect OpenRouter — sign in via the Hermes precheck panel in the operator dashboard, or run `hermes login` locally.',
-          url: '/api/hermes/doctor',
         },
       };
     }

--- a/client/src/harnesses/impls/hermes-agent/harness.ts
+++ b/client/src/harnesses/impls/hermes-agent/harness.ts
@@ -3,7 +3,7 @@ import type { Harness, HarnessContext, ReadyStatus, Solution } from '../../types
 import { HERMES_AGENT_HARNESS } from '../../names.js';
 import type { HermesHarnessAdapter } from './adapter.js';
 import { harvestOutput } from '../learner/harvest.js';
-import { probeHermesDoctor } from '../../../api/hermes-doctor-endpoint.js';
+import { probeHermesDoctor, probeHermesAuthStatus } from '../../../api/hermes-doctor-endpoint.js';
 
 export interface HermesHarnessConfig {
   adapter: HermesHarnessAdapter;
@@ -51,7 +51,13 @@ export class HermesHarness implements Harness {
    *   - `exitCode !== 0` → binary exists but `hermes doctor` reports a
    *     configuration problem (e.g. provider not signed in) → ready=false
    *     with a nextStep that points at the SPA precheck panel.
-   *   - `exitCode === 0` → ready=true.
+   *   - OpenRouter not authenticated → ready=false. `hermes doctor` exits 0
+   *     even when every provider is logged out (it treats missing providers
+   *     as warnings), so this third gate probes `hermes auth status
+   *     openrouter` directly. Hermes is OpenRouter-only, so a logged-out
+   *     OpenRouter means Hermes has no usable model provider and every
+   *     claim would burn (#332/#330/#348).
+   *   - all three gates pass → ready=true.
    */
   async isReady(_ctx?: { solverType: string; role?: 'restoration' | 'evaluation' }): Promise<ReadyStatus> {
     const config: { hermesPath?: string; hermesDoctorTimeoutMs?: number } = {};
@@ -79,6 +85,21 @@ export class HermesHarness implements Harness {
         nextStep: {
           description:
             'Run `hermes doctor` locally to surface the configuration problem, or open the Hermes precheck panel in the operator dashboard to sign in / select a provider.',
+          url: '/api/hermes/doctor',
+        },
+      };
+    }
+    // Third gate: `hermes doctor` exits 0 even when every model provider is
+    // logged out. Hermes is OpenRouter-only, so probe OpenRouter auth
+    // directly — a logged-out OpenRouter means Hermes cannot run a task.
+    const auth = probeHermesAuthStatus('openrouter', config);
+    if (!auth.authed) {
+      return {
+        ready: false,
+        reason: 'OpenRouter not connected — Hermes has no usable model provider',
+        nextStep: {
+          description:
+            'Connect OpenRouter — sign in via the Hermes precheck panel in the operator dashboard, or run `hermes login` locally.',
           url: '/api/hermes/doctor',
         },
       };

--- a/client/src/solver-nets/prediction-operator-ux.ts
+++ b/client/src/solver-nets/prediction-operator-ux.ts
@@ -217,23 +217,38 @@ function missingSolverNetStatus(
 }
 
 /**
- * Build a synthetic SolverNetConfig from the first entry in joinedSolverNets.
- * This lets the diagnostic loop run unchanged when an operator has joined a
- * SolverNet via the manifest-keyed flow but has no legacy solverNets[name] entry.
+ * Find the joinedSolverNets entry whose contract is the prediction SolverNet
+ * (`contract.id === 'prediction'`, i.e. solverType `prediction.v1`). Returns
+ * `undefined` when the operator has joined no prediction-contract SolverNet —
+ * the common case now that prediction is deprecated.
+ */
+function findPredictionJoined(
+  joinedSolverNets: Record<string, JoinedSolverNetConfig> | undefined,
+): JoinedSolverNetConfig | undefined {
+  if (!joinedSolverNets) return undefined;
+  return Object.values(joinedSolverNets).find(
+    (entry) => entry.contract?.id === 'prediction',
+  );
+}
+
+/**
+ * Build a synthetic SolverNetConfig from a prediction-contract joinedSolverNets
+ * entry. This lets the diagnostic loop run unchanged when an operator has joined
+ * the Prediction SolverNet via the manifest-keyed flow but has no legacy
+ * solverNets[name] entry.
  */
 function synthesizeFromJoined(
-  joinedSolverNets: Record<string, JoinedSolverNetConfig>,
+  joined: JoinedSolverNetConfig,
   solverType = 'prediction.v1',
 ): SolverNetConfig {
-  const first = Object.values(joinedSolverNets)[0];
-  const roles = rolesFromJoinedConfig(first);
+  const roles = rolesFromJoinedConfig(joined);
   return {
     enabled: true,
     solverType,
     roles: roles.length > 0 ? roles : ['solving'],
-    harness: first.harness ?? '',
-    model: first.model,
-    plugins: (first.plugins ?? []) as SolverNetConfig['plugins'],
+    harness: joined.harness ?? '',
+    model: joined.model,
+    plugins: (joined.plugins ?? []) as SolverNetConfig['plugins'],
     taskGenerator: { enabled: false },
   };
 }
@@ -248,11 +263,19 @@ export async function buildPredictionOperatorStatus({
   daemonRunning = false,
 }: BuildPredictionOperatorStatusOptions): Promise<PredictionOperatorStatus> {
   const legacy = config.solverNets[name];
-  const hasJoined = Object.keys(config.joinedSolverNets ?? {}).length > 0;
-  if (!legacy && !hasJoined) {
+  // Prediction is a deprecated SolverNet. Only emit prediction-operator
+  // diagnostics when the operator has a *genuine* prediction config: a legacy
+  // `solverNets.prediction` entry, or a `joinedSolverNets` entry whose contract
+  // is the prediction SolverNet (`contract.id === 'prediction'`). An operator
+  // who joined only non-prediction SolverNets (the normal case) must get no
+  // prediction diagnostics — synthesizing a prediction net from a non-prediction
+  // joined entry would mislabel its harness and raise a spurious ATTENTION
+  // (dogfood finding #9, issue #328).
+  const predictionJoined = findPredictionJoined(config.joinedSolverNets);
+  if (!legacy && !predictionJoined) {
     return missingSolverNetStatus(configPath, name, daemonRunning);
   }
-  const net: SolverNetConfig = legacy ?? synthesizeFromJoined(config.joinedSolverNets!, 'prediction.v1');
+  const net: SolverNetConfig = legacy ?? synthesizeFromJoined(predictionJoined!, 'prediction.v1');
 
   const diagnostics: PredictionOperatorDiagnostic[] = [];
   let loadedNet: LoadedSolverNet | undefined;

--- a/client/test/adapters/mech/adapter.test.ts
+++ b/client/test/adapters/mech/adapter.test.ts
@@ -318,7 +318,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
       taskDiscovery: {
         discoveryApi: mockDiscoveryApi,
         solverNetManifestCids: ['bafyfixturecid'],
-        // Opt out of the gh #300 ghost-task floor for this test — the
+        // Opt out of the ghost-task floor for this test — the
         // fixture candidates use tiny block numbers that pre-date the
         // production default floor; this test is about discovery
         // yielding, not floor filtering.
@@ -364,7 +364,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
     await adapter.stop();
   });
 
-  it('discovery filters out pre-floor candidates (gh #300 ghost-task floor)', async () => {
+  it('discovery filters out pre-floor candidates (ghost-task floor)', async () => {
     // The DiscoveryAPI (Ponder indexer or onchain-floor listClaimableTasks)
     // returns all claimable tasks regardless of when they were created.
     // Without a parallel floor filter here, the floor on the on-chain
@@ -507,7 +507,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
       taskDiscovery: {
         discoveryApi: mockDiscoveryApi,
         solverNetManifestCids: ['bafyfixturecid'],
-        // gh #300: opt out of the floor — fixtures use tiny block numbers.
+        // Opt out of the floor — fixtures use tiny block numbers.
         onchainFromBlock: 0,
       },
     });
@@ -566,7 +566,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
         discoveryApi: mockDiscoveryApi,
         solverNetManifestCids: ['bafyfixturecid'],
         allowedTaskIds: ['43'],
-        // gh #300: opt out of the floor — fixtures use tiny block numbers.
+        // Opt out of the floor — fixtures use tiny block numbers.
         onchainFromBlock: 0,
       },
     });
@@ -1647,7 +1647,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
   });
 });
 
-describe('DEFAULT_TASK_DISCOVERY_FROM_BLOCK (gh #300 — ghost-task floor)', () => {
+describe('DEFAULT_TASK_DISCOVERY_FROM_BLOCK (ghost-task floor)', () => {
   // The Base Sepolia floor sits just after the 2026-05-14T17:28Z rebuild of
   // the fufn validated-pool to `EVAL_SEMANTICS_VERSION='3'`. Tasks created
   // before that rebuild are admitted under a prior semantics regime and the

--- a/client/test/adapters/mech/adapter.test.ts
+++ b/client/test/adapters/mech/adapter.test.ts
@@ -807,7 +807,6 @@ describe('MechAdapter TaskCoordinator flow', () => {
       ok: false,
       reason: 'TCAttemptAlreadyFinalized(1, 0)',
     });
-    vi.mocked(fetchSignedTaskFromIpfs).mockResolvedValueOnce(signedTask({ id: 'watched-task' }));
 
     const adapter = new MechAdapter(TEST_CONFIG);
     await adapter.initialize();
@@ -833,11 +832,147 @@ describe('MechAdapter TaskCoordinator flow', () => {
       0,
       TEST_CONFIG.mechContractAddress,
     );
+    // The claimability gate runs before the restoration lookup — a terminal
+    // opportunity never pays the restoration / delivery / IPFS cost.
+    expect(fetchSignedTaskFromIpfs).not.toHaveBeenCalled();
     expect(getMarketplaceRequestDeliveryMech).not.toHaveBeenCalled();
     expect(findLatestDeliveryDataHexForRequest).not.toHaveBeenCalled();
     expect(fetchFromIpfs).not.toHaveBeenCalled();
 
     await adapter.stop();
+  });
+
+  it('prunes a terminal-reason evaluation opportunity before the expensive restoration lookup', async () => {
+    const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+    const { canClaimEvaluation, getTaskCidDigest } = await import('../../../src/adapters/mech/contracts.js');
+    const { fetchSignedTaskFromIpfs } = await import('../../../src/adapters/mech/ipfs.js');
+
+    vi.mocked(canClaimEvaluation).mockResolvedValueOnce({
+      ok: false,
+      reason: 'TCMaxVerdictsReached(1, 0)',
+    });
+
+    const adapter = new MechAdapter(TEST_CONFIG);
+    await adapter.initialize();
+    const solution = {
+      taskId: '1',
+      attemptIndex: 0,
+      requestId: REQUEST_ID,
+      operator: ('0x' + '66'.repeat(20)) as `0x${string}`,
+      transactionHash: TX_HASH,
+      blockNumber: 333,
+    };
+    (adapter as any).pendingEvaluationSolutions.set(REQUEST_ID, solution);
+
+    const announcement = await (adapter as any).evaluationAnnouncementForSolution(solution);
+
+    expect(announcement).toBeUndefined();
+    // Terminal reason -> pruned from the working set so the loop never re-scans it.
+    expect((adapter as any).pendingEvaluationSolutions.has(REQUEST_ID)).toBe(false);
+    // The claimability gate runs FIRST; the restoration lookup is never attempted.
+    expect(getTaskCidDigest).not.toHaveBeenCalled();
+    expect(fetchSignedTaskFromIpfs).not.toHaveBeenCalled();
+
+    await adapter.stop();
+  });
+
+  it('retains a transient-reason evaluation opportunity for retry', async () => {
+    const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+    const { canClaimEvaluation } = await import('../../../src/adapters/mech/contracts.js');
+
+    vi.mocked(canClaimEvaluation).mockResolvedValueOnce({
+      ok: false,
+      reason: 'HTTP request failed: 429 Too Many Requests',
+    });
+
+    const adapter = new MechAdapter(TEST_CONFIG);
+    await adapter.initialize();
+    const solution = {
+      taskId: '1',
+      attemptIndex: 0,
+      requestId: REQUEST_ID,
+      operator: ('0x' + '66'.repeat(20)) as `0x${string}`,
+      transactionHash: TX_HASH,
+      blockNumber: 333,
+    };
+    (adapter as any).pendingEvaluationSolutions.set(REQUEST_ID, solution);
+
+    const announcement = await (adapter as any).evaluationAnnouncementForSolution(solution);
+
+    expect(announcement).toBeUndefined();
+    // Transient reason -> kept in the working set; it must be retried next cycle.
+    expect((adapter as any).pendingEvaluationSolutions.has(REQUEST_ID)).toBe(true);
+
+    await adapter.stop();
+  });
+
+  it('retryPendingEvaluationSolutions drops terminal opportunities and keeps re-checking transient ones', async () => {
+    const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+    const { canClaimEvaluation } = await import('../../../src/adapters/mech/contracts.js');
+
+    const TERMINAL_REQUEST_ID = ('0x' + 'ce'.repeat(32)) as `0x${string}`;
+    const TRANSIENT_REQUEST_ID = ('0x' + 'cf'.repeat(32)) as `0x${string}`;
+
+    const adapter = new MechAdapter(TEST_CONFIG);
+    await adapter.initialize();
+    const mkSolution = (taskId: string, requestId: `0x${string}`) => ({
+      taskId,
+      attemptIndex: 0,
+      requestId,
+      operator: ('0x' + '66'.repeat(20)) as `0x${string}`,
+      transactionHash: TX_HASH,
+      blockNumber: 333,
+    });
+    (adapter as any).pendingEvaluationSolutions.set(TERMINAL_REQUEST_ID, mkSolution('1', TERMINAL_REQUEST_ID));
+    (adapter as any).pendingEvaluationSolutions.set(TRANSIENT_REQUEST_ID, mkSolution('2', TRANSIENT_REQUEST_ID));
+
+    // canClaimEvaluation: terminal task -> non-recoverable revert; transient task -> generic RPC error.
+    // mockImplementation persists across tests (vi.clearAllMocks only resets call
+    // data, not the implementation), so it is restored before this test returns.
+    const claimImpl = async (
+      _pc: unknown,
+      _safe: unknown,
+      _router: unknown,
+      taskId: unknown,
+    ): Promise<{ ok: true } | { ok: false; reason: string }> => {
+      if (String(taskId) === '1') {
+        return { ok: false, reason: 'TCEvaluationDeadlinePassed(1)' };
+      }
+      return { ok: false, reason: 'execution reverted: connection timeout' };
+    };
+    vi.mocked(canClaimEvaluation).mockImplementation(claimImpl as never);
+
+    const drain = async () => {
+      for await (const _ of (adapter as any).retryPendingEvaluationSolutions()) {
+        // nothing claimable in this scenario
+      }
+    };
+
+    // Cycle 1: both opportunities are checked.
+    await drain();
+    expect(canClaimEvaluation).toHaveBeenCalledTimes(2);
+    // Terminal one is pruned; transient one survives.
+    expect((adapter as any).pendingEvaluationSolutions.has(TERMINAL_REQUEST_ID)).toBe(false);
+    expect((adapter as any).pendingEvaluationSolutions.has(TRANSIENT_REQUEST_ID)).toBe(true);
+
+    // Cycle 2: only the transient opportunity is re-checked — terminal history is not re-scanned.
+    vi.mocked(canClaimEvaluation).mockClear();
+    await drain();
+    expect(canClaimEvaluation).toHaveBeenCalledTimes(1);
+    expect(canClaimEvaluation).toHaveBeenCalledWith(
+      expect.anything(),
+      TEST_CONFIG.safeAddress,
+      TEST_CONFIG.routerAddress,
+      '2',
+      0,
+      TEST_CONFIG.mechContractAddress,
+    );
+    expect((adapter as any).pendingEvaluationSolutions.has(TRANSIENT_REQUEST_ID)).toBe(true);
+
+    await adapter.stop();
+    // Restore the default so the persisted mockImplementation does not leak.
+    vi.mocked(canClaimEvaluation).mockReset();
+    vi.mocked(canClaimEvaluation).mockResolvedValue({ ok: true });
   });
 
   it('bounds the default delivery-log scan around delayed SolutionDeliveryClaimed events', async () => {

--- a/client/test/api/hermes-doctor-endpoint.test.ts
+++ b/client/test/api/hermes-doctor-endpoint.test.ts
@@ -17,7 +17,9 @@ vi.mock('node:child_process', () => ({
   spawnSync: (...args: unknown[]) => spawnSyncMock(...args),
 }));
 
-const { addHermesDoctorRoutes } = await import('../../src/api/hermes-doctor-endpoint.js');
+const { addHermesDoctorRoutes, probeHermesAuthStatus } = await import(
+  '../../src/api/hermes-doctor-endpoint.js'
+);
 
 interface HermesDoctorBody {
   installed: boolean;
@@ -176,5 +178,94 @@ describe('GET /api/hermes/doctor', () => {
 
     expect(body.stdout).toHaveLength(4000);
     expect(body.stderr).toHaveLength(4000);
+  });
+});
+
+describe('probeHermesAuthStatus', () => {
+  it('reports not-authed when `hermes auth status` prints "logged out" (exit 0)', () => {
+    // CRITICAL: hermes auth status always exits 0 — state is in stdout.
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      error: undefined,
+      stdout: 'openrouter: logged out\n',
+      stderr: '',
+    });
+
+    const result = probeHermesAuthStatus('openrouter');
+    expect(result.provider).toBe('openrouter');
+    expect(result.authed).toBe(false);
+    expect(result.raw).toBe('openrouter: logged out');
+  });
+
+  it('reports authed when `hermes auth status` prints a logged-in line (exit 0)', () => {
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      error: undefined,
+      stdout: 'openrouter: logged in as sk-or-...8f2a\n',
+      stderr: '',
+    });
+
+    const result = probeHermesAuthStatus('openrouter');
+    expect(result.provider).toBe('openrouter');
+    expect(result.authed).toBe(true);
+    expect(result.raw).toContain('logged in');
+  });
+
+  it('reports not-authed when stdout is empty even though exit code is 0', () => {
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      error: undefined,
+      stdout: '',
+      stderr: '',
+    });
+
+    const result = probeHermesAuthStatus('openrouter');
+    expect(result.authed).toBe(false);
+  });
+
+  it('reports not-authed gracefully when the hermes binary is not found (ENOENT)', () => {
+    spawnSyncMock.mockReturnValue({
+      status: null,
+      error: Object.assign(new Error('spawn hermes ENOENT'), { code: 'ENOENT' }),
+      stdout: '',
+      stderr: '',
+    });
+
+    const result = probeHermesAuthStatus('openrouter');
+    expect(result.authed).toBe(false);
+    expect(result.raw).toBe('');
+  });
+
+  it('reports not-authed when spawnSync errors (e.g. timeout) regardless of stdout', () => {
+    spawnSyncMock.mockReturnValue({
+      status: null,
+      signal: 'SIGTERM',
+      error: Object.assign(new Error('ETIMEDOUT'), { code: 'ETIMEDOUT' }),
+      stdout: 'openrouter: logged in\n',
+      stderr: '',
+    });
+
+    const result = probeHermesAuthStatus('openrouter');
+    expect(result.authed).toBe(false);
+  });
+
+  it('invokes `hermes auth status <provider>` with the configured binary and timeout', () => {
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      error: undefined,
+      stdout: 'openrouter: logged in\n',
+      stderr: '',
+    });
+
+    probeHermesAuthStatus('openrouter', {
+      hermesPath: '/opt/hermes/bin/hermes',
+      hermesDoctorTimeoutMs: 5_000,
+    });
+
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      '/opt/hermes/bin/hermes',
+      ['auth', 'status', 'openrouter'],
+      expect.objectContaining({ timeout: 5_000, encoding: 'utf8' }),
+    );
   });
 });

--- a/client/test/cli/commands/create.test.ts
+++ b/client/test/cli/commands/create.test.ts
@@ -329,7 +329,7 @@ describe('createCommand run() — post-completion output (hfmf)', () => {
     };
     await createCommand.run(ctx);
     expect(output).toContain(
-      'Quickstart: https://github.com/Jinn-Network/mono/blob/main/cargo/client/docs/build/quickstart.md',
+      'Quickstart: https://github.com/Jinn-Network/mono/blob/main/client/docs/build/quickstart.md',
     );
   });
 });

--- a/client/test/cli/commands/create.test.ts
+++ b/client/test/cli/commands/create.test.ts
@@ -329,7 +329,7 @@ describe('createCommand run() — post-completion output (hfmf)', () => {
     };
     await createCommand.run(ctx);
     expect(output).toContain(
-      'Quickstart: https://github.com/Jinn-Network/mono/blob/main/client/docs/build/quickstart.md',
+      'Quickstart: https://github.com/Jinn-Network/mono/blob/next/client/docs/build/quickstart.md',
     );
   });
 });

--- a/client/test/daemon/claim-readiness-gate.test.ts
+++ b/client/test/daemon/claim-readiness-gate.test.ts
@@ -170,6 +170,43 @@ describe('Daemon — claim readiness gate (#330)', () => {
     await daemon.stop();
   });
 
+  it('does NOT claim when Hermes reports OpenRouter not connected (#332)', async () => {
+    // v0.1.6 dogfood finding #3: `hermes doctor` exits 0 even when every
+    // model provider is logged out, so HermesHarness.isReady() now also
+    // gates on OpenRouter auth. The gate is harness-agnostic — it just reads
+    // the reason — so an "OpenRouter not connected" not-ready must block
+    // claims exactly like the missing-binary case.
+    const adapter = new LocalAdapter();
+    const claimSpy = vi.spyOn(adapter, 'claimTask');
+
+    const registry = controlledRegistry(() => ({
+      ready: false,
+      reason: 'OpenRouter not connected — Hermes has no usable model provider',
+    }));
+
+    const daemon = new Daemon({
+      adapter,
+      runner: new SimpleRunner(async (d) => `done: ${d}`),
+      taskSources: [],
+      dbPath: ':memory:',
+      restorationEngine: minimalEngineConfig(),
+      harnessReadinessRegistry: registry,
+    });
+    await daemon.start();
+
+    await adapter.postTask({
+      id: 'task-hermes-no-openrouter',
+      description: 'hermes SolverNet — OpenRouter not connected',
+      solverNetManifestCid: 'bafkrei.fake-cid',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(registry.isReadyForClaim).toHaveBeenCalledWith('bafkrei.fake-cid');
+    expect(claimSpy).not.toHaveBeenCalled();
+
+    await daemon.stop();
+  });
+
   it('surfaces the not-ready reason via a warn log on first transition', async () => {
     const adapter = new LocalAdapter();
 

--- a/client/test/daemon/claim-readiness-gate.test.ts
+++ b/client/test/daemon/claim-readiness-gate.test.ts
@@ -1,11 +1,10 @@
 // client/test/daemon/claim-readiness-gate.test.ts
 //
-// Regression for #330: the daemon must not claim tasks against a SolverNet
-// whose harness reports not-ready. Pre-fix on v0.1.6, a fresh operator who
-// joined SWE-rebench v2 without installing/authing Hermes burned 26 failed
-// claims in minutes — every claim landed because the gate was wired but
-// `HermesHarness` had no `isReady()` so the registry treated it as
-// always-ready.
+// Regression: the daemon must not claim tasks against a SolverNet whose
+// harness reports not-ready. A fresh operator who joined SWE-rebench v2
+// without installing/authing Hermes would otherwise burn failed claims —
+// every claim landed because the gate was wired but `HermesHarness` had no
+// `isReady()`, so the registry treated it as always-ready.
 //
 // The test spins up a real `Daemon` against a `LocalAdapter`, posts a task
 // whose `solverNetManifestCid` matches a joined entry, and verifies the
@@ -51,7 +50,7 @@ beforeEach(() => {
   _resetReadinessGateMemoForTests();
 });
 
-describe('Daemon — claim readiness gate (#330)', () => {
+describe('Daemon — claim readiness gate', () => {
   it('does NOT call adapter.claimTask when registry reports the harness not ready', async () => {
     const adapter = new LocalAdapter();
     const claimSpy = vi.spyOn(adapter, 'claimTask');
@@ -133,7 +132,7 @@ describe('Daemon — claim readiness gate (#330)', () => {
     await daemon.stop();
   });
 
-  it('does NOT claim for a Codex SolverNet when the codex harness reports not ready (#348)', async () => {
+  it('does NOT claim for a Codex SolverNet when the codex harness reports not ready', async () => {
     // Same-shape regression as the Hermes case above: a Codex-harness
     // SolverNet whose `codex` CLI is missing must not have tasks claimed
     // against it. The gate is harness-agnostic — it reads whatever reason
@@ -170,12 +169,12 @@ describe('Daemon — claim readiness gate (#330)', () => {
     await daemon.stop();
   });
 
-  it('does NOT claim when Hermes reports OpenRouter not connected (#332)', async () => {
-    // v0.1.6 dogfood finding #3: `hermes doctor` exits 0 even when every
-    // model provider is logged out, so HermesHarness.isReady() now also
-    // gates on OpenRouter auth. The gate is harness-agnostic — it just reads
-    // the reason — so an "OpenRouter not connected" not-ready must block
-    // claims exactly like the missing-binary case.
+  it('does NOT claim when Hermes reports OpenRouter not connected', async () => {
+    // `hermes doctor` exits 0 even when every model provider is logged out, so
+    // HermesHarness.isReady() also gates on OpenRouter auth. The gate is
+    // harness-agnostic — it just reads the reason — so an "OpenRouter not
+    // connected" not-ready must block claims exactly like the missing-binary
+    // case.
     const adapter = new LocalAdapter();
     const claimSpy = vi.spyOn(adapter, 'claimTask');
 

--- a/client/test/daemon/skip-log-dedup.test.ts
+++ b/client/test/daemon/skip-log-dedup.test.ts
@@ -50,7 +50,7 @@ describe('SkipLogDeduper (jinn-mono-kzan)', () => {
   });
 });
 
-describe('SkipLogDeduper work-skip cache (dogfood #14)', () => {
+describe('SkipLogDeduper work-skip cache', () => {
   it('shouldRecheck is true for a task never skipped', () => {
     const dedup = new SkipLogDeduper();
     expect(dedup.shouldRecheck('84')).toBe(true);
@@ -148,7 +148,7 @@ describe('SkipLogDeduper work-skip cache (dogfood #14)', () => {
   });
 });
 
-describe('engine-watcher work-skip semantics (dogfood #14 integration)', () => {
+describe('engine-watcher work-skip semantics (integration)', () => {
   /**
    * Mirrors the engine-watcher loop's decision logic against a fake
    * `canAcceptTask`, asserting the expensive call is NOT re-run within the TTL

--- a/client/test/daemon/skip-log-dedup.test.ts
+++ b/client/test/daemon/skip-log-dedup.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { SkipLogDeduper } from '../../src/daemon/skip-log-dedup.js';
+import { SkipLogDeduper, SKIP_RECHECK_TTL_MS } from '../../src/daemon/skip-log-dedup.js';
 
 describe('SkipLogDeduper (jinn-mono-kzan)', () => {
   it('logs the first skip for a (taskId, reason) pair and suppresses repeats', () => {
@@ -47,5 +47,202 @@ describe('SkipLogDeduper (jinn-mono-kzan)', () => {
     expect(dedup.shouldLog('3', 'reason')).toBe(true);
     // '1' was evicted, so the next skip for '1' logs again.
     expect(dedup.shouldLog('1', 'reason')).toBe(true);
+  });
+});
+
+describe('SkipLogDeduper work-skip cache (dogfood #14)', () => {
+  it('shouldRecheck is true for a task never skipped', () => {
+    const dedup = new SkipLogDeduper();
+    expect(dedup.shouldRecheck('84')).toBe(true);
+  });
+
+  it('fast-skips a recently-skipped task within the TTL', () => {
+    const dedup = new SkipLogDeduper();
+    const t0 = 1_000_000;
+    dedup.recordSkip('84', 'slot busy', t0);
+    // Same instant and any time strictly inside the TTL: fast-skip (no recheck).
+    expect(dedup.shouldRecheck('84', t0)).toBe(false);
+    expect(dedup.shouldRecheck('84', t0 + SKIP_RECHECK_TTL_MS - 1)).toBe(false);
+  });
+
+  it('re-checks a task once the TTL has elapsed', () => {
+    const dedup = new SkipLogDeduper();
+    const t0 = 1_000_000;
+    dedup.recordSkip('84', 'slot busy', t0);
+    // At exactly the TTL boundary and beyond, the task is due for re-check.
+    expect(dedup.shouldRecheck('84', t0 + SKIP_RECHECK_TTL_MS)).toBe(true);
+    expect(dedup.shouldRecheck('84', t0 + SKIP_RECHECK_TTL_MS + 5_000)).toBe(true);
+  });
+
+  it('never skip-caches a task forever — a stale skip always re-checks', () => {
+    const dedup = new SkipLogDeduper();
+    const t0 = 0;
+    dedup.recordSkip('84', 'harness not ready', t0);
+    // Even a very old skip must re-check: a task that became acceptable
+    // (operator enabled the harness) must not be stuck behind the cache.
+    expect(dedup.shouldRecheck('84', t0 + 24 * 60 * 60 * 1_000)).toBe(true);
+  });
+
+  it('recordSkip refreshes the TTL window from the latest skip', () => {
+    const dedup = new SkipLogDeduper();
+    const t0 = 1_000_000;
+    dedup.recordSkip('84', 'slot busy', t0);
+    // Re-record near the end of the first window: checkedAt moves to the new
+    // time, so the TTL counts afresh from there.
+    const t1 = t0 + SKIP_RECHECK_TTL_MS - 1;
+    dedup.recordSkip('84', 'slot busy', t1);
+    // A point past the *first* window but inside the *second* still fast-skips.
+    expect(dedup.shouldRecheck('84', t0 + SKIP_RECHECK_TTL_MS)).toBe(false);
+    expect(dedup.shouldRecheck('84', t1 + SKIP_RECHECK_TTL_MS - 1)).toBe(false);
+    // At the new window's boundary it re-checks again.
+    expect(dedup.shouldRecheck('84', t1 + SKIP_RECHECK_TTL_MS)).toBe(true);
+  });
+
+  it('forget() clears the work-skip cache so the task re-checks immediately', () => {
+    const dedup = new SkipLogDeduper();
+    const t0 = 1_000_000;
+    dedup.recordSkip('84', 'slot busy', t0);
+    expect(dedup.shouldRecheck('84', t0)).toBe(false);
+    // Accepting the task forgets it; the next skip must re-check, not fast-skip.
+    dedup.forget('84');
+    expect(dedup.shouldRecheck('84', t0)).toBe(true);
+  });
+
+  it('forget() clears both the log-dedup and the work-skip state', () => {
+    const dedup = new SkipLogDeduper();
+    const t0 = 1_000_000;
+    dedup.recordSkip('84', 'slot busy', t0);
+    expect(dedup.shouldLog('84', 'slot busy')).toBe(false);
+    expect(dedup.shouldRecheck('84', t0)).toBe(false);
+    dedup.forget('84');
+    // Log re-arms.
+    expect(dedup.shouldLog('84', 'slot busy')).toBe(true);
+  });
+
+  it('shouldLog stamps a fresh skip so a shouldLog-only caller still gets the TTL', () => {
+    const dedup = new SkipLogDeduper();
+    // A caller that only calls shouldLog (no explicit recordSkip) still gets a
+    // work-skip cache entry, so the work-skip fast path applies.
+    expect(dedup.shouldLog('84', 'slot busy')).toBe(true);
+    expect(dedup.shouldRecheck('84')).toBe(false);
+  });
+
+  it('shouldLog with an unchanged reason preserves the original checkedAt', () => {
+    const dedup = new SkipLogDeduper();
+    const t0 = 1_000_000;
+    dedup.recordSkip('84', 'slot busy', t0);
+    // A repeat shouldLog for the same reason refreshes recency but must NOT
+    // reset the TTL — otherwise a task that keeps re-skipping would never
+    // re-check.
+    dedup.shouldLog('84', 'slot busy');
+    expect(dedup.shouldRecheck('84', t0 + SKIP_RECHECK_TTL_MS)).toBe(true);
+  });
+
+  it('treats different taskIds independently in the work-skip cache', () => {
+    const dedup = new SkipLogDeduper();
+    const t0 = 1_000_000;
+    dedup.recordSkip('84', 'slot busy', t0);
+    expect(dedup.shouldRecheck('84', t0)).toBe(false);
+    // '85' was never skipped, so it must be re-checked.
+    expect(dedup.shouldRecheck('85', t0)).toBe(true);
+  });
+});
+
+describe('engine-watcher work-skip semantics (dogfood #14 integration)', () => {
+  /**
+   * Mirrors the engine-watcher loop's decision logic against a fake
+   * `canAcceptTask`, asserting the expensive call is NOT re-run within the TTL
+   * and IS re-run once the TTL elapses. This is the unit-level proxy for the
+   * loop in `_runEngineWatcherLoop` (which is private and would otherwise need
+   * a full Daemon to drive).
+   */
+  function runCycle(
+    dedup: SkipLogDeduper,
+    taskId: string,
+    now: number,
+    canAcceptTask: () => { ok: boolean; reason: string },
+  ): { checked: boolean; accepted: boolean } {
+    if (!dedup.shouldRecheck(taskId, now)) {
+      return { checked: false, accepted: false };
+    }
+    const accept = canAcceptTask();
+    if (!accept.ok) {
+      dedup.recordSkip(taskId, accept.reason, now);
+      dedup.shouldLog(taskId, accept.reason);
+      return { checked: true, accepted: false };
+    }
+    dedup.forget(taskId);
+    return { checked: true, accepted: true };
+  }
+
+  it('does not re-run canAcceptTask within the TTL', () => {
+    const dedup = new SkipLogDeduper();
+    let calls = 0;
+    const canAccept = () => {
+      calls++;
+      return { ok: false, reason: 'evaluator harness not enabled' };
+    };
+    const t0 = 1_000_000;
+    // First cycle: checks and records the skip.
+    expect(runCycle(dedup, '84', t0, canAccept).checked).toBe(true);
+    expect(calls).toBe(1);
+    // Subsequent cycles within the TTL: fast-skipped, canAcceptTask NOT called.
+    runCycle(dedup, '84', t0 + 1, canAccept);
+    runCycle(dedup, '84', t0 + 10_000, canAccept);
+    runCycle(dedup, '84', t0 + SKIP_RECHECK_TTL_MS - 1, canAccept);
+    expect(calls).toBe(1);
+  });
+
+  it('re-runs canAcceptTask after the TTL elapses', () => {
+    const dedup = new SkipLogDeduper();
+    let calls = 0;
+    const canAccept = () => {
+      calls++;
+      return { ok: false, reason: 'evaluator harness not enabled' };
+    };
+    const t0 = 1_000_000;
+    runCycle(dedup, '84', t0, canAccept);
+    expect(calls).toBe(1);
+    // Once the TTL has elapsed the task is re-checked.
+    runCycle(dedup, '84', t0 + SKIP_RECHECK_TTL_MS, canAccept);
+    expect(calls).toBe(2);
+  });
+
+  it('processes a task that becomes acceptable after the TTL', () => {
+    const dedup = new SkipLogDeduper();
+    let acceptable = false;
+    const canAccept = () =>
+      acceptable
+        ? { ok: true, reason: '' }
+        : { ok: false, reason: 'evaluator harness not enabled' };
+    const t0 = 1_000_000;
+    // Skipped initially.
+    expect(runCycle(dedup, '84', t0, canAccept).accepted).toBe(false);
+    // Operator enables the harness mid-TTL — but the cache fast-skips until TTL.
+    acceptable = true;
+    expect(runCycle(dedup, '84', t0 + 5_000, canAccept).accepted).toBe(false);
+    // After the TTL the task is re-checked and now accepted — never stuck.
+    expect(runCycle(dedup, '84', t0 + SKIP_RECHECK_TTL_MS, canAccept).accepted).toBe(true);
+  });
+
+  it('forgets an accepted task so a future skip re-checks immediately', () => {
+    const dedup = new SkipLogDeduper();
+    let calls = 0;
+    let acceptable = true;
+    const canAccept = () => {
+      calls++;
+      return acceptable
+        ? { ok: true, reason: '' }
+        : { ok: false, reason: 'slot busy' };
+    };
+    const t0 = 1_000_000;
+    // Task accepted → forgotten from both caches.
+    expect(runCycle(dedup, '84', t0, canAccept).accepted).toBe(true);
+    expect(calls).toBe(1);
+    // Slot fills again: the very next cycle must re-check (not fast-skip),
+    // because the accept path cleared the work-skip entry.
+    acceptable = false;
+    expect(runCycle(dedup, '84', t0 + 1, canAccept).checked).toBe(true);
+    expect(calls).toBe(2);
   });
 });

--- a/client/test/harnesses/impls/hermes-agent/is-ready.test.ts
+++ b/client/test/harnesses/impls/hermes-agent/is-ready.test.ts
@@ -5,22 +5,38 @@
 // an uninstalled / mis-configured hermes binary. Pre-fix HermesHarness had
 // no isReady; the registry treated it as always-ready and rvx's fresh
 // install burned 26 failed claims in minutes.
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { HermesHarness } from '../../../../src/harnesses/impls/hermes-agent/harness.js';
-import { probeHermesDoctor } from '../../../../src/api/hermes-doctor-endpoint.js';
+import {
+  probeHermesDoctor,
+  probeHermesAuthStatus,
+} from '../../../../src/api/hermes-doctor-endpoint.js';
 
 vi.mock('../../../../src/api/hermes-doctor-endpoint.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../../src/api/hermes-doctor-endpoint.js')>();
   return {
     ...actual,
     probeHermesDoctor: vi.fn(),
+    probeHermesAuthStatus: vi.fn(),
   };
 });
 
 const fakeAdapter = { name: 'hermes-agent', runTask: vi.fn() };
 
+beforeEach(() => {
+  vi.mocked(probeHermesDoctor).mockReset();
+  vi.mocked(probeHermesAuthStatus).mockReset();
+  // Default: OpenRouter authed so the auth gate passes unless a test
+  // overrides it. The doctor-level gates run first regardless.
+  vi.mocked(probeHermesAuthStatus).mockReturnValue({
+    provider: 'openrouter',
+    authed: true,
+    raw: 'openrouter: logged in',
+  });
+});
+
 describe('HermesHarness.isReady', () => {
-  it('returns ready=true when probeHermesDoctor reports installed and exit 0', async () => {
+  it('returns ready=true when doctor reports installed+exit0 AND OpenRouter is authed', async () => {
     vi.mocked(probeHermesDoctor).mockReturnValue({
       installed: true,
       exitCode: 0,
@@ -58,5 +74,52 @@ describe('HermesHarness.isReady', () => {
     expect(result.ready).toBe(false);
     expect(result.reason).toMatch(/doctor/i);
     expect(result.nextStep?.description).toMatch(/sign in|configure|hermes/i);
+  });
+
+  // Core regression for the v0.1.6 dogfood finding #3: `hermes doctor` exits 0
+  // even when every model provider is logged out. The auth gate must catch
+  // that — ready MUST be false even though the doctor probe says exit 0.
+  it('returns ready=false when OpenRouter is NOT authed even though hermes doctor exit is 0', async () => {
+    vi.mocked(probeHermesDoctor).mockReturnValue({
+      installed: true,
+      exitCode: 0,
+      stdout: 'all checks passed',
+      stderr: '',
+    });
+    vi.mocked(probeHermesAuthStatus).mockReturnValue({
+      provider: 'openrouter',
+      authed: false,
+      raw: 'openrouter: logged out',
+    });
+    const h = new HermesHarness({ adapter: fakeAdapter as any });
+    const result = await h.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+    expect(result.ready).toBe(false);
+    expect(result.reason).toMatch(/openrouter/i);
+    expect(result.reason).toMatch(/no usable model provider/i);
+    expect(result.nextStep?.description).toMatch(/openrouter|hermes login/i);
+  });
+
+  it('probes OpenRouter auth specifically', async () => {
+    vi.mocked(probeHermesDoctor).mockReturnValue({
+      installed: true,
+      exitCode: 0,
+      stdout: 'ok',
+      stderr: '',
+    });
+    const h = new HermesHarness({ adapter: fakeAdapter as any });
+    await h.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+    expect(probeHermesAuthStatus).toHaveBeenCalledWith('openrouter', expect.anything());
+  });
+
+  it('does not reach the auth gate when the binary is missing', async () => {
+    vi.mocked(probeHermesDoctor).mockReturnValue({
+      installed: false,
+      exitCode: null,
+      stdout: '',
+      stderr: '',
+    });
+    const h = new HermesHarness({ adapter: fakeAdapter as any });
+    await h.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+    expect(probeHermesAuthStatus).not.toHaveBeenCalled();
   });
 });

--- a/client/test/harnesses/impls/hermes-agent/is-ready.test.ts
+++ b/client/test/harnesses/impls/hermes-agent/is-ready.test.ts
@@ -1,10 +1,9 @@
 // client/test/harnesses/impls/hermes-agent/is-ready.test.ts
 //
-// Regression coverage for #330: HermesHarness must expose isReady() so the
-// readiness registry can prevent the claim loop from claiming tasks against
-// an uninstalled / mis-configured hermes binary. Pre-fix HermesHarness had
-// no isReady; the registry treated it as always-ready and rvx's fresh
-// install burned 26 failed claims in minutes.
+// Regression coverage: HermesHarness must expose isReady() so the readiness
+// registry can prevent the claim loop from claiming tasks against an
+// uninstalled / mis-configured hermes binary. Without isReady the registry
+// treats the harness as always-ready and a fresh install burns failed claims.
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { HermesHarness } from '../../../../src/harnesses/impls/hermes-agent/harness.js';
 import {
@@ -76,9 +75,9 @@ describe('HermesHarness.isReady', () => {
     expect(result.nextStep?.description).toMatch(/sign in|configure|hermes/i);
   });
 
-  // Core regression for the v0.1.6 dogfood finding #3: `hermes doctor` exits 0
-  // even when every model provider is logged out. The auth gate must catch
-  // that — ready MUST be false even though the doctor probe says exit 0.
+  // `hermes doctor` exits 0 even when every model provider is logged out. The
+  // auth gate must catch that — ready MUST be false even though the doctor
+  // probe says exit 0.
   it('returns ready=false when OpenRouter is NOT authed even though hermes doctor exit is 0', async () => {
     vi.mocked(probeHermesDoctor).mockReturnValue({
       installed: true,

--- a/client/test/solver-nets/prediction-operator-ux.test.ts
+++ b/client/test/solver-nets/prediction-operator-ux.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { buildPredictionOperatorStatus } from '../../src/solver-nets/prediction-operator-ux.js';
 import type { JinnConfig } from '../../src/config.js';
+import type { JoinedSolverNetConfig } from '../../src/solver-nets/registry.js';
 
 // Minimal stub deps: no harnesses needed for the missing-solvernet path.
 const minimalDeps = {
@@ -24,6 +25,26 @@ function minimalConfig(overrides: Partial<JinnConfig> = {}): JinnConfig {
   } as unknown as JinnConfig;
 }
 
+/** A non-prediction joined SolverNet entry (SWE-rebench v2). */
+const sweRebenchJoined: JoinedSolverNetConfig = {
+  manifestCid: 'bafkreichdzxtjav3rh5boyybgx6wolh7boqedxix4vvw44slfppwppshpi',
+  name: 'SWE-rebench v2',
+  contract: { id: 'swe-rebench-v2', version: 'v1' },
+  roles: ['solver', 'evaluator'],
+  harness: 'hermes-agent',
+  plugins: [],
+};
+
+/** A genuine prediction-contract joined SolverNet entry. */
+const predictionJoined: JoinedSolverNetConfig = {
+  manifestCid: 'bafkreigenuineprediction0000000000000000000000000000000000',
+  name: 'Prediction v1',
+  contract: { id: 'prediction', version: 'v1' },
+  roles: ['solver'],
+  harness: 'hermes-agent',
+  plugins: [],
+};
+
 describe('buildPredictionOperatorStatus — joinedSolverNets awareness (jinn-mono-hjex.2)', () => {
   it('emits prediction_solvernet_missing when both solverNets and joinedSolverNets are empty', async () => {
     const status = await buildPredictionOperatorStatus({
@@ -36,19 +57,17 @@ describe('buildPredictionOperatorStatus — joinedSolverNets awareness (jinn-mon
     const codes = status.diagnostics.map((d) => d.code);
     expect(codes).toContain('prediction_solvernet_missing');
   });
+});
 
-  it('does not emit prediction_solvernet_missing when joinedSolverNets has an entry (jinn-mono-hjex.2)', async () => {
+describe('buildPredictionOperatorStatus — gate on real prediction participation (issue #328, dogfood #9)', () => {
+  it('returns the benign missing status when the operator joined ONLY a non-prediction SolverNet', async () => {
+    // Dogfood finding #9: an operator on SWE-rebench v2 (hermes-agent) must not
+    // see prediction diagnostics. Prediction is a deprecated SolverNet.
     const status = await buildPredictionOperatorStatus({
       config: minimalConfig({
         solverNets: {},
         joinedSolverNets: {
-          'bafkreichdzxtjav3rh5boyybgx6wolh7boqedxix4vvw44slfppwppshpi': {
-            manifestCid: 'bafkreichdzxtjav3rh5boyybgx6wolh7boqedxix4vvw44slfppwppshpi',
-            name: 'SWE-rebench v2',
-            roles: ['solver', 'evaluator'],
-            harness: 'claude-code',
-            plugins: [],
-          },
+          [sweRebenchJoined.manifestCid]: sweRebenchJoined,
         },
       }),
       configPath: '/tmp/config.json',
@@ -57,21 +76,21 @@ describe('buildPredictionOperatorStatus — joinedSolverNets awareness (jinn-mon
     });
 
     const codes = status.diagnostics.map((d) => d.code);
-    expect(codes).not.toContain('prediction_solvernet_missing');
+    // No spurious harness-compat ATTENTION from mislabeling the SWE-rebench harness.
+    expect(codes).not.toContain('prediction_harness_unsupported');
+    // Only the benign missing diagnostic — deriveLiveNow filters this from the dashboard.
+    expect(codes).toEqual(['prediction_solvernet_missing']);
+    expect(status.ok).toBe(false);
   });
 
-  it('still runs harness diagnostics against a synthesized net from joinedSolverNets', async () => {
+  it('does not synthesize a prediction net from a non-prediction joined entry', async () => {
+    // The synthesized net would otherwise stamp prediction.v1 on the SWE-rebench
+    // harness and run the prediction-harness-compat check against it.
     const status = await buildPredictionOperatorStatus({
       config: minimalConfig({
         solverNets: {},
         joinedSolverNets: {
-          'bafkreichdzxtjav3rh5boyybgx6wolh7boqedxix4vvw44slfppwppshpi': {
-            manifestCid: 'bafkreichdzxtjav3rh5boyybgx6wolh7boqedxix4vvw44slfppwppshpi',
-            name: 'SWE-rebench v2',
-            roles: ['solver'],
-            harness: 'claude-code',
-            plugins: [],
-          },
+          [sweRebenchJoined.manifestCid]: sweRebenchJoined,
         },
       }),
       configPath: '/tmp/config.json',
@@ -79,13 +98,53 @@ describe('buildPredictionOperatorStatus — joinedSolverNets awareness (jinn-mon
       ...minimalDeps,
     });
 
-    // The net is synthesized as enabled — the diagnostic loop continues past the
-    // missing-solvernet guard. We won't see prediction_solvernet_missing.
+    // The SWE-rebench harness must not leak into the prediction status.
+    expect(status.harness).toBeUndefined();
+    expect(status.solverNet.harness).toBeUndefined();
+    expect(status.solverNet.enabled).toBe(false);
+  });
+
+  it('still produces real diagnostics for an operator genuinely on a prediction SolverNet', async () => {
+    const status = await buildPredictionOperatorStatus({
+      config: minimalConfig({
+        solverNets: {},
+        joinedSolverNets: {
+          [predictionJoined.manifestCid]: predictionJoined,
+        },
+      }),
+      configPath: '/tmp/config.json',
+      daemonRunning: true,
+      ...minimalDeps,
+    });
+
+    const codes = status.diagnostics.map((d) => d.code);
+    // The prediction-contract joined net IS synthesized — the diagnostic loop
+    // runs past the missing-solvernet guard.
+    expect(codes).not.toContain('prediction_solvernet_missing');
+    // With an empty harness list the synthesized net hits prediction_harness_unknown
+    // (the configured 'hermes-agent' harness is not in the stub registry) — the
+    // loop ran, which is what we're proving.
+    expect(codes).toContain('prediction_harness_unknown');
+    expect(status.kind).toBe('prediction.v1.operatorStatus');
+  });
+
+  it('picks the prediction-contract entry when joinedSolverNets mixes prediction and non-prediction nets', async () => {
+    const status = await buildPredictionOperatorStatus({
+      config: minimalConfig({
+        solverNets: {},
+        joinedSolverNets: {
+          // Non-prediction entry first — must NOT be the one synthesized.
+          [sweRebenchJoined.manifestCid]: sweRebenchJoined,
+          [predictionJoined.manifestCid]: predictionJoined,
+        },
+      }),
+      configPath: '/tmp/config.json',
+      daemonRunning: true,
+      ...minimalDeps,
+    });
+
     const codes = status.diagnostics.map((d) => d.code);
     expect(codes).not.toContain('prediction_solvernet_missing');
-    // With an empty harness list the synthesized net will hit prediction_harness_unknown
-    // (or prediction_harness_missing if harness is not found) — either way
-    // the loop ran, which is what we're proving.
     expect(status.kind).toBe('prediction.v1.operatorStatus');
   });
 });

--- a/client/test/solver-nets/prediction-operator-ux.test.ts
+++ b/client/test/solver-nets/prediction-operator-ux.test.ts
@@ -59,10 +59,10 @@ describe('buildPredictionOperatorStatus — joinedSolverNets awareness (jinn-mon
   });
 });
 
-describe('buildPredictionOperatorStatus — gate on real prediction participation (issue #328, dogfood #9)', () => {
+describe('buildPredictionOperatorStatus — gate on real prediction participation', () => {
   it('returns the benign missing status when the operator joined ONLY a non-prediction SolverNet', async () => {
-    // Dogfood finding #9: an operator on SWE-rebench v2 (hermes-agent) must not
-    // see prediction diagnostics. Prediction is a deprecated SolverNet.
+    // An operator on SWE-rebench v2 (hermes-agent) must not see prediction
+    // diagnostics. Prediction is a deprecated SolverNet.
     const status = await buildPredictionOperatorStatus({
       config: minimalConfig({
         solverNets: {},


### PR DESCRIPTION
## Summary

Follow-up fixes from the **v0.1.6 operator-app dogfood** (umbrella #328). Two test rounds against a live daemon (Base Sepolia) surfaced operator-facing issues and two daemon performance bugs; this PR lands all of them. 13 fix branches integrated; merged with zero conflicts.

## Fixes

**Operator dashboard / join form**
- STATUS hero tile now shows *why* it needs attention (was a bare "ATTENTION")
- **Hermes harness readiness now gates on OpenRouter auth** — was a false-positive `ready: true` with no model provider configured, which defeated the join-form readiness gate (#332) and the claim-loop gate (#330/#348), re-opening the "burned failed claims" dogfood bug. Hermes is now OpenRouter-only.
- Join-success card gained a **"Restart node now"** action (it instructed operators to restart but offered no way to)
- Restart-requested notice now auto-clears
- Offline banner no longer renders an inert fake `jinn run` button
- Spurious deprecated-`prediction.v1` "ATTENTION" no longer fires for operators who never joined a prediction SolverNet
- Internal `/api/...` paths no longer leak into operator-facing copy
- Inline-help "Read more" links fixed (`cargo/client/docs` → `client/docs`, `blob/main` → `blob/next`)
- Inline-help copy tightened; verbose cost-estimate breakdown shortened to a one-line caveat

**Daemon**
- Mech evaluation loop prunes terminal opportunities instead of re-scanning on-chain history every cycle
- Engine-watcher skip-caches a stale task backlog (TTL) and yields to the event loop — stops the "Daemon offline" banner flicker

**Tooling**
- testing-jinn-app skill: documented that `--no-ui` disables the in-app restart-respawn; fixed a stale `cargo/client` path

## Verification

- `typecheck` clean; full suite **3914 tests pass** (480 files); daemon suite **82 pass**
- Every operator-facing fix live-walked against a daemon on Base Sepolia
- Offline-banner flicker confirmed resolved (simulated the SPA detector: 1 isolated probe miss / 40, never 2 consecutive)

## Known follow-ups (not in this PR)

- **#14 residual** — occasional sub-threshold daemon event-loop micro-spikes remain (no longer trip the offline banner); needs a CPU profile, not another blind round. Heavily amplified by the test fleet's on-chain backlog.
- **Pre-existing** — 3 flaky `EADDRINUSE:7331` daemon tests under the parallel pool (verified pre-existing); `tsc` emitting `.js` into `src/` (build-hygiene).

Umbrella: #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)
