### PR TITLE
[codex] show real tJINN earned balance

### DIFF
--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -23,6 +23,9 @@ import {
   type ServiceBalanceErrorEntry,
   type StatusV1Response,
   TJINN_CHAIN_ID,
+  TJINN_PUBLIC_INVALID_SAFE_ERROR,
+  TJINN_PUBLIC_PARTIAL_ERROR,
+  TJINN_PUBLIC_READ_ERROR,
   TJINN_TOKEN_ADDRESS,
   type TjinnServiceStatus,
   type TjinnStatus,
@@ -54,6 +57,20 @@ const ERC20_BALANCE_OF_ABI = [
     outputs: [{ name: '', type: 'uint256' }],
   },
 ] as const;
+
+const TJINN_BALANCE_CACHE_TTL_MS = 30_000;
+const TJINN_BALANCE_TIMEOUT_MS = 4_000;
+
+interface TjinnBalanceSnapshot {
+  chainId: number;
+  balances: Map<string, string>;
+  errors: Map<string, string>;
+}
+
+const tjinnBalanceCache = new Map<
+  string,
+  { expiresAt: number; promise: Promise<TjinnBalanceSnapshot> }
+>();
 
 function readDaemonRuntime(earningDir: string | undefined): GatheredStatusRaw['daemonRuntime'] | undefined {
   if (!earningDir) return undefined;
@@ -284,6 +301,111 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function tJinnBalanceCacheKey(
+  ethereumRpcUrl: string,
+  safeKeys: readonly string[],
+): string {
+  return `${ethereumRpcUrl}\0${[...safeKeys].sort().join(',')}`;
+}
+
+function timeoutError(message: string): Error {
+  const error = new Error(message);
+  error.name = 'TimeoutError';
+  return error;
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(timeoutError(message)), timeoutMs);
+    promise
+      .then(resolve, reject)
+      .finally(() => clearTimeout(timer));
+  });
+}
+
+async function readTjinnBalances(
+  ethereumRpcUrl: string,
+  safeToAddress: Map<string, `0x${string}`>,
+): Promise<TjinnBalanceSnapshot> {
+  const safeEntries = [...safeToAddress.entries()];
+  const client = createPublicClient({
+    chain: sepolia,
+    transport: http(ethereumRpcUrl, { timeout: TJINN_BALANCE_TIMEOUT_MS }),
+  });
+  const chainId = await client.getChainId();
+  const balances = new Map<string, string>();
+  const errors = new Map<string, string>();
+
+  if (chainId !== TJINN_CHAIN_ID) {
+    for (const [key] of safeEntries) {
+      errors.set(key, TJINN_PUBLIC_READ_ERROR);
+    }
+    return { chainId, balances, errors };
+  }
+
+  const settled = await Promise.allSettled(
+    safeEntries.map(async ([key, safeAddress]) => {
+      const balance = await client.readContract({
+        address: TJINN_TOKEN_ADDRESS as `0x${string}`,
+        abi: ERC20_BALANCE_OF_ABI,
+        functionName: 'balanceOf',
+        args: [safeAddress],
+      });
+      return { key, balanceWei: balance.toString() };
+    }),
+  );
+
+  for (let i = 0; i < settled.length; i++) {
+    const result = settled[i]!;
+    if (result.status === 'fulfilled') {
+      balances.set(result.value.key, result.value.balanceWei);
+    } else {
+      const key = safeEntries[i]?.[0];
+      if (key) errors.set(key, TJINN_PUBLIC_READ_ERROR);
+    }
+  }
+
+  return { chainId, balances, errors };
+}
+
+async function getCachedTjinnBalances(
+  ethereumRpcUrl: string,
+  safeToAddress: Map<string, `0x${string}`>,
+): Promise<TjinnBalanceSnapshot> {
+  const safeKeys = [...safeToAddress.keys()].sort();
+  const cacheKey = tJinnBalanceCacheKey(ethereumRpcUrl, safeKeys);
+  const now = Date.now();
+  const cached = tjinnBalanceCache.get(cacheKey);
+  if (cached && cached.expiresAt > now) {
+    return cached.promise;
+  }
+
+  const promise = withTimeout(
+    readTjinnBalances(ethereumRpcUrl, safeToAddress),
+    TJINN_BALANCE_TIMEOUT_MS,
+    'tJINN balance collection timed out',
+  ).catch((): TjinnBalanceSnapshot => {
+    const errors = new Map<string, string>();
+    for (const key of safeKeys) {
+      errors.set(key, TJINN_PUBLIC_READ_ERROR);
+    }
+    return {
+      chainId: TJINN_CHAIN_ID,
+      balances: new Map<string, string>(),
+      errors,
+    };
+  });
+  tjinnBalanceCache.set(cacheKey, {
+    expiresAt: now + TJINN_BALANCE_CACHE_TTL_MS,
+    promise,
+  });
+  return promise;
+}
+
 async function sumPendingStakingRewards(
   rpcUrl: string,
   network: 'mainnet' | 'testnet',
@@ -392,7 +514,7 @@ async function gatherTjinnStatus(
         safeAddress,
         balanceWei: null,
         state: 'error',
-        error: 'Invalid Safe address in fleet state.',
+        error: TJINN_PUBLIC_INVALID_SAFE_ERROR,
       });
     }
   }
@@ -421,77 +543,45 @@ async function gatherTjinnStatus(
     };
   }
 
