### PR TITLE
fix(client): codex readiness gates on id_token expiry, deadlocking claims

### DIFF
--- a/client/src/api/codex-doctor-endpoint.ts
+++ b/client/src/api/codex-doctor-endpoint.ts
@@ -110,11 +110,22 @@ function jwtExpiry(token: string | null | undefined): number | undefined {
  *
  *   - A non-empty `OPENAI_API_KEY` in the file is API-key mode — there is no
  *     expiry, so presence is acceptable (`'ok'`).
- *   - Otherwise it is OAuth (`codex login`) mode: expiry-check the JWT `exp`
- *     of `id_token` (falling back to `access_token`). An expired token, or
- *     tokens we cannot expiry-check at all (no JWT / no `exp`), is treated as
- *     `'expired'` — the safe direction for a claim gate: a logged-out operator
- *     with a leftover file must not read as live (#366).
+ *   - Otherwise it is OAuth (`codex login`) mode. The live-ness signal is the
+ *     `refresh_token`: codex transparently mints fresh `id_token` /
+ *     `access_token` from it on its next run, so a present refresh_token means
+ *     the session is live (`'ok'`). The `id_token` is a ~1h OIDC token and the
+ *     `access_token` only lasts days — both routinely lapse between codex runs
+ *     on a perfectly healthy login, so gating on their `exp` false-fails the
+ *     readiness check and deadlocks the claim loop: the probe shells
+ *     `codex --version`, which never refreshes, so the daemon never claims,
+ *     never runs codex, and the tokens never rotate (#464).
+ *   - With no refresh_token, fall back to a best-effort bearer-token expiry
+ *     check (`access_token` first, `id_token` last). An expired or
+ *     un-checkable bearer token is `'expired'` — the safe direction for a
+ *     claim gate: a logged-out operator with a leftover file must not read as
+ *     live (#366). `codex logout` deletes `auth.json` outright, so a
+ *     structurally-valid file that still carries a refresh_token is a live
+ *     session.
  */
 function classifyAuthFile(auth: CodexAuthFile, nowMs: number): CodexAuthStatus {
   const fileApiKey = auth.OPENAI_API_KEY;
@@ -127,7 +138,15 @@ function classifyAuthFile(auth: CodexAuthFile, nowMs: number): CodexAuthStatus {
     // credential — treat as stale rather than live.
     return 'expired';
   }
-  const exp = jwtExpiry(tokens.id_token) ?? jwtExpiry(tokens.access_token);
+  // A present refresh_token is the live-ness signal: codex renews the
+  // short-lived id_token / access_token from it on demand (#464).
+  const refreshToken = tokens.refresh_token;
+  if (typeof refreshToken === 'string' && refreshToken.trim().length > 0) {
+    return 'ok';
+  }
+  // No refresh_token — best-effort bearer-token expiry check (access_token
+  // first, id_token only as a last resort).
+  const exp = jwtExpiry(tokens.access_token) ?? jwtExpiry(tokens.id_token);
   if (exp === undefined) {
     // Tokens present but not expiry-checkable — cannot prove liveness.
     return 'expired';

--- a/client/test/api/codex-doctor-endpoint.test.ts
+++ b/client/test/api/codex-doctor-endpoint.test.ts
@@ -5,9 +5,12 @@
  *
  * Codex has no `codex doctor` subcommand, so install detection shells
  * `codex --version`. Codex also exposes no auth-status subcommand, so auth
- * liveness is derived by parsing + expiry-checking the `auth.json` it
- * persists — existence alone is not enough (#366): a stale OAuth session
- * reads as logged-in to a naive existence check, false-gating the daemon.
+ * liveness is derived by parsing the `auth.json` it persists. The live-ness
+ * signal is the `refresh_token` (#464): codex mints fresh id/access tokens
+ * from it on demand, so the short-lived id_token (~1h) and access_token
+ * routinely lapse between runs on a perfectly healthy login. A genuinely
+ * dead session has no refresh_token and no usable credential (#366) — that
+ * must still read as not-live.
  *
  * We mock spawnSync (install probe) and readFileSync (auth-file read) so the
  * tests run without a real codex binary or a real `~/.codex/auth.json`.
@@ -68,7 +71,11 @@ function jwtWithExp(expSeconds: number | undefined): string {
   return `${header}.${payload}.signature`;
 }
 
-/** A well-formed OAuth (`chatgpt`-mode) auth.json whose id_token expires at `expSeconds`. */
+/**
+ * A well-formed OAuth (`chatgpt`-mode) auth.json — id_token + access_token both
+ * expire at `expSeconds`; a `refresh_token` is always present (as on a real
+ * logged-in `auth.json`).
+ */
 function oauthAuthJson(expSeconds: number): string {
   return JSON.stringify({
     auth_mode: 'chatgpt',
@@ -370,7 +377,7 @@ describe('probeCodexDoctor — auth detection (presence)', () => {
   });
 });
 
-describe('probeCodexDoctor — auth liveness (#366)', () => {
+describe('probeCodexDoctor — auth liveness (#366, #464)', () => {
   function okSpawn() {
     spawnSyncMock.mockReturnValue({
       status: 0,
@@ -396,16 +403,71 @@ describe('probeCodexDoctor — auth liveness (#366)', () => {
     expect(result.authStatus).toBe('ok');
   });
 
-  it('authStatus:expired for a stale OAuth auth.json whose id_token has expired', () => {
+  // #464 regression: a healthy `codex login` whose short-lived id_token AND
+  // access_token have lapsed is NOT a dead session — codex mints fresh tokens
+  // from the refresh_token on its next run. `oauthAuthJson` always carries a
+  // refresh_token, so this is a live login. Gating it 'expired' deadlocked the
+  // readiness gate: the probe shells `codex --version`, which never refreshes,
+  // so the daemon never claims, never runs codex, and the tokens never rotate.
+  it('authStatus:ok for a healthy login whose id_token + access_token have lapsed but a refresh_token is present (#464)', () => {
     okSpawn();
-    const pastExp = Math.floor(NOW_MS / 1000) - 3600; // expired an hour ago
+    const pastExp = Math.floor(NOW_MS / 1000) - 3600; // both short-lived tokens expired an hour ago
 
     const result = probeCodexDoctor({
       env: {},
       now: NOW_MS,
       readAuthFile: () => oauthAuthJson(pastExp),
     });
-    // The bug: existence-only detection read this as authenticated:true.
+    expect(result.authenticated).toBe(true);
+    expect(result.authStatus).toBe('ok');
+  });
+
+  // #464: the precise live failure — the ~1h OIDC id_token has rotated out,
+  // the access_token is still valid, the refresh_token is present.
+  it('authStatus:ok when only the short-lived id_token has expired (#464)', () => {
+    okSpawn();
+    const past = Math.floor(NOW_MS / 1000) - 3600;
+    const future = Math.floor(NOW_MS / 1000) + 7 * 86_400;
+
+    const result = probeCodexDoctor({
+      env: {},
+      now: NOW_MS,
+      readAuthFile: () =>
+        JSON.stringify({
+          auth_mode: 'chatgpt',
+          OPENAI_API_KEY: null,
+          tokens: {
+            id_token: jwtWithExp(past),
+            access_token: jwtWithExp(future),
+            refresh_token: 'rt_live',
+          },
+        }),
+    });
+    expect(result.authStatus).toBe('ok');
+  });
+
+  // #366 (corrected model): a genuinely dead session — short-lived tokens
+  // expired AND no refresh_token to renew them — must still read 'expired'.
+  // #464 corrected the prior model, which mislabelled a healthy login (tokens
+  // lapsed but refresh_token present) as 'stale'.
+  it('authStatus:expired for a dead session — tokens expired and no refresh_token', () => {
+    okSpawn();
+    const pastExp = Math.floor(NOW_MS / 1000) - 3600;
+
+    const result = probeCodexDoctor({
+      env: {},
+      now: NOW_MS,
+      readAuthFile: () =>
+        JSON.stringify({
+          auth_mode: 'chatgpt',
+          OPENAI_API_KEY: null,
+          tokens: {
+            id_token: jwtWithExp(pastExp),
+            access_token: jwtWithExp(pastExp),
+            // no refresh_token — nothing can renew this session
+          },
+        }),
+    });
     expect(result.authenticated).toBe(false);
     expect(result.authStatus).toBe('expired');
   });
@@ -449,7 +511,9 @@ describe('probeCodexDoctor — auth liveness (#366)', () => {
     expect(result.authStatus).toBe('expired');
   });
 
-  it('falls back to access_token expiry when id_token carries no exp', () => {
+  // With no refresh_token the classifier falls back to a bearer-token expiry
+  // check — access_token first, id_token only as a last resort.
+  it('authStatus:ok via the access_token bearer check when there is no refresh_token', () => {
     okSpawn();
     const futureExp = Math.floor(NOW_MS / 1000) + 3600;
 


### PR DESCRIPTION
## Summary

`classifyAuthFile` (`client/src/api/codex-doctor-endpoint.ts`) expiry-checked the codex `id_token` first. The `id_token` is a ~1h OIDC token that codex refreshes lazily — only when it actually runs — from the long-lived `refresh_token`. The harness-readiness probe shells `codex --version`, which never refreshes. So a healthy, logged-in operator whose `id_token` had rotated read as `authStatus: 'expired'`, the readiness gate skipped every claim, the daemon never ran codex, and the token never refreshed — a permanent claim-loop deadlock.

Observed live: daemon healthy, `codex login status` reported "Logged in using ChatGPT", `access_token` valid 9+ days, yet `[readiness] <cid> not ready (codex auth expired); skipping claims`.

## Fix

Classify OAuth (chatgpt-mode) liveness off the `refresh_token` — a present refresh_token means codex can mint fresh tokens on its next run. With no refresh_token, fall back to a bearer-token expiry check (`access_token` first, `id_token` last). A genuinely dead session — no refresh_token, no usable credential — still reads `expired`, preserving #366.

## Tests

Converts the prior #366 test (which mismodelled a healthy rotated-token login as a dead session) into the #464 regression test; adds the access_token-valid and dead-session-no-refresh-token cases.

- `codex-doctor-endpoint.test.ts` — 28/28 (2 new regression tests red before the fix, green after)
- `codex-is-ready.test.ts` — 4/4
- readiness-area suite (`readiness-gate`, `readiness-registry`, `harness-readiness-endpoint`) — 13/13
- `yarn build` clean

Verified live: after the fix the daemon's readiness gate passes and it claims tasks (`DISCOVERED → CLAIMED`).

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)