### PR TITLE
refactor(operator-app): promote Identity + Harness Readiness above the fold (§2.2, §2.9)

### DIFF
--- a/client/src/dashboard/spa/src/pages/Overview.test.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.test.tsx
@@ -870,3 +870,44 @@ describe('OverviewPage activity surface (issue #219)', () => {
     expect(screen.getByRole('button', { name: /retry/i })).toBeTruthy();
   });
 });
+
+// ── IdentityCard promotion — spec §2.2 ─────────────────────────────────────
+//
+// IdentityCard is a first-class identity surface (spec §2.2). It must render
+// above the fold on /overview without requiring the operator to expand the
+// "Advanced details" disclosure. This test fails before the promotion and
+// passes after IdentityCard is moved out of <AdvancedDetails>.
+describe('OverviewPage IdentityCard (spec §2.2)', () => {
+  it('renders IdentityCard above the fold (not buried under Advanced details) — spec §2.2', async () => {
+    getStatusMock.mockResolvedValue({
+      fleet: {
+        services: [
+          {
+            index: 0,
+            step: 'complete',
+            agentId: 42,
+            safeAddress: '0xSafe0000000000000000000000000000000000AA',
+            safeBoundToAgent: true,
+          },
+        ],
+      },
+      predictionV1: {
+        operator: { ok: true, solverNet: { name: 'prediction', enabled: false }, diagnostics: [] },
+        totals: { observedTasks: 0, activeTaskRuns: 0, solutions: 0, verdicts: 0, failed: 0 },
+      },
+    });
+    getBootstrapMock.mockResolvedValue({});
+    render(withProviders(<OverviewPage />));
+
+    // IdentityCard section header "Identity" must be in the DOM without
+    // expanding the Advanced details disclosure.
+    await waitFor(() => {
+      expect(screen.getByText('Identity')).toBeTruthy();
+    });
+
+    // Confirm IdentityCard is NOT a descendant of the AdvancedDetails toggle.
+    const identityEl = screen.getByText('Identity');
+    const advancedToggle = screen.getByRole('button', { name: /advanced details/i });
+    expect(advancedToggle.parentElement?.contains(identityEl)).toBe(false);
+  });
+});

--- a/client/src/dashboard/spa/src/pages/Overview.test.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.test.tsx
@@ -871,6 +871,38 @@ describe('OverviewPage activity surface (issue #219)', () => {
   });
 });
 
+// ── HarnessStatusPanel promotion — spec §2.9 ───────────────────────────────
+//
+// HarnessStatusPanel is a first-class harness-readiness surface (spec §2.9).
+// It must render above the fold on /overview without requiring the operator
+// to expand the "Advanced details" disclosure. This test fails before the
+// promotion and passes after HarnessStatusPanel is moved out of <AdvancedDetails>.
+describe('OverviewPage HarnessStatusPanel (spec §2.9)', () => {
+  it('renders HarnessStatusPanel above the fold (not buried under Advanced details) — spec §2.9', async () => {
+    getStatusMock.mockResolvedValue({
+      fleet: { services: [] },
+      predictionV1: {
+        operator: { ok: true, solverNet: { name: 'prediction', enabled: false }, diagnostics: [] },
+        totals: { observedTasks: 0, activeTaskRuns: 0, solutions: 0, verdicts: 0, failed: 0 },
+      },
+    });
+    getBootstrapMock.mockResolvedValue({});
+    render(withProviders(<OverviewPage />));
+
+    // HarnessStatusPanel renders "Harness Status" (its section header) in the
+    // loading/unavailable state ("Harness status unavailable") or after data loads.
+    // We wait for the harness panel — its unavailable state renders without data.
+    await waitFor(() => {
+      expect(screen.getByText(/harness status/i)).toBeTruthy();
+    });
+
+    // Confirm HarnessStatusPanel is NOT a descendant of the AdvancedDetails toggle.
+    const harnessEl = screen.getByText(/harness status/i);
+    const advancedToggle = screen.getByRole('button', { name: /advanced details/i });
+    expect(advancedToggle.parentElement?.contains(harnessEl)).toBe(false);
+  });
+});
+
 // ── IdentityCard promotion — spec §2.2 ─────────────────────────────────────
 //
 // IdentityCard is a first-class identity surface (spec §2.2). It must render

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -381,9 +381,8 @@ export function OverviewPage(): JSX.Element {
         safeAddress={services[0]?.safeAddress ?? null}
         services={services}
       />
-      <AdvancedDetails>
-        <HarnessStatusPanel />
-      </AdvancedDetails>
+      <HarnessStatusPanel />
+      <AdvancedDetails />
     </div>
   );
 }

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -375,13 +375,13 @@ export function OverviewPage(): JSX.Element {
        */}
       <ActivitySections />
 
+      <IdentityCard
+        agentId={services[0]?.agentId ?? null}
+        chain="Base Sepolia"
+        safeAddress={services[0]?.safeAddress ?? null}
+        services={services}
+      />
       <AdvancedDetails>
-        <IdentityCard
-          agentId={services[0]?.agentId ?? null}
-          chain="Base Sepolia"
-          safeAddress={services[0]?.safeAddress ?? null}
-          services={services}
-        />
         <HarnessStatusPanel />
       </AdvancedDetails>
     </div>


### PR DESCRIPTION
Closes #427.

**Stacked on #426 (Phase 1)** — will retarget to \`next\` once #426 merges. Diff against this base shows only Phase 2's two commits.

## Summary

Both `<IdentityCard>` and `<HarnessStatusPanel>` previously rendered only inside Overview's `▶ Advanced details` disclosure. Per [`client/OPERATOR-APP-SPEC.md`](client/OPERATOR-APP-SPEC.md) §2.2 (Identity) and §2.9 (Harness Readiness), both are first-class components — load-bearing for the operator's understanding of who they are on-chain and whether they can claim work. Both now render above the fold on Overview, between HeroStats/cards and the (now-empty) AdvancedDetails section.

## Changes

- `client/src/dashboard/spa/src/pages/Overview.tsx` — `<IdentityCard>` and `<HarnessStatusPanel>` extracted from `<AdvancedDetails>` and rendered as top-level sections, in order: IdentityCard → HarnessStatusPanel → AdvancedDetails.
- `client/src/dashboard/spa/src/pages/Overview.test.tsx` — two new tests, one per spec section. Each uses a DOM-containment check confirming the surface is NOT a descendant of the AdvancedDetails toggle.
- All IdentityCard props (`agentId`, `chain`, `safeAddress`, `services`) pass through unchanged.
- `<AdvancedDetails>` is now childless — its existing "No additional details available." placeholder renders when expanded. Acceptable for now; preserves the disclosure for future genuinely-advanced reference data (build sha, runtime flags, etc.).

## Tests

- 27 SPA tests pass in `Overview.test.tsx` (25 pre-existing + 2 new)
- Pre-existing failures in `HeroStats.test.tsx` / `JoinFlow.test.tsx` remain (unrelated, present on `next`)

## Implementation plan

[`docs/superpowers/plans/2026-05-20-operator-app-spec-alignment.md`](docs/superpowers/plans/2026-05-20-operator-app-spec-alignment.md), Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)