-  const client = createPublicClient({
-    chain: sepolia,
-    transport: http(ethereumRpcUrl),
-  });
-
-  try {
-    const chainId = await client.getChainId();
-    if (chainId !== TJINN_CHAIN_ID) {
-      const error = `Expected Sepolia chain ${TJINN_CHAIN_ID}, got ${chainId}.`;
-      return {
-        ...baseStatus,
-        state: 'error',
-        chainId,
-        safeBalanceWei: null,
-        safeCount,
-        services: services.map((svc) =>
-          svc.safeAddress ? { ...svc, state: 'error', error } : svc,
-        ),
-        error,
-      };
-    }
-
-    const balances = new Map<string, string>();
-    await Promise.all(
-      [...safeToAddress.entries()].map(async ([key, safeAddress]) => {
-        const balance = await client.readContract({
-          address: TJINN_TOKEN_ADDRESS as `0x${string}`,
-          abi: ERC20_BALANCE_OF_ABI,
-          functionName: 'balanceOf',
-          args: [safeAddress],
-        });
-        balances.set(key, balance.toString());
-      }),
-    );
-
-    let total = 0n;
-    for (const balance of balances.values()) {
-      total += BigInt(balance);
-    }
-
-    const hasServiceError = services.some((svc) => svc.state === 'error');
-    return {
-      ...baseStatus,
-      state: hasServiceError ? 'error' : 'ready',
-      safeBalanceWei: hasServiceError ? null : total.toString(),
-      safeCount,
-      services: services.map((svc) => {
-        if (!svc.safeAddress) return svc;
-        if (svc.state === 'error') return svc;
-        const balance = balances.get(svc.safeAddress.toLowerCase());
-        return balance === undefined
-          ? { ...svc, state: 'error', error: 'tJINN balance unavailable.' }
-          : { ...svc, state: 'ready', balanceWei: balance, error: null };
-      }),
-      error: hasServiceError ? 'Could not read tJINN for every Safe.' : null,
-    };
-  } catch (e) {
-    const error = e instanceof Error ? e.message : String(e);
-    return {
-      ...baseStatus,
-      state: 'error',
-      safeBalanceWei: null,
-      safeCount,
-      services: services.map((svc) =>
-        svc.safeAddress && svc.state !== 'error'
-          ? { ...svc, state: 'error', error }
-          : svc,
-      ),
-      error,
-    };
+  const snapshot = await getCachedTjinnBalances(ethereumRpcUrl, safeToAddress);
+  let total = 0n;
+  for (const balance of snapshot.balances.values()) {
+    total += BigInt(balance);
   }
+  const hasInvalidSafe = services.some((svc) => svc.error === TJINN_PUBLIC_INVALID_SAFE_ERROR);
+  const hasReadError = snapshot.errors.size > 0;
+  const hasAnyError = hasInvalidSafe || hasReadError;
+  const hasAnyBalance = snapshot.balances.size > 0;
+  const publicError = hasAnyError
+    ? hasAnyBalance
+      ? TJINN_PUBLIC_PARTIAL_ERROR
+      : hasInvalidSafe && !hasReadError
+        ? TJINN_PUBLIC_INVALID_SAFE_ERROR
+        : TJINN_PUBLIC_READ_ERROR
+    : null;
+
+  return {
+    ...baseStatus,
+    chainId: snapshot.chainId,
+    state: hasAnyError ? 'error' : 'ready',
+    safeBalanceWei: hasAnyBalance ? total.toString() : null,
+    safeCount,
+    services: services.map((svc) => {
+      if (!svc.safeAddress) return svc;
+      if (svc.state === 'error') return svc;
+      const key = svc.safeAddress.toLowerCase();
+      const balance = snapshot.balances.get(key);
+      if (balance !== undefined) {
+        return { ...svc, state: 'ready', balanceWei: balance, error: null };
+      }
+      return {
+        ...svc,
+        state: 'error',
+        error: snapshot.errors.get(key) ?? TJINN_PUBLIC_READ_ERROR,
+      };
+    }),
+    error: publicError,
+  };
 }
 
 function hasUsefulCacheValues(entry: BalanceCacheEntry, isAgentRole: boolean): boolean {

--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -2,13 +2,13 @@
  * Best-effort status collection for GET /v1/status (RPC + earning store + SQLite).
  */
 
-import { createPublicClient, http, type PublicClient } from 'viem';
+import { createPublicClient, getAddress, http, type PublicClient } from 'viem';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 /** Narrow RPC surface for balance fan-out (avoids PublicClient / chain-specific getBlock incompatibilities). */
 type StatusBalanceRpc = Pick<PublicClient, 'getBalance' | 'readContract'>;
-import { base, baseSepolia } from 'viem/chains';
+import { base, baseSepolia, sepolia } from 'viem/chains';
 import type { Store } from '../store/store.js';
 import type { JinnConfig } from '../config.js';
 import { FleetStateStore } from '../earning/store.js';
@@ -22,6 +22,10 @@ import {
   type GatheredStatusRaw,
   type ServiceBalanceErrorEntry,
   type StatusV1Response,
+  TJINN_CHAIN_ID,
+  TJINN_TOKEN_ADDRESS,
+  type TjinnServiceStatus,
+  type TjinnStatus,
   resolveMasterDailyEstimateWei,
 } from './status-build.js';
 import { listStolasClaimTargets } from '../earning/stolas-claim.js';
@@ -89,6 +93,8 @@ export function invalidatePredictionOperatorStatusCache(config: JinnConfig): voi
 export interface StatusGatherConfig {
   earningDir: string;
   rpcUrl: string;
+  /** Sepolia RPC endpoint for reading the real tJINN ERC-20 balance. */
+  ethereumRpcUrl?: string;
   network: 'mainnet' | 'testnet';
   pollIntervalMs: number;
   masterEthDailyEstimateWei?: string;
@@ -331,6 +337,160 @@ async function sumPendingStakingRewards(
       : { sum: total.toString(), pendingByService };
   } catch (e) {
     return { error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+async function gatherTjinnStatus(
+  ethereumRpcUrl: string | undefined,
+  fleet: FleetState | null,
+): Promise<TjinnStatus> {
+  const baseStatus = {
+    chainId: TJINN_CHAIN_ID,
+    tokenAddress: TJINN_TOKEN_ADDRESS,
+  };
+  if (!fleet) {
+    return {
+      ...baseStatus,
+      state: 'pending',
+      safeBalanceWei: null,
+      safeCount: 0,
+      services: [],
+      error: null,
+    };
+  }
+
+  const services: TjinnServiceStatus[] = [];
+  const safeToAddress = new Map<string, `0x${string}`>();
+
+  for (const svc of fleet.services) {
+    const index = displayFleetServiceIndex(svc);
+    const safeAddress = svc.safe_address;
+    if (!safeAddress) {
+      services.push({
+        index,
+        safeAddress: null,
+        balanceWei: null,
+        state: 'pending',
+        error: null,
+      });
+      continue;
+    }
+    try {
+      const checksum = getAddress(safeAddress);
+      const key = checksum.toLowerCase();
+      services.push({
+        index,
+        safeAddress: checksum,
+        balanceWei: null,
+        state: 'pending',
+        error: null,
+      });
+      safeToAddress.set(key, checksum as `0x${string}`);
+    } catch {
+      services.push({
+        index,
+        safeAddress,
+        balanceWei: null,
+        state: 'error',
+        error: 'Invalid Safe address in fleet state.',
+      });
+    }
+  }
+
+  const safeCount = safeToAddress.size;
+  if (safeCount === 0) {
+    const invalid = services.find((svc) => svc.state === 'error')?.error;
+    return {
+      ...baseStatus,
+      state: invalid ? 'error' : 'pending',
+      safeBalanceWei: null,
+      safeCount,
+      services,
+      error: invalid ?? null,
+    };
+  }
+
+  if (!ethereumRpcUrl) {
+    return {
+      ...baseStatus,
+      state: 'pending',
+      safeBalanceWei: null,
+      safeCount,
+      services,
+      error: null,
+    };
+  }
+
+  const client = createPublicClient({
+    chain: sepolia,
+    transport: http(ethereumRpcUrl),
+  });
+
+  try {
+    const chainId = await client.getChainId();
+    if (chainId !== TJINN_CHAIN_ID) {
+      const error = `Expected Sepolia chain ${TJINN_CHAIN_ID}, got ${chainId}.`;
+      return {
+        ...baseStatus,
+        state: 'error',
+        chainId,
+        safeBalanceWei: null,
+        safeCount,
+        services: services.map((svc) =>
+          svc.safeAddress ? { ...svc, state: 'error', error } : svc,
+        ),
+        error,
+      };
+    }
+
+    const balances = new Map<string, string>();
+    await Promise.all(
+      [...safeToAddress.entries()].map(async ([key, safeAddress]) => {
+        const balance = await client.readContract({
+          address: TJINN_TOKEN_ADDRESS as `0x${string}`,
+          abi: ERC20_BALANCE_OF_ABI,
+          functionName: 'balanceOf',
+          args: [safeAddress],
+        });
+        balances.set(key, balance.toString());
+      }),
+    );
+
+    let total = 0n;
+    for (const balance of balances.values()) {
+      total += BigInt(balance);
+    }
+
+    const hasServiceError = services.some((svc) => svc.state === 'error');
+    return {
+      ...baseStatus,
+      state: hasServiceError ? 'error' : 'ready',
+      safeBalanceWei: hasServiceError ? null : total.toString(),
+      safeCount,
+      services: services.map((svc) => {
+        if (!svc.safeAddress) return svc;
+        if (svc.state === 'error') return svc;
+        const balance = balances.get(svc.safeAddress.toLowerCase());
+        return balance === undefined
+          ? { ...svc, state: 'error', error: 'tJINN balance unavailable.' }
+          : { ...svc, state: 'ready', balanceWei: balance, error: null };
+      }),
+      error: hasServiceError ? 'Could not read tJINN for every Safe.' : null,
+    };
+  } catch (e) {
+    const error = e instanceof Error ? e.message : String(e);
+    return {
+      ...baseStatus,
+      state: 'error',
+      safeBalanceWei: null,
+      safeCount,
+      services: services.map((svc) =>
+        svc.safeAddress && svc.state !== 'error'
+          ? { ...svc, state: 'error', error }
+          : svc,
+      ),
+      error,
+    };
   }
 }
 
@@ -602,6 +762,7 @@ export async function gatherGatheredStatusRaw(
     master: {
       address: fleet?.master_address ?? null,
     },
+    tJinn: await gatherTjinnStatus(status.ethereumRpcUrl ?? status.config?.ethereumRpcUrl, fleet),
     rewardClaimIntervalMs: status.rewardClaimIntervalMs,
   };
 

--- a/client/src/api/status-build.ts
+++ b/client/src/api/status-build.ts
@@ -16,6 +16,28 @@ import type { TaskRunsStatus } from './task-runs-build.js';
 const DEFAULT_MASTER_ETH_DAILY_WEI = 1_000_000_000_000_000n;
 
 export type StatusHintsScope = 'full' | 'sqlite_only';
+export type TjinnStatusState = 'pending' | 'ready' | 'error';
+
+export const TJINN_CHAIN_ID = 11155111;
+export const TJINN_TOKEN_ADDRESS = '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A';
+
+export interface TjinnServiceStatus {
+  index: number;
+  safeAddress: string | null;
+  balanceWei: string | null;
+  state: TjinnStatusState;
+  error: string | null;
+}
+
+export interface TjinnStatus {
+  state: TjinnStatusState;
+  chainId: number;
+  tokenAddress: string;
+  safeBalanceWei: string | null;
+  safeCount: number;
+  services: TjinnServiceStatus[];
+  error: string | null;
+}
 
 export interface ServiceBalanceErrorEntry {
   agent?: string;
@@ -57,6 +79,8 @@ export interface GatheredStatusRaw {
   };
   pendingStakingRewardsWei?: string;
   pendingRewardsError?: string;
+  /** Sepolia tJINN ERC-20 balances across fleet Safes. */
+  tJinn?: TjinnStatus;
   /** ISO timestamp when the staking contract will next accept a checkpoint. */
   nextCheckpointAt?: string;
   pollIntervalMs: number;
@@ -136,6 +160,7 @@ export interface StatusV1Response {
     totalStakingRewardsWei?: string;
     pendingRewardsError?: string;
   };
+  tJinn: TjinnStatus;
   masterGas: {
     address: string | null;
     balanceWei?: string;
@@ -190,23 +215,23 @@ function fleetSummary(
   const services = fleet.services.map(s => {
     const di = displayFleetServiceIndex(s);
     return {
-    index: di,
-    step: s.step,
-    serviceId: s.service_id,
-    safeAddress: s.safe_address,
-    mechAddress: s.mech_address,
-    stakingAddress: s.staking_address,
-    agentId: s.agent_id ?? null,
-    identityRegistryAddress: s.identity_registry_address ?? null,
-    safeBoundToAgent: s.safe_bound_to_agent === true,
-    identityBindingStatus: (
-      s.safe_bound_to_agent === true
-        ? 'bound'
-        : s.agent_id && s.safe_address
-          ? 'pending'
-          : 'not_applicable'
-    ) as 'bound' | 'pending' | 'not_applicable',
-    evicted: evictedByServiceIndex?.[di] ?? false,
+      index: di,
+      step: s.step,
+      serviceId: s.service_id,
+      safeAddress: s.safe_address,
+      mechAddress: s.mech_address,
+      stakingAddress: s.staking_address,
+      agentId: s.agent_id ?? null,
+      identityRegistryAddress: s.identity_registry_address ?? null,
+      safeBoundToAgent: s.safe_bound_to_agent === true,
+      identityBindingStatus: (
+        s.safe_bound_to_agent === true
+          ? 'bound'
+          : s.agent_id && s.safe_address
+            ? 'pending'
+            : 'not_applicable'
+      ) as 'bound' | 'pending' | 'not_applicable',
+      evicted: evictedByServiceIndex?.[di] ?? false,
     };
   });
   const stakedLikeCount = fleet.services.filter(s => isStakedLikeServiceStep(s.step)).length;
@@ -248,6 +273,18 @@ function sumClaimedRewardsWei(raw: GatheredStatusRaw): bigint {
     }
   }
   return total;
+}
+
+function defaultTjinnStatus(): TjinnStatus {
+  return {
+    state: 'pending',
+    chainId: TJINN_CHAIN_ID,
+    tokenAddress: TJINN_TOKEN_ADDRESS,
+    safeBalanceWei: null,
+    safeCount: 0,
+    services: [],
+    error: null,
+  };
 }
 
 function buildEarningsHint(raw: GatheredStatusRaw, fleetSum: StatusV1Response['fleet']): string {
@@ -378,6 +415,7 @@ export function assembleStatusV1(raw: GatheredStatusRaw): StatusV1Response {
           : claimedRewardsWei.toString(),
       pendingRewardsError: raw.pendingRewardsError,
     },
+    tJinn: raw.tJinn ?? defaultTjinnStatus(),
     masterGas: {
       address: raw.master.address,
       balanceWei: raw.master.balanceWei,

--- a/client/src/api/status-build.ts
+++ b/client/src/api/status-build.ts
@@ -20,6 +20,15 @@ export type TjinnStatusState = 'pending' | 'ready' | 'error';
 
 export const TJINN_CHAIN_ID = 11155111;
 export const TJINN_TOKEN_ADDRESS = '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A';
+export const TJINN_PUBLIC_READ_ERROR = 'Sepolia tJINN balance temporarily unavailable.';
+export const TJINN_PUBLIC_PARTIAL_ERROR = 'Some Safe tJINN balances are temporarily unavailable.';
+export const TJINN_PUBLIC_INVALID_SAFE_ERROR = 'One or more Safe addresses are invalid.';
+
+const TJINN_PUBLIC_ERRORS = new Set([
+  TJINN_PUBLIC_READ_ERROR,
+  TJINN_PUBLIC_PARTIAL_ERROR,
+  TJINN_PUBLIC_INVALID_SAFE_ERROR,
+]);
 
 export interface TjinnServiceStatus {
   index: number;
@@ -287,6 +296,32 @@ function defaultTjinnStatus(): TjinnStatus {
   };
 }
 
+export function redactTjinnPublicError(
+  error: string | null | undefined,
+  fallback = TJINN_PUBLIC_READ_ERROR,
+): string | null {
+  if (!error) return null;
+  return TJINN_PUBLIC_ERRORS.has(error) ? error : fallback;
+}
+
+function publicServiceError(status: TjinnServiceStatus, fallback: string): string | null {
+  return redactTjinnPublicError(status.error, fallback);
+}
+
+function publicTjinnStatus(status: TjinnStatus): TjinnStatus {
+  const fallback = status.safeBalanceWei != null
+    ? TJINN_PUBLIC_PARTIAL_ERROR
+    : TJINN_PUBLIC_READ_ERROR;
+  return {
+    ...status,
+    error: redactTjinnPublicError(status.error, fallback),
+    services: status.services.map((svc) => ({
+      ...svc,
+      error: publicServiceError(svc, fallback),
+    })),
+  };
+}
+
 function buildEarningsHint(raw: GatheredStatusRaw, fleetSum: StatusV1Response['fleet']): string {
   if (raw.hintsScope === 'sqlite_only') {
     return 'Fleet and on-chain earnings hints omitted in API-only mode.';
@@ -415,7 +450,7 @@ export function assembleStatusV1(raw: GatheredStatusRaw): StatusV1Response {
           : claimedRewardsWei.toString(),
       pendingRewardsError: raw.pendingRewardsError,
     },
-    tJinn: raw.tJinn ?? defaultTjinnStatus(),
+    tJinn: publicTjinnStatus(raw.tJinn ?? defaultTjinnStatus()),
     masterGas: {
       address: raw.master.address,
       balanceWei: raw.master.balanceWei,

--- a/client/src/dashboard/spa/src/App.routing.test.tsx
+++ b/client/src/dashboard/spa/src/App.routing.test.tsx
@@ -112,7 +112,7 @@ describe('App routes', () => {
     );
     // Overview renders HeroStats with these canonical eyebrows.
     expect(screen.getByText(/solutions delivered/i)).toBeTruthy();
-    expect(screen.getByText(/jinn claimable/i)).toBeTruthy();
+    expect(screen.getByText(/tjinn earned/i)).toBeTruthy();
   });
 
   it('renders OverviewActivityPage on /overview/activity', async () => {

--- a/client/src/dashboard/spa/src/pages/Overview.test.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.test.tsx
@@ -499,9 +499,70 @@ describe('OverviewPage empty-state gating', () => {
     expect(screen.queryByTestId('live-now-band')).toBeNull();
   });
 
-  it('wires dashboard card actions to their real actions', async () => {
+  it('shows tJINN pending copy instead of staking reward zero or claim action', async () => {
     getStatusMock.mockResolvedValue({
       rewards: { pendingStakingRewardsWei: '1000000000000000000' },
+      tJinn: {
+        state: 'pending',
+        chainId: 11155111,
+        tokenAddress: '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A',
+        safeBalanceWei: null,
+        safeCount: 1,
+        services: [],
+        error: null,
+      },
+      fleet: { services: [] },
+      predictionV1: {
+        operator: { ok: true, solverNet: { name: 'prediction', enabled: false }, diagnostics: [] },
+        totals: { observedTasks: 0, activeTaskRuns: 0, solutions: 0, verdicts: 0, failed: 0 },
+      },
+    });
+    getBootstrapMock.mockResolvedValue({});
+    render(withProviders(<OverviewPage />));
+
+    expect(await screen.findByText(/tjinn earned/i)).toBeTruthy();
+    expect(await screen.findByText(/1 Safe found; waiting for Sepolia balance/i)).toBeTruthy();
+    expect(screen.getByText('Pending')).toBeTruthy();
+    expect(screen.queryByText('1.0000')).toBeNull();
+    expect(screen.queryByRole('button', { name: /claim now/i })).toBeNull();
+  });
+
+  it('shows tJINN error copy when the Sepolia balance read fails', async () => {
+    getStatusMock.mockResolvedValue({
+      tJinn: {
+        state: 'error',
+        chainId: 11155111,
+        tokenAddress: '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A',
+        safeBalanceWei: null,
+        safeCount: 1,
+        services: [],
+        error: 'Sepolia RPC unavailable',
+      },
+      fleet: { services: [] },
+      predictionV1: {
+        operator: { ok: true, solverNet: { name: 'prediction', enabled: false }, diagnostics: [] },
+        totals: { observedTasks: 0, activeTaskRuns: 0, solutions: 0, verdicts: 0, failed: 0 },
+      },
+    });
+    getBootstrapMock.mockResolvedValue({});
+    render(withProviders(<OverviewPage />));
+
+    expect(await screen.findByText(/tjinn earned/i)).toBeTruthy();
+    expect(await screen.findByText('Unavailable')).toBeTruthy();
+    expect(screen.getByText('Sepolia RPC unavailable')).toBeTruthy();
+  });
+
+  it('wires dashboard card actions to their real actions', async () => {
+    getStatusMock.mockResolvedValue({
+      tJinn: {
+        state: 'ready',
+        chainId: 11155111,
+        tokenAddress: '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A',
+        safeBalanceWei: '1000000000000000000',
+        safeCount: 1,
+        services: [],
+        error: null,
+      },
       masterGas: { balanceWei: '23000000000000000', runwayDaysExcess: 4 },
       fleet: { services: [] },
       predictionV1: {
@@ -520,12 +581,10 @@ describe('OverviewPage empty-state gating', () => {
     });
     const { history } = renderOverviewWithMemory();
 
-    expect(await screen.findByText(/jinn claimable/i)).toBeTruthy();
+    expect(await screen.findByText(/tjinn earned/i)).toBeTruthy();
     expect(screen.queryByText(/quick actions/i)).toBeNull();
     expect(screen.queryByRole('button', { name: /manage wallet/i })).toBeNull();
-
-    fireEvent.click(screen.getByRole('button', { name: /claim now/i }));
-    await waitFor(() => expect(claimRewardsMock).toHaveBeenCalledOnce());
+    expect(screen.queryByRole('button', { name: /claim now/i })).toBeNull();
 
     fireEvent.click(screen.getByRole('button', { name: /top up/i }));
     await waitFor(() => expect(triggerDripMock).toHaveBeenCalledOnce());
@@ -544,7 +603,15 @@ describe('OverviewPage empty-state gating', () => {
 // notice must disappear on its own.
 describe('OverviewPage restart notice', () => {
   const restartStatus = {
-    rewards: { pendingStakingRewardsWei: '1000000000000000000' },
+    tJinn: {
+      state: 'ready',
+      chainId: 11155111,
+      tokenAddress: '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A',
+      safeBalanceWei: '1000000000000000000',
+      safeCount: 1,
+      services: [],
+      error: null,
+    },
     masterGas: { balanceWei: '23000000000000000', runwayDaysExcess: 4 },
     fleet: { services: [] },
     predictionV1: {
@@ -595,7 +662,15 @@ describe('OverviewPage restart notice', () => {
 // request is in flight.
 describe('OverviewPage gas top-up', () => {
   const gasStatus = {
-    rewards: { pendingStakingRewardsWei: '1000000000000000000' },
+    tJinn: {
+      state: 'ready',
+      chainId: 11155111,
+      tokenAddress: '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A',
+      safeBalanceWei: '1000000000000000000',
+      safeCount: 1,
+      services: [],
+      error: null,
+    },
     masterGas: { balanceWei: '23000000000000000', runwayDaysExcess: 4 },
     fleet: { services: [] },
     predictionV1: {

--- a/client/src/dashboard/spa/src/pages/Overview.test.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.test.tsx
@@ -536,7 +536,7 @@ describe('OverviewPage empty-state gating', () => {
         safeBalanceWei: null,
         safeCount: 1,
         services: [],
-        error: 'Sepolia RPC unavailable',
+        error: 'HTTP request failed for https://rpc.sepolia.example?apikey=secret',
       },
       fleet: { services: [] },
       predictionV1: {
@@ -549,7 +549,37 @@ describe('OverviewPage empty-state gating', () => {
 
     expect(await screen.findByText(/tjinn earned/i)).toBeTruthy();
     expect(await screen.findByText('Unavailable')).toBeTruthy();
-    expect(screen.getByText('Sepolia RPC unavailable')).toBeTruthy();
+    expect(screen.getByText('Sepolia tJINN balance temporarily unavailable.')).toBeTruthy();
+    expect(screen.queryByText(/apikey=secret/i)).toBeNull();
+    expect(screen.queryByText(/rpc\.sepolia\.example/i)).toBeNull();
+  });
+
+  it('shows a partial tJINN total with generic error copy', async () => {
+    getStatusMock.mockResolvedValue({
+      tJinn: {
+        state: 'error',
+        chainId: 11155111,
+        tokenAddress: '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A',
+        safeBalanceWei: '1500000000000000000',
+        safeCount: 2,
+        services: [],
+        error: 'HTTP request failed for https://rpc.sepolia.example?apikey=secret',
+      },
+      fleet: { services: [] },
+      predictionV1: {
+        operator: { ok: true, solverNet: { name: 'prediction', enabled: false }, diagnostics: [] },
+        totals: { observedTasks: 0, activeTaskRuns: 0, solutions: 0, verdicts: 0, failed: 0 },
+      },
+    });
+    getBootstrapMock.mockResolvedValue({});
+    render(withProviders(<OverviewPage />));
+
+    expect(await screen.findByText(/tjinn earned/i)).toBeTruthy();
+    expect(await screen.findByText('1.5000')).toBeTruthy();
+    expect(screen.getByText('tJINN')).toBeTruthy();
+    expect(screen.getByText('Some Safe balances are temporarily unavailable.')).toBeTruthy();
+    expect(screen.queryByText(/apikey=secret/i)).toBeNull();
+    expect(screen.queryByText(/rpc\.sepolia\.example/i)).toBeNull();
   });
 
   it('wires dashboard card actions to their real actions', async () => {

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -31,6 +31,21 @@ interface OverviewStatusV1 {
   rewards?: {
     pendingStakingRewardsWei?: string;
   };
+  tJinn?: {
+    state?: 'pending' | 'ready' | 'error';
+    chainId?: number;
+    tokenAddress?: string;
+    safeBalanceWei?: string | null;
+    safeCount?: number;
+    error?: string | null;
+    services?: Array<{
+      index: number;
+      safeAddress: string | null;
+      balanceWei: string | null;
+      state: 'pending' | 'ready' | 'error';
+      error: string | null;
+    }>;
+  };
   masterGas?: {
     balanceWei?: string;
     runwayDaysExcess?: string | number | null;
@@ -101,6 +116,43 @@ function formatEth(wei?: string): string {
   } catch {
     return '—';
   }
+}
+
+function safeWord(count: number): string {
+  return count === 1 ? 'Safe' : 'Safes';
+}
+
+function formatTjinn(status?: OverviewStatusV1['tJinn']): {
+  value: string;
+  unit?: string;
+  sub: string;
+} {
+  if (!status) {
+    return { value: 'Pending', sub: 'Waiting for Sepolia balance.' };
+  }
+
+  const safeCount = status.safeCount ?? 0;
+  if (status.state === 'ready' && status.safeBalanceWei != null) {
+    return {
+      value: formatEth(status.safeBalanceWei),
+      unit: 'tJINN',
+      sub: `${safeCount} ${safeWord(safeCount)} on Sepolia`,
+    };
+  }
+
+  if (status.state === 'error') {
+    return {
+      value: 'Unavailable',
+      sub: status.error ?? 'Sepolia tJINN balance read failed.',
+    };
+  }
+
+  return {
+    value: 'Pending',
+    sub: safeCount > 0
+      ? `${safeCount} ${safeWord(safeCount)} found; waiting for Sepolia balance.`
+      : 'Waiting for Safe address.',
+  };
 }
 
 /**
@@ -200,7 +252,7 @@ export function OverviewPage(): JSX.Element {
   const evictedServiceId = firstEvictedService?.serviceId ?? null;
 
   const tasksDelivered = totals.solutions;
-  const jinnClaimable = formatEth(status?.rewards?.pendingStakingRewardsWei);
+  const tjinnEarned = formatTjinn(status?.tJinn);
   const gasBalanceEth = formatEth(status?.masterGas?.balanceWei);
   const gasRunwayDays = status?.masterGas?.runwayDaysExcess ?? '—';
   // Gate the LiveNow attention banner on the freshly-polled join map so a
@@ -258,7 +310,9 @@ export function OverviewPage(): JSX.Element {
     <div style={{ padding: '24px', display: 'flex', flexDirection: 'column', gap: '24px' }}>
       <HeroStats
         tasksDelivered={tasksDelivered}
-        jinnClaimable={jinnClaimable}
+        tjinnEarned={tjinnEarned.value}
+        tjinnEarnedUnit={tjinnEarned.unit}
+        tjinnEarnedSub={tjinnEarned.sub}
         gasBalanceEth={gasBalanceEth}
         gasRunwayDays={gasRunwayDays}
         statusLabel={LIVE_NOW_STATE_LABEL[liveNow.state]}
@@ -271,14 +325,6 @@ export function OverviewPage(): JSX.Element {
         activeAction={activeAction}
         evicted={isEvicted}
         evictedServiceId={evictedServiceId}
-        onClaim={() =>
-          runAction('Claim JINN', async () => {
-            const res = await api.claimRewards();
-            if (!res.ok) {
-              throw new Error(res.error ?? 'Reward claim failed.');
-            }
-            return { message: 'JINN claim command completed.' };
-          })}
         onTopUp={() =>
           runAction(
             'Top up gas',

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -141,9 +141,16 @@ function formatTjinn(status?: OverviewStatusV1['tJinn']): {
   }
 
   if (status.state === 'error') {
+    if (status.safeBalanceWei != null) {
+      return {
+        value: formatEth(status.safeBalanceWei),
+        unit: 'tJINN',
+        sub: 'Some Safe balances are temporarily unavailable.',
+      };
+    }
     return {
       value: 'Unavailable',
-      sub: status.error ?? 'Sepolia tJINN balance read failed.',
+      sub: 'Sepolia tJINN balance temporarily unavailable.',
     };
   }
 

--- a/client/src/dashboard/spa/src/pages/overview/HeroStats.test.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/HeroStats.test.tsx
@@ -5,7 +5,9 @@ import { HeroStats } from './HeroStats.js';
 function defaultProps() {
   return {
     tasksDelivered: 42,
-    jinnClaimable: '123',
+    tjinnEarned: '123',
+    tjinnEarnedUnit: 'tJINN',
+    tjinnEarnedSub: '1 Safe on Sepolia',
     gasBalanceEth: '0.5000',
     gasRunwayDays: 4,
     statusLabel: 'WORKING',
@@ -14,7 +16,6 @@ function defaultProps() {
     statusReason: '1 task restoring',
     activeAction: null,
     evicted: false,
-    onClaim: () => undefined,
     onTopUp: () => undefined,
     onRestart: () => undefined,
   };
@@ -24,14 +25,15 @@ describe('HeroStats', () => {
   it('renders overview stats plus compact status', () => {
     render(<HeroStats {...defaultProps()} />);
     expect(screen.getByText(/solutions delivered/i)).toBeTruthy();
-    expect(screen.getByText(/jinn claimable/i)).toBeTruthy();
-    expect(screen.queryByText(/jinn earned/i)).toBeNull();
+    expect(screen.getByText(/tjinn earned/i)).toBeTruthy();
+    expect(screen.queryByText(/jinn claimable/i)).toBeNull();
     expect(screen.getByText('42')).toBeTruthy();
     expect(screen.getByText('123')).toBeTruthy();
+    expect(screen.getByText('1 Safe on Sepolia')).toBeTruthy();
     expect(screen.getByText('0.5000')).toBeTruthy();
     expect(screen.getByText(/4 days runway/i)).toBeTruthy();
     expect(screen.getByText('WORKING')).toBeTruthy();
-    expect(screen.getByRole('button', { name: /claim now/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /claim now/i })).toBeNull();
     expect(screen.getByRole('button', { name: /top up/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /restart/i })).toBeTruthy();
     expect(screen.getByTestId('overview-status-stat').getAttribute('data-state')).toBe('working');
@@ -39,11 +41,9 @@ describe('HeroStats', () => {
     expect(screen.queryByText(/node status/i)).toBeNull();
   });
 
-  it('disables Claim now CTA when evicted=true and renders eviction notice (jinn-mono-hjex.3)', () => {
+  it('renders eviction notice without a claim CTA when evicted=true (jinn-mono-hjex.3)', () => {
     render(<HeroStats {...defaultProps()} evicted={true} />);
-    const claimBtn = screen.getByRole('button', { name: /claim now/i });
-    // Button must be disabled when service is evicted
-    expect(claimBtn).toHaveProperty('disabled', true);
+    expect(screen.queryByRole('button', { name: /claim now/i })).toBeNull();
     // Eviction explainer must be visible — no OLAS mention
     expect(screen.getByText(/service evicted/i)).toBeTruthy();
     expect(screen.queryByText(/OLAS/i)).toBeNull();

--- a/client/src/dashboard/spa/src/pages/overview/HeroStats.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/HeroStats.tsx
@@ -8,7 +8,9 @@ import type { LiveNowState } from './LiveNowBand.js';
 
 export interface HeroStatsProps {
   tasksDelivered: number;
-  jinnClaimable: string;
+  tjinnEarned: string;
+  tjinnEarnedUnit?: string;
+  tjinnEarnedSub?: string;
   gasBalanceEth: string;
   gasRunwayDays: number | string;
   statusLabel: string;
@@ -26,7 +28,6 @@ export interface HeroStatsProps {
   evicted?: boolean;
   /** Service ID of the evicted service. Required when evicted=true to wire the Re-stake CTA. */
   evictedServiceId?: number | null;
-  onClaim: () => void;
   onTopUp: () => void;
   onRestart: () => void;
   /** Called when the operator clicks "Re-stake now". Should POST to /v1/setup/restake/:serviceId. */
@@ -290,7 +291,9 @@ function StatusStat({
 
 export function HeroStats({
   tasksDelivered,
-  jinnClaimable,
+  tjinnEarned,
+  tjinnEarnedUnit,
+  tjinnEarnedSub,
   gasBalanceEth,
   gasRunwayDays,
   statusLabel,
@@ -300,7 +303,6 @@ export function HeroStats({
   activeAction,
   evicted = false,
   evictedServiceId,
-  onClaim,
   onTopUp,
   onRestart,
   onRestake,
@@ -315,22 +317,11 @@ export function HeroStats({
     >
       <Stat label="Solutions delivered" value={tasksDelivered} />
       <Stat
-        label="JINN claimable"
-        value={jinnClaimable}
-        unit="JINN"
-        action={(
-          <>
-            <ActionButton
-              action="Claim JINN"
-              activeAction={activeAction}
-              onClick={onClaim}
-              forceDisabled={evicted}
-            >
-              Claim now
-            </ActionButton>
-            {evicted ? <EvictionNotice serviceId={evictedServiceId} onRestake={onRestake} /> : null}
-          </>
-        )}
+        label="tJINN earned"
+        value={tjinnEarned}
+        unit={tjinnEarnedUnit}
+        sub={tjinnEarnedSub}
+        action={evicted ? <EvictionNotice serviceId={evictedServiceId} onRestake={onRestake} /> : undefined}
       />
       <Stat
         label="Gas"

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1208,6 +1208,7 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
       status: {
         earningDir: config.earningDir,
         rpcUrl: config.rpcUrl,
+        ethereumRpcUrl: config.ethereumRpcUrl,
         network: config.network,
         pollIntervalMs: config.pollIntervalMs,
         masterEthDailyEstimateWei: config.masterEthDailyEstimateWei,
@@ -2335,6 +2336,7 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     status: {
       earningDir: config.earningDir,
       rpcUrl: config.rpcUrl,
+      ethereumRpcUrl: config.ethereumRpcUrl,
       network: config.network,
       pollIntervalMs: config.pollIntervalMs,
       masterEthDailyEstimateWei: config.masterEthDailyEstimateWei,

--- a/client/test/api/gather-status.test.ts
+++ b/client/test/api/gather-status.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { JinnConfig } from '../../src/config.js';
+import { FleetStateStore } from '../../src/earning/store.js';
 import { TaskRunPersistence } from '../../src/harnesses/engine/persistence.js';
 import type { PredictionOperatorStatus } from '../../src/solver-nets/prediction-operator-ux.js';
 import { withTempStore } from '@test/store.js';
@@ -12,6 +13,103 @@ describe('gatherStatusForApi', () => {
     vi.doUnmock('viem');
     vi.doUnmock('../../src/solver-nets/prediction-operator-ux.js');
     vi.resetModules();
+  });
+
+  it('reads real tJINN balances on Sepolia and deduplicates shared Safe addresses', async () => {
+    const safeA = '0x3333333333333333333333333333333333333333';
+    const safeB = '0x4444444444444444444444444444444444444444';
+    const balanceReads: Array<{ token: string; safe: string; chainId: number }> = [];
+    vi.doMock('viem', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('viem')>();
+      return {
+        ...actual,
+        createPublicClient: ({ chain }: { chain: { id: number } }) => ({
+          getBlockNumber: async () => 123n,
+          getChainId: async () => chain.id,
+          getBalance: async () => 0n,
+          readContract: async (req: {
+            address: string;
+            functionName: string;
+            args?: readonly [`0x${string}`];
+          }) => {
+            if (chain.id === 11155111 && req.functionName === 'balanceOf') {
+              const safe = req.args?.[0] ?? '0x';
+              balanceReads.push({ token: req.address, safe, chainId: chain.id });
+              return safe.toLowerCase() === safeA.toLowerCase() ? 10n : 20n;
+            }
+            return 0n;
+          },
+        }),
+        http: () => ({}),
+      };
+    });
+    const { gatherStatusForApi } = await import('../../src/api/gather-status.js');
+
+    await withTempStore(async (store) => {
+      const earningDir = mkdtempSync(join(tmpdir(), 'jinn-status-test-'));
+      const fleetStore = new FleetStateStore(earningDir);
+      const state = await fleetStore.load('base-sepolia');
+      await fleetStore.save({
+        ...state,
+        master_address: '0x1111111111111111111111111111111111111111',
+        services: [
+          {
+            index: 1,
+            agent_address: '0x2222222222222222222222222222222222222222',
+            safe_address: safeA,
+            service_id: null,
+            mech_address: null,
+            staking_address: null,
+            step: 'awaiting_stake',
+            error: null,
+          },
+          {
+            index: 2,
+            agent_address: '0x5555555555555555555555555555555555555555',
+            safe_address: safeA,
+            service_id: null,
+            mech_address: null,
+            staking_address: null,
+            step: 'awaiting_stake',
+            error: null,
+          },
+          {
+            index: 3,
+            agent_address: '0x6666666666666666666666666666666666666666',
+            safe_address: safeB,
+            service_id: null,
+            mech_address: null,
+            staking_address: null,
+            step: 'awaiting_stake',
+            error: null,
+          },
+        ],
+      });
+
+      const apiStatus = await gatherStatusForApi(store, {
+        earningDir,
+        rpcUrl: 'http://base-sepolia.example',
+        ethereumRpcUrl: 'http://sepolia.example',
+        network: 'testnet',
+        pollIntervalMs: 5000,
+        rewardClaimIntervalMs: 0,
+      });
+
+      expect(apiStatus.tJinn).toMatchObject({
+        state: 'ready',
+        chainId: 11155111,
+        tokenAddress: '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A',
+        safeBalanceWei: '30',
+        safeCount: 2,
+        error: null,
+      });
+      expect(apiStatus.tJinn.services.map((svc) => svc.balanceWei)).toEqual(['10', '10', '20']);
+    });
+
+    expect(balanceReads).toEqual([
+      { token: '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A', safe: safeA, chainId: 11155111 },
+      { token: '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A', safe: safeB, chainId: 11155111 },
+    ]);
   });
 
   function mockStatusRpc(): void {

--- a/client/test/api/gather-status.test.ts
+++ b/client/test/api/gather-status.test.ts
@@ -10,6 +10,7 @@ import { withTempStore } from '@test/store.js';
 
 describe('gatherStatusForApi', () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.doUnmock('viem');
     vi.doUnmock('../../src/solver-nets/prediction-operator-ux.js');
     vi.resetModules();
@@ -110,6 +111,154 @@ describe('gatherStatusForApi', () => {
       { token: '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A', safe: safeA, chainId: 11155111 },
       { token: '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A', safe: safeB, chainId: 11155111 },
     ]);
+  });
+
+  it('keeps successful tJINN balances when one Safe read fails and redacts public errors', async () => {
+    const safeA = '0x3333333333333333333333333333333333333333';
+    const safeB = '0x4444444444444444444444444444444444444444';
+    vi.doMock('viem', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('viem')>();
+      return {
+        ...actual,
+        createPublicClient: ({ chain }: { chain: { id: number } }) => ({
+          getBlockNumber: async () => 123n,
+          getChainId: async () => chain.id,
+          getBalance: async () => 0n,
+          readContract: async (req: {
+            functionName: string;
+            args?: readonly [`0x${string}`];
+          }) => {
+            if (chain.id === 11155111 && req.functionName === 'balanceOf') {
+              const safe = req.args?.[0] ?? '0x';
+              if (safe.toLowerCase() === safeB.toLowerCase()) {
+                throw new Error('HTTP request failed for http://sepolia.example?apikey=secret');
+              }
+              return 10n;
+            }
+            return 0n;
+          },
+        }),
+        http: () => ({}),
+      };
+    });
+    const { gatherStatusForApi } = await import('../../src/api/gather-status.js');
+
+    await withTempStore(async (store) => {
+      const earningDir = mkdtempSync(join(tmpdir(), 'jinn-status-test-'));
+      const fleetStore = new FleetStateStore(earningDir);
+      const state = await fleetStore.load('base-sepolia');
+      await fleetStore.save({
+        ...state,
+        master_address: '0x1111111111111111111111111111111111111111',
+        services: [
+          {
+            index: 1,
+            agent_address: '0x2222222222222222222222222222222222222222',
+            safe_address: safeA,
+            service_id: null,
+            mech_address: null,
+            staking_address: null,
+            step: 'awaiting_stake',
+            error: null,
+          },
+          {
+            index: 2,
+            agent_address: '0x5555555555555555555555555555555555555555',
+            safe_address: safeB,
+            service_id: null,
+            mech_address: null,
+            staking_address: null,
+            step: 'awaiting_stake',
+            error: null,
+          },
+        ],
+      });
+
+      const apiStatus = await gatherStatusForApi(store, {
+        earningDir,
+        rpcUrl: 'http://base-sepolia.example',
+        ethereumRpcUrl: 'http://sepolia.example',
+        network: 'testnet',
+        pollIntervalMs: 5000,
+        rewardClaimIntervalMs: 0,
+      });
+
+      expect(apiStatus.tJinn.state).toBe('error');
+      expect(apiStatus.tJinn.safeBalanceWei).toBe('10');
+      expect(apiStatus.tJinn.error).toBe('Some Safe tJINN balances are temporarily unavailable.');
+      expect(apiStatus.tJinn.services.map((svc) => svc.state)).toEqual(['ready', 'error']);
+      expect(apiStatus.tJinn.services.map((svc) => svc.balanceWei)).toEqual(['10', null]);
+      expect(JSON.stringify(apiStatus.tJinn)).not.toContain('apikey=secret');
+      expect(JSON.stringify(apiStatus.tJinn)).not.toContain('sepolia.example');
+    });
+  });
+
+  it('caches tJINN balance reads for a short TTL', async () => {
+    let now = 1_700_000_000_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    const safeA = '0x3333333333333333333333333333333333333333';
+    const balanceReads: string[] = [];
+    vi.doMock('viem', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('viem')>();
+      return {
+        ...actual,
+        createPublicClient: ({ chain }: { chain: { id: number } }) => ({
+          getBlockNumber: async () => 123n,
+          getChainId: async () => chain.id,
+          getBalance: async () => 0n,
+          readContract: async (req: {
+            functionName: string;
+            args?: readonly [`0x${string}`];
+          }) => {
+            if (chain.id === 11155111 && req.functionName === 'balanceOf') {
+              balanceReads.push(req.args?.[0] ?? '0x');
+              return 10n;
+            }
+            return 0n;
+          },
+        }),
+        http: () => ({}),
+      };
+    });
+    const { gatherStatusForApi } = await import('../../src/api/gather-status.js');
+
+    await withTempStore(async (store) => {
+      const earningDir = mkdtempSync(join(tmpdir(), 'jinn-status-test-'));
+      const fleetStore = new FleetStateStore(earningDir);
+      const state = await fleetStore.load('base-sepolia');
+      await fleetStore.save({
+        ...state,
+        master_address: '0x1111111111111111111111111111111111111111',
+        services: [
+          {
+            index: 1,
+            agent_address: '0x2222222222222222222222222222222222222222',
+            safe_address: safeA,
+            service_id: null,
+            mech_address: null,
+            staking_address: null,
+            step: 'awaiting_stake',
+            error: null,
+          },
+        ],
+      });
+      const status = {
+        earningDir,
+        rpcUrl: 'http://base-sepolia.example',
+        ethereumRpcUrl: 'http://sepolia.example',
+        network: 'testnet' as const,
+        pollIntervalMs: 5000,
+        rewardClaimIntervalMs: 0,
+      };
+
+      await gatherStatusForApi(store, status);
+      now += 5_000;
+      await gatherStatusForApi(store, status);
+      now += 31_000;
+      await gatherStatusForApi(store, status);
+    });
+
+    expect(balanceReads).toEqual([safeA, safeA]);
   });
 
   function mockStatusRpc(): void {

--- a/client/test/api/status-build.test.ts
+++ b/client/test/api/status-build.test.ts
@@ -60,6 +60,15 @@ describe('assembleStatusV1', () => {
     expect(j.nextActions).toHaveLength(1);
     expect(j.nextActions[0]).toMatch(/npm run status/);
     expect(j.earnings.hint).toMatch(/omitted/);
+    expect(j.tJinn).toEqual({
+      state: 'pending',
+      chainId: 11155111,
+      tokenAddress: '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A',
+      safeBalanceWei: null,
+      safeCount: 0,
+      services: [],
+      error: null,
+    });
   });
 
   it('reports zero runway excess when balance is already below minimum', () => {
@@ -150,6 +159,42 @@ describe('assembleStatusV1', () => {
     const j = assembleStatusV1(raw);
     expect(j.rewards.claimedStakingRewardsWei).toBe('800');
     expect(j.rewards.totalStakingRewardsWei).toBe('1000');
+  });
+
+  it('passes tJINN status through separately from staking rewards', () => {
+    const raw: GatheredStatusRaw = {
+      shutdownState: 'running',
+      dbPath: '/tmp/x.db',
+      activityCounts: {},
+      recentActivity: [],
+      lastRewardClaimTickAt: null,
+      rewardClaimIntervalMs: 0,
+      fleet: minimalFleet(),
+      rpc: { ok: true, chainId: 8453, blockNumber: '1' },
+      master: { address: '0x1111111111111111111111111111111111111111' },
+      pendingStakingRewardsWei: '200',
+      tJinn: {
+        state: 'ready',
+        chainId: 11155111,
+        tokenAddress: '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A',
+        safeBalanceWei: '500',
+        safeCount: 1,
+        services: [{
+          index: 0,
+          safeAddress: '0x3333333333333333333333333333333333333333',
+          balanceWei: '500',
+          state: 'ready',
+          error: null,
+        }],
+        error: null,
+      },
+      pollIntervalMs: 5000,
+      masterDailyEstimateWei: '1',
+    };
+    const j = assembleStatusV1(raw);
+    expect(j.rewards.pendingStakingRewardsWei).toBe('200');
+    expect(j.tJinn.safeBalanceWei).toBe('500');
+    expect(j.tJinn.tokenAddress).toBe('0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A');
   });
 
   it('passes prediction.v1 status through when present', () => {

--- a/client/test/api/status-build.test.ts
+++ b/client/test/api/status-build.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   assembleStatusV1,
   resolveMasterDailyEstimateWei,
+  TJINN_PUBLIC_READ_ERROR,
   type GatheredStatusRaw,
 } from '../../src/api/status-build.js';
 import type { FleetState } from '../../src/earning/types.js';
@@ -195,6 +196,42 @@ describe('assembleStatusV1', () => {
     expect(j.rewards.pendingStakingRewardsWei).toBe('200');
     expect(j.tJinn.safeBalanceWei).toBe('500');
     expect(j.tJinn.tokenAddress).toBe('0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A');
+  });
+
+  it('redacts raw tJINN read errors at the public status boundary', () => {
+    const raw: GatheredStatusRaw = {
+      shutdownState: 'running',
+      dbPath: '/tmp/x.db',
+      activityCounts: {},
+      recentActivity: [],
+      lastRewardClaimTickAt: null,
+      rewardClaimIntervalMs: 0,
+      fleet: minimalFleet(),
+      rpc: { ok: true, chainId: 8453, blockNumber: '1' },
+      master: { address: '0x1111111111111111111111111111111111111111' },
+      tJinn: {
+        state: 'error',
+        chainId: 11155111,
+        tokenAddress: '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A',
+        safeBalanceWei: null,
+        safeCount: 1,
+        services: [{
+          index: 0,
+          safeAddress: '0x3333333333333333333333333333333333333333',
+          balanceWei: null,
+          state: 'error',
+          error: 'HTTP request failed for https://rpc.sepolia.example?apikey=secret',
+        }],
+        error: 'HTTP request failed for https://rpc.sepolia.example?apikey=secret',
+      },
+      pollIntervalMs: 5000,
+      masterDailyEstimateWei: '1',
+    };
+    const j = assembleStatusV1(raw);
+    expect(j.tJinn.error).toBe(TJINN_PUBLIC_READ_ERROR);
+    expect(j.tJinn.services[0]?.error).toBe(TJINN_PUBLIC_READ_ERROR);
+    expect(JSON.stringify(j.tJinn)).not.toContain('apikey=secret');
+    expect(JSON.stringify(j.tJinn)).not.toContain('rpc.sepolia.example');
   });
 
   it('passes prediction.v1 status through when present', () => {


### PR DESCRIPTION
## Summary

PR 4 for #220 / #406.

- Adds top-level `/v1/status.tJinn` with Sepolia tJINN token address, chain id, state, summed Safe balance, Safe count, service rows, and error state.
- Reads real Sepolia ERC-20 `balanceOf` for tJINN `0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A`.
- Deduplicates shared Safe addresses before summing `safeBalanceWei`.
- Threads `ethereumRpcUrl` into status wiring so live daemon status can read Sepolia.
- Rewires Overview/HeroStats from `rewards.pendingStakingRewardsWei` to `status.tJinn.safeBalanceWei`.
- Renames the hero tile to `tJINN earned`, shows pending/error copy, and removes the misleading `Claim now` action from that tile.

## Verification

- `yarn vitest run test/api/status-build.test.ts test/api/gather-status.test.ts src/dashboard/spa/src/pages/overview/HeroStats.test.tsx src/dashboard/spa/src/pages/Overview.test.tsx src/dashboard/spa/src/App.routing.test.tsx`
- `yarn typecheck`
- `yarn build:spa` (existing chunk-size warning only)

Part of #220
Closes #406