### PR TITLE
[codex] test-gate and redeploy TaskClaimEmitter

### DIFF
--- a/client/deployments/deployment-jinn-mvi-l2-baseSepolia.json
+++ b/client/deployments/deployment-jinn-mvi-l2-baseSepolia.json
@@ -2,11 +2,12 @@
   "network": "baseSepolia",
   "chainId": 84532,
   "deployer": "0x15e78734481bD31F6e183dad05225505a45ACd07",
-  "deployedAt": "2026-04-29T11:37:34.801Z",
+  "deployedAt": "2026-05-20T15:23:10.000Z",
+  "deployBlock": 41761151,
+  "txHash": "0x97524384c024a2bcfe11b3699bad53e8533bc25f43e64101ce1e0e4170491f9b",
   "contracts": {
-    "JinnClaimEmitter": "0xDB2f776D78d9aF12792C2C0f9875465eDaa859E7",
-    "RestorationActivityCheckerV2": "0x0e1B5f264F4FAdcFAA950fb00c58d9A39C040f70",
-    "JinnRouterV2": "0x13dae57a54A7DF862113BcA8Ee2fd3dEf6a6A94A",
+    "TaskClaimEmitter": "0xF60055534E377F4020eEA80356C0643E02f4f307",
+    "TaskActivityCheckerV3": "0x0e1B5f264F4FAdcFAA950fb00c58d9A39C040f70",
     "ServiceRegistry": "0x31D3202d8744B16A120117A053459DDFAE93c855"
   }
 }

--- a/client/test/earning/contracts.test.ts
+++ b/client/test/earning/contracts.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
 import {
+  DEFAULT_TESTNET_ARTIFACTS,
   IDENTITY_REGISTRY_ADDRESSES,
   getChainConfig,
+  loadJinnMviConfig,
 } from '../../src/earning/contracts.js';
 
 describe('getChainConfig', () => {
@@ -47,6 +50,27 @@ describe('getChainConfig', () => {
     );
     expect(IDENTITY_REGISTRY_ADDRESSES[84532]).toBe(
       '0x8004A818BFB912233c491871b3d84c89A494BD9e',
+    );
+  });
+
+  it('resolves bundled Base Sepolia JINN MVI L2 artifact to TaskClaimEmitter', () => {
+    const artifactPath = DEFAULT_TESTNET_ARTIFACTS.jinnMviL2;
+    const artifact = JSON.parse(readFileSync(artifactPath, 'utf8')) as {
+      contracts?: Record<string, string | undefined>;
+    };
+
+    expect(artifact.contracts?.TaskClaimEmitter).toMatch(/^0x[a-fA-F0-9]{40}$/);
+    expect(artifact.contracts?.TaskActivityCheckerV3).toBe(
+      '0x0e1B5f264F4FAdcFAA950fb00c58d9A39C040f70',
+    );
+    expect(artifact.contracts?.ServiceRegistry).toBe(
+      '0x31D3202d8744B16A120117A053459DDFAE93c855',
+    );
+    expect(artifact.contracts?.JinnClaimEmitter).toBeUndefined();
+    expect(artifact.contracts?.RestorationActivityCheckerV2).toBeUndefined();
+
+    expect(loadJinnMviConfig({ l2ArtifactPath: artifactPath }).claimEmitter).toBe(
+      artifact.contracts?.TaskClaimEmitter,
     );
   });
 });

--- a/client/test/earning/contracts.test.ts
+++ b/client/test/earning/contracts.test.ts
@@ -7,6 +7,11 @@ import {
   loadJinnMviConfig,
 } from '../../src/earning/contracts.js';
 
