### PR TITLE
fix(325): surface RPC throttling distinctly + first-run BYO-RPC nudge

### DIFF
--- a/client/src/api/solvernets-endpoints.ts
+++ b/client/src/api/solvernets-endpoints.ts
@@ -1488,7 +1488,14 @@ export function registerSolverNetsEndpoints(
       lastError:
         lastError === null
           ? null
-          : { message: lastError.message, at: lastError.at.toISOString() },
+          : {
+              message: lastError.message,
+              at: lastError.at.toISOString(),
+              // Forward the typed reason (currently only `rpc_rate_limited`)
+              // so the SPA can render an operator-actionable message rather
+              // than a generic "catalog failed" string. See jinn-mono #325.
+              ...(lastError.code !== undefined ? { code: lastError.code } : {}),
+            },
     });
   });
 

--- a/client/src/chain-read-errors.ts
+++ b/client/src/chain-read-errors.ts
@@ -51,3 +51,21 @@ export function isTransientEthReadError(error: unknown): boolean {
 
   return false;
 }
+
+/**
+ * True when an RPC read failed specifically because the endpoint rate-limited
+ * the daemon (HTTP 429 / "too many requests"). This is a strict subset of
+ * `isTransientEthReadError` — it deliberately does NOT match generic timeouts
+ * or 5xx errors. The shared default Base Sepolia RPC throttles the whole
+ * operator pool; classifying a throttle distinctly lets the UI tell the
+ * operator to add their own key rather than showing a generic outage message.
+ * See jinn-mono #325.
+ */
+export function isRateLimitedEthReadError(error: unknown): boolean {
+  const msg = flattenErrorMessage(error).toLowerCase();
+  return (
+    msg.includes('429') ||
+    msg.includes('rate limit') ||
+    msg.includes('too many requests')
+  );
+}

--- a/client/src/dashboard/spa/src/api/types.ts
+++ b/client/src/dashboard/spa/src/api/types.ts
@@ -45,6 +45,10 @@ export interface BootstrapState {
   }>;
   master_address?: string;
   chain?: string;
+  /** Operator-configured RPC URL (absent when the default is in use). */
+  rpcUrl?: string;
+  /** Chain default RPC URL — the shared, rate-limited trial endpoint. */
+  defaultRpcUrl?: string;
   fleet_agent_id?: string;
   fleet_safe_address?: string;
   funding?: {
@@ -654,10 +658,18 @@ export interface LaunchAction {
 /** Response shape for `PATCH /v1/solvernets/launched/:id/lifecycle`. */
 export type LifecycleTransition = LaunchedSolverNetRecord;
 
+/**
+ * Typed reason a registry catalog refresh failed. Currently only
+ * `rpc_rate_limited` — the configured RPC endpoint returned a 429. The SPA
+ * branches on this to show an operator-actionable message ("add your own RPC
+ * key") instead of a generic failure string. See jinn-mono #325.
+ */
+export type RegistryErrorCode = 'rpc_rate_limited';
+
 export interface RegistryListResponse {
   summaries: SolverNetManifestSummary[];
   lastRefreshedAt: Iso8601 | null;
-  lastError: { message: string; at: Iso8601 } | null;
+  lastError: { message: string; at: Iso8601; code?: RegistryErrorCode } | null;
 }
 
 export interface RegistryManifestResponse {

--- a/client/src/dashboard/spa/src/pages/configuration/NetworkSection.test.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/NetworkSection.test.tsx
@@ -18,4 +18,37 @@ describe('NetworkSection', () => {
     expect(screen.getByDisplayValue('https://my-tenderly.example/abc')).toBeTruthy();
     expect(screen.getByText(/locked/i)).toBeTruthy();
   });
+
+  it('expands by default and shows the shared-RPC warning when on the shared default', () => {
+    // jinn-mono #325: a first-run operator on the shared default RPC should
+    // see the BYO-RPC nudge without having to click the section open.
+    render(
+      <NetworkSection
+        chain="base-sepolia"
+        rpcUrl="https://sepolia.base.org"
+        defaultRpcUrl="https://sepolia.base.org"
+        rpcHealthy={true}
+        onRestartPending={() => undefined}
+      />,
+    );
+    // Body is expanded without a click — the RPC input is visible.
+    expect(screen.getByDisplayValue('https://sepolia.base.org')).toBeTruthy();
+    const warning = screen.getByTestId('network-shared-rpc-warning');
+    expect(warning.textContent).toMatch(/shared rpc/i);
+    expect(warning.textContent).toMatch(/your own free key/i);
+  });
+
+  it('does not show the shared-RPC warning when a custom RPC is configured', () => {
+    render(
+      <NetworkSection
+        chain="base-sepolia"
+        rpcUrl="https://my-own-key.example/rpc"
+        defaultRpcUrl="https://sepolia.base.org"
+        rpcHealthy={true}
+        onRestartPending={() => undefined}
+      />,
+    );
+    fireEvent.click(screen.getByText(/network/i));
+    expect(screen.queryByTestId('network-shared-rpc-warning')).toBeNull();
+  });
 });

--- a/client/src/dashboard/spa/src/pages/configuration/NetworkSection.tsx
+++ b/client/src/dashboard/spa/src/pages/configuration/NetworkSection.tsx
@@ -59,7 +59,7 @@ export function NetworkSection({
         label: rpcHealthy ? 'Healthy' : 'Unreachable',
         tone: rpcHealthy ? 'live' : 'danger',
       }}
-      defaultExpanded={defaultExpanded}
+      defaultExpanded={defaultExpanded || onSharedDefault}
       dirty={
         dirty
           ? {

--- a/client/src/dashboard/spa/src/pages/operator-catalog/RegistryCatalog.test.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/RegistryCatalog.test.tsx
@@ -357,4 +357,51 @@ describe('RegistryCatalog', () => {
       'subgraph 502',
     );
   });
+
+  it('surfaces a rate-limited RPC distinctly in the stale-warning row', async () => {
+    // jinn-mono #325: when the catalog refresh fails because the RPC is
+    // throttled, the stale indicator must show an operator-actionable line
+    // with a deep-link to Network settings, not a generic "stale (...)".
+    listRegistryMock.mockResolvedValue({
+      summaries: [],
+      lastRefreshedAt: '2026-05-05T01:23:00Z',
+      lastError: {
+        message: 'OnchainDiscoveryAPI: getLogs for MetadataSet failed',
+        at: '2026-05-05T01:24:00Z',
+        code: 'rpc_rate_limited',
+      },
+    });
+    render(withProviders(<RegistryCatalog />));
+    await waitFor(() =>
+      expect(screen.getByTestId('registry-catalog-warn')).toBeTruthy(),
+    );
+    const warn = screen.getByTestId('registry-catalog-warn');
+    expect(warn.getAttribute('data-error-code')).toBe('rpc_rate_limited');
+    expect(warn.textContent).toMatch(/rpc rate-limited — add your own key/i);
+    // Does NOT fall back to the generic "stale (...)" string.
+    expect(warn.textContent).not.toMatch(/^stale \(/i);
+    // Deep-links to the Network settings section.
+    const action = screen.getByTestId('registry-catalog-warn-action');
+    expect(action.getAttribute('href')).toBe('/operator#network');
+  });
+
+  it('explains rpc_rate_limited query errors with a BYO-RPC nudge', async () => {
+    listRegistryMock.mockRejectedValue(
+      Object.assign(new Error('rpc_rate_limited: 429 Too Many Requests'), {
+        code: 'rpc_rate_limited',
+      }),
+    );
+
+    render(withProviders(<RegistryCatalog />));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('registry-catalog-error')).toBeTruthy(),
+    );
+    expect(screen.getByText(/your rpc endpoint is rate-limited/i)).toBeTruthy();
+    expect(
+      screen.getByText(/open settings > network and add your own free key/i),
+    ).toBeTruthy();
+    const action = screen.getByTestId('registry-catalog-error-action');
+    expect(action.getAttribute('href')).toBe('/operator#network');
+  });
 });

