### PR TITLE
fix(client): swe-rebench eval cleanup — prune every round + disk-floor guard (#476)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,7 +278,7 @@ Config file first, env var override. File at `~/.jinn-client/config.json` or `--
 | ipfsGatewayUrl   | JINN_IPFS_GATEWAY_URL    | https://gateway.autonolas.tech    |
 | engine.workingDirRoot | JINN_ENGINE_WORKING_DIR_ROOT | ~/.jinn-client/engine/work   |
 | engine.implStateDirRoot | JINN_ENGINE_IMPL_STATE_DIR_ROOT | ~/.jinn-client/engine/impl-state |
-| _(none — env-only)_  | JINN_EVAL_IMAGE_CACHE_MAX | 20 (cap on the swe-rebench-v2 per-instance Docker image LRU) |
+| _(none — env-only)_  | JINN_EVAL_DISK_FLOOR_GB | 10 (free-disk floor in GB before each swe-rebench-v2 eval round; below it the runner prunes Docker and aborts the run cleanly if still short) |
 
 `JINN_PASSWORD` is env-only — never in config files.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,7 +278,7 @@ Config file first, env var override. File at `~/.jinn-client/config.json` or `--
 | ipfsGatewayUrl   | JINN_IPFS_GATEWAY_URL    | https://gateway.autonolas.tech    |
 | engine.workingDirRoot | JINN_ENGINE_WORKING_DIR_ROOT | ~/.jinn-client/engine/work   |
 | engine.implStateDirRoot | JINN_ENGINE_IMPL_STATE_DIR_ROOT | ~/.jinn-client/engine/impl-state |
-| _(none — env-only)_  | JINN_EVAL_DISK_FLOOR_GB | 10 (free-disk floor in GB before each swe-rebench-v2 eval round; below it the runner prunes Docker and aborts the run cleanly if still short) |
+| _(none — env-only)_  | JINN_EVAL_DISK_FLOOR_GB | 20 (free-disk floor in GB before each swe-rebench-v2 eval round; below it the runner prunes Docker and aborts the run cleanly if still short) |
 
 `JINN_PASSWORD` is env-only — never in config files.
 

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
@@ -27,7 +27,7 @@
  */
 
 import { spawn } from 'node:child_process';
-import { mkdtemp, writeFile, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, writeFile, readFile, rm, statfs } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
 import type { EvalRunner } from './index.js';
@@ -50,6 +50,52 @@ export class EvalCouldNotGradeError extends Error {
   }
 }
 
+/**
+ * Thrown by `runEval` when the disk cannot be brought above the eval
+ * disk-floor even after a broad prune. A clean abort — the caller stops
+ * gracefully; no instance is graded, nothing is marked. Distinct from
+ * `EvalCouldNotGradeError`: this is operator-environment, retryable, and must
+ * never be turned into a `scorable: false` admission (#476).
+ */
+export class InsufficientDiskError extends Error {
+  readonly freeBytes: number;
+  readonly floorBytes: number;
+  constructor(freeBytes: number, floorBytes: number) {
+    const gb = (n: number): string => (n / 1_000_000_000).toFixed(1);
+    super(
+      `insufficient disk for swe-rebench eval: ${gb(freeBytes)} GB free, ` +
+        `need ≥ ${gb(floorBytes)} GB`,
+    );
+    this.name = 'InsufficientDiskError';
+    this.freeBytes = freeBytes;
+    this.floorBytes = floorBytes;
+  }
+}
+
+/** Default free-disk floor required before an eval round: 10 GB. */
+export const DEFAULT_EVAL_DISK_FLOOR_BYTES = 10_000_000_000;
+
+/** Resolve the disk floor: explicit option > `JINN_EVAL_DISK_FLOOR_GB` env > default. */
+export function resolveDiskFloorBytes(opt: number | undefined): number {
+  if (typeof opt === 'number' && Number.isFinite(opt) && opt > 0) return Math.floor(opt);
+  const envRaw = process.env['JINN_EVAL_DISK_FLOOR_GB'];
+  if (envRaw !== undefined) {
+    const parsed = Number(envRaw);
+    if (Number.isFinite(parsed) && parsed > 0) return Math.floor(parsed * 1_000_000_000);
+    console.warn(
+      `[swe-rebench-v2] JINN_EVAL_DISK_FLOOR_GB=${JSON.stringify(envRaw)} is not a positive ` +
+        `number — using default ${DEFAULT_EVAL_DISK_FLOOR_BYTES / 1_000_000_000} GB`,
+    );
+  }
+  return DEFAULT_EVAL_DISK_FLOOR_BYTES;
+}
+
+/** Production disk probe: free bytes on the filesystem backing the temp dir. */
+async function defaultFreeDiskBytes(): Promise<number> {
+  const s = await statfs(tmpdir());
+  return s.bavail * s.bsize;
+}
+
 export interface PythonEvalRunnerOptions {
   /** Path to the cloned SWE-rebench-V2 repo (cached locally). */
   upstreamRepoDir: string;
@@ -68,6 +114,18 @@ export interface PythonEvalRunnerOptions {
    * (logged elsewhere if desired) so a flaky `docker` never escapes `runEval`.
    */
   pruneRound?: (image: string) => Promise<void>;
+  /**
+   * Required free disk (bytes) before an eval round starts. Explicit value >
+   * `JINN_EVAL_DISK_FLOOR_GB` env > {@link DEFAULT_EVAL_DISK_FLOOR_BYTES}.
+   */
+  diskFloorBytes?: number;
+  /** Probe of free disk (bytes). Defaults to a `statfs` on the temp dir. */
+  freeDiskBytes?: () => Promise<number>;
+  /**
+   * Broad reclaim invoked when free disk is below the floor. Defaults to
+   * `docker system prune -f`. MUST NOT throw.
+   */
+  systemPrune?: () => Promise<void>;
 }
 
 /**
@@ -182,12 +240,36 @@ function buildTestCommands(args: Parameters<EvalRunner['runEval']>[0]): string[]
 
 export class PythonEvalRunner implements EvalRunner {
   private readonly pruneRound: (image: string) => Promise<void>;
+  private readonly diskFloorBytes: number;
+  private readonly freeDiskBytes: () => Promise<number>;
+  private readonly systemPrune: () => Promise<void>;
 
   constructor(private readonly opts: PythonEvalRunnerOptions) {
     this.pruneRound = opts.pruneRound ?? defaultPruneRound;
+    this.diskFloorBytes = resolveDiskFloorBytes(opts.diskFloorBytes);
+    this.freeDiskBytes = opts.freeDiskBytes ?? defaultFreeDiskBytes;
+    this.systemPrune = opts.systemPrune ?? (() => runDocker(['system', 'prune', '-f']));
+  }
+
+  /**
+   * Ensure enough free disk for an eval round. Below the floor → broad prune →
+   * re-probe; still below → `InsufficientDiskError` (clean abort). (#476)
+   */
+  private async ensureDiskHeadroom(): Promise<void> {
+    const free = await this.freeDiskBytes();
+    if (free >= this.diskFloorBytes) return;
+    console.warn(
+      `[swe-rebench-v2] low disk (${(free / 1e9).toFixed(1)} GB) — running docker system prune`,
+    );
+    await this.systemPrune();
+    const afterPrune = await this.freeDiskBytes();
+    if (afterPrune < this.diskFloorBytes) {
+      throw new InsufficientDiskError(afterPrune, this.diskFloorBytes);
+    }
   }
 
   async runEval(args: Parameters<EvalRunner['runEval']>[0]): ReturnType<EvalRunner['runEval']> {
+    await this.ensureDiskHeadroom();
     try {
       return await this.runEvalImpl(args);
     } finally {

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
@@ -72,8 +72,13 @@ export class InsufficientDiskError extends Error {
   }
 }
 
-/** Default free-disk floor required before an eval round: 10 GB. */
-export const DEFAULT_EVAL_DISK_FLOOR_BYTES = 10_000_000_000;
+/**
+ * Default free-disk floor required before an eval round: 20 GB. A single
+ * SWE-rebench eval image was observed to peak transiently at ~12.6 GB, so the
+ * floor clears the worst observed instance with real margin. Override with
+ * `JINN_EVAL_DISK_FLOOR_GB` on constrained hosts.
+ */
+export const DEFAULT_EVAL_DISK_FLOOR_BYTES = 20_000_000_000;
 
 /** Resolve the disk floor: explicit option > `JINN_EVAL_DISK_FLOOR_GB` env > default. */
 export function resolveDiskFloorBytes(opt: number | undefined): number {

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
@@ -58,91 +58,48 @@ export interface PythonEvalRunnerOptions {
   /** Workers for parallel eval (defaults to 1; we run one task at a time). */
   maxWorkers?: number;
   /**
-   * Max number of distinct eval images to keep in the local Docker cache.
-   * The runner tracks an in-process LRU keyed by image tag; once usage exceeds
-   * this cap, the least-recently-used images are removed via
-   * {@link PythonEvalRunnerOptions.cleanupImage}.
+   * Removes a completed round's entire Docker footprint — the round's image,
+   * stopped containers, and build cache — so eval disk usage never
+   * accumulates across instances (#476). Called once per `runEval`, in a
+   * `finally`, even when the eval threw.
    *
-   * The leaderboard pool has hundreds of unique instances at ~3 GB/image, so
-   * an unbounded cache fills operator disks in days (jinn-mono-uy6v.11).
-   *
-   * Default: `process.env.JINN_EVAL_IMAGE_CACHE_MAX` parsed as an integer, or
-   * `DEFAULT_EVAL_IMAGE_CACHE_MAX` (20) if unset/invalid.
+   * Defaults to {@link defaultPruneRound}. Implementations MUST NOT throw —
+   * `runEval` guards defensively, but cleanup failures should be swallowed
+   * (logged elsewhere if desired) so a flaky `docker` never escapes `runEval`.
    */
-  imageCacheMax?: number;
-  /**
-   * Removes an image from the local Docker cache (or no-ops if the operator
-   * has chosen not to GC). Called for each eviction from the LRU.
-   *
-   * Defaults to `docker rmi <image>` via the system `docker` binary. Test
-   * suites inject a stub to capture the eviction order without shelling out.
-   *
-   * Implementations MUST NOT throw — failures should be swallowed (logged
-   * elsewhere if desired) so a missing/failed `docker rmi` never escapes
-   * `runEval`. The runner enforces this defensively too.
-   */
-  cleanupImage?: (image: string) => Promise<void>;
+  pruneRound?: (image: string) => Promise<void>;
 }
 
 /**
- * Default cap on the per-instance Docker image cache when no explicit
- * `imageCacheMax` and no `JINN_EVAL_IMAGE_CACHE_MAX` env var are configured.
- *
- * 20 images × ~3 GB/image ≈ 60 GB working set — small enough that even a
- * 256 GB disk has headroom, large enough that the steady-state loop on a
- * frequently-repeating subset of the pool rarely re-pulls.
+ * Spawn `docker <args>`, resolving regardless of outcome — a failed cleanup
+ * command is logged, never thrown (#476: cleanup must not break the eval loop).
  */
-export const DEFAULT_EVAL_IMAGE_CACHE_MAX = 20;
-
-export function resolveImageCacheMax(opt: number | undefined): number {
-  if (typeof opt === 'number' && Number.isFinite(opt) && opt > 0) return Math.floor(opt);
-  const envRaw = process.env['JINN_EVAL_IMAGE_CACHE_MAX'];
-  if (envRaw !== undefined) {
-    // `Number()` returns 0 for `""` / whitespace and NaN for strings with
-    // non-numeric content (e.g. `"garbage"`, `"1e3oops"`) — unlike `parseInt`,
-    // which would silently accept `parseInt("1e3oops") === 1`. Either way we
-    // reject anything that isn't a positive integer.
-    const parsed = Number(envRaw);
-    if (Number.isFinite(parsed) && Number.isInteger(parsed) && parsed > 0) return parsed;
-    // Surface the typo so operators discover it before the disk fills,
-    // rather than silently running on the default.
-    console.warn(
-      `[swe-rebench-v2] JINN_EVAL_IMAGE_CACHE_MAX=${JSON.stringify(envRaw)} is not a positive integer — using default ${DEFAULT_EVAL_IMAGE_CACHE_MAX}`,
-    );
-  }
-  return DEFAULT_EVAL_IMAGE_CACHE_MAX;
-}
-
-/**
- * Production `cleanupImage`: spawn `docker rmi <image>`. Errors are tolerated
- * — a missing/failed `docker rmi` is operationally survivable (the image
- * stays on disk; cache stays bloated for a while; not a correctness failure)
- * — but we warn on non-zero exit and on failed-to-spawn so a persistently-flaky
- * daemon (or a permission slip) becomes visible before disks fill. Silent
- * leaks were the original failure mode `jinn-mono-uy6v.11` exists to fix.
- *
- * We listen on `'exit'` rather than `'close'` and route stdio to `'ignore'`
- * so the resolve path doesn't depend on parent-side stream draining (which
- * can fail to fire `'close'` cleanly when piped without backpressure on the
- * right tick). The image tag + exit code is sufficient signal; operators can
- * grep the docker daemon log for the underlying reason.
- */
-function defaultCleanupImage(image: string): Promise<void> {
+function runDocker(args: string[]): Promise<void> {
   return new Promise((resolve) => {
-    const child = spawn('docker', ['rmi', image], { stdio: ['ignore', 'ignore', 'ignore'] });
+    const child = spawn('docker', args, { stdio: ['ignore', 'ignore', 'ignore'] });
     child.on('exit', (code, signal) => {
       if (code !== 0) {
         const status =
           code !== null ? `exited ${code}` : `terminated by signal ${signal ?? 'unknown'}`;
-        console.warn(`[swe-rebench-v2] docker rmi ${image} ${status}`);
+        console.warn(`[swe-rebench-v2] docker ${args.join(' ')} ${status}`);
       }
       resolve();
     });
     child.on('error', (err) => {
-      console.warn(`[swe-rebench-v2] docker rmi ${image} failed to spawn: ${err.message}`);
+      console.warn(`[swe-rebench-v2] docker ${args.join(' ')} failed to spawn: ${err.message}`);
       resolve();
     });
   });
+}
+
+/**
+ * Production `pruneRound`: remove the round's image, then prune stopped
+ * containers and build cache. Each step is best-effort.
+ */
+async function defaultPruneRound(image: string): Promise<void> {
+  if (image) await runDocker(['rmi', '-f', image]);
+  await runDocker(['container', 'prune', '-f']);
+  await runDocker(['builder', 'prune', '-f']);
 }
 
 /**
@@ -224,62 +181,23 @@ function buildTestCommands(args: Parameters<EvalRunner['runEval']>[0]): string[]
 }
 
 export class PythonEvalRunner implements EvalRunner {
-  /**
-   * LRU of image tags whose Docker layers may be cached locally. Stored as a
-   * `Set<string>` because `Set` preserves insertion order; we delete-then-add
-   * to refresh recency and `next()` on the keys iterator to find the
-   * least-recently-used entry.
-   */
-  private readonly imageLru = new Set<string>();
-  private readonly imageCacheMax: number;
-  private readonly cleanupImage: (image: string) => Promise<void>;
+  private readonly pruneRound: (image: string) => Promise<void>;
 
   constructor(private readonly opts: PythonEvalRunnerOptions) {
-    this.imageCacheMax = resolveImageCacheMax(opts.imageCacheMax);
-    this.cleanupImage = opts.cleanupImage ?? defaultCleanupImage;
+    this.pruneRound = opts.pruneRound ?? defaultPruneRound;
   }
 
   async runEval(args: Parameters<EvalRunner['runEval']>[0]): ReturnType<EvalRunner['runEval']> {
     try {
       return await this.runEvalImpl(args);
     } finally {
-      // Always record the image and run GC — even when the eval threw. A
-      // pull-and-crash failure (Docker storage IO error, image_arch_mismatch,
-      // patch_corrupt, eval_no_report) still left an image on disk; we must
-      // count it toward the cache cap so the failure path can't leak the LRU.
-      await this.recordImageUsage(args.image);
-    }
-  }
-
-  /**
-   * Move `image` to the most-recently-used slot of the in-process LRU; if the
-   * set now exceeds {@link imageCacheMax}, evict the oldest entries via
-   * {@link cleanupImage}. Eviction failures are swallowed so a flaky
-   * `docker rmi` cannot escape `runEval`.
-   *
-   * The cap is enforced after the just-used image is inserted: the
-   * just-evaluated image is the *most* recent, so repeat-evals of recently
-   * used instances never re-pull. Only when more than N distinct images have
-   * been used does the oldest get rmi'd.
-   */
-  private async recordImageUsage(image: string): Promise<void> {
-    if (!image) return;
-    // Refresh recency: delete-then-add reinserts at the tail of the set.
-    this.imageLru.delete(image);
-    this.imageLru.add(image);
-    while (this.imageLru.size > this.imageCacheMax) {
-      const oldest = this.imageLru.values().next().value;
-      if (!oldest) break;
-      this.imageLru.delete(oldest);
+      // Prune this round's full Docker footprint — even when the eval threw,
+      // a pull-and-crash still left an image on disk (#476).
       try {
-        await this.cleanupImage(oldest);
+        await this.pruneRound(args.image);
       } catch (err) {
-        // Best-effort GC: a failed rmi leaves the image on disk but mustn't
-        // break the loop. Warn so a flaky `docker` (or a permission slip)
-        // becomes visible before disks fill — silent leaks were the whole
-        // problem this bead exists to fix.
         const reason = err instanceof Error ? err.message : String(err);
-        console.warn(`[swe-rebench-v2] eval-image cleanup failed for ${oldest}: ${reason}`);
+        console.warn(`[swe-rebench-v2] pruneRound failed for ${args.image}: ${reason}`);
       }
     }
   }

--- a/client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts
+++ b/client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import {
   PythonEvalRunner,
   EvalCouldNotGradeError,
+  InsufficientDiskError,
   matchInfraSignature,
 } from '../../../../src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.js';
 
@@ -286,6 +287,61 @@ describe('PythonEvalRunner', () => {
       // runEval must still resolve with the graded result.
       const result = await runner.runEval({ ...REQUEST, instance_id: 'i1', image: 'img-C' });
       expect(result.passed_match).toBe(true);
+    });
+  });
+
+  // #476 — pre-eval disk-floor guard: probe free disk before each eval; if
+  // below the floor, broad-prune and re-probe; if still below, abort cleanly
+  // with InsufficientDiskError (distinct from EvalCouldNotGradeError).
+  describe('disk-floor guard (#476)', () => {
+    const GB = 1_000_000_000;
+
+    it('proceeds without pruning when free disk is above the floor', async () => {
+      const upstreamRepoDir = makeUpstreamFixture();
+      let systemPruneCalled = false;
+      const runner = new PythonEvalRunner({
+        upstreamRepoDir,
+        maxWorkers: 1,
+        pruneRound: async () => { /* no-op */ },
+        freeDiskBytes: async () => 50 * GB,
+        systemPrune: async () => { systemPruneCalled = true; },
+        diskFloorBytes: 10 * GB,
+      });
+      await runner.runEval(REQUEST);
+      expect(systemPruneCalled).toBe(false);
+    });
+
+    it('prunes and proceeds when a low disk recovers above the floor after system prune', async () => {
+      const upstreamRepoDir = makeUpstreamFixture();
+      const diskReadings = [5 * GB, 20 * GB];
+      let systemPruneCalled = false;
+      const runner = new PythonEvalRunner({
+        upstreamRepoDir,
+        maxWorkers: 1,
+        pruneRound: async () => { /* no-op */ },
+        freeDiskBytes: async () => diskReadings.shift() ?? 20 * GB,
+        systemPrune: async () => { systemPruneCalled = true; },
+        diskFloorBytes: 10 * GB,
+      });
+      const result = await runner.runEval(REQUEST);
+      expect(systemPruneCalled).toBe(true);
+      expect(result.passed_match).toBe(true);
+    });
+
+    it('throws InsufficientDiskError (clean abort) when disk stays below the floor after system prune', async () => {
+      const upstreamRepoDir = makeUpstreamFixture();
+      const runner = new PythonEvalRunner({
+        upstreamRepoDir,
+        maxWorkers: 1,
+        pruneRound: async () => { /* no-op */ },
+        freeDiskBytes: async () => 2 * GB,
+        systemPrune: async () => { /* no-op */ },
+        diskFloorBytes: 10 * GB,
+      });
+      const err = await runner.runEval(REQUEST).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(InsufficientDiskError);
+      expect((err as InsufficientDiskError).freeBytes).toBe(2 * GB);
+      expect((err as InsufficientDiskError).floorBytes).toBe(10 * GB);
     });
   });
 

--- a/client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts
+++ b/client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts
@@ -1,12 +1,10 @@
-import { describe, it, expect, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   PythonEvalRunner,
   EvalCouldNotGradeError,
-  DEFAULT_EVAL_IMAGE_CACHE_MAX,
-  resolveImageCacheMax,
   matchInfraSignature,
 } from '../../../../src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.js';
 
@@ -237,93 +235,26 @@ describe('PythonEvalRunner', () => {
       .rejects.toBeInstanceOf(EvalCouldNotGradeError);
   });
 
-  // jinn-mono-uy6v.11 — bound the per-instance Docker image cache so a
-  // long-running operator daemon does not accumulate ~3 GB/image until the
-  // disk fills. The runner keeps an in-process LRU of image names; when more
-  // than `imageCacheMax` distinct images have been used, the least-recently
-  // used ones are removed via the injected `cleanupImage` hook (which
-  // defaults to `docker rmi <image>` in production).
-  describe('LRU image cache GC (jinn-mono-uy6v.11)', () => {
-    it('does NOT remove any image while distinct usages ≤ cap (keeps repeat-evals fast)', async () => {
+  // #476 — replace the LRU with per-round pruning so eval disk usage never
+  // accumulates across instances. Each runEval call prunes its own Docker
+  // footprint immediately after the eval (success or failure).
+  describe('prune-after-every-round (#476)', () => {
+    it('prunes the round image after a successful eval', async () => {
       const upstreamRepoDir = makeUpstreamFixture();
-      const removed: string[] = [];
+      const pruned: string[] = [];
       const runner = new PythonEvalRunner({
         upstreamRepoDir,
         maxWorkers: 1,
-        imageCacheMax: 3,
-        cleanupImage: async (image) => { removed.push(image); },
+        pruneRound: async (image) => { pruned.push(image); },
       });
-      await runner.runEval({ ...REQUEST, instance_id: 'i1', image: 'img-1:latest' });
-      await runner.runEval({ ...REQUEST, instance_id: 'i2', image: 'img-2:latest' });
-      await runner.runEval({ ...REQUEST, instance_id: 'i3', image: 'img-3:latest' });
-      // Cache is full but not over capacity — nothing should be GC'd yet.
-      expect(removed).toEqual([]);
+      await runner.runEval({ ...REQUEST, instance_id: 'i1', image: 'img-A' });
+      expect(pruned).toEqual(['img-A']);
     });
 
-    it('evicts the least-recently-used image once usage exceeds the cap', async () => {
-      const upstreamRepoDir = makeUpstreamFixture();
-      const removed: string[] = [];
-      const runner = new PythonEvalRunner({
-        upstreamRepoDir,
-        maxWorkers: 1,
-        imageCacheMax: 2,
-        cleanupImage: async (image) => { removed.push(image); },
-      });
-      await runner.runEval({ ...REQUEST, instance_id: 'i1', image: 'img-1:latest' });
-      await runner.runEval({ ...REQUEST, instance_id: 'i2', image: 'img-2:latest' });
-      // Third distinct image — must evict the oldest (img-1).
-      await runner.runEval({ ...REQUEST, instance_id: 'i3', image: 'img-3:latest' });
-      expect(removed).toEqual(['img-1:latest']);
-      // Fourth — must evict the now-oldest (img-2).
-      await runner.runEval({ ...REQUEST, instance_id: 'i4', image: 'img-4:latest' });
-      expect(removed).toEqual(['img-1:latest', 'img-2:latest']);
-    });
-
-    it('refreshes LRU order on repeat-eval — re-using an image protects it from eviction', async () => {
-      const upstreamRepoDir = makeUpstreamFixture();
-      const removed: string[] = [];
-      const runner = new PythonEvalRunner({
-        upstreamRepoDir,
-        maxWorkers: 1,
-        imageCacheMax: 2,
-        cleanupImage: async (image) => { removed.push(image); },
-      });
-      await runner.runEval({ ...REQUEST, instance_id: 'i1', image: 'img-1:latest' });
-      await runner.runEval({ ...REQUEST, instance_id: 'i2', image: 'img-2:latest' });
-      // Re-use img-1 — now img-2 is the oldest.
-      await runner.runEval({ ...REQUEST, instance_id: 'i1-repeat', image: 'img-1:latest' });
-      expect(removed).toEqual([]);
-      // A new distinct image evicts img-2, not img-1.
-      await runner.runEval({ ...REQUEST, instance_id: 'i3', image: 'img-3:latest' });
-      expect(removed).toEqual(['img-2:latest']);
-    });
-
-    it('records the image in the LRU even when the eval throws EvalCouldNotGradeError', async () => {
-      // Cap of 1 — every new distinct image evicts the previous one. This
-      // proves cleanup runs in the failure path too (acceptance: cleanup must
-      // not be conditional on the success path).
-      const failingFixture = makeUpstreamFixture({
-        reportItem: { error: 'Task missing top-level image_name.' },
-      });
-      const removed: string[] = [];
-      const runner = new PythonEvalRunner({
-        upstreamRepoDir: failingFixture,
-        maxWorkers: 1,
-        imageCacheMax: 1,
-        cleanupImage: async (image) => { removed.push(image); },
-      });
-      await expect(runner.runEval({ ...REQUEST, instance_id: 'i1', image: 'img-1:latest' }))
-        .rejects.toBeInstanceOf(EvalCouldNotGradeError);
-      // A second distinct image — even after a failure — must evict the first.
-      await expect(runner.runEval({ ...REQUEST, instance_id: 'i2', image: 'img-2:latest' }))
-        .rejects.toBeInstanceOf(EvalCouldNotGradeError);
-      expect(removed).toEqual(['img-1:latest']);
-    });
-
-    it('also records the image in the LRU when the report is missing/unparseable (no-report failure path)', async () => {
-      // eval.py exits non-zero with no report file — runEval throws
+    it('prunes the round image even when the eval throws EvalCouldNotGradeError', async () => {
+      // eval.py exits non-zero without writing a report — runEval throws
       // EvalCouldNotGradeError('eval_no_report'). The image must still be
-      // tracked for GC, otherwise pull-and-crash failures leak the cache.
+      // pruned, otherwise pull-and-crash failures leave images on disk.
       const dir = mkdtempSync(join(tmpdir(), 'swe-rebench-eval-runner-test-'));
       tempDirs.push(dir);
       const scriptsDir = join(dir, 'scripts');
@@ -332,137 +263,29 @@ describe('PythonEvalRunner', () => {
       writeFileSync(join(scriptsDir, 'eval.py'), 'import sys\nsys.exit(2)\n');
       chmodSync(join(scriptsDir, 'eval.py'), 0o755);
 
-      const removed: string[] = [];
+      const pruned: string[] = [];
       const runner = new PythonEvalRunner({
         upstreamRepoDir: dir,
         maxWorkers: 1,
-        imageCacheMax: 1,
-        cleanupImage: async (image) => { removed.push(image); },
+        pruneRound: async (image) => { pruned.push(image); },
       });
-      await expect(runner.runEval({ ...REQUEST, instance_id: 'i1', image: 'img-1:latest' }))
+      await expect(runner.runEval({ ...REQUEST, instance_id: 'i1', image: 'img-B' }))
         .rejects.toBeInstanceOf(EvalCouldNotGradeError);
-      await expect(runner.runEval({ ...REQUEST, instance_id: 'i2', image: 'img-2:latest' }))
-        .rejects.toBeInstanceOf(EvalCouldNotGradeError);
-      expect(removed).toEqual(['img-1:latest']);
+      expect(pruned).toEqual(['img-B']);
     });
 
-    it('swallows cleanupImage errors so a failing docker rmi never escapes runEval', async () => {
+    it('a throwing pruneRound never escapes runEval', async () => {
+      // pruneRound throwing must not propagate — cleanup failures should be
+      // swallowed so a flaky `docker` never breaks the eval loop.
       const upstreamRepoDir = makeUpstreamFixture();
       const runner = new PythonEvalRunner({
         upstreamRepoDir,
         maxWorkers: 1,
-        imageCacheMax: 1,
-        cleanupImage: async () => { throw new Error('rmi blew up'); },
+        pruneRound: async () => { throw new Error('docker rmi blew up'); },
       });
-      await runner.runEval({ ...REQUEST, instance_id: 'i1', image: 'img-1:latest' });
-      // The second call would trigger cleanupImage(img-1). It must complete
-      // normally and return the graded result.
-      const result = await runner.runEval({ ...REQUEST, instance_id: 'i2', image: 'img-2:latest' });
+      // runEval must still resolve with the graded result.
+      const result = await runner.runEval({ ...REQUEST, instance_id: 'i1', image: 'img-C' });
       expect(result.passed_match).toBe(true);
-    });
-
-    it('reads the default cap from JINN_EVAL_IMAGE_CACHE_MAX when neither imageCacheMax nor cleanupImage is configured', async () => {
-      const upstreamRepoDir = makeUpstreamFixture();
-      const prev = process.env['JINN_EVAL_IMAGE_CACHE_MAX'];
-      const prevPath = process.env['PATH'];
-      // Stub `docker` on PATH with a script that records the rmi target and
-      // returns 0. Cap=1 → second distinct image triggers rmi of the first.
-      const stubDir = mkdtempSync(join(tmpdir(), 'swe-rebench-docker-stub-'));
-      tempDirs.push(stubDir);
-      const logPath = join(stubDir, 'rmi.log');
-      writeFileSync(join(stubDir, 'docker'), `#!/usr/bin/env bash\necho "$@" >> ${JSON.stringify(logPath)}\nexit 0\n`);
-      chmodSync(join(stubDir, 'docker'), 0o755);
-
-      process.env['JINN_EVAL_IMAGE_CACHE_MAX'] = '1';
-      process.env['PATH'] = `${stubDir}:${prevPath}`;
-      try {
-        const runner = new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 });
-        await runner.runEval({ ...REQUEST, instance_id: 'i1', image: 'img-1:latest' });
-        await runner.runEval({ ...REQUEST, instance_id: 'i2', image: 'img-2:latest' });
-      } finally {
-        if (prev === undefined) delete process.env['JINN_EVAL_IMAGE_CACHE_MAX'];
-        else process.env['JINN_EVAL_IMAGE_CACHE_MAX'] = prev;
-        if (prevPath === undefined) delete process.env['PATH'];
-        else process.env['PATH'] = prevPath;
-      }
-      const log = readFileSync(logPath, 'utf8');
-      expect(log).toContain('rmi');
-      expect(log).toContain('img-1:latest');
-      expect(log).not.toContain('img-2:latest');
-    });
-
-    it('falls back to DEFAULT_EVAL_IMAGE_CACHE_MAX when the env var is invalid (0 / negative / non-numeric / empty)', () => {
-      const prev = process.env['JINN_EVAL_IMAGE_CACHE_MAX'];
-      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      try {
-        const invalidInputs = ['0', '-5', 'garbage', '', '  ', '1e3oops'];
-        for (const garbage of invalidInputs) {
-          warn.mockClear();
-          process.env['JINN_EVAL_IMAGE_CACHE_MAX'] = garbage;
-          expect(resolveImageCacheMax(undefined)).toBe(DEFAULT_EVAL_IMAGE_CACHE_MAX);
-          // Operators who mistype the env var get a loud signal — silent
-          // fallback was the original review finding here. The literal value
-          // is interpolated so trailing whitespace / empty-string typos are
-          // unambiguous in the log.
-          expect(warn).toHaveBeenCalledTimes(1);
-          expect(warn).toHaveBeenCalledWith(
-            expect.stringContaining(`JINN_EVAL_IMAGE_CACHE_MAX=${JSON.stringify(garbage)}`),
-          );
-        }
-        // Sanity: a valid positive integer is honored and does NOT warn.
-        warn.mockClear();
-        process.env['JINN_EVAL_IMAGE_CACHE_MAX'] = '7';
-        expect(resolveImageCacheMax(undefined)).toBe(7);
-        expect(warn).not.toHaveBeenCalled();
-        // Explicit option always wins over env (positive option short-circuits).
-        process.env['JINN_EVAL_IMAGE_CACHE_MAX'] = '999';
-        expect(resolveImageCacheMax(3)).toBe(3);
-        // Invalid explicit option falls through to the env.
-        expect(resolveImageCacheMax(0)).toBe(999);
-        expect(resolveImageCacheMax(-1)).toBe(999);
-      } finally {
-        if (prev === undefined) delete process.env['JINN_EVAL_IMAGE_CACHE_MAX'];
-        else process.env['JINN_EVAL_IMAGE_CACHE_MAX'] = prev;
-        warn.mockRestore();
-      }
-    });
-
-    it('warns when the production docker rmi cleanup exits non-zero so a flaky daemon is visible (jinn-mono-uy6v.11)', async () => {
-      // Stub `docker` on PATH with a script that exits non-zero — simulating
-      // "image is in use by container", "permission denied", or a daemon
-      // restart. Pre-fix, `defaultCleanupImage` swallowed errors silently, so
-      // operators had zero visibility into a persistently-failing `docker rmi`
-      // until the disk filled.
-      const upstreamRepoDir = makeUpstreamFixture();
-      const prevPath = process.env['PATH'];
-      const prevCacheMax = process.env['JINN_EVAL_IMAGE_CACHE_MAX'];
-      const stubDir = mkdtempSync(join(tmpdir(), 'swe-rebench-docker-rmi-fail-stub-'));
-      tempDirs.push(stubDir);
-      writeFileSync(join(stubDir, 'docker'), '#!/usr/bin/env bash\nexit 1\n');
-      chmodSync(join(stubDir, 'docker'), 0o755);
-
-      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      process.env['PATH'] = `${stubDir}:${prevPath ?? ''}`;
-      process.env['JINN_EVAL_IMAGE_CACHE_MAX'] = '1';
-      let warnCalls: string[] = [];
-      try {
-        const runner = new PythonEvalRunner({ upstreamRepoDir, maxWorkers: 1 });
-        await runner.runEval({ ...REQUEST, instance_id: 'i1', image: 'img-1:latest' });
-        // Second distinct image → triggers cleanup of img-1 → docker stub exits 1.
-        await runner.runEval({ ...REQUEST, instance_id: 'i2', image: 'img-2:latest' });
-        warnCalls = warn.mock.calls.map((c) => String(c[0]));
-      } finally {
-        if (prevPath === undefined) delete process.env['PATH'];
-        else process.env['PATH'] = prevPath;
-        if (prevCacheMax === undefined) delete process.env['JINN_EVAL_IMAGE_CACHE_MAX'];
-        else process.env['JINN_EVAL_IMAGE_CACHE_MAX'] = prevCacheMax;
-        warn.mockRestore();
-      }
-      // Warn fired with the image tag + non-zero exit code. (Captured before
-      // mockRestore so a captures-after-restore quirk can't be the failure.)
-      const cleanupWarn = warnCalls.find((m) => m.includes('docker rmi img-1:latest'));
-      expect(cleanupWarn).toBeTruthy();
-      expect(cleanupWarn).toContain('exited 1');
     });
   });
 