+const BASE_SEPOLIA_TASK_CLAIM_EMITTER = '0xF60055534E377F4020eEA80356C0643E02f4f307';
+const BASE_SEPOLIA_TASK_CLAIM_EMITTER_DEPLOY_BLOCK = 41761151;
+const BASE_SEPOLIA_TASK_CLAIM_EMITTER_TX =
+  '0x97524384c024a2bcfe11b3699bad53e8533bc25f43e64101ce1e0e4170491f9b';
+
 describe('getChainConfig', () => {
   it('does not expose legacy claim coordination on Base Sepolia clean-break config', () => {
     const cfg = getChainConfig('base-sepolia');
@@ -56,10 +61,14 @@ describe('getChainConfig', () => {
   it('resolves bundled Base Sepolia JINN MVI L2 artifact to TaskClaimEmitter', () => {
     const artifactPath = DEFAULT_TESTNET_ARTIFACTS.jinnMviL2;
     const artifact = JSON.parse(readFileSync(artifactPath, 'utf8')) as {
+      deployBlock?: number;
+      txHash?: string;
       contracts?: Record<string, string | undefined>;
     };
 
-    expect(artifact.contracts?.TaskClaimEmitter).toMatch(/^0x[a-fA-F0-9]{40}$/);
+    expect(artifact.contracts?.TaskClaimEmitter).toBe(BASE_SEPOLIA_TASK_CLAIM_EMITTER);
+    expect(artifact.deployBlock).toBe(BASE_SEPOLIA_TASK_CLAIM_EMITTER_DEPLOY_BLOCK);
+    expect(artifact.txHash).toBe(BASE_SEPOLIA_TASK_CLAIM_EMITTER_TX);
     expect(artifact.contracts?.TaskActivityCheckerV3).toBe(
       '0x0e1B5f264F4FAdcFAA950fb00c58d9A39C040f70',
     );
@@ -70,7 +79,7 @@ describe('getChainConfig', () => {
     expect(artifact.contracts?.RestorationActivityCheckerV2).toBeUndefined();
 
     expect(loadJinnMviConfig({ l2ArtifactPath: artifactPath }).claimEmitter).toBe(
-      artifact.contracts?.TaskClaimEmitter,
+      BASE_SEPOLIA_TASK_CLAIM_EMITTER,
     );
   });
 });

--- a/contracts/deployment-jinn-mvi-l2-baseSepolia.json
+++ b/contracts/deployment-jinn-mvi-l2-baseSepolia.json
@@ -2,11 +2,12 @@
   "network": "baseSepolia",
   "chainId": 84532,
   "deployer": "0x15e78734481bD31F6e183dad05225505a45ACd07",
-  "deployedAt": "2026-04-29T11:37:34.801Z",
+  "deployedAt": "2026-05-20T15:23:10.000Z",
+  "deployBlock": 41761151,
+  "txHash": "0x97524384c024a2bcfe11b3699bad53e8533bc25f43e64101ce1e0e4170491f9b",
   "contracts": {
-    "JinnClaimEmitter": "0xDB2f776D78d9aF12792C2C0f9875465eDaa859E7",
-    "RestorationActivityCheckerV2": "0x0e1B5f264F4FAdcFAA950fb00c58d9A39C040f70",
-    "JinnRouterV2": "0x13dae57a54A7DF862113BcA8Ee2fd3dEf6a6A94A",
+    "TaskClaimEmitter": "0xF60055534E377F4020eEA80356C0643E02f4f307",
+    "TaskActivityCheckerV3": "0x0e1B5f264F4FAdcFAA950fb00c58d9A39C040f70",
     "ServiceRegistry": "0x31D3202d8744B16A120117A053459DDFAE93c855"
   }
 }

--- a/contracts/scripts/deploy-jinn-mvi-l2.ts
+++ b/contracts/scripts/deploy-jinn-mvi-l2.ts
@@ -38,11 +38,11 @@
  *   JINN_MVI_L2_CHECKER             override TaskActivityCheckerV3 address
  *   JINN_MVI_L2_REGISTRY            override OLAS ServiceRegistry address
  *   JINN_MVI_L2_ARTIFACT_PATH       path to the V3 TaskCoordinator deploy artifact
- *                                   (default: alongside this script's
- *                                   working directory)
+ *                                   (default: deployment-task-coordinator-router-v3-{network}.json,
+ *                                   except Base Sepolia defaults to the bundled -fast artifact)
  *   JINN_MVI_ALLOW_CHAIN            opt in to a non-whitelisted chainId
  *   PHASE1A_TIMING_PROFILE          "canonical" | "fast-test" — selects the
- *                                   V3 artifact suffix
+ *                                   V3 artifact suffix when explicitly set
  */
 
 import { ethers } from "hardhat";
@@ -162,6 +162,36 @@ function getTaskV3ArtifactPath(networkName: string, fastSuffix: boolean): string
   );
 }
 
+function isFastTimingProfile(profile: string | undefined): boolean {
+  return profile === "fast-test";
+}
+
+function shouldUseFastTaskV3Artifact(args: {
+  chainId: number;
+  env?: Record<string, string | undefined>;
+}): boolean {
+  const env = args.env ?? process.env;
+  if (env.PHASE1A_TIMING_PROFILE !== undefined) {
+    return isFastTimingProfile(env.PHASE1A_TIMING_PROFILE);
+  }
+  return args.chainId === CHAIN_ID_BASE_SEPOLIA;
+}
+
+export function resolveTaskV3ArtifactPath(args: {
+  networkName: string;
+  chainId: number;
+  env?: Record<string, string | undefined>;
+}): string {
+  const env = args.env ?? process.env;
+  return (
+    env.JINN_MVI_L2_ARTIFACT_PATH ??
+    getTaskV3ArtifactPath(
+      args.networkName,
+      shouldUseFastTaskV3Artifact({ chainId: args.chainId, env }),
+    )
+  );
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -247,7 +277,7 @@ async function main() {
     scriptName: "Jinn MVI L2 emitter",
   });
 
-  const fastSuffix = (process.env.PHASE1A_TIMING_PROFILE ?? "canonical") === "fast-test";
+  const outputFastSuffix = isFastTimingProfile(process.env.PHASE1A_TIMING_PROFILE);
 
   // Resolve wiring. On Hardhat tests we tolerate fully-mocked wiring
   // because both the V3 artifact and the ServiceRegistry are
@@ -280,9 +310,10 @@ async function main() {
     // Live / testnet path. Read the V3 artifact + chain-pinned
     // service registry, allow env overrides for any of the three.
     const normalizedNetwork = networkName === "base-sepolia" ? "baseSepolia" : networkName;
-    const v3Path =
-      process.env.JINN_MVI_L2_ARTIFACT_PATH
-        ?? getTaskV3ArtifactPath(normalizedNetwork, fastSuffix);
+    const v3Path = resolveTaskV3ArtifactPath({
+      networkName: normalizedNetwork,
+      chainId,
+    });
     const checker = resolveChecker({ artifactPath: v3Path });
     const registry = resolveServiceRegistry({ chainId });
     wiring = {
@@ -310,7 +341,7 @@ async function main() {
   console.log();
 
   const normalizedNetwork = networkName === "base-sepolia" ? "baseSepolia" : networkName;
-  const artifactName = getJinnMviL2ArtifactName(normalizedNetwork, fastSuffix);
+  const artifactName = getJinnMviL2ArtifactName(normalizedNetwork, outputFastSuffix);
   const output = {
     network: normalizedNetwork,
     chainId,

--- a/contracts/scripts/deploy-jinn-mvi-l2.ts
+++ b/contracts/scripts/deploy-jinn-mvi-l2.ts
@@ -79,6 +79,7 @@ interface JinnMviL2DeployResult {
   emitter: string;
   wiring: JinnMviL2Wiring;
   txHash: string;
+  deployBlock: number | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -161,6 +162,27 @@ function getTaskV3ArtifactPath(networkName: string, fastSuffix: boolean): string
   );
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function retryRead<T>(label: string, read: () => Promise<T>): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 6; attempt++) {
+    try {
+      return await read();
+    } catch (error) {
+      lastError = error;
+      await sleep(1_000);
+    }
+  }
+  throw new Error(
+    `[deployJinnMviL2] ${label} read failed after deploy: ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }`,
+  );
+}
+
 /**
  * Deploy `TaskClaimEmitter(checker, registry)`. Reads back
  * the immutable wiring from chain and asserts that each field lands
@@ -181,14 +203,17 @@ export async function deployJinnMviL2(
   );
   const tx = emitter.deploymentTransaction();
   await emitter.waitForDeployment();
+  const receipt = tx ? await tx.wait() : null;
   const address = await emitter.getAddress();
 
   // Sanity: the constructor's slot-pinning assembly already fired. Read
   // back the immutables and assert they round-trip — this catches the
   // unlikely case where the wrong factory is deployed (wrong artifact)
-  // and gives the operator a single point of confidence.
-  const checkerOnChain: string = await emitter.checker();
-  const registryOnChain: string = await emitter.serviceRegistry();
+  // and gives the operator a single point of confidence. Some public
+  // RPCs briefly return empty code after a successful receipt, so retry
+  // these post-deploy reads before failing the script.
+  const checkerOnChain: string = await retryRead("checker()", () => emitter.checker());
+  const registryOnChain: string = await retryRead("serviceRegistry()", () => emitter.serviceRegistry());
   if (checkerOnChain.toLowerCase() !== wiring.checker.toLowerCase()) {
     throw new Error(
       `[deployJinnMviL2] checker mismatch: expected ${wiring.checker}, got ${checkerOnChain}`,
@@ -204,6 +229,7 @@ export async function deployJinnMviL2(
     emitter: address,
     wiring,
     txHash: tx?.hash ?? "(unknown — already mined)",
+    deployBlock: receipt?.blockNumber ?? null,
   };
 }
 
@@ -280,6 +306,7 @@ async function main() {
   console.log("=== Deployment Summary ===");
   console.log(`  TaskClaimEmitter   ${result.emitter}`);
   console.log(`  tx                 ${result.txHash}`);
+  console.log(`  deployBlock        ${result.deployBlock ?? "(unknown)"}`);
   console.log();
 
   const normalizedNetwork = networkName === "base-sepolia" ? "baseSepolia" : networkName;
@@ -289,6 +316,8 @@ async function main() {
     chainId,
     deployer: deployer.address,
     deployedAt: new Date().toISOString(),
+    deployBlock: result.deployBlock,
+    txHash: result.txHash,
     contracts: {
       TaskClaimEmitter: result.emitter,
       TaskActivityCheckerV3: wiring.checker,

--- a/contracts/test/TaskCoordinatorRouterV3.integration.test.ts
+++ b/contracts/test/TaskCoordinatorRouterV3.integration.test.ts
@@ -11,6 +11,13 @@ describe("TaskCoordinator + JinnRouterV3 integration", function () {
   const VERDICT_A = ethers.keccak256(ethers.toUtf8Bytes("verdict-a"));
   const VERDICT_B = ethers.keccak256(ethers.toUtf8Bytes("verdict-b"));
   const NATIVE_PAYMENT_TYPE = "0xba699a34be8fe0e7725e93dcbce1701b0211a8ca61330aaeb8a05bf2ec7abed1";
+  const ONE = ethers.parseEther("1");
+  const SERVICE_ID = 48n;
+  const OPERATOR_RATIO = (ONE * 75n) / 100n;
+  const DAO_RATIO = (ONE * 25n) / 100n;
+  const JINN_FQN = "src/jinn/token/JINN.sol:JINN";
+  const DISTRIBUTOR_FQN = "src/jinn/distribution/JinnDistributor.sol:JinnDistributor";
+  const MOCK_MESSENGER_FQN = "src/jinn/cross-chain/MockMessenger.sol:MockMessenger";
 
   async function policy(maxClaims = 2, maxClaimsPerOperator = 1, ttl = 300) {
     const now = await time.latest();
@@ -32,8 +39,35 @@ describe("TaskCoordinator + JinnRouterV3 integration", function () {
     };
   }
 
-  async function deploy(solutionRate = ethers.parseEther("0.01"), verdictRate = ethers.parseEther("0.005")) {
-    const [owner, creator, operatorA, operatorB, evaluator] = await ethers.getSigners();
+  function expectedSnapshotHash(args: {
+    claimId: bigint;
+    serviceId: bigint;
+    taskCreationWeight: bigint;
+    solutionDeliveryWeight: bigint;
+    verdictDeliveryWeight: bigint;
+    multisig: string;
+  }): string {
+    return ethers.keccak256(
+      ethers.AbiCoder.defaultAbiCoder().encode(
+        ["uint256", "uint256", "uint256", "uint256", "uint256", "address"],
+        [
+          args.claimId,
+          args.serviceId,
+          args.taskCreationWeight,
+          args.solutionDeliveryWeight,
+          args.verdictDeliveryWeight,
+          args.multisig,
+        ],
+      ),
+    );
+  }
+
+  async function deploy(
+    solutionRate = ethers.parseEther("0.01"),
+    verdictRate = ethers.parseEther("0.005"),
+    activityKind: "mock" | "v3" = "mock",
+  ) {
+    const [owner, creator, operatorA, operatorB, evaluator, dao] = await ethers.getSigners();
 
     const Coordinator = await ethers.getContractFactory("TaskCoordinator");
     const coordinator = await Coordinator.deploy();
@@ -43,9 +77,17 @@ describe("TaskCoordinator + JinnRouterV3 integration", function () {
     const marketplace = await Marketplace.deploy();
     await marketplace.waitForDeployment();
 
-    const Activity = await ethers.getContractFactory("MockTaskActivityChecker");
-    const activity = await Activity.deploy();
-    await activity.waitForDeployment();
+    let activity: any;
+    if (activityKind === "v3") {
+      const Activity = await ethers.getContractFactory("TaskActivityCheckerV3");
+      activity = await Activity.deploy();
+      await activity.waitForDeployment();
+      await activity.initialize(ethers.parseEther("0.001"), await owner.getAddress(), 64, 0, 20);
+    } else {
+      const Activity = await ethers.getContractFactory("MockTaskActivityChecker");
+      activity = await Activity.deploy();
+      await activity.waitForDeployment();
+    }
 
     const Router = await ethers.getContractFactory("JinnRouterV3");
     const router = await Router.deploy();
@@ -58,12 +100,17 @@ describe("TaskCoordinator + JinnRouterV3 integration", function () {
       await coordinator.getAddress(),
       await activity.getAddress(),
     );
+    if (activityKind === "v3") {
+      await activity.connect(owner).setAuthorizedRouter(await router.getAddress());
+    }
 
     const Mech = await ethers.getContractFactory("MockTaskMech");
     const mechA = await Mech.deploy(solutionRate, NATIVE_PAYMENT_TYPE, await operatorA.getAddress());
     await mechA.waitForDeployment();
     const mechB = await Mech.deploy(solutionRate, NATIVE_PAYMENT_TYPE, await operatorB.getAddress());
     await mechB.waitForDeployment();
+    const operatorAVerdictMech = await Mech.deploy(verdictRate, NATIVE_PAYMENT_TYPE, await operatorA.getAddress());
+    await operatorAVerdictMech.waitForDeployment();
     const evaluatorMech = await Mech.deploy(verdictRate, NATIVE_PAYMENT_TYPE, await evaluator.getAddress());
     await evaluatorMech.waitForDeployment();
 
@@ -76,8 +123,10 @@ describe("TaskCoordinator + JinnRouterV3 integration", function () {
       operatorA,
       operatorB,
       evaluator,
+      dao,
       mechA,
       mechB,
+      operatorAVerdictMech,
       evaluatorMech,
       solutionRate,
       verdictRate,
@@ -179,5 +228,143 @@ describe("TaskCoordinator + JinnRouterV3 integration", function () {
     expect(await activity.taskCreationFinalized(1)).to.equal(true);
     expect((await router.taskPayments(1)).solutionBudgetRemaining).to.equal(0);
     expect((await router.taskPayments(1)).verdictBudgetRemaining).to.equal(0);
+  });
+
+  it("mints JINN from TaskCoordinatorRouterV3 activity via TaskClaimEmitter and MockMessenger", async function () {
+    const {
+      coordinator,
+      router,
+      marketplace,
+      activity,
+      operatorA,
+      operatorB,
+      evaluator,
+      dao,
+      mechA,
+      mechB,
+      operatorAVerdictMech,
+      evaluatorMech,
+      solutionRate,
+      verdictRate,
+    } = await deploy(ethers.parseEther("0.01"), ethers.parseEther("0.005"), "v3");
+
+    const p = await policy(2, 1);
+    await router.connect(operatorA).createTask(
+      TASK_CID,
+      SOLVER_TYPE,
+      p,
+      solutionRate,
+      verdictRate,
+      3600,
+      { value: solutionRate * 2n + verdictRate * 2n },
+    );
+
+    const first = await claimAndReadSolutionRequest(router, operatorA, 1, mechA);
+    const second = await claimAndReadSolutionRequest(router, operatorB, 1, mechB);
+
+    await marketplace.markDelivered(first.requestId, await mechA.getAddress());
+    await marketplace.markDelivered(second.requestId, await mechB.getAddress());
+    await router.connect(operatorA).claimSolutionDelivery(first.requestId, SOLUTION_A);
+    await router.connect(operatorB).claimSolutionDelivery(second.requestId, SOLUTION_B);
+
+    const verdictA = await claimAndReadVerdictRequest(router, evaluator, 1, first.attemptIndex, evaluatorMech);
+    const verdictB = await claimAndReadVerdictRequest(router, operatorA, 1, second.attemptIndex, operatorAVerdictMech);
+
+    await marketplace.markDelivered(verdictA.requestId, await evaluatorMech.getAddress());
+    await marketplace.markDelivered(verdictB.requestId, await operatorAVerdictMech.getAddress());
+    await router.connect(evaluator).claimVerdictDelivery(verdictA.requestId, VERDICT_A, 1);
+    await router.connect(operatorA).claimVerdictDelivery(verdictB.requestId, VERDICT_B, 1);
+
+    expect(await activity.taskCreationWeight(await operatorA.getAddress())).to.equal(ONE);
+    expect(await activity.solutionDeliveryWeight(await operatorA.getAddress())).to.equal(ONE);
+    expect(await activity.verdictDeliveryWeight(await operatorA.getAddress())).to.equal(ONE);
+
+    const Registry = await ethers.getContractFactory("MockServiceRegistryForEmitter");
+    const registry = await Registry.deploy();
+    await registry.waitForDeployment();
+    await registry.setMultisig(SERVICE_ID, await operatorA.getAddress());
+
+    const Emitter = await ethers.getContractFactory("TaskClaimEmitter");
+    const emitter = await Emitter.deploy(await activity.getAddress(), await registry.getAddress());
+    await emitter.waitForDeployment();
+
+    const MockMessenger = await ethers.getContractFactory(MOCK_MESSENGER_FQN);
+    const messenger = await MockMessenger.deploy(await operatorA.getAddress());
+    await messenger.waitForDeployment();
+
+    const Jinn = await ethers.getContractFactory(JINN_FQN);
+    const jinn = await Jinn.deploy("Jinn", "JINN", await operatorA.getAddress());
+    await jinn.waitForDeployment();
+
+    const Distributor = await ethers.getContractFactory(DISTRIBUTOR_FQN);
+    const distributor = await Distributor.deploy(
+      await operatorA.getAddress(),
+      await jinn.getAddress(),
+      await dao.getAddress(),
+      await messenger.getAddress(),
+      OPERATOR_RATIO,
+      DAO_RATIO,
+      1n,
+      1n,
+      1n,
+    );
+    await distributor.waitForDeployment();
+    await jinn.connect(operatorA).setMinter(await distributor.getAddress());
+
+    const emitTx = await emitter.connect(operatorA).emitClaim(SERVICE_ID);
+    const receipt = await emitTx.wait();
+    const ticket = receipt!.logs
+      .map((log: unknown) => {
+        try { return emitter.interface.parseLog(log); } catch { return null; }
+      })
+      .find((log: null | { name: string }) => log?.name === "ClaimTicket")!;
+
+    const claimId = ticket.args.claimId as bigint;
+    const taskCreationWeight = ticket.args.taskCreationWeight as bigint;
+    const solutionDeliveryWeight = ticket.args.solutionDeliveryWeight as bigint;
+    const verdictDeliveryWeight = ticket.args.verdictDeliveryWeight as bigint;
+    const multisig = ticket.args.multisig as string;
+
+    expect(claimId).to.equal(1n);
+    expect(ticket.args.serviceId).to.equal(SERVICE_ID);
+    expect(taskCreationWeight).to.equal(ONE);
+    expect(solutionDeliveryWeight).to.equal(ONE);
+    expect(verdictDeliveryWeight).to.equal(ONE);
+    expect(multisig).to.equal(await operatorA.getAddress());
+
+    const snapshotHash = expectedSnapshotHash({
+      claimId,
+      serviceId: SERVICE_ID,
+      taskCreationWeight,
+      solutionDeliveryWeight,
+      verdictDeliveryWeight,
+      multisig,
+    });
+    expect(await emitter.claimSnapshotHashes(claimId)).to.equal(snapshotHash);
+
+    await messenger.connect(operatorA).setFixture(claimId, {
+      serviceId: SERVICE_ID,
+      taskCreationWeight,
+      solutionDeliveryWeight,
+      verdictDeliveryWeight,
+      multisig,
+    });
+
+    const proof = ethers.AbiCoder.defaultAbiCoder().encode(["uint256"], [claimId]);
+    const operatorMinted = (3n * ONE * OPERATOR_RATIO) / ONE;
+    const daoMinted = (3n * ONE * DAO_RATIO) / ONE;
+
+    await expect(distributor.connect(evaluator).claim(proof))
+      .to.emit(distributor, "Claimed")
+      .withArgs(SERVICE_ID, await operatorA.getAddress(), operatorMinted, daoMinted, operatorMinted, daoMinted);
+
+    expect(await jinn.balanceOf(await operatorA.getAddress())).to.equal(operatorMinted);
+    expect(await jinn.balanceOf(await dao.getAddress())).to.equal(daoMinted);
+    expect(await distributor.totalClaimedOperator(SERVICE_ID)).to.equal(operatorMinted);
+    expect(await distributor.totalClaimedDao(SERVICE_ID)).to.equal(daoMinted);
+
+    const task = await coordinator.getTask(1);
+    expect(task.finalizedAttemptCount).to.equal(2);
+    expect(task.taskCreationCredited).to.equal(true);
   });
 });

--- a/contracts/test/jinn/cross-chain/JinnMviL2Deploy.test.ts
+++ b/contracts/test/jinn/cross-chain/JinnMviL2Deploy.test.ts
@@ -21,10 +21,39 @@ import {
   JINN_MVI_L2_ALLOWED_CHAINS,
   assertChainIdAllowed,
 } from "../../../scripts/lib/jinn-mvi-helpers";
-import { deployJinnMviL2 } from "../../../scripts/deploy-jinn-mvi-l2";
+import {
+  deployJinnMviL2,
+  resolveTaskV3ArtifactPath,
+} from "../../../scripts/deploy-jinn-mvi-l2";
 
 describe("Jinn MVI L2 emitter deploy script", function () {
   this.timeout(60_000);
+
+  describe("artifact defaults", function () {
+    it("uses the bundled Base Sepolia fast V3 router artifact by default", function () {
+      const artifactPath = resolveTaskV3ArtifactPath({
+        networkName: "baseSepolia",
+        chainId: CHAIN_ID_BASE_SEPOLIA,
+        env: {},
+      });
+
+      expect(artifactPath).to.equal(
+        `${process.cwd()}/deployment-task-coordinator-router-v3-baseSepolia-fast.json`,
+      );
+    });
+
+    it("honors an explicit Base Sepolia canonical timing profile", function () {
+      const artifactPath = resolveTaskV3ArtifactPath({
+        networkName: "baseSepolia",
+        chainId: CHAIN_ID_BASE_SEPOLIA,
+        env: { PHASE1A_TIMING_PROFILE: "canonical" },
+      });
+
+      expect(artifactPath).to.equal(
+        `${process.cwd()}/deployment-task-coordinator-router-v3-baseSepolia.json`,
+      );
+    });
+  });
 
   describe("chainId gate", function () {
     it("allows Hardhat + Base Sepolia by default", function () {


### PR DESCRIPTION
## Summary

PR 1 for #220 / #403.

- Extends the TaskCoordinatorRouterV3 integration test through the full earning mint path: `TaskActivityCheckerV3 -> TaskClaimEmitter -> MockMessenger -> JinnDistributor -> JINN.balanceOf`.
- Adds a client stale-artifact guard that rejects legacy Base Sepolia MVI L2 artifacts with `JinnClaimEmitter` / `RestorationActivityCheckerV2` keys.
- Ships the fresh Base Sepolia L2 artifact for `TaskClaimEmitter`.
- Adds `deployBlock` and `txHash` to the L2 deploy artifact and retries post-deploy sanity reads to survive public RPC code-propagation lag.

## Live deploy

- `TaskClaimEmitter`: `0xF60055534E377F4020eEA80356C0643E02f4f307`
- Deploy tx: `0x97524384c024a2bcfe11b3699bad53e8533bc25f43e64101ce1e0e4170491f9b`
- Deploy block: `41761151`
- Checker: `0x0e1B5f264F4FAdcFAA950fb00c58d9A39C040f70`
- ServiceRegistry: `0x31D3202d8744B16A120117A053459DDFAE93c855`

Live sanity emitted service `48` ClaimTicket in tx `0x02e4e81e0567a87de39e0ca5064dc05fa5a701beb8b83d3f00f1b4a0bae0642c`; the snapshot hash matched. Note: current ServiceRegistry maps service 48 to Safe `0x7828B7Aaf9bE4E2249d242a6f7D94b98bD0C43F4`, not the older spike Safe `0x0e767E28C6889CcD0DfB88E631a3702D56Ce24FC`.

## Verification

- `yarn vitest run test/earning/contracts.test.ts`
- `yarn test test/TaskCoordinatorRouterV3.integration.test.ts test/jinn/cross-chain/JinnMviL2Deploy.test.ts test/jinn/cross-chain/TaskClaimEmitter.test.ts test/jinn/distribution/JinnDistributor.test.ts`

Part of #220
Closes #403