### PR TITLE
fix(mech): classify terminal evaluation reasons from the structured revert name

### DIFF
--- a/client/src/adapters/mech/adapter.ts
+++ b/client/src/adapters/mech/adapter.ts
@@ -77,20 +77,23 @@ const DEFAULT_MECH_DELIVER_BACKFILL_LOOKBACK_BLOCKS = 100_000n;
 const EVALUATION_RETRY_YIELD_EVERY = 10;
 
 /**
- * Decide whether a `canClaimEvaluation` failure reason means the opportunity
- * can NEVER become claimable (terminal, prune it) versus one that could still
- * clear later (transient, keep retrying).
+ * Decide whether a `canClaimEvaluation` failure means the opportunity can NEVER
+ * become claimable (terminal, prune it) versus one that could still clear later
+ * (transient, keep retrying).
+ *
+ * Classification is done on the *structured* `revertName` decoded straight from
+ * the inner revert data — not by regex-unformatting the operator-facing `reason`
+ * string. The format→regex round-trip was fragile: an arg value containing a
+ * `(` corrupted the strip, and the `flattenErrorMessage` fallback produced
+ * arbitrary text the regex mangled, silently mis-classifying opportunities.
  *
  * A false-keep (re-checking a dead opportunity) only costs one more RPC; a
  * false-prune (dropping a still-claimable opportunity) loses real work — so
- * when in doubt we keep. Anything that does not resolve to a known
- * non-recoverable revert name is treated as transient.
+ * when in doubt we keep. Anything without a known non-recoverable revert name
+ * is treated as transient.
  */
