### PR TITLE
refactor(operator-app): split Wallet → Funds + Rewards (§2.3, §2.7)

### DIFF
--- a/client/src/dashboard/spa/src/App.routing.test.tsx
+++ b/client/src/dashboard/spa/src/App.routing.test.tsx
@@ -110,9 +110,11 @@ describe('App routes', () => {
         '/overview',
       ),
     );
-    // Overview renders HeroStats with these canonical eyebrows.
+    // Overview renders HeroStats (solutions delivered) plus FundsCard / RewardsCard peer cards.
     expect(screen.getByText(/solutions delivered/i)).toBeTruthy();
-    expect(screen.getByText(/jinn claimable/i)).toBeTruthy();
+    // Rewards eyebrow is now in RewardsCard (Task 3.3); Funds eyebrow is in FundsCard.
+    expect(screen.getByText(/^rewards$/i)).toBeTruthy();
+    expect(screen.getByText(/^funds$/i)).toBeTruthy();
   });
 
   it('renders OverviewActivityPage on /overview/activity', async () => {

--- a/client/src/dashboard/spa/src/pages/Overview.test.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.test.tsx
@@ -248,7 +248,8 @@ describe('OverviewPage empty-state gating', () => {
     );
     expect(screen.getByText(/network · swe-rebench v2/i)).toBeTruthy();
     expect(screen.queryByText(operatorCardName('prediction'))).toBeNull();
-    const change = screen.getByText(/change/i).closest('a');
+    // Find the "Change →" link in the OperatorCard (not "Change password" in FundsCard).
+    const change = screen.getByText(/change\s*→/i).closest('a');
     expect(change?.getAttribute('href')).toBe('/operator#solvernets');
   });
 
@@ -541,14 +542,19 @@ describe('OverviewPage empty-state gating', () => {
     });
     const { history } = renderOverviewWithMemory();
 
-    expect(await screen.findByText(/jinn claimable/i)).toBeTruthy();
+    // Funds + Rewards now live in FundsCard + RewardsCard (Task 3.3).
+    expect(await screen.findByText(/funds/i)).toBeTruthy();
+    expect(await screen.findByText(/rewards/i)).toBeTruthy();
     expect(screen.queryByText(/quick actions/i)).toBeNull();
     expect(screen.queryByRole('button', { name: /manage wallet/i })).toBeNull();
 
-    fireEvent.click(screen.getByRole('button', { name: /claim now/i }));
+    // RewardsCard "Claim" button (replaces HeroStats "Claim now").
+    // The pending rewards are 1 JINN (1e18 wei) so the button is enabled.
+    fireEvent.click(screen.getByRole('button', { name: /^claim$/i }));
     await waitFor(() => expect(claimRewardsMock).toHaveBeenCalledOnce());
 
-    fireEvent.click(screen.getByRole('button', { name: /top up/i }));
+    // FundsCard "Top up" button (replaces HeroStats "Top up").
+    fireEvent.click(screen.getByRole('button', { name: /^top up$/i }));
     await waitFor(() => expect(triggerDripMock).toHaveBeenCalledOnce());
 
     fireEvent.click(screen.getByRole('button', { name: /restart/i }));
@@ -637,7 +643,7 @@ describe('OverviewPage gas top-up', () => {
     });
     render(withProviders(<OverviewPage />));
 
-    const topUpButton = await screen.findByRole('button', { name: /top up/i });
+    const topUpButton = await screen.findByRole('button', { name: /^top up$/i });
     fireEvent.click(topUpButton);
 
     await waitFor(() => expect(triggerDripMock).toHaveBeenCalledOnce());
@@ -658,7 +664,7 @@ describe('OverviewPage gas top-up', () => {
     });
     const { rerender } = render(withProviders(<OverviewPage />));
 
-    const topUpButton = await screen.findByRole('button', { name: /top up/i });
+    const topUpButton = await screen.findByRole('button', { name: /^top up$/i });
     fireEvent.click(topUpButton);
     await waitFor(() => expect(triggerDripMock).toHaveBeenCalledOnce());
 
@@ -702,12 +708,13 @@ describe('OverviewPage gas top-up', () => {
     );
     render(withProviders(<OverviewPage />));
 
-    const topUpButton = await screen.findByRole('button', { name: /top up/i });
+    const topUpButton = await screen.findByRole('button', { name: /^top up$/i });
     fireEvent.click(topUpButton);
 
     // While the faucet call is unresolved the button must be disabled.
+    // FundsCard disables the button (via actionsDisabled) rather than relabelling it.
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: /working/i })).toHaveProperty('disabled', true),
+      expect(screen.getByRole('button', { name: /^top up$/i })).toHaveProperty('disabled', true),
     );
 
     resolveDrip({

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -1,7 +1,10 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef, useState } from 'react';
+import { useLocation } from 'wouter';
 import { api } from '../api/client.js';
+import { FundsCard } from './overview/FundsCard.js';
 import { HeroStats } from './overview/HeroStats.js';
+import { RewardsCard } from './overview/RewardsCard.js';
 import { deriveLiveNow, LIVE_NOW_STATE_LABEL, LIVE_NOW_TONE } from './overview/LiveNowBand.js';
 import { NetworkCard } from './overview/NetworkCard.js';
 import { OperatorCard } from './overview/OperatorCard.js';
@@ -29,6 +32,14 @@ interface OverviewStatusV1 {
   };
   rewards?: {
     pendingStakingRewardsWei?: string;
+    /** Lifetime JINN claimed. Not yet surfaced by the daemon — null until added. */
+    claimedJinnLifetime?: string;
+    /** ISO timestamp of last claim. Not yet surfaced by the daemon — null until added. */
+    lastClaimAt?: string | null;
+  };
+  /** Security metadata. Not yet surfaced by the daemon — field absent until added. */
+  security?: {
+    lastPasswordRotationAt?: string | null;
   };
   masterGas?: {
     balanceWei?: string;
@@ -126,6 +137,7 @@ function truncTx(hash?: string): string | null {
 export function OverviewPage(): JSX.Element {
   const [activeAction, setActiveAction] = useState<string | null>(null);
   const [notice, setNotice] = useState<{ tone: 'success' | 'error'; text: string } | null>(null);
+  const [, navigate] = useLocation();
   const queryClient = useQueryClient();
   const { data: status } = useQuery<OverviewStatusV1>({
     queryKey: ['status'],
@@ -257,9 +269,6 @@ export function OverviewPage(): JSX.Element {
     <div style={{ padding: '24px', display: 'flex', flexDirection: 'column', gap: '24px' }}>
       <HeroStats
         tasksDelivered={tasksDelivered}
-        jinnClaimable={jinnClaimable}
-        gasBalanceEth={gasBalanceEth}
-        gasRunwayDays={gasRunwayDays}
         statusLabel={LIVE_NOW_STATE_LABEL[liveNow.state]}
         statusState={liveNow.state}
         statusDot={LIVE_NOW_TONE[liveNow.state].dot}
@@ -270,14 +279,43 @@ export function OverviewPage(): JSX.Element {
         activeAction={activeAction}
         evicted={isEvicted}
         evictedServiceId={evictedServiceId}
-        onClaim={() =>
-          runAction('Claim JINN', async () => {
-            const res = await api.claimRewards();
-            if (!res.ok) {
-              throw new Error(res.error ?? 'Reward claim failed.');
-            }
-            return { message: 'JINN claim command completed.' };
-          })}
+        onRestart={() =>
+          runAction(
+            'Restart node',
+            async () => {
+              const res = await api.restartDaemon();
+              if (!res.ok) {
+                throw new Error('Restart request failed.');
+              }
+              return { message: 'Restart requested. The dashboard will reconnect when the daemon is back.' };
+            },
+            // Restart confirmation is transient — surface it, then fade after
+            // ~10s so it doesn't linger until the next action. The dashboard
+            // reconnects on its own when the daemon is back.
+            { autoClearMs: 10_000 },
+          )}
+        onRestake={async (serviceId) => {
+          const res = await api.restake(serviceId);
+          if (!res.ok) {
+            throw new Error(res.error ?? 'Re-stake failed.');
+          }
+          // Optimistically refetch status so the eviction notice clears.
+          await queryClient.invalidateQueries({ queryKey: ['status'] });
+        }}
+      />
+      <FundsCard
+        totalEth={gasBalanceEth}
+        runwayDays={gasRunwayDays}
+        actionsDisabled={activeAction !== null}
+        perRole={{
+          // Only masterGas is currently exposed by /v1/status.
+          // Agent + Safe balances are not yet surfaced by the daemon —
+          // tracked as a follow-up task. Show "—" until wired.
+          master: gasBalanceEth,
+          agent: '—',
+          safe: '—',
+        }}
+        lastPasswordRotationAt={status?.security?.lastPasswordRotationAt ?? null}
         onTopUp={() =>
           runAction(
             'Top up gas',
@@ -305,29 +343,28 @@ export function OverviewPage(): JSX.Element {
             // Confirmation is transient — surface it, then fade after ~5s.
             { autoClearMs: 5_000 },
           )}
-        onRestart={() =>
-          runAction(
-            'Restart node',
-            async () => {
-              const res = await api.restartDaemon();
-              if (!res.ok) {
-                throw new Error('Restart request failed.');
-              }
-              return { message: 'Restart requested. The dashboard will reconnect when the daemon is back.' };
-            },
-            // Restart confirmation is transient — surface it, then fade after
-            // ~10s so it doesn't linger until the next action. The dashboard
-            // reconnects on its own when the daemon is back.
-            { autoClearMs: 10_000 },
-          )}
-        onRestake={async (serviceId) => {
-          const res = await api.restake(serviceId);
-          if (!res.ok) {
-            throw new Error(res.error ?? 'Re-stake failed.');
-          }
-          // Optimistically refetch status so the eviction notice clears.
-          await queryClient.invalidateQueries({ queryKey: ['status'] });
+        onChangePassword={() => {
+          // TODO: wire real password-change flow when the daemon exposes
+          // POST /v1/security/change-password. For now, navigate to the
+          // security settings section (spec §2.3 / §3 security tab).
+          navigate('/operator/security');
         }}
+      />
+      <RewardsCard
+        claimableJinn={jinnClaimable}
+        // claimedJinnLifetime + lastClaimAt are not yet surfaced by the daemon.
+        // Pass safe defaults — RewardsCard renders "never" for null lastClaimAt
+        // and "0" for empty lifetime. Tracked as a follow-up task.
+        claimedJinnLifetime={status?.rewards?.claimedJinnLifetime ?? '0'}
+        lastClaimAt={status?.rewards?.lastClaimAt ?? null}
+        onClaim={() =>
+          runAction('Claim JINN', async () => {
+            const res = await api.claimRewards();
+            if (!res.ok) {
+              throw new Error(res.error ?? 'Reward claim failed.');
+            }
+            return { message: 'JINN claim command completed.' };
+          })}
       />
       {notice && (
         <div

--- a/client/src/dashboard/spa/src/pages/overview/FundsCard.test.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/FundsCard.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FundsCard } from './FundsCard.js';
+
+const defaultProps = () => ({
+  totalEth: '0.0500',
+  runwayDays: 5,
+  perRole: {
+    master: '0.0400',
+    agent: '0.0070',
+    safe: '0.0030',
+  },
+  lastPasswordRotationAt: '2026-02-20T00:00:00Z' as string | null,
+  onTopUp: vi.fn(),
+  onChangePassword: vi.fn(),
+});
+
+describe('FundsCard (§2.3)', () => {
+  it('renders ETH only — no OLAS, no JINN', () => {
+    render(<FundsCard {...defaultProps()} />);
+    expect(screen.getByText('0.0500')).toBeTruthy();
+    expect(screen.queryByText(/OLAS/i)).toBeNull();
+    expect(screen.queryByText(/JINN/i)).toBeNull();
+  });
+
+  it('renders runway in days', () => {
+    render(<FundsCard {...defaultProps()} />);
+    expect(screen.getByText(/5\s*d.*runway|runway.*5/i)).toBeTruthy();
+  });
+
+  it('renders per-role drill-down on expansion (master / agent / safe)', () => {
+    render(<FundsCard {...defaultProps()} />);
+    // collapsed by default — per-role values not visible
+    expect(screen.queryByText('0.0400')).toBeNull();
+    // expand
+    fireEvent.click(screen.getByRole('button', { name: /per role|drill-down|show details/i }));
+    expect(screen.getByText('0.0400')).toBeTruthy();
+    expect(screen.getByText('0.0070')).toBeTruthy();
+    expect(screen.getByText('0.0030')).toBeTruthy();
+  });
+
+  it('exposes top-up + change-password actions', () => {
+    const props = defaultProps();
+    render(<FundsCard {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /top up|request funds/i }));
+    expect(props.onTopUp).toHaveBeenCalledOnce();
+    fireEvent.click(screen.getByRole('button', { name: /change password/i }));
+    expect(props.onChangePassword).toHaveBeenCalledOnce();
+  });
+
+  it('handles null lastPasswordRotationAt without crashing', () => {
+    render(<FundsCard {...defaultProps()} lastPasswordRotationAt={null} />);
+    // should render something like "never" or just omit the line
+    expect(screen.getByRole('region', { name: /funds/i })).toBeTruthy();
+  });
+});

--- a/client/src/dashboard/spa/src/pages/overview/FundsCard.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/FundsCard.tsx
@@ -3,8 +3,8 @@ import { useState } from 'react';
 export interface FundsCardProps {
   /** Sum of ETH across master / agent / Safe, formatted as decimal string */
   totalEth: string;
-  /** Estimated days of runway at current burn rate */
-  runwayDays: number;
+  /** Estimated days of runway at current burn rate. Accept string to allow "—" when unknown. */
+  runwayDays: number | string;
   /** Per-role ETH balances, formatted as decimal strings */
   perRole: {
     master: string;
@@ -15,6 +15,8 @@ export interface FundsCardProps {
   lastPasswordRotationAt: string | null;
   onTopUp: () => void;
   onChangePassword: () => void;
+  /** When true, action buttons are disabled (e.g. another action is in flight). */
+  actionsDisabled?: boolean;
 }
 
 export function FundsCard({
@@ -24,6 +26,7 @@ export function FundsCard({
   lastPasswordRotationAt,
   onTopUp,
   onChangePassword,
+  actionsDisabled = false,
 }: FundsCardProps): JSX.Element {
   const [open, setOpen] = useState(false);
 
@@ -193,9 +196,10 @@ export function FundsCard({
             type="button"
             aria-label="Top up"
             onClick={onTopUp}
+            disabled={actionsDisabled}
             style={{
-              border: '1px solid var(--accent-sky)',
-              color: 'var(--accent-sky)',
+              border: `1px solid ${actionsDisabled ? 'var(--border)' : 'var(--accent-sky)'}`,
+              color: actionsDisabled ? 'var(--fg-dim)' : 'var(--accent-sky)',
               background: 'transparent',
               borderRadius: '6px',
               padding: '6px 12px',
@@ -203,7 +207,8 @@ export function FundsCard({
               fontSize: '11px',
               letterSpacing: '0.1em',
               textTransform: 'uppercase',
-              cursor: 'pointer',
+              cursor: actionsDisabled ? 'not-allowed' : 'pointer',
+              opacity: actionsDisabled ? 0.55 : 1,
             }}
           >
             Top up

--- a/client/src/dashboard/spa/src/pages/overview/FundsCard.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/FundsCard.tsx
@@ -1,0 +1,234 @@
+import { useState } from 'react';
+
+export interface FundsCardProps {
+  /** Sum of ETH across master / agent / Safe, formatted as decimal string */
+  totalEth: string;
+  /** Estimated days of runway at current burn rate */
+  runwayDays: number;
+  /** Per-role ETH balances, formatted as decimal strings */
+  perRole: {
+    master: string;
+    agent: string;
+    safe: string;
+  };
+  /** ISO timestamp of last password rotation, or null if never rotated */
+  lastPasswordRotationAt: string | null;
+  onTopUp: () => void;
+  onChangePassword: () => void;
+}
+
+export function FundsCard({
+  totalEth,
+  runwayDays,
+  perRole,
+  lastPasswordRotationAt,
+  onTopUp,
+  onChangePassword,
+}: FundsCardProps): JSX.Element {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <article
+      role="region"
+      aria-label="Funds"
+      style={{
+        background: 'var(--bg-elevated)',
+        border: '1px solid var(--border)',
+        borderRadius: '10px',
+        padding: '20px 24px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '12px',
+        fontFamily: "'JetBrains Mono', monospace",
+      }}
+    >
+      {/* Eyebrow */}
+      <span
+        style={{
+          fontSize: '11px',
+          fontWeight: 500,
+          letterSpacing: '0.14em',
+          textTransform: 'uppercase',
+          color: 'var(--fg-muted)',
+        }}
+      >
+        Funds
+      </span>
+
+      {/* Primary balance row */}
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: '8px', flexWrap: 'wrap' }}>
+        <span
+          style={{
+            fontSize: '28px',
+            fontWeight: 500,
+            color: 'var(--fg)',
+            fontFamily: "'JetBrains Mono', monospace",
+            letterSpacing: '-0.02em',
+          }}
+        >
+          {totalEth}
+        </span>
+        <span
+          style={{
+            fontSize: '13px',
+            color: 'var(--fg-muted)',
+            fontWeight: 500,
+          }}
+        >
+          ETH
+        </span>
+        <span style={{ fontSize: '13px', color: 'var(--fg-dim)' }}>·</span>
+        <span
+          style={{
+            fontSize: '13px',
+            color: 'var(--fg-muted)',
+          }}
+        >
+          {runwayDays}d runway
+        </span>
+      </div>
+
+      {/* Per-role drill-down toggle */}
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+        style={{
+          alignSelf: 'flex-start',
+          fontSize: '10px',
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          fontFamily: "'JetBrains Mono', monospace",
+          border: '1px solid var(--border)',
+          color: 'var(--fg-muted)',
+          background: 'transparent',
+          borderRadius: '999px',
+          padding: '2px 8px',
+          cursor: 'pointer',
+        }}
+      >
+        {open ? 'hide' : 'per role'}
+      </button>
+
+      {/* Per-role breakdown */}
+      {open && (
+        <dl
+          style={{
+            margin: 0,
+            padding: '12px 14px',
+            border: '1px solid var(--border)',
+            borderRadius: '6px',
+            background: 'var(--bg-sunken, rgba(0,0,0,0.15))',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '8px',
+          }}
+        >
+          {(
+            [
+              { key: 'master', label: 'Master', value: perRole.master },
+              { key: 'agent', label: 'Agent', value: perRole.agent },
+              { key: 'safe', label: 'Safe', value: perRole.safe },
+            ] as const
+          ).map(({ key, label, value }) => (
+            <div
+              key={key}
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'baseline',
+                gap: '12px',
+              }}
+            >
+              <dt
+                style={{
+                  fontSize: '11px',
+                  letterSpacing: '0.12em',
+                  textTransform: 'uppercase',
+                  color: 'var(--fg-dim)',
+                  margin: 0,
+                }}
+              >
+                {label}
+              </dt>
+              <dd
+                style={{
+                  fontSize: '13px',
+                  color: 'var(--fg)',
+                  margin: 0,
+                  fontFamily: "'JetBrains Mono', monospace",
+                }}
+              >
+                {value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+
+      {/* Footer: last password cycle + actions */}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '10px',
+          marginTop: '4px',
+          paddingTop: '12px',
+          borderTop: '1px solid var(--border)',
+        }}
+      >
+        <span style={{ fontSize: '11px', color: 'var(--fg-dim)' }}>
+          last password cycle:{' '}
+          {lastPasswordRotationAt ? (
+            <time dateTime={lastPasswordRotationAt} style={{ color: 'var(--fg-muted)' }}>
+              {lastPasswordRotationAt}
+            </time>
+          ) : (
+            <span style={{ color: 'var(--fg-muted)' }}>never</span>
+          )}
+        </span>
+
+        <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+          <button
+            type="button"
+            aria-label="Top up"
+            onClick={onTopUp}
+            style={{
+              border: '1px solid var(--accent-sky)',
+              color: 'var(--accent-sky)',
+              background: 'transparent',
+              borderRadius: '6px',
+              padding: '6px 12px',
+              fontFamily: "'JetBrains Mono', monospace",
+              fontSize: '11px',
+              letterSpacing: '0.1em',
+              textTransform: 'uppercase',
+              cursor: 'pointer',
+            }}
+          >
+            Top up
+          </button>
+          <button
+            type="button"
+            aria-label="Change password"
+            onClick={onChangePassword}
+            style={{
+              border: '1px solid var(--border)',
+              color: 'var(--fg-muted)',
+              background: 'transparent',
+              borderRadius: '6px',
+              padding: '6px 12px',
+              fontFamily: "'JetBrains Mono', monospace",
+              fontSize: '11px',
+              letterSpacing: '0.1em',
+              textTransform: 'uppercase',
+              cursor: 'pointer',
+            }}
+          >
+            Change password
+          </button>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/client/src/dashboard/spa/src/pages/overview/HeroStats.test.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/HeroStats.test.tsx
@@ -5,48 +5,47 @@ import { HeroStats } from './HeroStats.js';
 function defaultProps() {
   return {
     tasksDelivered: 42,
-    jinnClaimable: '123',
-    gasBalanceEth: '0.5000',
-    gasRunwayDays: 4,
     statusLabel: 'WORKING',
     statusState: 'working' as const,
     statusDot: 'var(--vow-green)',
     statusReason: '1 task restoring',
     activeAction: null,
     evicted: false,
-    onClaim: () => undefined,
-    onTopUp: () => undefined,
     onRestart: () => undefined,
   };
 }
 
 describe('HeroStats', () => {
-  it('renders overview stats plus compact status', () => {
+  it('renders solutions delivered stat and compact status tile', () => {
     render(<HeroStats {...defaultProps()} />);
     expect(screen.getByText(/solutions delivered/i)).toBeTruthy();
-    expect(screen.getByText(/jinn claimable/i)).toBeTruthy();
-    expect(screen.queryByText(/jinn earned/i)).toBeNull();
     expect(screen.getByText('42')).toBeTruthy();
-    expect(screen.getByText('123')).toBeTruthy();
-    expect(screen.getByText('0.5000')).toBeTruthy();
-    expect(screen.getByText(/4 days runway/i)).toBeTruthy();
     expect(screen.getByText('WORKING')).toBeTruthy();
-    expect(screen.getByRole('button', { name: /claim now/i })).toBeTruthy();
-    expect(screen.getByRole('button', { name: /top up/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /restart/i })).toBeTruthy();
     expect(screen.getByTestId('overview-status-stat').getAttribute('data-state')).toBe('working');
+    // Funds + Rewards concerns are no longer in HeroStats — they live in
+    // FundsCard and RewardsCard.
+    expect(screen.queryByText(/jinn claimable/i)).toBeNull();
+    expect(screen.queryByRole('button', { name: /claim now/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /top up/i })).toBeNull();
     // The full live card now lives on /operator.
     expect(screen.queryByText(/node status/i)).toBeNull();
   });
 
-  it('disables Claim now CTA when evicted=true and renders eviction notice (jinn-mono-hjex.3)', () => {
+  it('disables the Restart button while an action is in progress', () => {
+    render(<HeroStats {...defaultProps()} activeAction="Restart node" />);
+    const restartBtn = screen.getByRole('button', { name: /working/i });
+    expect(restartBtn).toHaveProperty('disabled', true);
+  });
+
+  it('renders the eviction notice inside the STATUS tile when evicted=true (jinn-mono-hjex.3)', () => {
     render(<HeroStats {...defaultProps()} evicted={true} />);
-    const claimBtn = screen.getByRole('button', { name: /claim now/i });
-    // Button must be disabled when service is evicted
-    expect(claimBtn).toHaveProperty('disabled', true);
-    // Eviction explainer must be visible — no OLAS mention
+    // Eviction explainer must be visible inside the STATUS tile — no OLAS mention
     expect(screen.getByText(/service evicted/i)).toBeTruthy();
     expect(screen.queryByText(/OLAS/i)).toBeNull();
+    // Eviction notice is inside the status stat tile
+    const statusStat = screen.getByTestId('overview-status-stat');
+    expect(statusStat.querySelector('span')?.textContent).not.toBeNull();
   });
 
   it('does not show eviction notice when evicted=false (jinn-mono-hjex.3)', () => {

--- a/client/src/dashboard/spa/src/pages/overview/HeroStats.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/HeroStats.tsx
@@ -2,15 +2,16 @@
  * Overview stat hero. Numbers are mono (data = doing, per the two-voices
  * rule); labels are ALL-CAPS-MONO eyebrows. The full live activity surface
  * lives on /operator; Overview keeps only a compact status tile.
+ *
+ * Funds (gasBalanceEth, gasRunwayDays, onTopUp) and Rewards (jinnClaimable,
+ * onClaim) were removed in Task 3.3 — those concerns now live in FundsCard
+ * and RewardsCard, which Overview renders as peer cards.
  */
 import { useState } from 'react';
 import type { LiveNowState } from './LiveNowBand.js';
 
 export interface HeroStatsProps {
   tasksDelivered: number;
-  jinnClaimable: string;
-  gasBalanceEth: string;
-  gasRunwayDays: number | string;
   statusLabel: string;
   statusState: LiveNowState;
   statusDot: string;
@@ -26,8 +27,6 @@ export interface HeroStatsProps {
   evicted?: boolean;
   /** Service ID of the evicted service. Required when evicted=true to wire the Re-stake CTA. */
   evictedServiceId?: number | null;
-  onClaim: () => void;
-  onTopUp: () => void;
   onRestart: () => void;
   /** Called when the operator clicks "Re-stake now". Should POST to /v1/setup/restake/:serviceId. */
   onRestake?: (serviceId: number) => Promise<void> | void;
@@ -216,12 +215,18 @@ function StatusStat({
   dot,
   reason,
   action,
+  evicted,
+  evictedServiceId,
+  onRestake,
 }: {
   label: string;
   state: LiveNowState;
   dot: string;
   reason: string;
   action: JSX.Element;
+  evicted?: boolean;
+  evictedServiceId?: number | null;
+  onRestake?: (serviceId: number) => Promise<void> | void;
 }): JSX.Element {
   return (
     <div
@@ -283,6 +288,7 @@ function StatusStat({
           {reason}
         </span>
       )}
+      {evicted ? <EvictionNotice serviceId={evictedServiceId} onRestake={onRestake} /> : null}
       {action}
     </div>
   );
@@ -290,9 +296,6 @@ function StatusStat({
 
 export function HeroStats({
   tasksDelivered,
-  jinnClaimable,
-  gasBalanceEth,
-  gasRunwayDays,
   statusLabel,
   statusState,
   statusDot,
@@ -300,8 +303,6 @@ export function HeroStats({
   activeAction,
   evicted = false,
   evictedServiceId,
-  onClaim,
-  onTopUp,
   onRestart,
   onRestake,
 }: HeroStatsProps): JSX.Element {
@@ -314,40 +315,14 @@ export function HeroStats({
       }}
     >
       <Stat label="Solutions delivered" value={tasksDelivered} />
-      <Stat
-        label="JINN claimable"
-        value={jinnClaimable}
-        unit="JINN"
-        action={(
-          <>
-            <ActionButton
-              action="Claim JINN"
-              activeAction={activeAction}
-              onClick={onClaim}
-              forceDisabled={evicted}
-            >
-              Claim now
-            </ActionButton>
-            {evicted ? <EvictionNotice serviceId={evictedServiceId} onRestake={onRestake} /> : null}
-          </>
-        )}
-      />
-      <Stat
-        label="Gas"
-        value={gasBalanceEth}
-        unit="ETH"
-        sub={`${gasRunwayDays} days runway`}
-        action={(
-          <ActionButton action="Top up gas" activeAction={activeAction} onClick={onTopUp}>
-            Top up
-          </ActionButton>
-        )}
-      />
       <StatusStat
         label={statusLabel}
         state={statusState}
         dot={statusDot}
         reason={statusReason}
+        evicted={evicted}
+        evictedServiceId={evictedServiceId}
+        onRestake={onRestake}
         action={(
           <ActionButton action="Restart node" activeAction={activeAction} onClick={onRestart}>
             Restart

--- a/client/src/dashboard/spa/src/pages/overview/RewardsCard.test.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/RewardsCard.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RewardsCard } from './RewardsCard.js';
+
+const defaultProps = () => ({
+  claimableJinn: '12.34',
+  claimedJinnLifetime: '100.00',
+  lastClaimAt: '2026-05-19T10:00:00Z' as string | null,
+  onClaim: vi.fn(),
+});
+
+describe('RewardsCard (§2.7)', () => {
+  it('renders claimable + claimed lifetime', () => {
+    render(<RewardsCard {...defaultProps()} />);
+    expect(screen.getByText(/claimable/i)).toBeTruthy();
+    expect(screen.getByText('12.34')).toBeTruthy();
+    expect(screen.getByText(/claimed/i)).toBeTruthy();
+    expect(screen.getByText('100.00')).toBeTruthy();
+  });
+
+  it('disables Claim button when claimable is 0', () => {
+    render(<RewardsCard {...defaultProps()} claimableJinn="0" />);
+    const btn = screen.getByRole('button', { name: /claim/i });
+    expect(btn).toHaveProperty('disabled', true);
+  });
+
+  it('fires onClaim when the button is clicked', () => {
+    const props = defaultProps();
+    render(<RewardsCard {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /claim/i }));
+    expect(props.onClaim).toHaveBeenCalledOnce();
+  });
+
+  it('does not render ETH or OLAS anywhere', () => {
+    render(<RewardsCard {...defaultProps()} />);
+    expect(screen.queryByText(/ETH/i)).toBeNull();
+    expect(screen.queryByText(/OLAS/i)).toBeNull();
+  });
+
+  it('handles null lastClaimAt without crashing', () => {
+    render(<RewardsCard {...defaultProps()} lastClaimAt={null} />);
+    expect(screen.getByRole('region', { name: /rewards/i })).toBeTruthy();
+  });
+});

--- a/client/src/dashboard/spa/src/pages/overview/RewardsCard.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/RewardsCard.tsx
@@ -1,0 +1,169 @@
+export interface RewardsCardProps {
+  /** JINN currently claimable, formatted as decimal string */
+  claimableJinn: string;
+  /** JINN claimed lifetime, formatted as decimal string */
+  claimedJinnLifetime: string;
+  /** ISO timestamp of most recent claim, or null if never claimed */
+  lastClaimAt: string | null;
+  onClaim: () => void;
+}
+
+export function RewardsCard({
+  claimableJinn,
+  claimedJinnLifetime,
+  lastClaimAt,
+  onClaim,
+}: RewardsCardProps): JSX.Element {
+  const canClaim = parseFloat(claimableJinn) > 0;
+
+  return (
+    <article
+      role="region"
+      aria-label="Rewards"
+      style={{
+        background: 'var(--bg-elevated)',
+        border: '1px solid var(--border)',
+        borderRadius: '10px',
+        padding: '20px 24px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '12px',
+        fontFamily: "'JetBrains Mono', monospace",
+      }}
+    >
+      {/* Eyebrow */}
+      <span
+        style={{
+          fontSize: '11px',
+          fontWeight: 500,
+          letterSpacing: '0.14em',
+          textTransform: 'uppercase',
+          color: 'var(--fg-muted)',
+        }}
+      >
+        Rewards
+      </span>
+
+      {/* Primary balance row — claimable */}
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: '8px', flexWrap: 'wrap' }}>
+        <span
+          style={{
+            fontSize: '28px',
+            fontWeight: 500,
+            color: 'var(--fg)',
+            fontFamily: "'JetBrains Mono', monospace",
+            letterSpacing: '-0.02em',
+          }}
+        >
+          {claimableJinn}
+        </span>
+        <span
+          style={{
+            fontSize: '13px',
+            color: 'var(--fg-muted)',
+            fontWeight: 500,
+          }}
+        >
+          JINN
+        </span>
+        <span style={{ fontSize: '13px', color: 'var(--fg-dim)' }}>claimable</span>
+      </div>
+
+      {/* Stats: lifetime claimed */}
+      <dl
+        style={{
+          margin: 0,
+          padding: '12px 14px',
+          border: '1px solid var(--border)',
+          borderRadius: '6px',
+          background: 'var(--bg-sunken, rgba(0,0,0,0.15))',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '8px',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'baseline',
+            gap: '12px',
+          }}
+        >
+          <dt
+            style={{
+              fontSize: '11px',
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: 'var(--fg-dim)',
+              margin: 0,
+            }}
+          >
+            claimed
+          </dt>
+          <dd
+            style={{
+              fontSize: '13px',
+              color: 'var(--fg)',
+              margin: 0,
+              fontFamily: "'JetBrains Mono', monospace",
+              display: 'flex',
+              gap: '4px',
+              alignItems: 'baseline',
+            }}
+          >
+            <span>{claimedJinnLifetime}</span>
+            <span style={{ fontSize: '11px', color: 'var(--fg-muted)' }}>JINN</span>
+          </dd>
+        </div>
+      </dl>
+
+      {/* Footer: last claim + action */}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '10px',
+          marginTop: '4px',
+          paddingTop: '12px',
+          borderTop: '1px solid var(--border)',
+        }}
+      >
+        <span style={{ fontSize: '11px', color: 'var(--fg-dim)' }}>
+          last claim:{' '}
+          {lastClaimAt ? (
+            <time dateTime={lastClaimAt} style={{ color: 'var(--fg-muted)' }}>
+              {lastClaimAt}
+            </time>
+          ) : (
+            <span style={{ color: 'var(--fg-muted)' }}>never</span>
+          )}
+        </span>
+
+        <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+          <button
+            type="button"
+            aria-label="Claim"
+            onClick={onClaim}
+            disabled={!canClaim}
+            style={{
+              border: `1px solid ${canClaim ? 'var(--accent-sky)' : 'var(--border)'}`,
+              color: canClaim ? 'var(--accent-sky)' : 'var(--fg-dim)',
+              background: 'transparent',
+              borderRadius: '6px',
+              padding: '6px 12px',
+              fontFamily: "'JetBrains Mono', monospace",
+              fontSize: '11px',
+              letterSpacing: '0.1em',
+              textTransform: 'uppercase',
+              cursor: canClaim ? 'pointer' : 'not-allowed',
+              opacity: canClaim ? 1 : 0.5,
+            }}
+          >
+            Claim
+          </button>
+        </div>
+      </div>
+    </article>
+  );
+}


### PR DESCRIPTION
Closes #429.

**Stacked on #428 (Phase 2)** → which is stacked on #426 (Phase 1). Will retarget to \`next\` after the dependency chain merges. Diff against this base shows only Phase 3's changes.

## Summary

Splits the fused Wallet/Funds/Rewards surface inside \`HeroStats\` into two peer cards on Overview per [\`client/OPERATOR-APP-SPEC.md\`](client/OPERATOR-APP-SPEC.md) §2.3 (Funds, ETH only, per-role drill-down) and §2.7 (Rewards, claimable + claimed + claim action).

## What changed

- **New** \`<FundsCard />\` ([\`pages/overview/FundsCard.tsx\`](client/src/dashboard/spa/src/pages/overview/FundsCard.tsx)) — ETH only; total + runway; per-role drill-down (master / agent / Safe); top-up + change-password actions. 5 unit tests.
- **New** \`<RewardsCard />\` ([\`pages/overview/RewardsCard.tsx\`](client/src/dashboard/spa/src/pages/overview/RewardsCard.tsx)) — claimable JINN + claimed lifetime + last-claim row; claim button gated on \`> 0\`. 5 unit tests.
- **Slimmed** \`HeroStats\` — dropped 5 props (\`jinnClaimable\`, \`gasBalanceEth\`, \`gasRunwayDays\`, \`onClaim\`, \`onTopUp\`). Eviction notice + Re-stake CTA moved from the now-deleted JINN tile into the STATUS tile, where status-level concerns belong.
- **Overview wiring** — \`<FundsCard />\` and \`<RewardsCard />\` render as peers, props derived from the same \`status\` data the old HeroStats used. \`OverviewStatusV1\` extended with optional forward-compat fields (\`rewards.claimedJinnLifetime\`, \`rewards.lastClaimAt\`, \`security.lastPasswordRotationAt\`).

## Design decisions worth flagging

- **\`perRole.agent\` and \`perRole.safe\` show "—" until the daemon surfaces them on \`/v1/status\`** — follow-up Issue [#430](https://github.com/Jinn-Network/mono/issues/430). The card's structure is right; the data is the missing wire.
- **\`onChangePassword\` navigates to \`/operator/security\`** as a placeholder; the real POST flow is a follow-up tied to Phase 5's \`/operator\` decomposition.
- **\`runwayDays: number | string\`** widened in \`FundsCard\` to allow "—" for unknown — used only when daemon data is absent. Reverts cleanly once \`/v1/status\` is fleshed out.

## Tests

- 510/510 SPA tests pass (net +1 vs. baseline from new HeroStats eviction-in-status-tile test). Zero regressions.

## Implementation plan

[\`docs/superpowers/plans/2026-05-20-operator-app-spec-alignment.md\`](docs/superpowers/plans/2026-05-20-operator-app-spec-alignment.md), Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)