### PR TITLE
[codex] add emit-only JINN claim loop

### DIFF
--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -254,7 +254,8 @@ export const JinnConfigSchema = z.object({
 
   /**
    * RPC endpoint for the L1 governance chain (Ethereum / Sepolia) where the
-   * JinnDistributor lives. Required when jinnDistributorAddress is set.
+   * JinnDistributor lives. Testnet defaults to a public Sepolia RPC; mainnet
+   * requires an operator override when L1 submit mode is configured.
    * Env: JINN_ETHEREUM_RPC_URL.
    */
   ethereumRpcUrl: z.string().url().optional(),
@@ -274,10 +275,10 @@ export const JinnConfigSchema = z.object({
   jinnL1Network: z.enum(['sepolia', 'ethereum']).default('sepolia'),
 
   /**
-   * JinnDistributor address on the L1 governance chain. Setting this enables
-   * the cross-chain claim loop. When set, ethereumRpcUrl MUST also be set.
-   * Resolved from jinnMviL1DeploymentPath when omitted; otherwise a manual
-   * override. Env: JINN_DISTRIBUTOR_ADDRESS.
+   * JinnDistributor address on the L1 governance chain. Required for
+   * jinnClaimSubmissionMode='submit'. When set for submit mode, ethereumRpcUrl
+   * MUST also be set. Resolved from jinnMviL1DeploymentPath when omitted;
+   * otherwise a manual override. Env: JINN_DISTRIBUTOR_ADDRESS.
    */
   jinnDistributorAddress: z
     .string()
@@ -314,6 +315,21 @@ export const JinnConfigSchema = z.object({
    * Env: JINN_MESSENGER_MODE.
    */
   jinnMessengerMode: z.enum(['canonical', 'mock']).default('canonical'),
+
+  /**
+   * Claim submission mode. `emit-only` only submits TaskClaimEmitter.emitClaim
+   * on L2 and records the resulting ticket. `submit` continues into the L1
+   * messenger/distributor path.
+   * Env: JINN_CLAIM_SUBMISSION_MODE.
+   */
+  jinnClaimSubmissionMode: z.enum(['emit-only', 'submit']).default('emit-only'),
+
+  /**
+   * Explicit operator gate for the cross-chain JINN claim loop. Disabled by
+   * default until the testnet PR1/PR3 dependencies are live.
+   * Env: JINN_CLAIM_LOOP_ENABLED=1|true|yes.
+   */
+  jinnClaimLoopEnabled: z.boolean().default(false),
 
   /**
    * How often the daemon ticks the cross-chain JINN claim loop (ms). Default
@@ -655,10 +671,13 @@ export const JinnConfigSchema = z.object({
    */
   reputationEnabled: z.boolean().default(false),
 }).refine(
-  (cfg) => !cfg.jinnDistributorAddress || !!cfg.ethereumRpcUrl,
+  (cfg) =>
+    cfg.jinnClaimSubmissionMode !== 'submit' ||
+    !cfg.jinnDistributorAddress ||
+    !!cfg.ethereumRpcUrl,
   {
     message:
-      'ethereumRpcUrl must be set when jinnDistributorAddress is configured ' +
+      'ethereumRpcUrl must be set when jinnDistributorAddress is configured in submit mode ' +
       '(env JINN_ETHEREUM_RPC_URL or config field). The cross-chain claim loop ' +
       'cannot reach the L1 governance chain without it.',
     path: ['ethereumRpcUrl'],
@@ -690,6 +709,8 @@ export const DEFAULT_CONFIG_PATH = join(DEFAULT_DIR, 'config.json');
  * historical sync — see ponder.config.ts).
  */
 export const DEFAULT_TESTNET_DISCOVERY_URL = 'https://jinn-indexer-production.up.railway.app';
+
+export const DEFAULT_TESTNET_ETHEREUM_RPC_URL = 'https://ethereum-sepolia-rpc.publicnode.com';
 
 
 export type ConfigLoadErrorCode =
@@ -815,6 +836,13 @@ export function loadConfig(configPath?: string): JinnConfig {
   if (env['JINN_CLAIM_EMITTER_ADDRESS']) merged.jinnClaimEmitterAddress = env['JINN_CLAIM_EMITTER_ADDRESS'];
   if (env['JINN_MESSENGER_ADDRESS']) merged.jinnMessengerAddress = env['JINN_MESSENGER_ADDRESS'];
   if (env['JINN_MESSENGER_MODE']) merged.jinnMessengerMode = env['JINN_MESSENGER_MODE'];
+  if (env['JINN_CLAIM_SUBMISSION_MODE']) {
+    merged.jinnClaimSubmissionMode = env['JINN_CLAIM_SUBMISSION_MODE'];
+  }
+  if (env['JINN_CLAIM_LOOP_ENABLED'] !== undefined) {
+    const v = env['JINN_CLAIM_LOOP_ENABLED'].trim().toLowerCase();
+    merged.jinnClaimLoopEnabled = v === '1' || v === 'true' || v === 'yes';
+  }
   if (env['JINN_CLAIM_LOOP_INTERVAL_MS'] !== undefined) {
     merged.jinnClaimLoopIntervalMs = parseInt(env['JINN_CLAIM_LOOP_INTERVAL_MS'], 10);
   }
@@ -940,6 +968,10 @@ export function loadConfig(configPath?: string): JinnConfig {
       url: existing?.url ?? DEFAULT_TESTNET_DISCOVERY_URL,
       fallbackToOnchain: existing?.fallbackToOnchain ?? true,
     };
+  }
+
+  if (resolvedNetwork === 'testnet' && !merged.ethereumRpcUrl) {
+    merged.ethereumRpcUrl = DEFAULT_TESTNET_ETHEREUM_RPC_URL;
   }
 
   // Keep the legacy BASE_RPC_URL override for Base mainnet only. Testnet must
@@ -1092,6 +1124,8 @@ const TRACKED_ENV_VARS = [
   'JINN_CLAIM_EMITTER_ADDRESS',
   'JINN_MESSENGER_ADDRESS',
   'JINN_MESSENGER_MODE',
+  'JINN_CLAIM_SUBMISSION_MODE',
+  'JINN_CLAIM_LOOP_ENABLED',
   'JINN_CLAIM_LOOP_INTERVAL_MS',
   'JINN_STAKING_MODE',
   'JINN_TARGET_SERVICES',

--- a/client/src/daemon/jinn-claim-loop-wiring.ts
+++ b/client/src/daemon/jinn-claim-loop-wiring.ts
@@ -1,0 +1,83 @@
+import type { Address, PublicClient, WalletClient } from 'viem';
+import type { JinnMviConfig } from '../earning/contracts.js';
+import type { FleetStateStore } from '../earning/store.js';
+import type { JinnOnchainNetwork } from '../earning/viem-clients.js';
+import type { Store } from '../store/store.js';
+import type {
+  JinnClaimLoopConfig,
+  JinnClaimSubmissionMode,
+  JinnMessengerMode,
+} from './jinn-claim-loop.js';
+
+export interface JinnClaimL1ClientBundle {
+  public: PublicClient;
+  wallet: WalletClient;
+}
+
+export function shouldWireJinnClaimL1Signer(args: {
+  enabled: boolean;
+  intervalMs: number;
+  submissionMode: JinnClaimSubmissionMode;
+  distributorAddress?: string;
+  ethereumRpcUrl?: string;
+}): boolean {
+  return (
+    args.enabled &&
+    args.intervalMs > 0 &&
+    args.submissionMode === 'submit' &&
+    !!args.distributorAddress &&
+    !!args.ethereumRpcUrl
+  );
+}
+
+export function buildJinnClaimLoopConfig(args: {
+  enabled: boolean;
+  intervalMs: number;
+  submissionMode: JinnClaimSubmissionMode;
+  messengerMode: JinnMessengerMode;
+  mvi: Pick<JinnMviConfig, 'claimEmitter' | 'distributor' | 'messenger'>;
+  l2Client: PublicClient;
+  l2ProofClient?: PublicClient;
+  l2Wallet: WalletClient;
+  l1Clients?: JinnClaimL1ClientBundle;
+  store: FleetStateStore;
+  chain: JinnOnchainNetwork;
+  optimismPortalAddress?: Address;
+  disputeGameFactoryAddress?: Address;
+  jinnStore?: Store;
+}): JinnClaimLoopConfig | undefined {
+  if (!args.enabled || args.intervalMs <= 0 || !args.mvi.claimEmitter) {
+    return undefined;
+  }
+
+  const base = {
+    intervalMs: args.intervalMs,
+    submissionMode: args.submissionMode,
+    l2Client: args.l2Client,
+    l2ProofClient: args.l2ProofClient,
+    l2Wallet: args.l2Wallet,
+    store: args.store,
+    chain: args.chain,
+    claimEmitterAddress: args.mvi.claimEmitter as Address,
+    messengerMode: args.messengerMode,
+    optimismPortalAddress: args.optimismPortalAddress,
+    disputeGameFactoryAddress: args.disputeGameFactoryAddress,
+    jinnStore: args.jinnStore,
+  } satisfies Omit<JinnClaimLoopConfig, 'l1Client' | 'l1Wallet'>;
+
+  if (args.submissionMode === 'emit-only') {
+    return base;
+  }
+
+  if (!args.l1Clients || !args.mvi.distributor || !args.mvi.messenger) {
+    return undefined;
+  }
+
+  return {
+    ...base,
+    l1Client: args.l1Clients.public,
+    l1Wallet: args.l1Clients.wallet,
+    distributorAddress: args.mvi.distributor as Address,
+    messengerAddress: args.mvi.messenger as Address,
+  };
+}

--- a/client/src/daemon/jinn-claim-loop.ts
+++ b/client/src/daemon/jinn-claim-loop.ts
@@ -16,21 +16,24 @@
  *      Sepolia / Ethereum. The distributor verifies, applies channel
  *      weights, and mints to the operator multisig + DAO Timelock.
  *
- * The loop is disabled when no `distributorAddress` is configured. Each
- * tick iterates over staked services in the FleetStateStore. Failures are
- * logged and surfaced via `tick_error` observability events; they don't
- * crash the daemon. Replay protection lives entirely in the distributor's
- * accumulators — repeated submissions are no-ops on the second mint.
+ * The loop is disabled unless the operator explicitly enables it. Each tick
+ * iterates over staked services in the FleetStateStore. Failures are logged
+ * and surfaced via `tick_error` observability events; they don't crash the
+ * daemon. Replay protection lives entirely in the distributor's accumulators
+ * — repeated submissions are no-ops on the second mint.
  *
- * Configuration: `jinnClaimLoopIntervalMs` (default 1h), `jinnMessengerMode`
- * (`canonical` | `mock`). The `mock` path requires the daemon's L1 wallet to
- * be the MockMessenger's owner (set at deploy).
+ * Configuration: `jinnClaimLoopEnabled`, `jinnClaimLoopIntervalMs` (default
+ * 1h), `jinnClaimSubmissionMode` (`emit-only` | `submit`),
+ * `jinnMessengerMode` (`canonical` | `mock`). The `mock` submit path requires
+ * the daemon's L1 wallet to be the MockMessenger's owner (set at deploy).
  *
- * Automated `run()` / `runOnce()` **only execute mock-mode** emit→fixture→claim.
- * When `jinnMessengerMode === 'canonical'`, scheduled ticks **skip** emitting:
- * canonical OP-Stack finality is multi-day (see R-1); operators should use mock
- * for burn-in and run `tsx scripts/verify-canonical-canary.ts` for
- * verifier-only proofs after an intentional L2 emit.
+ * Automated submit-mode `run()` / `runOnce()` **only execute mock-mode**
+ * emit→fixture→claim. When `jinnMessengerMode === 'canonical'`, scheduled
+ * submit ticks **skip** emitting: canonical OP-Stack finality is multi-day
+ * (see R-1); operators should use mock for burn-in and run
+ * `tsx scripts/verify-canonical-canary.ts` for verifier-only proofs after an
+ * intentional L2 emit. Emit-only mode stops after the L2 ticket and can run
+ * without L1 wiring.
  */
 
 import type { Address, Hex, PublicClient, WalletClient } from 'viem';
@@ -56,9 +59,12 @@ import {
 } from './jinn-claim-loop-canonical.js';
 
 export type JinnMessengerMode = 'canonical' | 'mock';
+export type JinnClaimSubmissionMode = 'emit-only' | 'submit';
 
 export interface JinnClaimLoopConfig {
   intervalMs: number;
+  /** 'emit-only' records L2 tickets only; 'submit' continues to L1. */
+  submissionMode: JinnClaimSubmissionMode;
   /** PublicClient bound to the L2 measurement chain (Base / Base Sepolia). */
   l2Client: PublicClient;
   /**
@@ -70,18 +76,18 @@ export interface JinnClaimLoopConfig {
   /** WalletClient bound to L2 — pays gas for `emitClaim`. */
   l2Wallet: WalletClient;
   /** PublicClient bound to the L1 governance chain (Ethereum / Sepolia). */
-  l1Client: PublicClient;
+  l1Client?: PublicClient;
   /** WalletClient bound to L1 — pays gas for `setFixture` (mock) + `claim`. */
-  l1Wallet: WalletClient;
+  l1Wallet?: WalletClient;
   /** Per-service state. We tick each service with a stake. */
   store: FleetStateStore;
   chain: 'base' | 'base-sepolia';
   /** L2 TaskClaimEmitter address. Required. */
   claimEmitterAddress: Address;
   /** L1 JinnDistributor address. Required. */
-  distributorAddress: Address;
+  distributorAddress?: Address;
   /** L1 messenger address. Required (MockMessenger or CanonicalOpStackMessenger). */
-  messengerAddress: Address;
+  messengerAddress?: Address;
   /** 'canonical' or 'mock'. Defaults to 'canonical'. */
   messengerMode: JinnMessengerMode;
   /** Canonical-mode only — L1 OptimismPortal2 anchoring L2 output roots. */
@@ -121,8 +127,10 @@ export class JinnClaimLoop {
     const result: JinnClaimTickResult = { ticks: 0, emits: 0, submits: 0, errors: 0 };
 
     // Spec / Phase D: MockMessenger drives automated Sepolia burn-in; canonical
-    // verification is verifier-only and must not spam emitClaim each interval.
-    if (this.config.messengerMode === 'canonical') {
+    // submit verification is verifier-only and must not spam emitClaim each
+    // interval. Emit-only mode intentionally stops after recording the L2
+    // ticket, so it is allowed to run with any messenger mode.
+    if (this.config.submissionMode === 'submit' && this.config.messengerMode === 'canonical') {
       const detail =
         '[jinn-claim] Automated runOnce skips messengerMode=canonical (multi-day OP finality). ' +
         'Set jinnMessengerMode=mock for Sepolia burn-in, or run `tsx scripts/verify-canonical-canary.ts` ' +
@@ -195,6 +203,31 @@ export class JinnClaimLoop {
       }, 'jinn-claim');
     }
 
+    if (this.config.submissionMode === 'emit-only') {
+      const snapshot = await this.readSnapshot(serviceId, emitTxHash);
+      if (snapshot.multisig.toLowerCase() !== multisig.toLowerCase()) {
+        throw new Error(
+          `[jinn-claim] L2 ClaimTicket multisig ${snapshot.multisig} does not match ` +
+            `service multisig ${multisig} — refusing to record emit-only ticket`,
+        );
+      }
+      const detail =
+        `Recorded ClaimTicket claimId=${snapshot.claimId} service=${serviceId} ` +
+        `weights=${snapshot.taskCreationWeight}/${snapshot.solutionDeliveryWeight}/` +
+        `${snapshot.verdictDeliveryWeight}`;
+      console.log(`[jinn-claim] Service ${serviceId}: ${detail}`);
+      if (this.config.jinnStore) {
+        emitEvent(this.config.jinnStore, {
+          kind: 'jinn_claim_ticket_recorded',
+          serviceIndex: displayIndex,
+          txHash: emitTxHash,
+          outcome: 'ok',
+          detail,
+        }, 'jinn-claim');
+      }
+      return;
+    }
+
     // Step B + C — diverge by mode.
     let submitTxHash: Hex;
     if (this.config.messengerMode === 'mock') {
@@ -246,6 +279,7 @@ export class JinnClaimLoop {
     emitTxHash: Hex;
     multisig: Address;
   }): Promise<Hex> {
+    const { l1Client, l1Wallet, messengerAddress, distributorAddress } = this.requireL1SubmitConfig();
     const snapshot = await this.readSnapshot(args.serviceId, args.emitTxHash);
     if (snapshot.multisig.toLowerCase() !== args.multisig.toLowerCase()) {
       throw new Error(
@@ -256,26 +290,27 @@ export class JinnClaimLoop {
 
     // Plant the fixture (daemon wallet must be MockMessenger.owner).
     const fixtureTx = await plantMockFixture(
-      this.config.l1Client,
-      this.config.l1Wallet,
-      this.config.messengerAddress,
+      l1Client,
+      l1Wallet,
+      messengerAddress,
       snapshot,
     );
-    await waitForTransactionReceiptWithRetry(this.config.l1Client, fixtureTx);
+    await waitForTransactionReceiptWithRetry(l1Client, fixtureTx);
 
     // Submit the claim on L1.
     const claimTx = await submitMockClaim(
-      this.config.l1Client,
-      this.config.l1Wallet,
-      this.config.distributorAddress,
+      l1Client,
+      l1Wallet,
+      distributorAddress,
       snapshot.claimId,
     );
-    await waitForTransactionReceiptWithRetry(this.config.l1Client, claimTx);
+    await waitForTransactionReceiptWithRetry(l1Client, claimTx);
     return claimTx;
   }
 
   /** Canonical-mode Step B + C: build OP-Stack proof, submit on L1. */
   async submitCanonical(args: { serviceId: bigint; emitTxHash: Hex }): Promise<Hex> {
+    const { l1Client, messengerAddress } = this.requireL1SubmitConfig();
     if (!this.config.optimismPortalAddress || !this.config.disputeGameFactoryAddress) {
       throw new Error(
         '[jinn-claim-loop] canonical mode requires optimismPortalAddress + disputeGameFactoryAddress',
@@ -299,7 +334,7 @@ export class JinnClaimLoop {
 
     const result = await buildCanonicalProof(
       {
-        l1Client: this.config.l1Client,
+        l1Client,
         l2ProofClient: this.config.l2ProofClient ?? this.config.l2Client,
         targetChain: this.config.chain === 'base-sepolia' ? baseSepolia : base,
         optimismPortal: this.config.optimismPortalAddress,
@@ -310,8 +345,8 @@ export class JinnClaimLoop {
     );
 
     await verifyCanonicalClaimCanary(
-      this.config.l1Client,
-      this.config.messengerAddress,
+      l1Client,
+      messengerAddress,
       result.proof,
     );
     // Verifier-only canary path: no L1 transaction submitted; return the L2 emit tx.
@@ -342,6 +377,30 @@ export class JinnClaimLoop {
       );
     }
     return snapshot;
+  }
+
+  private requireL1SubmitConfig(): {
+    l1Client: PublicClient;
+    l1Wallet: WalletClient;
+    distributorAddress: Address;
+    messengerAddress: Address;
+  } {
+    if (
+      !this.config.l1Client ||
+      !this.config.l1Wallet ||
+      !this.config.distributorAddress ||
+      !this.config.messengerAddress
+    ) {
+      throw new Error(
+        '[jinn-claim-loop] submit mode requires L1 client, L1 wallet, distributor, and messenger wiring',
+      );
+    }
+    return {
+      l1Client: this.config.l1Client,
+      l1Wallet: this.config.l1Wallet,
+      distributorAddress: this.config.distributorAddress,
+      messengerAddress: this.config.messengerAddress,
+    };
   }
 
   /** Loop forever, sleeping `intervalMs` between ticks. */

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -62,6 +62,10 @@ import { MechAdapter } from './adapters/mech/adapter.js';
 import { ClaudeRunner } from './runner/claude.js';
 import type { RunnerContext } from './runner/runner.js';
 import { Daemon } from './daemon/daemon.js';
+import {
+  buildJinnClaimLoopConfig,
+  shouldWireJinnClaimL1Signer,
+} from './daemon/jinn-claim-loop-wiring.js';
 import { createJinnPublicClient, createJinnWalletClient, createJinnL1PublicClient, createJinnL1WalletClient } from './earning/viem-clients.js';
 import { privateKeyToAccount } from 'viem/accounts';
 import { getAddress, type Address } from 'viem';
@@ -1750,8 +1754,15 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
   // ── L1 (Sepolia / Ethereum mainnet) clients for cross-chain JINN claim loop ──
   // Uses the agent EOA because MockMessenger.owner is the agent on testnet.
   // Same key as L2; only the chain differs.
+  const shouldWireJinnClaimL1 = shouldWireJinnClaimL1Signer({
+    enabled: config.jinnClaimLoopEnabled,
+    intervalMs: config.jinnClaimLoopIntervalMs,
+    submissionMode: config.jinnClaimSubmissionMode,
+    distributorAddress: JINN_MVI_CONFIG.distributor,
+    ethereumRpcUrl: config.ethereumRpcUrl,
+  });
   const l1ClientsForJinnClaim =
-    JINN_MVI_CONFIG.distributor && config.ethereumRpcUrl
+    shouldWireJinnClaimL1 && config.ethereumRpcUrl
       ? {
           public: createJinnL1PublicClient(config.ethereumRpcUrl, config.jinnL1Network),
           wallet: createJinnL1WalletClient(
@@ -1761,15 +1772,33 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
           ),
         }
       : undefined;
-  if (l1ClientsForJinnClaim) {
+  const jinnClaimLoopConfig = buildJinnClaimLoopConfig({
+    enabled: config.jinnClaimLoopEnabled,
+    intervalMs: config.jinnClaimLoopIntervalMs,
+    submissionMode: config.jinnClaimSubmissionMode,
+    messengerMode: JINN_CLAIM_MESSENGER_MODE,
+    mvi: JINN_MVI_CONFIG,
+    l2Client: agentClients.publicClient,
+    l2ProofClient,
+    l2Wallet: agentClients.walletClient,
+    l1Clients: l1ClientsForJinnClaim,
+    store: earningStore,
+    chain: NETWORK_CHAIN,
+    optimismPortalAddress,
+    disputeGameFactoryAddress,
+  });
+  if (jinnClaimLoopConfig) {
     console.log(
-      `[main] JinnClaimLoop: enabled (mode=${JINN_CLAIM_MESSENGER_MODE}, ` +
+      `[main] JinnClaimLoop: enabled (submission=${config.jinnClaimSubmissionMode}, ` +
+      `mode=${JINN_CLAIM_MESSENGER_MODE}, ` +
       `interval=${config.jinnClaimLoopIntervalMs}ms, distributor=${JINN_MVI_CONFIG.distributor}, ` +
       `emitter=${JINN_MVI_CONFIG.claimEmitter})`,
     );
+  } else if (!config.jinnClaimLoopEnabled) {
+    console.log('[main] JinnClaimLoop: disabled (jinnClaimLoopEnabled=false)');
   } else {
     console.log(
-      `[main] JinnClaimLoop: disabled (JinnDistributor artifact/override or JINN_ETHEREUM_RPC_URL not set)`,
+      `[main] JinnClaimLoop: disabled (missing claim-loop artifacts, interval disabled, or L1 submit wiring)`,
     );
   }
 
@@ -2358,29 +2387,7 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
             distributorAddress: CHAIN_CONFIG.distributorAddress,
           }
         : undefined,
-    jinnClaim:
-      l1ClientsForJinnClaim &&
-      JINN_MVI_CONFIG.claimEmitter &&
-      JINN_MVI_CONFIG.messenger &&
-      JINN_MVI_CONFIG.distributor &&
-      config.jinnClaimLoopIntervalMs > 0
-        ? {
-            intervalMs: config.jinnClaimLoopIntervalMs,
-            l2Client: agentClients.publicClient,
-            l2ProofClient,
-            l2Wallet: agentClients.walletClient,
-            l1Client: l1ClientsForJinnClaim.public,
-            l1Wallet: l1ClientsForJinnClaim.wallet,
-            store: earningStore,
-            chain: NETWORK_CHAIN,
-            claimEmitterAddress: JINN_MVI_CONFIG.claimEmitter as `0x${string}`,
-            distributorAddress: JINN_MVI_CONFIG.distributor as `0x${string}`,
-            messengerAddress: JINN_MVI_CONFIG.messenger as `0x${string}`,
-            messengerMode: JINN_CLAIM_MESSENGER_MODE,
-            optimismPortalAddress,
-            disputeGameFactoryAddress,
-          }
-        : undefined,
+    jinnClaim: jinnClaimLoopConfig,
     restorationEngine: {
       paths: {
         workingDirRoot: config.engine.workingDirRoot,

--- a/client/src/observability/emit-event.ts
+++ b/client/src/observability/emit-event.ts
@@ -9,6 +9,7 @@ export type LifecycleKind =
   | 'reward_claimed'
   | 'balance_topup'
   | 'jinn_claim_emitted'
+  | 'jinn_claim_ticket_recorded'
   | 'jinn_claim_submitted'
   | 'jinn_claim_canonical_skip'
   | 'engine_transition'

--- a/client/test/config.test.ts
+++ b/client/test/config.test.ts
@@ -2,7 +2,12 @@ import { mkdtemp, rm, writeFile } from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { DEFAULT_TESTNET_DISCOVERY_URL, loadConfig, buildConfigProvenance } from '../src/config.js';
+import {
+  DEFAULT_TESTNET_DISCOVERY_URL,
+  DEFAULT_TESTNET_ETHEREUM_RPC_URL,
+  loadConfig,
+  buildConfigProvenance,
+} from '../src/config.js';
 
 describe('loadConfig RPC override handling', () => {
   const dirs: string[] = [];
@@ -15,6 +20,9 @@ describe('loadConfig RPC override handling', () => {
   const originalJinnDiscoveryMode = process.env['JINN_DISCOVERY_MODE'];
   const originalJinnDiscoveryUrl = process.env['JINN_DISCOVERY_URL'];
   const originalJinnDiscoveryFallback = process.env['JINN_DISCOVERY_FALLBACK'];
+  const originalJinnEthereumRpcUrl = process.env['JINN_ETHEREUM_RPC_URL'];
+  const originalJinnClaimSubmissionMode = process.env['JINN_CLAIM_SUBMISSION_MODE'];
+  const originalJinnClaimLoopEnabled = process.env['JINN_CLAIM_LOOP_ENABLED'];
   const originalTestnetL2Deployment = process.env['JINN_TESTNET_L2_DEPLOYMENT'];
   const originalTestnetTokenDeployment = process.env['JINN_TESTNET_TOKEN_DEPLOYMENT'];
   const originalOperatorDonationEnabled = process.env['JINN_OPERATOR_DONATION_ENABLED'];
@@ -72,6 +80,24 @@ describe('loadConfig RPC override handling', () => {
       delete process.env['JINN_DISCOVERY_FALLBACK'];
     } else {
       process.env['JINN_DISCOVERY_FALLBACK'] = originalJinnDiscoveryFallback;
+    }
+
+    if (originalJinnEthereumRpcUrl === undefined) {
+      delete process.env['JINN_ETHEREUM_RPC_URL'];
+    } else {
+      process.env['JINN_ETHEREUM_RPC_URL'] = originalJinnEthereumRpcUrl;
+    }
+
+    if (originalJinnClaimSubmissionMode === undefined) {
+      delete process.env['JINN_CLAIM_SUBMISSION_MODE'];
+    } else {
+      process.env['JINN_CLAIM_SUBMISSION_MODE'] = originalJinnClaimSubmissionMode;
+    }
+
+    if (originalJinnClaimLoopEnabled === undefined) {
+      delete process.env['JINN_CLAIM_LOOP_ENABLED'];
+    } else {
+      process.env['JINN_CLAIM_LOOP_ENABLED'] = originalJinnClaimLoopEnabled;
     }
 
     if (originalTestnetL2Deployment === undefined) {
@@ -389,9 +415,52 @@ describe('loadConfig RPC override handling', () => {
     expect(ds!.eligibility).toEqual({ minClosedTrades: 20, minTradedNotionalMultiple: 5.0 });
   });
 
-  it('rejects partial L1 cross-chain config (distributor without ethereumRpcUrl)', async () => {
+  it('defaults testnet L1 RPC and leaves the claim loop disabled in emit-only mode', async () => {
+    const configPath = await writeConfigFile({ network: 'testnet' });
+
+    delete process.env['BASE_RPC_URL'];
+    delete process.env['BASE_SEPOLIA_RPC_URL'];
+    delete process.env['JINN_RPC_URL'];
+    delete process.env['JINN_NETWORK'];
+    delete process.env['JINN_ETHEREUM_RPC_URL'];
+    delete process.env['JINN_CLAIM_SUBMISSION_MODE'];
+    delete process.env['JINN_CLAIM_LOOP_ENABLED'];
+
+    const config = loadConfig(configPath);
+
+    expect(config.ethereumRpcUrl).toBe(DEFAULT_TESTNET_ETHEREUM_RPC_URL);
+    expect(config.jinnClaimSubmissionMode).toBe('emit-only');
+    expect(config.jinnClaimLoopEnabled).toBe(false);
+  });
+
+  it('does not default ethereumRpcUrl on mainnet', async () => {
+    const configPath = await writeConfigFile({ network: 'mainnet' });
+
+    delete process.env['JINN_NETWORK'];
+    delete process.env['JINN_ETHEREUM_RPC_URL'];
+
+    const config = loadConfig(configPath);
+
+    expect(config.network).toBe('mainnet');
+    expect(config.ethereumRpcUrl).toBeUndefined();
+  });
+
+  it('loads claim submission mode and loop enabled gate from env', async () => {
+    const configPath = await writeConfigFile({ network: 'testnet' });
+
+    process.env['JINN_CLAIM_SUBMISSION_MODE'] = 'submit';
+    process.env['JINN_CLAIM_LOOP_ENABLED'] = 'yes';
+
+    const config = loadConfig(configPath);
+
+    expect(config.jinnClaimSubmissionMode).toBe('submit');
+    expect(config.jinnClaimLoopEnabled).toBe(true);
+  });
+
+  it('rejects mainnet partial L1 cross-chain config (distributor without ethereumRpcUrl)', async () => {
     const configPath = await writeConfigFile({
-      network: 'testnet',
+      network: 'mainnet',
+      jinnClaimSubmissionMode: 'submit',
       jinnDistributorAddress: '0x1111111111111111111111111111111111111111',
       // ethereumRpcUrl intentionally missing
     });
@@ -414,6 +483,22 @@ describe('loadConfig RPC override handling', () => {
     const hit = issues.find((i) => i.path === 'ethereumRpcUrl');
     expect(hit).toBeDefined();
     expect(hit!.message).toMatch(/ethereumRpcUrl/);
+  });
+
+  it('does not require ethereumRpcUrl for emit-only config', async () => {
+    const configPath = await writeConfigFile({
+      network: 'mainnet',
+      jinnClaimSubmissionMode: 'emit-only',
+      jinnDistributorAddress: '0x1111111111111111111111111111111111111111',
+    });
+
+    delete process.env['JINN_NETWORK'];
+    delete process.env['JINN_ETHEREUM_RPC_URL'];
+
+    const config = loadConfig(configPath);
+
+    expect(config.jinnClaimSubmissionMode).toBe('emit-only');
+    expect(config.ethereumRpcUrl).toBeUndefined();
   });
 
   it('accepts L1 cross-chain config when ethereumRpcUrl is set', async () => {

--- a/client/test/daemon/jinn-claim-loop.test.ts
+++ b/client/test/daemon/jinn-claim-loop.test.ts
@@ -144,9 +144,16 @@ function mockL1Wallet() {
   } as any;
 }
 
+function mockJinnStore() {
+  return {
+    recordActivityEvent: vi.fn(),
+  } as any;
+}
+
 function baseConfig(overrides: Partial<JinnClaimLoopConfig> = {}): JinnClaimLoopConfig {
   return {
     intervalMs: 60_000,
+    submissionMode: 'submit',
     l2Client: mockL2Client(),
     l2Wallet: mockL2Wallet(),
     l1Client: mockL1Client(),
@@ -162,6 +169,68 @@ function baseConfig(overrides: Partial<JinnClaimLoopConfig> = {}): JinnClaimLoop
 }
 
 describe('JinnClaimLoop', () => {
+  describe('emit-only mode', () => {
+    it('emits and records the L2 ClaimTicket without L1 wiring', async () => {
+      const l2Client = mockL2Client();
+      const l2Wallet = mockL2Wallet();
+      const jinnStore = mockJinnStore();
+      const cfg = baseConfig({
+        submissionMode: 'emit-only',
+        l2Client,
+        l2Wallet,
+        l1Client: undefined,
+        l1Wallet: undefined,
+        distributorAddress: undefined,
+        messengerAddress: undefined,
+        jinnStore,
+      });
+      const loop = new JinnClaimLoop(cfg);
+      const result = await loop.runOnce();
+
+      expect(result).toMatchObject({ ticks: 1, emits: 1, submits: 0, errors: 0 });
+      expect(l2Client.simulateContract).toHaveBeenCalledTimes(1);
+      expect(l2Wallet.writeContract).toHaveBeenCalledTimes(1);
+      expect(l2Client.getLogs).toHaveBeenCalledTimes(1);
+      const recordedEvents = (jinnStore.recordActivityEvent as any).mock.calls.map((call: any[]) => call[0]);
+      expect(recordedEvents.some((event: any) => event.kind === 'jinn_claim_emitted')).toBe(true);
+      const ticketEvent = recordedEvents.find((event: any) => event.kind === 'jinn_claim_ticket_recorded');
+      expect(ticketEvent).toBeDefined();
+      expect(ticketEvent.detail).toContain(`claimId=${CLAIM_ID}`);
+    });
+
+    it('never calls L1 fixture or distributor claim in emit-only mode', async () => {
+      const l1Client = mockL1Client();
+      const l1Wallet = mockL1Wallet();
+      const cfg = baseConfig({
+        submissionMode: 'emit-only',
+        l1Client,
+        l1Wallet,
+      });
+      const loop = new JinnClaimLoop(cfg);
+      const result = await loop.runOnce();
+
+      expect(result.submits).toBe(0);
+      expect(l1Client.simulateContract).not.toHaveBeenCalled();
+      expect(l1Wallet.writeContract).not.toHaveBeenCalled();
+    });
+
+    it('does not apply the canonical scheduled-run skip in emit-only mode', async () => {
+      const cfg = baseConfig({
+        submissionMode: 'emit-only',
+        messengerMode: 'canonical',
+        l1Client: undefined,
+        l1Wallet: undefined,
+        distributorAddress: undefined,
+        messengerAddress: undefined,
+      });
+      const loop = new JinnClaimLoop(cfg);
+      const result = await loop.runOnce();
+
+      expect(result).toMatchObject({ ticks: 1, emits: 1, submits: 0, errors: 0 });
+      expect(cfg.l2Client.simulateContract).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('mock mode', () => {
     it('emits ClaimTicket on L2 and submits fixture + claim on L1', async () => {
       const cfg = baseConfig();

--- a/client/test/main/jinn-claim-loop-wiring.test.ts
+++ b/client/test/main/jinn-claim-loop-wiring.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildJinnClaimLoopConfig,
+  shouldWireJinnClaimL1Signer,
+} from '../../src/daemon/jinn-claim-loop-wiring.js';
+
+const CLAIM_EMITTER = '0x1111111111111111111111111111111111111111' as const;
+const DISTRIBUTOR = '0x2222222222222222222222222222222222222222' as const;
+const MESSENGER = '0x3333333333333333333333333333333333333333' as const;
+
+function baseArgs(overrides: Record<string, unknown> = {}) {
+  return {
+    enabled: true,
+    intervalMs: 60_000,
+    submissionMode: 'emit-only' as const,
+    messengerMode: 'mock' as const,
+    mvi: {
+      claimEmitter: CLAIM_EMITTER,
+      distributor: DISTRIBUTOR,
+      messenger: MESSENGER,
+    },
+    l2Client: {} as any,
+    l2Wallet: {} as any,
+    store: {} as any,
+    chain: 'base-sepolia' as const,
+    ...overrides,
+  };
+}
+
+describe('jinn claim loop wiring', () => {
+  it('does not request L1 signer wiring for emit-only mode', () => {
+    expect(shouldWireJinnClaimL1Signer({
+      enabled: true,
+      intervalMs: 60_000,
+      submissionMode: 'emit-only',
+      distributorAddress: DISTRIBUTOR,
+      ethereumRpcUrl: 'https://ethereum-sepolia-rpc.publicnode.com',
+    })).toBe(false);
+  });
+
+  it('builds emit-only config without L1 clients, distributor, or messenger', () => {
+    const cfg = buildJinnClaimLoopConfig(baseArgs({
+      mvi: { claimEmitter: CLAIM_EMITTER },
+    }));
+
+    expect(cfg).toBeDefined();
+    expect(cfg?.submissionMode).toBe('emit-only');
+    expect(cfg?.claimEmitterAddress).toBe(CLAIM_EMITTER);
+    expect(cfg?.l1Client).toBeUndefined();
+    expect(cfg?.l1Wallet).toBeUndefined();
+    expect(cfg?.distributorAddress).toBeUndefined();
+    expect(cfg?.messengerAddress).toBeUndefined();
+  });
+
+  it('requires L1 signer wiring for submit mode', () => {
+    expect(shouldWireJinnClaimL1Signer({
+      enabled: true,
+      intervalMs: 60_000,
+      submissionMode: 'submit',
+      distributorAddress: DISTRIBUTOR,
+      ethereumRpcUrl: 'https://ethereum-sepolia-rpc.publicnode.com',
+    })).toBe(true);
+
+    expect(buildJinnClaimLoopConfig(baseArgs({
+      submissionMode: 'submit',
+      l1Clients: undefined,
+    }))).toBeUndefined();
+
+    const l1Clients = { public: {} as any, wallet: {} as any };
+    const cfg = buildJinnClaimLoopConfig(baseArgs({
+      submissionMode: 'submit',
+      l1Clients,
+    }));
+
+    expect(cfg).toBeDefined();
+    expect(cfg?.l1Client).toBe(l1Clients.public);
+    expect(cfg?.l1Wallet).toBe(l1Clients.wallet);
+    expect(cfg?.distributorAddress).toBe(DISTRIBUTOR);
+    expect(cfg?.messengerAddress).toBe(MESSENGER);
+  });
+
+  it('does not build config unless the explicit enable gate is true', () => {
+    expect(buildJinnClaimLoopConfig(baseArgs({ enabled: false }))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

PR 2 for #220 / #404.

- Adds keyless public Sepolia RPC default for testnet: `https://ethereum-sepolia-rpc.publicnode.com`.
- Adds `jinnClaimSubmissionMode: 'emit-only' | 'submit'` and `jinnClaimLoopEnabled`.
- Keeps testnet claim loop disabled by default until PR 1 + PR 3 are live.
- Adds emit-only claim mode: daemon emits the L2 `ClaimTicket`, records the ticket, and never calls `MockMessenger.setFixture` or `JinnDistributor.claim`.
- Adds pure claim-loop wiring helper so emit-only mode does not require L1 signer/client wiring.

## Dependency / rollout

Do not flip `jinnClaimLoopEnabled` default-on until #407 and the standing relayer PR are live and verified. Canaries can opt in explicitly with `JINN_CLAIM_LOOP_ENABLED=1`.

## Verification

- `yarn vitest run test/config.test.ts test/daemon/jinn-claim-loop.test.ts test/main/jinn-claim-loop-wiring.test.ts`
- `yarn tsc --noEmit`

Part of #220
Closes #404