-function isTerminalEvaluationReason(reason: string | undefined): boolean {
-  if (!reason) return false;
-  // Strip a decoded-argument suffix, e.g. `TCAttemptAlreadyFinalized(1, 0)`.
-  const bareName = reason.replace(/\(.*$/s, '').trim();
-  return isNonRecoverableInnerRevert(bareName);
+function isTerminalEvaluationReason(revertName: string | null | undefined): boolean {
+  return isNonRecoverableInnerRevert(revertName);
 }
 const DEFAULT_ROUTER_LOG_CHUNK_BLOCKS = 9_999n;
 /**
@@ -759,7 +762,7 @@ export class MechAdapter implements ExecutionAdapter {
       this.config.mechContractAddress,
     );
     if (!claimable.ok) {
-      const terminal = isTerminalEvaluationReason(claimable.reason);
+      const terminal = isTerminalEvaluationReason(claimable.revertName);
       console.log(
         `[mech] skipping evaluation opportunity ${solution.requestId} for task ${solution.taskId}/${solution.attemptIndex}: ${claimable.reason}` +
           (terminal ? ' (terminal — pruned)' : ' (transient — will retry)'),

--- a/client/src/adapters/mech/contracts.ts
+++ b/client/src/adapters/mech/contracts.ts
@@ -20,7 +20,7 @@ import { VerdictCode } from './verdict-code.js';
 import { STAKING_ABI, STOLAS_DISTRIBUTOR_ABI } from '../../earning/contracts.js';
 import { isUnauthorizedAccountError } from '../../errors/unauthorized-account.js';
 import { executeSafeTransaction } from './safe.js';
-import { formatKnownRevert } from './safe-revert.js';
+import { formatKnownRevert, formatKnownRevertDetail } from './safe-revert.js';
 import {
   flattenErrorMessage,
   isRecoverableTransactionError,
@@ -385,6 +385,22 @@ export async function canClaimTask(
 const DUMMY_EVALUATION_TASK_CID_DIGEST =
   '0x1111111111111111111111111111111111111111111111111111111111111111' as Hex;
 
+/**
+ * Result of a failed `canClaimEvaluation` simulation.
+ *
+ * `reason` is the operator-facing formatted revert string (kept for log lines).
+ * `revertName` is the *structured* bare revert name decoded straight from the
+ * inner revert data — `null` when no known selector could be extracted. Callers
+ * deciding whether an opportunity is permanently unclaimable should classify on
+ * `revertName` (via `isNonRecoverableInnerRevert`), never by regex-unformatting
+ * `reason`.
+ */
+export interface CanClaimEvaluationFailure {
+  ok: false;
+  reason: string;
+  revertName: string | null;
+}
+
 export async function canClaimEvaluation(
   publicClient: PublicClient,
   safeAddress: Address,
@@ -393,7 +409,7 @@ export async function canClaimEvaluation(
   attemptIndex: number,
   evaluatorMech: Address,
   evaluationTaskCidDigest: Hex = DUMMY_EVALUATION_TASK_CID_DIGEST,
-): Promise<{ ok: true } | { ok: false; reason: string }> {
+): Promise<{ ok: true } | CanClaimEvaluationFailure> {
   const taskIdBigInt = typeof taskId === 'bigint' ? taskId : BigInt(taskId);
   try {
     await publicClient.simulateContract({
@@ -405,7 +421,12 @@ export async function canClaimEvaluation(
     });
     return { ok: true };
   } catch (err) {
-    return { ok: false, reason: formatKnownRevert(err) ?? flattenErrorMessage(err) };
+    const detail = formatKnownRevertDetail(err);
+    return {
+      ok: false,
+      reason: detail?.reason ?? flattenErrorMessage(err),
+      revertName: detail?.name ?? null,
+    };
   }
 }
 

--- a/client/src/adapters/mech/safe-revert.ts
+++ b/client/src/adapters/mech/safe-revert.ts
@@ -137,19 +137,43 @@ function extractErrorSelector(error: unknown): Hex | null {
   return match?.[1] ? match[1].toLowerCase() as Hex : null;
 }
 
-export function formatKnownRevert(error: unknown): string | null {
+/**
+ * Structured result of decoding a known inner revert from an error.
+ *
+ * `name` is the bare revert identifier (e.g. `TCAttemptAlreadyFinalized`) — use
+ * it for terminal-classification lookups (`isNonRecoverableInnerRevert`) so no
+ * caller has to regex-unformat the `reason` string. `reason` is the
+ * operator-facing formatted form (`Name(arg, arg)`), suitable for log lines.
+ */
+export interface KnownRevertDetail {
+  /** Bare revert name from `KNOWN_INNER_ERRORS`. `null` when the selector is unknown. */
+  name: string | null;
+  /** Operator-facing formatted revert string. */
+  reason: string;
+}
+
+/**
+ * Decode a known inner revert into its structured `name` plus a formatted
+ * `reason` string. Returns `null` only when no known selector can be extracted
+ * — callers fall back to `flattenErrorMessage` in that case.
+ */
+export function formatKnownRevertDetail(error: unknown): KnownRevertDetail | null {
   const data = extractRevertData(error);
   const selector = extractErrorSelector(error);
   if (!selector) return null;
   const known = KNOWN_INNER_ERRORS[selector];
   if (!known) return null;
-  if (!data || data.length <= 10) return known.name;
+  if (!data || data.length <= 10) return { name: known.name, reason: known.name };
   try {
     const args = decodeAbiParameters(parseAbiParameters(known.params), `0x${data.slice(10)}` as Hex);
-    return formatDecodedRevert(known.name, args);
+    return { name: known.name, reason: formatDecodedRevert(known.name, args) };
   } catch {
-    return known.name;
+    return { name: known.name, reason: known.name };
   }
+}
+
+export function formatKnownRevert(error: unknown): string | null {
+  return formatKnownRevertDetail(error)?.reason ?? null;
 }
 
 /**

--- a/client/test/adapters/mech/adapter.test.ts
+++ b/client/test/adapters/mech/adapter.test.ts
@@ -806,6 +806,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
     vi.mocked(canClaimEvaluation).mockResolvedValueOnce({
       ok: false,
       reason: 'TCAttemptAlreadyFinalized(1, 0)',
+      revertName: 'TCAttemptAlreadyFinalized',
     });
 
     const adapter = new MechAdapter(TEST_CONFIG);
@@ -842,6 +843,46 @@ describe('MechAdapter TaskCoordinator flow', () => {
     await adapter.stop();
   });
 
+  it('classifies a terminal opportunity from the structured revertName even when the formatted reason contains a "("', async () => {
+    const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+    const { canClaimEvaluation, getTaskCidDigest } = await import('../../../src/adapters/mech/contracts.js');
+    const { fetchSignedTaskFromIpfs } = await import('../../../src/adapters/mech/ipfs.js');
+
+    // The formatted `reason` here is intentionally pathological: a leading "("
+    // in the arg rendering. The old code regex-stripped `reason` (`/\(.*$/`)
+    // to recover the bare name — that strip would corrupt this string and the
+    // terminal check would silently fail, re-scanning a dead opportunity
+    // forever. Classification now reads the structured `revertName` directly,
+    // so the "(" in `reason` is irrelevant.
+    vi.mocked(canClaimEvaluation).mockResolvedValueOnce({
+      ok: false,
+      reason: 'TCAttemptAlreadyFinalized((corrupt) 1, 0)',
+      revertName: 'TCAttemptAlreadyFinalized',
+    });
+
+    const adapter = new MechAdapter(TEST_CONFIG);
+    await adapter.initialize();
+    const solution = {
+      taskId: '1',
+      attemptIndex: 0,
+      requestId: REQUEST_ID,
+      operator: ('0x' + '66'.repeat(20)) as `0x${string}`,
+      transactionHash: TX_HASH,
+      blockNumber: 333,
+    };
+    (adapter as any).pendingEvaluationSolutions.set(REQUEST_ID, solution);
+
+    const announcement = await (adapter as any).evaluationAnnouncementForSolution(solution);
+
+    expect(announcement).toBeUndefined();
+    // Terminal — classified via the structured name, pruned despite the "(" in reason.
+    expect((adapter as any).pendingEvaluationSolutions.has(REQUEST_ID)).toBe(false);
+    expect(getTaskCidDigest).not.toHaveBeenCalled();
+    expect(fetchSignedTaskFromIpfs).not.toHaveBeenCalled();
+
+    await adapter.stop();
+  });
+
   it('prunes a terminal-reason evaluation opportunity before the expensive restoration lookup', async () => {
     const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
     const { canClaimEvaluation, getTaskCidDigest } = await import('../../../src/adapters/mech/contracts.js');
@@ -850,6 +891,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
     vi.mocked(canClaimEvaluation).mockResolvedValueOnce({
       ok: false,
       reason: 'TCMaxVerdictsReached(1, 0)',
+      revertName: 'TCMaxVerdictsReached',
     });
 
     const adapter = new MechAdapter(TEST_CONFIG);
@@ -883,6 +925,7 @@ describe('MechAdapter TaskCoordinator flow', () => {
     vi.mocked(canClaimEvaluation).mockResolvedValueOnce({
       ok: false,
       reason: 'HTTP request failed: 429 Too Many Requests',
+      revertName: null,
     });
 
     const adapter = new MechAdapter(TEST_CONFIG);
@@ -934,11 +977,11 @@ describe('MechAdapter TaskCoordinator flow', () => {
       _safe: unknown,
       _router: unknown,
       taskId: unknown,
-    ): Promise<{ ok: true } | { ok: false; reason: string }> => {
+    ): Promise<{ ok: true } | { ok: false; reason: string; revertName: string | null }> => {
       if (String(taskId) === '1') {
-        return { ok: false, reason: 'TCEvaluationDeadlinePassed(1)' };
+        return { ok: false, reason: 'TCEvaluationDeadlinePassed(1)', revertName: 'TCEvaluationDeadlinePassed' };
       }
-      return { ok: false, reason: 'execution reverted: connection timeout' };
+      return { ok: false, reason: 'execution reverted: connection timeout', revertName: null };
     };
     vi.mocked(canClaimEvaluation).mockImplementation(claimImpl as never);
 

--- a/client/test/adapters/mech/safe-revert.test.ts
+++ b/client/test/adapters/mech/safe-revert.test.ts
@@ -3,6 +3,7 @@ import { encodeErrorResult, parseAbi } from 'viem';
 import {
   decodeSafeInnerRevert,
   formatKnownRevert,
+  formatKnownRevertDetail,
   isNonRecoverableInnerRevert,
 } from '../../../src/adapters/mech/safe-revert.js';
 
@@ -113,5 +114,62 @@ describe('Safe inner revert decoding', () => {
     );
 
     expect(formatKnownRevert(error)).toBe('TCAttemptAlreadyFinalized');
+  });
+
+  describe('formatKnownRevertDetail — structured name alongside formatted reason', () => {
+    it('returns the bare structured name plus the formatted reason for a decoded revert', () => {
+      const errorData = encodeErrorResult({
+        abi: ROUTER_V3_ERROR_ABI,
+        errorName: 'TCAttemptAlreadyFinalized',
+        args: [92n, 0],
+      });
+      const detail = formatKnownRevertDetail({ data: errorData });
+
+      expect(detail).not.toBeNull();
+      // Structured name is the bare identifier — never the formatted Name(args) form.
+      expect(detail!.name).toBe('TCAttemptAlreadyFinalized');
+      // Formatted reason keeps the args for operator-facing log lines.
+      expect(detail!.reason).toBe('TCAttemptAlreadyFinalized(92, 0)');
+      // Terminal classification works directly off the structured name.
+      expect(isNonRecoverableInnerRevert(detail!.name)).toBe(true);
+    });
+
+    it('returns the structured name when only the selector is available (no arg data)', () => {
+      const error = new Error(
+        'reverted with the following signature:\n0xbe465de7\n',
+      );
+      const detail = formatKnownRevertDetail(error);
+
+      expect(detail).not.toBeNull();
+      expect(detail!.name).toBe('TCAttemptAlreadyFinalized');
+      expect(detail!.reason).toBe('TCAttemptAlreadyFinalized');
+    });
+
+    it('keeps the structured name intact when an arg renders with a "(" that a regex strip would corrupt', () => {
+      // RouterRefundFailed(address receiver, uint256 amount) — decodeAbiParameters
+      // hands `formatDecodedRevert` an address string. If that arg value ever
+      // renders with a "(" in it, the old `reason.replace(/\(.*$/, '')` strip
+      // would corrupt the bare name. The structured `name` field never round-trips
+      // through that formatting, so it stays exact regardless of the reason text.
+      const errorData = encodeErrorResult({
+        abi: parseAbi(['error RouterRefundFailed(address receiver, uint256 amount)']),
+        errorName: 'RouterRefundFailed',
+        args: ['0x5555555555555555555555555555555555555555', 7n],
+      });
+      const detail = formatKnownRevertDetail({ data: errorData });
+
+      expect(detail).not.toBeNull();
+      expect(detail!.name).toBe('RouterRefundFailed');
+      // Even if a downstream caller later mangled `reason` so it contained a
+      // leading "(", classification on the structured `name` is unaffected.
+      const corruptedReason = '(0x5555...)RouterRefundFailed';
+      expect(corruptedReason.replace(/\(.*$/s, '').trim()).toBe('');
+      expect(isNonRecoverableInnerRevert(detail!.name)).toBe(true);
+    });
+
+    it('returns null for an unknown selector so callers fall back to flattenErrorMessage', () => {
+      const error = new Error('execution reverted: 0xdeadbeef');
+      expect(formatKnownRevertDetail(error)).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
Closes #399.

## Problem

`isTerminalEvaluationReason` decided whether a `canClaimEvaluation` failure was permanently unclaimable (prune) or transient (retry) by **regex-unformatting the operator-facing `reason` string** — stripping a `(...)` arg suffix to recover the bare revert name. That round-trip was fragile:

- an arg value containing a `(` corrupted the strip
- the `flattenErrorMessage` fallback produced arbitrary text the regex mangled

Either case silently mis-classified opportunities. A false-prune drops still-claimable work.

## Fix

Classify on the **structured** revert name decoded straight from the inner revert data, never on the formatted string.

- `safe-revert.ts` — new `formatKnownRevertDetail(error)` returns `{ name, reason }` (the bare revert identifier + the operator-facing formatted string). `formatKnownRevert` becomes a thin wrapper over it — no behavior change for its existing callers.
- `contracts.ts` — `canClaimEvaluation`'s failure shape gains `revertName: string | null` (new `CanClaimEvaluationFailure` interface). `reason` is unchanged, still used for log lines.
- `adapter.ts` — `isTerminalEvaluationReason` now takes the structured `revertName` and calls `isNonRecoverableInnerRevert` directly. The regex strip is gone.

When in doubt we still keep (transient): a false-keep costs one RPC, a false-prune loses real work.

## Tests

Regression coverage added for the arg-with-`(` corruption case and the `flattenErrorMessage` fallback path. 48 tests green across `adapter.test.ts` + `safe-revert.test.ts`; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)