### PR TITLE
feat(operator-app): show real tJINN earned in WalletCard

### DIFF
--- a/client/src/dashboard/spa/src/api/types.ts
+++ b/client/src/dashboard/spa/src/api/types.ts
@@ -1,5 +1,41 @@
 export type StructuredEventKind = 'intent' | 'reward' | 'fleet' | 'system' | 'error' | 'log';
 
+// ── tJINN status (#406) ───────────────────────────────────────────────────────
+//
+// Mirror of the daemon-side `TjinnStatus` / `TjinnServiceStatus` /
+// `TjinnStatusState` from `client/src/api/status-build.ts`. Surfaced on the
+// `/v1/status` response as `tJinn` (PR #447, daemon half). Mirrored here —
+// rather than imported — to keep the SPA build off the daemon type graph,
+// matching the established pattern for `LauncherStatusResponse` etc.
+
+/** Read state for the Sepolia tJINN ERC-20 Safe balance. */
+export type TjinnStatusState = 'pending' | 'ready' | 'error';
+
+/** Per-service tJINN Safe balance entry. */
+export interface TjinnServiceStatus {
+  index: number;
+  safeAddress: string | null;
+  balanceWei: string | null;
+  state: TjinnStatusState;
+  error: string | null;
+}
+
+/**
+ * Real Sepolia tJINN ERC-20 Safe balance, summed across the operator's fleet
+ * Safes (deduplicated on shared Safe addresses). `safeBalanceWei` is null
+ * unless `state === 'ready'`; a `ready` state with a null balance is a
+ * confirmed-empty balance and should render as `0`.
+ */
+export interface TjinnStatus {
+  state: TjinnStatusState;
+  chainId: number;
+  tokenAddress: string;
+  safeBalanceWei: string | null;
+  safeCount: number;
+  services: TjinnServiceStatus[];
+  error: string | null;
+}
+
 export interface StructuredEvent {
   schemaVersion: 1;
   id: string;

--- a/client/src/dashboard/spa/src/pages/Overview.test.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.test.tsx
@@ -199,6 +199,74 @@ describe('OverviewPage Wallet wiring', () => {
     await waitFor(() => expect(claimRewardsMock).toHaveBeenCalledOnce());
   });
 
+  it('wires the tJINN-earned value from status.tJinn.safeBalanceWei, not pending staking rewards', async () => {
+    getStatusMock.mockResolvedValue({
+      ...baseStatus,
+      rewards: { pendingStakingRewardsWei: '999000000000000000000' },
+      tJinn: {
+        state: 'ready',
+        chainId: 11155111,
+        tokenAddress: '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A',
+        safeBalanceWei: '1500000000000000000',
+        safeCount: 1,
+        services: [],
+        error: null,
+      },
+    });
+    getBootstrapMock.mockResolvedValue({});
+    render(withProviders(<OverviewPage />));
+
+    // The tJINN-earned value derives from status.tJinn.safeBalanceWei
+    // (1.5 tJINN) — NOT from rewards.pendingStakingRewardsWei (999 JINN).
+    await waitFor(() =>
+      expect(screen.getByTestId('tjinn-earned-value').textContent).toBe('1.5000'),
+    );
+    expect(screen.getByText(/tJINN earned/i)).toBeTruthy();
+    const tjinnValue = screen.getByTestId('tjinn-earned-value');
+    expect(tjinnValue.textContent).not.toBe('999.0000');
+    // The 999 figure still renders, but as the claimable staking-reward stat
+    // row — a distinct element from the tJINN-earned value.
+    const claimable999 = screen.getByText('999.0000');
+    expect(claimable999).not.toBe(tjinnValue);
+    expect(tjinnValue.contains(claimable999)).toBe(false);
+  });
+
+  it('renders a confirmed-empty tJINN balance (ready + null) as 0', async () => {
+    getStatusMock.mockResolvedValue({
+      ...baseStatus,
+      tJinn: {
+        state: 'ready',
+        chainId: 11155111,
+        tokenAddress: '0x0bc0B2f733bF4229FD58Baaac5ebFEf2AEc83C4A',
+        safeBalanceWei: null,
+        safeCount: 1,
+        services: [],
+        error: null,
+      },
+    });
+    getBootstrapMock.mockResolvedValue({});
+    render(withProviders(<OverviewPage />));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('tjinn-earned-value').textContent).toBe('0.0000'),
+    );
+    // A confirmed-empty balance is distinguishable from loading — no state copy.
+    expect(screen.queryByTestId('tjinn-earned-state')).toBeNull();
+  });
+
+  it('shows pending tJINN copy when status.tJinn is absent (older daemon)', async () => {
+    getStatusMock.mockResolvedValue(baseStatus);
+    getBootstrapMock.mockResolvedValue({});
+    render(withProviders(<OverviewPage />));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('tjinn-earned-value').textContent).toBe('pending'),
+    );
+    expect(screen.getByTestId('tjinn-earned-state').textContent).toMatch(
+      /waiting for sepolia balance/i,
+    );
+  });
+
   it('surfaces a one-line gas top-up confirmation with the tx hash + amount', async () => {
     getStatusMock.mockResolvedValue(baseStatus);
     getBootstrapMock.mockResolvedValue({});

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -5,7 +5,7 @@ import { WalletCard, type ServiceIdentity } from './overview/WalletCard.js';
 import { NodeHealthCard, type DaemonStatus, type RpcStatus } from './overview/NodeHealthCard.js';
 import { ActivityCard, type ActivityJoinedNet, type ActivityTask } from './overview/ActivityCard.js';
 import { computeEffectivePlugins } from './configuration/effective-plugins.js';
-import type { SolverNetsCatalogResponse } from '../api/types.js';
+import type { SolverNetsCatalogResponse, TjinnStatus } from '../api/types.js';
 import { Alert, AlertDescription } from '../components/ui/alert.js';
 
 /**
@@ -79,6 +79,11 @@ interface OverviewStatusV1 {
     /** ISO timestamp of last claim. Not yet surfaced by the daemon — null until added. */
     lastClaimAt?: string | null;
   };
+  /**
+   * Real Sepolia tJINN ERC-20 Safe balance (#406, daemon half PR #447).
+   * Optional: older daemons predate this field.
+   */
+  tJinn?: TjinnStatus;
   /** Security metadata. Not yet surfaced by the daemon — field absent until added. */
   security?: {
     lastPasswordRotationAt?: string | null;
@@ -298,6 +303,19 @@ export function OverviewPage(): JSX.Element {
   const evictedServiceId = firstEvictedService?.serviceId ?? null;
 
   const jinnClaimable = formatEth(status?.rewards?.pendingStakingRewardsWei);
+
+  // tJINN earned — the real Sepolia ERC-20 Safe balance (#406). When the read
+  // has resolved (`state === 'ready'`) a null `safeBalanceWei` is a
+  // confirmed-empty balance, so format it as '0' rather than the bare '—'
+  // `formatEth` returns for missing input. `pending`/`error` keep '—'; the
+  // state copy handled by WalletCard's `tjinnDisplay` carries the meaning.
+  const tjinnState = status?.tJinn?.state ?? 'pending';
+  const tjinnEarned =
+    status?.tJinn?.state === 'ready'
+      ? formatEth(status.tJinn.safeBalanceWei ?? '0')
+      : formatEth(status?.tJinn?.safeBalanceWei ?? undefined);
+  const tjinnError = status?.tJinn?.error ?? null;
+
   const gasBalanceEth = formatEth(status?.masterGas?.balanceWei);
   const gasRunwayDays = status?.masterGas?.runwayDaysExcess ?? '—';
 
@@ -560,6 +578,9 @@ export function OverviewPage(): JSX.Element {
           }}
           claimableJinn={jinnClaimable}
           claimedJinnLifetime={status?.rewards?.claimedJinnLifetime ?? '0'}
+          tjinnEarned={tjinnEarned}
+          tjinnState={tjinnState}
+          tjinnError={tjinnError}
           lastClaimAt={status?.rewards?.lastClaimAt ?? null}
           agentId={services[0]?.agentId ?? null}
           masterAddress={bootstrap?.master_address ?? null}

--- a/client/src/dashboard/spa/src/pages/overview/WalletCard.test.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/WalletCard.test.tsx
@@ -17,6 +17,9 @@ function defaultProps(): WalletCardProps {
     perRole: { master: '0.0088', agent: '—', safe: '—' },
     claimableJinn: '0.0000',
     claimedJinnLifetime: '0',
+    tjinnEarned: '0.0000',
+    tjinnState: 'ready',
+    tjinnError: null,
     lastClaimAt: null,
     agentId: 5879,
     masterAddress: '0x53e25264C86db85b6168F7824f5c39abd5281787',
@@ -75,6 +78,65 @@ describe('WalletCard', () => {
     expect(claim.disabled).toBe(false);
     // "last claim" line is commented out.
     expect(rewards.textContent).not.toMatch(/last claim/i);
+  });
+
+  it('shows the tJINN-earned stat in the Rewards section when the read is ready', () => {
+    const { ui } = wrap(
+      <WalletCard
+        {...defaultProps()}
+        tjinnEarned="1.5000"
+        tjinnState="ready"
+        claimableJinn="999.0000"
+      />,
+    );
+    render(ui);
+    const rewards = screen.getByTestId('wallet-section-rewards');
+    expect(rewards.textContent).toMatch(/tJINN earned/i);
+    // The tJINN-earned value renders the real Safe balance, not the staking
+    // reward — it is a distinct element from the 999 claimable JINN stat.
+    const tjinnValue = screen.getByTestId('tjinn-earned-value');
+    expect(tjinnValue.textContent).toBe('1.5000');
+    const claimable = screen.getByText('999.0000');
+    expect(claimable).not.toBe(tjinnValue);
+    expect(tjinnValue.contains(claimable)).toBe(false);
+    // Ready state shows the unit and emits no state copy.
+    expect(rewards.textContent).toContain('tJINN');
+    expect(screen.queryByTestId('tjinn-earned-state')).toBeNull();
+  });
+
+  it('shows pending copy and no value while the tJINN read is unresolved', () => {
+    const { ui } = wrap(
+      <WalletCard {...defaultProps()} tjinnEarned="—" tjinnState="pending" />,
+    );
+    render(ui);
+    expect(screen.getByTestId('tjinn-earned-value').textContent).toBe('pending');
+    expect(screen.getByTestId('tjinn-earned-state').textContent).toMatch(
+      /waiting for sepolia balance/i,
+    );
+  });
+
+  it('shows the error string when the tJINN read failed', () => {
+    const { ui } = wrap(
+      <WalletCard
+        {...defaultProps()}
+        tjinnEarned="—"
+        tjinnState="error"
+        tjinnError="Sepolia tJINN balance temporarily unavailable."
+      />,
+    );
+    render(ui);
+    expect(screen.getByTestId('tjinn-earned-value').textContent).toBe('unavailable');
+    expect(screen.getByTestId('tjinn-earned-state').textContent).toMatch(
+      /temporarily unavailable/i,
+    );
+  });
+
+  it('wraps the tJINN-earned row in a polite live region', () => {
+    const { ui } = wrap(<WalletCard {...defaultProps()} />);
+    render(ui);
+    const region = screen.getByTestId('tjinn-earned-region');
+    expect(region.getAttribute('aria-live')).toBe('polite');
+    expect(region.getAttribute('aria-atomic')).toBe('true');
   });
 
   it('disables Claim when claimable is zero', () => {

--- a/client/src/dashboard/spa/src/pages/overview/WalletCard.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/WalletCard.tsx
@@ -12,6 +12,7 @@ import {
   TooltipTrigger,
 } from '../../components/ui/tooltip.js';
 import { Alert, AlertDescription } from '../../components/ui/alert.js';
+import type { TjinnStatusState } from '../../api/types.js';
 
 /**
  * Wallet — single consolidated card on /overview that absorbed the
@@ -48,6 +49,16 @@ export interface WalletCardProps {
   claimableJinn: string;
   /** JINN claimed lifetime, formatted as decimal string */
   claimedJinnLifetime: string;
+  /**
+   * Real Sepolia tJINN ERC-20 Safe balance, formatted as a decimal string
+   * (#406). Only meaningful when `tjinnState === 'ready'`; `pending`/`error`
+   * render state copy from `tjinnDisplay` instead.
+   */
+  tjinnEarned: string;
+  /** Read state for the Sepolia tJINN balance. */
+  tjinnState: TjinnStatusState;
+  /** Public read error string, if the Sepolia balance is unavailable. */
+  tjinnError?: string | null;
   // lastClaimAt stays in the props so re-enabling the "last claim" row is
   // a one-block restore.
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
@@ -77,11 +88,38 @@ function trunc(addr: string | null | undefined): string {
   return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
 }
 
+/**
+ * Display value + supporting copy for the tJINN-earned row, keyed on the read
+ * state. A single lookup keeps `value` and `copy` in lockstep — `ready` shows
+ * the formatted balance with no copy; `pending`/`error` show placeholder copy
+ * instead of a misleading bare zero while the Sepolia read is unresolved.
+ */
+function tjinnDisplay(
+  state: TjinnStatusState,
+  tjinnEarned: string,
+  tjinnError: string | null | undefined,
+): { value: string; copy: string | null } {
+  switch (state) {
+    case 'ready':
+      return { value: tjinnEarned, copy: null };
+    case 'error':
+      return {
+        value: 'unavailable',
+        copy: tjinnError ?? 'Sepolia tJINN balance temporarily unavailable.',
+      };
+    case 'pending':
+      return { value: 'pending', copy: 'Waiting for Sepolia balance.' };
+  }
+}
+
 export function WalletCard({
   totalEth,
   runwayDays,
   claimableJinn,
   claimedJinnLifetime,
+  tjinnEarned,
+  tjinnState,
+  tjinnError,
   agentId,
   masterAddress,
   safeAddress,
@@ -94,6 +132,11 @@ export function WalletCard({
 }: WalletCardProps): JSX.Element {
   const [, navigate] = useLocation();
   const canClaim = parseFloat(claimableJinn) > 0;
+  const { value: tjinnValue, copy: tjinnStateCopy } = tjinnDisplay(
+    tjinnState,
+    tjinnEarned,
+    tjinnError,
+  );
 
   // ── Identity binding-pending retry — preserved from IdentityCard ──
   const pendingBinding = services.find((s) => s.agentId !== null && !s.safeBoundToAgent);
@@ -162,6 +205,37 @@ export function WalletCard({
         {/* ── REWARDS ───────────────────────────────────────────────────── */}
         <div className="flex flex-col gap-3" data-testid="wallet-section-rewards">
           <span className={sectionLabel}>Rewards</span>
+
+          {/*
+            tJINN earned — the real Sepolia tJINN ERC-20 Safe balance (#406).
+            Distinct from the JINN staking rewards below: this is the token
+            minted by JinnDistributor, not the OLAS staking-proxy pending
+            surface. Wrapped in a polite live region so screen readers
+            announce when the ~5s poll resolves pending → ready.
+          */}
+          <div
+            className="flex flex-col gap-1"
+            data-testid="tjinn-earned-region"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            <span className={sectionLabel}>tJINN earned</span>
+            <div className="flex items-baseline gap-2">
+              <span
+                className={statBig}
+                data-testid="tjinn-earned-value"
+                style={tjinnState === 'error' ? { color: 'var(--break-red)' } : undefined}
+              >
+                {tjinnValue}
+              </span>
+              {tjinnState === 'ready' && <span className={statUnit}>tJINN</span>}
+            </div>
+            {tjinnStateCopy && (
+              <span className={statAux} data-testid="tjinn-earned-state">
+                {tjinnStateCopy}
+              </span>
+            )}
+          </div>
 
           <div className="flex flex-col gap-1">
             <span className={sectionLabel}>Claimable</span>


### PR DESCRIPTION
## Run-mode

FIX / operator dashboard. Target branch: `next`.

## Summary

The operator dashboard's Rewards section surfaced only OLAS staking rewards (`rewards.pendingStakingRewardsWei`) — not the real Sepolia tJINN ERC-20 minted by `JinnDistributor`. This wires the daemon's `/v1/status` `tJinn` object into the operator app so operators see their real tJINN Safe balance.

- **`api/types.ts`** — mirror the daemon-side `TjinnStatus` / `TjinnServiceStatus` / `TjinnStatusState` wire shapes (from `client/src/api/status-build.ts`), mirrored rather than imported to keep the SPA build off the daemon type graph (established pattern for `LauncherStatusResponse` etc.).
- **`WalletCard.tsx`** — add a **"tJINN earned"** stat row to the existing Rewards section, matching the surrounding `statBig`/`statUnit`/`statAux` styling. `pending` / `ready` / `error` states handled by a `tjinnDisplay` switch cribbed from the closed #448 branch; the value is wrapped in an `aria-live="polite"` / `aria-atomic="true"` region so screen readers announce when the ~5s poll resolves. The card is not restructured.
- **`Overview.tsx`** — add an optional `tJinn?` field to the `/v1/status` shape (optional — older daemons predate it), derive the formatted value via the existing `formatEth` (a `ready` state with a null `safeBalanceWei` is a confirmed-empty balance and renders `0`, not a bare `—`), and pass it to `<WalletCard>`.

## Tests

`#406` is a `fix` shape — included genuine regression coverage:
- `WalletCard.test.tsx`: the tJINN-earned value renders the real Safe balance and is a **distinct DOM element** from the claimable staking-reward stat; plus pending/error state copy and the `aria-live` region.
- `Overview.test.tsx`: the tJINN-earned value derives from `status.tJinn.safeBalanceWei` (1.5 tJINN) and not `rewards.pendingStakingRewardsWei` (999 JINN); confirmed-empty (`ready` + `null`) renders `0`; absent `tJinn` (older daemon) renders pending copy.

## Verification

- `tsc --noEmit` (daemon side): pass
- SPA `tsc -p tsconfig.json`: pass
- SPA `vite build`: pass
- `vitest run` WalletCard.test.tsx + Overview.test.tsx: 26 passed

## Notes

- Supersedes the **closed #448**, which targeted `RewardsCard.tsx` — since deleted on `next` (consolidated into `WalletCard.tsx`). The reviewed `tjinnDisplay` / wei-handling / `aria-live` logic from that branch was cribbed.
- Daemon half (the `/v1/status` `tJinn` object) is **#447**, already merged.

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)