### PR TITLE
fix(client): show task run claim start time

### DIFF
--- a/client/src/api/prediction-v1-build.ts
+++ b/client/src/api/prediction-v1-build.ts
@@ -42,6 +42,7 @@ export interface PredictionV1TaskRunSummary {
   implName: string | null;
   windowStartTs: number;
   windowEndTs: number;
+  runStartedAt: number | null;
   stateUpdatedAt: number;
   manifestCid: string | null;
   deliveryTxHash: string | null;
@@ -151,6 +152,7 @@ function toSummary(run: PersistedTaskRun): PredictionV1TaskRunSummary {
     implName: run.implName,
     windowStartTs: run.windowStartTs,
     windowEndTs: run.windowEndTs,
+    runStartedAt: run.runStartedAt,
     stateUpdatedAt: run.stateUpdatedAt,
     manifestCid: run.manifestCid,
     deliveryTxHash: run.deliveryTxHash,

--- a/client/src/api/task-runs-build.ts
+++ b/client/src/api/task-runs-build.ts
@@ -21,6 +21,7 @@ export interface TaskRunSummary {
   implName: string | null;
   windowStartTs: number;
   windowEndTs: number;
+  runStartedAt: number | null;
   stateUpdatedAt: number;
   manifestCid: string | null;
   deliveryTxHash: string | null;
@@ -109,6 +110,7 @@ function toSummary(run: PersistedTaskRun): TaskRunSummary {
     implName: run.implName,
     windowStartTs: run.windowStartTs,
     windowEndTs: run.windowEndTs,
+    runStartedAt: run.runStartedAt,
     stateUpdatedAt: run.stateUpdatedAt,
     manifestCid: run.manifestCid,
     deliveryTxHash: run.deliveryTxHash,

--- a/client/src/daemon/daemon.ts
+++ b/client/src/daemon/daemon.ts
@@ -502,9 +502,11 @@ export class Daemon {
       }
 
       let request;
+      let runStartedAt: number;
       try {
         request = await this.adapter.claimTask(taskAnnouncement.taskId);
         this.store.recordOwnActivity(request.requestId, 'claimed');
+        runStartedAt = Date.now();
       } catch (err) {
         console.error(
           `[daemon] claimTask failed for task ${taskAnnouncement.taskId}:`,
@@ -546,6 +548,7 @@ export class Daemon {
           taskRole: (request.task.role ?? 'restoration') as 'restoration' | 'evaluation',
           windowStartTs,
           windowEndTs,
+          runStartedAt,
           task: request.task,
         });
 

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -54,6 +54,7 @@ interface TaskRunRow {
   implName?: string | null;
   windowStartTs?: number;
   windowEndTs?: number;
+  runStartedAt?: number | null;
   stateUpdatedAt: number;
   manifestCid?: string | null;
   deliveryTxHash?: string | null;
@@ -403,6 +404,7 @@ export function OverviewPage(): JSX.Element {
           state: r.state,
           implName: r.implName ?? null,
           windowStartTs: r.windowStartTs ?? 0,
+          runStartedAt: r.runStartedAt ?? null,
           stateUpdatedAt: r.stateUpdatedAt,
           deliveryTxHash: r.deliveryTxHash ?? null,
         });

--- a/client/src/dashboard/spa/src/pages/overview/ActivityCard.test.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/ActivityCard.test.tsx
@@ -38,6 +38,7 @@ const baseTask: ActivityTask = {
   state: 'COMPLETE',
   implName: 'hermes-agent',
   windowStartTs: Date.now() - 120_000,
+  runStartedAt: Date.now() - 120_000,
   stateUpdatedAt: Date.now() - 60_000,
   deliveryTxHash: null,
 };
@@ -91,6 +92,32 @@ describe('ActivityCard', () => {
     expect(table.textContent).toMatch(/running/i);
     expect(table.textContent).toMatch(/solver/i);
     expect(table.textContent).toMatch(/evaluator/i);
+  });
+
+  it('shows STARTED from runStartedAt instead of an old task window start', () => {
+    const now = Date.now();
+    const sixDaysAgo = now - 6 * 86_400_000;
+    const twoMinutesAgo = now - 120_000;
+    const { ui } = wrap(
+      <ActivityCard
+        joined={joined}
+        tasks={[
+          {
+            ...baseTask,
+            requestId: 'fresh-claim',
+            windowStartTs: sixDaysAgo,
+            runStartedAt: twoMinutesAgo,
+            stateUpdatedAt: twoMinutesAgo,
+          },
+        ]}
+      />,
+    );
+
+    render(ui);
+
+    const row = screen.getByTestId('activity-task-row-fresh-claim');
+    expect(row.textContent).toMatch(/2m ago/);
+    expect(row.textContent).not.toMatch(/6d ago/);
   });
 
   it('renders the empty-tasks state when there are no task runs', () => {

--- a/client/src/dashboard/spa/src/pages/overview/ActivityCard.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/ActivityCard.tsx
@@ -51,8 +51,10 @@ export interface ActivityTask {
   state: string;
   /** Harness/impl name the task ran under. */
   implName: string | null;
-  /** Unix ms timestamp the run claimed (window-start). */
+  /** Unix ms timestamp for the task's execution window start. */
   windowStartTs: number;
+  /** Unix ms timestamp captured when this operator successfully claimed the run. */
+  runStartedAt: number | null;
   /** Unix ms timestamp of the last state update. */
   stateUpdatedAt: number;
   /** Optional on-chain delivery tx for explorer linking. */
@@ -332,9 +334,7 @@ export function ActivityCard({ joined, tasks }: ActivityCardProps): JSX.Element 
                                 </Badge>
                               </TableCell>
                               <TableCell className="text-muted-foreground">
-                                {formatRelative(
-                                  t.windowStartTs || t.stateUpdatedAt,
-                                )}
+                                {formatRelative(t.runStartedAt ?? t.stateUpdatedAt)}
                               </TableCell>
                             </TableRow>
                           );

--- a/client/src/harnesses/engine/persistence.ts
+++ b/client/src/harnesses/engine/persistence.ts
@@ -60,6 +60,7 @@ CREATE TABLE IF NOT EXISTS task_runs (
 
   window_start_ts         INTEGER NOT NULL,
   window_end_ts           INTEGER NOT NULL,
+  run_started_at          INTEGER,
 
   pre_snapshot_captured_at  INTEGER,
   pre_snapshot_payload      TEXT,
@@ -127,6 +128,8 @@ export interface PersistedTaskRunInput {
   taskRole?: 'restoration' | 'evaluation';
   windowStartTs: number;
   windowEndTs: number;
+  /** Unix ms timestamp captured when this operator successfully claimed the run. */
+  runStartedAt?: number;
   /**
    * Full Task payload, captured at observe() time.
    * Required: production callers always thread it (daemon.ts); making this
@@ -157,6 +160,8 @@ export interface PersistedTaskRun {
 
   windowStartTs: number;
   windowEndTs: number;
+  /** Unix ms timestamp captured when this operator successfully claimed the run. */
+  runStartedAt: number | null;
 
   preSnapshotCapturedAt: number | null;
   preSnapshotPayload: unknown | null;    // deserialized JSON
@@ -262,6 +267,7 @@ interface RawRow {
   impl_state_dir: string | null;
   window_start_ts: number;
   window_end_ts: number;
+  run_started_at: number | null;
   pre_snapshot_captured_at: number | null;
   pre_snapshot_payload: string | null;
   post_snapshot_captured_at: number | null;
@@ -304,6 +310,7 @@ function runAdditiveMigrations(db: Database.Database): void {
     { column: 'task_role',           ddl: 'ALTER TABLE task_runs ADD COLUMN task_role TEXT' },
     { column: 'task_id',             ddl: 'ALTER TABLE task_runs ADD COLUMN task_id TEXT' },
     { column: 'attempt_index',       ddl: 'ALTER TABLE task_runs ADD COLUMN attempt_index INTEGER' },
+    { column: 'run_started_at',      ddl: 'ALTER TABLE task_runs ADD COLUMN run_started_at INTEGER' },
     // ERC-8004 payload v2 (jinn-mono-9fe5): persists executor mode + codeDigest
     // from pack() so deliver() can emit a v2 setMetadata payload after the
     // transient maps are cleared.
@@ -353,6 +360,7 @@ function rowToTaskRun(row: RawRow): PersistedTaskRun {
     implStateDir: row.impl_state_dir,
     windowStartTs: row.window_start_ts,
     windowEndTs: row.window_end_ts,
+    runStartedAt: row.run_started_at,
     preSnapshotCapturedAt: row.pre_snapshot_captured_at,
     preSnapshotPayload: parseJson(row.pre_snapshot_payload),
     postSnapshotCapturedAt: row.post_snapshot_captured_at,
@@ -396,14 +404,15 @@ export class TaskRunPersistence {
    * `requestId` already exists, this is a no-op (INSERT OR IGNORE).
    */
   insertDiscovered(input: PersistedTaskRunInput): void {
+    const now = Date.now();
     this.db.prepare(`
       INSERT OR IGNORE INTO task_runs (
         request_id, task_id, attempt_index, task_cid, onchain_creation_tx, onchain_creation_block,
-        solver_type, task_role, state, state_updated_at, window_start_ts, window_end_ts,
+        solver_type, task_role, state, state_updated_at, window_start_ts, window_end_ts, run_started_at,
         task_payload
       ) VALUES (
         @requestId, @taskId, @attemptIndex, @taskCid, @onchainCreationTx, @onchainCreationBlock,
-        @solverType, @taskRole, 'DISCOVERED', @now, @windowStartTs, @windowEndTs,
+        @solverType, @taskRole, 'DISCOVERED', @now, @windowStartTs, @windowEndTs, @runStartedAt,
         @taskPayload
       )
     `).run({
@@ -415,9 +424,10 @@ export class TaskRunPersistence {
       onchainCreationBlock: input.onchainCreationBlock,
       solverType: input.solverType ?? null,
       taskRole: input.taskRole ?? null,
-      now: Date.now(),
+      now,
       windowStartTs: input.windowStartTs,
       windowEndTs: input.windowEndTs,
+      runStartedAt: input.runStartedAt ?? now,
       taskPayload: input.task ? JSON.stringify(input.task) : null,
     });
   }

--- a/client/test/api/prediction-v1-build.test.ts
+++ b/client/test/api/prediction-v1-build.test.ts
@@ -14,6 +14,7 @@ function seedPredictionRun(
     state?: 'DISCOVERED' | 'COMPLETE' | 'FAILED';
     stateUpdatedAt?: number;
     solverType?: string;
+    runStartedAt?: number;
   },
 ): void {
   persistence.insertDiscovered({
@@ -24,6 +25,7 @@ function seedPredictionRun(
     onchainCreationBlock: 1,
     solverType: input.solverType ?? 'prediction.v1',
     taskRole: input.taskRole ?? 'restoration',
+    runStartedAt: input.runStartedAt,
     windowStartTs: 1_000,
     windowEndTs: 2_000,
     task: {
@@ -247,6 +249,26 @@ describe('gatherPredictionV1Status', () => {
       expect(result.recentTasks.map((task) => task.requestId)).toEqual(
         expect.arrayContaining(['canonical-prediction', 'legacy-prediction']),
       );
+    });
+  });
+
+  it('includes runStartedAt in prediction task summaries', async () => {
+    await withTempStore(async (store) => {
+      const persistence = new TaskRunPersistence(store.db);
+      seedPredictionRun(store, persistence, {
+        requestId: 'recent-prediction-claim',
+        taskId: 'prediction-recent-task',
+        runStartedAt: 50_000,
+        stateUpdatedAt: 60_000,
+      });
+
+      const result = gatherPredictionV1Status(store);
+
+      expect(result.recentTasks[0]).toMatchObject({
+        requestId: 'recent-prediction-claim',
+        windowStartTs: 1_000,
+        runStartedAt: 50_000,
+      });
     });
   });
 });

--- a/client/test/api/task-runs-build.test.ts
+++ b/client/test/api/task-runs-build.test.ts
@@ -103,6 +103,26 @@ describe('gatherTaskRunsStatus', () => {
       expect(status.totals.localErrors).toBe(1);
     });
   });
+
+  it('includes runStartedAt in task run summaries distinct from windowStartTs', async () => {
+    await withTempStore(async (store) => {
+      const persistence = new TaskRunPersistence(store.db);
+      insertTask(persistence, {
+        requestId: 'fresh-claim',
+        taskId: 'task-fresh',
+        taskRole: 'restoration',
+        runStartedAt: 10_000,
+      });
+
+      const status = gatherTaskRunsStatus(store);
+
+      expect(status.inFlight[0]).toMatchObject({
+        requestId: 'fresh-claim',
+        windowStartTs: 1_000,
+        runStartedAt: 10_000,
+      });
+    });
+  });
 });
 
 function insertTask(
@@ -111,6 +131,7 @@ function insertTask(
     requestId: string;
     taskId: string;
     taskRole: 'restoration' | 'evaluation';
+    runStartedAt?: number;
   },
 ): void {
   persistence.insertDiscovered({
@@ -121,6 +142,7 @@ function insertTask(
     onchainCreationBlock: 1,
     solverType: 'swe-rebench-v2.v1',
     taskRole: input.taskRole,
+    runStartedAt: input.runStartedAt,
     windowStartTs: 1_000,
     windowEndTs: 2_000,
     task: {

--- a/client/test/daemon/daemon.test.ts
+++ b/client/test/daemon/daemon.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect } from 'vitest';
+import Database from 'better-sqlite3';
 import { Daemon, type DaemonConfig } from '../../src/daemon/daemon.js';
 import { LocalAdapter } from '../../src/adapters/local/adapter.js';
 import { SimpleRunner } from '../../src/runner/simple.js';
@@ -64,4 +65,78 @@ describe('Daemon', () => {
     await daemon.stop();
     expect(daemon.getShutdownState()).toBe('clean');
   });
+
+  it('persists a recent runStartedAt after claiming a task with an old window start', async () => {
+    const adapter = new LocalAdapter();
+    const dbPath = join(mkdtempSync(join(tmpdir(), 'jinn-daemon-started-test-')), 'jinn.db');
+    const daemon = new Daemon({
+      adapter,
+      runner: new SimpleRunner(async (desc) => `Done: ${desc}`),
+      taskSources: [],
+      dbPath,
+      restorationEngine: minimalEngineConfig(),
+    });
+    await daemon.start();
+
+    try {
+      const beforeClaim = Date.now();
+      const oldWindowStart = beforeClaim - 6 * 86_400_000;
+      await adapter.postTask({
+        id: 'old-window-fresh-claim',
+        description: 'old window, newly claimed',
+        window: { startTs: oldWindowStart, endTs: beforeClaim + 3_600_000 },
+      });
+
+      await waitForTaskRunRow(dbPath, '1');
+      const afterClaim = Date.now();
+      await daemon.stop();
+
+      const db = new Database(dbPath, { readonly: true });
+      try {
+        const row = db
+          .prepare(
+            `SELECT window_start_ts, run_started_at
+             FROM task_runs
+             WHERE task_id = ?`,
+          )
+          .get('1') as { window_start_ts: number; run_started_at: number };
+        expect(row.window_start_ts).toBe(oldWindowStart);
+        expect(row.run_started_at).toBeGreaterThanOrEqual(beforeClaim);
+        expect(row.run_started_at).toBeLessThanOrEqual(afterClaim);
+      } finally {
+        db.close();
+      }
+    } finally {
+      if (daemon.getShutdownState() !== 'clean') {
+        await daemon.stop();
+      }
+    }
+  });
 });
+
+async function waitForTaskRunRow(
+  dbPath: string,
+  taskId: string,
+): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (Date.now() < deadline) {
+    let db: Database.Database | undefined;
+    try {
+      db = new Database(dbPath, { readonly: true, fileMustExist: true });
+      const row = db
+        .prepare(
+          `SELECT 1
+           FROM task_runs
+           WHERE task_id = ?`,
+        )
+        .get(taskId) as { 1: number } | undefined;
+      if (row) return;
+    } catch {
+      // DB file may not exist during the first few milliseconds of daemon startup.
+    } finally {
+      db?.close();
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for task run row for taskId ${taskId}`);
+}

--- a/client/test/harnesses/engine/persistence.test.ts
+++ b/client/test/harnesses/engine/persistence.test.ts
@@ -67,6 +67,7 @@ describe('runAdditiveMigrations', () => {
     expect(columns).toContain('manifest_generated_at');
     expect(columns).toContain('evidence_hash');
     expect(columns).toContain('task_payload');
+    expect(columns).toContain('run_started_at');
 
     db.close();
   });
@@ -116,6 +117,25 @@ describe('TaskRunPersistence', () => {
       p.insertDiscovered(makeInput({ solverType: undefined }));
       const intent = p.getByRequestId('req-001');
       expect(intent!.solverType).toBeNull();
+    });
+
+    it('persists an explicit runStartedAt distinct from the task window start', () => {
+      p.insertDiscovered(makeInput({
+        runStartedAt: 1_700_000,
+        windowStartTs: 2_000_000,
+      }));
+      const intent = p.getByRequestId('req-001');
+      expect(intent!.runStartedAt).toBe(1_700_000);
+      expect(intent!.windowStartTs).toBe(2_000_000);
+    });
+
+    it('defaults runStartedAt to observe time when omitted', () => {
+      const before = Date.now();
+      p.insertDiscovered(makeInput({ runStartedAt: undefined }));
+      const after = Date.now();
+      const intent = p.getByRequestId('req-001');
+      expect(intent!.runStartedAt).toBeGreaterThanOrEqual(before);
+      expect(intent!.runStartedAt).toBeLessThanOrEqual(after);
     });
   });
 


### PR DESCRIPTION
## Summary

- Add nullable `run_started_at` persistence for task runs and default new observations to the observe/claim time.
- Thread daemon claim time through task-run summaries, prediction.v1 summaries, and Overview activity rows.
- Render the Activity STARTED column from `runStartedAt ?? stateUpdatedAt` so old task windows do not make fresh claims look stale.

Closes #470

## Test Plan

- `cd client && yarn build:sdk && yarn vitest run test/daemon/daemon.test.ts test/harnesses/engine/persistence.test.ts test/api/task-runs-build.test.ts test/api/prediction-v1-build.test.ts src/dashboard/spa/src/pages/overview/ActivityCard.test.tsx`
- `cd client && yarn typecheck && yarn build`
- `cd client && yarn test`

## Notes

This is stacked on `feat/471-generator-health` and targets that branch.