--- a/client/src/dashboard/spa/src/pages/operator-catalog/RegistryCatalog.test.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/RegistryCatalog.test.tsx
@@ -399,7 +399,7 @@ describe('RegistryCatalog', () => {
     );
     expect(screen.getByText(/your rpc endpoint is rate-limited/i)).toBeTruthy();
     expect(
-      screen.getByText(/open settings > network and add your own free key/i),
+      screen.getByText(/open the network section and add your own free key/i),
     ).toBeTruthy();
     const action = screen.getByTestId('registry-catalog-error-action');
     expect(action.getAttribute('href')).toBe('/operator#network');

--- a/client/src/dashboard/spa/src/pages/operator-catalog/RegistryCatalog.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/RegistryCatalog.tsx
@@ -71,12 +71,13 @@ interface RegistryErrorCopy {
 /**
  * Operator-facing copy for a rate-limited RPC. The default Base Sepolia RPC is
  * shared across the whole operator pool, so a 429 here is an operator-actionable
- * condition — point them at Settings to add their own free key rather than
- * leaving them with a generic "catalog not found". See jinn-mono #325.
+ * condition — point them at the Network section to add their own free key
+ * rather than leaving them with a generic "catalog not found". See
+ * jinn-mono #325.
  */
 const RPC_RATE_LIMITED_COPY: RegistryErrorCopy = {
   title: 'Your RPC endpoint is rate-limited.',
-  detail: 'Open Settings > Network and add your own free key.',
+  detail: 'Open the Network section and add your own free key.',
   actionHref: '/operator#network',
   actionLabel: 'Open Network settings →',
 };

--- a/client/src/dashboard/spa/src/pages/operator-catalog/RegistryCatalog.tsx
+++ b/client/src/dashboard/spa/src/pages/operator-catalog/RegistryCatalog.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Link } from 'wouter';
 import { api } from '../../api/client.js';
 import type {
+  RegistryErrorCode,
   RegistryListResponse,
   SolverNetManifestSummary,
 } from '../../api/types.js';
@@ -53,11 +54,34 @@ function errorCode(error: unknown): string | null {
     if (typeof code === 'string') return code;
     if (error.message.includes('subsystem_not_ready')) return 'subsystem_not_ready';
     if (error.message.includes('registry_unavailable')) return 'registry_unavailable';
+    if (error.message.includes('rpc_rate_limited')) return 'rpc_rate_limited';
   }
   return null;
 }
 
