### PR TITLE
fix(engine): canAcceptTask uses cached harness readiness, not a per-task blocking probe

### DIFF
--- a/client/src/harnesses/engine/engine.ts
+++ b/client/src/harnesses/engine/engine.ts
@@ -424,12 +424,39 @@ export class TaskEngine {
     }
   }
 
+  /**
+   * Pre-claim acceptance check used by the daemon's engine-watcher loop.
+   *
+   * Performance contract (issue #398): this runs once per task announcement,
+   * on the engine-watcher hot path, for every observed task. It MUST NOT
+   * perform per-task blocking I/O. In particular it does not probe
+   * `impl.isReady()` — for the Hermes harness that runs two blocking
+   * `spawnSync` child processes, so a backlog would pay per-task blocking
+   * spawns and starve the daemon event loop.
+   *
+   * Harness readiness for the claim gate is instead served O(1) from the
+   * daemon's cached `HarnessReadinessRegistry` snapshot: the engine-watcher
+   * loop calls `gateClaimByReadiness(...)` immediately after `canAcceptTask`
+   * returns. A ~tickIntervalMs-stale snapshot is acceptable — harness
+   * readiness changes on a minutes scale (auth/config) and the daemon
+   * already trusts that cached registry for its post-`canAcceptTask` gate.
+   *
+   * `claim()` (the DISCOVERED → CLAIMED transition) still probes
+   * `impl.isReady()` directly — it runs once per claimed task, not per
+   * announcement, and is the authoritative pre-execution gate.
+   */
   async canAcceptTask(input: {
     solverType?: string;
     taskRole?: 'restoration' | 'evaluation';
     task?: Task;
   }): Promise<{ ok: true } | { ok: false; reason: string }> {
-    const reason = await this.runnableFailureReason(input.solverType, input.taskRole ?? 'restoration', input.task);
+    const reason = await this.runnableFailureReason(
+      input.solverType,
+      input.taskRole ?? 'restoration',
+      input.task,
+      undefined,
+      { skipReadinessProbe: true },
+    );
     return reason ? { ok: false, reason } : { ok: true };
   }
 
@@ -863,11 +890,23 @@ export class TaskEngine {
     return null;
   }
 
+  /**
+   * Shared eligibility evaluation behind both `canAcceptTask` and `claim`.
+   *
+   * `opts.skipReadinessProbe` (issue #398): when true, the per-task
+   * `impl.isReady()` probe is skipped. The engine-watcher's `canAcceptTask`
+   * sets this — it relies on the daemon's cached `HarnessReadinessRegistry`
+   * (via `gateClaimByReadiness`) for the readiness gate instead of a
+   * blocking per-announcement probe. `claim()` leaves it false so the
+   * DISCOVERED → CLAIMED transition still runs the authoritative readiness
+   * probe (once per claimed task, not per announcement).
+   */
   private async runnableFailureReason(
     solverType: string | undefined,
     role: 'restoration' | 'evaluation',
     task?: Task,
     currentRequestId?: string,
+    opts: { skipReadinessProbe?: boolean } = {},
   ): Promise<string | null> {
     // Per-launch operator-eligibility filter (Task 28 of
     // `spec/2026-05-05-solvernet-creation-and-launch.md` §14). When the
@@ -932,7 +971,12 @@ export class TaskEngine {
         }
       }
     }
