### PR TITLE
feat(codex): support local Ollama provider

### DIFF
--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -15,6 +15,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { isIP } from 'node:net';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { z } from 'zod';
@@ -60,6 +61,20 @@ export interface DefaultSolverNetConfig extends Record<string, unknown> {
 export const DEFAULT_SOLVER_NETS: Record<string, DefaultSolverNetConfig> = {};
 
 const HarnessNameSchema = z.string().transform((name) => canonicalHarnessName(name));
+
+function isLocalCodexBaseUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+    if (url.username || url.password) return false;
+    const hostname = url.hostname.toLowerCase();
+    if (hostname === 'localhost') return true;
+    if (hostname === '[::1]' || hostname === '::1') return true;
+    return isIP(hostname) === 4 && hostname.startsWith('127.');
+  } catch {
+    return false;
+  }
+}
 
 export const JinnConfigSchema = z.object({
   /**
@@ -153,6 +168,16 @@ export const JinnConfigSchema = z.object({
 
   /** Path to the `codex` executable. Defaults to `codex` when unset. */
   codexPath: z.string().optional(),
+
+  /** Default Codex model when a SolverNet does not specify one. */
+  codexModel: z.string().optional(),
+
+  /** Local Codex provider base URL, e.g. http://127.0.0.1:11434/v1 for Ollama. */
+  codexBaseUrl: z
+    .string()
+    .url()
+    .refine(isLocalCodexBaseUrl, 'codexBaseUrl must be a local HTTP(S) URL')
+    .optional(),
 
   /**
    * Timeout in ms for `codex --version` health-check runs.
@@ -770,6 +795,8 @@ export function loadConfig(configPath?: string): JinnConfig {
     merged.hermesDoctorTimeoutMs = parseInt(env['JINN_HERMES_DOCTOR_TIMEOUT_MS'], 10);
   }
   if (env['JINN_CODEX_PATH'])        merged.codexPath = env['JINN_CODEX_PATH'];
+  if (env['JINN_CODEX_MODEL'])       merged.codexModel = env['JINN_CODEX_MODEL'];
+  if (env['JINN_CODEX_BASE_URL'])    merged.codexBaseUrl = env['JINN_CODEX_BASE_URL'];
   if (env['JINN_CODEX_DOCTOR_TIMEOUT_MS']) {
     merged.codexDoctorTimeoutMs = parseInt(env['JINN_CODEX_DOCTOR_TIMEOUT_MS'], 10);
   }
@@ -1071,6 +1098,10 @@ const TRACKED_ENV_VARS = [
   'JINN_HERMES_MODEL',
   'JINN_HERMES_PROVIDER',
   'JINN_HERMES_DOCTOR_TIMEOUT_MS',
+  'JINN_CODEX_PATH',
+  'JINN_CODEX_MODEL',
+  'JINN_CODEX_BASE_URL',
+  'JINN_CODEX_DOCTOR_TIMEOUT_MS',
   'JINN_RUNTIME_MODE',
   'JINN_PEERS',
   'JINN_DISCOVERY_MODE',

--- a/client/src/harnesses/impls/index.ts
+++ b/client/src/harnesses/impls/index.ts
@@ -69,6 +69,8 @@ export interface HarnessEnv {
   codexPath?: string;
   /** Default Codex model when a SolverNet does not specify one. */
   codexModel?: string;
+  /** Local OpenAI-compatible Codex provider base URL. */
+  codexBaseUrl?: string;
   /**
    * Timeout (ms) for the `codex --version` probe in the Codex variant of
    * `LearnerHarness.isReady`.
@@ -253,6 +255,7 @@ export function buildHarnesses(env: HarnessEnv): Harness[] {
   const codexLearnerAdapter = new CodexCodeHarnessAdapter({
     codexPath: env.codexPath,
     codexModel: env.codexModel,
+    codexBaseUrl: env.codexBaseUrl,
     storePath: env.storePath,
     daemonApiUrl: env.daemonApiUrl,
     daemonApiToken: env.daemonApiToken,
@@ -263,6 +266,8 @@ export function buildHarnesses(env: HarnessEnv): Harness[] {
     adapter: codexLearnerAdapter,
     claudePath: env.claudePath,
     ...(env.codexPath !== undefined ? { codexPath: env.codexPath } : {}),
+    ...(env.codexModel !== undefined ? { codexModel: env.codexModel } : {}),
+    ...(env.codexBaseUrl !== undefined ? { codexBaseUrl: env.codexBaseUrl } : {}),
     ...(env.codexDoctorTimeoutMs !== undefined
       ? { codexDoctorTimeoutMs: env.codexDoctorTimeoutMs }
       : {}),

--- a/client/src/harnesses/impls/learner/adapters/codex-code.ts
+++ b/client/src/harnesses/impls/learner/adapters/codex-code.ts
@@ -1,5 +1,6 @@
 import { spawn, spawnSync, type ChildProcess, type SpawnOptions } from 'node:child_process';
 import { accessSync, constants, createWriteStream, mkdirSync } from 'node:fs';
+import { isIP } from 'node:net';
 import { dirname, join, resolve } from 'node:path';
 import { finished } from 'node:stream/promises';
 import { fileURLToPath } from 'node:url';
@@ -9,6 +10,7 @@ import type { HarnessAdapter, TaskSessionInputs } from '../types.js';
 export interface CodexCodeHarnessAdapterConfig {
   codexPath?: string;
   codexModel?: string;
+  codexBaseUrl?: string;
   storePath?: string;
   daemonApiUrl?: string;
   daemonApiToken?: string;
@@ -27,6 +29,7 @@ export interface CodexCodeHarnessAdapterConfig {
 }
 
 const DEFAULT_CODEX_MODEL = 'gpt-5.4-mini';
+const LOCAL_CODEX_PROVIDER = 'jinn-local';
 const MACOS_CODEX_APP_BINARY = '/Applications/Codex.app/Contents/Resources/codex';
 
 const ENV_ALLOWLIST = [
@@ -91,6 +94,49 @@ function taskContextJson(inputs: TaskSessionInputs): string {
   }
 }
 
+function codexConfigPath(parts: string[]): string {
+  return parts.map((part) =>
+    /^[A-Za-z0-9_-]+$/.test(part)
+      ? part
+      : `"${part.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+  ).join('.');
+}
+
+function codexConfigValue(value: string): string {
+  return JSON.stringify(value);
+}
+
+export function isLocalCodexBaseUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+    if (url.username || url.password) return false;
+    const hostname = url.hostname.toLowerCase();
+    if (hostname === 'localhost') return true;
+    if (hostname === '[::1]' || hostname === '::1') return true;
+    return isIP(hostname) === 4 && hostname.startsWith('127.');
+  } catch {
+    return false;
+  }
+}
+
+function codexProviderConfigArgs(baseUrl: string | undefined): string[] {
+  const normalizedBaseUrl = baseUrl?.trim();
+  if (!normalizedBaseUrl) return [];
+  if (normalizedBaseUrl && !isLocalCodexBaseUrl(normalizedBaseUrl)) {
+    throw new Error('codex-code adapter: codexBaseUrl must be local; remote custom providers are not supported');
+  }
+
+  const args = [`model_provider=${codexConfigValue(LOCAL_CODEX_PROVIDER)}`];
+  if (normalizedBaseUrl) {
+    const prefix = ['model_providers', LOCAL_CODEX_PROVIDER];
+    args.push(`${codexConfigPath([...prefix, 'name'])}=${codexConfigValue(LOCAL_CODEX_PROVIDER)}`);
+    args.push(`${codexConfigPath([...prefix, 'base_url'])}=${codexConfigValue(normalizedBaseUrl)}`);
+    args.push(`${codexConfigPath([...prefix, 'wire_api'])}=${codexConfigValue('responses')}`);
+  }
+  return args;
+}
+
 /**
  * Construct the initial task prompt for the Codex Code agent.
  *
@@ -138,6 +184,7 @@ export class CodexCodeHarnessAdapter implements HarnessAdapter {
 
   private readonly codexPath: string;
   private readonly codexModel: string;
+  private readonly codexBaseUrl: string | undefined;
   private readonly storePath: string | undefined;
   private readonly daemonApiUrl: string | undefined;
   private readonly daemonApiToken: string | undefined;
@@ -149,6 +196,7 @@ export class CodexCodeHarnessAdapter implements HarnessAdapter {
   constructor(config: CodexCodeHarnessAdapterConfig = {}) {
     this.codexPath = config.codexPath ?? defaultCodexPath();
     this.codexModel = config.codexModel ?? DEFAULT_CODEX_MODEL;
+    this.codexBaseUrl = config.codexBaseUrl;
     this.storePath = config.storePath;
     this.daemonApiUrl = config.daemonApiUrl;
     this.daemonApiToken = config.daemonApiToken;
@@ -221,6 +269,9 @@ export class CodexCodeHarnessAdapter implements HarnessAdapter {
       '-m',
       inputs.model ?? inputs.claudeModel ?? this.codexModel,
     ];
+    for (const configArg of codexProviderConfigArgs(this.codexBaseUrl)) {
+      args.push('-c', configArg);
+    }
     for (const configArg of prepared.configArgs) {
       args.push('-c', configArg);
     }

--- a/client/src/harnesses/impls/learner/harness.ts
+++ b/client/src/harnesses/impls/learner/harness.ts
@@ -14,6 +14,7 @@ import { resolvePluginRoot } from './plugin-path.js';
 import { harvestOutput } from './harvest.js';
 import { buildClaudeIsReady } from '../../../preflight/claude-auth.js';
 import { probeCodexDoctor } from '../../../api/codex-doctor-endpoint.js';
+import { isLocalCodexBaseUrl } from './adapters/codex-code.js';
 
 /**
  * `Harness` shell. Bridges the engine's dispatch contract
@@ -30,6 +31,7 @@ export class LearnerHarness implements Harness {
   private readonly pluginRoot: string;
   private readonly claudePath: string;
   private readonly codexPath: string | undefined;
+  private readonly codexBaseUrl: string | undefined;
   private readonly codexDoctorTimeoutMs: number | undefined;
   private readonly runtimeMode: 'bare' | 'container' | 'docker-compose';
 
@@ -40,6 +42,7 @@ export class LearnerHarness implements Harness {
     this.pluginRoot = config.pluginRoot ?? resolvePluginRoot();
     this.claudePath = config.claudePath ?? 'claude';
     this.codexPath = config.codexPath;
+    this.codexBaseUrl = config.codexBaseUrl;
     this.codexDoctorTimeoutMs = config.codexDoctorTimeoutMs;
     this.runtimeMode = config.runtimeMode ?? 'bare';
   }
@@ -80,6 +83,8 @@ export class LearnerHarness implements Harness {
    *     failed claims (#348).
    *   - `exitCode !== 0` → binary exists but `codex --version` failed →
    *     ready=false pointing at the Codex precheck panel.
+   *   - local `codexBaseUrl` → binary runs and the local sidecar owns auth, so
+   *     Codex auth is not required.
    *   - `authStatus: 'not_configured'` → binary runs but no `OPENAI_API_KEY`
    *     and no `codex login` session → ready=false with a sign-in nextStep.
    *   - `authStatus: 'expired'` → an `auth.json` is present but its OAuth
@@ -116,6 +121,20 @@ export class LearnerHarness implements Harness {
         nextStep: {
           description:
             'Run `codex --version` locally to surface the problem, or open the Codex precheck panel in the operator dashboard.',
+          url: '/api/codex/doctor',
+        },
+      };
+    }
+    if (this.codexBaseUrl) {
+      if (isLocalCodexBaseUrl(this.codexBaseUrl)) {
+        return { ready: true };
+      }
+      return {
+        ready: false,
+        reason: 'codex base URL must be local',
+        nextStep: {
+          description:
+            'Use a local Codex provider URL such as http://127.0.0.1:11434/v1 or unset JINN_CODEX_BASE_URL.',
           url: '/api/codex/doctor',
         },
       };

--- a/client/src/harnesses/impls/learner/types.ts
+++ b/client/src/harnesses/impls/learner/types.ts
@@ -130,6 +130,10 @@ export interface LearnerHarnessConfig {
    * passed to `probeCodexDoctor()`. Defaults to 'codex' (from PATH).
    */
   codexPath?: string;
+  /** Default Codex model when a SolverNet does not specify one. */
+  codexModel?: string;
+  /** Local OpenAI-compatible Codex provider base URL. */
+  codexBaseUrl?: string;
   /**
    * Timeout (ms) for the `codex --version` probe in the Codex variant's
    * `isReady()`. Defaults to 30s.

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1875,6 +1875,8 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     hermesProvider: config.hermesProvider,
     hermesDoctorTimeoutMs: config.hermesDoctorTimeoutMs,
     codexPath: config.codexPath,
+    codexModel: config.codexModel,
+    codexBaseUrl: config.codexBaseUrl,
     codexDoctorTimeoutMs: config.codexDoctorTimeoutMs,
   })) {
     implRegistry.register(impl);

--- a/client/test/config.test.ts
+++ b/client/test/config.test.ts
@@ -1105,3 +1105,95 @@ describe('hermes config keys', () => {
     expect(cfg.hermesPath).toBe('/opt/hermes/bin/hermes');
   });
 });
+
+describe('codex local provider config keys', () => {
+  const dirs: string[] = [];
+  const CODEX_ENV_KEYS = [
+    'JINN_CODEX_MODEL',
+    'JINN_CODEX_BASE_URL',
+  ] as const;
+  const saved: Record<string, string | undefined> = {};
+  for (const k of CODEX_ENV_KEYS) saved[k] = process.env[k];
+
+  afterEach(async () => {
+    for (const k of CODEX_ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  async function writeConfigFile(contents: Record<string, unknown>): Promise<string> {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'jinn-codex-config-'));
+    dirs.push(dir);
+    const configPath = path.join(dir, 'config.json');
+    await writeFile(configPath, JSON.stringify(contents, null, 2));
+    return configPath;
+  }
+
+  it('loads local Codex provider config from file', async () => {
+    const configPath = await writeConfigFile({
+      network: 'testnet',
+      codexModel: 'llama3.1',
+      codexBaseUrl: 'http://127.0.0.1:11434/v1',
+    });
+
+    const cfg = loadConfig(configPath);
+
+    expect(cfg.codexModel).toBe('llama3.1');
+    expect(cfg.codexBaseUrl).toBe('http://127.0.0.1:11434/v1');
+  });
+
+  it('env vars override Codex provider config values', async () => {
+    const configPath = await writeConfigFile({
+      network: 'testnet',
+      codexModel: 'gpt-5.4-mini',
+      codexBaseUrl: 'http://127.0.0.1:11434/v1',
+    });
+    process.env['JINN_CODEX_MODEL'] = 'qwen2.5-coder';
+    process.env['JINN_CODEX_BASE_URL'] = 'http://localhost:1234/v1';
+
+    const cfg = loadConfig(configPath);
+
+    expect(cfg.codexModel).toBe('qwen2.5-coder');
+    expect(cfg.codexBaseUrl).toBe('http://localhost:1234/v1');
+  });
+
+  it('rejects remote Codex provider base URLs', async () => {
+    const configPath = await writeConfigFile({
+      network: 'testnet',
+      codexBaseUrl: 'https://api.openai.com/v1',
+    });
+
+    let caught: any;
+    try {
+      loadConfig(configPath);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught?.code).toBe('config_invalid');
+    const issues: Array<{ path: string; message: string }> = caught.details?.issues ?? [];
+    expect(issues.some((issue) =>
+      issue.path === 'codexBaseUrl' && /must be a local/i.test(issue.message)
+    )).toBe(true);
+  });
+
+  it('rejects credentials embedded in Codex provider base URLs', async () => {
+    const configPath = await writeConfigFile({
+      network: 'testnet',
+      codexBaseUrl: 'http://user:pass@127.0.0.1:11434/v1',
+    });
+
+    let caught: any;
+    try {
+      loadConfig(configPath);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught?.code).toBe('config_invalid');
+    const issues: Array<{ path: string; message: string }> = caught.details?.issues ?? [];
+    expect(issues.some((issue) =>
+      issue.path === 'codexBaseUrl' && /must be a local/i.test(issue.message)
+    )).toBe(true);
+  });
+});

--- a/client/test/harnesses/impls/build-harnesses.test.ts
+++ b/client/test/harnesses/impls/build-harnesses.test.ts
@@ -1,7 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { buildHarnesses } from '../../../src/harnesses/impls/index.js';
 import { CLAUDE_CODE_HARNESS, CODEX_HARNESS } from '../../../src/harnesses/names.js';
+import { probeCodexDoctor } from '../../../src/api/codex-doctor-endpoint.js';
 import type { Harness } from '../../../src/harnesses/types.js';
+
+vi.mock('../../../src/api/codex-doctor-endpoint.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../src/api/codex-doctor-endpoint.js')>();
+  return {
+    ...actual,
+    probeCodexDoctor: vi.fn(),
+  };
+});
 
 const ENV = {
   stub: true as const,
@@ -75,5 +85,25 @@ describe('buildHarnesses — external impls + disabledNames', () => {
     });
     expect(impls.some((impl) => impl.name === CODEX_HARNESS)).toBe(false);
     expect(impls.some((impl) => impl.name === CLAUDE_CODE_HARNESS)).toBe(true);
+  });
+
+  it('threads local Codex provider config into the Codex harness readiness', async () => {
+    vi.mocked(probeCodexDoctor).mockReturnValue({
+      installed: true,
+      authenticated: false,
+      authStatus: 'not_configured',
+      exitCode: 0,
+      stdout: 'codex 1.2.3',
+      stderr: '',
+    });
+    const impls = buildHarnesses({
+      ...ENV,
+      codexBaseUrl: 'http://127.0.0.1:11434/v1',
+    });
+    const codex = impls.find((impl) => impl.name === CODEX_HARNESS);
+
+    expect(codex).toBeDefined();
+    await expect(codex!.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' }))
+      .resolves.toEqual({ ready: true });
   });
 });

--- a/client/test/harnesses/impls/learner/codex-code-adapter.test.ts
+++ b/client/test/harnesses/impls/learner/codex-code-adapter.test.ts
@@ -277,6 +277,127 @@ describe('CodexCodeHarnessAdapter', () => {
     }
   });
 
+  it('passes local Codex provider config for Ollama-compatible endpoints', async () => {
+    const calls: SpawnCall[] = [];
+    const spawnFn = vi.fn((command: string, args: string[], options: { env?: NodeJS.ProcessEnv; cwd?: string }) => {
+      calls.push({ command, args, options });
+      return fakeCodexChild();
+    });
+    const workingDir = mkdtempSync(join(tmpdir(), 'jinn-codex-ollama-work-'));
+    const implStateDir = mkdtempSync(join(tmpdir(), 'jinn-codex-ollama-state-'));
+    try {
+      const adapter = new CodexCodeHarnessAdapter({
+        codexPath: 'codex-test',
+        codexModel: 'llama3.1',
+        codexBaseUrl: 'http://127.0.0.1:11434/v1',
+        clientRoot: '/client/root',
+        _spawnFn: spawnFn as never,
+        _runSessionStartHook: false,
+      });
+
+      await adapter.runTask({
+        taskId: 'swe-rebench-task-restoration',
+        requestId: '0x' + '7'.repeat(64),
+        solverType: 'swe-rebench-v2.v1',
+        taskBody: sweTask() as never,
+        implStateDir,
+        workingDir,
+        pluginRoots: [sweRuntimePluginRoot, networkToolsPluginRoot],
+        windowStartTs: 1,
+        windowEndTs: 2,
+        msUntilEndTs: 1,
+        mode: 'train',
+        abort: new AbortController().signal,
+      }, learnerPluginRoot);
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]!.args).toEqual(expect.arrayContaining([
+        '--ignore-user-config',
+        '-m',
+        'llama3.1',
+        '-c',
+        'model_provider="jinn-local"',
+        '-c',
+        'model_providers.jinn-local.name="jinn-local"',
+        '-c',
+        'model_providers.jinn-local.base_url="http://127.0.0.1:11434/v1"',
+        '-c',
+        'model_providers.jinn-local.wire_api="responses"',
+      ]));
+    } finally {
+      rmSync(workingDir, { recursive: true, force: true });
+      rmSync(implStateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects non-local Codex provider URLs before spawning', async () => {
+    const spawnFn = vi.fn();
+    const workingDir = mkdtempSync(join(tmpdir(), 'jinn-codex-remote-work-'));
+    const implStateDir = mkdtempSync(join(tmpdir(), 'jinn-codex-remote-state-'));
+    try {
+      const adapter = new CodexCodeHarnessAdapter({
+        codexPath: 'codex-test',
+        codexBaseUrl: 'https://api.openai.com/v1',
+        clientRoot: '/client/root',
+        _spawnFn: spawnFn as never,
+        _runSessionStartHook: false,
+      });
+
+      await expect(adapter.runTask({
+        taskId: 'swe-rebench-task-restoration',
+        requestId: '0x' + '7'.repeat(64),
+        solverType: 'swe-rebench-v2.v1',
+        taskBody: sweTask() as never,
+        implStateDir,
+        workingDir,
+        pluginRoots: [sweRuntimePluginRoot, networkToolsPluginRoot],
+        windowStartTs: 1,
+        windowEndTs: 2,
+        msUntilEndTs: 1,
+        mode: 'train',
+        abort: new AbortController().signal,
+      }, learnerPluginRoot)).rejects.toThrow(/codexBaseUrl must be local/i);
+      expect(spawnFn).not.toHaveBeenCalled();
+    } finally {
+      rmSync(workingDir, { recursive: true, force: true });
+      rmSync(implStateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects Codex provider URLs with embedded credentials before spawning', async () => {
+    const spawnFn = vi.fn();
+    const workingDir = mkdtempSync(join(tmpdir(), 'jinn-codex-url-creds-work-'));
+    const implStateDir = mkdtempSync(join(tmpdir(), 'jinn-codex-url-creds-state-'));
+    try {
+      const adapter = new CodexCodeHarnessAdapter({
+        codexPath: 'codex-test',
+        codexBaseUrl: 'http://user:pass@127.0.0.1:11434/v1',
+        clientRoot: '/client/root',
+        _spawnFn: spawnFn as never,
+        _runSessionStartHook: false,
+      });
+
+      await expect(adapter.runTask({
+        taskId: 'swe-rebench-task-restoration',
+        requestId: '0x' + '7'.repeat(64),
+        solverType: 'swe-rebench-v2.v1',
+        taskBody: sweTask() as never,
+        implStateDir,
+        workingDir,
+        pluginRoots: [sweRuntimePluginRoot, networkToolsPluginRoot],
+        windowStartTs: 1,
+        windowEndTs: 2,
+        msUntilEndTs: 1,
+        mode: 'train',
+        abort: new AbortController().signal,
+      }, learnerPluginRoot)).rejects.toThrow(/codexBaseUrl must be local/i);
+      expect(spawnFn).not.toHaveBeenCalled();
+    } finally {
+      rmSync(workingDir, { recursive: true, force: true });
+      rmSync(implStateDir, { recursive: true, force: true });
+    }
+  });
+
   it('round-trips swe-rebench solution payload through Codex adapter and learner harvester', async () => {
     const spawnFn = vi.fn((_command: string, _args: string[], options: { env?: NodeJS.ProcessEnv; cwd?: string }) =>
       fakeCodexChild(() => {

--- a/client/test/harnesses/impls/learner/codex-is-ready.test.ts
+++ b/client/test/harnesses/impls/learner/codex-is-ready.test.ts
@@ -80,6 +80,62 @@ describe('LearnerHarness.isReady — Codex variant (#348)', () => {
     expect(result.nextStep?.description).toMatch(/sign in|OPENAI_API_KEY|codex login/i);
   });
 
+  it('returns ready=true for local Codex provider when binary is installed without OpenAI auth', async () => {
+    vi.mocked(probeCodexDoctor).mockReturnValue({
+      installed: true,
+      authenticated: false,
+      authStatus: 'not_configured',
+      exitCode: 0,
+      stdout: 'codex 1.2.3',
+      stderr: '',
+    });
+    const harness = new LearnerHarness({
+      name: CODEX_HARNESS,
+      adapter: new NoOpAdapter(),
+      codexBaseUrl: 'http://127.0.0.1:11434/v1',
+    });
+    const result = await harness.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+    expect(result.ready).toBe(true);
+  });
+
+  it('still requires the Codex binary for local provider readiness', async () => {
+    vi.mocked(probeCodexDoctor).mockReturnValue({
+      installed: false,
+      authenticated: false,
+      authStatus: 'not_configured',
+      exitCode: null,
+      stdout: '',
+      stderr: '',
+    });
+    const harness = new LearnerHarness({
+      name: CODEX_HARNESS,
+      adapter: new NoOpAdapter(),
+      codexBaseUrl: 'http://127.0.0.1:11434/v1',
+    });
+    const result = await harness.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+    expect(result.ready).toBe(false);
+    expect(result.reason).toMatch(/not installed/i);
+  });
+
+  it('does not skip Codex auth for remote provider URLs', async () => {
+    vi.mocked(probeCodexDoctor).mockReturnValue({
+      installed: true,
+      authenticated: false,
+      authStatus: 'not_configured',
+      exitCode: 0,
+      stdout: 'codex 1.2.3',
+      stderr: '',
+    });
+    const harness = new LearnerHarness({
+      name: CODEX_HARNESS,
+      adapter: new NoOpAdapter(),
+      codexBaseUrl: 'https://api.openai.com/v1',
+    });
+    const result = await harness.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+    expect(result.ready).toBe(false);
+    expect(result.reason).toMatch(/base URL must be local/i);
+  });
+
   // #366: a stale/expired auth.json must not read as ready. The reason MUST
   // be distinct from the not-configured case so the operator sees a
   // re-login hint rather than a first-time sign-in hint.


### PR DESCRIPTION
## Summary
- add local-only Codex base URL config for Ollama/OpenAI-compatible endpoints
- pass a per-run internal Codex provider (`jinn-local`) to `codex exec --ignore-user-config`
- let Codex readiness skip OpenAI auth only for validated local base URLs, while still requiring the codex binary

## Scope
- Codex/config/readiness wiring only
- no Hermes, Gemini, engine routing, SolverNet registry, UI, Docker, or compose changes

## Tests
- real smoke: `codex exec --ignore-user-config` against a local `/v1/responses` mock returned `SMOKE_OK`
- `npx vitest run test/harnesses/impls/learner/codex-code-adapter.test.ts test/harnesses/impls/learner/codex-is-ready.test.ts test/harnesses/impls/build-harnesses.test.ts test/config.test.ts`
- `yarn typecheck`

## Team review
- final team-review round reported no new in-scope findings