-function registryErrorCopy(error: unknown): { title: string; detail: string } {
+interface RegistryErrorCopy {
+  title: string;
+  detail: string;
+  /** When set, render an in-app link to this route (e.g. `/operator#network`). */
+  actionHref?: string;
+  /** Link text for `actionHref`. */
+  actionLabel?: string;
+}
+
+/**
+ * Operator-facing copy for a rate-limited RPC. The default Base Sepolia RPC is
+ * shared across the whole operator pool, so a 429 here is an operator-actionable
+ * condition — point them at Settings to add their own free key rather than
+ * leaving them with a generic "catalog not found". See jinn-mono #325.
+ */
+const RPC_RATE_LIMITED_COPY: RegistryErrorCopy = {
+  title: 'Your RPC endpoint is rate-limited.',
+  detail: 'Open Settings > Network and add your own free key.',
+  actionHref: '/operator#network',
+  actionLabel: 'Open Network settings →',
+};
+
+function registryErrorCopy(error: unknown): RegistryErrorCopy {
   switch (errorCode(error)) {
     case 'subsystem_not_ready':
       return {
@@ -69,12 +93,54 @@ function registryErrorCopy(error: unknown): { title: string; detail: string } {
         title: 'Registry cache is unavailable.',
         detail: 'The daemon could not read the SolverNet registry cache. Retry after startup finishes; check daemon logs if it keeps failing.',
       };
+    case 'rpc_rate_limited':
+      return RPC_RATE_LIMITED_COPY;
     default:
       return {
         title: 'Failed to load registry catalog.',
         detail: error instanceof Error ? error.message : 'Unknown error',
       };
   }
+}
+
+/**
+ * Stale-catalog indicator shown in the meta row. A registry refresh can fail
+ * without the HTTP query itself erroring (the endpoint returns 200 with a
+ * populated `lastError`), so this is where a rate-limited RPC actually
+ * surfaces in the steady-state UI. The `rpc_rate_limited` branch swaps the
+ * generic "stale" text for an operator-actionable line + a deep-link to the
+ * Network settings section. See jinn-mono #325.
+ */
+function RegistryStaleWarning({
+  code,
+  message,
+}: {
+  code?: RegistryErrorCode;
+  message: string;
+}): JSX.Element {
+  if (code === 'rpc_rate_limited') {
+    return (
+      <span
+        data-testid="registry-catalog-warn"
+        data-error-code="rpc_rate_limited"
+        style={{ color: 'var(--wane)', display: 'inline-flex', gap: '8px' }}
+      >
+        <span>RPC rate-limited — add your own key</span>
+        <Link
+          href="/operator#network"
+          data-testid="registry-catalog-warn-action"
+          style={{ color: 'var(--accent-sky)', textDecoration: 'none' }}
+        >
+          Network settings →
+        </Link>
+      </span>
+    );
+  }
+  return (
+    <span data-testid="registry-catalog-warn" style={{ color: 'var(--wane)' }}>
+      stale ({message})
+    </span>
+  );
 }
 
 function StatusBadge({
@@ -356,6 +422,21 @@ export function RegistryCatalog({
           <span style={{ color: 'var(--fg-muted)', fontSize: '12px' }}>
             {copy.detail}
           </span>
+          {copy.actionHref && copy.actionLabel && (
+            <Link
+              href={copy.actionHref}
+              data-testid="registry-catalog-error-action"
+              style={{
+                color: 'var(--accent-sky)',
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: '12px',
+                textDecoration: 'none',
+                marginTop: '2px',
+              }}
+            >
+              {copy.actionLabel}
+            </Link>
+          )}
         </div>
         <button
           type="button"
@@ -407,12 +488,10 @@ export function RegistryCatalog({
           {lastRefreshed ?? 'never'}
         </span>
         {lastError && (
-          <span
-            data-testid="registry-catalog-warn"
-            style={{ color: 'var(--wane)' }}
-          >
-            stale ({lastError.message})
-          </span>
+          <RegistryStaleWarning
+            code={lastError.code}
+            message={lastError.message}
+          />
         )}
       </div>
 

--- a/client/src/dashboard/spa/src/regions/AwaitingFundingCard.test.tsx
+++ b/client/src/dashboard/spa/src/regions/AwaitingFundingCard.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * Tests for the first-run BYO-RPC nudge on the funding card (jinn-mono #325).
+ *
+ * The card itself talks to `api.triggerDrip`; we only exercise the static
+ * shared-RPC affordance here, so the api module is stubbed to a no-op.
+ */
+
+vi.mock('../api/client.js', () => ({
+  api: {
+    triggerDrip: async () => ({ ok: false, reason: 'not used in this test' }),
+  },
+}));
+
+const { AwaitingFundingCard } = await import('./AwaitingFundingCard.js');
+
+const BASE_PROPS = {
+  address: '0x1111111111111111111111111111111111111111',
+  minimumWei: '10000000000000000',
+  chainExplorerBase: 'https://sepolia.basescan.org',
+};
+
+describe('AwaitingFundingCard — shared-RPC nudge', () => {
+  it('shows the BYO-RPC nudge when on the shared default RPC', () => {
+    render(<AwaitingFundingCard {...BASE_PROPS} onSharedDefaultRpc />);
+    const nudge = screen.getByTestId('onboarding-shared-rpc-nudge');
+    expect(nudge.textContent).toMatch(/shared trial rpc/i);
+    expect(nudge.textContent).toMatch(/add your own key/i);
+  });
+
+  it('omits the nudge when a custom RPC is configured', () => {
+    render(<AwaitingFundingCard {...BASE_PROPS} onSharedDefaultRpc={false} />);
+    expect(screen.queryByTestId('onboarding-shared-rpc-nudge')).toBeNull();
+  });
+
+  it('omits the nudge by default (prop unset)', () => {
+    render(<AwaitingFundingCard {...BASE_PROPS} />);
+    expect(screen.queryByTestId('onboarding-shared-rpc-nudge')).toBeNull();
+  });
+});

--- a/client/src/dashboard/spa/src/regions/AwaitingFundingCard.tsx
+++ b/client/src/dashboard/spa/src/regions/AwaitingFundingCard.tsx
@@ -8,6 +8,12 @@ interface Props {
   /** Daemon's configured chain (e.g. 'base' or 'base-sepolia'). Surfaced in
    *  the funding-card copy so the operator knows which network to send on. */
   chain?: string;
+  /**
+   * True when the daemon is running on the shared default RPC. Surfaces a
+   * one-line BYO-RPC nudge in the first-run flow so the operator sees the
+   * option before they bounce off a rate-limit failure later. See jinn-mono #325.
+   */
+  onSharedDefaultRpc?: boolean;
 }
 
 const CHAIN_DISPLAY_NAME: Record<string, string> = {
@@ -20,6 +26,7 @@ export function AwaitingFundingCard({
   minimumWei,
   chainExplorerBase,
   chain,
+  onSharedDefaultRpc = false,
 }: Props): JSX.Element {
   const [copied, setCopied] = useState(false);
   const [fundingStartedAt, setFundingStartedAt] = useState<number | null>(null);
@@ -276,6 +283,16 @@ export function AwaitingFundingCard({
       {dripStatus.state === 'failed' && (
         <p className="j-mono text-[11px]" style={{ color: 'var(--break-red)' }}>
           {dripStatus.reason}
+        </p>
+      )}
+      {onSharedDefaultRpc && (
+        <p
+          data-testid="onboarding-shared-rpc-nudge"
+          className="j-mono text-[11px]"
+          style={{ color: 'var(--fg-dim)' }}
+        >
+          Using a shared trial RPC — add your own key in Settings &gt; Network
+          for reliable operation.
         </p>
       )}
     </div>

--- a/client/src/dashboard/spa/src/regions/AwaitingFundingCard.tsx
+++ b/client/src/dashboard/spa/src/regions/AwaitingFundingCard.tsx
@@ -291,7 +291,7 @@ export function AwaitingFundingCard({
           className="j-mono text-[11px]"
           style={{ color: 'var(--fg-dim)' }}
         >
-          Using a shared trial RPC — add your own key in Settings &gt; Network
+          Using a shared trial RPC — add your own key in the Network section
           for reliable operation.
         </p>
       )}

--- a/client/src/dashboard/spa/src/regions/Onboarding.tsx
+++ b/client/src/dashboard/spa/src/regions/Onboarding.tsx
@@ -158,10 +158,7 @@ export function Onboarding(): JSX.Element {
                       minimumWei={bootstrap.funding?.targetWei ?? '10000000000000000'}
                       chainExplorerBase={explorer}
                       chain={bootstrap.chain}
-                      onSharedDefaultRpc={
-                        bootstrap.rpcUrl === undefined ||
-                        bootstrap.rpcUrl === bootstrap.defaultRpcUrl
-                      }
+                      onSharedDefaultRpc={bootstrap.rpcUrl === bootstrap.defaultRpcUrl}
                     />
                   )}
                   {!showError && p === 3 && status === 'active' && (

--- a/client/src/dashboard/spa/src/regions/Onboarding.tsx
+++ b/client/src/dashboard/spa/src/regions/Onboarding.tsx
@@ -158,6 +158,10 @@ export function Onboarding(): JSX.Element {
                       minimumWei={bootstrap.funding?.targetWei ?? '10000000000000000'}
                       chainExplorerBase={explorer}
                       chain={bootstrap.chain}
+                      onSharedDefaultRpc={
+                        bootstrap.rpcUrl === undefined ||
+                        bootstrap.rpcUrl === bootstrap.defaultRpcUrl
+                      }
                     />
                   )}
                   {!showError && p === 3 && status === 'active' && (

--- a/client/src/discovery/onchain.ts
+++ b/client/src/discovery/onchain.ts
@@ -48,8 +48,27 @@ import { JINN_ROUTER_ABI } from '../adapters/mech/types.js';
 import { canClaimTask } from '../adapters/mech/contracts.js';
 import { manifestDigestForCid } from '../adapters/mech/digest.js';
 import { resolveMostRecentWins, type SetMetadataEvent, type SetMetadataLifecyclePayload } from '../solvernets/most-recent-wins.js';
+import { isRateLimitedEthReadError } from '../chain-read-errors.js';
 import { PLUGIN_PAYLOAD_TUPLE, REVOCATION_PAYLOAD_TUPLE } from '../erc8004/abis.js';
 import { PLUGIN_METADATA_KEY_PREFIX } from '../erc8004/plugin-registry.js';
+
+/**
+ * Wrap an RPC read failure into a `DiscoveryUnavailableError`, preserving a
+ * typed `rpc_rate_limited` code when the underlying error is a 429 / "too many
+ * requests". The shared default RPC throttles the whole operator pool; without
+ * this signal a throttle is indistinguishable from any other transport failure
+ * and the operator UI cannot tell them to add their own key. See jinn-mono #325.
+ */
+function discoveryUnavailableFromReadError(
+  message: string,
+  cause: unknown,
+): DiscoveryUnavailableError {
+  return new DiscoveryUnavailableError(
+    message,
+    cause,
+    isRateLimitedEthReadError(cause) ? 'rpc_rate_limited' : undefined,
+  );
+}
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -575,7 +594,7 @@ export function createOnchainDiscoveryAPI(opts: OnchainDiscoveryAPIOptions): Dis
     try {
       currentBlock = await (client as PublicClient).getBlockNumber();
     } catch (err) {
-      throw new DiscoveryUnavailableError(
+      throw discoveryUnavailableFromReadError(
         `OnchainDiscoveryAPI.findClaimableTasks: failed to get block number`,
         err,
       );
@@ -645,7 +664,7 @@ export function createOnchainDiscoveryAPI(opts: OnchainDiscoveryAPIOptions): Dis
       );
     } catch (err) {
       if (err instanceof DiscoveryUnavailableError) throw err;
-      throw new DiscoveryUnavailableError(
+      throw discoveryUnavailableFromReadError(
         `OnchainDiscoveryAPI.findClaimableTasks: getLogs for TaskCreated failed`,
         err,
       );
@@ -734,7 +753,7 @@ export function createOnchainDiscoveryAPI(opts: OnchainDiscoveryAPIOptions): Dis
       );
     } catch (err) {
       if (err instanceof DiscoveryUnavailableError) throw err;
-      throw new DiscoveryUnavailableError(
+      throw discoveryUnavailableFromReadError(
         `OnchainDiscoveryAPI.findClaimableTasks: getLogs for TaskAttemptCreated failed`,
         err,
       );
@@ -803,7 +822,7 @@ export function createOnchainDiscoveryAPI(opts: OnchainDiscoveryAPIOptions): Dis
     try {
       currentBlock = await (client as PublicClient).getBlockNumber();
     } catch (err) {
-      throw new DiscoveryUnavailableError(
+      throw discoveryUnavailableFromReadError(
         `OnchainDiscoveryAPI: failed to get block number`,
         err,
       );
@@ -838,7 +857,7 @@ export function createOnchainDiscoveryAPI(opts: OnchainDiscoveryAPIOptions): Dis
       );
     } catch (err) {
       if (err instanceof DiscoveryUnavailableError) throw err;
-      throw new DiscoveryUnavailableError(
+      throw discoveryUnavailableFromReadError(
         `OnchainDiscoveryAPI: getLogs for MetadataSet failed`,
         err,
       );
@@ -963,7 +982,7 @@ export function createOnchainDiscoveryAPI(opts: OnchainDiscoveryAPIOptions): Dis
       });
     } catch (err) {
       if (err instanceof DiscoveryUnavailableError) throw err;
-      throw new DiscoveryUnavailableError(
+      throw discoveryUnavailableFromReadError(
         `OnchainDiscoveryAPI.queryEnvelopes: onchain query failed`,
         err,
       );
@@ -986,7 +1005,7 @@ export function createOnchainDiscoveryAPI(opts: OnchainDiscoveryAPIOptions): Dis
     try {
       currentBlock = await (client as PublicClient).getBlockNumber();
     } catch (err) {
-      throw new DiscoveryUnavailableError(
+      throw discoveryUnavailableFromReadError(
         `OnchainDiscoveryAPI.listPluginPublications: failed to get block number`,
         err,
       );
@@ -1029,7 +1048,7 @@ export function createOnchainDiscoveryAPI(opts: OnchainDiscoveryAPIOptions): Dis
       );
     } catch (err) {
       if (err instanceof DiscoveryUnavailableError) throw err;
-      throw new DiscoveryUnavailableError(
+      throw discoveryUnavailableFromReadError(
         `OnchainDiscoveryAPI.listPluginPublications: getLogs for MetadataSet failed`,
         err,
       );

--- a/client/src/discovery/types.ts
+++ b/client/src/discovery/types.ts
@@ -242,12 +242,28 @@ export interface DiscoveryAPI {
  * The `withFallback` wrapper catches this class (plus network-shaped errors)
  * and routes to the floor implementation for the duration of the outage.
  */
+/**
+ * Machine-readable reason a discovery read failed. `rpc_rate_limited` is the
+ * one branch callers act on distinctly: it means the configured RPC endpoint
+ * returned a 429 (or otherwise rate-limited the daemon), which — on the shared
+ * default RPC — is an operator-actionable condition ("add your own key"), not
+ * an indexer outage. Any other transport failure is left untyped (`undefined`).
+ */
+export type DiscoveryUnavailableCode = 'rpc_rate_limited';
+
 export class DiscoveryUnavailableError extends Error {
   override readonly cause?: unknown;
+  /**
+   * Typed reason, when one can be classified — currently only
+   * `rpc_rate_limited`, surfaced end-to-end so the operator UI can render a
+   * distinct "your RPC is throttled" message instead of a generic failure.
+   */
+  readonly code?: DiscoveryUnavailableCode;
 
-  constructor(message: string, cause?: unknown) {
+  constructor(message: string, cause?: unknown, code?: DiscoveryUnavailableCode) {
     super(message);
     this.name = 'DiscoveryUnavailableError';
     this.cause = cause;
+    this.code = code;
   }
 }

--- a/client/src/solvernets/daemon-init.ts
+++ b/client/src/solvernets/daemon-init.ts
@@ -72,7 +72,8 @@ import {
   type LifecycleTransitionDeps,
 } from './lifecycle-transitions.js';
 import type { SolverNetRegistryClient, SolverNetManifestSummary } from './registry-client.js';
-import type { DiscoveryAPI } from '../discovery/types.js';
+import type { DiscoveryAPI, DiscoveryUnavailableCode } from '../discovery/types.js';
+import { DiscoveryUnavailableError } from '../discovery/types.js';
 import type { LaunchedSolverNetRecord, SolverNetStore } from './store.js';
 
 // Import viem types lazily-named — keep the runtime import scoped so unit
@@ -113,8 +114,15 @@ export interface SolverNetCatalogCache {
   stop(): void;
   /** Last successful refresh. `null` until the first refresh lands. */
   lastRefreshedAt(): Date | null;
-  /** Last refresh error, if any. Cleared on the next successful refresh. */
-  lastError(): { message: string; at: Date } | null;
+  /**
+   * Last refresh error, if any. Cleared on the next successful refresh.
+   *
+   * `code` carries a typed reason when one can be classified — currently only
+   * `rpc_rate_limited` (the configured RPC returned a 429). The operator UI
+   * branches on this to render a distinct, actionable message instead of a
+   * generic "catalog failed to load". See jinn-mono #325.
+   */
+  lastError(): { message: string; at: Date; code?: DiscoveryUnavailableCode } | null;
 }
 
 /**
@@ -380,7 +388,7 @@ interface CatalogCacheConfig {
 function createCatalogCache(config: CatalogCacheConfig): SolverNetCatalogCache {
   let snapshot: SolverNetManifestSummary[] = [];
   let lastRefreshedAt: Date | null = null;
-  let lastError: { message: string; at: Date } | null = null;
+  let lastError: { message: string; at: Date; code?: DiscoveryUnavailableCode } | null = null;
   const now = config.now ?? (() => new Date());
 
   const setInt = config.scheduler?.setInterval ?? ((cb, ms) => setInterval(cb, ms));
@@ -396,8 +404,21 @@ function createCatalogCache(config: CatalogCacheConfig): SolverNetCatalogCache {
       lastError = null;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      lastError = { message, at: now() };
-      config.logger.warn(`[solvernet] catalog refresh failed: ${message}`);
+      // Preserve the typed `rpc_rate_limited` signal so the operator UI can
+      // tell a throttled RPC apart from a generic catalog failure. The error
+      // may arrive directly (the on-chain floor wrapped a 429) or as the
+      // `cause` of an enrichment-layer error — check both. See jinn-mono #325.
+      const code =
+        err instanceof DiscoveryUnavailableError && err.code !== undefined
+          ? err.code
+          : err instanceof Error &&
+              (err as { cause?: unknown }).cause instanceof DiscoveryUnavailableError
+            ? ((err as { cause?: unknown }).cause as DiscoveryUnavailableError).code
+            : undefined;
+      lastError = { message, at: now(), ...(code !== undefined ? { code } : {}) };
+      config.logger.warn(
+        `[solvernet] catalog refresh failed${code ? ` (${code})` : ''}: ${message}`,
+      );
     }
   }
 

--- a/client/src/solvernets/daemon-init.ts
+++ b/client/src/solvernets/daemon-init.ts
@@ -375,6 +375,20 @@ export async function initSolverNetSubsystem(
 
 // ── Catalog cache ───────────────────────────────────────────────────────────
 
+/**
+ * Recover the typed `DiscoveryUnavailableError.code` from a refresh failure.
+ * In every current production path the on-chain floor throws the
+ * DiscoveryUnavailableError directly; the `cause` lookup is defensive — should
+ * an enrichment layer ever wrap the error, the typed signal is still recovered
+ * rather than collapsed to a generic failure. See jinn-mono #325.
+ */
+function discoveryCodeOf(err: unknown): DiscoveryUnavailableCode | undefined {
+  if (err instanceof DiscoveryUnavailableError) return err.code;
+  const cause = err instanceof Error ? (err as { cause?: unknown }).cause : undefined;
+  if (cause instanceof DiscoveryUnavailableError) return cause.code;
+  return undefined;
+}
+
 interface CatalogCacheConfig {
   registryClient: SolverNetRegistryClient;
   network: 'base-sepolia' | 'base';
@@ -405,16 +419,8 @@ function createCatalogCache(config: CatalogCacheConfig): SolverNetCatalogCache {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       // Preserve the typed `rpc_rate_limited` signal so the operator UI can
-      // tell a throttled RPC apart from a generic catalog failure. The error
-      // may arrive directly (the on-chain floor wrapped a 429) or as the
-      // `cause` of an enrichment-layer error — check both. See jinn-mono #325.
-      const code =
-        err instanceof DiscoveryUnavailableError && err.code !== undefined
-          ? err.code
-          : err instanceof Error &&
-              (err as { cause?: unknown }).cause instanceof DiscoveryUnavailableError
-            ? ((err as { cause?: unknown }).cause as DiscoveryUnavailableError).code
-            : undefined;
+      // tell a throttled RPC apart from a generic catalog failure.
+      const code = discoveryCodeOf(err);
       lastError = { message, at: now(), ...(code !== undefined ? { code } : {}) };
       config.logger.warn(
         `[solvernet] catalog refresh failed${code ? ` (${code})` : ''}: ${message}`,

--- a/client/test/api/solvernets-endpoints.test.ts
+++ b/client/test/api/solvernets-endpoints.test.ts
@@ -1551,22 +1551,24 @@ function makeOwnedRecord(args: {
  * as the real cache from `daemon-init.ts`; refresh() is a noop unless the test
  * supplies a `refreshHandler`.
  */
+type MockCatalogError = { message: string; at: Date; code?: 'rpc_rate_limited' };
+
 interface MockCatalog extends SolverNetCatalogCache {
   refreshCalls: number;
   setSnapshot: (snapshot: SolverNetManifestSummary[]) => void;
-  setError: (err: { message: string; at: Date } | null) => void;
+  setError: (err: MockCatalogError | null) => void;
   setLastRefreshedAt: (at: Date | null) => void;
 }
 
 function makeMockCatalog(initial: {
   snapshot?: SolverNetManifestSummary[];
   lastRefreshedAt?: Date | null;
-  lastError?: { message: string; at: Date } | null;
+  lastError?: MockCatalogError | null;
   refreshHandler?: () => Promise<void>;
 } = {}): MockCatalog {
   let snapshot: SolverNetManifestSummary[] = initial.snapshot ?? [];
   let lastRefreshedAt: Date | null = initial.lastRefreshedAt ?? null;
-  let lastError: { message: string; at: Date } | null = initial.lastError ?? null;
+  let lastError: MockCatalogError | null = initial.lastError ?? null;
   let refreshCalls = 0;
   const refreshHandler = initial.refreshHandler;
 
@@ -2022,6 +2024,31 @@ describe('GET /v1/solvernets/registry (Task 15)', () => {
       message: 'subgraph timed out',
       at: errAt.toISOString(),
     });
+  });
+
+  it('passes the rpc_rate_limited code through in the lastError payload', async () => {
+    // jinn-mono #325: the typed throttle signal must survive the daemon→SPA
+    // hop so the operator UI can render an actionable message.
+    const errAt = new Date('2026-05-06T01:00:00.000Z');
+    const catalog = makeMockCatalog({
+      snapshot: [],
+      lastError: {
+        message: 'OnchainDiscoveryAPI: getLogs for MetadataSet failed',
+        at: errAt,
+        code: 'rpc_rate_limited',
+      },
+    });
+    const { app } = buildTestApp({ store, catalog });
+
+    const res = await app.request('/v1/solvernets/registry', {
+      method: 'GET',
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      lastError: { message: string; at: string; code?: string } | null;
+    };
+    expect(body.lastError?.code).toBe('rpc_rate_limited');
   });
 
   it('forces a refresh when ?refresh=1 is supplied', async () => {

--- a/client/test/chain-read-errors.test.ts
+++ b/client/test/chain-read-errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isTransientEthReadError } from '../src/chain-read-errors.js';
+import { isRateLimitedEthReadError, isTransientEthReadError } from '../src/chain-read-errors.js';
 
 describe('isTransientEthReadError', () => {
   it('returns true for common RPC transport signals', () => {
@@ -15,5 +15,27 @@ describe('isTransientEthReadError', () => {
   it('returns true for ethers-style server error codes', () => {
     expect(isTransientEthReadError({ code: 'SERVER_ERROR', message: 'bad gateway' })).toBe(true);
     expect(isTransientEthReadError({ code: 'TIMEOUT', message: 'x' })).toBe(true);
+  });
+});
+
+describe('isRateLimitedEthReadError', () => {
+  it('returns true only for 429 / rate-limit signals', () => {
+    expect(isRateLimitedEthReadError(new Error('429 Too Many Requests'))).toBe(true);
+    expect(isRateLimitedEthReadError(new Error('HTTP request failed: rate limit exceeded'))).toBe(true);
+    expect(isRateLimitedEthReadError(new Error('the endpoint returned: Too Many Requests'))).toBe(true);
+  });
+
+  it('returns false for other transient failures it must not over-claim', () => {
+    // These are transient but NOT rate limits — they must classify as
+    // undefined so the UI does not tell the operator to swap their RPC key.
+    expect(isRateLimitedEthReadError(new Error('fetch failed'))).toBe(false);
+    expect(isRateLimitedEthReadError(new Error('Internal JSON-RPC error. (-32603)'))).toBe(false);
+    expect(isRateLimitedEthReadError(new Error('502 bad gateway'))).toBe(false);
+    expect(isRateLimitedEthReadError(new Error('request timed out'))).toBe(false);
+    expect(isRateLimitedEthReadError({ code: 'TIMEOUT', message: 'x' })).toBe(false);
+  });
+
+  it('returns false for opaque revert strings', () => {
+    expect(isRateLimitedEthReadError(new Error('execution reverted'))).toBe(false);
   });
 });

--- a/client/test/discovery/onchain.test.ts
+++ b/client/test/discovery/onchain.test.ts
@@ -754,6 +754,89 @@ describe('OnchainDiscoveryAPI — findClaimableTasks', () => {
       }),
     ).rejects.toThrow(DiscoveryUnavailableError);
   });
+
+  it('preserves an `rpc_rate_limited` code when the RPC returns a 429', async () => {
+    // jinn-mono #325: a throttled shared RPC must be classifiable end-to-end so
+    // the operator UI can render an actionable "add your own key" message
+    // rather than a generic "catalog not found".
+    const mockClient = {
+      getBlockNumber: vi.fn(async () => { throw new Error('HTTP 429: Too Many Requests'); }),
+      getLogs: vi.fn(async () => []),
+      simulateContract: vi.fn(async () => ({ result: undefined })),
+    };
+
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      routerAddress: ROUTER,
+      safeAddress: SAFE_ADDRESS,
+      mechAddress: MECH_ADDRESS,
+      publicClient: mockClient as never,
+    });
+
+    let caught: unknown;
+    try {
+      await api.findClaimableTasks({
+        solverNetManifestCids: [MANIFEST_CID],
+        operatorAddress: OPERATOR_ADDRESS,
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(DiscoveryUnavailableError);
+    expect((caught as DiscoveryUnavailableError).code).toBe('rpc_rate_limited');
+  });
+
+  it('leaves `code` undefined for a non-rate-limit RPC failure', async () => {
+    const mockClient = {
+      getBlockNumber: vi.fn(async () => { throw new Error('fetch failed: connection reset'); }),
+      getLogs: vi.fn(async () => []),
+      simulateContract: vi.fn(async () => ({ result: undefined })),
+    };
+
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      routerAddress: ROUTER,
+      safeAddress: SAFE_ADDRESS,
+      mechAddress: MECH_ADDRESS,
+      publicClient: mockClient as never,
+    });
+
+    let caught: unknown;
+    try {
+      await api.findClaimableTasks({
+        solverNetManifestCids: [MANIFEST_CID],
+        operatorAddress: OPERATOR_ADDRESS,
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(DiscoveryUnavailableError);
+    expect((caught as DiscoveryUnavailableError).code).toBeUndefined();
+  });
+
+  it('preserves `rpc_rate_limited` through a getLogs failure on listLaunchedSolverNets', async () => {
+    const mockClient = {
+      getBlockNumber: vi.fn(async () => CURRENT_BLOCK),
+      getLogs: vi.fn(async () => { throw new Error('the RPC endpoint says: rate limit exceeded'); }),
+      simulateContract: vi.fn(async () => ({ result: undefined })),
+    };
+
+    const api = createOnchainDiscoveryAPI({
+      chainId: CHAIN_ID,
+      identityRegistryAddress: IDENTITY_REGISTRY,
+      taskDiscoveryFromBlock: 0,
+      publicClient: mockClient as never,
+    });
+
+    let caught: unknown;
+    try {
+      await api.listLaunchedSolverNets();
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(DiscoveryUnavailableError);
+    expect((caught as DiscoveryUnavailableError).code).toBe('rpc_rate_limited');
+  });
 });
 
 describe('OnchainDiscoveryAPI — cursorCache', () => {

--- a/client/test/solvernets/daemon-init.test.ts
+++ b/client/test/solvernets/daemon-init.test.ts
@@ -42,6 +42,7 @@ import type {
   MetadataPublisher,
   SetMetadataPublishResult,
 } from '../../src/solvernets/registry-client-erc8004.js';
+import { DiscoveryUnavailableError } from '../../src/discovery/types.js';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -410,7 +411,59 @@ describe('initSolverNetSubsystem — catalog cache', () => {
 
       expect(subsystem.catalog.getCatalog()).toEqual([]);
       expect(subsystem.catalog.lastError()?.message).toContain('subgraph 503');
+      // A generic failure carries no typed code.
+      expect(subsystem.catalog.lastError()?.code).toBeUndefined();
       expect(subsystem.catalog.lastRefreshedAt()).toBeNull();
+    } finally {
+      subsystem.stop();
+    }
+  });
+
+  it('propagates an rpc_rate_limited code from a throttled RPC', async () => {
+    // jinn-mono #325: when the registry refresh fails because the RPC is
+    // rate-limited, the catalog cache must surface the typed code so the
+    // operator UI can render an actionable message instead of "stale".
+    const registryClient = makeMockRegistryClient({
+      summaries: [],
+      failNextList: new DiscoveryUnavailableError(
+        'OnchainDiscoveryAPI: getLogs for MetadataSet failed',
+        new Error('429 Too Many Requests'),
+        'rpc_rate_limited',
+      ),
+    });
+
+    const subsystem = await initSolverNetSubsystem(buildDeps({ registryClient }));
+    try {
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(subsystem.catalog.lastError()?.code).toBe('rpc_rate_limited');
+    } finally {
+      subsystem.stop();
+    }
+  });
+
+  it('reads rpc_rate_limited from an enrichment-layer error cause', async () => {
+    // The error can arrive wrapped: the registry client's IPFS-enrichment
+    // layer may surface its own Error whose `cause` is the typed
+    // DiscoveryUnavailableError. The cache must still extract the code.
+    const wrapped = new Error('listLaunched failed during enrichment');
+    (wrapped as { cause?: unknown }).cause = new DiscoveryUnavailableError(
+      'OnchainDiscoveryAPI: getLogs for MetadataSet failed',
+      undefined,
+      'rpc_rate_limited',
+    );
+    const registryClient = makeMockRegistryClient({
+      summaries: [],
+      failNextList: wrapped,
+    });
+
+    const subsystem = await initSolverNetSubsystem(buildDeps({ registryClient }));
+    try {
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(subsystem.catalog.lastError()?.code).toBe('rpc_rate_limited');
     } finally {
       subsystem.stop();
     }


### PR DESCRIPTION
Closes #325

## Problem

The default Base Sepolia RPC is a single shared endpoint throttled across the whole operator pool. When it returns a 429, the daemon detected it internally but discarded the signal into a generic "catalog not found" failure — giving a first-run operator no way to know it was an RPC problem.

Project owner decision: implement Option 1 + Option 2 in one PR.

## Option 1 — end-to-end 429 classification

- `chain-read-errors.ts` — new `isRateLimitedEthReadError()`, a strict 429-only subset of `isTransientEthReadError` (deliberately excludes timeouts / 5xx).
- `discovery/types.ts` — `DiscoveryUnavailableError` gains a typed `code` (`DiscoveryUnavailableCode = 'rpc_rate_limited'`).
- `discovery/onchain.ts` — every `getLogs` / `getBlockNumber` read failure is wrapped via a new `discoveryUnavailableFromReadError()` helper that preserves `rpc_rate_limited` when the underlying error is a 429.
- `solvernets/daemon-init.ts` — `createCatalogCache.refresh()` propagates the structured code into `lastError` (reads it off the error directly or off its `cause`).
- `api/solvernets-endpoints.ts` — `/v1/solvernets/registry` forwards `lastError.code` in its payload.
- `RegistryCatalog.tsx` — new `rpc_rate_limited` branch in both the error card and the stale-warning row, with operator-facing copy ("Your RPC endpoint is rate-limited. Open Settings > Network and add your own free key.") and a deep-link to `/operator#network`.

## Option 2 — promote the BYO-RPC nudge into first-run

- `NetworkSection.tsx` — the section now auto-expands when the operator is on the shared default RPC, so the existing `network-shared-rpc-warning` banner is visible without a click.
- `AwaitingFundingCard.tsx` — a concise one-line "using a shared trial RPC — add your own key" nudge in the funding step, wired from `Onboarding.tsx` via a new `onSharedDefaultRpc` prop derived from bootstrap `rpcUrl`/`defaultRpcUrl`.

## Out of scope (deferred — Option 3)

Not changing the default RPC and not adding a fallback endpoint.

## Tests

- 429-classification path: `chain-read-errors` (new `isRateLimitedEthReadError`), `onchain` discovery (429 → `code === 'rpc_rate_limited'`, non-429 → undefined), `daemon-init` catalog cache (typed code propagation incl. via error `cause`), registry endpoint (`code` passthrough).
- New SPA copy branches: `RegistryCatalog` (warn row + error card), `NetworkSection` (auto-expand + banner), `AwaitingFundingCard` (nudge).

## Verification

- `yarn typecheck` — clean (exit 0).
- `yarn test` — 481 files, 3908 passed, 8 skipped, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)