### PR TITLE
chore(spa): stop tsc -b emitting .js into src/

### DIFF
--- a/client/src/dashboard/spa/tsconfig.json
+++ b/client/src/dashboard/spa/tsconfig.json
@@ -12,7 +12,8 @@
     "skipLibCheck": true,
     "isolatedModules": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "noEmit": true
   },
   "include": ["src", "vite.config.ts"]
 }


### PR DESCRIPTION
## Summary

The operator SPA's `tsconfig.json` lacked `noEmit`, so the `tsc -b` typecheck step of `build:spa` emitted `.js` files in-place across the SPA `src/` — and into the daemon-side files the SPA imports (`harnesses/cost-estimates.ts`, `harnesses/names.ts`, `plugins/types.ts`). Vite/vitest resolve `.js` before `.tsx`, so those stale emits silently shadow the real source (this bit the v0.1.6 dogfood QA gate). Vite owns the SPA build; `tsc -b` is only a typecheck gate and must not emit — the standard Vite-app config.

## Change

One line: `"noEmit": true` in `client/src/dashboard/spa/tsconfig.json`.

## Verified

`yarn build:spa` succeeds, SPA bundle still produced, **0 stray `.js`** emitted into `src/` afterwards.

Cleanup follow-up from the #328 dogfood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)