### PR TITLE
[codex] expose real tJINN status balance

### DIFF
--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -930,10 +930,6 @@ export async function gatherGatheredStatusRaw(
     transport: http(status.rpcUrl),
   });
 
-  // The tJINN read started above (overlapping the Base-RPC fan-out). It never
-  // rejects, so a plain await is safe here.
-  raw.tJinn = await tJinnPromise;
-
   try {
     const [blockNumber, chainId] = await Promise.all([
       client.getBlockNumber(),
@@ -1043,6 +1039,12 @@ export async function gatherGatheredStatusRaw(
       raw.serviceBalanceErrors = bal.errorsByDisplay;
     }
   }
+
+  // The tJINN read started up front (overlapping the Base-RPC fan-out). It is
+  // awaited here, as late as possible — after ALL other awaited Base-chain work
+  // — so the up-to-4s tJINN timeout never serializes the Base fan-out behind it.
+  // `gatherTjinnStatus` is internally error-safe, so a plain await is safe.
+  raw.tJinn = await tJinnPromise;
 
   return raw;
 }

--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -8,11 +8,16 @@ import { join } from 'node:path';
 
 /** Narrow RPC surface for balance fan-out (avoids PublicClient / chain-specific getBlock incompatibilities). */
 type StatusBalanceRpc = Pick<PublicClient, 'getBalance' | 'readContract'>;
-import { base, baseSepolia, sepolia } from 'viem/chains';
+import { base, baseSepolia } from 'viem/chains';
 import type { Store } from '../store/store.js';
 import type { JinnConfig } from '../config.js';
 import { FleetStateStore } from '../earning/store.js';
-import { getChainConfig } from '../earning/contracts.js';
+import {
+  DEFAULT_TESTNET_ARTIFACTS,
+  getChainConfig,
+  loadJinnMviConfig,
+} from '../earning/contracts.js';
+import { createJinnL1PublicClient } from '../earning/viem-clients.js';
 import { stage1MinMasterEth } from '../earning/bootstrap.js';
 import { JINN_STAKING_ABI } from '../earning/jinn-rewards.js';
 import type { FleetState } from '../earning/types.js';
@@ -20,13 +25,12 @@ import { displayFleetServiceIndex } from '../earning/fleet-display-index.js';
 import {
   assembleStatusV1,
   type GatheredStatusRaw,
+  pendingTjinnStatus,
   type ServiceBalanceErrorEntry,
   type StatusV1Response,
-  TJINN_CHAIN_ID,
   TJINN_PUBLIC_INVALID_SAFE_ERROR,
   TJINN_PUBLIC_PARTIAL_ERROR,
   TJINN_PUBLIC_READ_ERROR,
-  TJINN_TOKEN_ADDRESS,
   type TjinnServiceStatus,
   type TjinnStatus,
   resolveMasterDailyEstimateWei,
@@ -61,10 +65,56 @@ const ERC20_BALANCE_OF_ABI = [
 const TJINN_BALANCE_CACHE_TTL_MS = 30_000;
 const TJINN_BALANCE_TIMEOUT_MS = 4_000;
 
+/**
+ * tJINN token address + chain id resolved from the bundled JINN MVI L1
+ * deployment artifact — the single source of truth. Used only when the caller
+ * (`main.ts`) does not thread explicit values through `StatusGatherConfig`
+ * (e.g. test callers, sqlite-only introspection without config). Lazy + cached
+ * so the artifact read happens at most once per process.
+ */
+let cachedTjinnArtifactIdentity: { tokenAddress: string; chainId: number } | undefined;
+function defaultTjinnIdentity(): { tokenAddress: string; chainId: number } {
+  if (!cachedTjinnArtifactIdentity) {
+    let tokenAddress: string | undefined;
+    let chainId: number | undefined;
+    try {
+      const mvi = loadJinnMviConfig({ l1ArtifactPath: DEFAULT_TESTNET_ARTIFACTS.jinnMviL1 });
+      tokenAddress = mvi.jinn;
+      chainId = mvi.l1ChainId;
+    } catch {
+      // Fall through to the hard defaults below if the artifact is unreadable.
+    }
+    cachedTjinnArtifactIdentity = {
+      tokenAddress: tokenAddress ?? '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A',
+      chainId: chainId ?? 11155111,
+    };
+  }
+  return cachedTjinnArtifactIdentity;
+}
+
+function resolveTjinnIdentity(
+  status: StatusGatherConfig | undefined,
+): { tokenAddress: string; chainId: number } {
+  const fallback = defaultTjinnIdentity();
+  return {
+    tokenAddress: status?.tjinnTokenAddress ?? fallback.tokenAddress,
+    chainId: status?.tjinnChainId ?? fallback.chainId,
+  };
+}
+
 interface TjinnBalanceSnapshot {
   chainId: number;
   balances: Map<string, string>;
   errors: Map<string, string>;
+}
+
+/** Fill a fresh errors Map with `TJINN_PUBLIC_READ_ERROR` for every key. */
+function errorsForAllKeys(keys: Iterable<string>): Map<string, string> {
+  const errors = new Map<string, string>();
+  for (const key of keys) {
+    errors.set(key, TJINN_PUBLIC_READ_ERROR);
+  }
+  return errors;
 }
 
 const tjinnBalanceCache = new Map<
@@ -110,8 +160,15 @@ export function invalidatePredictionOperatorStatusCache(config: JinnConfig): voi
 export interface StatusGatherConfig {
   earningDir: string;
   rpcUrl: string;
-  /** Sepolia RPC endpoint for reading the real tJINN ERC-20 balance. */
-  ethereumRpcUrl?: string;
+  /**
+   * tJINN ERC-20 token address — resolved from the bundled JINN MVI L1
+   * deployment artifact in `main.ts` (single source of truth). Optional so
+   * test callers can omit it; gather-status falls back to the artifact-derived
+   * default when absent.
+   */
+  tjinnTokenAddress?: string;
+  /** tJINN chain id — resolved from the same artifact as `tjinnTokenAddress`. */
+  tjinnChainId?: number;
   network: 'mainnet' | 'testnet';
   pollIntervalMs: number;
   masterEthDailyEstimateWei?: string;
@@ -329,43 +386,41 @@ function withTimeout<T>(
 
 async function readTjinnBalances(
   ethereumRpcUrl: string,
+  tokenAddress: string,
+  expectedChainId: number,
   safeToAddress: Map<string, `0x${string}`>,
 ): Promise<TjinnBalanceSnapshot> {
   const safeEntries = [...safeToAddress.entries()];
-  const client = createPublicClient({
-    chain: sepolia,
-    transport: http(ethereumRpcUrl, { timeout: TJINN_BALANCE_TIMEOUT_MS }),
-  });
+  const client = createJinnL1PublicClient(ethereumRpcUrl, 'sepolia');
   const chainId = await client.getChainId();
   const balances = new Map<string, string>();
-  const errors = new Map<string, string>();
 
-  if (chainId !== TJINN_CHAIN_ID) {
-    for (const [key] of safeEntries) {
-      errors.set(key, TJINN_PUBLIC_READ_ERROR);
-    }
-    return { chainId, balances, errors };
+  if (chainId !== expectedChainId) {
+    return { chainId, balances, errors: errorsForAllKeys(safeToAddress.keys()) };
   }
 
-  const settled = await Promise.allSettled(
-    safeEntries.map(async ([key, safeAddress]) => {
-      const balance = await client.readContract({
-        address: TJINN_TOKEN_ADDRESS as `0x${string}`,
-        abi: ERC20_BALANCE_OF_ABI,
-        functionName: 'balanceOf',
-        args: [safeAddress],
-      });
-      return { key, balanceWei: balance.toString() };
-    }),
-  );
+  const errors = new Map<string, string>();
+  // Single multicall3 round-trip (Sepolia has multicall3). `allowFailure: true`
+  // preserves the per-Safe partial-failure handling — a failed entry yields a
+  // `{ status: 'failure' }` result rather than rejecting the whole batch.
+  const results = await client.multicall({
+    allowFailure: true,
+    contracts: safeEntries.map(([, safeAddress]) => ({
+      address: tokenAddress as `0x${string}`,
+      abi: ERC20_BALANCE_OF_ABI,
+      functionName: 'balanceOf',
+      args: [safeAddress],
+    })),
+  });
 
-  for (let i = 0; i < settled.length; i++) {
-    const result = settled[i]!;
-    if (result.status === 'fulfilled') {
-      balances.set(result.value.key, result.value.balanceWei);
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i]!;
+    const key = safeEntries[i]?.[0];
+    if (!key) continue;
+    if (result.status === 'success') {
+      balances.set(key, (result.result as bigint).toString());
     } else {
-      const key = safeEntries[i]?.[0];
-      if (key) errors.set(key, TJINN_PUBLIC_READ_ERROR);
+      errors.set(key, TJINN_PUBLIC_READ_ERROR);
     }
   }
 
@@ -374,6 +429,8 @@ async function readTjinnBalances(
 
 async function getCachedTjinnBalances(
   ethereumRpcUrl: string,
+  tokenAddress: string,
+  expectedChainId: number,
   safeToAddress: Map<string, `0x${string}`>,
 ): Promise<TjinnBalanceSnapshot> {
   const safeKeys = [...safeToAddress.keys()].sort();
@@ -385,18 +442,14 @@ async function getCachedTjinnBalances(
   }
 
   const promise = withTimeout(
-    readTjinnBalances(ethereumRpcUrl, safeToAddress),
+    readTjinnBalances(ethereumRpcUrl, tokenAddress, expectedChainId, safeToAddress),
     TJINN_BALANCE_TIMEOUT_MS,
     'tJINN balance collection timed out',
   ).catch((): TjinnBalanceSnapshot => {
-    const errors = new Map<string, string>();
-    for (const key of safeKeys) {
-      errors.set(key, TJINN_PUBLIC_READ_ERROR);
-    }
     return {
-      chainId: TJINN_CHAIN_ID,
+      chainId: expectedChainId,
       balances: new Map<string, string>(),
-      errors,
+      errors: errorsForAllKeys(safeKeys),
     };
   });
   tjinnBalanceCache.set(cacheKey, {
@@ -462,23 +515,34 @@ async function sumPendingStakingRewards(
   }
 }
 
+/**
+ * Resolve the public error string for a tJINN status with at least one error.
+ *
+ * Flattened from a 3-deep nested ternary into guard clauses:
+ *  - partial success (some balances read) → PARTIAL
+ *  - only invalid-Safe errors             → INVALID_SAFE
+ *  - otherwise (RPC read failures)        → READ_ERROR
+ *
+ * Caller must only invoke this when `hasInvalidSafe || hasReadError` is true.
+ */
+function tjinnPublicError(opts: {
+  hasInvalidSafe: boolean;
+  hasReadError: boolean;
+  hasAnyBalance: boolean;
+}): string {
+  if (opts.hasAnyBalance) return TJINN_PUBLIC_PARTIAL_ERROR;
+  if (opts.hasInvalidSafe && !opts.hasReadError) return TJINN_PUBLIC_INVALID_SAFE_ERROR;
+  return TJINN_PUBLIC_READ_ERROR;
+}
+
 async function gatherTjinnStatus(
   ethereumRpcUrl: string | undefined,
+  tokenAddress: string,
+  chainId: number,
   fleet: FleetState | null,
 ): Promise<TjinnStatus> {
-  const baseStatus = {
-    chainId: TJINN_CHAIN_ID,
-    tokenAddress: TJINN_TOKEN_ADDRESS,
-  };
   if (!fleet) {
-    return {
-      ...baseStatus,
-      state: 'pending',
-      safeBalanceWei: null,
-      safeCount: 0,
-      services: [],
-      error: null,
-    };
+    return pendingTjinnStatus(tokenAddress, chainId);
   }
 
   const services: TjinnServiceStatus[] = [];
@@ -522,28 +586,24 @@ async function gatherTjinnStatus(
   const safeCount = safeToAddress.size;
   if (safeCount === 0) {
     const invalid = services.find((svc) => svc.state === 'error')?.error;
-    return {
-      ...baseStatus,
+    return pendingTjinnStatus(tokenAddress, chainId, {
       state: invalid ? 'error' : 'pending',
-      safeBalanceWei: null,
       safeCount,
       services,
       error: invalid ?? null,
-    };
+    });
   }
 
   if (!ethereumRpcUrl) {
-    return {
-      ...baseStatus,
-      state: 'pending',
-      safeBalanceWei: null,
-      safeCount,
-      services,
-      error: null,
-    };
+    return pendingTjinnStatus(tokenAddress, chainId, { safeCount, services });
   }
 
-  const snapshot = await getCachedTjinnBalances(ethereumRpcUrl, safeToAddress);
+  const snapshot = await getCachedTjinnBalances(
+    ethereumRpcUrl,
+    tokenAddress,
+    chainId,
+    safeToAddress,
+  );
   let total = 0n;
   for (const balance of snapshot.balances.values()) {
     total += BigInt(balance);
@@ -553,20 +613,14 @@ async function gatherTjinnStatus(
   const hasAnyError = hasInvalidSafe || hasReadError;
   const hasAnyBalance = snapshot.balances.size > 0;
   const publicError = hasAnyError
-    ? hasAnyBalance
-      ? TJINN_PUBLIC_PARTIAL_ERROR
-      : hasInvalidSafe && !hasReadError
-        ? TJINN_PUBLIC_INVALID_SAFE_ERROR
-        : TJINN_PUBLIC_READ_ERROR
+    ? tjinnPublicError({ hasInvalidSafe, hasReadError, hasAnyBalance })
     : null;
 
-  return {
-    ...baseStatus,
-    chainId: snapshot.chainId,
+  return pendingTjinnStatus(tokenAddress, snapshot.chainId, {
     state: hasAnyError ? 'error' : 'ready',
     safeBalanceWei: hasAnyBalance ? total.toString() : null,
     safeCount,
-    services: services.map((svc) => {
+    services: services.map((svc): TjinnServiceStatus => {
       if (!svc.safeAddress) return svc;
       if (svc.state === 'error') return svc;
       const key = svc.safeAddress.toLowerCase();
@@ -581,7 +635,7 @@ async function gatherTjinnStatus(
       };
     }),
     error: publicError,
-  };
+  });
 }
 
 function hasUsefulCacheValues(entry: BalanceCacheEntry, isAgentRole: boolean): boolean {
@@ -734,6 +788,8 @@ export async function gatherGatheredStatusRaw(
     status?.pollIntervalMs ?? 5000,
   );
 
+  const tjinnIdentity = resolveTjinnIdentity(status);
+
   // portfolio.v0 lifecycle data — best-effort, never throws
   let portfolioV0: ReturnType<typeof gatherPortfolioV0Status> | undefined;
   try {
@@ -805,6 +861,8 @@ export async function gatherGatheredStatusRaw(
     serviceBalances: {},
     pendingByService: {},
     claimedByService: store.getClaimedRewardsByService(),
+    tjinnTokenAddress: tjinnIdentity.tokenAddress,
+    tjinnChainId: tjinnIdentity.chainId,
   };
 
   if (!status) {
@@ -822,6 +880,17 @@ export async function gatherGatheredStatusRaw(
     testnetMechDeploymentPath: status.testnetMechDeploymentPath,
     testnetStolasDeploymentPath: status.testnetStolasDeploymentPath,
   });
+
+  // Start the Sepolia tJINN read up front so it overlaps the Base-RPC fan-out
+  // below for free. `gatherTjinnStatus` is internally error-safe (it catches
+  // and returns a snapshot), so the promise never rejects — it is awaited at
+  // the point its result is assigned to `raw.tJinn`.
+  const tJinnPromise = gatherTjinnStatus(
+    status.network === 'testnet' ? status.config?.ethereumRpcUrl : undefined,
+    tjinnIdentity.tokenAddress,
+    tjinnIdentity.chainId,
+    fleet,
+  );
 
   const raw: GatheredStatusRaw = {
     ...baseRaw,
@@ -852,12 +921,6 @@ export async function gatherGatheredStatusRaw(
     master: {
       address: fleet?.master_address ?? null,
     },
-    tJinn: await gatherTjinnStatus(
-      status.network === 'testnet'
-        ? (status.ethereumRpcUrl ?? status.config?.ethereumRpcUrl)
-        : undefined,
-      fleet,
-    ),
     rewardClaimIntervalMs: status.rewardClaimIntervalMs,
   };
 
@@ -866,6 +929,10 @@ export async function gatherGatheredStatusRaw(
     chain: viemChain,
     transport: http(status.rpcUrl),
   });
+
+  // The tJINN read started above (overlapping the Base-RPC fan-out). It never
+  // rejects, so a plain await is safe here.
+  raw.tJinn = await tJinnPromise;
 
   try {
     const [blockNumber, chainId] = await Promise.all([

--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -2,13 +2,13 @@
  * Best-effort status collection for GET /v1/status (RPC + earning store + SQLite).
  */
 
-import { createPublicClient, http, type PublicClient } from 'viem';
+import { createPublicClient, getAddress, http, type PublicClient } from 'viem';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 /** Narrow RPC surface for balance fan-out (avoids PublicClient / chain-specific getBlock incompatibilities). */
 type StatusBalanceRpc = Pick<PublicClient, 'getBalance' | 'readContract'>;
-import { base, baseSepolia } from 'viem/chains';
+import { base, baseSepolia, sepolia } from 'viem/chains';
 import type { Store } from '../store/store.js';
 import type { JinnConfig } from '../config.js';
 import { FleetStateStore } from '../earning/store.js';
@@ -22,6 +22,13 @@ import {
   type GatheredStatusRaw,
   type ServiceBalanceErrorEntry,
   type StatusV1Response,
+  TJINN_CHAIN_ID,
+  TJINN_PUBLIC_INVALID_SAFE_ERROR,
+  TJINN_PUBLIC_PARTIAL_ERROR,
+  TJINN_PUBLIC_READ_ERROR,
+  TJINN_TOKEN_ADDRESS,
+  type TjinnServiceStatus,
+  type TjinnStatus,
   resolveMasterDailyEstimateWei,
 } from './status-build.js';
 import { listStolasClaimTargets } from '../earning/stolas-claim.js';
@@ -50,6 +57,20 @@ const ERC20_BALANCE_OF_ABI = [
     outputs: [{ name: '', type: 'uint256' }],
   },
 ] as const;
+
+const TJINN_BALANCE_CACHE_TTL_MS = 30_000;
+const TJINN_BALANCE_TIMEOUT_MS = 4_000;
+
+interface TjinnBalanceSnapshot {
+  chainId: number;
+  balances: Map<string, string>;
+  errors: Map<string, string>;
+}
+
+const tjinnBalanceCache = new Map<
+  string,
+  { expiresAt: number; promise: Promise<TjinnBalanceSnapshot> }
+>();
 
 function readDaemonRuntime(earningDir: string | undefined): GatheredStatusRaw['daemonRuntime'] | undefined {
   if (!earningDir) return undefined;
@@ -89,6 +110,8 @@ export function invalidatePredictionOperatorStatusCache(config: JinnConfig): voi
 export interface StatusGatherConfig {
   earningDir: string;
   rpcUrl: string;
+  /** Sepolia RPC endpoint for reading the real tJINN ERC-20 balance. */
+  ethereumRpcUrl?: string;
   network: 'mainnet' | 'testnet';
   pollIntervalMs: number;
   masterEthDailyEstimateWei?: string;
@@ -278,6 +301,111 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function tJinnBalanceCacheKey(
+  ethereumRpcUrl: string,
+  safeKeys: readonly string[],
+): string {
+  return `${ethereumRpcUrl}\0${[...safeKeys].sort().join(',')}`;
+}
+
+function timeoutError(message: string): Error {
+  const error = new Error(message);
+  error.name = 'TimeoutError';
+  return error;
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(timeoutError(message)), timeoutMs);
+    promise
+      .then(resolve, reject)
+      .finally(() => clearTimeout(timer));
+  });
+}
+
+async function readTjinnBalances(
+  ethereumRpcUrl: string,
+  safeToAddress: Map<string, `0x${string}`>,
+): Promise<TjinnBalanceSnapshot> {
+  const safeEntries = [...safeToAddress.entries()];
+  const client = createPublicClient({
+    chain: sepolia,
+    transport: http(ethereumRpcUrl, { timeout: TJINN_BALANCE_TIMEOUT_MS }),
+  });
+  const chainId = await client.getChainId();
+  const balances = new Map<string, string>();
+  const errors = new Map<string, string>();
+
+  if (chainId !== TJINN_CHAIN_ID) {
+    for (const [key] of safeEntries) {
+      errors.set(key, TJINN_PUBLIC_READ_ERROR);
+    }
+    return { chainId, balances, errors };
+  }
+
+  const settled = await Promise.allSettled(
+    safeEntries.map(async ([key, safeAddress]) => {
+      const balance = await client.readContract({
+        address: TJINN_TOKEN_ADDRESS as `0x${string}`,
+        abi: ERC20_BALANCE_OF_ABI,
+        functionName: 'balanceOf',
+        args: [safeAddress],
+      });
+      return { key, balanceWei: balance.toString() };
+    }),
+  );
+
+  for (let i = 0; i < settled.length; i++) {
+    const result = settled[i]!;
+    if (result.status === 'fulfilled') {
+      balances.set(result.value.key, result.value.balanceWei);
+    } else {
+      const key = safeEntries[i]?.[0];
+      if (key) errors.set(key, TJINN_PUBLIC_READ_ERROR);
+    }
+  }
+
+  return { chainId, balances, errors };
+}
+
+async function getCachedTjinnBalances(
+  ethereumRpcUrl: string,
+  safeToAddress: Map<string, `0x${string}`>,
+): Promise<TjinnBalanceSnapshot> {
+  const safeKeys = [...safeToAddress.keys()].sort();
+  const cacheKey = tJinnBalanceCacheKey(ethereumRpcUrl, safeKeys);
+  const now = Date.now();
+  const cached = tjinnBalanceCache.get(cacheKey);
+  if (cached && cached.expiresAt > now) {
+    return cached.promise;
+  }
+
+  const promise = withTimeout(
+    readTjinnBalances(ethereumRpcUrl, safeToAddress),
+    TJINN_BALANCE_TIMEOUT_MS,
+    'tJINN balance collection timed out',
+  ).catch((): TjinnBalanceSnapshot => {
+    const errors = new Map<string, string>();
+    for (const key of safeKeys) {
+      errors.set(key, TJINN_PUBLIC_READ_ERROR);
+    }
+    return {
+      chainId: TJINN_CHAIN_ID,
+      balances: new Map<string, string>(),
+      errors,
+    };
+  });
+  tjinnBalanceCache.set(cacheKey, {
+    expiresAt: now + TJINN_BALANCE_CACHE_TTL_MS,
+    promise,
+  });
+  return promise;
+}
+
 async function sumPendingStakingRewards(
   rpcUrl: string,
   network: 'mainnet' | 'testnet',
@@ -332,6 +460,128 @@ async function sumPendingStakingRewards(
   } catch (e) {
     return { error: e instanceof Error ? e.message : String(e) };
   }
+}
+
+async function gatherTjinnStatus(
+  ethereumRpcUrl: string | undefined,
+  fleet: FleetState | null,
+): Promise<TjinnStatus> {
+  const baseStatus = {
+    chainId: TJINN_CHAIN_ID,
+    tokenAddress: TJINN_TOKEN_ADDRESS,
+  };
+  if (!fleet) {
+    return {
+      ...baseStatus,
+      state: 'pending',
+      safeBalanceWei: null,
+      safeCount: 0,
+      services: [],
+      error: null,
+    };
+  }
+
+  const services: TjinnServiceStatus[] = [];
+  const safeToAddress = new Map<string, `0x${string}`>();
+
+  for (const svc of fleet.services) {
+    const index = displayFleetServiceIndex(svc);
+    const safeAddress = svc.safe_address;
+    if (!safeAddress) {
+      services.push({
+        index,
+        safeAddress: null,
+        balanceWei: null,
+        state: 'pending',
+        error: null,
+      });
+      continue;
+    }
+    try {
+      const checksum = getAddress(safeAddress);
+      const key = checksum.toLowerCase();
+      services.push({
+        index,
+        safeAddress: checksum,
+        balanceWei: null,
+        state: 'pending',
+        error: null,
+      });
+      safeToAddress.set(key, checksum as `0x${string}`);
+    } catch {
+      services.push({
+        index,
+        safeAddress,
+        balanceWei: null,
+        state: 'error',
+        error: TJINN_PUBLIC_INVALID_SAFE_ERROR,
+      });
+    }
+  }
+
+  const safeCount = safeToAddress.size;
+  if (safeCount === 0) {
+    const invalid = services.find((svc) => svc.state === 'error')?.error;
+    return {
+      ...baseStatus,
+      state: invalid ? 'error' : 'pending',
+      safeBalanceWei: null,
+      safeCount,
+      services,
+      error: invalid ?? null,
+    };
+  }
+
+  if (!ethereumRpcUrl) {
+    return {
+      ...baseStatus,
+      state: 'pending',
+      safeBalanceWei: null,
+      safeCount,
+      services,
+      error: null,
+    };
+  }
+
+  const snapshot = await getCachedTjinnBalances(ethereumRpcUrl, safeToAddress);
+  let total = 0n;
+  for (const balance of snapshot.balances.values()) {
+    total += BigInt(balance);
+  }
+  const hasInvalidSafe = services.some((svc) => svc.error === TJINN_PUBLIC_INVALID_SAFE_ERROR);
+  const hasReadError = snapshot.errors.size > 0;
+  const hasAnyError = hasInvalidSafe || hasReadError;
+  const hasAnyBalance = snapshot.balances.size > 0;
+  const publicError = hasAnyError
+    ? hasAnyBalance
+      ? TJINN_PUBLIC_PARTIAL_ERROR
+      : hasInvalidSafe && !hasReadError
+        ? TJINN_PUBLIC_INVALID_SAFE_ERROR
+        : TJINN_PUBLIC_READ_ERROR
+    : null;
+
+  return {
+    ...baseStatus,
+    chainId: snapshot.chainId,
+    state: hasAnyError ? 'error' : 'ready',
+    safeBalanceWei: hasAnyBalance ? total.toString() : null,
+    safeCount,
+    services: services.map((svc) => {
+      if (!svc.safeAddress) return svc;
+      if (svc.state === 'error') return svc;
+      const key = svc.safeAddress.toLowerCase();
+      const balance = snapshot.balances.get(key);
+      if (balance !== undefined) {
+        return { ...svc, state: 'ready', balanceWei: balance, error: null };
+      }
+      return {
+        ...svc,
+        state: 'error',
+        error: snapshot.errors.get(key) ?? TJINN_PUBLIC_READ_ERROR,
+      };
+    }),
+    error: publicError,
+  };
 }
 
 function hasUsefulCacheValues(entry: BalanceCacheEntry, isAgentRole: boolean): boolean {
@@ -602,6 +852,12 @@ export async function gatherGatheredStatusRaw(
     master: {
       address: fleet?.master_address ?? null,
     },
+    tJinn: await gatherTjinnStatus(
+      status.network === 'testnet'
+        ? (status.ethereumRpcUrl ?? status.config?.ethereumRpcUrl)
+        : undefined,
+      fleet,
+    ),
     rewardClaimIntervalMs: status.rewardClaimIntervalMs,
   };
 

--- a/client/src/api/status-build.ts
+++ b/client/src/api/status-build.ts
@@ -92,10 +92,15 @@ export interface GatheredStatusRaw {
    * tJINN ERC-20 token address — resolved from the bundled JINN MVI L1
    * deployment artifact (single source of truth) and threaded through from
    * `main.ts`. Used to build the fallback pending status when `tJinn` is absent.
+   * Optional: not meaningfully present on mainnet/older paths and absent in
+   * many test fixtures — callers must handle `undefined`.
    */
-  tjinnTokenAddress: string;
-  /** tJINN chain id — resolved from the same artifact as `tjinnTokenAddress`. */
-  tjinnChainId: number;
+  tjinnTokenAddress?: string;
+  /**
+   * tJINN chain id — resolved from the same artifact as `tjinnTokenAddress`.
+   * Optional for the same reasons as `tjinnTokenAddress`.
+   */
+  tjinnChainId?: number;
   /** ISO timestamp when the staking contract will next accept a checkpoint. */
   nextCheckpointAt?: string;
   pollIntervalMs: number;
@@ -297,16 +302,21 @@ function sumClaimedRewardsWei(raw: GatheredStatusRaw): bigint {
  * gather-status and the status assembler would otherwise hand-roll. Pass
  * `overrides` to set `safeCount`, `services`, `error`, etc. while keeping the
  * token/chain/`pending` defaults.
+ *
+ * `tokenAddress`/`chainId` are optional: on mainnet/older paths (and many test
+ * fixtures) the tJINN identity is not resolved. When absent, a sane empty
+ * pending status is produced — empty token address and chain id `0` — rather
+ * than a bogus address.
  */
 export function pendingTjinnStatus(
-  tokenAddress: string,
-  chainId: number,
+  tokenAddress: string | undefined,
+  chainId: number | undefined,
   overrides?: Partial<TjinnStatus>,
 ): TjinnStatus {
   return {
     state: 'pending',
-    chainId,
-    tokenAddress,
+    chainId: chainId ?? 0,
+    tokenAddress: tokenAddress ?? '',
     safeBalanceWei: null,
     safeCount: 0,
     services: [],
@@ -321,8 +331,8 @@ function publicTjinnError(error: string): string {
 
 function publicTjinnStatus(
   status: TjinnStatus | undefined,
-  tokenAddress: string,
-  chainId: number,
+  tokenAddress: string | undefined,
+  chainId: number | undefined,
 ): TjinnStatus {
   if (!status) return pendingTjinnStatus(tokenAddress, chainId);
   return {

--- a/client/src/api/status-build.ts
+++ b/client/src/api/status-build.ts
@@ -18,8 +18,6 @@ const DEFAULT_MASTER_ETH_DAILY_WEI = 1_000_000_000_000_000n;
 export type StatusHintsScope = 'full' | 'sqlite_only';
 export type TjinnStatusState = 'pending' | 'ready' | 'error';
 
-export const TJINN_CHAIN_ID = 11155111;
-export const TJINN_TOKEN_ADDRESS = '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A';
 export const TJINN_PUBLIC_READ_ERROR = 'Sepolia tJINN balance temporarily unavailable.';
 export const TJINN_PUBLIC_PARTIAL_ERROR = 'Some Safe tJINN balances are temporarily unavailable.';
 export const TJINN_PUBLIC_INVALID_SAFE_ERROR = 'One or more Safe addresses are invalid.';
@@ -90,6 +88,14 @@ export interface GatheredStatusRaw {
   pendingRewardsError?: string;
   /** Sepolia tJINN ERC-20 balances across fleet Safes. */
   tJinn?: TjinnStatus;
+  /**
+   * tJINN ERC-20 token address — resolved from the bundled JINN MVI L1
+   * deployment artifact (single source of truth) and threaded through from
+   * `main.ts`. Used to build the fallback pending status when `tJinn` is absent.
+   */
+  tjinnTokenAddress: string;
+  /** tJINN chain id — resolved from the same artifact as `tjinnTokenAddress`. */
+  tjinnChainId: number;
   /** ISO timestamp when the staking contract will next accept a checkpoint. */
   nextCheckpointAt?: string;
   pollIntervalMs: number;
@@ -284,15 +290,28 @@ function sumClaimedRewardsWei(raw: GatheredStatusRaw): bigint {
   return total;
 }
 
-function defaultTjinnStatus(): TjinnStatus {
+/**
+ * Build a `TjinnStatus` in the `pending` state for a given token/chain.
+ *
+ * Single builder for the near-identical pending `TjinnStatus` literals that
+ * gather-status and the status assembler would otherwise hand-roll. Pass
+ * `overrides` to set `safeCount`, `services`, `error`, etc. while keeping the
+ * token/chain/`pending` defaults.
+ */
+export function pendingTjinnStatus(
+  tokenAddress: string,
+  chainId: number,
+  overrides?: Partial<TjinnStatus>,
+): TjinnStatus {
   return {
     state: 'pending',
-    chainId: TJINN_CHAIN_ID,
-    tokenAddress: TJINN_TOKEN_ADDRESS,
+    chainId,
+    tokenAddress,
     safeBalanceWei: null,
     safeCount: 0,
     services: [],
     error: null,
+    ...overrides,
   };
 }
 
@@ -300,8 +319,12 @@ function publicTjinnError(error: string): string {
   return TJINN_PUBLIC_ERRORS.has(error) ? error : TJINN_PUBLIC_READ_ERROR;
 }
 
-function publicTjinnStatus(status: TjinnStatus | undefined): TjinnStatus {
-  if (!status) return defaultTjinnStatus();
+function publicTjinnStatus(
+  status: TjinnStatus | undefined,
+  tokenAddress: string,
+  chainId: number,
+): TjinnStatus {
+  if (!status) return pendingTjinnStatus(tokenAddress, chainId);
   return {
     ...status,
     error: status.error ? publicTjinnError(status.error) : null,
@@ -440,7 +463,7 @@ export function assembleStatusV1(raw: GatheredStatusRaw): StatusV1Response {
           : claimedRewardsWei.toString(),
       pendingRewardsError: raw.pendingRewardsError,
     },
-    tJinn: publicTjinnStatus(raw.tJinn),
+    tJinn: publicTjinnStatus(raw.tJinn, raw.tjinnTokenAddress, raw.tjinnChainId),
     masterGas: {
       address: raw.master.address,
       balanceWei: raw.master.balanceWei,

--- a/client/src/api/status-build.ts
+++ b/client/src/api/status-build.ts
@@ -16,6 +16,37 @@ import type { TaskRunsStatus } from './task-runs-build.js';
 const DEFAULT_MASTER_ETH_DAILY_WEI = 1_000_000_000_000_000n;
 
 export type StatusHintsScope = 'full' | 'sqlite_only';
+export type TjinnStatusState = 'pending' | 'ready' | 'error';
+
+export const TJINN_CHAIN_ID = 11155111;
+export const TJINN_TOKEN_ADDRESS = '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A';
+export const TJINN_PUBLIC_READ_ERROR = 'Sepolia tJINN balance temporarily unavailable.';
+export const TJINN_PUBLIC_PARTIAL_ERROR = 'Some Safe tJINN balances are temporarily unavailable.';
+export const TJINN_PUBLIC_INVALID_SAFE_ERROR = 'One or more Safe addresses are invalid.';
+
+const TJINN_PUBLIC_ERRORS = new Set([
+  TJINN_PUBLIC_READ_ERROR,
+  TJINN_PUBLIC_PARTIAL_ERROR,
+  TJINN_PUBLIC_INVALID_SAFE_ERROR,
+]);
+
+export interface TjinnServiceStatus {
+  index: number;
+  safeAddress: string | null;
+  balanceWei: string | null;
+  state: TjinnStatusState;
+  error: string | null;
+}
+
+export interface TjinnStatus {
+  state: TjinnStatusState;
+  chainId: number;
+  tokenAddress: string;
+  safeBalanceWei: string | null;
+  safeCount: number;
+  services: TjinnServiceStatus[];
+  error: string | null;
+}
 
 export interface ServiceBalanceErrorEntry {
   agent?: string;
@@ -57,6 +88,8 @@ export interface GatheredStatusRaw {
   };
   pendingStakingRewardsWei?: string;
   pendingRewardsError?: string;
+  /** Sepolia tJINN ERC-20 balances across fleet Safes. */
+  tJinn?: TjinnStatus;
   /** ISO timestamp when the staking contract will next accept a checkpoint. */
   nextCheckpointAt?: string;
   pollIntervalMs: number;
@@ -136,6 +169,7 @@ export interface StatusV1Response {
     totalStakingRewardsWei?: string;
     pendingRewardsError?: string;
   };
+  tJinn: TjinnStatus;
   masterGas: {
     address: string | null;
     balanceWei?: string;
@@ -248,6 +282,34 @@ function sumClaimedRewardsWei(raw: GatheredStatusRaw): bigint {
     }
   }
   return total;
+}
+
+function defaultTjinnStatus(): TjinnStatus {
+  return {
+    state: 'pending',
+    chainId: TJINN_CHAIN_ID,
+    tokenAddress: TJINN_TOKEN_ADDRESS,
+    safeBalanceWei: null,
+    safeCount: 0,
+    services: [],
+    error: null,
+  };
+}
+
+function publicTjinnError(error: string): string {
+  return TJINN_PUBLIC_ERRORS.has(error) ? error : TJINN_PUBLIC_READ_ERROR;
+}
+
+function publicTjinnStatus(status: TjinnStatus | undefined): TjinnStatus {
+  if (!status) return defaultTjinnStatus();
+  return {
+    ...status,
+    error: status.error ? publicTjinnError(status.error) : null,
+    services: status.services.map((service) => ({
+      ...service,
+      error: service.error ? publicTjinnError(service.error) : null,
+    })),
+  };
 }
 
 function buildEarningsHint(raw: GatheredStatusRaw, fleetSum: StatusV1Response['fleet']): string {
@@ -378,6 +440,7 @@ export function assembleStatusV1(raw: GatheredStatusRaw): StatusV1Response {
           : claimedRewardsWei.toString(),
       pendingRewardsError: raw.pendingRewardsError,
     },
+    tJinn: publicTjinnStatus(raw.tJinn),
     masterGas: {
       address: raw.master.address,
       balanceWei: raw.master.balanceWei,

--- a/client/src/cli/introspection-context.ts
+++ b/client/src/cli/introspection-context.ts
@@ -56,7 +56,6 @@ export async function gatherIntrospectionRaw(opts?: {
   const status: StatusGatherConfig = {
     earningDir: config.earningDir,
     rpcUrl: config.rpcUrl,
-    ethereumRpcUrl: config.ethereumRpcUrl,
     network: config.network,
     pollIntervalMs: config.pollIntervalMs,
     masterEthDailyEstimateWei: config.masterEthDailyEstimateWei,
@@ -65,6 +64,11 @@ export async function gatherIntrospectionRaw(opts?: {
     testnetL2TokenDeploymentPath: config.testnetL2TokenDeploymentPath,
     testnetMechDeploymentPath: config.testnetMechDeploymentPath,
     testnetStolasDeploymentPath: config.testnetStolasDeploymentPath,
+    // `config` carries `ethereumRpcUrl` (the Sepolia tJINN read endpoint) —
+    // gather-status reads it via `config?.ethereumRpcUrl`, so threading the
+    // full config is sufficient (no separate top-level field needed).
+    config,
+    configPath,
   };
   const local = await gatherGatheredStatusRaw(store, status);
   return tryMergeStatusFromHttp(config, local);

--- a/client/src/cli/introspection-context.ts
+++ b/client/src/cli/introspection-context.ts
@@ -56,6 +56,7 @@ export async function gatherIntrospectionRaw(opts?: {
   const status: StatusGatherConfig = {
     earningDir: config.earningDir,
     rpcUrl: config.rpcUrl,
+    ethereumRpcUrl: config.ethereumRpcUrl,
     network: config.network,
     pollIntervalMs: config.pollIntervalMs,
     masterEthDailyEstimateWei: config.masterEthDailyEstimateWei,

--- a/client/src/earning/contracts.ts
+++ b/client/src/earning/contracts.ts
@@ -842,6 +842,8 @@ export const STOLAS_STAKING_SLOTS_ABI = [
  */
 export interface JinnMviConfig {
   jinn?: string;
+  /** L1 chain id from the L1 artifact (e.g. 11155111 for Sepolia). */
+  l1ChainId?: number;
   timelock?: string;
   governor?: string;
   distributor?: string;
@@ -897,6 +899,7 @@ export function loadJinnMviConfig(args: {
     }
     const artifact = JSON.parse(readFileSync(resolved, 'utf8')) as JinnMviL1Artifact;
     out.jinn = artifact.contracts?.JINN;
+    if (typeof artifact.chainId === 'number') out.l1ChainId = artifact.chainId;
     out.timelock = artifact.contracts?.TimelockController;
     out.governor = artifact.contracts?.JinnGovernor;
     out.distributor = artifact.contracts?.JinnDistributor;

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1212,7 +1212,11 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
       status: {
         earningDir: config.earningDir,
         rpcUrl: config.rpcUrl,
-        ethereumRpcUrl: config.ethereumRpcUrl,
+        // tJINN identity comes from the bundled JINN MVI L1 artifact
+        // (`JINN_MVI_CONFIG`) — one source of truth. The Sepolia RPC endpoint
+        // is read from `config.ethereumRpcUrl` via the threaded `config`.
+        tjinnTokenAddress: JINN_MVI_CONFIG.jinn,
+        tjinnChainId: JINN_MVI_CONFIG.l1ChainId,
         network: config.network,
         pollIntervalMs: config.pollIntervalMs,
         masterEthDailyEstimateWei: config.masterEthDailyEstimateWei,
@@ -2365,7 +2369,11 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     status: {
       earningDir: config.earningDir,
       rpcUrl: config.rpcUrl,
-      ethereumRpcUrl: config.ethereumRpcUrl,
+      // tJINN identity comes from the bundled JINN MVI L1 artifact
+      // (`JINN_MVI_CONFIG`) — one source of truth. The Sepolia RPC endpoint
+      // is read from `config.ethereumRpcUrl` via the threaded `config`.
+      tjinnTokenAddress: JINN_MVI_CONFIG.jinn,
+      tjinnChainId: JINN_MVI_CONFIG.l1ChainId,
       network: config.network,
       pollIntervalMs: config.pollIntervalMs,
       masterEthDailyEstimateWei: config.masterEthDailyEstimateWei,

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1212,6 +1212,7 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
       status: {
         earningDir: config.earningDir,
         rpcUrl: config.rpcUrl,
+        ethereumRpcUrl: config.ethereumRpcUrl,
         network: config.network,
         pollIntervalMs: config.pollIntervalMs,
         masterEthDailyEstimateWei: config.masterEthDailyEstimateWei,
@@ -2364,6 +2365,7 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     status: {
       earningDir: config.earningDir,
       rpcUrl: config.rpcUrl,
+      ethereumRpcUrl: config.ethereumRpcUrl,
       network: config.network,
       pollIntervalMs: config.pollIntervalMs,
       masterEthDailyEstimateWei: config.masterEthDailyEstimateWei,

--- a/client/test/api/gather-status.test.ts
+++ b/client/test/api/gather-status.test.ts
@@ -21,6 +21,12 @@ describe('gatherStatusForApi', () => {
     const safeB = '0x4444444444444444444444444444444444444444';
     const stakingProxy = '0x5555555555555555555555555555555555555555';
     const balanceReads: Array<{ token: string; safe: string; chainId: number }> = [];
+    const balanceOf = (token: string, safe: string): bigint => {
+      balanceReads.push({ token, safe, chainId: 11155111 });
+      return safe.toLowerCase() === safeA.toLowerCase()
+        ? 1500000000000000000n
+        : 2000000000000000000n;
+    };
     vi.doMock('viem', async (importOriginal) => {
       const actual = await importOriginal<typeof import('viem')>();
       return {
@@ -29,18 +35,28 @@ describe('gatherStatusForApi', () => {
           getBlockNumber: async () => 123n,
           getChainId: async () => chain.id,
           getBalance: async () => 0n,
+          // tJINN balances are read in one multicall3 round-trip (E2).
+          multicall: async (req: {
+            contracts: ReadonlyArray<{
+              address: string;
+              functionName: string;
+              args?: readonly [`0x${string}`];
+            }>;
+          }) =>
+            req.contracts.map((c) => {
+              if (chain.id === 11155111 && c.functionName === 'balanceOf') {
+                return {
+                  status: 'success' as const,
+                  result: balanceOf(c.address, (c.args?.[0] as string | undefined) ?? '0x'),
+                };
+              }
+              return { status: 'success' as const, result: 0n };
+            }),
           readContract: async (req: {
             address: string;
             functionName: string;
             args?: readonly [`0x${string}`] | readonly [bigint];
           }) => {
-            if (chain.id === 11155111 && req.functionName === 'balanceOf') {
-              const safe = (req.args?.[0] as string | undefined) ?? '0x';
-              balanceReads.push({ token: req.address, safe, chainId: chain.id });
-              return safe.toLowerCase() === safeA.toLowerCase()
-                ? 1500000000000000000n
-                : 2000000000000000000n;
-            }
             if (chain.id === 84532 && req.functionName === 'calculateStakingReward') {
               return 999000000000000000000n;
             }
@@ -99,7 +115,8 @@ describe('gatherStatusForApi', () => {
       const apiStatus = await gatherStatusForApi(store, {
         earningDir,
         rpcUrl: 'http://base-sepolia.example',
-        ethereumRpcUrl: 'http://sepolia.example',
+        // The Sepolia tJINN RPC endpoint is read from config.ethereumRpcUrl.
+        config: { ethereumRpcUrl: 'http://sepolia.example' } as unknown as JinnConfig,
         network: 'testnet',
         pollIntervalMs: 5000,
         rewardClaimIntervalMs: 0,
@@ -181,19 +198,30 @@ describe('gatherStatusForApi', () => {
           getBlockNumber: async () => 123n,
           getChainId: async () => chain.id,
           getBalance: async () => 0n,
-          readContract: async (req: {
-            functionName: string;
-            args?: readonly [`0x${string}`];
-          }) => {
-            if (chain.id === 11155111 && req.functionName === 'balanceOf') {
-              const safe = req.args?.[0] ?? '0x';
-              if (safe.toLowerCase() === safeB.toLowerCase()) {
-                throw new Error('HTTP request failed for http://sepolia.example?apikey=secret');
+          // tJINN balances read via multicall3 with allowFailure: true — a
+          // per-Safe failure surfaces as a `{ status: 'failure' }` entry.
+          multicall: async (req: {
+            contracts: ReadonlyArray<{
+              functionName: string;
+              args?: readonly [`0x${string}`];
+            }>;
+          }) =>
+            req.contracts.map((c) => {
+              if (chain.id === 11155111 && c.functionName === 'balanceOf') {
+                const safe = c.args?.[0] ?? '0x';
+                if (safe.toLowerCase() === safeB.toLowerCase()) {
+                  return {
+                    status: 'failure' as const,
+                    error: new Error(
+                      'HTTP request failed for http://sepolia.example?apikey=secret',
+                    ),
+                  };
+                }
+                return { status: 'success' as const, result: 10n };
               }
-              return 10n;
-            }
-            return 0n;
-          },
+              return { status: 'success' as const, result: 0n };
+            }),
+          readContract: async () => 0n,
         }),
         http: () => ({}),
       };
@@ -234,7 +262,8 @@ describe('gatherStatusForApi', () => {
       const apiStatus = await gatherStatusForApi(store, {
         earningDir,
         rpcUrl: 'http://base-sepolia.example',
-        ethereumRpcUrl: 'http://sepolia.example',
+        // The Sepolia tJINN RPC endpoint is read from config.ethereumRpcUrl.
+        config: { ethereumRpcUrl: 'http://sepolia.example' } as unknown as JinnConfig,
         network: 'testnet',
         pollIntervalMs: 5000,
         rewardClaimIntervalMs: 0,

--- a/client/test/api/gather-status.test.ts
+++ b/client/test/api/gather-status.test.ts
@@ -3,15 +3,251 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { JinnConfig } from '../../src/config.js';
+import { FleetStateStore } from '../../src/earning/store.js';
 import { TaskRunPersistence } from '../../src/harnesses/engine/persistence.js';
 import type { PredictionOperatorStatus } from '../../src/solver-nets/prediction-operator-ux.js';
 import { withTempStore } from '@test/store.js';
 
 describe('gatherStatusForApi', () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.doUnmock('viem');
     vi.doUnmock('../../src/solver-nets/prediction-operator-ux.js');
     vi.resetModules();
+  });
+
+  it('reads real tJINN balances on Sepolia separately from pending staking rewards', async () => {
+    const safeA = '0x3333333333333333333333333333333333333333';
+    const safeB = '0x4444444444444444444444444444444444444444';
+    const stakingProxy = '0x5555555555555555555555555555555555555555';
+    const balanceReads: Array<{ token: string; safe: string; chainId: number }> = [];
+    vi.doMock('viem', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('viem')>();
+      return {
+        ...actual,
+        createPublicClient: ({ chain }: { chain: { id: number } }) => ({
+          getBlockNumber: async () => 123n,
+          getChainId: async () => chain.id,
+          getBalance: async () => 0n,
+          readContract: async (req: {
+            address: string;
+            functionName: string;
+            args?: readonly [`0x${string}`] | readonly [bigint];
+          }) => {
+            if (chain.id === 11155111 && req.functionName === 'balanceOf') {
+              const safe = (req.args?.[0] as string | undefined) ?? '0x';
+              balanceReads.push({ token: req.address, safe, chainId: chain.id });
+              return safe.toLowerCase() === safeA.toLowerCase()
+                ? 1500000000000000000n
+                : 2000000000000000000n;
+            }
+            if (chain.id === 84532 && req.functionName === 'calculateStakingReward') {
+              return 999000000000000000000n;
+            }
+            if (req.functionName === 'getNextRewardCheckpointTimestamp') return 0n;
+            if (req.functionName === 'getStakingState') return 0;
+            if (req.functionName === 'getServiceInfo') return { inactivity: 0n };
+            return 0n;
+          },
+        }),
+        http: () => ({}),
+      };
+    });
+    const { gatherStatusForApi } = await import('../../src/api/gather-status.js');
+
+    await withTempStore(async (store) => {
+      const earningDir = mkdtempSync(join(tmpdir(), 'jinn-status-test-'));
+      const fleetStore = new FleetStateStore(earningDir);
+      const state = await fleetStore.load('base-sepolia');
+      await fleetStore.save({
+        ...state,
+        master_address: '0x1111111111111111111111111111111111111111',
+        services: [
+          {
+            index: 1,
+            agent_address: '0x2222222222222222222222222222222222222222',
+            safe_address: safeA,
+            service_id: 41,
+            mech_address: null,
+            staking_address: stakingProxy,
+            step: 'complete',
+            error: null,
+          },
+          {
+            index: 2,
+            agent_address: '0x6666666666666666666666666666666666666666',
+            safe_address: safeA,
+            service_id: 42,
+            mech_address: null,
+            staking_address: stakingProxy,
+            step: 'complete',
+            error: null,
+          },
+          {
+            index: 3,
+            agent_address: '0x7777777777777777777777777777777777777777',
+            safe_address: safeB,
+            service_id: 43,
+            mech_address: null,
+            staking_address: stakingProxy,
+            step: 'complete',
+            error: null,
+          },
+        ],
+      });
+
+      const apiStatus = await gatherStatusForApi(store, {
+        earningDir,
+        rpcUrl: 'http://base-sepolia.example',
+        ethereumRpcUrl: 'http://sepolia.example',
+        network: 'testnet',
+        pollIntervalMs: 5000,
+        rewardClaimIntervalMs: 0,
+      });
+
+      expect(apiStatus.rewards.pendingStakingRewardsWei).toBe('2997000000000000000000');
+      expect(apiStatus.tJinn).toMatchObject({
+        state: 'ready',
+        chainId: 11155111,
+        tokenAddress: '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A',
+        safeBalanceWei: '3500000000000000000',
+        safeCount: 2,
+        error: null,
+      });
+      expect(apiStatus.tJinn.safeBalanceWei).not.toBe(apiStatus.rewards.pendingStakingRewardsWei);
+      expect(apiStatus.tJinn.services.map((svc) => svc.balanceWei)).toEqual([
+        '1500000000000000000',
+        '1500000000000000000',
+        '2000000000000000000',
+      ]);
+    });
+
+    expect(balanceReads).toEqual([
+      { token: '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A', safe: safeA, chainId: 11155111 },
+      { token: '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A', safe: safeB, chainId: 11155111 },
+    ]);
+  });
+
+  it('marks tJINN balance pending when the Sepolia RPC URL is unavailable', async () => {
+    mockStatusRpc();
+    const { gatherStatusForApi } = await import('../../src/api/gather-status.js');
+
+    await withTempStore(async (store) => {
+      const earningDir = mkdtempSync(join(tmpdir(), 'jinn-status-test-'));
+      const fleetStore = new FleetStateStore(earningDir);
+      const state = await fleetStore.load('base-sepolia');
+      await fleetStore.save({
+        ...state,
+        master_address: '0x1111111111111111111111111111111111111111',
+        services: [
+          {
+            index: 1,
+            agent_address: '0x2222222222222222222222222222222222222222',
+            safe_address: '0x3333333333333333333333333333333333333333',
+            service_id: null,
+            mech_address: null,
+            staking_address: null,
+            step: 'awaiting_stake',
+            error: null,
+          },
+        ],
+      });
+
+      const apiStatus = await gatherStatusForApi(store, {
+        earningDir,
+        rpcUrl: 'http://base-sepolia.example',
+        network: 'testnet',
+        pollIntervalMs: 5000,
+        rewardClaimIntervalMs: 0,
+      });
+
+      expect(apiStatus.tJinn).toMatchObject({
+        state: 'pending',
+        safeBalanceWei: null,
+        safeCount: 1,
+        error: null,
+      });
+    });
+  });
+
+  it('keeps successful tJINN balances when one Safe read fails and redacts public errors', async () => {
+    const safeA = '0x3333333333333333333333333333333333333333';
+    const safeB = '0x4444444444444444444444444444444444444444';
+    vi.doMock('viem', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('viem')>();
+      return {
+        ...actual,
+        createPublicClient: ({ chain }: { chain: { id: number } }) => ({
+          getBlockNumber: async () => 123n,
+          getChainId: async () => chain.id,
+          getBalance: async () => 0n,
+          readContract: async (req: {
+            functionName: string;
+            args?: readonly [`0x${string}`];
+          }) => {
+            if (chain.id === 11155111 && req.functionName === 'balanceOf') {
+              const safe = req.args?.[0] ?? '0x';
+              if (safe.toLowerCase() === safeB.toLowerCase()) {
+                throw new Error('HTTP request failed for http://sepolia.example?apikey=secret');
+              }
+              return 10n;
+            }
+            return 0n;
+          },
+        }),
+        http: () => ({}),
+      };
+    });
+    const { gatherStatusForApi } = await import('../../src/api/gather-status.js');
+
+    await withTempStore(async (store) => {
+      const earningDir = mkdtempSync(join(tmpdir(), 'jinn-status-test-'));
+      const fleetStore = new FleetStateStore(earningDir);
+      const state = await fleetStore.load('base-sepolia');
+      await fleetStore.save({
+        ...state,
+        master_address: '0x1111111111111111111111111111111111111111',
+        services: [
+          {
+            index: 1,
+            agent_address: '0x2222222222222222222222222222222222222222',
+            safe_address: safeA,
+            service_id: null,
+            mech_address: null,
+            staking_address: null,
+            step: 'awaiting_stake',
+            error: null,
+          },
+          {
+            index: 2,
+            agent_address: '0x5555555555555555555555555555555555555555',
+            safe_address: safeB,
+            service_id: null,
+            mech_address: null,
+            staking_address: null,
+            step: 'awaiting_stake',
+            error: null,
+          },
+        ],
+      });
+
+      const apiStatus = await gatherStatusForApi(store, {
+        earningDir,
+        rpcUrl: 'http://base-sepolia.example',
+        ethereumRpcUrl: 'http://sepolia.example',
+        network: 'testnet',
+        pollIntervalMs: 5000,
+        rewardClaimIntervalMs: 0,
+      });
+
+      expect(apiStatus.tJinn.state).toBe('error');
+      expect(apiStatus.tJinn.safeBalanceWei).toBe('10');
+      expect(apiStatus.tJinn.error).toBe('Some Safe tJINN balances are temporarily unavailable.');
+      expect(apiStatus.tJinn.services.map((svc) => svc.state)).toEqual(['ready', 'error']);
+      expect(apiStatus.tJinn.services.map((svc) => svc.balanceWei)).toEqual(['10', null]);
+      expect(JSON.stringify(apiStatus.tJinn)).not.toContain('apikey=secret');
+      expect(JSON.stringify(apiStatus.tJinn)).not.toContain('sepolia.example');
+    });
   });
 
   function mockStatusRpc(): void {

--- a/client/test/api/status-build.test.ts
+++ b/client/test/api/status-build.test.ts
@@ -7,6 +7,17 @@ import {
 } from '../../src/api/status-build.js';
 import type { FleetState } from '../../src/earning/types.js';
 
+// tJINN identity is resolved from the bundled JINN MVI L1 artifact and threaded
+// onto GatheredStatusRaw. These match deployment-jinn-mvi-l1-sepolia.json.
+const TJINN_TOKEN_ADDRESS = '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A';
+const TJINN_CHAIN_ID = 11155111;
+
+/** The two tJINN-identity fields every GatheredStatusRaw literal must carry. */
+const tjinnIdentityFields = {
+  tjinnTokenAddress: TJINN_TOKEN_ADDRESS,
+  tjinnChainId: TJINN_CHAIN_ID,
+} as const;
+
 function minimalFleet(overrides: Partial<FleetState> = {}): FleetState {
   return {
     master_address: '0x1111111111111111111111111111111111111111',
@@ -43,6 +54,7 @@ describe('resolveMasterDailyEstimateWei', () => {
 describe('assembleStatusV1', () => {
   it('marks sqlite_only mode and short-circuits next actions', () => {
     const raw: GatheredStatusRaw = {
+      ...tjinnIdentityFields,
       hintsScope: 'sqlite_only',
       shutdownState: 'running',
       dbPath: '/tmp/x.db',
@@ -74,6 +86,7 @@ describe('assembleStatusV1', () => {
 
   it('reports zero runway excess when balance is already below minimum', () => {
     const raw: GatheredStatusRaw = {
+      ...tjinnIdentityFields,
       shutdownState: 'running',
       dbPath: '/tmp/x.db',
       activityCounts: {},
@@ -96,6 +109,7 @@ describe('assembleStatusV1', () => {
 
   it('flags low master balance vs minimum', () => {
     const raw: GatheredStatusRaw = {
+      ...tjinnIdentityFields,
       shutdownState: 'running',
       dbPath: '/tmp/x.db',
       activityCounts: {},
@@ -121,6 +135,7 @@ describe('assembleStatusV1', () => {
 
   it('includes RPC failure in next actions when full mode', () => {
     const raw: GatheredStatusRaw = {
+      ...tjinnIdentityFields,
       shutdownState: 'running',
       dbPath: '/tmp/x.db',
       activityCounts: {},
@@ -140,6 +155,7 @@ describe('assembleStatusV1', () => {
 
   it('reports total rewards as claimed plus claimable', () => {
     const raw: GatheredStatusRaw = {
+      ...tjinnIdentityFields,
       shutdownState: 'running',
       dbPath: '/tmp/x.db',
       activityCounts: {},
@@ -164,6 +180,7 @@ describe('assembleStatusV1', () => {
 
   it('keeps real tJINN balance separate from pending staking rewards', () => {
     const raw: GatheredStatusRaw = {
+      ...tjinnIdentityFields,
       shutdownState: 'running',
       dbPath: '/tmp/x.db',
       activityCounts: {},
@@ -200,6 +217,7 @@ describe('assembleStatusV1', () => {
 
   it('redacts raw tJINN read errors at the public status boundary', () => {
     const raw: GatheredStatusRaw = {
+      ...tjinnIdentityFields,
       shutdownState: 'running',
       dbPath: '/tmp/x.db',
       activityCounts: {},
@@ -236,6 +254,7 @@ describe('assembleStatusV1', () => {
 
   it('passes prediction.v1 status through when present', () => {
     const raw: GatheredStatusRaw = {
+      ...tjinnIdentityFields,
       shutdownState: 'running',
       dbPath: '/tmp/x.db',
       activityCounts: {},
@@ -273,6 +292,7 @@ describe('assembleStatusV1', () => {
 
   it('passes generic task-run status through when present', () => {
     const raw: GatheredStatusRaw = {
+      ...tjinnIdentityFields,
       shutdownState: 'running',
       dbPath: '/tmp/x.db',
       activityCounts: {},

--- a/client/test/api/status-build.test.ts
+++ b/client/test/api/status-build.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   assembleStatusV1,
   resolveMasterDailyEstimateWei,
+  TJINN_PUBLIC_READ_ERROR,
   type GatheredStatusRaw,
 } from '../../src/api/status-build.js';
 import type { FleetState } from '../../src/earning/types.js';
@@ -60,6 +61,15 @@ describe('assembleStatusV1', () => {
     expect(j.nextActions).toHaveLength(1);
     expect(j.nextActions[0]).toMatch(/npm run status/);
     expect(j.earnings.hint).toMatch(/omitted/);
+    expect(j.tJinn).toEqual({
+      state: 'pending',
+      chainId: 11155111,
+      tokenAddress: '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A',
+      safeBalanceWei: null,
+      safeCount: 0,
+      services: [],
+      error: null,
+    });
   });
 
   it('reports zero runway excess when balance is already below minimum', () => {
@@ -150,6 +160,78 @@ describe('assembleStatusV1', () => {
     const j = assembleStatusV1(raw);
     expect(j.rewards.claimedStakingRewardsWei).toBe('800');
     expect(j.rewards.totalStakingRewardsWei).toBe('1000');
+  });
+
+  it('keeps real tJINN balance separate from pending staking rewards', () => {
+    const raw: GatheredStatusRaw = {
+      shutdownState: 'running',
+      dbPath: '/tmp/x.db',
+      activityCounts: {},
+      recentActivity: [],
+      lastRewardClaimTickAt: null,
+      rewardClaimIntervalMs: 0,
+      fleet: minimalFleet(),
+      rpc: { ok: true, chainId: 8453, blockNumber: '1' },
+      master: { address: '0x1111111111111111111111111111111111111111' },
+      pendingStakingRewardsWei: '999000000000000000000',
+      tJinn: {
+        state: 'ready',
+        chainId: 11155111,
+        tokenAddress: '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A',
+        safeBalanceWei: '1500000000000000000',
+        safeCount: 1,
+        services: [{
+          index: 1,
+          safeAddress: '0x3333333333333333333333333333333333333333',
+          balanceWei: '1500000000000000000',
+          state: 'ready',
+          error: null,
+        }],
+        error: null,
+      },
+      pollIntervalMs: 5000,
+      masterDailyEstimateWei: '1',
+    };
+    const j = assembleStatusV1(raw);
+    expect(j.rewards.pendingStakingRewardsWei).toBe('999000000000000000000');
+    expect(j.tJinn.safeBalanceWei).toBe('1500000000000000000');
+    expect(j.tJinn.safeBalanceWei).not.toBe(j.rewards.pendingStakingRewardsWei);
+  });
+
+  it('redacts raw tJINN read errors at the public status boundary', () => {
+    const raw: GatheredStatusRaw = {
+      shutdownState: 'running',
+      dbPath: '/tmp/x.db',
+      activityCounts: {},
+      recentActivity: [],
+      lastRewardClaimTickAt: null,
+      rewardClaimIntervalMs: 0,
+      fleet: minimalFleet(),
+      rpc: { ok: true, chainId: 8453, blockNumber: '1' },
+      master: { address: '0x1111111111111111111111111111111111111111' },
+      tJinn: {
+        state: 'error',
+        chainId: 11155111,
+        tokenAddress: '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A',
+        safeBalanceWei: null,
+        safeCount: 1,
+        services: [{
+          index: 1,
+          safeAddress: '0x3333333333333333333333333333333333333333',
+          balanceWei: null,
+          state: 'error',
+          error: 'HTTP request failed for https://rpc.sepolia.example?apikey=secret',
+        }],
+        error: 'HTTP request failed for https://rpc.sepolia.example?apikey=secret',
+      },
+      pollIntervalMs: 5000,
+      masterDailyEstimateWei: '1',
+    };
+    const j = assembleStatusV1(raw);
+    expect(j.tJinn.error).toBe(TJINN_PUBLIC_READ_ERROR);
+    expect(j.tJinn.services[0]?.error).toBe(TJINN_PUBLIC_READ_ERROR);
+    expect(JSON.stringify(j.tJinn)).not.toContain('apikey=secret');
+    expect(JSON.stringify(j.tJinn)).not.toContain('rpc.sepolia.example');
   });
 
   it('passes prediction.v1 status through when present', () => {


### PR DESCRIPTION
## Summary

Part of #406.

- Adds top-level `/v1/status.tJinn` with Sepolia chain id, token address, Safe balance, Safe count, per-service rows, and public state/error fields.
- Reads real Sepolia tJINN ERC-20 `balanceOf` for token `0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A`.
- Deduplicates shared Safe addresses before summing the top-level balance.
- Keeps `rewards.pendingStakingRewardsWei` separate from real tJINN earned and redacts raw RPC failures before they reach `/v1/status`.

## Verification

- `yarn vitest run test/api/gather-status.test.ts test/api/status-build.test.ts`

Part of #406
