### PR TITLE
fix(client): recover underpriced tx replacements

### DIFF
--- a/client/src/adapters/mech/safe.ts
+++ b/client/src/adapters/mech/safe.ts
@@ -12,10 +12,9 @@ import { privateKeyToAccount } from 'viem/accounts';
 import { base } from 'viem/chains';
 import { SAFE_ABI } from './types.js';
 import {
-  getDefaultTxSubmissionLedger,
-  recoverStuckNonceIfNeeded,
+  type TxSubmissionLedger,
+  withNonceLedger,
   withRecoverableRetry,
-  viemFeeOverridesForAttempt,
 } from '../../tx-retry.js';
 import {
   SafeInnerRevertError,
@@ -37,6 +36,10 @@ export interface SafeTransactionParams {
   data: Hex;
 }
 
+export interface SafeExecutionOptions {
+  ledger?: TxSubmissionLedger;
+}
+
 // Per-Safe transaction lock to prevent nonce races when concurrent
 // loops (creator + harness) share the same Safe
 const safeLocks = new Map<string, Promise<void>>();
@@ -45,6 +48,7 @@ export async function executeSafeTransaction(
   publicClient: PublicClient,
   walletClient: WalletClient,
   params: SafeTransactionParams,
+  options: SafeExecutionOptions = {},
 ): Promise<Hex> {
   const lockKey = params.safeAddress.toLowerCase();
 
@@ -58,7 +62,7 @@ export async function executeSafeTransaction(
   await pending;
 
   try {
-    const hash = await executeSafeTransactionInner(publicClient, walletClient, params);
+    const hash = await executeSafeTransactionInner(publicClient, walletClient, params, options);
     return hash;
   } finally {
     releaseLock();
@@ -69,25 +73,20 @@ async function executeSafeTransactionInner(
   publicClient: PublicClient,
   walletClient: WalletClient,
   params: SafeTransactionParams,
+  options: SafeExecutionOptions,
 ): Promise<Hex> {
   const { safeAddress, to, value, data } = params;
   const account = walletClient.account;
   if (!account) throw new Error('Wallet client has no account');
-  const chainId = Number(await publicClient.getChainId());
   const from = account.address;
-  const ledger = getDefaultTxSubmissionLedger();
-  await recoverStuckNonceIfNeeded({
-    publicClient,
-    walletClient: walletClient as unknown as { account?: unknown; sendTransaction: (tx: any) => Promise<Hex> },
-    ledger,
-    from,
-  });
-  const eoaNonce = Number(await publicClient.getTransactionCount({
-    address: from,
-    blockTag: 'pending',
-  }));
 
-  return withRecoverableRetry(
+  return withNonceLedger({
+    publicClient,
+    walletClient,
+    ledger: options.ledger,
+    from,
+    recoverStuckNonce: true,
+  }, async (nonceLedger) => withRecoverableRetry(
     async (attemptIndex) => {
       const nonce = await publicClient.readContract({
         address: safeAddress,
@@ -122,9 +121,7 @@ async function executeSafeTransactionInner(
       sigBytes[64] = sigBytes[64] + 4;
       const safeSignature = `0x${sigBytes.toString('hex')}` as Hex;
 
-      const previous = await ledger.getTxSubmission({ chainId, from, nonce: eoaNonce });
-      const feeOverrides = await viemFeeOverridesForAttempt(publicClient, attemptIndex, {
-        previousFees: previous?.resolvedAtMs == null ? previous?.fees : undefined,
+      const feeResult = await nonceLedger.feeResultForAttempt(attemptIndex, {
         forceEstimate: true,
       });
 
@@ -149,8 +146,8 @@ async function executeSafeTransactionInner(
           account,
           chain: walletClient.chain,
           value: params.value,
-          nonce: eoaNonce,
-          ...feeOverrides,
+          nonce: nonceLedger.nonce,
+          ...feeResult.overrides,
         });
       } catch (writeErr) {
         // viem pre-flight gas estimation may revert with GS013 when the inner
@@ -173,14 +170,10 @@ async function executeSafeTransactionInner(
         }
         throw writeErr;
       }
-      await ledger.recordTxSubmission({
-        chainId,
-        from,
-        nonce: eoaNonce,
+      await nonceLedger.recordSubmitted({
         hash,
         logicalTx: 'safe.execTransaction',
-        submittedAtMs: Date.now(),
-        fees: feeOverrides,
+        fees: feeResult.snapshot,
         to: safeAddress,
         value: params.value,
         data,
@@ -206,12 +199,7 @@ async function executeSafeTransactionInner(
         }
         throw new Error(`Safe execTransaction reverted (GS026/GS013 possible stale nonce, txHash=${hash})`);
       }
-      await ledger.markTxSubmissionResolved({
-        chainId,
-        from,
-        nonce: eoaNonce,
-        resolvedAtMs: Date.now(),
-      });
+      await nonceLedger.markResolved();
       return hash;
     },
     {
@@ -219,7 +207,7 @@ async function executeSafeTransactionInner(
         console.error(`[safe/viem] execTransaction retry ${attempt}: ${message}`);
       },
     },
-  );
+  ));
 }
 
 export function createClients(rpcUrl: string, privateKey: Hex, chain?: Chain): { publicClient: PublicClient; walletClient: WalletClient; account: ReturnType<typeof privateKeyToAccount> } {

--- a/client/src/adapters/mech/safe.ts
+++ b/client/src/adapters/mech/safe.ts
@@ -12,6 +12,8 @@ import { privateKeyToAccount } from 'viem/accounts';
 import { base } from 'viem/chains';
 import { SAFE_ABI } from './types.js';
 import {
+  getDefaultTxSubmissionLedger,
+  recoverStuckNonceIfNeeded,
   withRecoverableRetry,
   viemFeeOverridesForAttempt,
 } from '../../tx-retry.js';
@@ -71,6 +73,19 @@ async function executeSafeTransactionInner(
   const { safeAddress, to, value, data } = params;
   const account = walletClient.account;
   if (!account) throw new Error('Wallet client has no account');
+  const chainId = Number(await publicClient.getChainId());
+  const from = account.address;
+  const ledger = getDefaultTxSubmissionLedger();
+  await recoverStuckNonceIfNeeded({
+    publicClient,
+    walletClient: walletClient as unknown as { account?: unknown; sendTransaction: (tx: any) => Promise<Hex> },
+    ledger,
+    from,
+  });
+  const eoaNonce = Number(await publicClient.getTransactionCount({
+    address: from,
+    blockTag: 'pending',
+  }));
 
   return withRecoverableRetry(
     async (attemptIndex) => {
@@ -107,7 +122,11 @@ async function executeSafeTransactionInner(
       sigBytes[64] = sigBytes[64] + 4;
       const safeSignature = `0x${sigBytes.toString('hex')}` as Hex;
 
-      const feeOverrides = await viemFeeOverridesForAttempt(publicClient, attemptIndex);
+      const previous = await ledger.getTxSubmission({ chainId, from, nonce: eoaNonce });
+      const feeOverrides = await viemFeeOverridesForAttempt(publicClient, attemptIndex, {
+        previousFees: previous?.resolvedAtMs == null ? previous?.fees : undefined,
+        forceEstimate: true,
+      });
 
       let hash: Hex;
       try {
@@ -130,6 +149,7 @@ async function executeSafeTransactionInner(
           account,
           chain: walletClient.chain,
           value: params.value,
+          nonce: eoaNonce,
           ...feeOverrides,
         });
       } catch (writeErr) {
@@ -153,6 +173,18 @@ async function executeSafeTransactionInner(
         }
         throw writeErr;
       }
+      await ledger.recordTxSubmission({
+        chainId,
+        from,
+        nonce: eoaNonce,
+        hash,
+        logicalTx: 'safe.execTransaction',
+        submittedAtMs: Date.now(),
+        fees: feeOverrides,
+        to: safeAddress,
+        value: params.value,
+        data,
+      });
       // Wait inside the retry attempt so reverted Safe executions caused by
       // stale nonce signatures (GS026/GS013) re-read nonce and re-sign.
       const receipt = await publicClient.waitForTransactionReceipt({ hash });
@@ -174,6 +206,12 @@ async function executeSafeTransactionInner(
         }
         throw new Error(`Safe execTransaction reverted (GS026/GS013 possible stale nonce, txHash=${hash})`);
       }
+      await ledger.markTxSubmissionResolved({
+        chainId,
+        from,
+        nonce: eoaNonce,
+        resolvedAtMs: Date.now(),
+      });
       return hash;
     },
     {

--- a/client/src/api/prediction-v1-build.ts
+++ b/client/src/api/prediction-v1-build.ts
@@ -42,6 +42,7 @@ export interface PredictionV1TaskRunSummary {
   implName: string | null;
   windowStartTs: number;
   windowEndTs: number;
+  runStartedAt: number | null;
   stateUpdatedAt: number;
   manifestCid: string | null;
   deliveryTxHash: string | null;
@@ -151,6 +152,7 @@ function toSummary(run: PersistedTaskRun): PredictionV1TaskRunSummary {
     implName: run.implName,
     windowStartTs: run.windowStartTs,
     windowEndTs: run.windowEndTs,
+    runStartedAt: run.runStartedAt,
     stateUpdatedAt: run.stateUpdatedAt,
     manifestCid: run.manifestCid,
     deliveryTxHash: run.deliveryTxHash,

--- a/client/src/api/task-runs-build.ts
+++ b/client/src/api/task-runs-build.ts
@@ -21,6 +21,7 @@ export interface TaskRunSummary {
   implName: string | null;
   windowStartTs: number;
   windowEndTs: number;
+  runStartedAt: number | null;
   stateUpdatedAt: number;
   manifestCid: string | null;
   deliveryTxHash: string | null;
@@ -109,6 +110,7 @@ function toSummary(run: PersistedTaskRun): TaskRunSummary {
     implName: run.implName,
     windowStartTs: run.windowStartTs,
     windowEndTs: run.windowEndTs,
+    runStartedAt: run.runStartedAt,
     stateUpdatedAt: run.stateUpdatedAt,
     manifestCid: run.manifestCid,
     deliveryTxHash: run.deliveryTxHash,

--- a/client/src/daemon/daemon.ts
+++ b/client/src/daemon/daemon.ts
@@ -502,9 +502,11 @@ export class Daemon {
       }
 
       let request;
+      let runStartedAt: number;
       try {
         request = await this.adapter.claimTask(taskAnnouncement.taskId);
         this.store.recordOwnActivity(request.requestId, 'claimed');
+        runStartedAt = Date.now();
       } catch (err) {
         console.error(
           `[daemon] claimTask failed for task ${taskAnnouncement.taskId}:`,
@@ -546,6 +548,7 @@ export class Daemon {
           taskRole: (request.task.role ?? 'restoration') as 'restoration' | 'evaluation',
           windowStartTs,
           windowEndTs,
+          runStartedAt,
           task: request.task,
         });
 

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -54,6 +54,7 @@ interface TaskRunRow {
   implName?: string | null;
   windowStartTs?: number;
   windowEndTs?: number;
+  runStartedAt?: number | null;
   stateUpdatedAt: number;
   manifestCid?: string | null;
   deliveryTxHash?: string | null;
@@ -403,6 +404,7 @@ export function OverviewPage(): JSX.Element {
           state: r.state,
           implName: r.implName ?? null,
           windowStartTs: r.windowStartTs ?? 0,
+          runStartedAt: r.runStartedAt ?? null,
           stateUpdatedAt: r.stateUpdatedAt,
           deliveryTxHash: r.deliveryTxHash ?? null,
         });

--- a/client/src/dashboard/spa/src/pages/overview/ActivityCard.test.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/ActivityCard.test.tsx
@@ -38,6 +38,7 @@ const baseTask: ActivityTask = {
   state: 'COMPLETE',
   implName: 'hermes-agent',
   windowStartTs: Date.now() - 120_000,
+  runStartedAt: Date.now() - 120_000,
   stateUpdatedAt: Date.now() - 60_000,
   deliveryTxHash: null,
 };
@@ -91,6 +92,32 @@ describe('ActivityCard', () => {
     expect(table.textContent).toMatch(/running/i);
     expect(table.textContent).toMatch(/solver/i);
     expect(table.textContent).toMatch(/evaluator/i);
+  });
+
+  it('shows STARTED from runStartedAt instead of an old task window start', () => {
+    const now = Date.now();
+    const sixDaysAgo = now - 6 * 86_400_000;
+    const twoMinutesAgo = now - 120_000;
+    const { ui } = wrap(
+      <ActivityCard
+        joined={joined}
+        tasks={[
+          {
+            ...baseTask,
+            requestId: 'fresh-claim',
+            windowStartTs: sixDaysAgo,
+            runStartedAt: twoMinutesAgo,
+            stateUpdatedAt: twoMinutesAgo,
+          },
+        ]}
+      />,
+    );
+
+    render(ui);
+
+    const row = screen.getByTestId('activity-task-row-fresh-claim');
+    expect(row.textContent).toMatch(/2m ago/);
+    expect(row.textContent).not.toMatch(/6d ago/);
   });
 
   it('renders the empty-tasks state when there are no task runs', () => {

--- a/client/src/dashboard/spa/src/pages/overview/ActivityCard.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/ActivityCard.tsx
@@ -51,8 +51,10 @@ export interface ActivityTask {
   state: string;
   /** Harness/impl name the task ran under. */
   implName: string | null;
-  /** Unix ms timestamp the run claimed (window-start). */
+  /** Unix ms timestamp for the task's execution window start. */
   windowStartTs: number;
+  /** Unix ms timestamp captured when this operator successfully claimed the run. */
+  runStartedAt: number | null;
   /** Unix ms timestamp of the last state update. */
   stateUpdatedAt: number;
   /** Optional on-chain delivery tx for explorer linking. */
@@ -332,9 +334,7 @@ export function ActivityCard({ joined, tasks }: ActivityCardProps): JSX.Element 
                                 </Badge>
                               </TableCell>
                               <TableCell className="text-muted-foreground">
-                                {formatRelative(
-                                  t.windowStartTs || t.stateUpdatedAt,
-                                )}
+                                {formatRelative(t.runStartedAt ?? t.stateUpdatedAt)}
                               </TableCell>
                             </TableRow>
                           );

--- a/client/src/earning/safe-adapter.ts
+++ b/client/src/earning/safe-adapter.ts
@@ -21,10 +21,16 @@ import {
   type Address,
   type Chain,
   type Hex,
+  type PublicClient,
 } from 'viem';
 import { base, baseSepolia } from 'viem/chains';
 import { privateKeyToAccount } from 'viem/accounts';
-import { viemFeeOverridesForAttempt, withRecoverableRetry } from '../tx-retry.js';
+import {
+  getDefaultTxSubmissionLedger,
+  recoverStuckNonceIfNeeded,
+  viemFeeOverridesForAttempt,
+  withRecoverableRetry,
+} from '../tx-retry.js';
 
 export type { MetaTransactionData, TransactionResult };
 
@@ -272,6 +278,17 @@ export async function executeSafeTxDirect(opts: {
   const to = opts.to as Address;
   const value = opts.value ?? 0n;
   const explicitGasLimit = opts.gasLimit;
+  const ledger = getDefaultTxSubmissionLedger();
+  await recoverStuckNonceIfNeeded({
+    publicClient: publicClient as PublicClient,
+    walletClient,
+    ledger,
+    from: account.address,
+  });
+  const eoaNonce = Number(await publicClient.getTransactionCount({
+    address: account.address,
+    blockTag: 'pending',
+  }));
 
   const hash = await withRecoverableRetry(
     async (attemptIndex) => {
@@ -333,12 +350,21 @@ export async function executeSafeTxDirect(opts: {
         }
       }
 
-      const feeOverrides = await viemFeeOverridesForAttempt(publicClient, attemptIndex);
+      const previous = await ledger.getTxSubmission({
+        chainId,
+        from: account.address,
+        nonce: eoaNonce,
+      });
+      const feeOverrides = await viemFeeOverridesForAttempt(publicClient, attemptIndex, {
+        previousFees: previous?.resolvedAtMs == null ? previous?.fees : undefined,
+        forceEstimate: true,
+      });
       const txParams: Parameters<typeof walletClient.sendTransaction>[0] = {
         account,
         to: safeAddress,
         data,
         gas: resolvedGas + BigInt(attemptIndex) * 50_000n,
+        nonce: eoaNonce,
         ...feeOverrides,
       };
       if (
@@ -349,7 +375,20 @@ export async function executeSafeTxDirect(opts: {
       ) {
         delete (txParams as { gasPrice?: bigint }).gasPrice;
       }
-      return walletClient.sendTransaction(txParams);
+      const hash = await walletClient.sendTransaction(txParams);
+      await ledger.recordTxSubmission({
+        chainId,
+        from: account.address,
+        nonce: eoaNonce,
+        hash,
+        logicalTx: 'safe.execTransaction.direct',
+        submittedAtMs: Date.now(),
+        fees: feeOverrides,
+        to: safeAddress,
+        data,
+        value: 0n,
+      });
+      return hash;
     },
     {
       onRetry: ({ attempt, message }) => {

--- a/client/src/earning/safe-adapter.ts
+++ b/client/src/earning/safe-adapter.ts
@@ -21,14 +21,13 @@ import {
   type Address,
   type Chain,
   type Hex,
-  type PublicClient,
 } from 'viem';
 import { base, baseSepolia } from 'viem/chains';
 import { privateKeyToAccount } from 'viem/accounts';
 import {
-  getDefaultTxSubmissionLedger,
-  recoverStuckNonceIfNeeded,
-  viemFeeOverridesForAttempt,
+  removeConflictingLegacyGasPrice,
+  type TxSubmissionLedger,
+  withNonceLedger,
   withRecoverableRetry,
 } from '../tx-retry.js';
 
@@ -259,6 +258,7 @@ export async function executeSafeTxDirect(opts: {
   value?: bigint;
   data: Hex;
   gasLimit?: bigint;
+  ledger?: TxSubmissionLedger;
 }): Promise<{ hash: string }> {
   const executionRpcUrl = await resolveExecutionRpcUrl(opts.rpcUrl);
   const chainId = await createPublicClient({ transport: http(executionRpcUrl) }).getChainId();
@@ -278,19 +278,15 @@ export async function executeSafeTxDirect(opts: {
   const to = opts.to as Address;
   const value = opts.value ?? 0n;
   const explicitGasLimit = opts.gasLimit;
-  const ledger = getDefaultTxSubmissionLedger();
-  await recoverStuckNonceIfNeeded({
-    publicClient: publicClient as PublicClient,
-    walletClient,
-    ledger,
-    from: account.address,
-  });
-  const eoaNonce = Number(await publicClient.getTransactionCount({
-    address: account.address,
-    blockTag: 'pending',
-  }));
 
-  const hash = await withRecoverableRetry(
+  const hash = await withNonceLedger({
+    publicClient,
+    walletClient,
+    ledger: opts.ledger,
+    from: account.address,
+    chainId,
+    recoverStuckNonce: true,
+  }, async (nonceLedger) => withRecoverableRetry(
     async (attemptIndex) => {
       const nonce = await publicClient.readContract({
         address: safeAddress,
@@ -350,13 +346,7 @@ export async function executeSafeTxDirect(opts: {
         }
       }
 
-      const previous = await ledger.getTxSubmission({
-        chainId,
-        from: account.address,
-        nonce: eoaNonce,
-      });
-      const feeOverrides = await viemFeeOverridesForAttempt(publicClient, attemptIndex, {
-        previousFees: previous?.resolvedAtMs == null ? previous?.fees : undefined,
+      const feeResult = await nonceLedger.feeResultForAttempt(attemptIndex, {
         forceEstimate: true,
       });
       const txParams: Parameters<typeof walletClient.sendTransaction>[0] = {
@@ -364,26 +354,15 @@ export async function executeSafeTxDirect(opts: {
         to: safeAddress,
         data,
         gas: resolvedGas + BigInt(attemptIndex) * 50_000n,
-        nonce: eoaNonce,
-        ...feeOverrides,
+        nonce: nonceLedger.nonce,
+        ...feeResult.overrides,
       };
-      if (
-        'maxFeePerGas' in txParams &&
-        txParams.maxFeePerGas !== undefined &&
-        'maxPriorityFeePerGas' in txParams &&
-        txParams.maxPriorityFeePerGas !== undefined
-      ) {
-        delete (txParams as { gasPrice?: bigint }).gasPrice;
-      }
+      removeConflictingLegacyGasPrice(txParams);
       const hash = await walletClient.sendTransaction(txParams);
-      await ledger.recordTxSubmission({
-        chainId,
-        from: account.address,
-        nonce: eoaNonce,
+      await nonceLedger.recordSubmitted({
         hash,
         logicalTx: 'safe.execTransaction.direct',
-        submittedAtMs: Date.now(),
-        fees: feeOverrides,
+        fees: feeResult.snapshot,
         to: safeAddress,
         data,
         value: 0n,
@@ -395,7 +374,7 @@ export async function executeSafeTxDirect(opts: {
         console.error(`[safe-adapter] executeSafeTxDirect retry ${attempt}: ${message}`);
       },
     },
-  );
+  ));
 
   return { hash };
 }

--- a/client/src/harnesses/engine/persistence.ts
+++ b/client/src/harnesses/engine/persistence.ts
@@ -60,6 +60,7 @@ CREATE TABLE IF NOT EXISTS task_runs (
 
   window_start_ts         INTEGER NOT NULL,
   window_end_ts           INTEGER NOT NULL,
+  run_started_at          INTEGER,
 
   pre_snapshot_captured_at  INTEGER,
   pre_snapshot_payload      TEXT,
@@ -127,6 +128,8 @@ export interface PersistedTaskRunInput {
   taskRole?: 'restoration' | 'evaluation';
   windowStartTs: number;
   windowEndTs: number;
+  /** Unix ms timestamp captured when this operator successfully claimed the run. */
+  runStartedAt?: number;
   /**
    * Full Task payload, captured at observe() time.
    * Required: production callers always thread it (daemon.ts); making this
@@ -157,6 +160,8 @@ export interface PersistedTaskRun {
 
   windowStartTs: number;
   windowEndTs: number;
+  /** Unix ms timestamp captured when this operator successfully claimed the run. */
+  runStartedAt: number | null;
 
   preSnapshotCapturedAt: number | null;
   preSnapshotPayload: unknown | null;    // deserialized JSON
@@ -262,6 +267,7 @@ interface RawRow {
   impl_state_dir: string | null;
   window_start_ts: number;
   window_end_ts: number;
+  run_started_at: number | null;
   pre_snapshot_captured_at: number | null;
   pre_snapshot_payload: string | null;
   post_snapshot_captured_at: number | null;
@@ -304,6 +310,7 @@ function runAdditiveMigrations(db: Database.Database): void {
     { column: 'task_role',           ddl: 'ALTER TABLE task_runs ADD COLUMN task_role TEXT' },
     { column: 'task_id',             ddl: 'ALTER TABLE task_runs ADD COLUMN task_id TEXT' },
     { column: 'attempt_index',       ddl: 'ALTER TABLE task_runs ADD COLUMN attempt_index INTEGER' },
+    { column: 'run_started_at',      ddl: 'ALTER TABLE task_runs ADD COLUMN run_started_at INTEGER' },
     // ERC-8004 payload v2 (jinn-mono-9fe5): persists executor mode + codeDigest
     // from pack() so deliver() can emit a v2 setMetadata payload after the
     // transient maps are cleared.
@@ -353,6 +360,7 @@ function rowToTaskRun(row: RawRow): PersistedTaskRun {
     implStateDir: row.impl_state_dir,
     windowStartTs: row.window_start_ts,
     windowEndTs: row.window_end_ts,
+    runStartedAt: row.run_started_at,
     preSnapshotCapturedAt: row.pre_snapshot_captured_at,
     preSnapshotPayload: parseJson(row.pre_snapshot_payload),
     postSnapshotCapturedAt: row.post_snapshot_captured_at,
@@ -396,14 +404,15 @@ export class TaskRunPersistence {
    * `requestId` already exists, this is a no-op (INSERT OR IGNORE).
    */
   insertDiscovered(input: PersistedTaskRunInput): void {
+    const now = Date.now();
     this.db.prepare(`
       INSERT OR IGNORE INTO task_runs (
         request_id, task_id, attempt_index, task_cid, onchain_creation_tx, onchain_creation_block,
-        solver_type, task_role, state, state_updated_at, window_start_ts, window_end_ts,
+        solver_type, task_role, state, state_updated_at, window_start_ts, window_end_ts, run_started_at,
         task_payload
       ) VALUES (
         @requestId, @taskId, @attemptIndex, @taskCid, @onchainCreationTx, @onchainCreationBlock,
-        @solverType, @taskRole, 'DISCOVERED', @now, @windowStartTs, @windowEndTs,
+        @solverType, @taskRole, 'DISCOVERED', @now, @windowStartTs, @windowEndTs, @runStartedAt,
         @taskPayload
       )
     `).run({
@@ -415,9 +424,10 @@ export class TaskRunPersistence {
       onchainCreationBlock: input.onchainCreationBlock,
       solverType: input.solverType ?? null,
       taskRole: input.taskRole ?? null,
-      now: Date.now(),
+      now,
       windowStartTs: input.windowStartTs,
       windowEndTs: input.windowEndTs,
+      runStartedAt: input.runStartedAt ?? now,
       taskPayload: input.task ? JSON.stringify(input.task) : null,
     });
   }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -28,6 +28,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { loadConfig, getConfigPathFromArgs, DEFAULT_CONFIG_PATH } from './config.js';
 import { Store } from './store/store.js';
 import { startApiServer, isEmbeddedAgentEnabled, type ApiServer } from './api/server.js';
+import { setDefaultTxSubmissionLedger } from './tx-retry.js';
 // addHarnessReadinessRoutes is wired through startApiServer's holder ref now
 // (jinn-mono-u34i). No direct import needed.
 import { CapturePublishUnavailableError } from './api/captures.js';
@@ -861,6 +862,7 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
   // /v1/bootstrap + /v1/events + /v1/status here. The same Store instance is
   // later passed into Daemon so we don't double-open the SQLite file.
   const sharedStore = new Store(config.dbPath);
+  setDefaultTxSubmissionLedger(sharedStore);
   const capturesStore = new CapturesStore(sharedStore);
   let captureReceiver: Receiver | undefined;
   try {

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -7,6 +7,7 @@ import type {
   EnvelopeProjectionQuery,
 } from '../corpus/types.js';
 import { TASK_RUNS_SCHEMA } from '../harnesses/engine/persistence.js';
+import type { TxSubmissionKey, TxSubmissionLedgerEntry } from '../tx-retry.js';
 import { normalizeEnvelopeRole, type Role } from '../types/envelope.js';
 
 export interface ActivityEventInput {
@@ -277,6 +278,26 @@ CREATE TABLE IF NOT EXISTS activity_events (
 CREATE INDEX IF NOT EXISTS idx_activity_events_ts ON activity_events (ts DESC);
 CREATE INDEX IF NOT EXISTS idx_activity_events_req ON activity_events (request_id);
 CREATE INDEX IF NOT EXISTS idx_activity_events_service_idx ON activity_events (service_index);
+
+CREATE TABLE IF NOT EXISTS tx_submissions (
+  chain_id INTEGER NOT NULL,
+  from_address TEXT NOT NULL,
+  nonce INTEGER NOT NULL,
+  hash TEXT,
+  logical_tx TEXT,
+  submitted_at_ms INTEGER NOT NULL,
+  max_fee_per_gas TEXT,
+  max_priority_fee_per_gas TEXT,
+  gas_price TEXT,
+  to_address TEXT,
+  value_wei TEXT,
+  data TEXT,
+  resolved_at_ms INTEGER,
+  PRIMARY KEY (chain_id, from_address, nonce)
+);
+CREATE INDEX IF NOT EXISTS idx_tx_submissions_unresolved
+  ON tx_submissions (chain_id, from_address, nonce)
+  WHERE resolved_at_ms IS NULL;
 
 CREATE TABLE IF NOT EXISTS reward_claims (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -645,6 +666,107 @@ export class Store {
   getDaemonStartedAt(): string | null {
     const row = this.db.prepare('SELECT value FROM config WHERE key = ?').get('daemon_started_at') as { value: string } | undefined;
     return row?.value ?? null;
+  }
+
+  recordTxSubmission(entry: TxSubmissionLedgerEntry): void {
+    this.db.prepare(
+      `INSERT INTO tx_submissions
+         (chain_id, from_address, nonce, hash, logical_tx, submitted_at_ms,
+          max_fee_per_gas, max_priority_fee_per_gas, gas_price, to_address, value_wei, data, resolved_at_ms)
+       VALUES
+         (@chainId, @fromAddress, @nonce, @hash, @logicalTx, @submittedAtMs,
+          @maxFeePerGas, @maxPriorityFeePerGas, @gasPrice, @toAddress, @valueWei, @data, @resolvedAtMs)
+       ON CONFLICT(chain_id, from_address, nonce) DO UPDATE SET
+         hash = excluded.hash,
+         logical_tx = excluded.logical_tx,
+         submitted_at_ms = excluded.submitted_at_ms,
+         max_fee_per_gas = excluded.max_fee_per_gas,
+         max_priority_fee_per_gas = excluded.max_priority_fee_per_gas,
+         gas_price = excluded.gas_price,
+         to_address = excluded.to_address,
+         value_wei = excluded.value_wei,
+         data = excluded.data,
+         resolved_at_ms = excluded.resolved_at_ms`,
+    ).run({
+      chainId: entry.chainId,
+      fromAddress: entry.from.toLowerCase(),
+      nonce: entry.nonce,
+      hash: entry.hash ?? null,
+      logicalTx: entry.logicalTx ?? null,
+      submittedAtMs: entry.submittedAtMs,
+      maxFeePerGas: entry.fees.maxFeePerGas?.toString() ?? null,
+      maxPriorityFeePerGas: entry.fees.maxPriorityFeePerGas?.toString() ?? null,
+      gasPrice: entry.fees.gasPrice?.toString() ?? null,
+      toAddress: entry.to?.toLowerCase() ?? null,
+      valueWei: entry.value?.toString() ?? null,
+      data: entry.data ?? null,
+      resolvedAtMs: entry.resolvedAtMs ?? null,
+    });
+  }
+
+  getTxSubmission(key: TxSubmissionKey): TxSubmissionLedgerEntry | null {
+    const row = this.db.prepare(
+      `SELECT chain_id, from_address, nonce, hash, logical_tx, submitted_at_ms,
+              max_fee_per_gas, max_priority_fee_per_gas, gas_price,
+              to_address, value_wei, data, resolved_at_ms
+       FROM tx_submissions
+       WHERE chain_id = @chainId
+         AND from_address = @fromAddress
+         AND nonce = @nonce`,
+    ).get({
+      chainId: key.chainId,
+      fromAddress: key.from.toLowerCase(),
+      nonce: key.nonce,
+    }) as {
+      chain_id: number;
+      from_address: string;
+      nonce: number;
+      hash: string | null;
+      logical_tx: string | null;
+      submitted_at_ms: number;
+      max_fee_per_gas: string | null;
+      max_priority_fee_per_gas: string | null;
+      gas_price: string | null;
+      to_address: string | null;
+      value_wei: string | null;
+      data: string | null;
+      resolved_at_ms: number | null;
+    } | undefined;
+    if (!row) return null;
+    return {
+      chainId: row.chain_id,
+      from: row.from_address as TxSubmissionLedgerEntry['from'],
+      nonce: row.nonce,
+      hash: row.hash as TxSubmissionLedgerEntry['hash'],
+      logicalTx: row.logical_tx ?? undefined,
+      submittedAtMs: row.submitted_at_ms,
+      fees: {
+        ...(row.max_fee_per_gas !== null ? { maxFeePerGas: BigInt(row.max_fee_per_gas) } : {}),
+        ...(row.max_priority_fee_per_gas !== null
+          ? { maxPriorityFeePerGas: BigInt(row.max_priority_fee_per_gas) }
+          : {}),
+        ...(row.gas_price !== null ? { gasPrice: BigInt(row.gas_price) } : {}),
+      },
+      to: row.to_address as TxSubmissionLedgerEntry['to'],
+      value: row.value_wei === null ? undefined : BigInt(row.value_wei),
+      data: row.data as TxSubmissionLedgerEntry['data'],
+      resolvedAtMs: row.resolved_at_ms,
+    };
+  }
+
+  markTxSubmissionResolved(key: TxSubmissionKey & { resolvedAtMs: number }): void {
+    this.db.prepare(
+      `UPDATE tx_submissions
+       SET resolved_at_ms = @resolvedAtMs
+       WHERE chain_id = @chainId
+         AND from_address = @fromAddress
+         AND nonce = @nonce`,
+    ).run({
+      chainId: key.chainId,
+      fromAddress: key.from.toLowerCase(),
+      nonce: key.nonce,
+      resolvedAtMs: key.resolvedAtMs,
+    });
   }
 
   /** Generic config row (e.g. last_reward_claim_tick_at). */

--- a/client/src/tx-retry.ts
+++ b/client/src/tx-retry.ts
@@ -11,6 +11,9 @@ export const TX_RETRY_DEFAULTS = {
   maxDelayMs: 12_000,
   /** Extra fee bump per retry attempt after the first (basis points, 1500 = +15%) */
   feeBumpBpsPerAttempt: 1500,
+  /** Minimum bump over the previously submitted fee for same-sender nonce replacement. */
+  replacementBumpBps: 1500,
+  stuckNonceAfterMs: 120_000,
 } as const;
 
 export function flattenErrorMessage(error: unknown): string {
@@ -216,8 +219,71 @@ export interface TxRetryOptions {
   maxAttempts?: number;
   baseDelayMs?: number;
   maxDelayMs?: number;
+  ledger?: TxSubmissionLedger;
+  logicalTx?: string;
+  stuckNonceAfterMs?: number;
   /** If set, invoked before each retry (attempt >= 1) for logging/metrics */
   onRetry?: (info: { attempt: number; error: unknown; message: string }) => void;
+}
+
+export interface TxFeeSnapshot {
+  maxFeePerGas?: bigint;
+  maxPriorityFeePerGas?: bigint;
+  gasPrice?: bigint;
+}
+
+export interface TxSubmissionKey {
+  chainId: number;
+  from: Address;
+  nonce: number;
+}
+
+export interface TxSubmissionLedgerEntry extends TxSubmissionKey {
+  hash?: Hex;
+  logicalTx?: string;
+  submittedAtMs: number;
+  fees: TxFeeSnapshot;
+  to?: Address;
+  value?: bigint;
+  data?: Hex;
+  resolvedAtMs?: number | null;
+}
+
+type MaybePromise<T> = T | Promise<T>;
+
+export interface TxSubmissionLedger {
+  getTxSubmission(key: TxSubmissionKey): MaybePromise<TxSubmissionLedgerEntry | null>;
+  recordTxSubmission(entry: TxSubmissionLedgerEntry): MaybePromise<void>;
+  markTxSubmissionResolved(key: TxSubmissionKey & { resolvedAtMs: number }): MaybePromise<void>;
+}
+
+export function createMemoryTxSubmissionLedger(): TxSubmissionLedger {
+  const entries = new Map<string, TxSubmissionLedgerEntry>();
+  const keyFor = (key: TxSubmissionKey) =>
+    `${key.chainId}:${key.from.toLowerCase()}:${key.nonce}`;
+
+  return {
+    getTxSubmission(key) {
+      return entries.get(keyFor(key)) ?? null;
+    },
+    recordTxSubmission(entry) {
+      entries.set(keyFor(entry), { ...entry, resolvedAtMs: entry.resolvedAtMs ?? null });
+    },
+    markTxSubmissionResolved(key) {
+      const existing = entries.get(keyFor(key));
+      if (existing) entries.set(keyFor(key), { ...existing, resolvedAtMs: key.resolvedAtMs });
+    },
+  };
+}
+
+let defaultTxSubmissionLedger: TxSubmissionLedger = createMemoryTxSubmissionLedger();
+
+export function setDefaultTxSubmissionLedger(ledger: TxSubmissionLedger): void {
+  defaultTxSubmissionLedger = ledger;
+}
+
+export function getDefaultTxSubmissionLedger(): TxSubmissionLedger {
+  return defaultTxSubmissionLedger;
 }
 
 export async function withRecoverableRetry<T>(
@@ -271,28 +337,87 @@ export async function waitForContractCode(
   throw new Error(`No contract code at ${address} after ${maxAttempts} getCode attempts`);
 }
 
+function mulDivCeil(value: bigint, numerator: bigint, denominator: bigint): bigint {
+  return (value * numerator + denominator - 1n) / denominator;
+}
+
+function maxBigInt(...values: Array<bigint | undefined>): bigint | undefined {
+  const present = values.filter((value): value is bigint => value !== undefined);
+  if (present.length === 0) return undefined;
+  return present.reduce((max, value) => (value > max ? value : max), present[0]!);
+}
+
+function replacementBump(value: bigint): bigint {
+  return mulDivCeil(
+    value,
+    10000n + BigInt(TX_RETRY_DEFAULTS.replacementBumpBps),
+    10000n,
+  );
+}
+
+function attemptBump(value: bigint, attemptIndex: number): bigint {
+  if (attemptIndex <= 0) return value;
+  const bps = BigInt(TX_RETRY_DEFAULTS.feeBumpBpsPerAttempt) * BigInt(attemptIndex);
+  return mulDivCeil(value, 10000n + bps, 10000n);
+}
+
+export function mergeFeeEstimateWithPrevious(
+  current: TxFeeSnapshot,
+  previous?: TxFeeSnapshot | null,
+  attemptIndex = 0,
+): TxFeeSnapshot {
+  if (current.gasPrice !== undefined || previous?.gasPrice !== undefined) {
+    const gasPrice = maxBigInt(
+      current.gasPrice === undefined ? undefined : attemptBump(current.gasPrice, attemptIndex),
+      previous?.gasPrice === undefined ? undefined : replacementBump(previous.gasPrice),
+    );
+    return gasPrice === undefined ? {} : { gasPrice };
+  }
+
+  const maxFeePerGas = maxBigInt(
+    current.maxFeePerGas === undefined ? undefined : attemptBump(current.maxFeePerGas, attemptIndex),
+    previous?.maxFeePerGas === undefined ? undefined : replacementBump(previous.maxFeePerGas),
+  );
+  const maxPriorityFeePerGas = maxBigInt(
+    current.maxPriorityFeePerGas === undefined
+      ? undefined
+      : attemptBump(current.maxPriorityFeePerGas, attemptIndex),
+    previous?.maxPriorityFeePerGas === undefined
+      ? undefined
+      : replacementBump(previous.maxPriorityFeePerGas),
+  );
+  if (maxFeePerGas !== undefined && maxPriorityFeePerGas !== undefined) {
+    return { maxFeePerGas, maxPriorityFeePerGas };
+  }
+  return {};
+}
+
 /** EIP-1559 or legacy gas overrides for viem, increasingly aggressive on later attempts. */
 export async function viemFeeOverridesForAttempt(
   publicClient: PublicClient,
   attemptIndex: number,
+  options: {
+    previousFees?: TxFeeSnapshot | null;
+    forceEstimate?: boolean;
+  } = {},
 ): Promise<
   | { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }
   | { gasPrice: bigint }
   | Record<string, never>
 > {
-  if (attemptIndex <= 0) return {};
-
-  const bps = BigInt(TX_RETRY_DEFAULTS.feeBumpBpsPerAttempt) * BigInt(attemptIndex);
-  const mult = 10000n + bps;
-  const apply = (v: bigint) => (v * mult) / 10000n;
+  if (attemptIndex <= 0 && !options.previousFees && !options.forceEstimate) return {};
 
   try {
     const fees = await publicClient.estimateFeesPerGas();
     if (fees.maxFeePerGas !== undefined && fees.maxPriorityFeePerGas !== undefined) {
-      return {
-        maxFeePerGas: apply(fees.maxFeePerGas),
-        maxPriorityFeePerGas: apply(fees.maxPriorityFeePerGas),
-      };
+      return mergeFeeEstimateWithPrevious(
+        {
+          maxFeePerGas: fees.maxFeePerGas,
+          maxPriorityFeePerGas: fees.maxPriorityFeePerGas,
+        },
+        options.previousFees,
+        attemptIndex,
+      ) as { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint };
     }
   } catch {
     // fall through to gasPrice
@@ -300,9 +425,18 @@ export async function viemFeeOverridesForAttempt(
 
   try {
     const gasPrice = await publicClient.getGasPrice();
-    return { gasPrice: apply(gasPrice) };
+    return mergeFeeEstimateWithPrevious(
+      { gasPrice },
+      options.previousFees,
+      attemptIndex,
+    ) as { gasPrice: bigint };
   } catch {
-    return {};
+    return options.previousFees
+      ? (mergeFeeEstimateWithPrevious({}, options.previousFees, attemptIndex) as
+          | { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }
+          | { gasPrice: bigint }
+          | Record<string, never>)
+      : {};
   }
 }
 
@@ -341,6 +475,112 @@ export async function waitForTransactionReceiptWithRetry(
   throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
+async function resolveTxChainId(publicClient: PublicClient): Promise<number> {
+  return Number(await (publicClient as unknown as { getChainId: () => Promise<number | bigint> }).getChainId());
+}
+
+async function resolvePendingNonce(
+  publicClient: PublicClient,
+  from: Address,
+): Promise<number> {
+  return Number(await (publicClient as unknown as {
+    getTransactionCount: (args: { address: Address; blockTag: 'pending' }) => Promise<number | bigint>;
+  }).getTransactionCount({ address: from, blockTag: 'pending' }));
+}
+
+async function resolveLatestNonce(
+  publicClient: PublicClient,
+  from: Address,
+): Promise<number> {
+  return Number(await (publicClient as unknown as {
+    getTransactionCount: (args: { address: Address; blockTag: 'latest' }) => Promise<number | bigint>;
+  }).getTransactionCount({ address: from, blockTag: 'latest' }));
+}
+
+function accountAddress(account: unknown): Address | undefined {
+  if (account && typeof account === 'object' && typeof (account as { address?: unknown }).address === 'string') {
+    return (account as { address: Address }).address;
+  }
+  return undefined;
+}
+
+function supportsNonceTracking(publicClient: PublicClient): boolean {
+  const client = publicClient as unknown as {
+    getChainId?: unknown;
+    getTransactionCount?: unknown;
+  };
+  return typeof client.getChainId === 'function' && typeof client.getTransactionCount === 'function';
+}
+
+function isEmptyFees(fees: TxFeeSnapshot): boolean {
+  return fees.maxFeePerGas === undefined
+    && fees.maxPriorityFeePerGas === undefined
+    && fees.gasPrice === undefined;
+}
+
+export async function recoverStuckNonceIfNeeded(args: {
+  publicClient: PublicClient;
+  walletClient: { account?: unknown; sendTransaction: (tx: any) => Promise<Hex> };
+  ledger?: TxSubmissionLedger;
+  from: Address;
+  staleAfterMs?: number;
+  nowMs?: number;
+}): Promise<{
+  nonce: number;
+  previousHash?: Hex;
+  recoveryHash: Hex;
+} | null> {
+  const ledger = args.ledger ?? defaultTxSubmissionLedger;
+  const chainId = await resolveTxChainId(args.publicClient);
+  const [pendingNonce, latestNonce] = await Promise.all([
+    resolvePendingNonce(args.publicClient, args.from),
+    resolveLatestNonce(args.publicClient, args.from),
+  ]);
+  if (pendingNonce <= latestNonce) return null;
+
+  const nowMs = args.nowMs ?? Date.now();
+  const staleAfterMs = args.staleAfterMs ?? TX_RETRY_DEFAULTS.stuckNonceAfterMs;
+
+  for (let nonce = latestNonce; nonce < pendingNonce; nonce++) {
+    const entry = await ledger.getTxSubmission({ chainId, from: args.from, nonce });
+    if (!entry || entry.resolvedAtMs != null) continue;
+    if (nowMs - entry.submittedAtMs < staleAfterMs) continue;
+
+    const feeOverrides = await viemFeeOverridesForAttempt(args.publicClient, 1, {
+      previousFees: entry.fees,
+      forceEstimate: true,
+    });
+    const account = args.walletClient.account;
+    const tx = {
+      account,
+      to: args.from,
+      value: 0n,
+      nonce,
+      ...feeOverrides,
+    };
+    if ('maxFeePerGas' in tx && 'maxPriorityFeePerGas' in tx) {
+      delete (tx as { gasPrice?: bigint }).gasPrice;
+    }
+    const recoveryHash = await args.walletClient.sendTransaction(tx);
+    const fees = feeOverrides as TxFeeSnapshot;
+    await ledger.recordTxSubmission({
+      chainId,
+      from: args.from,
+      nonce,
+      hash: recoveryHash,
+      logicalTx: 'stuck-nonce-recovery',
+      submittedAtMs: nowMs,
+      fees,
+      to: args.from,
+      value: 0n,
+    });
+    await args.publicClient.waitForTransactionReceipt({ hash: recoveryHash });
+    await ledger.markTxSubmissionResolved({ chainId, from: args.from, nonce, resolvedAtMs: nowMs });
+    return { nonce, previousHash: entry.hash, recoveryHash };
+  }
+  return null;
+}
+
 export async function viemSendTransactionWithRetry(
   walletClient: { sendTransaction: (tx: any) => Promise<Hex> },
   publicClient: PublicClient,
@@ -360,19 +600,65 @@ export async function viemSendTransactionWithRetry(
   const maxAttempts = options.maxAttempts ?? TX_RETRY_DEFAULTS.maxAttempts;
   const baseDelayMs = options.baseDelayMs ?? TX_RETRY_DEFAULTS.baseDelayMs;
   const maxDelayMs = options.maxDelayMs ?? TX_RETRY_DEFAULTS.maxDelayMs;
+  const ledger = options.ledger ?? defaultTxSubmissionLedger;
+  const from = accountAddress(txRequest.account);
+  const shouldTrackNonce = from !== undefined && supportsNonceTracking(publicClient);
+  const chainId = shouldTrackNonce ? await resolveTxChainId(publicClient) : undefined;
+  if (from && shouldTrackNonce) {
+    await recoverStuckNonceIfNeeded({
+      publicClient,
+      walletClient: walletClient as { account?: unknown; sendTransaction: (tx: any) => Promise<Hex> },
+      ledger,
+      from,
+      staleAfterMs: options.stuckNonceAfterMs,
+    });
+  }
+  const explicitNonce =
+    txRequest.nonce !== undefined
+      ? Number(txRequest.nonce)
+      : from && shouldTrackNonce
+        ? await resolvePendingNonce(publicClient, from)
+        : undefined;
 
   let lastError: unknown;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     try {
-      const overrides = await viemFeeOverridesForAttempt(publicClient, attempt);
-      const req = { ...txRequest, ...overrides };
+      const previous =
+        from && chainId !== undefined && explicitNonce !== undefined
+          ? await ledger.getTxSubmission({ chainId, from, nonce: explicitNonce })
+          : null;
+      const overrides = await viemFeeOverridesForAttempt(publicClient, attempt, {
+        previousFees: previous?.resolvedAtMs == null ? previous?.fees : undefined,
+        forceEstimate: shouldTrackNonce,
+      });
+      const req = {
+        ...txRequest,
+        ...(explicitNonce !== undefined ? { nonce: explicitNonce } : {}),
+        ...overrides,
+      };
       
       // If we provided maxFeePerGas, ensure gasPrice is not somehow inherited
       if ('maxFeePerGas' in req && 'maxPriorityFeePerGas' in req) {
         delete (req as any).gasPrice;
       }
 
-      return await walletClient.sendTransaction(req);
+      const hash = await walletClient.sendTransaction(req);
+      const fees = overrides as TxFeeSnapshot;
+      if (from && chainId !== undefined && explicitNonce !== undefined && !isEmptyFees(fees)) {
+        await ledger.recordTxSubmission({
+          chainId,
+          from,
+          nonce: explicitNonce,
+          hash,
+          logicalTx: options.logicalTx,
+          submittedAtMs: Date.now(),
+          fees,
+          to: txRequest.to,
+          value: txRequest.value,
+          data: txRequest.data,
+        });
+      }
+      return hash;
     } catch (err) {
       lastError = err;
       if (!isRecoverableTransactionError(err) || attempt >= maxAttempts - 1) {

--- a/client/src/tx-retry.ts
+++ b/client/src/tx-retry.ts
@@ -232,6 +232,58 @@ export interface TxFeeSnapshot {
   gasPrice?: bigint;
 }
 
+export type Eip1559FeeOverrides = {
+  maxFeePerGas: bigint;
+  maxPriorityFeePerGas: bigint;
+  gasPrice?: undefined;
+};
+
+export type LegacyFeeOverrides = {
+  gasPrice: bigint;
+  maxFeePerGas?: undefined;
+  maxPriorityFeePerGas?: undefined;
+};
+
+export type EmptyFeeOverrides = {
+  maxFeePerGas?: undefined;
+  maxPriorityFeePerGas?: undefined;
+  gasPrice?: undefined;
+};
+
+export type TxFeeOverrides = Eip1559FeeOverrides | LegacyFeeOverrides | EmptyFeeOverrides;
+
+export type TxFeeOverrideResult =
+  | { kind: 'eip1559'; overrides: Eip1559FeeOverrides; snapshot: TxFeeSnapshot }
+  | { kind: 'legacy'; overrides: LegacyFeeOverrides; snapshot: TxFeeSnapshot }
+  | { kind: 'none'; overrides: EmptyFeeOverrides; snapshot: TxFeeSnapshot };
+
+export type TxRecoveryTransactionRequest = TxFeeOverrides & {
+  account?: unknown;
+  to: Address;
+  value: bigint;
+  nonce: number;
+};
+
+export interface TxRecoveryWalletClient {
+  account?: unknown;
+  sendTransaction(tx: TxRecoveryTransactionRequest): Promise<Hex>;
+}
+
+export type TxRetryTransactionRequest = TxFeeOverrides & {
+  account?: unknown;
+  to?: Address;
+  data?: Hex;
+  value?: bigint;
+  gas?: bigint;
+  nonce?: number;
+  [key: string]: unknown;
+};
+
+export interface TxRetryWalletClient {
+  account?: unknown;
+  sendTransaction(tx: TxRetryTransactionRequest): Promise<Hex>;
+}
+
 export interface TxSubmissionKey {
   chainId: number;
   from: Address;
@@ -255,6 +307,40 @@ export interface TxSubmissionLedger {
   getTxSubmission(key: TxSubmissionKey): MaybePromise<TxSubmissionLedgerEntry | null>;
   recordTxSubmission(entry: TxSubmissionLedgerEntry): MaybePromise<void>;
   markTxSubmissionResolved(key: TxSubmissionKey & { resolvedAtMs: number }): MaybePromise<void>;
+}
+
+export interface NonceLedgerSubmission {
+  hash?: Hex;
+  logicalTx?: string;
+  submittedAtMs?: number;
+  fees: TxFeeSnapshot;
+  to?: Address;
+  value?: bigint;
+  data?: Hex;
+}
+
+export interface NonceLedgerContext {
+  ledger: TxSubmissionLedger;
+  chainId: number;
+  from: Address;
+  nonce: number;
+  feeResultForAttempt(
+    attemptIndex: number,
+    options?: { forceEstimate?: boolean },
+  ): Promise<TxFeeOverrideResult>;
+  recordSubmitted(entry: NonceLedgerSubmission): Promise<void>;
+  markResolved(resolvedAtMs?: number): Promise<void>;
+}
+
+export interface WithNonceLedgerArgs {
+  publicClient: PublicClient;
+  walletClient?: TxRecoveryWalletClient;
+  ledger?: TxSubmissionLedger;
+  from: Address;
+  nonce?: number;
+  chainId?: number;
+  recoverStuckNonce?: boolean;
+  staleAfterMs?: number;
 }
 
 export function createMemoryTxSubmissionLedger(): TxSubmissionLedger {
@@ -392,6 +478,75 @@ export function mergeFeeEstimateWithPrevious(
   return {};
 }
 
+function feeOverrideResultFromSnapshot(snapshot: TxFeeSnapshot): TxFeeOverrideResult {
+  if (snapshot.maxFeePerGas !== undefined && snapshot.maxPriorityFeePerGas !== undefined) {
+    const overrides: Eip1559FeeOverrides = {
+      maxFeePerGas: snapshot.maxFeePerGas,
+      maxPriorityFeePerGas: snapshot.maxPriorityFeePerGas,
+    };
+    return { kind: 'eip1559', overrides, snapshot: overrides };
+  }
+
+  if (snapshot.gasPrice !== undefined) {
+    const overrides: LegacyFeeOverrides = { gasPrice: snapshot.gasPrice };
+    return { kind: 'legacy', overrides, snapshot: overrides };
+  }
+
+  return { kind: 'none', overrides: {}, snapshot: {} };
+}
+
+/**
+ * EIP-1559 or legacy gas overrides for viem, increasingly aggressive on later attempts.
+ *
+ * The result carries both the spreadable viem transaction overrides and the
+ * ledger snapshot, keeping call sites from recasting the override object.
+ */
+export async function viemFeeOverrideResultForAttempt(
+  publicClient: PublicClient,
+  attemptIndex: number,
+  options: {
+    previousFees?: TxFeeSnapshot | null;
+    forceEstimate?: boolean;
+  } = {},
+): Promise<TxFeeOverrideResult> {
+  if (attemptIndex <= 0 && !options.previousFees && !options.forceEstimate) {
+    return feeOverrideResultFromSnapshot({});
+  }
+
+  try {
+    const fees = await publicClient.estimateFeesPerGas();
+    if (fees.maxFeePerGas !== undefined && fees.maxPriorityFeePerGas !== undefined) {
+      return feeOverrideResultFromSnapshot(
+        mergeFeeEstimateWithPrevious(
+          {
+            maxFeePerGas: fees.maxFeePerGas,
+            maxPriorityFeePerGas: fees.maxPriorityFeePerGas,
+          },
+          options.previousFees,
+          attemptIndex,
+        ),
+      );
+    }
+  } catch {
+    // fall through to gasPrice
+  }
+
+  try {
+    const gasPrice = await publicClient.getGasPrice();
+    return feeOverrideResultFromSnapshot(
+      mergeFeeEstimateWithPrevious(
+        { gasPrice },
+        options.previousFees,
+        attemptIndex,
+      ),
+    );
+  } catch {
+    return options.previousFees
+      ? feeOverrideResultFromSnapshot(mergeFeeEstimateWithPrevious({}, options.previousFees, attemptIndex))
+      : feeOverrideResultFromSnapshot({});
+  }
+}
+
 /** EIP-1559 or legacy gas overrides for viem, increasingly aggressive on later attempts. */
 export async function viemFeeOverridesForAttempt(
   publicClient: PublicClient,
@@ -400,44 +555,8 @@ export async function viemFeeOverridesForAttempt(
     previousFees?: TxFeeSnapshot | null;
     forceEstimate?: boolean;
   } = {},
-): Promise<
-  | { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }
-  | { gasPrice: bigint }
-  | Record<string, never>
-> {
-  if (attemptIndex <= 0 && !options.previousFees && !options.forceEstimate) return {};
-
-  try {
-    const fees = await publicClient.estimateFeesPerGas();
-    if (fees.maxFeePerGas !== undefined && fees.maxPriorityFeePerGas !== undefined) {
-      return mergeFeeEstimateWithPrevious(
-        {
-          maxFeePerGas: fees.maxFeePerGas,
-          maxPriorityFeePerGas: fees.maxPriorityFeePerGas,
-        },
-        options.previousFees,
-        attemptIndex,
-      ) as { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint };
-    }
-  } catch {
-    // fall through to gasPrice
-  }
-
-  try {
-    const gasPrice = await publicClient.getGasPrice();
-    return mergeFeeEstimateWithPrevious(
-      { gasPrice },
-      options.previousFees,
-      attemptIndex,
-    ) as { gasPrice: bigint };
-  } catch {
-    return options.previousFees
-      ? (mergeFeeEstimateWithPrevious({}, options.previousFees, attemptIndex) as
-          | { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }
-          | { gasPrice: bigint }
-          | Record<string, never>)
-      : {};
-  }
+): Promise<TxFeeOverrides> {
+  return (await viemFeeOverrideResultForAttempt(publicClient, attemptIndex, options)).overrides;
 }
 
 export async function waitForTransactionReceiptWithRetry(
@@ -476,25 +595,21 @@ export async function waitForTransactionReceiptWithRetry(
 }
 
 async function resolveTxChainId(publicClient: PublicClient): Promise<number> {
-  return Number(await (publicClient as unknown as { getChainId: () => Promise<number | bigint> }).getChainId());
+  return Number(await publicClient.getChainId());
 }
 
 async function resolvePendingNonce(
   publicClient: PublicClient,
   from: Address,
 ): Promise<number> {
-  return Number(await (publicClient as unknown as {
-    getTransactionCount: (args: { address: Address; blockTag: 'pending' }) => Promise<number | bigint>;
-  }).getTransactionCount({ address: from, blockTag: 'pending' }));
+  return Number(await publicClient.getTransactionCount({ address: from, blockTag: 'pending' }));
 }
 
 async function resolveLatestNonce(
   publicClient: PublicClient,
   from: Address,
 ): Promise<number> {
-  return Number(await (publicClient as unknown as {
-    getTransactionCount: (args: { address: Address; blockTag: 'latest' }) => Promise<number | bigint>;
-  }).getTransactionCount({ address: from, blockTag: 'latest' }));
+  return Number(await publicClient.getTransactionCount({ address: from, blockTag: 'latest' }));
 }
 
 function accountAddress(account: unknown): Address | undefined {
@@ -518,11 +633,85 @@ function isEmptyFees(fees: TxFeeSnapshot): boolean {
     && fees.gasPrice === undefined;
 }
 
+export function removeConflictingLegacyGasPrice<T extends TxFeeSnapshot>(tx: T): void {
+  if (tx.maxFeePerGas !== undefined && tx.maxPriorityFeePerGas !== undefined) {
+    delete tx.gasPrice;
+  }
+}
+
+function withoutFeeOverrides<T extends TxFeeSnapshot>(tx: T): Omit<T, keyof TxFeeSnapshot> {
+  const {
+    maxFeePerGas: _maxFeePerGas,
+    maxPriorityFeePerGas: _maxPriorityFeePerGas,
+    gasPrice: _gasPrice,
+    ...baseRequest
+  } = tx;
+  return baseRequest;
+}
+
+export async function withNonceLedger<T>(
+  args: WithNonceLedgerArgs,
+  fn: (context: NonceLedgerContext) => Promise<T>,
+): Promise<T> {
+  const ledger = args.ledger ?? defaultTxSubmissionLedger;
+  const chainId = args.chainId ?? await resolveTxChainId(args.publicClient);
+
+  if (args.recoverStuckNonce) {
+    if (!args.walletClient) {
+      throw new Error('withNonceLedger recovery requested without a wallet client');
+    }
+    await recoverStuckNonceIfNeeded({
+      publicClient: args.publicClient,
+      walletClient: args.walletClient,
+      ledger,
+      chainId,
+      from: args.from,
+      staleAfterMs: args.staleAfterMs,
+    });
+  }
+
+  const nonce = args.nonce ?? await resolvePendingNonce(args.publicClient, args.from);
+  const key = { chainId, from: args.from, nonce };
+  const context: NonceLedgerContext = {
+    ledger,
+    chainId,
+    from: args.from,
+    nonce,
+    async feeResultForAttempt(attemptIndex, options = {}) {
+      const previous = await ledger.getTxSubmission(key);
+      return viemFeeOverrideResultForAttempt(args.publicClient, attemptIndex, {
+        previousFees: previous?.resolvedAtMs == null ? previous?.fees : undefined,
+        forceEstimate: options.forceEstimate,
+      });
+    },
+    async recordSubmitted(entry) {
+      await ledger.recordTxSubmission({
+        chainId,
+        from: args.from,
+        nonce,
+        hash: entry.hash,
+        logicalTx: entry.logicalTx,
+        submittedAtMs: entry.submittedAtMs ?? Date.now(),
+        fees: entry.fees,
+        to: entry.to,
+        value: entry.value,
+        data: entry.data,
+      });
+    },
+    async markResolved(resolvedAtMs = Date.now()) {
+      await ledger.markTxSubmissionResolved({ chainId, from: args.from, nonce, resolvedAtMs });
+    },
+  };
+
+  return fn(context);
+}
+
 export async function recoverStuckNonceIfNeeded(args: {
   publicClient: PublicClient;
-  walletClient: { account?: unknown; sendTransaction: (tx: any) => Promise<Hex> };
+  walletClient: TxRecoveryWalletClient;
   ledger?: TxSubmissionLedger;
   from: Address;
+  chainId?: number;
   staleAfterMs?: number;
   nowMs?: number;
 }): Promise<{
@@ -531,8 +720,8 @@ export async function recoverStuckNonceIfNeeded(args: {
   recoveryHash: Hex;
 } | null> {
   const ledger = args.ledger ?? defaultTxSubmissionLedger;
-  const chainId = await resolveTxChainId(args.publicClient);
-  const [pendingNonce, latestNonce] = await Promise.all([
+  const [chainId, pendingNonce, latestNonce] = await Promise.all([
+    args.chainId ?? resolveTxChainId(args.publicClient),
     resolvePendingNonce(args.publicClient, args.from),
     resolveLatestNonce(args.publicClient, args.from),
   ]);
@@ -551,18 +740,15 @@ export async function recoverStuckNonceIfNeeded(args: {
       forceEstimate: true,
     });
     const account = args.walletClient.account;
-    const tx = {
+    const tx: TxRecoveryTransactionRequest = {
       account,
       to: args.from,
       value: 0n,
       nonce,
       ...feeOverrides,
     };
-    if ('maxFeePerGas' in tx && 'maxPriorityFeePerGas' in tx) {
-      delete (tx as { gasPrice?: bigint }).gasPrice;
-    }
+    removeConflictingLegacyGasPrice(tx);
     const recoveryHash = await args.walletClient.sendTransaction(tx);
-    const fees = feeOverrides as TxFeeSnapshot;
     await ledger.recordTxSubmission({
       chainId,
       from: args.from,
@@ -570,7 +756,7 @@ export async function recoverStuckNonceIfNeeded(args: {
       hash: recoveryHash,
       logicalTx: 'stuck-nonce-recovery',
       submittedAtMs: nowMs,
-      fees,
+      fees: feeOverrides,
       to: args.from,
       value: 0n,
     });
@@ -582,19 +768,9 @@ export async function recoverStuckNonceIfNeeded(args: {
 }
 
 export async function viemSendTransactionWithRetry(
-  walletClient: { sendTransaction: (tx: any) => Promise<Hex> },
+  walletClient: TxRetryWalletClient,
   publicClient: PublicClient,
-  txRequest: {
-    account: any;
-    to?: Address;
-    data?: Hex;
-    value?: bigint;
-    gas?: bigint;
-    maxFeePerGas?: bigint;
-    maxPriorityFeePerGas?: bigint;
-    gasPrice?: bigint;
-    [key: string]: any;
-  },
+  txRequest: TxRetryTransactionRequest,
   options: TxRetryOptions = {},
 ): Promise<Hex> {
   const maxAttempts = options.maxAttempts ?? TX_RETRY_DEFAULTS.maxAttempts;
@@ -603,74 +779,73 @@ export async function viemSendTransactionWithRetry(
   const ledger = options.ledger ?? defaultTxSubmissionLedger;
   const from = accountAddress(txRequest.account);
   const shouldTrackNonce = from !== undefined && supportsNonceTracking(publicClient);
-  const chainId = shouldTrackNonce ? await resolveTxChainId(publicClient) : undefined;
-  if (from && shouldTrackNonce) {
-    await recoverStuckNonceIfNeeded({
-      publicClient,
-      walletClient: walletClient as { account?: unknown; sendTransaction: (tx: any) => Promise<Hex> },
-      ledger,
-      from,
-      staleAfterMs: options.stuckNonceAfterMs,
-    });
-  }
-  const explicitNonce =
-    txRequest.nonce !== undefined
-      ? Number(txRequest.nonce)
-      : from && shouldTrackNonce
-        ? await resolvePendingNonce(publicClient, from)
-        : undefined;
+  const requestedNonce = txRequest.nonce === undefined ? undefined : Number(txRequest.nonce);
 
-  let lastError: unknown;
-  for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    try {
-      const previous =
-        from && chainId !== undefined && explicitNonce !== undefined
-          ? await ledger.getTxSubmission({ chainId, from, nonce: explicitNonce })
-          : null;
-      const overrides = await viemFeeOverridesForAttempt(publicClient, attempt, {
-        previousFees: previous?.resolvedAtMs == null ? previous?.fees : undefined,
-        forceEstimate: shouldTrackNonce,
-      });
-      const req = {
-        ...txRequest,
-        ...(explicitNonce !== undefined ? { nonce: explicitNonce } : {}),
-        ...overrides,
-      };
-      
-      // If we provided maxFeePerGas, ensure gasPrice is not somehow inherited
-      if ('maxFeePerGas' in req && 'maxPriorityFeePerGas' in req) {
-        delete (req as any).gasPrice;
-      }
+  const sendWithRetry = async (nonceLedger?: NonceLedgerContext): Promise<Hex> => {
+    const pinnedNonce = nonceLedger?.nonce ?? requestedNonce;
 
-      const hash = await walletClient.sendTransaction(req);
-      const fees = overrides as TxFeeSnapshot;
-      if (from && chainId !== undefined && explicitNonce !== undefined && !isEmptyFees(fees)) {
-        await ledger.recordTxSubmission({
-          chainId,
-          from,
-          nonce: explicitNonce,
-          hash,
-          logicalTx: options.logicalTx,
-          submittedAtMs: Date.now(),
-          fees,
-          to: txRequest.to,
-          value: txRequest.value,
-          data: txRequest.data,
+    let lastError: unknown;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        const feeResult = nonceLedger
+          ? await nonceLedger.feeResultForAttempt(attempt, { forceEstimate: true })
+          : await viemFeeOverrideResultForAttempt(publicClient, attempt);
+        const nonceOverride = pinnedNonce !== undefined ? { nonce: pinnedNonce } : {};
+        const req: TxRetryTransactionRequest =
+          feeResult.kind === 'none'
+            ? {
+                ...txRequest,
+                ...nonceOverride,
+              }
+            : {
+                ...withoutFeeOverrides(txRequest),
+                ...nonceOverride,
+                ...feeResult.overrides,
+              };
+        removeConflictingLegacyGasPrice(req);
+
+        const hash = await walletClient.sendTransaction(req);
+        if (nonceLedger && !isEmptyFees(feeResult.snapshot)) {
+          await nonceLedger.recordSubmitted({
+            hash,
+            logicalTx: options.logicalTx,
+            fees: feeResult.snapshot,
+            to: txRequest.to,
+            value: txRequest.value,
+            data: txRequest.data,
+          });
+        }
+        return hash;
+      } catch (err) {
+        lastError = err;
+        if (!isRecoverableTransactionError(err) || attempt >= maxAttempts - 1) {
+          throw err;
+        }
+        options.onRetry?.({
+          attempt: attempt + 1,
+          error: err,
+          message: flattenErrorMessage(err),
         });
+        await backoffDelay(attempt, baseDelayMs, maxDelayMs);
       }
-      return hash;
-    } catch (err) {
-      lastError = err;
-      if (!isRecoverableTransactionError(err) || attempt >= maxAttempts - 1) {
-        throw err;
-      }
-      options.onRetry?.({
-        attempt: attempt + 1,
-        error: err,
-        message: flattenErrorMessage(err),
-      });
-      await backoffDelay(attempt, baseDelayMs, maxDelayMs);
     }
+    throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  };
+
+  if (from && shouldTrackNonce) {
+    return withNonceLedger(
+      {
+        publicClient,
+        walletClient,
+        ledger,
+        from,
+        nonce: requestedNonce,
+        recoverStuckNonce: true,
+        staleAfterMs: options.stuckNonceAfterMs,
+      },
+      sendWithRetry,
+    );
   }
-  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+
+  return sendWithRetry();
 }

--- a/client/test/api/prediction-v1-build.test.ts
+++ b/client/test/api/prediction-v1-build.test.ts
@@ -14,6 +14,7 @@ function seedPredictionRun(
     state?: 'DISCOVERED' | 'COMPLETE' | 'FAILED';
     stateUpdatedAt?: number;
     solverType?: string;
+    runStartedAt?: number;
   },
 ): void {
   persistence.insertDiscovered({
@@ -24,6 +25,7 @@ function seedPredictionRun(
     onchainCreationBlock: 1,
     solverType: input.solverType ?? 'prediction.v1',
     taskRole: input.taskRole ?? 'restoration',
+    runStartedAt: input.runStartedAt,
     windowStartTs: 1_000,
     windowEndTs: 2_000,
     task: {
@@ -247,6 +249,26 @@ describe('gatherPredictionV1Status', () => {
       expect(result.recentTasks.map((task) => task.requestId)).toEqual(
         expect.arrayContaining(['canonical-prediction', 'legacy-prediction']),
       );
+    });
+  });
+
+  it('includes runStartedAt in prediction task summaries', async () => {
+    await withTempStore(async (store) => {
+      const persistence = new TaskRunPersistence(store.db);
+      seedPredictionRun(store, persistence, {
+        requestId: 'recent-prediction-claim',
+        taskId: 'prediction-recent-task',
+        runStartedAt: 50_000,
+        stateUpdatedAt: 60_000,
+      });
+
+      const result = gatherPredictionV1Status(store);
+
+      expect(result.recentTasks[0]).toMatchObject({
+        requestId: 'recent-prediction-claim',
+        windowStartTs: 1_000,
+        runStartedAt: 50_000,
+      });
     });
   });
 });

--- a/client/test/api/task-runs-build.test.ts
+++ b/client/test/api/task-runs-build.test.ts
@@ -103,6 +103,26 @@ describe('gatherTaskRunsStatus', () => {
       expect(status.totals.localErrors).toBe(1);
     });
   });
+
+  it('includes runStartedAt in task run summaries distinct from windowStartTs', async () => {
+    await withTempStore(async (store) => {
+      const persistence = new TaskRunPersistence(store.db);
+      insertTask(persistence, {
+        requestId: 'fresh-claim',
+        taskId: 'task-fresh',
+        taskRole: 'restoration',
+        runStartedAt: 10_000,
+      });
+
+      const status = gatherTaskRunsStatus(store);
+
+      expect(status.inFlight[0]).toMatchObject({
+        requestId: 'fresh-claim',
+        windowStartTs: 1_000,
+        runStartedAt: 10_000,
+      });
+    });
+  });
 });
 
 function insertTask(
@@ -111,6 +131,7 @@ function insertTask(
     requestId: string;
     taskId: string;
     taskRole: 'restoration' | 'evaluation';
+    runStartedAt?: number;
   },
 ): void {
   persistence.insertDiscovered({
@@ -121,6 +142,7 @@ function insertTask(
     onchainCreationBlock: 1,
     solverType: 'swe-rebench-v2.v1',
     taskRole: input.taskRole,
+    runStartedAt: input.runStartedAt,
     windowStartTs: 1_000,
     windowEndTs: 2_000,
     task: {

--- a/client/test/daemon/daemon.test.ts
+++ b/client/test/daemon/daemon.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect } from 'vitest';
+import Database from 'better-sqlite3';
 import { Daemon, type DaemonConfig } from '../../src/daemon/daemon.js';
 import { LocalAdapter } from '../../src/adapters/local/adapter.js';
 import { SimpleRunner } from '../../src/runner/simple.js';
@@ -64,4 +65,78 @@ describe('Daemon', () => {
     await daemon.stop();
     expect(daemon.getShutdownState()).toBe('clean');
   });
+
+  it('persists a recent runStartedAt after claiming a task with an old window start', async () => {
+    const adapter = new LocalAdapter();
+    const dbPath = join(mkdtempSync(join(tmpdir(), 'jinn-daemon-started-test-')), 'jinn.db');
+    const daemon = new Daemon({
+      adapter,
+      runner: new SimpleRunner(async (desc) => `Done: ${desc}`),
+      taskSources: [],
+      dbPath,
+      restorationEngine: minimalEngineConfig(),
+    });
+    await daemon.start();
+
+    try {
+      const beforeClaim = Date.now();
+      const oldWindowStart = beforeClaim - 6 * 86_400_000;
+      await adapter.postTask({
+        id: 'old-window-fresh-claim',
+        description: 'old window, newly claimed',
+        window: { startTs: oldWindowStart, endTs: beforeClaim + 3_600_000 },
+      });
+
+      await waitForTaskRunRow(dbPath, '1');
+      const afterClaim = Date.now();
+      await daemon.stop();
+
+      const db = new Database(dbPath, { readonly: true });
+      try {
+        const row = db
+          .prepare(
+            `SELECT window_start_ts, run_started_at
+             FROM task_runs
+             WHERE task_id = ?`,
+          )
+          .get('1') as { window_start_ts: number; run_started_at: number };
+        expect(row.window_start_ts).toBe(oldWindowStart);
+        expect(row.run_started_at).toBeGreaterThanOrEqual(beforeClaim);
+        expect(row.run_started_at).toBeLessThanOrEqual(afterClaim);
+      } finally {
+        db.close();
+      }
+    } finally {
+      if (daemon.getShutdownState() !== 'clean') {
+        await daemon.stop();
+      }
+    }
+  });
 });
+
+async function waitForTaskRunRow(
+  dbPath: string,
+  taskId: string,
+): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (Date.now() < deadline) {
+    let db: Database.Database | undefined;
+    try {
+      db = new Database(dbPath, { readonly: true, fileMustExist: true });
+      const row = db
+        .prepare(
+          `SELECT 1
+           FROM task_runs
+           WHERE task_id = ?`,
+        )
+        .get(taskId) as { 1: number } | undefined;
+      if (row) return;
+    } catch {
+      // DB file may not exist during the first few milliseconds of daemon startup.
+    } finally {
+      db?.close();
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for task run row for taskId ${taskId}`);
+}

--- a/client/test/harnesses/engine/persistence.test.ts
+++ b/client/test/harnesses/engine/persistence.test.ts
@@ -67,6 +67,7 @@ describe('runAdditiveMigrations', () => {
     expect(columns).toContain('manifest_generated_at');
     expect(columns).toContain('evidence_hash');
     expect(columns).toContain('task_payload');
+    expect(columns).toContain('run_started_at');
 
     db.close();
   });
@@ -116,6 +117,25 @@ describe('TaskRunPersistence', () => {
       p.insertDiscovered(makeInput({ solverType: undefined }));
       const intent = p.getByRequestId('req-001');
       expect(intent!.solverType).toBeNull();
+    });
+
+    it('persists an explicit runStartedAt distinct from the task window start', () => {
+      p.insertDiscovered(makeInput({
+        runStartedAt: 1_700_000,
+        windowStartTs: 2_000_000,
+      }));
+      const intent = p.getByRequestId('req-001');
+      expect(intent!.runStartedAt).toBe(1_700_000);
+      expect(intent!.windowStartTs).toBe(2_000_000);
+    });
+
+    it('defaults runStartedAt to observe time when omitted', () => {
+      const before = Date.now();
+      p.insertDiscovered(makeInput({ runStartedAt: undefined }));
+      const after = Date.now();
+      const intent = p.getByRequestId('req-001');
+      expect(intent!.runStartedAt).toBeGreaterThanOrEqual(before);
+      expect(intent!.runStartedAt).toBeLessThanOrEqual(after);
     });
   });
 

--- a/client/test/store/store.test.ts
+++ b/client/test/store/store.test.ts
@@ -28,6 +28,52 @@ describe('Store', () => {
     expect(store.getShutdownState()).toBe('clean');
   });
 
+  it('persists unresolved transaction submissions for replacement fee recovery', () => {
+    store.recordTxSubmission({
+      chainId: 84532,
+      from: '0x1111111111111111111111111111111111111111',
+      nonce: 7,
+      hash: `0x${'11'.repeat(32)}`,
+      logicalTx: 'safe.execTransaction',
+      submittedAtMs: 1_000,
+      fees: {
+        maxFeePerGas: 100n,
+        maxPriorityFeePerGas: 10n,
+      },
+      to: '0x2222222222222222222222222222222222222222',
+      value: 0n,
+      data: '0x1234',
+    });
+
+    expect(store.getTxSubmission({
+      chainId: 84532,
+      from: '0x1111111111111111111111111111111111111111',
+      nonce: 7,
+    })).toMatchObject({
+      hash: `0x${'11'.repeat(32)}`,
+      logicalTx: 'safe.execTransaction',
+      fees: {
+        maxFeePerGas: 100n,
+        maxPriorityFeePerGas: 10n,
+      },
+      data: '0x1234',
+      resolvedAtMs: null,
+    });
+
+    store.markTxSubmissionResolved({
+      chainId: 84532,
+      from: '0x1111111111111111111111111111111111111111',
+      nonce: 7,
+      resolvedAtMs: 2_000,
+    });
+
+    expect(store.getTxSubmission({
+      chainId: 84532,
+      from: '0x1111111111111111111111111111111111111111',
+      nonce: 7,
+    })?.resolvedAtMs).toBe(2_000);
+  });
+
   it('aggregates own activity and config rows', () => {
     store.recordOwnActivity('r1', 'delivered');
     store.recordOwnActivity('r2', 'evaluated');

--- a/client/test/tx-retry.test.ts
+++ b/client/test/tx-retry.test.ts
@@ -6,6 +6,7 @@ import {
   recoverStuckNonceIfNeeded,
   viemSendTransactionWithRetry,
   withRecoverableRetry,
+  withNonceLedger,
   viemFeeOverridesForAttempt,
   waitForContractCode,
 } from '../src/tx-retry.js';
@@ -320,6 +321,87 @@ describe('tx-retry', () => {
     });
   });
 
+  describe('withNonceLedger', () => {
+    it('resolves chain/from/nonce once and records submissions through the provided ledger', async () => {
+      const from = '0x1111111111111111111111111111111111111111' as const;
+      const ledger = createMemoryTxSubmissionLedger();
+      await ledger.recordTxSubmission({
+        chainId: 84532,
+        from,
+        nonce: 7,
+        hash: `0x${'11'.repeat(32)}`,
+        logicalTx: 'previous',
+        submittedAtMs: 1_000,
+        fees: {
+          maxFeePerGas: 100n,
+          maxPriorityFeePerGas: 10n,
+        },
+      });
+      const publicClient = {
+        getChainId: vi.fn().mockResolvedValue(84532),
+        getTransactionCount: vi.fn().mockResolvedValue(7),
+        estimateFeesPerGas: vi.fn().mockResolvedValue({
+          maxFeePerGas: 80n,
+          maxPriorityFeePerGas: 8n,
+        }),
+        getGasPrice: vi.fn(),
+      };
+
+      const result = await withNonceLedger(
+        {
+          publicClient: publicClient as never,
+          ledger,
+          from,
+        },
+        async (nonceLedger) => {
+          expect(nonceLedger.chainId).toBe(84532);
+          expect(nonceLedger.from).toBe(from);
+          expect(nonceLedger.nonce).toBe(7);
+
+          const feeResult = await nonceLedger.feeResultForAttempt(1, {
+            forceEstimate: true,
+          });
+          expect(feeResult).toMatchObject({
+            kind: 'eip1559',
+            overrides: {
+              maxFeePerGas: 115n,
+              maxPriorityFeePerGas: 12n,
+            },
+          });
+
+          await nonceLedger.recordSubmitted({
+            hash: `0x${'22'.repeat(32)}`,
+            logicalTx: 'helper.test',
+            fees: feeResult.snapshot,
+            to: '0x2222222222222222222222222222222222222222',
+            value: 1n,
+            data: '0x1234',
+            submittedAtMs: 2_000,
+          });
+          await nonceLedger.markResolved(3_000);
+          return 'ok';
+        },
+      );
+
+      expect(result).toBe('ok');
+      expect(publicClient.getChainId).toHaveBeenCalledTimes(1);
+      expect(publicClient.getTransactionCount).toHaveBeenCalledWith({
+        address: from,
+        blockTag: 'pending',
+      });
+      const submitted = await ledger.getTxSubmission({ chainId: 84532, from, nonce: 7 });
+      expect(submitted).toMatchObject({
+        hash: `0x${'22'.repeat(32)}`,
+        logicalTx: 'helper.test',
+        resolvedAtMs: 3_000,
+        fees: {
+          maxFeePerGas: 115n,
+          maxPriorityFeePerGas: 12n,
+        },
+      });
+    });
+  });
+
   describe('stuck nonce recovery', () => {
     it('detects an old unresolved nonce and clears it with a bumped self-transfer', async () => {
       const from = '0x1111111111111111111111111111111111111111' as const;
@@ -360,10 +442,12 @@ describe('tx-retry', () => {
         walletClient,
         ledger,
         from,
+        chainId: 84532,
         staleAfterMs: 30_000,
         nowMs: 61_000,
       });
 
+      expect(publicClient.getChainId).not.toHaveBeenCalled();
       expect(result?.recoveryHash).toBe(`0x${'22'.repeat(32)}`);
       expect(sendTransaction).toHaveBeenCalledWith({
         account: walletClient.account,

--- a/client/test/tx-retry.test.ts
+++ b/client/test/tx-retry.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  createMemoryTxSubmissionLedger,
   flattenErrorMessage,
   isRecoverableTransactionError,
+  recoverStuckNonceIfNeeded,
+  viemSendTransactionWithRetry,
   withRecoverableRetry,
   viemFeeOverridesForAttempt,
   waitForContractCode,
@@ -244,6 +247,134 @@ describe('tx-retry', () => {
       const o = await viemFeeOverridesForAttempt(publicClient as never, 2);
       expect('maxFeePerGas' in o && o.maxFeePerGas).toBe(130n);
       expect('maxPriorityFeePerGas' in o && o.maxPriorityFeePerGas).toBe(13n);
+    });
+
+    it('bumps EIP-1559 replacement fees from the previous submitted fee when the fresh estimate is lower', async () => {
+      const publicClient = {
+        estimateFeesPerGas: vi.fn().mockResolvedValue({
+          maxFeePerGas: 90n,
+          maxPriorityFeePerGas: 9n,
+        }),
+        getGasPrice: vi.fn(),
+      };
+      const o = await viemFeeOverridesForAttempt(publicClient as never, 1, {
+        previousFees: {
+          maxFeePerGas: 100n,
+          maxPriorityFeePerGas: 10n,
+        },
+      });
+      expect(o).toEqual({
+        maxFeePerGas: 115n,
+        maxPriorityFeePerGas: 12n,
+      });
+    });
+
+    it('bumps legacy replacement gasPrice from the previous submitted fee when the fresh estimate is lower', async () => {
+      const publicClient = {
+        estimateFeesPerGas: vi.fn().mockRejectedValue(new Error('legacy chain')),
+        getGasPrice: vi.fn().mockResolvedValue(90n),
+      };
+      const o = await viemFeeOverridesForAttempt(publicClient as never, 1, {
+        previousFees: { gasPrice: 100n },
+      });
+      expect(o).toEqual({ gasPrice: 115n });
+    });
+  });
+
+  describe('viemSendTransactionWithRetry', () => {
+    const account = {
+      address: '0x1111111111111111111111111111111111111111',
+    } as const;
+
+    it('pins an explicit EOA nonce across replacement retries', async () => {
+      const publicClient = {
+        getChainId: vi.fn().mockResolvedValue(84532),
+        getTransactionCount: vi.fn().mockResolvedValue(7),
+        estimateFeesPerGas: vi.fn().mockResolvedValue({
+          maxFeePerGas: 100n,
+          maxPriorityFeePerGas: 10n,
+        }),
+        getGasPrice: vi.fn(),
+      };
+      const sendTransaction = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('replacement transaction underpriced'))
+        .mockResolvedValueOnce(`0x${'aa'.repeat(32)}`);
+
+      await expect(
+        viemSendTransactionWithRetry(
+          { sendTransaction },
+          publicClient as never,
+          {
+            account,
+            to: '0x2222222222222222222222222222222222222222',
+            value: 1n,
+          },
+          { maxAttempts: 2, baseDelayMs: 1, maxDelayMs: 1 },
+        ),
+      ).resolves.toBe(`0x${'aa'.repeat(32)}`);
+
+      expect(sendTransaction).toHaveBeenCalledTimes(2);
+      expect(sendTransaction.mock.calls[0]![0].nonce).toBe(7);
+      expect(sendTransaction.mock.calls[1]![0].nonce).toBe(7);
+    });
+  });
+
+  describe('stuck nonce recovery', () => {
+    it('detects an old unresolved nonce and clears it with a bumped self-transfer', async () => {
+      const from = '0x1111111111111111111111111111111111111111' as const;
+      const ledger = createMemoryTxSubmissionLedger();
+      await ledger.recordTxSubmission({
+        chainId: 84532,
+        from,
+        nonce: 7,
+        hash: `0x${'11'.repeat(32)}`,
+        logicalTx: 'safe.execTransaction',
+        submittedAtMs: 1_000,
+        fees: {
+          maxFeePerGas: 100n,
+          maxPriorityFeePerGas: 10n,
+        },
+      });
+      const publicClient = {
+        getChainId: vi.fn().mockResolvedValue(84532),
+        getTransactionCount: vi
+          .fn()
+          .mockResolvedValueOnce(8)
+          .mockResolvedValueOnce(7),
+        estimateFeesPerGas: vi.fn().mockResolvedValue({
+          maxFeePerGas: 80n,
+          maxPriorityFeePerGas: 8n,
+        }),
+        getGasPrice: vi.fn(),
+        waitForTransactionReceipt: vi.fn().mockResolvedValue({ status: 'success' }),
+      };
+      const sendTransaction = vi.fn().mockResolvedValue(`0x${'22'.repeat(32)}`);
+      const walletClient = {
+        account: { address: from },
+        sendTransaction,
+      };
+
+      const result = await recoverStuckNonceIfNeeded({
+        publicClient: publicClient as never,
+        walletClient,
+        ledger,
+        from,
+        staleAfterMs: 30_000,
+        nowMs: 61_000,
+      });
+
+      expect(result?.recoveryHash).toBe(`0x${'22'.repeat(32)}`);
+      expect(sendTransaction).toHaveBeenCalledWith({
+        account: walletClient.account,
+        to: from,
+        value: 0n,
+        nonce: 7,
+        maxFeePerGas: 115n,
+        maxPriorityFeePerGas: 12n,
+      });
+      const resolved = await ledger.getTxSubmission({ chainId: 84532, from, nonce: 7 });
+      expect(resolved?.resolvedAtMs).toBe(61_000);
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #469.

- Persist submitted EOA nonce fee snapshots keyed by chain/from/nonce so replacement retries bump against the previously submitted fee, not only fresh RPC estimates.
- Pin explicit EOA nonce during generic and Safe transaction retries so resubmissions replace the pending tx.
- Add stuck nonce detection for `pending > latest` with an unresolved stale ledger entry, clearing via a 0-value self-transfer using replacement-bumped fees.
- Wire the daemon Store as the persisted tx submission ledger.

## Validation

- `cd client && yarn vitest run test/tx-retry.test.ts test/store/store.test.ts test/daemon/balance-topup-loop.test.ts test/earning/agent-wallet-binding.test.ts test/earning/migrate-agent-id.test.ts test/adapters/mech/eviction-recovery.test.ts test/earning/orphan-sweep.test.ts test/earning/stolas-claim.test.ts test/earning/bootstrap-mech-safe-direct.test.ts` -> 9 files, 92 tests passed
- `cd client && yarn typecheck` -> passed
- `cd client && yarn build` -> passed; Vite emitted the existing chunk-size warning

## Notes

A broader `yarn test` was attempted before the lightweight-mock compatibility guard landed. It exposed mocked-client failures that are now covered by the affected targeted rerun above; it also hit an existing helper startup timeout in `test/helpers/multi-op-daemon.test.ts`.