-    if (impl.isReady) {
+    // The per-task `impl.isReady()` probe is the only blocking I/O on this
+    // path (the Hermes harness spawns child processes synchronously). The
+    // engine-watcher's `canAcceptTask` skips it — readiness is gated O(1) by
+    // the daemon's cached `HarnessReadinessRegistry` right after this call.
+    // `claim()` keeps it as the authoritative pre-execution check.
+    if (!opts.skipReadinessProbe && impl.isReady) {
       const status = await impl.isReady({ solverType: routingKey, role });
       if (!status.ready) {
         return `impl '${impl.name}' not ready: ${status.reason ?? 'unknown'}${status.nextStep?.cli ? ` — run \`${status.nextStep.cli}\`` : ''}`;

--- a/client/test/harnesses/engine/claim-gate.test.ts
+++ b/client/test/harnesses/engine/claim-gate.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -190,5 +190,76 @@ describe('TaskEngine.claim — impl gate', () => {
     await engine.callClaim(persisted);
     const after = engine.db.getByRequestId(input.requestId)!;
     expect(after.state).toBe(TaskRunState.CLAIMED);
+  });
+
+  // ── Issue #398: canAcceptTask must not run a per-task blocking probe ─────────
+  //
+  // canAcceptTask runs once per task announcement on the engine-watcher hot
+  // path. impl.isReady() is the only blocking I/O it could hit (the Hermes
+  // harness spawns child processes synchronously). The daemon already gates
+  // claims O(1) against the cached HarnessReadinessRegistry immediately after
+  // canAcceptTask returns, so canAcceptTask must NOT probe isReady() itself.
+  describe('canAcceptTask — issue #398 readiness probe', () => {
+    it('does NOT invoke impl.isReady() (cached registry gates this downstream)', async () => {
+      const isReady = vi.fn(async () => ({ ready: true }) as ReadyStatus);
+      const engine = new TestEngine({
+        store,
+        paths: { workingDirRoot: '/tmp', implStateDirRoot: '/tmp' },
+        implRegistry: { findFor: () => stubImpl({ isReady }) },
+      });
+
+      const accept = await engine.canAcceptTask({
+        solverType: 'portfolio.v0',
+        taskRole: 'restoration',
+        task: { id: 'announced-task', description: 'test', solverType: 'portfolio.v0', role: 'restoration' },
+      });
+
+      expect(accept).toEqual({ ok: true });
+      // The expensive per-task readiness probe must never be reached.
+      expect(isReady).not.toHaveBeenCalled();
+    });
+
+    it('still accepts a task even when the harness would report not-ready (gate is downstream)', async () => {
+      // A harness whose isReady() reports not-ready must NOT make
+      // canAcceptTask reject — the cached-registry gate in the daemon is the
+      // authoritative readiness check on the watcher path.
+      const isReady = vi.fn(async () => ({
+        ready: false,
+        reason: 'would block if probed',
+      }) as ReadyStatus);
+      const engine = new TestEngine({
+        store,
+        paths: { workingDirRoot: '/tmp', implStateDirRoot: '/tmp' },
+        implRegistry: { findFor: () => stubImpl({ isReady }) },
+      });
+
+      const accept = await engine.canAcceptTask({
+        solverType: 'portfolio.v0',
+        taskRole: 'restoration',
+        task: { id: 'announced-task', description: 'test', solverType: 'portfolio.v0', role: 'restoration' },
+      });
+
+      expect(accept).toEqual({ ok: true });
+      expect(isReady).not.toHaveBeenCalled();
+    });
+
+    it('claim() still probes impl.isReady() — the per-claim authoritative gate is unchanged', async () => {
+      // Contrast with canAcceptTask: claim() runs once per claimed task (not
+      // per announcement) and has no downstream cached-registry gate, so it
+      // must keep probing isReady().
+      const isReady = vi.fn(async () => ({ ready: true }) as ReadyStatus);
+      const engine = new TestEngine({
+        store,
+        paths: { workingDirRoot: '/tmp', implStateDirRoot: '/tmp' },
+        implRegistry: { findFor: () => stubImpl({ isReady }) },
+      });
+      const input = makeInput();
+      engine.db.insertDiscovered(input);
+
+      await engine.callClaim(engine.db.getByRequestId(input.requestId)!);
+
+      expect(isReady).toHaveBeenCalledTimes(1);
+      expect(engine.db.getByRequestId(input.requestId)!.state).toBe(TaskRunState.CLAIMED);
+    });
   });
 });


### PR DESCRIPTION
Closes #398.

## Problem

`TaskEngine.canAcceptTask()` ran `impl.isReady()` uncached for **every task announcement** on the engine-watcher hot path. For the Hermes harness, `isReady()` spawns two blocking `spawnSync` child processes — so a task backlog paid per-task blocking spawns and starved the daemon event loop.

## Fix

Dropped the redundant per-task `impl.isReady()` probe from `canAcceptTask`'s path — **scoped, not blanket-removed**. The shared `runnableFailureReason` helper is also used by `claim()`, which genuinely needs the probe, so a `skipReadinessProbe` option is threaded through:

- `canAcceptTask` sets `skipReadinessProbe: true`. Readiness for the claim gate is served O(1) from the daemon's cached `HarnessReadinessRegistry` — the engine-watcher loop calls `gateClaimByReadiness(...)` one line after `canAcceptTask` returns. A ~tick-stale snapshot is acceptable; harness readiness changes on a minutes scale.
- `claim()` (the DISCOVERED → CLAIMED transition) leaves it unset — the `impl.isReady()` probe stays as the authoritative pre-execution gate. It runs once per *claimed* task, not per announcement.

Routing `canAcceptTask` through the cached registry directly was rejected: `TaskEngine` has no registry reference (it lives on the daemon, threaded into `gateClaimByReadiness`), and the watcher already calls that gate — adding a registry dependency to the engine would be the messier change.

## Tests

3 new regression tests in `claim-gate.test.ts`:
- `canAcceptTask` does NOT invoke `impl.isReady()` (spy asserts zero calls)
- `canAcceptTask` accepts even when the harness reports not-ready (gate is downstream)
- `claim()` still probes `impl.isReady()` exactly once

Verification: `tsc --noEmit` clean; per-file vitest green — `claim-gate` 10/10, `engine` 51/51, `joined-eligibility` 18/18, `prediction-v1-runtime-gate` 8/8, `claim-readiness-gate` 5/5, `skip-log-dedup` 19/19, `daemon` 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)