--- a/client/test/harnesses/impls/swe-rebench-v2-evaluator/harness.test.ts
+++ b/client/test/harnesses/impls/swe-rebench-v2-evaluator/harness.test.ts
@@ -552,11 +552,11 @@ describe('SweRebenchV2EvaluatorHarness — run', () => {
     await expect(harness.run(ctx)).rejects.toThrow(/not enabled/);
   });
 
-  it('reuses a single EvalRunner across run() calls so the LRU image cache accumulates (jinn-mono-uy6v.11)', async () => {
+  it('reuses a single EvalRunner across run() calls so per-round pruning fires on the shared runner (jinn-mono-uy6v.11)', async () => {
     // Regression: pre-fix, `new PythonEvalRunner(...)` was constructed inside
-    // each `run()` call, so the in-process LRU image cache was rebuilt empty
-    // every invocation and `cleanupImage` never fired in production. The
-    // existing LRU-eviction tests didn't catch this because they exercise
+    // each `run()` call, so the in-process runner was rebuilt empty every
+    // invocation and per-round pruning never fired in production. The
+    // existing pruning tests didn't catch this because they exercise
     // PythonEvalRunner directly. This test pins the harness→runner wiring:
     // the runner factory must be invoked exactly once across multiple run()
     // calls, regardless of how many distinct tasks the harness grades.

--- a/docs/superpowers/plans/2026-05-21-swe-rebench-eval-cleanup-robustness.md
+++ b/docs/superpowers/plans/2026-05-21-swe-rebench-eval-cleanup-robustness.md
@@ -1,0 +1,412 @@
+# SWE-rebench Eval Cleanup Robustness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the SWE-rebench eval runner's count-based Docker image LRU (which fills operator disks) with prune-after-every-round plus a pre-eval disk-floor guard, so the eval pipeline never exhausts the disk.
+
+**Architecture:** All changes are in `client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts` (shared by `validate-pool` and the daemon evaluator). Task 1 removes the LRU and prunes each round's full Docker footprint (image + stopped containers + build cache) the moment the round ends. Task 2 adds a disk-headroom check before each round: prune broadly when low, abort the run cleanly (typed error) when the floor genuinely can't be met.
+
+**Tech Stack:** TypeScript (Node 22, ESM), Vitest. No new dependencies (`node:fs/promises` `statfs` for the disk probe).
+
+**Spec:** `docs/superpowers/specs/2026-05-21-swe-rebench-eval-cleanup-robustness-design.md` · **Issue:** [#476](https://github.com/Jinn-Network/mono/issues/476)
+
+---
+
+## File Structure
+
+| File | Change |
+|---|---|
+| `client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts` | **Modify** — remove the LRU (`imageLru`, `imageCacheMax`, `resolveImageCacheMax`, `DEFAULT_EVAL_IMAGE_CACHE_MAX`, `recordImageUsage`); add `pruneRound` + `defaultPruneRound`; add `InsufficientDiskError`, the disk probe, and `ensureDiskHeadroom`. |
+| `client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts` | **Modify** — replace the `LRU image cache GC` describe block with prune-after-every-round tests; add disk-floor-guard tests; drop the `resolveImageCacheMax` import/tests. |
+
+---
+
+## Task 1: Prune-after-every-round (remove the LRU)
+
+**Files:**
+- Modify: `client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts`
+- Test: `client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts`
+
+- [ ] **Step 1: Rewrite the eviction tests as prune-after-every-round tests**
+
+In `eval-runner.test.ts`: remove `resolveImageCacheMax` from the import block at the top of the file. Delete the entire `describe('LRU image cache GC (jinn-mono-uy6v.11)', ...)` block and replace it with:
+
+```ts
+  // #476: the runner prunes each round's full Docker footprint immediately
+  // after the eval, so disk usage never accumulates across instances.
+  describe('prune-after-every-round (#476)', () => {
+    it('prunes the round image after a successful eval', async () => {
+      const pruned: string[] = [];
+      const runner = makeRunnerWithReport(SUCCESS_REPORT, {
+        pruneRound: async (image) => { pruned.push(image); },
+      });
+      await runner.runEval(baseArgs({ image: 'img-A' }));
+      expect(pruned).toEqual(['img-A']);
+    });
+
+    it('prunes the round image even when the eval throws', async () => {
+      const pruned: string[] = [];
+      const runner = makeRunnerNoReport({
+        pruneRound: async (image) => { pruned.push(image); },
+      });
+      await expect(runner.runEval(baseArgs({ image: 'img-B' }))).rejects.toThrow(
+        EvalCouldNotGradeError,
+      );
+      expect(pruned).toEqual(['img-B']);
+    });
+
+    it('a throwing pruneRound never escapes runEval', async () => {
+      const runner = makeRunnerWithReport(SUCCESS_REPORT, {
+        pruneRound: async () => { throw new Error('docker rmi blew up'); },
+      });
+      await expect(runner.runEval(baseArgs({ image: 'img-C' }))).resolves.toBeDefined();
+    });
+  });
+```
+
+Match the existing test file's helpers: reuse however the existing tests build a runner + a fake report (the pre-existing eviction tests already did this — `makeRunnerWithReport` / `makeRunnerNoReport` / `baseArgs` / `SUCCESS_REPORT` are the names used here; if the file's helpers are named differently, use the file's actual helper names — the existing `'records the image in the LRU even when the eval throws'` and `'...report is missing/unparseable...'` tests are the templates for the success and no-report paths respectively).
+
+- [ ] **Step 2: Run the tests — verify they fail**
+
+Run: `cd client && yarn vitest run test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts`
+Expected: FAIL — `pruneRound` is not an accepted option; `resolveImageCacheMax` import is unresolved.
+
+- [ ] **Step 3: Remove the LRU machinery from `eval-runner.ts`**
+
+Delete these from `eval-runner.ts`:
+- `DEFAULT_EVAL_IMAGE_CACHE_MAX` (the `export const`) and `resolveImageCacheMax` (the whole `export function`).
+- The `imageCacheMax?` field and its doc-comment from the `PythonEvalRunnerOptions` interface.
+- The `imageLru`, `imageCacheMax` class fields from `PythonEvalRunner`.
+- The entire `recordImageUsage` method.
+
+- [ ] **Step 4: Add `pruneRound` + `defaultPruneRound`**
+
+Replace the `cleanupImage?` option in `PythonEvalRunnerOptions` with:
+
+```ts
+  /**
+   * Removes a completed round's entire Docker footprint — the round's image,
+   * stopped containers, and build cache — so eval disk usage never
+   * accumulates across instances (#476). Called once per `runEval`, in a
+   * `finally`, even when the eval threw.
+   *
+   * Defaults to {@link defaultPruneRound}. Implementations MUST NOT throw —
+   * `runEval` guards defensively, but cleanup failures should be swallowed
+   * (logged elsewhere if desired) so a flaky `docker` never escapes `runEval`.
+   */
+  pruneRound?: (image: string) => Promise<void>;
+```
+
+Replace `defaultCleanupImage` with a shared `runDocker` helper and `defaultPruneRound`:
+
+```ts
+/**
+ * Spawn `docker <args>`, resolving regardless of outcome — a failed cleanup
+ * command is logged, never thrown (#476: cleanup must not break the eval loop).
+ */
+function runDocker(args: string[]): Promise<void> {
+  return new Promise((resolve) => {
+    const child = spawn('docker', args, { stdio: ['ignore', 'ignore', 'ignore'] });
+    child.on('exit', (code, signal) => {
+      if (code !== 0) {
+        const status =
+          code !== null ? `exited ${code}` : `terminated by signal ${signal ?? 'unknown'}`;
+        console.warn(`[swe-rebench-v2] docker ${args.join(' ')} ${status}`);
+      }
+      resolve();
+    });
+    child.on('error', (err) => {
+      console.warn(`[swe-rebench-v2] docker ${args.join(' ')} failed to spawn: ${err.message}`);
+      resolve();
+    });
+  });
+}
+
+/**
+ * Production `pruneRound`: remove the round's image, then prune stopped
+ * containers and build cache. Each step is best-effort.
+ */
+async function defaultPruneRound(image: string): Promise<void> {
+  if (image) await runDocker(['rmi', '-f', image]);
+  await runDocker(['container', 'prune', '-f']);
+  await runDocker(['builder', 'prune', '-f']);
+}
+```
+
+- [ ] **Step 5: Wire `pruneRound` into `runEval`**
+
+In `PythonEvalRunner`: replace the `imageLru` / `imageCacheMax` / `cleanupImage` fields with a single field, and set it in the constructor:
+
+```ts
+  private readonly pruneRound: (image: string) => Promise<void>;
+
+  constructor(private readonly opts: PythonEvalRunnerOptions) {
+    this.pruneRound = opts.pruneRound ?? defaultPruneRound;
+  }
+```
+
+Replace the `runEval` body's `finally` so it prunes the round (defensively swallowing any throw):
+
+```ts
+  async runEval(args: Parameters<EvalRunner['runEval']>[0]): ReturnType<EvalRunner['runEval']> {
+    try {
+      return await this.runEvalImpl(args);
+    } finally {
+      // Prune this round's full Docker footprint — even when the eval threw,
+      // a pull-and-crash still left an image on disk (#476).
+      try {
+        await this.pruneRound(args.image);
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        console.warn(`[swe-rebench-v2] pruneRound failed for ${args.image}: ${reason}`);
+      }
+    }
+  }
+```
+
+- [ ] **Step 6: Run the tests — verify they pass**
+
+Run: `cd client && yarn vitest run test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts`
+Expected: PASS — the 3 new prune tests plus all pre-existing non-LRU tests. If a non-LRU test still references `imageCacheMax`/`cleanupImage`, update it to `pruneRound` (do not weaken assertions).
+
+- [ ] **Step 7: Typecheck + commit**
+
+Run: `cd client && yarn typecheck` → exit 0. (Confirms no remaining references to the deleted `resolveImageCacheMax` / `imageCacheMax` / `cleanupImage` across the codebase — if the daemon evaluator harness or its setup passes `imageCacheMax`/`cleanupImage`, remove those args there too.)
+
+```bash
+git add client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts
+git commit -m "fix(client): swe-rebench eval prunes each round's Docker footprint, no LRU (#476)"
+```
+
+---
+
+## Task 2: Pre-eval disk-floor guard
+
+**Files:**
+- Modify: `client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts`
+- Test: `client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new describe block to `eval-runner.test.ts`:
+
+```ts
+  // #476: before each eval the runner ensures disk headroom — prune when low,
+  // abort cleanly when the floor genuinely can't be met.
+  describe('pre-eval disk-floor guard (#476)', () => {
+    const GB = 1_000_000_000;
+
+    it('proceeds without pruning when free disk is above the floor', async () => {
+      let systemPruned = false;
+      const runner = makeRunnerWithReport(SUCCESS_REPORT, {
+        pruneRound: async () => {},
+        freeDiskBytes: async () => 50 * GB,
+        systemPrune: async () => { systemPruned = true; },
+        diskFloorBytes: 10 * GB,
+      });
+      await runner.runEval(baseArgs({ image: 'img-A' }));
+      expect(systemPruned).toBe(false);
+    });
+
+    it('prunes and proceeds when a low disk recovers above the floor', async () => {
+      let systemPruned = false;
+      const free = [5 * GB, 20 * GB]; // before prune, after prune
+      const runner = makeRunnerWithReport(SUCCESS_REPORT, {
+        pruneRound: async () => {},
+        freeDiskBytes: async () => free.shift() ?? 20 * GB,
+        systemPrune: async () => { systemPruned = true; },
+        diskFloorBytes: 10 * GB,
+      });
+      await runner.runEval(baseArgs({ image: 'img-A' }));
+      expect(systemPruned).toBe(true);
+    });
+
+    it('throws InsufficientDiskError (clean abort) when disk stays below the floor', async () => {
+      const runner = makeRunnerWithReport(SUCCESS_REPORT, {
+        pruneRound: async () => {},
+        freeDiskBytes: async () => 2 * GB, // stays low before and after prune
+        systemPrune: async () => {},
+        diskFloorBytes: 10 * GB,
+      });
+      await expect(runner.runEval(baseArgs({ image: 'img-A' }))).rejects.toThrow(
+        InsufficientDiskError,
+      );
+    });
+  });
+```
+
+Add `InsufficientDiskError` to the imports from `../../../../src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.js`.
+
+- [ ] **Step 2: Run the tests — verify they fail**
+
+Run: `cd client && yarn vitest run test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts`
+Expected: FAIL — `InsufficientDiskError`, `freeDiskBytes`, `systemPrune`, `diskFloorBytes` are not exported / not accepted options.
+
+- [ ] **Step 3: Add `InsufficientDiskError`, the disk probe, and the floor constant**
+
+In `eval-runner.ts`, add to the imports: `import { mkdtemp, writeFile, readFile, rm, statfs } from 'node:fs/promises';` (extend the existing `node:fs/promises` import).
+
+Add near `EvalCouldNotGradeError`:
+
+```ts
+/**
+ * Thrown by `runEval` when the disk cannot be brought above the eval
+ * disk-floor even after a broad prune. A clean abort — the caller stops
+ * gracefully; no instance is graded, nothing is marked. Distinct from
+ * `EvalCouldNotGradeError`: this is operator-environment, retryable, and must
+ * never be turned into a `scorable: false` admission (#476).
+ */
+export class InsufficientDiskError extends Error {
+  readonly freeBytes: number;
+  readonly floorBytes: number;
+  constructor(freeBytes: number, floorBytes: number) {
+    const gb = (n: number): string => (n / 1_000_000_000).toFixed(1);
+    super(
+      `insufficient disk for swe-rebench eval: ${gb(freeBytes)} GB free, ` +
+        `need ≥ ${gb(floorBytes)} GB`,
+    );
+    this.name = 'InsufficientDiskError';
+    this.freeBytes = freeBytes;
+    this.floorBytes = floorBytes;
+  }
+}
+
+/** Default free-disk floor required before an eval round: 10 GB. */
+export const DEFAULT_EVAL_DISK_FLOOR_BYTES = 10_000_000_000;
+
+/** Resolve the disk floor: explicit option > `JINN_EVAL_DISK_FLOOR_GB` env > default. */
+export function resolveDiskFloorBytes(opt: number | undefined): number {
+  if (typeof opt === 'number' && Number.isFinite(opt) && opt > 0) return Math.floor(opt);
+  const envRaw = process.env['JINN_EVAL_DISK_FLOOR_GB'];
+  if (envRaw !== undefined) {
+    const parsed = Number(envRaw);
+    if (Number.isFinite(parsed) && parsed > 0) return Math.floor(parsed * 1_000_000_000);
+    console.warn(
+      `[swe-rebench-v2] JINN_EVAL_DISK_FLOOR_GB=${JSON.stringify(envRaw)} is not a positive ` +
+        `number — using default ${DEFAULT_EVAL_DISK_FLOOR_BYTES / 1_000_000_000} GB`,
+    );
+  }
+  return DEFAULT_EVAL_DISK_FLOOR_BYTES;
+}
+
+/** Production disk probe: free bytes on the filesystem backing the temp dir. */
+async function defaultFreeDiskBytes(): Promise<number> {
+  const s = await statfs(tmpdir());
+  return s.bavail * s.bsize;
+}
+```
+
+- [ ] **Step 4: Add the three new options**
+
+In `PythonEvalRunnerOptions`, add after `pruneRound`:
+
+```ts
+  /**
+   * Required free disk (bytes) before an eval round starts. Explicit value >
+   * `JINN_EVAL_DISK_FLOOR_GB` env > {@link DEFAULT_EVAL_DISK_FLOOR_BYTES}.
+   */
+  diskFloorBytes?: number;
+  /** Probe of free disk (bytes). Defaults to a `statfs` on the temp dir. */
+  freeDiskBytes?: () => Promise<number>;
+  /**
+   * Broad reclaim invoked when free disk is below the floor. Defaults to
+   * `docker system prune -f`. MUST NOT throw.
+   */
+  systemPrune?: () => Promise<void>;
+```
+
+- [ ] **Step 5: Wire the guard into `runEval`**
+
+In `PythonEvalRunner`, add the fields + constructor wiring:
+
+```ts
+  private readonly pruneRound: (image: string) => Promise<void>;
+  private readonly diskFloorBytes: number;
+  private readonly freeDiskBytes: () => Promise<number>;
+  private readonly systemPrune: () => Promise<void>;
+
+  constructor(private readonly opts: PythonEvalRunnerOptions) {
+    this.pruneRound = opts.pruneRound ?? defaultPruneRound;
+    this.diskFloorBytes = resolveDiskFloorBytes(opts.diskFloorBytes);
+    this.freeDiskBytes = opts.freeDiskBytes ?? defaultFreeDiskBytes;
+    this.systemPrune = opts.systemPrune ?? (() => runDocker(['system', 'prune', '-f']));
+  }
+```
+
+Add the guard method:
+
+```ts
+  /**
+   * Ensure enough free disk for an eval round. Below the floor → broad prune →
+   * re-probe; still below → `InsufficientDiskError` (clean abort). (#476)
+   */
+  private async ensureDiskHeadroom(): Promise<void> {
+    const free = await this.freeDiskBytes();
+    if (free >= this.diskFloorBytes) return;
+    console.warn(
+      `[swe-rebench-v2] low disk (${(free / 1e9).toFixed(1)} GB) — running docker system prune`,
+    );
+    await this.systemPrune();
+    const afterPrune = await this.freeDiskBytes();
+    if (afterPrune < this.diskFloorBytes) {
+      throw new InsufficientDiskError(afterPrune, this.diskFloorBytes);
+    }
+  }
+```
+
+Call it at the very top of `runEval`, before the `try`:
+
+```ts
+  async runEval(args: Parameters<EvalRunner['runEval']>[0]): ReturnType<EvalRunner['runEval']> {
+    await this.ensureDiskHeadroom();
+    try {
+      return await this.runEvalImpl(args);
+    } finally {
+      try {
+        await this.pruneRound(args.image);
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        console.warn(`[swe-rebench-v2] pruneRound failed for ${args.image}: ${reason}`);
+      }
+    }
+  }
+```
+
+(`ensureDiskHeadroom` throwing before the `try` means a clean abort with no `pruneRound` — correct: nothing ran, nothing to prune.)
+
+- [ ] **Step 6: Run the tests — verify they pass**
+
+Run: `cd client && yarn vitest run test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts`
+Expected: PASS — all prune + disk-guard tests plus the pre-existing suite.
+
+- [ ] **Step 7: Typecheck, build, commit**
+
+Run: `cd client && yarn typecheck` → exit 0. Then `cd client && yarn build` → exit 0, 0 `error TS`.
+
+```bash
+git add client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts
+git commit -m "fix(client): swe-rebench eval aborts cleanly below the disk floor (#476)
+
+Closes #476"
+```
+
+---
+
+## Manual verification (after Task 2)
+
+`cd client && yarn build`, then run a small validation batch on a machine with Docker:
+`node dist/bin/jinn.js solver-nets validate-pool swe-rebench-v2 --limit 5` — confirm `docker system df` after the run shows no accumulated eval images/containers (each round pruned), and that Docker disk usage stays flat across the 5 instances instead of growing ~3 GB each.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- §1 prune-after-every-round → Task 1 (image + container-prune + builder-prune; LRU removed). ✓
+- §2 pre-eval disk-floor guard → Task 2 (`ensureDiskHeadroom`: probe → prune → re-probe → `InsufficientDiskError`). ✓
+- §3 failure semantics — `InsufficientDiskError` is a distinct typed error (not `EvalCouldNotGradeError`), so it never becomes a `scorable: false`; it propagates to callers which stop via existing error handling. **Partial:** the residual caller-side nicety — `validate-pool` recognising `EvalCouldNotGradeError(reason='docker_storage_io_error')` as retryable rather than writing `scorable:false` — is *not* in this plan; with §2 in place the disk no longer reaches 100%, so `docker_storage_io_error` becomes rare. Tracked as a fast-follow on #476 (needs `client/src/cli/commands/solver-nets.ts`).
+- §4 scope → all in `eval-runner.ts`; both consumers inherit it. ✓
+
+**2. Placeholder scan:** Every code step carries complete code; every run step an exact command + expected result. The one soft spot — "use the file's actual helper names" in Task 1 Step 1 — is a deliberate instruction to match existing test helpers (the implementer reads the test file), not a vacuous placeholder.
+
+**3. Type consistency:** `pruneRound: (image: string) => Promise<void>` — same signature in the option, the field, and `defaultPruneRound`. `freeDiskBytes: () => Promise<number>`, `systemPrune: () => Promise<void>`, `diskFloorBytes: number` — consistent across option/field/constructor. `InsufficientDiskError` exported and imported in the test. `resolveDiskFloorBytes` mirrors the (now-deleted) `resolveImageCacheMax` shape.

--- a/docs/superpowers/specs/2026-05-21-swe-rebench-eval-cleanup-robustness-design.md
+++ b/docs/superpowers/specs/2026-05-21-swe-rebench-eval-cleanup-robustness-design.md
@@ -1,0 +1,81 @@
+# SWE-rebench Eval Cleanup Robustness — Design
+
+**Version:** 0.1
+**Date:** 2026-05-21
+**Author:** Captain (brainstormed with Oak)
+**Issue:** [#476](https://github.com/Jinn-Network/mono/issues/476)
+
+## Problem
+
+`client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts` — the SWE-rebench eval runner shared by `validate-pool` and the daemon's swe-rebench evaluator — manages Docker eval images with a **count-based LRU**: keep the last `JINN_EVAL_IMAGE_CACHE_MAX` (default 20) images, `docker rmi` the rest.
+
+Three defects make it fill operator disks:
+
+1. **Count-based, not disk-based.** 20 images × ~3 GB per SWE-rebench image ≈ 60 GB. The cap *is* "fill a 60 GB Docker disk"; it is blind to how much disk actually exists or remains.
+2. **Only evicts tagged images.** Stopped containers, build cache, and dangling layers accumulate uncounted by the LRU.
+3. **No pre-eval disk guard.** The runner starts each eval unconditionally; when the disk fills mid-pull it false-marks the casualty `docker_storage_io_error` (a *permanent* `scorable: false`) and keeps going until even a 30 KB state-file write fails with `ENOSPC`.
+
+Observed live (2026-05-21): a `validate-pool --limit 30` run filled a 460 GB Mac, corrupted Docker's content store, false-marked 4 instances, and died mid-write. Recovery required a full Docker wipe.
+
+## Goals
+
+- Peak eval disk footprint ≈ **one instance**, on any machine, regardless of total disk size — no per-machine tuning.
+- Cleanup removes the **whole per-round footprint**: container + image + build cache / dangling layers.
+- Disk pressure produces a **clean stop** — never Docker corruption, never a permanent false `scorable: false`, never a mid-write death.
+
+## Non-goals
+
+- **Cross-round image reuse.** The LRU's only real purpose was avoiding a re-pull when the *same* instance is evaluated again soon. This design gives that up deliberately. `validate-pool` evaluates each instance exactly once, so it loses nothing; the daemon evaluator occasionally re-pulls an image — a speed/bandwidth cost, accepted in exchange for disk-safety. (A small cache could be reintroduced later if re-pull cost is ever measured to matter — explicitly deferred, YAGNI.)
+- Changing the eval logic, scoring, or substrate verification — only the Docker resource lifecycle changes.
+
+## Approach
+
+### 1. Prune-after-every-round (replaces the LRU)
+
+After each eval round completes — in `eval-runner.ts`'s existing post-eval `finally` — remove that round's entire Docker footprint:
+
+- the per-instance **container** (force-remove, even if exited),
+- the per-instance **image**,
+- **build cache and dangling layers** produced by the round.
+
+The `imageLru`, `imageCacheMax`, `resolveImageCacheMax`, and `JINN_EVAL_IMAGE_CACHE_MAX` mechanism is **removed entirely**. With nothing retained between rounds, peak disk is one instance's footprint (~3 GB) instead of 20×.
+
+Cleanup remains best-effort: a failed `docker rm`/`rmi`/prune is logged (`console.warn`) but never escapes `runEval` — same tolerance the current `defaultCleanupImage` has.
+
+### 2. Pre-eval disk-floor guard
+
+Before starting each eval round, probe the disk space available to Docker's storage. If it is below a **floor** (default **10 GB**, overridable via env):
+
+1. Run a broader reclaim (`docker system prune -f`) and re-probe.
+2. If still below the floor, **abort the run cleanly**: surface a typed `insufficient_disk` outcome. The caller stops gracefully — no instance is evaluated, no instance is marked, on-disk state is left consistent.
+
+The exact disk probe (host `df` on the Docker data dir vs. an in-container `df` vs. `docker system df`) is an implementation detail for the plan; the contract is "a number of bytes free, compared against the floor."
+
+### 3. Failure semantics
+
+- `ENOSPC` and `docker_storage_io_error` are classified as **retryable infra errors**, distinct from genuine gradeability failures. They **must not** write a `scorable: false` admission entry — the instance is left *unvalidated* so a later run retries it.
+- On an infra abort, `validate-pool` persists progress-so-far with an atomic write and exits cleanly with a clear message, rather than dying mid-rename.
+
+### 4. Scope
+
+All changes are in `eval-runner.ts` plus the small caller-side handling of the new `insufficient_disk` outcome in `validate-pool` (the CLI command) and the daemon's evaluator harness. Both consumers inherit robust cleanup; no SolverType or scoring logic changes.
+
+## Error handling
+
+| Condition | Behaviour |
+|---|---|
+| `docker rm/rmi/prune` fails (post-round) | Logged `console.warn`, swallowed — never escapes `runEval`. |
+| Free disk < floor before a round | Reclaim, re-probe; still low → `insufficient_disk`, clean abort. |
+| `ENOSPC` / `docker_storage_io_error` during a round | Retryable infra error; no `scorable:false` written; instance left unvalidated. |
+| Genuine ungradeable (pytest missing, gold-patch-not-resolved, …) | Unchanged — real `scorable:false` with reason. |
+
+## Testing
+
+- **Unit:** after a round, cleanup invokes container-remove + image-remove + cache-prune (inject the docker fns; assert all three called).
+- **Unit:** disk-floor guard — below floor → reclaim invoked; still below → `insufficient_disk` outcome, no eval run; above floor → proceeds normally. (Inject the disk probe.)
+- **Unit:** `ENOSPC` / `docker_storage_io_error` classify as retryable infra errors and produce **no** `scorable:false` admission entry.
+- **Regression:** existing `eval-runner` tests stay green; tests asserting the old LRU/`imageCacheMax` behaviour are removed or rewritten to the new model (justified by this design).
+
+## Rollout
+
+Pure operator-side robustness fix; no protocol or on-chain change. Ships as a normal `fix` PR to `next`.


### PR DESCRIPTION
## Summary

The SWE-rebench eval runner (`eval-runner.ts`, shared by `validate-pool` and the daemon evaluator) capped Docker eval images with a **count-based LRU** — `JINN_EVAL_IMAGE_CACHE_MAX`, default 20. At ~3 GB/image that cap *is* "fill a 60 GB Docker disk"; it ignored stopped containers and build cache, and had no pre-eval disk check. A live `validate-pool` run filled a 460 GB Mac, corrupted Docker's content store, false-marked instances, and died mid-write (#476).

This PR replaces that with:

- **Prune-after-every-round.** The LRU is gone. After each eval round, the runner removes that round's full Docker footprint — the per-instance image, stopped containers, and build cache. Peak disk ≈ one instance instead of 20×.
- **Pre-eval disk-floor guard.** Before each round the runner probes free disk; below the floor it runs a broad `docker system prune` and re-probes; still below → `InsufficientDiskError`, a clean abort (no instance graded, nothing marked) — distinct from `EvalCouldNotGradeError` so it never becomes a permanent `scorable:false`.
- Disk-floor default **20 GB** (`JINN_EVAL_DISK_FLOOR_GB` override) — sized to clear the worst single-instance footprint observed in verification (~12.6 GB).

Brainstormed → spec → plan → subagent-driven implementation, each task spec- and code-reviewed. Spec: `docs/superpowers/specs/2026-05-21-swe-rebench-eval-cleanup-robustness-design.md`.

## Test plan

- New unit tests in `eval-runner.test.ts` — prune-after-every-round (success / throw / throwing-pruneRound-swallowed) and the disk-floor guard (above-floor / low-then-recovered / clean-abort). 65/65 in the evaluator suite; typecheck + build clean.
- **Verified live** against real Docker + real SWE-rebench evals — `validate-pool --limit 6`:
  - Docker `Images` size **spiked per instance then dropped back** each round (e.g. 12.6 GB → 277 MB between rounds 1 and 2); no monotonic accumulation.
  - Run **completed cleanly (exit 0)**; ended at Docker 0 B / host disk 62 GB → 61 GB across 6 full evals. The old build burned 60 GB in ~18 instances and crashed.

## Notes

- Out of scope (noted in the plan): `validate-pool` treating `docker_storage_io_error` as a *permanent* `scorable:false` — a fast-follow; with the disk-floor guard in place that condition is now rare.

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)