### PR TITLE
feat(client): publish swe-rebench vetted pool artifact

### DIFF
--- a/client/src/adapters/mech/safe.ts
+++ b/client/src/adapters/mech/safe.ts
@@ -12,10 +12,9 @@ import { privateKeyToAccount } from 'viem/accounts';
 import { base } from 'viem/chains';
 import { SAFE_ABI } from './types.js';
 import {
-  getDefaultTxSubmissionLedger,
-  recoverStuckNonceIfNeeded,
+  type TxSubmissionLedger,
+  withNonceLedger,
   withRecoverableRetry,
-  viemFeeOverridesForAttempt,
 } from '../../tx-retry.js';
 import {
   SafeInnerRevertError,
@@ -37,6 +36,10 @@ export interface SafeTransactionParams {
   data: Hex;
 }
 
+export interface SafeExecutionOptions {
+  ledger?: TxSubmissionLedger;
+}
+
 // Per-Safe transaction lock to prevent nonce races when concurrent
 // loops (creator + harness) share the same Safe
 const safeLocks = new Map<string, Promise<void>>();
@@ -45,6 +48,7 @@ export async function executeSafeTransaction(
   publicClient: PublicClient,
   walletClient: WalletClient,
   params: SafeTransactionParams,
+  options: SafeExecutionOptions = {},
 ): Promise<Hex> {
   const lockKey = params.safeAddress.toLowerCase();
 
@@ -58,7 +62,7 @@ export async function executeSafeTransaction(
   await pending;
 
   try {
-    const hash = await executeSafeTransactionInner(publicClient, walletClient, params);
+    const hash = await executeSafeTransactionInner(publicClient, walletClient, params, options);
     return hash;
   } finally {
     releaseLock();
@@ -69,25 +73,20 @@ async function executeSafeTransactionInner(
   publicClient: PublicClient,
   walletClient: WalletClient,
   params: SafeTransactionParams,
+  options: SafeExecutionOptions,
 ): Promise<Hex> {
   const { safeAddress, to, value, data } = params;
   const account = walletClient.account;
   if (!account) throw new Error('Wallet client has no account');
-  const chainId = Number(await publicClient.getChainId());
   const from = account.address;
-  const ledger = getDefaultTxSubmissionLedger();
-  await recoverStuckNonceIfNeeded({
-    publicClient,
-    walletClient: walletClient as unknown as { account?: unknown; sendTransaction: (tx: any) => Promise<Hex> },
-    ledger,
-    from,
-  });
-  const eoaNonce = Number(await publicClient.getTransactionCount({
-    address: from,
-    blockTag: 'pending',
-  }));
 
-  return withRecoverableRetry(
+  return withNonceLedger({
+    publicClient,
+    walletClient,
+    ledger: options.ledger,
+    from,
+    recoverStuckNonce: true,
+  }, async (nonceLedger) => withRecoverableRetry(
     async (attemptIndex) => {
       const nonce = await publicClient.readContract({
         address: safeAddress,
@@ -122,9 +121,7 @@ async function executeSafeTransactionInner(
       sigBytes[64] = sigBytes[64] + 4;
       const safeSignature = `0x${sigBytes.toString('hex')}` as Hex;
 
-      const previous = await ledger.getTxSubmission({ chainId, from, nonce: eoaNonce });
-      const feeOverrides = await viemFeeOverridesForAttempt(publicClient, attemptIndex, {
-        previousFees: previous?.resolvedAtMs == null ? previous?.fees : undefined,
+      const feeResult = await nonceLedger.feeResultForAttempt(attemptIndex, {
         forceEstimate: true,
       });
 
@@ -149,8 +146,8 @@ async function executeSafeTransactionInner(
           account,
           chain: walletClient.chain,
           value: params.value,
-          nonce: eoaNonce,
-          ...feeOverrides,
+          nonce: nonceLedger.nonce,
+          ...feeResult.overrides,
         });
       } catch (writeErr) {
         // viem pre-flight gas estimation may revert with GS013 when the inner
@@ -173,14 +170,10 @@ async function executeSafeTransactionInner(
         }
         throw writeErr;
       }
-      await ledger.recordTxSubmission({
-        chainId,
-        from,
-        nonce: eoaNonce,
+      await nonceLedger.recordSubmitted({
         hash,
         logicalTx: 'safe.execTransaction',
-        submittedAtMs: Date.now(),
-        fees: feeOverrides,
+        fees: feeResult.snapshot,
         to: safeAddress,
         value: params.value,
         data,
@@ -206,12 +199,7 @@ async function executeSafeTransactionInner(
         }
         throw new Error(`Safe execTransaction reverted (GS026/GS013 possible stale nonce, txHash=${hash})`);
       }
-      await ledger.markTxSubmissionResolved({
-        chainId,
-        from,
-        nonce: eoaNonce,
-        resolvedAtMs: Date.now(),
-      });
+      await nonceLedger.markResolved();
       return hash;
     },
     {
@@ -219,7 +207,7 @@ async function executeSafeTransactionInner(
         console.error(`[safe/viem] execTransaction retry ${attempt}: ${message}`);
       },
     },
-  );
+  ));
 }
 
 export function createClients(rpcUrl: string, privateKey: Hex, chain?: Chain): { publicClient: PublicClient; walletClient: WalletClient; account: ReturnType<typeof privateKeyToAccount> } {

--- a/client/src/adapters/mech/safe.ts
+++ b/client/src/adapters/mech/safe.ts
@@ -12,6 +12,8 @@ import { privateKeyToAccount } from 'viem/accounts';
 import { base } from 'viem/chains';
 import { SAFE_ABI } from './types.js';
 import {
+  getDefaultTxSubmissionLedger,
+  recoverStuckNonceIfNeeded,
   withRecoverableRetry,
   viemFeeOverridesForAttempt,
 } from '../../tx-retry.js';
@@ -71,6 +73,19 @@ async function executeSafeTransactionInner(
   const { safeAddress, to, value, data } = params;
   const account = walletClient.account;
   if (!account) throw new Error('Wallet client has no account');
+  const chainId = Number(await publicClient.getChainId());
+  const from = account.address;
+  const ledger = getDefaultTxSubmissionLedger();
+  await recoverStuckNonceIfNeeded({
+    publicClient,
+    walletClient: walletClient as unknown as { account?: unknown; sendTransaction: (tx: any) => Promise<Hex> },
+    ledger,
+    from,
+  });
+  const eoaNonce = Number(await publicClient.getTransactionCount({
+    address: from,
+    blockTag: 'pending',
+  }));
 
   return withRecoverableRetry(
     async (attemptIndex) => {
@@ -107,7 +122,11 @@ async function executeSafeTransactionInner(
       sigBytes[64] = sigBytes[64] + 4;
       const safeSignature = `0x${sigBytes.toString('hex')}` as Hex;
 
-      const feeOverrides = await viemFeeOverridesForAttempt(publicClient, attemptIndex);
+      const previous = await ledger.getTxSubmission({ chainId, from, nonce: eoaNonce });
+      const feeOverrides = await viemFeeOverridesForAttempt(publicClient, attemptIndex, {
+        previousFees: previous?.resolvedAtMs == null ? previous?.fees : undefined,
+        forceEstimate: true,
+      });
 
       let hash: Hex;
       try {
@@ -130,6 +149,7 @@ async function executeSafeTransactionInner(
           account,
           chain: walletClient.chain,
           value: params.value,
+          nonce: eoaNonce,
           ...feeOverrides,
         });
       } catch (writeErr) {
@@ -153,6 +173,18 @@ async function executeSafeTransactionInner(
         }
         throw writeErr;
       }
+      await ledger.recordTxSubmission({
+        chainId,
+        from,
+        nonce: eoaNonce,
+        hash,
+        logicalTx: 'safe.execTransaction',
+        submittedAtMs: Date.now(),
+        fees: feeOverrides,
+        to: safeAddress,
+        value: params.value,
+        data,
+      });
       // Wait inside the retry attempt so reverted Safe executions caused by
       // stale nonce signatures (GS026/GS013) re-read nonce and re-sign.
       const receipt = await publicClient.waitForTransactionReceipt({ hash });
@@ -174,6 +206,12 @@ async function executeSafeTransactionInner(
         }
         throw new Error(`Safe execTransaction reverted (GS026/GS013 possible stale nonce, txHash=${hash})`);
       }
+      await ledger.markTxSubmissionResolved({
+        chainId,
+        from,
+        nonce: eoaNonce,
+        resolvedAtMs: Date.now(),
+      });
       return hash;
     },
     {

--- a/client/src/api/prediction-v1-build.ts
+++ b/client/src/api/prediction-v1-build.ts
@@ -42,6 +42,7 @@ export interface PredictionV1TaskRunSummary {
   implName: string | null;
   windowStartTs: number;
   windowEndTs: number;
+  runStartedAt: number | null;
   stateUpdatedAt: number;
   manifestCid: string | null;
   deliveryTxHash: string | null;
@@ -151,6 +152,7 @@ function toSummary(run: PersistedTaskRun): PredictionV1TaskRunSummary {
     implName: run.implName,
     windowStartTs: run.windowStartTs,
     windowEndTs: run.windowEndTs,
+    runStartedAt: run.runStartedAt,
     stateUpdatedAt: run.stateUpdatedAt,
     manifestCid: run.manifestCid,
     deliveryTxHash: run.deliveryTxHash,

--- a/client/src/api/task-runs-build.ts
+++ b/client/src/api/task-runs-build.ts
@@ -21,6 +21,7 @@ export interface TaskRunSummary {
   implName: string | null;
   windowStartTs: number;
   windowEndTs: number;
+  runStartedAt: number | null;
   stateUpdatedAt: number;
   manifestCid: string | null;
   deliveryTxHash: string | null;
@@ -109,6 +110,7 @@ function toSummary(run: PersistedTaskRun): TaskRunSummary {
     implName: run.implName,
     windowStartTs: run.windowStartTs,
     windowEndTs: run.windowEndTs,
+    runStartedAt: run.runStartedAt,
     stateUpdatedAt: run.stateUpdatedAt,
     manifestCid: run.manifestCid,
     deliveryTxHash: run.deliveryTxHash,

--- a/client/src/daemon/daemon.ts
+++ b/client/src/daemon/daemon.ts
@@ -502,9 +502,11 @@ export class Daemon {
       }
 
       let request;
+      let runStartedAt: number;
       try {
         request = await this.adapter.claimTask(taskAnnouncement.taskId);
         this.store.recordOwnActivity(request.requestId, 'claimed');
+        runStartedAt = Date.now();
       } catch (err) {
         console.error(
           `[daemon] claimTask failed for task ${taskAnnouncement.taskId}:`,
@@ -546,6 +548,7 @@ export class Daemon {
           taskRole: (request.task.role ?? 'restoration') as 'restoration' | 'evaluation',
           windowStartTs,
           windowEndTs,
+          runStartedAt,
           task: request.task,
         });
 

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -54,6 +54,7 @@ interface TaskRunRow {
   implName?: string | null;
   windowStartTs?: number;
   windowEndTs?: number;
+  runStartedAt?: number | null;
   stateUpdatedAt: number;
   manifestCid?: string | null;
   deliveryTxHash?: string | null;
@@ -403,6 +404,7 @@ export function OverviewPage(): JSX.Element {
           state: r.state,
           implName: r.implName ?? null,
           windowStartTs: r.windowStartTs ?? 0,
+          runStartedAt: r.runStartedAt ?? null,
           stateUpdatedAt: r.stateUpdatedAt,
           deliveryTxHash: r.deliveryTxHash ?? null,
         });

--- a/client/src/dashboard/spa/src/pages/overview/ActivityCard.test.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/ActivityCard.test.tsx
@@ -38,6 +38,7 @@ const baseTask: ActivityTask = {
   state: 'COMPLETE',
   implName: 'hermes-agent',
   windowStartTs: Date.now() - 120_000,
+  runStartedAt: Date.now() - 120_000,
   stateUpdatedAt: Date.now() - 60_000,
   deliveryTxHash: null,
 };
@@ -91,6 +92,32 @@ describe('ActivityCard', () => {
     expect(table.textContent).toMatch(/running/i);
     expect(table.textContent).toMatch(/solver/i);
     expect(table.textContent).toMatch(/evaluator/i);
+  });
+
+  it('shows STARTED from runStartedAt instead of an old task window start', () => {
+    const now = Date.now();
+    const sixDaysAgo = now - 6 * 86_400_000;
+    const twoMinutesAgo = now - 120_000;
+    const { ui } = wrap(
+      <ActivityCard
+        joined={joined}
+        tasks={[
+          {
+            ...baseTask,
+            requestId: 'fresh-claim',
+            windowStartTs: sixDaysAgo,
+            runStartedAt: twoMinutesAgo,
+            stateUpdatedAt: twoMinutesAgo,
+          },
+        ]}
+      />,
+    );
+
+    render(ui);
+
+    const row = screen.getByTestId('activity-task-row-fresh-claim');
+    expect(row.textContent).toMatch(/2m ago/);
+    expect(row.textContent).not.toMatch(/6d ago/);
   });
 
   it('renders the empty-tasks state when there are no task runs', () => {

--- a/client/src/dashboard/spa/src/pages/overview/ActivityCard.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/ActivityCard.tsx
@@ -51,8 +51,10 @@ export interface ActivityTask {
   state: string;
   /** Harness/impl name the task ran under. */
   implName: string | null;
-  /** Unix ms timestamp the run claimed (window-start). */
+  /** Unix ms timestamp for the task's execution window start. */
   windowStartTs: number;
+  /** Unix ms timestamp captured when this operator successfully claimed the run. */
+  runStartedAt: number | null;
   /** Unix ms timestamp of the last state update. */
   stateUpdatedAt: number;
   /** Optional on-chain delivery tx for explorer linking. */
@@ -332,9 +334,7 @@ export function ActivityCard({ joined, tasks }: ActivityCardProps): JSX.Element 
                                 </Badge>
                               </TableCell>
                               <TableCell className="text-muted-foreground">
-                                {formatRelative(
-                                  t.windowStartTs || t.stateUpdatedAt,
-                                )}
+                                {formatRelative(t.runStartedAt ?? t.stateUpdatedAt)}
                               </TableCell>
                             </TableRow>
                           );

--- a/client/src/earning/safe-adapter.ts
+++ b/client/src/earning/safe-adapter.ts
@@ -21,10 +21,16 @@ import {
   type Address,
   type Chain,
   type Hex,
+  type PublicClient,
 } from 'viem';
 import { base, baseSepolia } from 'viem/chains';
 import { privateKeyToAccount } from 'viem/accounts';
-import { viemFeeOverridesForAttempt, withRecoverableRetry } from '../tx-retry.js';
+import {
+  getDefaultTxSubmissionLedger,
+  recoverStuckNonceIfNeeded,
+  viemFeeOverridesForAttempt,
+  withRecoverableRetry,
+} from '../tx-retry.js';
 
 export type { MetaTransactionData, TransactionResult };
 
@@ -272,6 +278,17 @@ export async function executeSafeTxDirect(opts: {
   const to = opts.to as Address;
   const value = opts.value ?? 0n;
   const explicitGasLimit = opts.gasLimit;
+  const ledger = getDefaultTxSubmissionLedger();
+  await recoverStuckNonceIfNeeded({
+    publicClient: publicClient as PublicClient,
+    walletClient,
+    ledger,
+    from: account.address,
+  });
+  const eoaNonce = Number(await publicClient.getTransactionCount({
+    address: account.address,
+    blockTag: 'pending',
+  }));
 
   const hash = await withRecoverableRetry(
     async (attemptIndex) => {
@@ -333,12 +350,21 @@ export async function executeSafeTxDirect(opts: {
         }
       }
 
-      const feeOverrides = await viemFeeOverridesForAttempt(publicClient, attemptIndex);
+      const previous = await ledger.getTxSubmission({
+        chainId,
+        from: account.address,
+        nonce: eoaNonce,
+      });
+      const feeOverrides = await viemFeeOverridesForAttempt(publicClient, attemptIndex, {
+        previousFees: previous?.resolvedAtMs == null ? previous?.fees : undefined,
+        forceEstimate: true,
+      });
       const txParams: Parameters<typeof walletClient.sendTransaction>[0] = {
         account,
         to: safeAddress,
         data,
         gas: resolvedGas + BigInt(attemptIndex) * 50_000n,
+        nonce: eoaNonce,
         ...feeOverrides,
       };
       if (
@@ -349,7 +375,20 @@ export async function executeSafeTxDirect(opts: {
       ) {
         delete (txParams as { gasPrice?: bigint }).gasPrice;
       }
-      return walletClient.sendTransaction(txParams);
+      const hash = await walletClient.sendTransaction(txParams);
+      await ledger.recordTxSubmission({
+        chainId,
+        from: account.address,
+        nonce: eoaNonce,
+        hash,
+        logicalTx: 'safe.execTransaction.direct',
+        submittedAtMs: Date.now(),
+        fees: feeOverrides,
+        to: safeAddress,
+        data,
+        value: 0n,
+      });
+      return hash;
     },
     {
       onRetry: ({ attempt, message }) => {

--- a/client/src/earning/safe-adapter.ts
+++ b/client/src/earning/safe-adapter.ts
@@ -21,14 +21,13 @@ import {
   type Address,
   type Chain,
   type Hex,
-  type PublicClient,
 } from 'viem';
 import { base, baseSepolia } from 'viem/chains';
 import { privateKeyToAccount } from 'viem/accounts';
 import {
-  getDefaultTxSubmissionLedger,
-  recoverStuckNonceIfNeeded,
-  viemFeeOverridesForAttempt,
+  removeConflictingLegacyGasPrice,
+  type TxSubmissionLedger,
+  withNonceLedger,
   withRecoverableRetry,
 } from '../tx-retry.js';
 
@@ -259,6 +258,7 @@ export async function executeSafeTxDirect(opts: {
   value?: bigint;
   data: Hex;
   gasLimit?: bigint;
+  ledger?: TxSubmissionLedger;
 }): Promise<{ hash: string }> {
   const executionRpcUrl = await resolveExecutionRpcUrl(opts.rpcUrl);
   const chainId = await createPublicClient({ transport: http(executionRpcUrl) }).getChainId();
@@ -278,19 +278,15 @@ export async function executeSafeTxDirect(opts: {
   const to = opts.to as Address;
   const value = opts.value ?? 0n;
   const explicitGasLimit = opts.gasLimit;
-  const ledger = getDefaultTxSubmissionLedger();
-  await recoverStuckNonceIfNeeded({
-    publicClient: publicClient as PublicClient,
-    walletClient,
-    ledger,
-    from: account.address,
-  });
-  const eoaNonce = Number(await publicClient.getTransactionCount({
-    address: account.address,
-    blockTag: 'pending',
-  }));
 
-  const hash = await withRecoverableRetry(
+  const hash = await withNonceLedger({
+    publicClient,
+    walletClient,
+    ledger: opts.ledger,
+    from: account.address,
+    chainId,
+    recoverStuckNonce: true,
+  }, async (nonceLedger) => withRecoverableRetry(
     async (attemptIndex) => {
       const nonce = await publicClient.readContract({
         address: safeAddress,
@@ -350,13 +346,7 @@ export async function executeSafeTxDirect(opts: {
         }
       }
 
-      const previous = await ledger.getTxSubmission({
-        chainId,
-        from: account.address,
-        nonce: eoaNonce,
-      });
-      const feeOverrides = await viemFeeOverridesForAttempt(publicClient, attemptIndex, {
-        previousFees: previous?.resolvedAtMs == null ? previous?.fees : undefined,
+      const feeResult = await nonceLedger.feeResultForAttempt(attemptIndex, {
         forceEstimate: true,
       });
       const txParams: Parameters<typeof walletClient.sendTransaction>[0] = {
@@ -364,26 +354,15 @@ export async function executeSafeTxDirect(opts: {
         to: safeAddress,
         data,
         gas: resolvedGas + BigInt(attemptIndex) * 50_000n,
-        nonce: eoaNonce,
-        ...feeOverrides,
+        nonce: nonceLedger.nonce,
+        ...feeResult.overrides,
       };
-      if (
-        'maxFeePerGas' in txParams &&
-        txParams.maxFeePerGas !== undefined &&
-        'maxPriorityFeePerGas' in txParams &&
-        txParams.maxPriorityFeePerGas !== undefined
-      ) {
-        delete (txParams as { gasPrice?: bigint }).gasPrice;
-      }
+      removeConflictingLegacyGasPrice(txParams);
       const hash = await walletClient.sendTransaction(txParams);
-      await ledger.recordTxSubmission({
-        chainId,
-        from: account.address,
-        nonce: eoaNonce,
+      await nonceLedger.recordSubmitted({
         hash,
         logicalTx: 'safe.execTransaction.direct',
-        submittedAtMs: Date.now(),
-        fees: feeOverrides,
+        fees: feeResult.snapshot,
         to: safeAddress,
         data,
         value: 0n,
@@ -395,7 +374,7 @@ export async function executeSafeTxDirect(opts: {
         console.error(`[safe-adapter] executeSafeTxDirect retry ${attempt}: ${message}`);
       },
     },
-  );
+  ));
 
   return { hash };
 }

--- a/client/src/harnesses/engine/persistence.ts
+++ b/client/src/harnesses/engine/persistence.ts
@@ -60,6 +60,7 @@ CREATE TABLE IF NOT EXISTS task_runs (
 
   window_start_ts         INTEGER NOT NULL,
   window_end_ts           INTEGER NOT NULL,
+  run_started_at          INTEGER,
 
   pre_snapshot_captured_at  INTEGER,
   pre_snapshot_payload      TEXT,
@@ -127,6 +128,8 @@ export interface PersistedTaskRunInput {
   taskRole?: 'restoration' | 'evaluation';
   windowStartTs: number;
   windowEndTs: number;
+  /** Unix ms timestamp captured when this operator successfully claimed the run. */
+  runStartedAt?: number;
   /**
    * Full Task payload, captured at observe() time.
    * Required: production callers always thread it (daemon.ts); making this
@@ -157,6 +160,8 @@ export interface PersistedTaskRun {
 
   windowStartTs: number;
   windowEndTs: number;
+  /** Unix ms timestamp captured when this operator successfully claimed the run. */
+  runStartedAt: number | null;
 
   preSnapshotCapturedAt: number | null;
   preSnapshotPayload: unknown | null;    // deserialized JSON
@@ -262,6 +267,7 @@ interface RawRow {
   impl_state_dir: string | null;
   window_start_ts: number;
   window_end_ts: number;
+  run_started_at: number | null;
   pre_snapshot_captured_at: number | null;
   pre_snapshot_payload: string | null;
   post_snapshot_captured_at: number | null;
@@ -304,6 +310,7 @@ function runAdditiveMigrations(db: Database.Database): void {
     { column: 'task_role',           ddl: 'ALTER TABLE task_runs ADD COLUMN task_role TEXT' },
     { column: 'task_id',             ddl: 'ALTER TABLE task_runs ADD COLUMN task_id TEXT' },
     { column: 'attempt_index',       ddl: 'ALTER TABLE task_runs ADD COLUMN attempt_index INTEGER' },
+    { column: 'run_started_at',      ddl: 'ALTER TABLE task_runs ADD COLUMN run_started_at INTEGER' },
     // ERC-8004 payload v2 (jinn-mono-9fe5): persists executor mode + codeDigest
     // from pack() so deliver() can emit a v2 setMetadata payload after the
     // transient maps are cleared.
@@ -353,6 +360,7 @@ function rowToTaskRun(row: RawRow): PersistedTaskRun {
     implStateDir: row.impl_state_dir,
     windowStartTs: row.window_start_ts,
     windowEndTs: row.window_end_ts,
+    runStartedAt: row.run_started_at,
     preSnapshotCapturedAt: row.pre_snapshot_captured_at,
     preSnapshotPayload: parseJson(row.pre_snapshot_payload),
     postSnapshotCapturedAt: row.post_snapshot_captured_at,
@@ -396,14 +404,15 @@ export class TaskRunPersistence {
    * `requestId` already exists, this is a no-op (INSERT OR IGNORE).
    */
   insertDiscovered(input: PersistedTaskRunInput): void {
+    const now = Date.now();
     this.db.prepare(`
       INSERT OR IGNORE INTO task_runs (
         request_id, task_id, attempt_index, task_cid, onchain_creation_tx, onchain_creation_block,
-        solver_type, task_role, state, state_updated_at, window_start_ts, window_end_ts,
+        solver_type, task_role, state, state_updated_at, window_start_ts, window_end_ts, run_started_at,
         task_payload
       ) VALUES (
         @requestId, @taskId, @attemptIndex, @taskCid, @onchainCreationTx, @onchainCreationBlock,
-        @solverType, @taskRole, 'DISCOVERED', @now, @windowStartTs, @windowEndTs,
+        @solverType, @taskRole, 'DISCOVERED', @now, @windowStartTs, @windowEndTs, @runStartedAt,
         @taskPayload
       )
     `).run({
@@ -415,9 +424,10 @@ export class TaskRunPersistence {
       onchainCreationBlock: input.onchainCreationBlock,
       solverType: input.solverType ?? null,
       taskRole: input.taskRole ?? null,
-      now: Date.now(),
+      now,
       windowStartTs: input.windowStartTs,
       windowEndTs: input.windowEndTs,
+      runStartedAt: input.runStartedAt ?? now,
       taskPayload: input.task ? JSON.stringify(input.task) : null,
     });
   }

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
@@ -120,6 +120,11 @@ export interface PythonEvalRunnerOptions {
    */
   pruneRound?: (image: string) => Promise<void>;
   /**
+   * Resolves the eval image digest while the image is still local, before
+   * per-round pruning removes it. Defaults to `docker image inspect`.
+   */
+  resolveImageDigest?: (image: string) => Promise<string | null>;
+  /**
    * Required free disk (bytes) before an eval round starts. Explicit value >
    * `JINN_EVAL_DISK_FLOOR_GB` env > {@link DEFAULT_EVAL_DISK_FLOOR_BYTES}.
    */
@@ -163,6 +168,36 @@ async function defaultPruneRound(image: string): Promise<void> {
   if (image) await runDocker(['rmi', '-f', image]);
   await runDocker(['container', 'prune', '-f']);
   await runDocker(['builder', 'prune', '-f']);
+}
+
+function runDockerForOutput(args: string[]): Promise<{ exitCode: number; stdout: string }> {
+  return new Promise((resolve) => {
+    const child = spawn('docker', args, { stdio: ['ignore', 'pipe', 'ignore'] });
+    let stdout = '';
+    child.stdout?.on('data', (d) => { stdout += d.toString(); });
+    child.on('exit', (code) => {
+      resolve({ exitCode: code ?? 1, stdout });
+    });
+    child.on('error', () => {
+      resolve({ exitCode: 1, stdout: '' });
+    });
+  });
+}
+
+async function defaultResolveImageDigest(imageName: string): Promise<string | null> {
+  const res = await runDockerForOutput([
+    'image', 'inspect', imageName, '--format', '{{json .RepoDigests}}',
+  ]);
+  if (res.exitCode !== 0) return null;
+  let parsed: unknown;
+  try { parsed = JSON.parse(res.stdout.trim()); } catch { return null; }
+  if (!Array.isArray(parsed) || parsed.length === 0) return null;
+  const first = parsed[0];
+  if (typeof first !== 'string') return null;
+  const at = first.indexOf('@');
+  if (at === -1) return null;
+  const digest = first.slice(at + 1);
+  return /^sha256:[0-9a-f]{64}$/.test(digest) ? digest : null;
 }
 
 /**
@@ -248,12 +283,14 @@ export class PythonEvalRunner implements EvalRunner {
   private readonly diskFloorBytes: number;
   private readonly freeDiskBytes: () => Promise<number>;
   private readonly systemPrune: () => Promise<void>;
+  private readonly resolveImageDigest: (image: string) => Promise<string | null>;
 
   constructor(private readonly opts: PythonEvalRunnerOptions) {
     this.pruneRound = opts.pruneRound ?? defaultPruneRound;
     this.diskFloorBytes = resolveDiskFloorBytes(opts.diskFloorBytes);
     this.freeDiskBytes = opts.freeDiskBytes ?? defaultFreeDiskBytes;
     this.systemPrune = opts.systemPrune ?? (() => runDocker(['system', 'prune', '-f']));
+    this.resolveImageDigest = opts.resolveImageDigest ?? defaultResolveImageDigest;
   }
 
   /**
@@ -276,7 +313,18 @@ export class PythonEvalRunner implements EvalRunner {
   async runEval(args: Parameters<EvalRunner['runEval']>[0]): ReturnType<EvalRunner['runEval']> {
     await this.ensureDiskHeadroom();
     try {
-      return await this.runEvalImpl(args);
+      const result = await this.runEvalImpl(args);
+      let imageDigest: string | null = null;
+      try {
+        imageDigest = await this.resolveImageDigest(args.image);
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        console.warn(`[swe-rebench-v2] resolveImageDigest failed for ${args.image}: ${reason}`);
+      }
+      return {
+        ...result,
+        ...(imageDigest ? { imageDigest } : {}),
+      };
     } finally {
       // Prune this round's full Docker footprint — even when the eval threw,
       // a pull-and-crash still left an image on disk (#476).

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.ts
@@ -31,6 +31,10 @@ import { mkdtemp, writeFile, readFile, rm, statfs } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
 import type { EvalRunner } from './index.js';
+import {
+  defaultCommandRunner,
+  resolveImageDigest as resolveSubstrateImageDigest,
+} from '../../../solver-types/_swe-rebench-v2-substrate.js';
 
 /**
  * Thrown when the eval could not actually grade the solution. There is no
@@ -143,21 +147,20 @@ export interface PythonEvalRunnerOptions {
  * command is logged, never thrown (#476: cleanup must not break the eval loop).
  */
 function runDocker(args: string[]): Promise<void> {
-  return new Promise((resolve) => {
-    const child = spawn('docker', args, { stdio: ['ignore', 'ignore', 'ignore'] });
-    child.on('exit', (code, signal) => {
-      if (code !== 0) {
-        const status =
-          code !== null ? `exited ${code}` : `terminated by signal ${signal ?? 'unknown'}`;
-        console.warn(`[swe-rebench-v2] docker ${args.join(' ')} ${status}`);
+  return defaultCommandRunner('docker', args)
+    .then((res) => {
+      if (res.exitCode !== 0) {
+        const detail = (res.stderr || res.stdout).trim();
+        console.warn(
+          `[swe-rebench-v2] docker ${args.join(' ')} exited ${res.exitCode}` +
+            `${detail ? `: ${detail.slice(-500)}` : ''}`,
+        );
       }
-      resolve();
+    })
+    .catch((err: unknown) => {
+      const reason = err instanceof Error ? err.message : String(err);
+      console.warn(`[swe-rebench-v2] docker ${args.join(' ')} failed to spawn: ${reason}`);
     });
-    child.on('error', (err) => {
-      console.warn(`[swe-rebench-v2] docker ${args.join(' ')} failed to spawn: ${err.message}`);
-      resolve();
-    });
-  });
 }
 
 /**
@@ -170,34 +173,8 @@ async function defaultPruneRound(image: string): Promise<void> {
   await runDocker(['builder', 'prune', '-f']);
 }
 
-function runDockerForOutput(args: string[]): Promise<{ exitCode: number; stdout: string }> {
-  return new Promise((resolve) => {
-    const child = spawn('docker', args, { stdio: ['ignore', 'pipe', 'ignore'] });
-    let stdout = '';
-    child.stdout?.on('data', (d) => { stdout += d.toString(); });
-    child.on('exit', (code) => {
-      resolve({ exitCode: code ?? 1, stdout });
-    });
-    child.on('error', () => {
-      resolve({ exitCode: 1, stdout: '' });
-    });
-  });
-}
-
 async function defaultResolveImageDigest(imageName: string): Promise<string | null> {
-  const res = await runDockerForOutput([
-    'image', 'inspect', imageName, '--format', '{{json .RepoDigests}}',
-  ]);
-  if (res.exitCode !== 0) return null;
-  let parsed: unknown;
-  try { parsed = JSON.parse(res.stdout.trim()); } catch { return null; }
-  if (!Array.isArray(parsed) || parsed.length === 0) return null;
-  const first = parsed[0];
-  if (typeof first !== 'string') return null;
-  const at = first.indexOf('@');
-  if (at === -1) return null;
-  const digest = first.slice(at + 1);
-  return /^sha256:[0-9a-f]{64}$/.test(digest) ? digest : null;
+  return resolveSubstrateImageDigest(imageName, defaultCommandRunner);
 }
 
 /**

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/harness.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/harness.ts
@@ -61,6 +61,10 @@ import {
   defaultStateDir as defaultSolverTypeStateDir,
   loadSweRebenchV2Pool,
 } from '../../../solver-types/swe-rebench-v2.js';
+import {
+  PoolCacheStore,
+  loadPoolWithCacheFallback,
+} from '../../../solver-types/_swe-rebench-v2-pool-cache.js';
 
 const DEFAULT_IPFS_REGISTRY_URL = 'https://registry.autonolas.tech';
 const UPSTREAM_REPO_URL = 'https://github.com/SWE-rebench/SWE-rebench-V2.git';
@@ -151,6 +155,10 @@ export class SweRebenchV2EvaluatorHarness implements Harness {
    * call and the disk-budget bead (jinn-mono-uy6v.11) is a no-op.
    */
   private cachedRunner: EvalRunner | undefined;
+  private cachedFetcher: HfFetcher | undefined;
+  private cachedPool:
+    | { stateDir: string; promise: Promise<PoolTask[]> }
+    | undefined;
 
   constructor(opts: SweRebenchV2EvaluatorHarnessOptions = {}) {
     this.stub = opts.stub ?? false;
@@ -175,6 +183,39 @@ export class SweRebenchV2EvaluatorHarness implements Harness {
       this.cachedRunner = make({ upstreamRepoDir });
     }
     return this.cachedRunner;
+  }
+
+  private getFetcher(): HfFetcher {
+    if (this.deps.fetcher) return this.deps.fetcher;
+    if (!this.cachedFetcher) {
+      this.cachedFetcher = new HttpHfFetcher();
+    }
+    return this.cachedFetcher;
+  }
+
+  private loadPoolForRecheck(stateDir: string): Promise<PoolTask[]> {
+    if (!this.cachedPool || this.cachedPool.stateDir !== stateDir) {
+      const loadPool = this.deps.loadPool ?? loadSweRebenchV2Pool;
+      const promise = loadPoolWithCacheFallback({
+        loadPool,
+        cache: new PoolCacheStore({ stateDir }),
+        currentPool: [],
+      }).then((result) => {
+        if (result.pool.length > 0) return result.pool;
+        if (result.error) {
+          throw new Error(result.error.message);
+        }
+        return result.pool;
+      });
+      this.cachedPool = { stateDir, promise };
+    }
+    const cached = this.cachedPool;
+    return cached.promise.catch((err) => {
+      if (this.cachedPool === cached) {
+        this.cachedPool = undefined;
+      }
+      throw err;
+    });
   }
 
   private async isDockerReachable(now: number = Date.now()): Promise<boolean> {
@@ -504,18 +545,21 @@ export class SweRebenchV2EvaluatorHarness implements Harness {
       this.deps.stateDir ??
       process.env['JINN_SWE_REBENCH_V2_STATE_DIR'] ??
       defaultSolverTypeStateDir();
-    const recheckFetcher: HfFetcher = this.deps.fetcher ?? new HttpHfFetcher();
-    const loadPool = this.deps.loadPool ?? loadSweRebenchV2Pool;
-    const recheckRow = await this.recheckSubstrate(task, recheckFetcher, loadPool, stateDir);
+    const fetcher: HfFetcher = this.getFetcher();
+    const recheckRow = await this.recheckSubstrate(
+      task,
+      fetcher,
+      () => this.loadPoolForRecheck(stateDir),
+      stateDir,
+    );
     // ── End substrate recheck ─────────────────────────────────────────────────
 
-    const fetcher: HfFetcher = this.deps.fetcher ?? new HttpHfFetcher();
     const runner: EvalRunner = this.getRunner(state.upstreamRepoDir);
     const evaluator = new SweRebenchV2Evaluator({ fetcher, runner });
 
     let graded: Awaited<ReturnType<SweRebenchV2Evaluator['grade']>>;
     try {
-      graded = await evaluator.grade({ task, solutionPayload });
+      graded = await evaluator.grade({ task, solutionPayload, row: recheckRow });
     } catch (err) {
       if (err instanceof EvalCouldNotGradeError) {
         // The eval never actually graded the solution (Docker down, patch

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/harness.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/harness.ts
@@ -53,6 +53,7 @@ import {
   loadVettedPoolArtifactScorableEntries,
   parseVettedPoolArtifact,
   vettedPoolArtifactRefFromEligibility,
+  type ScorableVettedPoolArtifactEntries,
 } from '../../../solver-types/_swe-rebench-v2-validated-pool.js';
 import {
   computeRowHash,
@@ -87,6 +88,12 @@ interface EnabledState {
   enabled: true;
   enabledAt: string;
   upstreamRepoDir: string;
+}
+
+interface CachedPublishedPoolArtifact {
+  evalSemanticsVersion: string;
+  artifactHash: string;
+  entries: ScorableVettedPoolArtifactEntries;
 }
 
 export interface SweRebenchV2EvaluatorHarnessOptions {
@@ -168,6 +175,7 @@ export class SweRebenchV2EvaluatorHarness implements Harness {
   private cachedPool:
     | { stateDir: string; promise: Promise<PoolTask[]> }
     | undefined;
+  private readonly publishedPoolArtifactCache = new Map<string, Promise<CachedPublishedPoolArtifact>>();
 
   constructor(opts: SweRebenchV2EvaluatorHarnessOptions = {}) {
     this.stub = opts.stub ?? false;
@@ -226,6 +234,46 @@ export class SweRebenchV2EvaluatorHarness implements Harness {
       }
       throw err;
     });
+  }
+
+  private loadPublishedPoolArtifact(artifactCid: string): Promise<CachedPublishedPoolArtifact> {
+    const cached = this.publishedPoolArtifactCache.get(artifactCid);
+    if (cached) return cached;
+
+    const fetchArtifact = this.deps.fetchFromIpfs ?? fetchFromIpfs;
+    const promise = (async () => {
+      let rawArtifact: unknown;
+      try {
+        rawArtifact = await fetchArtifact(this.ipfsGatewayUrl, artifactCid);
+      } catch (err) {
+        throw new SkippableError(
+          'vetted_pool_fetch_failed',
+          `cannot fetch vetted pool artifact ${artifactCid}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      try {
+        const artifact = parseVettedPoolArtifact(rawArtifact);
+        return {
+          evalSemanticsVersion: artifact.evalSemanticsVersion,
+          artifactHash: hashVettedPoolArtifact(artifact),
+          entries: loadVettedPoolArtifactScorableEntries(artifact),
+        };
+      } catch (err) {
+        throw new SkippableError(
+          'vetted_pool_artifact_invalid',
+          `invalid vetted pool artifact ${artifactCid}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    })();
+
+    this.publishedPoolArtifactCache.set(artifactCid, promise);
+    promise.catch(() => {
+      if (this.publishedPoolArtifactCache.get(artifactCid) === promise) {
+        this.publishedPoolArtifactCache.delete(artifactCid);
+      }
+    });
+    return promise;
   }
 
   private async isDockerReachable(now: number = Date.now()): Promise<boolean> {
@@ -542,28 +590,14 @@ export class SweRebenchV2EvaluatorHarness implements Harness {
       );
     }
 
-    const fetchArtifact = this.deps.fetchFromIpfs ?? fetchFromIpfs;
-    let rawArtifact: unknown;
+    const artifact = await this.loadPublishedPoolArtifact(ref.artifactCid);
     try {
-      rawArtifact = await fetchArtifact(this.ipfsGatewayUrl, ref.artifactCid);
-    } catch (err) {
-      throw new SkippableError(
-        'vetted_pool_fetch_failed',
-        `cannot fetch vetted pool artifact ${ref.artifactCid}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
-
-    let entries;
-    try {
-      const artifact = parseVettedPoolArtifact(rawArtifact);
       if (artifact.evalSemanticsVersion !== ref.evalSemanticsVersion) {
         throw new Error(`artifact semanticsVersion=${artifact.evalSemanticsVersion} does not match ref=${ref.evalSemanticsVersion}`);
       }
-      const actualHash = hashVettedPoolArtifact(artifact);
-      if (actualHash !== ref.artifactHash) {
-        throw new Error(`artifact hash ${actualHash} does not match ref ${ref.artifactHash}`);
+      if (artifact.artifactHash !== ref.artifactHash) {
+        throw new Error(`artifact hash ${artifact.artifactHash} does not match ref ${ref.artifactHash}`);
       }
-      entries = loadVettedPoolArtifactScorableEntries(artifact);
     } catch (err) {
       throw new SkippableError(
         'vetted_pool_artifact_invalid',
@@ -571,7 +605,7 @@ export class SweRebenchV2EvaluatorHarness implements Harness {
       );
     }
 
-    if (!entries.byId.has(task.instance_id)) {
+    if (!artifact.entries.byId.has(task.instance_id)) {
       throw new SkippableError(
         'vetted_pool_instance_missing_or_unscorable',
         `${task.instance_id} is not present as scorable in vetted pool artifact ${ref.artifactCid}`,

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/harness.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/harness.ts
@@ -38,7 +38,7 @@ import type {
 import { REQUIRES_LIVE_DAEMON_READINESS, SkippableError } from '../../types.js';
 import type { Task } from '../../../types/task.js';
 import { SignedEnvelopeSchema, normalizeEnvelopeRole } from '../../../types/envelope.js';
-import { uploadToIpfs } from '../../../adapters/mech/ipfs.js';
+import { fetchFromIpfs, uploadToIpfs } from '../../../adapters/mech/ipfs.js';
 import { SweRebenchV2Evaluator, type EvalRunner, type HfFetcher, type HfRow } from './index.js';
 import {
   PythonEvalRunner,
@@ -49,6 +49,10 @@ import { HttpHfFetcher } from './hf-fetcher.js';
 import {
   ValidatedPoolStore,
   EVAL_SEMANTICS_VERSION,
+  hashVettedPoolArtifact,
+  loadVettedPoolArtifactScorableEntries,
+  parseVettedPoolArtifact,
+  vettedPoolArtifactRefFromEligibility,
 } from '../../../solver-types/_swe-rebench-v2-validated-pool.js';
 import {
   computeRowHash,
@@ -67,6 +71,7 @@ import {
 } from '../../../solver-types/_swe-rebench-v2-pool-cache.js';
 
 const DEFAULT_IPFS_REGISTRY_URL = 'https://registry.autonolas.tech';
+const DEFAULT_IPFS_GATEWAY_URL = 'https://gateway.autonolas.tech';
 const UPSTREAM_REPO_URL = 'https://github.com/SWE-rebench/SWE-rebench-V2.git';
 const STATE_FILE = 'state.json';
 const ENABLE_CLI = 'jinn harnesses enable swe-rebench-v2-evaluator';
@@ -95,6 +100,8 @@ export interface SweRebenchV2EvaluatorHarnessOptions {
   implStateDir?: string;
   /** IPFS registry URL used to pin test logs. Defaults to Autonolas gateway. */
   ipfsRegistryUrl?: string;
+  /** IPFS gateway URL used to fetch launcher-published vetted pool artifacts. */
+  ipfsGatewayUrl?: string;
   /**
    * Test-only injection points. Production runs use Node's child_process
    * + node:fs + the bundled HFFetcher / PythonEvalRunner.
@@ -118,6 +125,7 @@ export interface SweRebenchV2EvaluatorHarnessOptions {
      */
     makeRunner?: (opts: PythonEvalRunnerOptions) => EvalRunner;
     uploadToIpfs?: typeof uploadToIpfs;
+    fetchFromIpfs?: typeof fetchFromIpfs;
     /**
      * Override the state directory used for the {@link ValidatedPoolStore}
      * substrate-recheck. Defaults to `JINN_SWE_REBENCH_V2_STATE_DIR` env
@@ -140,6 +148,7 @@ export class SweRebenchV2EvaluatorHarness implements Harness {
   private readonly stub: boolean;
   private readonly implStateDir: string | undefined;
   private readonly ipfsRegistryUrl: string;
+  private readonly ipfsGatewayUrl: string;
   private readonly deps: NonNullable<SweRebenchV2EvaluatorHarnessOptions['_testDeps']>;
   /** The engine's claim-eligibility check calls `isReady()` per candidate
    *  task per tick (~17 Hz potential). Cache the live `docker info` result
@@ -164,6 +173,7 @@ export class SweRebenchV2EvaluatorHarness implements Harness {
     this.stub = opts.stub ?? false;
     this.implStateDir = opts.implStateDir;
     this.ipfsRegistryUrl = opts.ipfsRegistryUrl ?? DEFAULT_IPFS_REGISTRY_URL;
+    this.ipfsGatewayUrl = opts.ipfsGatewayUrl ?? process.env['JINN_IPFS_GATEWAY_URL'] ?? DEFAULT_IPFS_GATEWAY_URL;
     this.deps = opts._testDeps ?? {};
   }
 
@@ -503,6 +513,85 @@ export class SweRebenchV2EvaluatorHarness implements Harness {
     return recheckRow;
   }
 
+  private async loadPublishedPoolRow(
+    task: ReturnType<typeof SweRebenchV2TaskSchema.parse>,
+    runtimeTask: Task,
+    fetcher: HfFetcher,
+  ): Promise<HfRow | null> {
+    let ref;
+    try {
+      ref = vettedPoolArtifactRefFromEligibility(runtimeTask.eligibility);
+    } catch (err) {
+      throw new SkippableError(
+        'vetted_pool_ref_invalid',
+        `invalid vetted pool ref: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    if (!ref) return null;
+
+    if (runtimeTask.solverNetManifestCid && ref.manifestCid !== runtimeTask.solverNetManifestCid) {
+      throw new SkippableError(
+        'vetted_pool_manifest_mismatch',
+        `vetted pool ref manifestCid ${ref.manifestCid} does not match task manifestCid ${runtimeTask.solverNetManifestCid}`,
+      );
+    }
+    if (ref.evalSemanticsVersion !== EVAL_SEMANTICS_VERSION) {
+      throw new SkippableError(
+        'vetted_pool_semantics_mismatch',
+        `vetted pool ref semanticsVersion=${ref.evalSemanticsVersion} does not match evaluator semanticsVersion=${EVAL_SEMANTICS_VERSION}`,
+      );
+    }
+
+    const fetchArtifact = this.deps.fetchFromIpfs ?? fetchFromIpfs;
+    let rawArtifact: unknown;
+    try {
+      rawArtifact = await fetchArtifact(this.ipfsGatewayUrl, ref.artifactCid);
+    } catch (err) {
+      throw new SkippableError(
+        'vetted_pool_fetch_failed',
+        `cannot fetch vetted pool artifact ${ref.artifactCid}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    let entries;
+    try {
+      const artifact = parseVettedPoolArtifact(rawArtifact);
+      if (artifact.evalSemanticsVersion !== ref.evalSemanticsVersion) {
+        throw new Error(`artifact semanticsVersion=${artifact.evalSemanticsVersion} does not match ref=${ref.evalSemanticsVersion}`);
+      }
+      const actualHash = hashVettedPoolArtifact(artifact);
+      if (actualHash !== ref.artifactHash) {
+        throw new Error(`artifact hash ${actualHash} does not match ref ${ref.artifactHash}`);
+      }
+      entries = loadVettedPoolArtifactScorableEntries(artifact);
+    } catch (err) {
+      throw new SkippableError(
+        'vetted_pool_artifact_invalid',
+        `invalid vetted pool artifact ${ref.artifactCid}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    if (!entries.byId.has(task.instance_id)) {
+      throw new SkippableError(
+        'vetted_pool_instance_missing_or_unscorable',
+        `${task.instance_id} is not present as scorable in vetted pool artifact ${ref.artifactCid}`,
+      );
+    }
+
+    try {
+      return await fetcher.fetchTaskRow({
+        hf_dataset: task.hf_dataset,
+        hf_split: task.hf_split,
+        instance_id: task.instance_id,
+      });
+    } catch (err) {
+      throw new SkippableError(
+        'hf_fetch_failed',
+        `cannot load grading row after vetted-pool admission: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
   async run(ctx: HarnessContext): Promise<Solution> {
     if (this.stub) {
       throw new Error(
@@ -546,7 +635,8 @@ export class SweRebenchV2EvaluatorHarness implements Harness {
       process.env['JINN_SWE_REBENCH_V2_STATE_DIR'] ??
       defaultSolverTypeStateDir();
     const fetcher: HfFetcher = this.getFetcher();
-    const recheckRow = await this.recheckSubstrate(
+    const publishedPoolRow = await this.loadPublishedPoolRow(task, ctx.task, fetcher);
+    const recheckRow = publishedPoolRow ?? await this.recheckSubstrate(
       task,
       fetcher,
       () => this.loadPoolForRecheck(stateDir),

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/hf-fetcher.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/hf-fetcher.ts
@@ -9,6 +9,7 @@
  * silently grading against a missing instance.
  */
 
+import { sleep as defaultSleep } from '../../../tx-retry.js';
 import type { HfFetcher, HfRow } from './index.js';
 
 export interface HttpHfFetcherOptions {
@@ -29,7 +30,7 @@ export interface HttpHfFetcherOptions {
   retryBackoffMs?: number[];
   /** Minimum spacing between HF HTTP requests. Defaults to 250ms. */
   minRequestIntervalMs?: number;
-  /** Sleep implementation. Defaults to setTimeout (allows test injection). */
+  /** Sleep implementation. Defaults to the shared tx-retry sleep (allows test injection). */
   sleep?: (ms: number) => Promise<void>;
   /** Shared request limiter. Defaults to the module-level HF limiter. */
   limiter?: HfRequestLimiter;
@@ -87,7 +88,7 @@ export class HttpHfFetcher implements HfFetcher {
     this.fetchImpl = opts.fetchImpl ?? fetch.bind(globalThis);
     this.retryBackoffMs = opts.retryBackoffMs ?? DEFAULT_RETRY_BACKOFF_MS;
     this.minRequestIntervalMs = opts.minRequestIntervalMs ?? DEFAULT_MIN_REQUEST_INTERVAL_MS;
-    this.sleep = opts.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+    this.sleep = opts.sleep ?? defaultSleep;
     this.limiter = opts.limiter ?? sharedHfRequestLimiter;
   }
 

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/hf-fetcher.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/hf-fetcher.ts
@@ -27,10 +27,48 @@ export interface HttpHfFetcherOptions {
    * 404) are not retried — they're not transient.
    */
   retryBackoffMs?: number[];
+  /** Minimum spacing between HF HTTP requests. Defaults to 250ms. */
+  minRequestIntervalMs?: number;
+  /** Sleep implementation. Defaults to setTimeout (allows test injection). */
+  sleep?: (ms: number) => Promise<void>;
+  /** Shared request limiter. Defaults to the module-level HF limiter. */
+  limiter?: HfRequestLimiter;
 }
 
 const DEFAULT_BASE_URL = 'https://datasets-server.huggingface.co/rows';
 const DEFAULT_RETRY_BACKOFF_MS = [200, 800, 3200];
+const DEFAULT_MIN_REQUEST_INTERVAL_MS = 250;
+
+export interface HfRequestLimiter {
+  schedule<T>(fn: () => Promise<T>, opts: {
+    minRequestIntervalMs: number;
+    sleep: (ms: number) => Promise<void>;
+  }): Promise<T>;
+}
+
+class SharedHfRequestLimiter implements HfRequestLimiter {
+  private tail: Promise<void> = Promise.resolve();
+  private lastStartedAt = 0;
+
+  schedule<T>(fn: () => Promise<T>, opts: {
+    minRequestIntervalMs: number;
+    sleep: (ms: number) => Promise<void>;
+  }): Promise<T> {
+    const run = this.tail.catch(() => undefined).then(async () => {
+      const elapsed = Date.now() - this.lastStartedAt;
+      const waitMs = Math.max(0, opts.minRequestIntervalMs - elapsed);
+      if (waitMs > 0) {
+        await opts.sleep(waitMs);
+      }
+      this.lastStartedAt = Date.now();
+      return fn();
+    });
+    this.tail = run.then(() => undefined, () => undefined);
+    return run;
+  }
+}
+
+const sharedHfRequestLimiter = new SharedHfRequestLimiter();
 
 export class HttpHfFetcher implements HfFetcher {
   private readonly baseUrl: string;
@@ -38,6 +76,9 @@ export class HttpHfFetcher implements HfFetcher {
   private readonly maxRows: number;
   private readonly fetchImpl: typeof fetch;
   private readonly retryBackoffMs: number[];
+  private readonly minRequestIntervalMs: number;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly limiter: HfRequestLimiter;
 
   constructor(opts: HttpHfFetcherOptions = {}) {
     this.baseUrl = opts.baseUrl ?? DEFAULT_BASE_URL;
@@ -45,21 +86,33 @@ export class HttpHfFetcher implements HfFetcher {
     this.maxRows = opts.maxRows ?? 1000;
     this.fetchImpl = opts.fetchImpl ?? fetch.bind(globalThis);
     this.retryBackoffMs = opts.retryBackoffMs ?? DEFAULT_RETRY_BACKOFF_MS;
+    this.minRequestIntervalMs = opts.minRequestIntervalMs ?? DEFAULT_MIN_REQUEST_INTERVAL_MS;
+    this.sleep = opts.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+    this.limiter = opts.limiter ?? sharedHfRequestLimiter;
   }
 
   private async fetchWithRetry(url: string): Promise<Response> {
     let lastErr: unknown = null;
     for (let attempt = 0; attempt <= this.retryBackoffMs.length; attempt += 1) {
+      let retryAfterMs: number | undefined;
       try {
-        const res = await this.fetchImpl(url);
-        if (res.ok || (res.status >= 400 && res.status < 500)) return res;
-        // 5xx → retry-eligible
+        const res = await this.limiter.schedule(
+          () => this.fetchImpl(url),
+          { minRequestIntervalMs: this.minRequestIntervalMs, sleep: this.sleep },
+        );
+        if (res.ok || !isRetryableStatus(res.status)) return res;
+        if (attempt >= this.retryBackoffMs.length) return res;
+        retryAfterMs = retryAfterHeaderMs(res.headers.get('Retry-After'));
         lastErr = new Error(`HF returned ${res.status}`);
       } catch (err) {
         lastErr = err;
+        if (attempt >= this.retryBackoffMs.length) {
+          if (lastErr instanceof Error) throw lastErr;
+          throw new Error('HF fetch failed after retries');
+        }
       }
       if (attempt < this.retryBackoffMs.length) {
-        await new Promise((r) => setTimeout(r, this.retryBackoffMs[attempt]));
+        await this.sleep(retryAfterMs ?? this.retryBackoffMs[attempt]);
       }
     }
     if (lastErr instanceof Error) throw lastErr;
@@ -151,4 +204,21 @@ function stringField(v: unknown): string | undefined {
 function arrayOfStrings(v: unknown): string[] {
   if (!Array.isArray(v)) return [];
   return v.filter((s): s is string => typeof s === 'string');
+}
+
+function isRetryableStatus(status: number): boolean {
+  return status === 408 || status === 429 || status >= 500;
+}
+
+function retryAfterHeaderMs(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return seconds * 1000;
+  }
+  const dateMs = Date.parse(value);
+  if (!Number.isNaN(dateMs)) {
+    return Math.max(0, dateMs - Date.now());
+  }
+  return undefined;
 }

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/index.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/index.ts
@@ -43,6 +43,11 @@ export interface EvalRunner {
     failed: string[];
     log: string;
     exitCode: number;
+    /**
+     * Digest of the eval image observed while it was still present locally.
+     * Production runners may prune images before callers can inspect Docker.
+     */
+    imageDigest?: string;
   }>;
 }
 

--- a/client/src/harnesses/impls/swe-rebench-v2-evaluator/index.ts
+++ b/client/src/harnesses/impls/swe-rebench-v2-evaluator/index.ts
@@ -49,6 +49,7 @@ export interface EvalRunner {
 export interface GradeArgs {
   task: SweRebenchV2Task;
   solutionPayload: SweRebenchV2SolutionPayload;
+  row?: HfRow;
 }
 
 export class SweRebenchV2Evaluator {
@@ -57,7 +58,7 @@ export class SweRebenchV2Evaluator {
   ) {}
 
   async grade(args: GradeArgs): Promise<SweRebenchV2VerdictPayload & { test_log: string }> {
-    const row = await this.deps.fetcher.fetchTaskRow({
+    const row = args.row ?? await this.deps.fetcher.fetchTaskRow({
       hf_dataset: args.task.hf_dataset,
       hf_split: args.task.hf_split,
       instance_id: args.task.instance_id,

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -28,6 +28,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { loadConfig, getConfigPathFromArgs, DEFAULT_CONFIG_PATH } from './config.js';
 import { Store } from './store/store.js';
 import { startApiServer, isEmbeddedAgentEnabled, type ApiServer } from './api/server.js';
+import { setDefaultTxSubmissionLedger } from './tx-retry.js';
 // addHarnessReadinessRoutes is wired through startApiServer's holder ref now
 // (jinn-mono-u34i). No direct import needed.
 import { CapturePublishUnavailableError } from './api/captures.js';
@@ -861,6 +862,7 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
   // /v1/bootstrap + /v1/events + /v1/status here. The same Store instance is
   // later passed into Daemon so we don't double-open the SQLite file.
   const sharedStore = new Store(config.dbPath);
+  setDefaultTxSubmissionLedger(sharedStore);
   const capturesStore = new CapturesStore(sharedStore);
   let captureReceiver: Receiver | undefined;
   try {

--- a/client/src/solver-types/_swe-rebench-v2-substrate.ts
+++ b/client/src/solver-types/_swe-rebench-v2-substrate.ts
@@ -9,6 +9,7 @@
  */
 
 import { createHash } from 'node:crypto';
+import { spawn } from 'node:child_process';
 
 export interface RowHashInput {
   hf_dataset: string;
@@ -60,6 +61,16 @@ export type CommandRunner = (
   args: string[],
   opts?: { cwd?: string },
 ) => Promise<CommandResult>;
+
+export const defaultCommandRunner: CommandRunner = (bin, args, opts) => new Promise((resolve, reject) => {
+  const child = spawn(bin, args, { ...(opts ?? {}), stdio: ['ignore', 'pipe', 'pipe'] });
+  let stdout = '';
+  let stderr = '';
+  child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
+  child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
+  child.on('error', reject);
+  child.on('close', (code: number | null) => resolve({ exitCode: code ?? 1, stdout, stderr }));
+});
 
 /**
  * Resolve the digest of a local Docker image via `docker image inspect`.

--- a/client/src/solver-types/_swe-rebench-v2-validated-pool.ts
+++ b/client/src/solver-types/_swe-rebench-v2-validated-pool.ts
@@ -22,11 +22,16 @@
 
 import { readFile, writeFile, mkdir, stat, rename, unlink } from 'node:fs/promises';
 import { createHash, randomBytes } from 'node:crypto';
-import { spawn } from 'node:child_process';
 import { resolve as resolvePath, dirname, join } from 'node:path';
 import type { PoolTask } from './_swe-rebench-v2-pool.js';
 import type { EvalRunner, HfFetcher, HfRow } from '../harnesses/impls/swe-rebench-v2-evaluator/index.js';
-import { computeRowHash, resolveImageDigest, resolveUpstreamEvalCommit, type CommandRunner } from './_swe-rebench-v2-substrate.js';
+import {
+  computeRowHash,
+  defaultCommandRunner,
+  resolveImageDigest,
+  resolveUpstreamEvalCommit,
+  type CommandRunner,
+} from './_swe-rebench-v2-substrate.js';
 import { canonicalJson } from '../harnesses/engine/canonical-json.js';
 
 // In-process mutex map: serialises concurrent record() calls against the
@@ -142,6 +147,19 @@ function isValidFile(raw: unknown, evalSemanticsVersion: string): raw is Validat
 
 function publicationPath(stateDir: string): string {
   return resolvePath(join(stateDir, PUBLICATION_FILE));
+}
+
+async function writeJsonAtomic(file: string, value: unknown): Promise<void> {
+  await mkdir(dirname(file), { recursive: true });
+  const tmp = `${file}.${randomBytes(6).toString('hex')}.tmp`;
+  await writeFile(tmp, JSON.stringify(value, null, 2));
+  try {
+    await rename(tmp, file); // POSIX rename is atomic
+  } catch (err) {
+    // Best-effort tempfile cleanup — don't mask the original error.
+    await unlink(tmp).catch(() => undefined);
+    throw err;
+  }
 }
 
 function isObject(raw: unknown): raw is Record<string, unknown> {
@@ -312,16 +330,7 @@ export class ValidatedPoolStore {
   }
 
   private async writeAtomic(file: ValidatedPoolFile): Promise<void> {
-    await mkdir(dirname(this.file), { recursive: true });
-    const tmp = `${this.file}.${randomBytes(6).toString('hex')}.tmp`;
-    await writeFile(tmp, JSON.stringify(file, null, 2));
-    try {
-      await rename(tmp, this.file); // POSIX rename is atomic
-    } catch (err) {
-      // Best-effort tempfile cleanup — don't mask the original error.
-      await unlink(tmp).catch(() => undefined);
-      throw err;
-    }
+    await writeJsonAtomic(this.file, file);
   }
 
   /** The set of instance ids known scorable for `evalSemanticsVersion`, or
@@ -459,16 +468,7 @@ export async function writeVettedPoolArtifactPublication(args: {
     ref,
     artifact,
   };
-  const file = publicationPath(args.stateDir);
-  await mkdir(dirname(file), { recursive: true });
-  const tmp = `${file}.${randomBytes(6).toString('hex')}.tmp`;
-  await writeFile(tmp, JSON.stringify(publication, null, 2));
-  try {
-    await rename(tmp, file);
-  } catch (err) {
-    await unlink(tmp).catch(() => undefined);
-    throw err;
-  }
+  await writeJsonAtomic(publicationPath(args.stateDir), publication);
   return publication;
 }
 
@@ -517,15 +517,6 @@ function looksPython(patch: string | undefined): boolean {
   // Match `--- a/<p>` / `+++ b/<p>` / `diff --git a/<p>` ending in .py
   return /(?:^|\n)(?:---|\+\+\+|diff --git) [ab]\/\S+\.py(?:\s|$)/.test(patch);
 }
-
-const defaultCommandRunner: CommandRunner = (bin, args, opts) => new Promise((resolve, reject) => {
-  const child = spawn(bin, args, { ...(opts ?? {}), stdio: ['ignore', 'pipe', 'pipe'] });
-  let stdout = ''; let stderr = '';
-  child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
-  child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
-  child.on('error', reject);
-  child.on('close', (code: number | null) => resolve({ exitCode: code ?? 1, stdout, stderr }));
-});
 
 export interface ValidatePoolDeps {
   fetcher: HfFetcher;

--- a/client/src/solver-types/_swe-rebench-v2-validated-pool.ts
+++ b/client/src/solver-types/_swe-rebench-v2-validated-pool.ts
@@ -21,12 +21,13 @@
  */
 
 import { readFile, writeFile, mkdir, stat, rename, unlink } from 'node:fs/promises';
-import { randomBytes } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import { resolve as resolvePath, dirname, join } from 'node:path';
 import type { PoolTask } from './_swe-rebench-v2-pool.js';
 import type { EvalRunner, HfFetcher, HfRow } from '../harnesses/impls/swe-rebench-v2-evaluator/index.js';
 import { computeRowHash, resolveImageDigest, resolveUpstreamEvalCommit, type CommandRunner } from './_swe-rebench-v2-substrate.js';
+import { canonicalJson } from '../harnesses/engine/canonical-json.js';
 
 // In-process mutex map: serialises concurrent record() calls against the
 // same file. Entries are never removed; bounded by the number of distinct
@@ -64,6 +65,11 @@ function withWriteLock<T>(file: string, fn: () => Promise<T>): Promise<T> {
 export const EVAL_SEMANTICS_VERSION = '3';
 
 const SCHEMA_VERSION = 'swe-rebench-v2-validated-pool.v1' as const;
+export const SWE_REBENCH_V2_VETTED_POOL_ARTIFACT_TYPE = 'swe-rebench-v2-vetted-pool.v1' as const;
+export const SOLVERNET_ARTIFACT_REF_SCHEMA_VERSION = 'solvernet.artifact-ref.v1' as const;
+export const VETTED_POOL_REF_ELIGIBILITY_KEY = 'vettedPoolRef' as const;
+const PUBLICATION_SCHEMA_VERSION = 'swe-rebench-v2-vetted-pool-publication.v1' as const;
+const PUBLICATION_FILE = 'vetted-pool-artifact-publication.json';
 
 export interface ValidatedPoolEntry {
   scorable: boolean;
@@ -87,6 +93,40 @@ interface ValidatedPoolFile {
   entries: Record<string, ValidatedPoolEntry>;
 }
 
+export interface SweRebenchV2VettedPoolArtifactEntry extends ValidatedPoolEntry {
+  instance_id: string;
+  scorable: true;
+}
+
+export interface SweRebenchV2VettedPoolArtifact {
+  schemaVersion: typeof SWE_REBENCH_V2_VETTED_POOL_ARTIFACT_TYPE;
+  evalSemanticsVersion: string;
+  generatedAt: string;
+  entries: SweRebenchV2VettedPoolArtifactEntry[];
+}
+
+export interface SolverNetArtifactRef {
+  schemaVersion: typeof SOLVERNET_ARTIFACT_REF_SCHEMA_VERSION;
+  manifestCid: string;
+  artifactType: typeof SWE_REBENCH_V2_VETTED_POOL_ARTIFACT_TYPE;
+  artifactCid: string;
+  artifactHash: `sha256:${string}`;
+  evalSemanticsVersion: string;
+  publishedAt: string;
+}
+
+export interface VettedPoolArtifactPublication {
+  schemaVersion: typeof PUBLICATION_SCHEMA_VERSION;
+  updatedAt: string;
+  ref: SolverNetArtifactRef;
+  artifact: SweRebenchV2VettedPoolArtifact;
+}
+
+export interface ScorableVettedPoolArtifactEntries {
+  ids: Set<string>;
+  byId: Map<string, SweRebenchV2VettedPoolArtifactEntry>;
+}
+
 function freshFile(evalSemanticsVersion: string): ValidatedPoolFile {
   return { schemaVersion: SCHEMA_VERSION, evalSemanticsVersion, updatedAt: new Date().toISOString(), entries: {} };
 }
@@ -98,6 +138,150 @@ function isValidFile(raw: unknown, evalSemanticsVersion: string): raw is Validat
     (raw as ValidatedPoolFile).evalSemanticsVersion === evalSemanticsVersion &&
     typeof (raw as ValidatedPoolFile).entries === 'object' && (raw as ValidatedPoolFile).entries !== null
   );
+}
+
+function publicationPath(stateDir: string): string {
+  return resolvePath(join(stateDir, PUBLICATION_FILE));
+}
+
+function isObject(raw: unknown): raw is Record<string, unknown> {
+  return typeof raw === 'object' && raw !== null;
+}
+
+function isSha256(value: unknown): value is `sha256:${string}` {
+  return typeof value === 'string' && /^sha256:[0-9a-f]{64}$/u.test(value);
+}
+
+function parseVettedPoolArtifactEntry(raw: unknown): SweRebenchV2VettedPoolArtifactEntry | null {
+  if (!isObject(raw)) return null;
+  if (typeof raw['instance_id'] !== 'string' || raw['instance_id'].length === 0) return null;
+  if (raw['scorable'] !== true) return null;
+  if (typeof raw['reason'] !== 'string') return null;
+  if (typeof raw['checkedAt'] !== 'string') return null;
+  const entry: SweRebenchV2VettedPoolArtifactEntry = {
+    instance_id: raw['instance_id'],
+    scorable: true,
+    reason: raw['reason'],
+    checkedAt: raw['checkedAt'],
+    ...(typeof raw['rowHash'] === 'string' ? { rowHash: raw['rowHash'] } : {}),
+    ...(typeof raw['imageName'] === 'string' ? { imageName: raw['imageName'] } : {}),
+    ...(typeof raw['imageDigest'] === 'string' ? { imageDigest: raw['imageDigest'] } : {}),
+    ...(typeof raw['upstreamEvalCommit'] === 'string' ? { upstreamEvalCommit: raw['upstreamEvalCommit'] } : {}),
+  };
+  return entry;
+}
+
+export function parseVettedPoolArtifact(raw: unknown): SweRebenchV2VettedPoolArtifact {
+  if (!isObject(raw)) throw new Error('vetted pool artifact must be an object');
+  if (raw['schemaVersion'] !== SWE_REBENCH_V2_VETTED_POOL_ARTIFACT_TYPE) {
+    throw new Error(`vetted pool artifact schemaVersion must be ${SWE_REBENCH_V2_VETTED_POOL_ARTIFACT_TYPE}`);
+  }
+  if (typeof raw['evalSemanticsVersion'] !== 'string') {
+    throw new Error('vetted pool artifact evalSemanticsVersion must be a string');
+  }
+  if (typeof raw['generatedAt'] !== 'string') {
+    throw new Error('vetted pool artifact generatedAt must be a string');
+  }
+  if (!Array.isArray(raw['entries'])) {
+    throw new Error('vetted pool artifact entries must be an array');
+  }
+  const entries = raw['entries'].map(parseVettedPoolArtifactEntry);
+  if (entries.some((e) => e === null)) {
+    throw new Error('vetted pool artifact contains an invalid or unscorable entry');
+  }
+  return {
+    schemaVersion: SWE_REBENCH_V2_VETTED_POOL_ARTIFACT_TYPE,
+    evalSemanticsVersion: raw['evalSemanticsVersion'],
+    generatedAt: raw['generatedAt'],
+    entries: (entries as SweRebenchV2VettedPoolArtifactEntry[]).sort((a, b) => a.instance_id.localeCompare(b.instance_id)),
+  };
+}
+
+function normalizeVettedPoolArtifact(artifact: SweRebenchV2VettedPoolArtifact): SweRebenchV2VettedPoolArtifact {
+  return {
+    schemaVersion: SWE_REBENCH_V2_VETTED_POOL_ARTIFACT_TYPE,
+    evalSemanticsVersion: artifact.evalSemanticsVersion,
+    generatedAt: artifact.generatedAt,
+    entries: [...artifact.entries]
+      .map((entry) => ({ ...entry, scorable: true as const }))
+      .sort((a, b) => a.instance_id.localeCompare(b.instance_id)),
+  };
+}
+
+export function hashVettedPoolArtifact(artifact: SweRebenchV2VettedPoolArtifact): `sha256:${string}` {
+  const canonical = canonicalJson(normalizeVettedPoolArtifact(artifact));
+  return `sha256:${createHash('sha256').update(canonical).digest('hex')}`;
+}
+
+export function loadVettedPoolArtifactScorableEntries(raw: unknown): ScorableVettedPoolArtifactEntries {
+  const artifact = parseVettedPoolArtifact(raw);
+  const byId = new Map<string, SweRebenchV2VettedPoolArtifactEntry>();
+  for (const entry of artifact.entries) {
+    byId.set(entry.instance_id, entry);
+  }
+  return { ids: new Set(byId.keys()), byId };
+}
+
+export function createVettedPoolArtifactRef(args: {
+  manifestCid: string;
+  artifactCid: string;
+  artifactHash: `sha256:${string}`;
+  evalSemanticsVersion: string;
+  publishedAt: string;
+}): SolverNetArtifactRef {
+  return {
+    schemaVersion: SOLVERNET_ARTIFACT_REF_SCHEMA_VERSION,
+    manifestCid: args.manifestCid,
+    artifactType: SWE_REBENCH_V2_VETTED_POOL_ARTIFACT_TYPE,
+    artifactCid: args.artifactCid,
+    artifactHash: args.artifactHash,
+    evalSemanticsVersion: args.evalSemanticsVersion,
+    publishedAt: args.publishedAt,
+  };
+}
+
+export function sweRebenchV2VettedPoolArtifactMetadataKey(manifestCid: string): string {
+  return `solvernet-artifact:${manifestCid}:swe-rebench-v2-vetted-pool`;
+}
+
+export function parseVettedPoolArtifactRef(raw: unknown): SolverNetArtifactRef {
+  if (!isObject(raw)) throw new Error('vetted pool artifact ref must be an object');
+  if (raw['schemaVersion'] !== SOLVERNET_ARTIFACT_REF_SCHEMA_VERSION) {
+    throw new Error(`vetted pool artifact ref schemaVersion must be ${SOLVERNET_ARTIFACT_REF_SCHEMA_VERSION}`);
+  }
+  if (raw['artifactType'] !== SWE_REBENCH_V2_VETTED_POOL_ARTIFACT_TYPE) {
+    throw new Error(`vetted pool artifact ref artifactType must be ${SWE_REBENCH_V2_VETTED_POOL_ARTIFACT_TYPE}`);
+  }
+  if (typeof raw['manifestCid'] !== 'string' || raw['manifestCid'].length === 0) {
+    throw new Error('vetted pool artifact ref manifestCid must be a string');
+  }
+  if (typeof raw['artifactCid'] !== 'string' || raw['artifactCid'].length === 0) {
+    throw new Error('vetted pool artifact ref artifactCid must be a string');
+  }
+  if (!isSha256(raw['artifactHash'])) {
+    throw new Error('vetted pool artifact ref artifactHash must be sha256:<64 hex>');
+  }
+  if (typeof raw['evalSemanticsVersion'] !== 'string') {
+    throw new Error('vetted pool artifact ref evalSemanticsVersion must be a string');
+  }
+  if (typeof raw['publishedAt'] !== 'string') {
+    throw new Error('vetted pool artifact ref publishedAt must be a string');
+  }
+  return {
+    schemaVersion: SOLVERNET_ARTIFACT_REF_SCHEMA_VERSION,
+    manifestCid: raw['manifestCid'],
+    artifactType: SWE_REBENCH_V2_VETTED_POOL_ARTIFACT_TYPE,
+    artifactCid: raw['artifactCid'],
+    artifactHash: raw['artifactHash'],
+    evalSemanticsVersion: raw['evalSemanticsVersion'],
+    publishedAt: raw['publishedAt'],
+  };
+}
+
+export function vettedPoolArtifactRefFromEligibility(eligibility: Record<string, unknown> | undefined): SolverNetArtifactRef | null {
+  const raw = eligibility?.[VETTED_POOL_REF_ELIGIBILITY_KEY];
+  if (raw === undefined) return null;
+  return parseVettedPoolArtifactRef(raw);
 }
 
 export class ValidatedPoolStore {
@@ -158,6 +342,18 @@ export class ValidatedPoolStore {
     return ids;
   }
 
+  async getScorableEntries(evalSemanticsVersion: string): Promise<{
+    entries: Record<string, ValidatedPoolEntry>;
+    updatedAt: string;
+  } | null> {
+    const raw = await this.readRaw();
+    if (!isValidFile(raw, evalSemanticsVersion)) return null;
+    return {
+      updatedAt: raw.updatedAt,
+      entries: Object.fromEntries(Object.entries(raw.entries).filter(([, entry]) => entry.scorable)),
+    };
+  }
+
   /** The entry for `instanceId`, or `null` if not validated for this semantics version. */
   async getEntry(instanceId: string, evalSemanticsVersion: string): Promise<ValidatedPoolEntry | null> {
     const f = await this.loadForWrite(evalSemanticsVersion);
@@ -178,6 +374,102 @@ export class ValidatedPoolStore {
       this.cache = file;
     });
   }
+}
+
+export async function exportScorableVettedPoolArtifact(
+  store: ValidatedPoolStore,
+  evalSemanticsVersion: string,
+  opts: { generatedAt?: string } = {},
+): Promise<SweRebenchV2VettedPoolArtifact | null> {
+  const scorable = await store.getScorableEntries(evalSemanticsVersion);
+  if (!scorable) return null;
+  const entries = Object.entries(scorable.entries)
+    .map(([instance_id, entry]) => ({
+      instance_id,
+      scorable: true as const,
+      reason: entry.reason,
+      checkedAt: entry.checkedAt,
+      ...(entry.rowHash ? { rowHash: entry.rowHash } : {}),
+      ...(entry.imageName ? { imageName: entry.imageName } : {}),
+      ...(entry.imageDigest ? { imageDigest: entry.imageDigest } : {}),
+      ...(entry.upstreamEvalCommit ? { upstreamEvalCommit: entry.upstreamEvalCommit } : {}),
+    }))
+    .sort((a, b) => a.instance_id.localeCompare(b.instance_id));
+  return {
+    schemaVersion: SWE_REBENCH_V2_VETTED_POOL_ARTIFACT_TYPE,
+    evalSemanticsVersion,
+    generatedAt: opts.generatedAt ?? scorable.updatedAt,
+    entries,
+  };
+}
+
+function parsePublication(raw: unknown): VettedPoolArtifactPublication {
+  if (!isObject(raw) || raw['schemaVersion'] !== PUBLICATION_SCHEMA_VERSION) {
+    throw new Error(`vetted pool publication schemaVersion must be ${PUBLICATION_SCHEMA_VERSION}`);
+  }
+  if (typeof raw['updatedAt'] !== 'string') {
+    throw new Error('vetted pool publication updatedAt must be a string');
+  }
+  const ref = parseVettedPoolArtifactRef(raw['ref']);
+  const artifact = parseVettedPoolArtifact(raw['artifact']);
+  const actualHash = hashVettedPoolArtifact(artifact);
+  if (actualHash !== ref.artifactHash) {
+    throw new Error(`vetted pool publication hash mismatch: ref=${ref.artifactHash} artifact=${actualHash}`);
+  }
+  return {
+    schemaVersion: PUBLICATION_SCHEMA_VERSION,
+    updatedAt: raw['updatedAt'],
+    ref,
+    artifact,
+  };
+}
+
+export async function readVettedPoolArtifactPublication(args: {
+  stateDir: string;
+  manifestCid?: string;
+  evalSemanticsVersion?: string;
+}): Promise<VettedPoolArtifactPublication | null> {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(await readFile(publicationPath(args.stateDir), 'utf8'));
+  } catch {
+    return null;
+  }
+  const publication = parsePublication(raw);
+  if (args.manifestCid !== undefined && publication.ref.manifestCid !== args.manifestCid) return null;
+  if (args.evalSemanticsVersion !== undefined && publication.ref.evalSemanticsVersion !== args.evalSemanticsVersion) return null;
+  return publication;
+}
+
+export async function writeVettedPoolArtifactPublication(args: {
+  stateDir: string;
+  ref: SolverNetArtifactRef;
+  artifact: SweRebenchV2VettedPoolArtifact;
+  updatedAt?: string;
+}): Promise<VettedPoolArtifactPublication> {
+  const artifact = parseVettedPoolArtifact(args.artifact);
+  const ref = parseVettedPoolArtifactRef(args.ref);
+  const artifactHash = hashVettedPoolArtifact(artifact);
+  if (artifactHash !== ref.artifactHash) {
+    throw new Error(`vetted pool publication hash mismatch: ref=${ref.artifactHash} artifact=${artifactHash}`);
+  }
+  const publication: VettedPoolArtifactPublication = {
+    schemaVersion: PUBLICATION_SCHEMA_VERSION,
+    updatedAt: args.updatedAt ?? new Date().toISOString(),
+    ref,
+    artifact,
+  };
+  const file = publicationPath(args.stateDir);
+  await mkdir(dirname(file), { recursive: true });
+  const tmp = `${file}.${randomBytes(6).toString('hex')}.tmp`;
+  await writeFile(tmp, JSON.stringify(publication, null, 2));
+  try {
+    await rename(tmp, file);
+  } catch (err) {
+    await unlink(tmp).catch(() => undefined);
+    throw err;
+  }
+  return publication;
 }
 
 export type AdmissionMode = 'required' | 'python-floor';
@@ -338,9 +630,10 @@ export async function validatePoolInstances(
         pass_to_pass: row.PASS_TO_PASS,
       });
       const checkedAt = new Date().toISOString();
-      // Resolve digest AFTER the eval ran — that's when the image is guaranteed
-      // to be present locally with its RepoDigests populated.
-      const imageDigest = await resolveImageDigest(row.image_name, runner);
+      // Prefer the digest captured by a real runner before per-round pruning.
+      // Test runners that do not carry it still use the legacy post-eval
+      // Docker inspect fallback.
+      const imageDigest = res.imageDigest ?? await resolveImageDigest(row.image_name, runner);
       const substrate = {
         checkedAt,
         rowHash,

--- a/client/src/solver-types/swe-rebench-v2.ts
+++ b/client/src/solver-types/swe-rebench-v2.ts
@@ -19,6 +19,7 @@ import type { TaskGenerator } from '../tasks/sources.js';
 import type { TaskClaimPolicy, TaskV1 } from '../types/task-document.js';
 import { signTaskV1 } from '../tasks/signing.js';
 import type { LaunchedSolverNetRecord } from '../solvernets/store.js';
+import { uploadToIpfs } from '../adapters/mech/ipfs.js';
 import type { SolverTypeDefinition } from './solver-type.js';
 import {
   selectNextPostingCandidate,
@@ -30,7 +31,15 @@ import {
   ValidatedPoolStore,
   filterToScorablePool,
   EVAL_SEMANTICS_VERSION,
+  VETTED_POOL_REF_ELIGIBILITY_KEY,
+  createVettedPoolArtifactRef,
+  exportScorableVettedPoolArtifact,
+  hashVettedPoolArtifact,
+  loadVettedPoolArtifactScorableEntries,
+  readVettedPoolArtifactPublication,
+  writeVettedPoolArtifactPublication,
   type AdmissionMode,
+  type SolverNetArtifactRef,
 } from './_swe-rebench-v2-validated-pool.js';
 import {
   buildHistoricalPool,
@@ -44,6 +53,7 @@ export const HF_DATASET = 'nebius/SWE-rebench-leaderboard';
 const SOLVER_TYPE = 'swe-rebench-v2.v1';
 const CONTRACT_ID = 'swe-rebench-v2';
 const CONTRACT_VERSION = 'v1';
+const DEFAULT_IPFS_REGISTRY_URL = 'https://registry.autonolas.tech';
 
 /** How long the pool is cached before a full refresh (24 h). */
 const POOL_REFRESH_MS = 24 * 60 * 60 * 1000;
@@ -66,6 +76,7 @@ export interface SweRebenchV2AutoConfig {
 
 export interface SweRebenchV2GeneratorStaticConfig {
   stateDir?: string;
+  ipfsRegistryUrl?: string;
   agentEoa?: `0x${string}`;
   safeAddress?: `0x${string}`;
   agentPrivateKey?: `0x${string}`;
@@ -94,6 +105,7 @@ export type SweRebenchV2GeneratorTick = TaskGenerator & {
 interface InternalSweRebenchV2GeneratorConfig extends SweRebenchV2AutoConfig {
   getGeneratorConfig?: () => SweRebenchV2GeneratorRuntimeConfig | unknown;
   solverNetManifestCid?: string;
+  ipfsRegistryUrl?: string;
   creator?: {
     agentEoa?: `0x${string}`;
     safeAddress?: `0x${string}`;
@@ -235,6 +247,63 @@ function normalizeClaimPolicy(raw: unknown): TaskClaimPolicy {
   };
 }
 
+async function resolvePublishedVettedPool(args: {
+  stateDir: string;
+  manifestCid: string | undefined;
+  store: ValidatedPoolStore;
+  nowIso: string;
+  ipfsRegistryUrl: string;
+  upload: typeof uploadToIpfs;
+}): Promise<{
+  scorableIds: Set<string> | null;
+  artifactRef: SolverNetArtifactRef | null;
+  mode: 'published' | 'published-from-local' | 'no-publication' | 'no-manifest';
+}> {
+  if (!args.manifestCid) {
+    return { scorableIds: null, artifactRef: null, mode: 'no-manifest' };
+  }
+
+  const existing = await readVettedPoolArtifactPublication({
+    stateDir: args.stateDir,
+    manifestCid: args.manifestCid,
+    evalSemanticsVersion: EVAL_SEMANTICS_VERSION,
+  });
+  if (existing) {
+    return {
+      scorableIds: loadVettedPoolArtifactScorableEntries(existing.artifact).ids,
+      artifactRef: existing.ref,
+      mode: 'published',
+    };
+  }
+
+  const artifact = await exportScorableVettedPoolArtifact(args.store, EVAL_SEMANTICS_VERSION, {
+    generatedAt: args.nowIso,
+  });
+  if (!artifact || artifact.entries.length === 0) {
+    return { scorableIds: null, artifactRef: null, mode: 'no-publication' };
+  }
+
+  const artifactCid = await args.upload(args.ipfsRegistryUrl, artifact);
+  const artifactRef = createVettedPoolArtifactRef({
+    manifestCid: args.manifestCid,
+    artifactCid,
+    artifactHash: hashVettedPoolArtifact(artifact),
+    evalSemanticsVersion: EVAL_SEMANTICS_VERSION,
+    publishedAt: args.nowIso,
+  });
+  await writeVettedPoolArtifactPublication({
+    stateDir: args.stateDir,
+    ref: artifactRef,
+    artifact,
+    updatedAt: args.nowIso,
+  });
+  return {
+    scorableIds: loadVettedPoolArtifactScorableEntries(artifact).ids,
+    artifactRef,
+    mode: 'published-from-local',
+  };
+}
+
 async function maybeSignTask(
   task: Task,
   opts: {
@@ -288,6 +357,7 @@ function makeSweRebenchV2Generator(config: InternalSweRebenchV2GeneratorConfig):
   let poolLoadedAt = 0;
   let poolFromCache = false;
   let floorWarned = false;
+  let publicationWarned = false;
   let lastPostedLanguage: string | undefined;
   let lastPollAt: string | undefined;
   let lastPollSummary: SweRebenchV2GeneratorStateSnapshot['lastPollSummary'];
@@ -340,12 +410,49 @@ function makeSweRebenchV2Generator(config: InternalSweRebenchV2GeneratorConfig):
     }
     lastPollAt = new Date(now).toISOString();
 
-    // Restrict to instances we can actually score (validated gold-patch pool).
-    // In required mode (default): absent or stale admission data → empty pool,
-    // emit a startup warning. In python-floor mode (local/dev opt-in): fall
-    // back to Python-only instances when no validation data exists.
-    // See jinn-mono-uy6v.9.
-    const scorableIds = await validatedPoolStore.getScorableIds(EVAL_SEMANTICS_VERSION);
+    const publishedPool = await resolvePublishedVettedPool({
+      stateDir: config.stateDir,
+      manifestCid: config.solverNetManifestCid,
+      store: validatedPoolStore,
+      nowIso: lastPollAt,
+      ipfsRegistryUrl:
+        config.ipfsRegistryUrl ??
+        process.env['JINN_IPFS_REGISTRY_URL'] ??
+        DEFAULT_IPFS_REGISTRY_URL,
+      upload: uploadToIpfs,
+    }).catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      lastError = {
+        message: `vetted pool publication failed: ${message}`,
+        at: new Date().toISOString(),
+      };
+      console.warn(`[swe-rebench-v2-gen] ${lastError.message}`);
+      return null;
+    });
+    if (publishedPool === null) {
+      lastPollSummary = { poolSize: 0, posted: 0, skipped: pool.length };
+      return null;
+    }
+    if (
+      genConfig.admissionMode === 'required' &&
+      publishedPool.mode === 'no-manifest' &&
+      !publicationWarned
+    ) {
+      publicationWarned = true;
+      console.warn(
+        `[swe-rebench-v2-gen] no solverNetManifestCid is available, so the launcher cannot stamp a vetted pool artifact ref; admissionMode='required' is fail-closed.`,
+      );
+    }
+
+    // Restrict to instances in the launcher's published pool artifact. If the
+    // launcher has no publication yet but local scorable data exists, the
+    // helper above publishes it once before this filter runs. Python-floor is
+    // preserved only for local/dev generators.
+    const scorableIds = publishedPool.artifactRef
+      ? publishedPool.scorableIds
+      : genConfig.admissionMode === 'python-floor'
+        ? await validatedPoolStore.getScorableIds(EVAL_SEMANTICS_VERSION)
+        : null;
     const { pool: eligiblePool, mode: poolMode } = filterToScorablePool(
       pool,
       scorableIds,
@@ -443,11 +550,17 @@ function makeSweRebenchV2Generator(config: InternalSweRebenchV2GeneratorConfig):
       },
       claimPolicy,
       spec,
+      ...(publishedPool.artifactRef
+        ? { context: { [VETTED_POOL_REF_ELIGIBILITY_KEY]: publishedPool.artifactRef } }
+        : {}),
       eligibility: {
         hf_dataset: candidate.hf_dataset,
         hf_split: candidate.hf_split,
         instance_id: candidate.instance_id,
         generatorConfig: genConfig,
+        ...(publishedPool.artifactRef
+          ? { [VETTED_POOL_REF_ELIGIBILITY_KEY]: publishedPool.artifactRef }
+          : {}),
       },
     };
 
@@ -514,6 +627,7 @@ export function makeSweRebenchV2GeneratorForLaunchedRecord(
     stateDir,
     getGeneratorConfig: () => configRef.current,
     solverNetManifestCid: recordRef.current.manifestCid,
+    ipfsRegistryUrl: staticConfig.ipfsRegistryUrl,
     creator: {
       agentEoa: staticConfig.agentEoa,
       safeAddress: staticConfig.safeAddress,

--- a/client/src/solver-types/swe-rebench-v2.ts
+++ b/client/src/solver-types/swe-rebench-v2.ts
@@ -247,6 +247,12 @@ function normalizeClaimPolicy(raw: unknown): TaskClaimPolicy {
   };
 }
 
+interface PublishedVettedPool {
+  scorableIds: Set<string> | null;
+  artifactRef: SolverNetArtifactRef | null;
+  mode: 'published' | 'published-from-local' | 'no-publication' | 'no-manifest';
+}
+
 async function resolvePublishedVettedPool(args: {
   stateDir: string;
   manifestCid: string | undefined;
@@ -254,11 +260,7 @@ async function resolvePublishedVettedPool(args: {
   nowIso: string;
   ipfsRegistryUrl: string;
   upload: typeof uploadToIpfs;
-}): Promise<{
-  scorableIds: Set<string> | null;
-  artifactRef: SolverNetArtifactRef | null;
-  mode: 'published' | 'published-from-local' | 'no-publication' | 'no-manifest';
-}> {
+}): Promise<PublishedVettedPool> {
   if (!args.manifestCid) {
     return { scorableIds: null, artifactRef: null, mode: 'no-manifest' };
   }
@@ -364,6 +366,7 @@ function makeSweRebenchV2Generator(config: InternalSweRebenchV2GeneratorConfig):
   let lastError: SweRebenchV2GeneratorStateSnapshot['lastError'];
   let totalPosted = 0;
   let lastPostedInstanceId: string | undefined;
+  let publishedPoolCache: PublishedVettedPool | null = null;
 
   async function refreshPool(): Promise<void> {
     const result = await loadPoolWithCacheFallback({
@@ -410,25 +413,31 @@ function makeSweRebenchV2Generator(config: InternalSweRebenchV2GeneratorConfig):
     }
     lastPollAt = new Date(now).toISOString();
 
-    const publishedPool = await resolvePublishedVettedPool({
-      stateDir: config.stateDir,
-      manifestCid: config.solverNetManifestCid,
-      store: validatedPoolStore,
-      nowIso: lastPollAt,
-      ipfsRegistryUrl:
-        config.ipfsRegistryUrl ??
-        process.env['JINN_IPFS_REGISTRY_URL'] ??
-        DEFAULT_IPFS_REGISTRY_URL,
-      upload: uploadToIpfs,
-    }).catch((err) => {
-      const message = err instanceof Error ? err.message : String(err);
-      lastError = {
-        message: `vetted pool publication failed: ${message}`,
-        at: new Date().toISOString(),
-      };
-      console.warn(`[swe-rebench-v2-gen] ${lastError.message}`);
-      return null;
-    });
+    let publishedPool: PublishedVettedPool | null = publishedPoolCache;
+    if (!publishedPool) {
+      publishedPool = await resolvePublishedVettedPool({
+        stateDir: config.stateDir,
+        manifestCid: config.solverNetManifestCid,
+        store: validatedPoolStore,
+        nowIso: lastPollAt,
+        ipfsRegistryUrl:
+          config.ipfsRegistryUrl ??
+          process.env['JINN_IPFS_REGISTRY_URL'] ??
+          DEFAULT_IPFS_REGISTRY_URL,
+        upload: uploadToIpfs,
+      }).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        lastError = {
+          message: `vetted pool publication failed: ${message}`,
+          at: new Date().toISOString(),
+        };
+        console.warn(`[swe-rebench-v2-gen] ${lastError.message}`);
+        return null;
+      });
+      if (publishedPool?.artifactRef) {
+        publishedPoolCache = publishedPool;
+      }
+    }
     if (publishedPool === null) {
       lastPollSummary = { poolSize: 0, posted: 0, skipped: pool.length };
       return null;
@@ -550,9 +559,6 @@ function makeSweRebenchV2Generator(config: InternalSweRebenchV2GeneratorConfig):
       },
       claimPolicy,
       spec,
-      ...(publishedPool.artifactRef
-        ? { context: { [VETTED_POOL_REF_ELIGIBILITY_KEY]: publishedPool.artifactRef } }
-        : {}),
       eligibility: {
         hf_dataset: candidate.hf_dataset,
         hf_split: candidate.hf_split,

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -7,6 +7,7 @@ import type {
   EnvelopeProjectionQuery,
 } from '../corpus/types.js';
 import { TASK_RUNS_SCHEMA } from '../harnesses/engine/persistence.js';
+import type { TxSubmissionKey, TxSubmissionLedgerEntry } from '../tx-retry.js';
 import { normalizeEnvelopeRole, type Role } from '../types/envelope.js';
 
 export interface ActivityEventInput {
@@ -277,6 +278,26 @@ CREATE TABLE IF NOT EXISTS activity_events (
 CREATE INDEX IF NOT EXISTS idx_activity_events_ts ON activity_events (ts DESC);
 CREATE INDEX IF NOT EXISTS idx_activity_events_req ON activity_events (request_id);
 CREATE INDEX IF NOT EXISTS idx_activity_events_service_idx ON activity_events (service_index);
+
+CREATE TABLE IF NOT EXISTS tx_submissions (
+  chain_id INTEGER NOT NULL,
+  from_address TEXT NOT NULL,
+  nonce INTEGER NOT NULL,
+  hash TEXT,
+  logical_tx TEXT,
+  submitted_at_ms INTEGER NOT NULL,
+  max_fee_per_gas TEXT,
+  max_priority_fee_per_gas TEXT,
+  gas_price TEXT,
+  to_address TEXT,
+  value_wei TEXT,
+  data TEXT,
+  resolved_at_ms INTEGER,
+  PRIMARY KEY (chain_id, from_address, nonce)
+);
+CREATE INDEX IF NOT EXISTS idx_tx_submissions_unresolved
+  ON tx_submissions (chain_id, from_address, nonce)
+  WHERE resolved_at_ms IS NULL;
 
 CREATE TABLE IF NOT EXISTS reward_claims (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -645,6 +666,107 @@ export class Store {
   getDaemonStartedAt(): string | null {
     const row = this.db.prepare('SELECT value FROM config WHERE key = ?').get('daemon_started_at') as { value: string } | undefined;
     return row?.value ?? null;
+  }
+
+  recordTxSubmission(entry: TxSubmissionLedgerEntry): void {
+    this.db.prepare(
+      `INSERT INTO tx_submissions
+         (chain_id, from_address, nonce, hash, logical_tx, submitted_at_ms,
+          max_fee_per_gas, max_priority_fee_per_gas, gas_price, to_address, value_wei, data, resolved_at_ms)
+       VALUES
+         (@chainId, @fromAddress, @nonce, @hash, @logicalTx, @submittedAtMs,
+          @maxFeePerGas, @maxPriorityFeePerGas, @gasPrice, @toAddress, @valueWei, @data, @resolvedAtMs)
+       ON CONFLICT(chain_id, from_address, nonce) DO UPDATE SET
+         hash = excluded.hash,
+         logical_tx = excluded.logical_tx,
+         submitted_at_ms = excluded.submitted_at_ms,
+         max_fee_per_gas = excluded.max_fee_per_gas,
+         max_priority_fee_per_gas = excluded.max_priority_fee_per_gas,
+         gas_price = excluded.gas_price,
+         to_address = excluded.to_address,
+         value_wei = excluded.value_wei,
+         data = excluded.data,
+         resolved_at_ms = excluded.resolved_at_ms`,
+    ).run({
+      chainId: entry.chainId,
+      fromAddress: entry.from.toLowerCase(),
+      nonce: entry.nonce,
+      hash: entry.hash ?? null,
+      logicalTx: entry.logicalTx ?? null,
+      submittedAtMs: entry.submittedAtMs,
+      maxFeePerGas: entry.fees.maxFeePerGas?.toString() ?? null,
+      maxPriorityFeePerGas: entry.fees.maxPriorityFeePerGas?.toString() ?? null,
+      gasPrice: entry.fees.gasPrice?.toString() ?? null,
+      toAddress: entry.to?.toLowerCase() ?? null,
+      valueWei: entry.value?.toString() ?? null,
+      data: entry.data ?? null,
+      resolvedAtMs: entry.resolvedAtMs ?? null,
+    });
+  }
+
+  getTxSubmission(key: TxSubmissionKey): TxSubmissionLedgerEntry | null {
+    const row = this.db.prepare(
+      `SELECT chain_id, from_address, nonce, hash, logical_tx, submitted_at_ms,
+              max_fee_per_gas, max_priority_fee_per_gas, gas_price,
+              to_address, value_wei, data, resolved_at_ms
+       FROM tx_submissions
+       WHERE chain_id = @chainId
+         AND from_address = @fromAddress
+         AND nonce = @nonce`,
+    ).get({
+      chainId: key.chainId,
+      fromAddress: key.from.toLowerCase(),
+      nonce: key.nonce,
+    }) as {
+      chain_id: number;
+      from_address: string;
+      nonce: number;
+      hash: string | null;
+      logical_tx: string | null;
+      submitted_at_ms: number;
+      max_fee_per_gas: string | null;
+      max_priority_fee_per_gas: string | null;
+      gas_price: string | null;
+      to_address: string | null;
+      value_wei: string | null;
+      data: string | null;
+      resolved_at_ms: number | null;
+    } | undefined;
+    if (!row) return null;
+    return {
+      chainId: row.chain_id,
+      from: row.from_address as TxSubmissionLedgerEntry['from'],
+      nonce: row.nonce,
+      hash: row.hash as TxSubmissionLedgerEntry['hash'],
+      logicalTx: row.logical_tx ?? undefined,
+      submittedAtMs: row.submitted_at_ms,
+      fees: {
+        ...(row.max_fee_per_gas !== null ? { maxFeePerGas: BigInt(row.max_fee_per_gas) } : {}),
+        ...(row.max_priority_fee_per_gas !== null
+          ? { maxPriorityFeePerGas: BigInt(row.max_priority_fee_per_gas) }
+          : {}),
+        ...(row.gas_price !== null ? { gasPrice: BigInt(row.gas_price) } : {}),
+      },
+      to: row.to_address as TxSubmissionLedgerEntry['to'],
+      value: row.value_wei === null ? undefined : BigInt(row.value_wei),
+      data: row.data as TxSubmissionLedgerEntry['data'],
+      resolvedAtMs: row.resolved_at_ms,
+    };
+  }
+
+  markTxSubmissionResolved(key: TxSubmissionKey & { resolvedAtMs: number }): void {
+    this.db.prepare(
+      `UPDATE tx_submissions
+       SET resolved_at_ms = @resolvedAtMs
+       WHERE chain_id = @chainId
+         AND from_address = @fromAddress
+         AND nonce = @nonce`,
+    ).run({
+      chainId: key.chainId,
+      fromAddress: key.from.toLowerCase(),
+      nonce: key.nonce,
+      resolvedAtMs: key.resolvedAtMs,
+    });
   }
 
   /** Generic config row (e.g. last_reward_claim_tick_at). */

--- a/client/src/tx-retry.ts
+++ b/client/src/tx-retry.ts
@@ -11,6 +11,9 @@ export const TX_RETRY_DEFAULTS = {
   maxDelayMs: 12_000,
   /** Extra fee bump per retry attempt after the first (basis points, 1500 = +15%) */
   feeBumpBpsPerAttempt: 1500,
+  /** Minimum bump over the previously submitted fee for same-sender nonce replacement. */
+  replacementBumpBps: 1500,
+  stuckNonceAfterMs: 120_000,
 } as const;
 
 export function flattenErrorMessage(error: unknown): string {
@@ -216,8 +219,71 @@ export interface TxRetryOptions {
   maxAttempts?: number;
   baseDelayMs?: number;
   maxDelayMs?: number;
+  ledger?: TxSubmissionLedger;
+  logicalTx?: string;
+  stuckNonceAfterMs?: number;
   /** If set, invoked before each retry (attempt >= 1) for logging/metrics */
   onRetry?: (info: { attempt: number; error: unknown; message: string }) => void;
+}
+
+export interface TxFeeSnapshot {
+  maxFeePerGas?: bigint;
+  maxPriorityFeePerGas?: bigint;
+  gasPrice?: bigint;
+}
+
+export interface TxSubmissionKey {
+  chainId: number;
+  from: Address;
+  nonce: number;
+}
+
+export interface TxSubmissionLedgerEntry extends TxSubmissionKey {
+  hash?: Hex;
+  logicalTx?: string;
+  submittedAtMs: number;
+  fees: TxFeeSnapshot;
+  to?: Address;
+  value?: bigint;
+  data?: Hex;
+  resolvedAtMs?: number | null;
+}
+
+type MaybePromise<T> = T | Promise<T>;
+
+export interface TxSubmissionLedger {
+  getTxSubmission(key: TxSubmissionKey): MaybePromise<TxSubmissionLedgerEntry | null>;
+  recordTxSubmission(entry: TxSubmissionLedgerEntry): MaybePromise<void>;
+  markTxSubmissionResolved(key: TxSubmissionKey & { resolvedAtMs: number }): MaybePromise<void>;
+}
+
+export function createMemoryTxSubmissionLedger(): TxSubmissionLedger {
+  const entries = new Map<string, TxSubmissionLedgerEntry>();
+  const keyFor = (key: TxSubmissionKey) =>
+    `${key.chainId}:${key.from.toLowerCase()}:${key.nonce}`;
+
+  return {
+    getTxSubmission(key) {
+      return entries.get(keyFor(key)) ?? null;
+    },
+    recordTxSubmission(entry) {
+      entries.set(keyFor(entry), { ...entry, resolvedAtMs: entry.resolvedAtMs ?? null });
+    },
+    markTxSubmissionResolved(key) {
+      const existing = entries.get(keyFor(key));
+      if (existing) entries.set(keyFor(key), { ...existing, resolvedAtMs: key.resolvedAtMs });
+    },
+  };
+}
+
+let defaultTxSubmissionLedger: TxSubmissionLedger = createMemoryTxSubmissionLedger();
+
+export function setDefaultTxSubmissionLedger(ledger: TxSubmissionLedger): void {
+  defaultTxSubmissionLedger = ledger;
+}
+
+export function getDefaultTxSubmissionLedger(): TxSubmissionLedger {
+  return defaultTxSubmissionLedger;
 }
 
 export async function withRecoverableRetry<T>(
@@ -271,28 +337,87 @@ export async function waitForContractCode(
   throw new Error(`No contract code at ${address} after ${maxAttempts} getCode attempts`);
 }
 
+function mulDivCeil(value: bigint, numerator: bigint, denominator: bigint): bigint {
+  return (value * numerator + denominator - 1n) / denominator;
+}
+
+function maxBigInt(...values: Array<bigint | undefined>): bigint | undefined {
+  const present = values.filter((value): value is bigint => value !== undefined);
+  if (present.length === 0) return undefined;
+  return present.reduce((max, value) => (value > max ? value : max), present[0]!);
+}
+
+function replacementBump(value: bigint): bigint {
+  return mulDivCeil(
+    value,
+    10000n + BigInt(TX_RETRY_DEFAULTS.replacementBumpBps),
+    10000n,
+  );
+}
+
+function attemptBump(value: bigint, attemptIndex: number): bigint {
+  if (attemptIndex <= 0) return value;
+  const bps = BigInt(TX_RETRY_DEFAULTS.feeBumpBpsPerAttempt) * BigInt(attemptIndex);
+  return mulDivCeil(value, 10000n + bps, 10000n);
+}
+
+export function mergeFeeEstimateWithPrevious(
+  current: TxFeeSnapshot,
+  previous?: TxFeeSnapshot | null,
+  attemptIndex = 0,
+): TxFeeSnapshot {
+  if (current.gasPrice !== undefined || previous?.gasPrice !== undefined) {
+    const gasPrice = maxBigInt(
+      current.gasPrice === undefined ? undefined : attemptBump(current.gasPrice, attemptIndex),
+      previous?.gasPrice === undefined ? undefined : replacementBump(previous.gasPrice),
+    );
+    return gasPrice === undefined ? {} : { gasPrice };
+  }
+
+  const maxFeePerGas = maxBigInt(
+    current.maxFeePerGas === undefined ? undefined : attemptBump(current.maxFeePerGas, attemptIndex),
+    previous?.maxFeePerGas === undefined ? undefined : replacementBump(previous.maxFeePerGas),
+  );
+  const maxPriorityFeePerGas = maxBigInt(
+    current.maxPriorityFeePerGas === undefined
+      ? undefined
+      : attemptBump(current.maxPriorityFeePerGas, attemptIndex),
+    previous?.maxPriorityFeePerGas === undefined
+      ? undefined
+      : replacementBump(previous.maxPriorityFeePerGas),
+  );
+  if (maxFeePerGas !== undefined && maxPriorityFeePerGas !== undefined) {
+    return { maxFeePerGas, maxPriorityFeePerGas };
+  }
+  return {};
+}
+
 /** EIP-1559 or legacy gas overrides for viem, increasingly aggressive on later attempts. */
 export async function viemFeeOverridesForAttempt(
   publicClient: PublicClient,
   attemptIndex: number,
+  options: {
+    previousFees?: TxFeeSnapshot | null;
+    forceEstimate?: boolean;
+  } = {},
 ): Promise<
   | { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }
   | { gasPrice: bigint }
   | Record<string, never>
 > {
-  if (attemptIndex <= 0) return {};
-
-  const bps = BigInt(TX_RETRY_DEFAULTS.feeBumpBpsPerAttempt) * BigInt(attemptIndex);
-  const mult = 10000n + bps;
-  const apply = (v: bigint) => (v * mult) / 10000n;
+  if (attemptIndex <= 0 && !options.previousFees && !options.forceEstimate) return {};
 
   try {
     const fees = await publicClient.estimateFeesPerGas();
     if (fees.maxFeePerGas !== undefined && fees.maxPriorityFeePerGas !== undefined) {
-      return {
-        maxFeePerGas: apply(fees.maxFeePerGas),
-        maxPriorityFeePerGas: apply(fees.maxPriorityFeePerGas),
-      };
+      return mergeFeeEstimateWithPrevious(
+        {
+          maxFeePerGas: fees.maxFeePerGas,
+          maxPriorityFeePerGas: fees.maxPriorityFeePerGas,
+        },
+        options.previousFees,
+        attemptIndex,
+      ) as { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint };
     }
   } catch {
     // fall through to gasPrice
@@ -300,9 +425,18 @@ export async function viemFeeOverridesForAttempt(
 
   try {
     const gasPrice = await publicClient.getGasPrice();
-    return { gasPrice: apply(gasPrice) };
+    return mergeFeeEstimateWithPrevious(
+      { gasPrice },
+      options.previousFees,
+      attemptIndex,
+    ) as { gasPrice: bigint };
   } catch {
-    return {};
+    return options.previousFees
+      ? (mergeFeeEstimateWithPrevious({}, options.previousFees, attemptIndex) as
+          | { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }
+          | { gasPrice: bigint }
+          | Record<string, never>)
+      : {};
   }
 }
 
@@ -341,6 +475,112 @@ export async function waitForTransactionReceiptWithRetry(
   throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
+async function resolveTxChainId(publicClient: PublicClient): Promise<number> {
+  return Number(await (publicClient as unknown as { getChainId: () => Promise<number | bigint> }).getChainId());
+}
+
+async function resolvePendingNonce(
+  publicClient: PublicClient,
+  from: Address,
+): Promise<number> {
+  return Number(await (publicClient as unknown as {
+    getTransactionCount: (args: { address: Address; blockTag: 'pending' }) => Promise<number | bigint>;
+  }).getTransactionCount({ address: from, blockTag: 'pending' }));
+}
+
+async function resolveLatestNonce(
+  publicClient: PublicClient,
+  from: Address,
+): Promise<number> {
+  return Number(await (publicClient as unknown as {
+    getTransactionCount: (args: { address: Address; blockTag: 'latest' }) => Promise<number | bigint>;
+  }).getTransactionCount({ address: from, blockTag: 'latest' }));
+}
+
+function accountAddress(account: unknown): Address | undefined {
+  if (account && typeof account === 'object' && typeof (account as { address?: unknown }).address === 'string') {
+    return (account as { address: Address }).address;
+  }
+  return undefined;
+}
+
+function supportsNonceTracking(publicClient: PublicClient): boolean {
+  const client = publicClient as unknown as {
+    getChainId?: unknown;
+    getTransactionCount?: unknown;
+  };
+  return typeof client.getChainId === 'function' && typeof client.getTransactionCount === 'function';
+}
+
+function isEmptyFees(fees: TxFeeSnapshot): boolean {
+  return fees.maxFeePerGas === undefined
+    && fees.maxPriorityFeePerGas === undefined
+    && fees.gasPrice === undefined;
+}
+
+export async function recoverStuckNonceIfNeeded(args: {
+  publicClient: PublicClient;
+  walletClient: { account?: unknown; sendTransaction: (tx: any) => Promise<Hex> };
+  ledger?: TxSubmissionLedger;
+  from: Address;
+  staleAfterMs?: number;
+  nowMs?: number;
+}): Promise<{
+  nonce: number;
+  previousHash?: Hex;
+  recoveryHash: Hex;
+} | null> {
+  const ledger = args.ledger ?? defaultTxSubmissionLedger;
+  const chainId = await resolveTxChainId(args.publicClient);
+  const [pendingNonce, latestNonce] = await Promise.all([
+    resolvePendingNonce(args.publicClient, args.from),
+    resolveLatestNonce(args.publicClient, args.from),
+  ]);
+  if (pendingNonce <= latestNonce) return null;
+
+  const nowMs = args.nowMs ?? Date.now();
+  const staleAfterMs = args.staleAfterMs ?? TX_RETRY_DEFAULTS.stuckNonceAfterMs;
+
+  for (let nonce = latestNonce; nonce < pendingNonce; nonce++) {
+    const entry = await ledger.getTxSubmission({ chainId, from: args.from, nonce });
+    if (!entry || entry.resolvedAtMs != null) continue;
+    if (nowMs - entry.submittedAtMs < staleAfterMs) continue;
+
+    const feeOverrides = await viemFeeOverridesForAttempt(args.publicClient, 1, {
+      previousFees: entry.fees,
+      forceEstimate: true,
+    });
+    const account = args.walletClient.account;
+    const tx = {
+      account,
+      to: args.from,
+      value: 0n,
+      nonce,
+      ...feeOverrides,
+    };
+    if ('maxFeePerGas' in tx && 'maxPriorityFeePerGas' in tx) {
+      delete (tx as { gasPrice?: bigint }).gasPrice;
+    }
+    const recoveryHash = await args.walletClient.sendTransaction(tx);
+    const fees = feeOverrides as TxFeeSnapshot;
+    await ledger.recordTxSubmission({
+      chainId,
+      from: args.from,
+      nonce,
+      hash: recoveryHash,
+      logicalTx: 'stuck-nonce-recovery',
+      submittedAtMs: nowMs,
+      fees,
+      to: args.from,
+      value: 0n,
+    });
+    await args.publicClient.waitForTransactionReceipt({ hash: recoveryHash });
+    await ledger.markTxSubmissionResolved({ chainId, from: args.from, nonce, resolvedAtMs: nowMs });
+    return { nonce, previousHash: entry.hash, recoveryHash };
+  }
+  return null;
+}
+
 export async function viemSendTransactionWithRetry(
   walletClient: { sendTransaction: (tx: any) => Promise<Hex> },
   publicClient: PublicClient,
@@ -360,19 +600,65 @@ export async function viemSendTransactionWithRetry(
   const maxAttempts = options.maxAttempts ?? TX_RETRY_DEFAULTS.maxAttempts;
   const baseDelayMs = options.baseDelayMs ?? TX_RETRY_DEFAULTS.baseDelayMs;
   const maxDelayMs = options.maxDelayMs ?? TX_RETRY_DEFAULTS.maxDelayMs;
+  const ledger = options.ledger ?? defaultTxSubmissionLedger;
+  const from = accountAddress(txRequest.account);
+  const shouldTrackNonce = from !== undefined && supportsNonceTracking(publicClient);
+  const chainId = shouldTrackNonce ? await resolveTxChainId(publicClient) : undefined;
+  if (from && shouldTrackNonce) {
+    await recoverStuckNonceIfNeeded({
+      publicClient,
+      walletClient: walletClient as { account?: unknown; sendTransaction: (tx: any) => Promise<Hex> },
+      ledger,
+      from,
+      staleAfterMs: options.stuckNonceAfterMs,
+    });
+  }
+  const explicitNonce =
+    txRequest.nonce !== undefined
+      ? Number(txRequest.nonce)
+      : from && shouldTrackNonce
+        ? await resolvePendingNonce(publicClient, from)
+        : undefined;
 
   let lastError: unknown;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     try {
-      const overrides = await viemFeeOverridesForAttempt(publicClient, attempt);
-      const req = { ...txRequest, ...overrides };
+      const previous =
+        from && chainId !== undefined && explicitNonce !== undefined
+          ? await ledger.getTxSubmission({ chainId, from, nonce: explicitNonce })
+          : null;
+      const overrides = await viemFeeOverridesForAttempt(publicClient, attempt, {
+        previousFees: previous?.resolvedAtMs == null ? previous?.fees : undefined,
+        forceEstimate: shouldTrackNonce,
+      });
+      const req = {
+        ...txRequest,
+        ...(explicitNonce !== undefined ? { nonce: explicitNonce } : {}),
+        ...overrides,
+      };
       
       // If we provided maxFeePerGas, ensure gasPrice is not somehow inherited
       if ('maxFeePerGas' in req && 'maxPriorityFeePerGas' in req) {
         delete (req as any).gasPrice;
       }
 
-      return await walletClient.sendTransaction(req);
+      const hash = await walletClient.sendTransaction(req);
+      const fees = overrides as TxFeeSnapshot;
+      if (from && chainId !== undefined && explicitNonce !== undefined && !isEmptyFees(fees)) {
+        await ledger.recordTxSubmission({
+          chainId,
+          from,
+          nonce: explicitNonce,
+          hash,
+          logicalTx: options.logicalTx,
+          submittedAtMs: Date.now(),
+          fees,
+          to: txRequest.to,
+          value: txRequest.value,
+          data: txRequest.data,
+        });
+      }
+      return hash;
     } catch (err) {
       lastError = err;
       if (!isRecoverableTransactionError(err) || attempt >= maxAttempts - 1) {

--- a/client/src/tx-retry.ts
+++ b/client/src/tx-retry.ts
@@ -232,6 +232,58 @@ export interface TxFeeSnapshot {
   gasPrice?: bigint;
 }
 
+export type Eip1559FeeOverrides = {
+  maxFeePerGas: bigint;
+  maxPriorityFeePerGas: bigint;
+  gasPrice?: undefined;
+};
+
+export type LegacyFeeOverrides = {
+  gasPrice: bigint;
+  maxFeePerGas?: undefined;
+  maxPriorityFeePerGas?: undefined;
+};
+
+export type EmptyFeeOverrides = {
+  maxFeePerGas?: undefined;
+  maxPriorityFeePerGas?: undefined;
+  gasPrice?: undefined;
+};
+
+export type TxFeeOverrides = Eip1559FeeOverrides | LegacyFeeOverrides | EmptyFeeOverrides;
+
+export type TxFeeOverrideResult =
+  | { kind: 'eip1559'; overrides: Eip1559FeeOverrides; snapshot: TxFeeSnapshot }
+  | { kind: 'legacy'; overrides: LegacyFeeOverrides; snapshot: TxFeeSnapshot }
+  | { kind: 'none'; overrides: EmptyFeeOverrides; snapshot: TxFeeSnapshot };
+
+export type TxRecoveryTransactionRequest = TxFeeOverrides & {
+  account?: unknown;
+  to: Address;
+  value: bigint;
+  nonce: number;
+};
+
+export interface TxRecoveryWalletClient {
+  account?: unknown;
+  sendTransaction(tx: TxRecoveryTransactionRequest): Promise<Hex>;
+}
+
+export type TxRetryTransactionRequest = TxFeeOverrides & {
+  account?: unknown;
+  to?: Address;
+  data?: Hex;
+  value?: bigint;
+  gas?: bigint;
+  nonce?: number;
+  [key: string]: unknown;
+};
+
+export interface TxRetryWalletClient {
+  account?: unknown;
+  sendTransaction(tx: TxRetryTransactionRequest): Promise<Hex>;
+}
+
 export interface TxSubmissionKey {
   chainId: number;
   from: Address;
@@ -255,6 +307,40 @@ export interface TxSubmissionLedger {
   getTxSubmission(key: TxSubmissionKey): MaybePromise<TxSubmissionLedgerEntry | null>;
   recordTxSubmission(entry: TxSubmissionLedgerEntry): MaybePromise<void>;
   markTxSubmissionResolved(key: TxSubmissionKey & { resolvedAtMs: number }): MaybePromise<void>;
+}
+
+export interface NonceLedgerSubmission {
+  hash?: Hex;
+  logicalTx?: string;
+  submittedAtMs?: number;
+  fees: TxFeeSnapshot;
+  to?: Address;
+  value?: bigint;
+  data?: Hex;
+}
+
+export interface NonceLedgerContext {
+  ledger: TxSubmissionLedger;
+  chainId: number;
+  from: Address;
+  nonce: number;
+  feeResultForAttempt(
+    attemptIndex: number,
+    options?: { forceEstimate?: boolean },
+  ): Promise<TxFeeOverrideResult>;
+  recordSubmitted(entry: NonceLedgerSubmission): Promise<void>;
+  markResolved(resolvedAtMs?: number): Promise<void>;
+}
+
+export interface WithNonceLedgerArgs {
+  publicClient: PublicClient;
+  walletClient?: TxRecoveryWalletClient;
+  ledger?: TxSubmissionLedger;
+  from: Address;
+  nonce?: number;
+  chainId?: number;
+  recoverStuckNonce?: boolean;
+  staleAfterMs?: number;
 }
 
 export function createMemoryTxSubmissionLedger(): TxSubmissionLedger {
@@ -392,6 +478,75 @@ export function mergeFeeEstimateWithPrevious(
   return {};
 }
 
+function feeOverrideResultFromSnapshot(snapshot: TxFeeSnapshot): TxFeeOverrideResult {
+  if (snapshot.maxFeePerGas !== undefined && snapshot.maxPriorityFeePerGas !== undefined) {
+    const overrides: Eip1559FeeOverrides = {
+      maxFeePerGas: snapshot.maxFeePerGas,
+      maxPriorityFeePerGas: snapshot.maxPriorityFeePerGas,
+    };
+    return { kind: 'eip1559', overrides, snapshot: overrides };
+  }
+
+  if (snapshot.gasPrice !== undefined) {
+    const overrides: LegacyFeeOverrides = { gasPrice: snapshot.gasPrice };
+    return { kind: 'legacy', overrides, snapshot: overrides };
+  }
+
+  return { kind: 'none', overrides: {}, snapshot: {} };
+}
+
+/**
+ * EIP-1559 or legacy gas overrides for viem, increasingly aggressive on later attempts.
+ *
+ * The result carries both the spreadable viem transaction overrides and the
+ * ledger snapshot, keeping call sites from recasting the override object.
+ */
+export async function viemFeeOverrideResultForAttempt(
+  publicClient: PublicClient,
+  attemptIndex: number,
+  options: {
+    previousFees?: TxFeeSnapshot | null;
+    forceEstimate?: boolean;
+  } = {},
+): Promise<TxFeeOverrideResult> {
+  if (attemptIndex <= 0 && !options.previousFees && !options.forceEstimate) {
+    return feeOverrideResultFromSnapshot({});
+  }
+
+  try {
+    const fees = await publicClient.estimateFeesPerGas();
+    if (fees.maxFeePerGas !== undefined && fees.maxPriorityFeePerGas !== undefined) {
+      return feeOverrideResultFromSnapshot(
+        mergeFeeEstimateWithPrevious(
+          {
+            maxFeePerGas: fees.maxFeePerGas,
+            maxPriorityFeePerGas: fees.maxPriorityFeePerGas,
+          },
+          options.previousFees,
+          attemptIndex,
+        ),
+      );
+    }
+  } catch {
+    // fall through to gasPrice
+  }
+
+  try {
+    const gasPrice = await publicClient.getGasPrice();
+    return feeOverrideResultFromSnapshot(
+      mergeFeeEstimateWithPrevious(
+        { gasPrice },
+        options.previousFees,
+        attemptIndex,
+      ),
+    );
+  } catch {
+    return options.previousFees
+      ? feeOverrideResultFromSnapshot(mergeFeeEstimateWithPrevious({}, options.previousFees, attemptIndex))
+      : feeOverrideResultFromSnapshot({});
+  }
+}
+
 /** EIP-1559 or legacy gas overrides for viem, increasingly aggressive on later attempts. */
 export async function viemFeeOverridesForAttempt(
   publicClient: PublicClient,
@@ -400,44 +555,8 @@ export async function viemFeeOverridesForAttempt(
     previousFees?: TxFeeSnapshot | null;
     forceEstimate?: boolean;
   } = {},
-): Promise<
-  | { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }
-  | { gasPrice: bigint }
-  | Record<string, never>
-> {
-  if (attemptIndex <= 0 && !options.previousFees && !options.forceEstimate) return {};
-
-  try {
-    const fees = await publicClient.estimateFeesPerGas();
-    if (fees.maxFeePerGas !== undefined && fees.maxPriorityFeePerGas !== undefined) {
-      return mergeFeeEstimateWithPrevious(
-        {
-          maxFeePerGas: fees.maxFeePerGas,
-          maxPriorityFeePerGas: fees.maxPriorityFeePerGas,
-        },
-        options.previousFees,
-        attemptIndex,
-      ) as { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint };
-    }
-  } catch {
-    // fall through to gasPrice
-  }
-
-  try {
-    const gasPrice = await publicClient.getGasPrice();
-    return mergeFeeEstimateWithPrevious(
-      { gasPrice },
-      options.previousFees,
-      attemptIndex,
-    ) as { gasPrice: bigint };
-  } catch {
-    return options.previousFees
-      ? (mergeFeeEstimateWithPrevious({}, options.previousFees, attemptIndex) as
-          | { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }
-          | { gasPrice: bigint }
-          | Record<string, never>)
-      : {};
-  }
+): Promise<TxFeeOverrides> {
+  return (await viemFeeOverrideResultForAttempt(publicClient, attemptIndex, options)).overrides;
 }
 
 export async function waitForTransactionReceiptWithRetry(
@@ -476,25 +595,21 @@ export async function waitForTransactionReceiptWithRetry(
 }
 
 async function resolveTxChainId(publicClient: PublicClient): Promise<number> {
-  return Number(await (publicClient as unknown as { getChainId: () => Promise<number | bigint> }).getChainId());
+  return Number(await publicClient.getChainId());
 }
 
 async function resolvePendingNonce(
   publicClient: PublicClient,
   from: Address,
 ): Promise<number> {
-  return Number(await (publicClient as unknown as {
-    getTransactionCount: (args: { address: Address; blockTag: 'pending' }) => Promise<number | bigint>;
-  }).getTransactionCount({ address: from, blockTag: 'pending' }));
+  return Number(await publicClient.getTransactionCount({ address: from, blockTag: 'pending' }));
 }
 
 async function resolveLatestNonce(
   publicClient: PublicClient,
   from: Address,
 ): Promise<number> {
-  return Number(await (publicClient as unknown as {
-    getTransactionCount: (args: { address: Address; blockTag: 'latest' }) => Promise<number | bigint>;
-  }).getTransactionCount({ address: from, blockTag: 'latest' }));
+  return Number(await publicClient.getTransactionCount({ address: from, blockTag: 'latest' }));
 }
 
 function accountAddress(account: unknown): Address | undefined {
@@ -518,11 +633,85 @@ function isEmptyFees(fees: TxFeeSnapshot): boolean {
     && fees.gasPrice === undefined;
 }
 
+export function removeConflictingLegacyGasPrice<T extends TxFeeSnapshot>(tx: T): void {
+  if (tx.maxFeePerGas !== undefined && tx.maxPriorityFeePerGas !== undefined) {
+    delete tx.gasPrice;
+  }
+}
+
+function withoutFeeOverrides<T extends TxFeeSnapshot>(tx: T): Omit<T, keyof TxFeeSnapshot> {
+  const {
+    maxFeePerGas: _maxFeePerGas,
+    maxPriorityFeePerGas: _maxPriorityFeePerGas,
+    gasPrice: _gasPrice,
+    ...baseRequest
+  } = tx;
+  return baseRequest;
+}
+
+export async function withNonceLedger<T>(
+  args: WithNonceLedgerArgs,
+  fn: (context: NonceLedgerContext) => Promise<T>,
+): Promise<T> {
+  const ledger = args.ledger ?? defaultTxSubmissionLedger;
+  const chainId = args.chainId ?? await resolveTxChainId(args.publicClient);
+
+  if (args.recoverStuckNonce) {
+    if (!args.walletClient) {
+      throw new Error('withNonceLedger recovery requested without a wallet client');
+    }
+    await recoverStuckNonceIfNeeded({
+      publicClient: args.publicClient,
+      walletClient: args.walletClient,
+      ledger,
+      chainId,
+      from: args.from,
+      staleAfterMs: args.staleAfterMs,
+    });
+  }
+
+  const nonce = args.nonce ?? await resolvePendingNonce(args.publicClient, args.from);
+  const key = { chainId, from: args.from, nonce };
+  const context: NonceLedgerContext = {
+    ledger,
+    chainId,
+    from: args.from,
+    nonce,
+    async feeResultForAttempt(attemptIndex, options = {}) {
+      const previous = await ledger.getTxSubmission(key);
+      return viemFeeOverrideResultForAttempt(args.publicClient, attemptIndex, {
+        previousFees: previous?.resolvedAtMs == null ? previous?.fees : undefined,
+        forceEstimate: options.forceEstimate,
+      });
+    },
+    async recordSubmitted(entry) {
+      await ledger.recordTxSubmission({
+        chainId,
+        from: args.from,
+        nonce,
+        hash: entry.hash,
+        logicalTx: entry.logicalTx,
+        submittedAtMs: entry.submittedAtMs ?? Date.now(),
+        fees: entry.fees,
+        to: entry.to,
+        value: entry.value,
+        data: entry.data,
+      });
+    },
+    async markResolved(resolvedAtMs = Date.now()) {
+      await ledger.markTxSubmissionResolved({ chainId, from: args.from, nonce, resolvedAtMs });
+    },
+  };
+
+  return fn(context);
+}
+
 export async function recoverStuckNonceIfNeeded(args: {
   publicClient: PublicClient;
-  walletClient: { account?: unknown; sendTransaction: (tx: any) => Promise<Hex> };
+  walletClient: TxRecoveryWalletClient;
   ledger?: TxSubmissionLedger;
   from: Address;
+  chainId?: number;
   staleAfterMs?: number;
   nowMs?: number;
 }): Promise<{
@@ -531,8 +720,8 @@ export async function recoverStuckNonceIfNeeded(args: {
   recoveryHash: Hex;
 } | null> {
   const ledger = args.ledger ?? defaultTxSubmissionLedger;
-  const chainId = await resolveTxChainId(args.publicClient);
-  const [pendingNonce, latestNonce] = await Promise.all([
+  const [chainId, pendingNonce, latestNonce] = await Promise.all([
+    args.chainId ?? resolveTxChainId(args.publicClient),
     resolvePendingNonce(args.publicClient, args.from),
     resolveLatestNonce(args.publicClient, args.from),
   ]);
@@ -551,18 +740,15 @@ export async function recoverStuckNonceIfNeeded(args: {
       forceEstimate: true,
     });
     const account = args.walletClient.account;
-    const tx = {
+    const tx: TxRecoveryTransactionRequest = {
       account,
       to: args.from,
       value: 0n,
       nonce,
       ...feeOverrides,
     };
-    if ('maxFeePerGas' in tx && 'maxPriorityFeePerGas' in tx) {
-      delete (tx as { gasPrice?: bigint }).gasPrice;
-    }
+    removeConflictingLegacyGasPrice(tx);
     const recoveryHash = await args.walletClient.sendTransaction(tx);
-    const fees = feeOverrides as TxFeeSnapshot;
     await ledger.recordTxSubmission({
       chainId,
       from: args.from,
@@ -570,7 +756,7 @@ export async function recoverStuckNonceIfNeeded(args: {
       hash: recoveryHash,
       logicalTx: 'stuck-nonce-recovery',
       submittedAtMs: nowMs,
-      fees,
+      fees: feeOverrides,
       to: args.from,
       value: 0n,
     });
@@ -582,19 +768,9 @@ export async function recoverStuckNonceIfNeeded(args: {
 }
 
 export async function viemSendTransactionWithRetry(
-  walletClient: { sendTransaction: (tx: any) => Promise<Hex> },
+  walletClient: TxRetryWalletClient,
   publicClient: PublicClient,
-  txRequest: {
-    account: any;
-    to?: Address;
-    data?: Hex;
-    value?: bigint;
-    gas?: bigint;
-    maxFeePerGas?: bigint;
-    maxPriorityFeePerGas?: bigint;
-    gasPrice?: bigint;
-    [key: string]: any;
-  },
+  txRequest: TxRetryTransactionRequest,
   options: TxRetryOptions = {},
 ): Promise<Hex> {
   const maxAttempts = options.maxAttempts ?? TX_RETRY_DEFAULTS.maxAttempts;
@@ -603,74 +779,73 @@ export async function viemSendTransactionWithRetry(
   const ledger = options.ledger ?? defaultTxSubmissionLedger;
   const from = accountAddress(txRequest.account);
   const shouldTrackNonce = from !== undefined && supportsNonceTracking(publicClient);
-  const chainId = shouldTrackNonce ? await resolveTxChainId(publicClient) : undefined;
-  if (from && shouldTrackNonce) {
-    await recoverStuckNonceIfNeeded({
-      publicClient,
-      walletClient: walletClient as { account?: unknown; sendTransaction: (tx: any) => Promise<Hex> },
-      ledger,
-      from,
-      staleAfterMs: options.stuckNonceAfterMs,
-    });
-  }
-  const explicitNonce =
-    txRequest.nonce !== undefined
-      ? Number(txRequest.nonce)
-      : from && shouldTrackNonce
-        ? await resolvePendingNonce(publicClient, from)
-        : undefined;
+  const requestedNonce = txRequest.nonce === undefined ? undefined : Number(txRequest.nonce);
 
-  let lastError: unknown;
-  for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    try {
-      const previous =
-        from && chainId !== undefined && explicitNonce !== undefined
-          ? await ledger.getTxSubmission({ chainId, from, nonce: explicitNonce })
-          : null;
-      const overrides = await viemFeeOverridesForAttempt(publicClient, attempt, {
-        previousFees: previous?.resolvedAtMs == null ? previous?.fees : undefined,
-        forceEstimate: shouldTrackNonce,
-      });
-      const req = {
-        ...txRequest,
-        ...(explicitNonce !== undefined ? { nonce: explicitNonce } : {}),
-        ...overrides,
-      };
-      
-      // If we provided maxFeePerGas, ensure gasPrice is not somehow inherited
-      if ('maxFeePerGas' in req && 'maxPriorityFeePerGas' in req) {
-        delete (req as any).gasPrice;
-      }
+  const sendWithRetry = async (nonceLedger?: NonceLedgerContext): Promise<Hex> => {
+    const pinnedNonce = nonceLedger?.nonce ?? requestedNonce;
 
-      const hash = await walletClient.sendTransaction(req);
-      const fees = overrides as TxFeeSnapshot;
-      if (from && chainId !== undefined && explicitNonce !== undefined && !isEmptyFees(fees)) {
-        await ledger.recordTxSubmission({
-          chainId,
-          from,
-          nonce: explicitNonce,
-          hash,
-          logicalTx: options.logicalTx,
-          submittedAtMs: Date.now(),
-          fees,
-          to: txRequest.to,
-          value: txRequest.value,
-          data: txRequest.data,
+    let lastError: unknown;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        const feeResult = nonceLedger
+          ? await nonceLedger.feeResultForAttempt(attempt, { forceEstimate: true })
+          : await viemFeeOverrideResultForAttempt(publicClient, attempt);
+        const nonceOverride = pinnedNonce !== undefined ? { nonce: pinnedNonce } : {};
+        const req: TxRetryTransactionRequest =
+          feeResult.kind === 'none'
+            ? {
+                ...txRequest,
+                ...nonceOverride,
+              }
+            : {
+                ...withoutFeeOverrides(txRequest),
+                ...nonceOverride,
+                ...feeResult.overrides,
+              };
+        removeConflictingLegacyGasPrice(req);
+
+        const hash = await walletClient.sendTransaction(req);
+        if (nonceLedger && !isEmptyFees(feeResult.snapshot)) {
+          await nonceLedger.recordSubmitted({
+            hash,
+            logicalTx: options.logicalTx,
+            fees: feeResult.snapshot,
+            to: txRequest.to,
+            value: txRequest.value,
+            data: txRequest.data,
+          });
+        }
+        return hash;
+      } catch (err) {
+        lastError = err;
+        if (!isRecoverableTransactionError(err) || attempt >= maxAttempts - 1) {
+          throw err;
+        }
+        options.onRetry?.({
+          attempt: attempt + 1,
+          error: err,
+          message: flattenErrorMessage(err),
         });
+        await backoffDelay(attempt, baseDelayMs, maxDelayMs);
       }
-      return hash;
-    } catch (err) {
-      lastError = err;
-      if (!isRecoverableTransactionError(err) || attempt >= maxAttempts - 1) {
-        throw err;
-      }
-      options.onRetry?.({
-        attempt: attempt + 1,
-        error: err,
-        message: flattenErrorMessage(err),
-      });
-      await backoffDelay(attempt, baseDelayMs, maxDelayMs);
     }
+    throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  };
+
+  if (from && shouldTrackNonce) {
+    return withNonceLedger(
+      {
+        publicClient,
+        walletClient,
+        ledger,
+        from,
+        nonce: requestedNonce,
+        recoverStuckNonce: true,
+        staleAfterMs: options.stuckNonceAfterMs,
+      },
+      sendWithRetry,
+    );
   }
-  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+
+  return sendWithRetry();
 }

--- a/client/test/api/prediction-v1-build.test.ts
+++ b/client/test/api/prediction-v1-build.test.ts
@@ -14,6 +14,7 @@ function seedPredictionRun(
     state?: 'DISCOVERED' | 'COMPLETE' | 'FAILED';
     stateUpdatedAt?: number;
     solverType?: string;
+    runStartedAt?: number;
   },
 ): void {
   persistence.insertDiscovered({
@@ -24,6 +25,7 @@ function seedPredictionRun(
     onchainCreationBlock: 1,
     solverType: input.solverType ?? 'prediction.v1',
     taskRole: input.taskRole ?? 'restoration',
+    runStartedAt: input.runStartedAt,
     windowStartTs: 1_000,
     windowEndTs: 2_000,
     task: {
@@ -247,6 +249,26 @@ describe('gatherPredictionV1Status', () => {
       expect(result.recentTasks.map((task) => task.requestId)).toEqual(
         expect.arrayContaining(['canonical-prediction', 'legacy-prediction']),
       );
+    });
+  });
+
+  it('includes runStartedAt in prediction task summaries', async () => {
+    await withTempStore(async (store) => {
+      const persistence = new TaskRunPersistence(store.db);
+      seedPredictionRun(store, persistence, {
+        requestId: 'recent-prediction-claim',
+        taskId: 'prediction-recent-task',
+        runStartedAt: 50_000,
+        stateUpdatedAt: 60_000,
+      });
+
+      const result = gatherPredictionV1Status(store);
+
+      expect(result.recentTasks[0]).toMatchObject({
+        requestId: 'recent-prediction-claim',
+        windowStartTs: 1_000,
+        runStartedAt: 50_000,
+      });
     });
   });
 });

--- a/client/test/api/task-runs-build.test.ts
+++ b/client/test/api/task-runs-build.test.ts
@@ -103,6 +103,26 @@ describe('gatherTaskRunsStatus', () => {
       expect(status.totals.localErrors).toBe(1);
     });
   });
+
+  it('includes runStartedAt in task run summaries distinct from windowStartTs', async () => {
+    await withTempStore(async (store) => {
+      const persistence = new TaskRunPersistence(store.db);
+      insertTask(persistence, {
+        requestId: 'fresh-claim',
+        taskId: 'task-fresh',
+        taskRole: 'restoration',
+        runStartedAt: 10_000,
+      });
+
+      const status = gatherTaskRunsStatus(store);
+
+      expect(status.inFlight[0]).toMatchObject({
+        requestId: 'fresh-claim',
+        windowStartTs: 1_000,
+        runStartedAt: 10_000,
+      });
+    });
+  });
 });
 
 function insertTask(
@@ -111,6 +131,7 @@ function insertTask(
     requestId: string;
     taskId: string;
     taskRole: 'restoration' | 'evaluation';
+    runStartedAt?: number;
   },
 ): void {
   persistence.insertDiscovered({
@@ -121,6 +142,7 @@ function insertTask(
     onchainCreationBlock: 1,
     solverType: 'swe-rebench-v2.v1',
     taskRole: input.taskRole,
+    runStartedAt: input.runStartedAt,
     windowStartTs: 1_000,
     windowEndTs: 2_000,
     task: {

--- a/client/test/daemon/daemon.test.ts
+++ b/client/test/daemon/daemon.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect } from 'vitest';
+import Database from 'better-sqlite3';
 import { Daemon, type DaemonConfig } from '../../src/daemon/daemon.js';
 import { LocalAdapter } from '../../src/adapters/local/adapter.js';
 import { SimpleRunner } from '../../src/runner/simple.js';
@@ -64,4 +65,78 @@ describe('Daemon', () => {
     await daemon.stop();
     expect(daemon.getShutdownState()).toBe('clean');
   });
+
+  it('persists a recent runStartedAt after claiming a task with an old window start', async () => {
+    const adapter = new LocalAdapter();
+    const dbPath = join(mkdtempSync(join(tmpdir(), 'jinn-daemon-started-test-')), 'jinn.db');
+    const daemon = new Daemon({
+      adapter,
+      runner: new SimpleRunner(async (desc) => `Done: ${desc}`),
+      taskSources: [],
+      dbPath,
+      restorationEngine: minimalEngineConfig(),
+    });
+    await daemon.start();
+
+    try {
+      const beforeClaim = Date.now();
+      const oldWindowStart = beforeClaim - 6 * 86_400_000;
+      await adapter.postTask({
+        id: 'old-window-fresh-claim',
+        description: 'old window, newly claimed',
+        window: { startTs: oldWindowStart, endTs: beforeClaim + 3_600_000 },
+      });
+
+      await waitForTaskRunRow(dbPath, '1');
+      const afterClaim = Date.now();
+      await daemon.stop();
+
+      const db = new Database(dbPath, { readonly: true });
+      try {
+        const row = db
+          .prepare(
+            `SELECT window_start_ts, run_started_at
+             FROM task_runs
+             WHERE task_id = ?`,
+          )
+          .get('1') as { window_start_ts: number; run_started_at: number };
+        expect(row.window_start_ts).toBe(oldWindowStart);
+        expect(row.run_started_at).toBeGreaterThanOrEqual(beforeClaim);
+        expect(row.run_started_at).toBeLessThanOrEqual(afterClaim);
+      } finally {
+        db.close();
+      }
+    } finally {
+      if (daemon.getShutdownState() !== 'clean') {
+        await daemon.stop();
+      }
+    }
+  });
 });
+
+async function waitForTaskRunRow(
+  dbPath: string,
+  taskId: string,
+): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (Date.now() < deadline) {
+    let db: Database.Database | undefined;
+    try {
+      db = new Database(dbPath, { readonly: true, fileMustExist: true });
+      const row = db
+        .prepare(
+          `SELECT 1
+           FROM task_runs
+           WHERE task_id = ?`,
+        )
+        .get(taskId) as { 1: number } | undefined;
+      if (row) return;
+    } catch {
+      // DB file may not exist during the first few milliseconds of daemon startup.
+    } finally {
+      db?.close();
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for task run row for taskId ${taskId}`);
+}

--- a/client/test/harnesses/engine/persistence.test.ts
+++ b/client/test/harnesses/engine/persistence.test.ts
@@ -67,6 +67,7 @@ describe('runAdditiveMigrations', () => {
     expect(columns).toContain('manifest_generated_at');
     expect(columns).toContain('evidence_hash');
     expect(columns).toContain('task_payload');
+    expect(columns).toContain('run_started_at');
 
     db.close();
   });
@@ -116,6 +117,25 @@ describe('TaskRunPersistence', () => {
       p.insertDiscovered(makeInput({ solverType: undefined }));
       const intent = p.getByRequestId('req-001');
       expect(intent!.solverType).toBeNull();
+    });
+
+    it('persists an explicit runStartedAt distinct from the task window start', () => {
+      p.insertDiscovered(makeInput({
+        runStartedAt: 1_700_000,
+        windowStartTs: 2_000_000,
+      }));
+      const intent = p.getByRequestId('req-001');
+      expect(intent!.runStartedAt).toBe(1_700_000);
+      expect(intent!.windowStartTs).toBe(2_000_000);
+    });
+
+    it('defaults runStartedAt to observe time when omitted', () => {
+      const before = Date.now();
+      p.insertDiscovered(makeInput({ runStartedAt: undefined }));
+      const after = Date.now();
+      const intent = p.getByRequestId('req-001');
+      expect(intent!.runStartedAt).toBeGreaterThanOrEqual(before);
+      expect(intent!.runStartedAt).toBeLessThanOrEqual(after);
     });
   });
 

--- a/client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts
+++ b/client/test/harnesses/impls/swe-rebench-v2-evaluator/eval-runner.test.ts
@@ -252,6 +252,28 @@ describe('PythonEvalRunner', () => {
       expect(pruned).toEqual(['img-A']);
     });
 
+    it('carries the image digest resolved before pruning removes the local image', async () => {
+      const upstreamRepoDir = makeUpstreamFixture();
+      const events: string[] = [];
+      const digest = 'sha256:' + 'a'.repeat(64);
+      const runner = new PythonEvalRunner({
+        upstreamRepoDir,
+        maxWorkers: 1,
+        resolveImageDigest: async (image) => {
+          events.push(`digest:${image}`);
+          return digest;
+        },
+        pruneRound: async (image) => {
+          events.push(`prune:${image}`);
+        },
+      });
+
+      const result = await runner.runEval({ ...REQUEST, instance_id: 'i1', image: 'img-A' });
+
+      expect(result.imageDigest).toBe(digest);
+      expect(events).toEqual(['digest:img-A', 'prune:img-A']);
+    });
+
     it('prunes the round image even when the eval throws EvalCouldNotGradeError', async () => {
       // eval.py exits non-zero without writing a report — runEval throws
       // EvalCouldNotGradeError('eval_no_report'). The image must still be

--- a/client/test/harnesses/impls/swe-rebench-v2-evaluator/harness.test.ts
+++ b/client/test/harnesses/impls/swe-rebench-v2-evaluator/harness.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readFileSync
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { SweRebenchV2EvaluatorHarness } from '../../../../src/harnesses/impls/swe-rebench-v2-evaluator/harness.js';
+import { HttpHfFetcher } from '../../../../src/harnesses/impls/swe-rebench-v2-evaluator/hf-fetcher.js';
 import type { Task } from '../../../../src/types/task.js';
 import type { HarnessContext } from '../../../../src/harnesses/types.js';
 import {
@@ -600,6 +601,58 @@ describe('SweRebenchV2EvaluatorHarness — run', () => {
     const runner = makeRunner.mock.results[0]?.value as { runEval: ReturnType<typeof vi.fn> };
     expect(runner.runEval).toHaveBeenCalledTimes(2);
   });
+
+  it('retries a transient HF 429 during substrate recheck and still emits a verdict', async () => {
+    const hfRow = {
+      instance_id: 'unidata__netcdf-c-1925',
+      repo: 'Unidata/netcdf-c',
+      image_name: 'docker.io/swerebenchv2/test:latest',
+      FAIL_TO_PASS: ['test_a'],
+      PASS_TO_PASS: ['test_b'],
+      test_patch: 'diff --git ...',
+      install_config: { test_cmd: 'make test', log_parser: 'pytest' },
+    };
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('rate limited', { status: 429 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        rows: [{ row: hfRow }],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    const fetcher = new HttpHfFetcher({
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      retryBackoffMs: [0],
+      minRequestIntervalMs: 0,
+      sleep: vi.fn(async () => undefined),
+    });
+    const runner = {
+      runEval: vi.fn().mockResolvedValue({
+        passed_match: true,
+        passed: ['test_a'],
+        failed: [],
+        log: 'ok after retry',
+        exitCode: 0,
+      }),
+    };
+    const harness = new SweRebenchV2EvaluatorHarness({
+      implStateDir,
+      _testDeps: {
+        fetcher,
+        runner,
+        uploadToIpfs: vi.fn().mockResolvedValue('bafy-retry-log'),
+        stateDir: implStateDir,
+      },
+    });
+
+    const sol = await harness.run(buildHarnessContext(
+      implStateDir,
+      buildEvaluationTask(buildSolverEnvelope()),
+    ));
+
+    expect(sol.gating).toMatchObject({ verdict: 'PASS' });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(runner.runEval).toHaveBeenCalledTimes(1);
+    expect(existsSync(join(implStateDir, 'swe-rebench-v2-verdict.json'))).toBe(true);
+  });
 });
 
 describe('SweRebenchV2EvaluatorHarness — verdict-time substrate recheck', () => {
@@ -804,5 +857,34 @@ describe('SweRebenchV2EvaluatorHarness — verdict-time substrate recheck', () =
     expect(sol.gating).toMatchObject({ verdict: 'PASS' });
     // Confirm the runner was actually invoked (grading happened).
     expect(runner.runEval).toHaveBeenCalledTimes(1);
+  });
+
+  it('loads the evaluator pool once and shares it across run() calls', async () => {
+    await seedAdmission(stateDir, INSTANCE_ID, {
+      scorable: true,
+      rowHash: MATCHING_ROW_HASH,
+    });
+    const loadPool = makeMatchingPoolLoader();
+    const runner = {
+      runEval: vi.fn().mockResolvedValue({
+        passed_match: true,
+        passed: ['test_a'],
+        failed: [],
+        log: 'ok',
+        exitCode: 0,
+      }),
+    };
+    const harness = makeHarness({
+      fetcher: { fetchTaskRow: vi.fn().mockResolvedValue(STUB_ROW) },
+      loadPool,
+      runner,
+      uploadToIpfs: vi.fn().mockResolvedValue('bafy-ok'),
+    });
+
+    await harness.run(makeCtx());
+    await harness.run(makeCtx());
+
+    expect(loadPool).toHaveBeenCalledTimes(1);
+    expect(runner.runEval).toHaveBeenCalledTimes(2);
   });
 });

--- a/client/test/harnesses/impls/swe-rebench-v2-evaluator/harness.test.ts
+++ b/client/test/harnesses/impls/swe-rebench-v2-evaluator/harness.test.ts
@@ -939,11 +939,15 @@ describe('SweRebenchV2EvaluatorHarness — verdict-time substrate recheck', () =
       uploadToIpfs: vi.fn().mockResolvedValue('bafy-ok'),
     });
 
-    const sol = await harness.run(buildHarnessContext(implStateDir, task));
+    const ctx = buildHarnessContext(implStateDir, task);
+    const sol = await harness.run(ctx);
+    const second = await harness.run(ctx);
 
     expect(sol.gating).toMatchObject({ verdict: 'PASS' });
+    expect(second.gating).toMatchObject({ verdict: 'PASS' });
+    expect(fetchFromIpfs).toHaveBeenCalledTimes(1);
     expect(fetchFromIpfs).toHaveBeenCalledWith(expect.any(String), 'bafy-vetted-pool');
-    expect(runner.runEval).toHaveBeenCalledTimes(1);
+    expect(runner.runEval).toHaveBeenCalledTimes(2);
     expect(loadPool).not.toHaveBeenCalled();
     expect(runCommand).not.toHaveBeenCalled();
   });

--- a/client/test/harnesses/impls/swe-rebench-v2-evaluator/harness.test.ts
+++ b/client/test/harnesses/impls/swe-rebench-v2-evaluator/harness.test.ts
@@ -9,7 +9,10 @@ import type { HarnessContext } from '../../../../src/harnesses/types.js';
 import {
   ValidatedPoolStore,
   EVAL_SEMANTICS_VERSION,
+  createVettedPoolArtifactRef,
+  hashVettedPoolArtifact,
   type ValidatedPoolEntry,
+  type SweRebenchV2VettedPoolArtifact,
 } from '../../../../src/solver-types/_swe-rebench-v2-validated-pool.js';
 import { computeRowHash } from '../../../../src/solver-types/_swe-rebench-v2-substrate.js';
 
@@ -886,5 +889,101 @@ describe('SweRebenchV2EvaluatorHarness — verdict-time substrate recheck', () =
 
     expect(loadPool).toHaveBeenCalledTimes(1);
     expect(runner.runEval).toHaveBeenCalledTimes(2);
+  });
+
+  it('grades launcher-posted tasks from the published pool ref without local admission data', async () => {
+    const artifact: SweRebenchV2VettedPoolArtifact = {
+      schemaVersion: 'swe-rebench-v2-vetted-pool.v1',
+      evalSemanticsVersion: EVAL_SEMANTICS_VERSION,
+      generatedAt: '2026-05-22T00:00:00.000Z',
+      entries: [
+        {
+          instance_id: INSTANCE_ID,
+          scorable: true,
+          reason: 'gold-patch-resolves',
+          checkedAt: '2026-05-14T00:00:00Z',
+          rowHash: MATCHING_ROW_HASH,
+          imageName: IMAGE_NAME,
+          imageDigest: IMAGE_DIGEST,
+        },
+      ],
+    };
+    const ref = createVettedPoolArtifactRef({
+      manifestCid: 'bafy-launch-manifest',
+      artifactCid: 'bafy-vetted-pool',
+      artifactHash: hashVettedPoolArtifact(artifact),
+      evalSemanticsVersion: EVAL_SEMANTICS_VERSION,
+      publishedAt: '2026-05-22T00:00:00.000Z',
+    });
+    const task = buildEvaluationTask(buildSolverEnvelope());
+    task.solverNetManifestCid = 'bafy-launch-manifest';
+    task.eligibility = { vettedPoolRef: ref };
+    const runner = {
+      runEval: vi.fn().mockResolvedValue({
+        passed_match: true,
+        passed: ['test_a'],
+        failed: [],
+        log: 'ok',
+        exitCode: 0,
+      }),
+    };
+    const loadPool = makeMatchingPoolLoader();
+    const runCommand = makeMatchingDockerInspect();
+    const fetchFromIpfs = vi.fn().mockResolvedValue(artifact);
+    const harness = makeHarness({
+      fetcher: { fetchTaskRow: vi.fn().mockResolvedValue(STUB_ROW) },
+      fetchFromIpfs,
+      loadPool,
+      runCommand: runCommand as unknown as typeof import('../../../../src/harnesses/impls/swe-rebench-v2-evaluator/harness.js').runCommand,
+      runner,
+      uploadToIpfs: vi.fn().mockResolvedValue('bafy-ok'),
+    });
+
+    const sol = await harness.run(buildHarnessContext(implStateDir, task));
+
+    expect(sol.gating).toMatchObject({ verdict: 'PASS' });
+    expect(fetchFromIpfs).toHaveBeenCalledWith(expect.any(String), 'bafy-vetted-pool');
+    expect(runner.runEval).toHaveBeenCalledTimes(1);
+    expect(loadPool).not.toHaveBeenCalled();
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it('skips launcher-posted tasks when the published pool ref omits the instance', async () => {
+    const artifact: SweRebenchV2VettedPoolArtifact = {
+      schemaVersion: 'swe-rebench-v2-vetted-pool.v1',
+      evalSemanticsVersion: EVAL_SEMANTICS_VERSION,
+      generatedAt: '2026-05-22T00:00:00.000Z',
+      entries: [
+        {
+          instance_id: 'other__repo-1',
+          scorable: true,
+          reason: 'gold-patch-resolves',
+          checkedAt: '2026-05-14T00:00:00Z',
+        },
+      ],
+    };
+    const ref = createVettedPoolArtifactRef({
+      manifestCid: 'bafy-launch-manifest',
+      artifactCid: 'bafy-vetted-pool',
+      artifactHash: hashVettedPoolArtifact(artifact),
+      evalSemanticsVersion: EVAL_SEMANTICS_VERSION,
+      publishedAt: '2026-05-22T00:00:00.000Z',
+    });
+    const task = buildEvaluationTask(buildSolverEnvelope());
+    task.solverNetManifestCid = 'bafy-launch-manifest';
+    task.eligibility = { vettedPoolRef: ref };
+    const { SkippableError } = await import('../../../../src/harnesses/types.js');
+    const harness = makeHarness({
+      fetcher: { fetchTaskRow: vi.fn() },
+      fetchFromIpfs: vi.fn().mockResolvedValue(artifact),
+      runner: { runEval: vi.fn() },
+      uploadToIpfs: vi.fn(),
+    });
+
+    const err = await harness.run(buildHarnessContext(implStateDir, task)).catch((e) => e);
+
+    expect(err).toBeInstanceOf(SkippableError);
+    expect(err.reason).toBe('vetted_pool_instance_missing_or_unscorable');
+    expect(err.reason).not.toBe('admission_missing_or_unscorable');
   });
 });

--- a/client/test/harnesses/impls/swe-rebench-v2-evaluator/hf-fetcher.test.ts
+++ b/client/test/harnesses/impls/swe-rebench-v2-evaluator/hf-fetcher.test.ts
@@ -117,7 +117,7 @@ describe('HttpHfFetcher', () => {
 
   it('throws when HF datasets-server returns non-2xx', async () => {
     const fetchImpl = vi.fn().mockResolvedValue(new Response('rate limited', { status: 429 }));
-    const fetcher = new HttpHfFetcher({ fetchImpl });
+    const fetcher = new HttpHfFetcher({ fetchImpl, retryBackoffMs: [] });
     await expect(
       fetcher.fetchTaskRow({
         hf_dataset: 'nebius/SWE-rebench-leaderboard',
@@ -155,6 +155,86 @@ describe('HttpHfFetcher', () => {
 });
 
 describe('HttpHfFetcher — retry budget for transient failures', () => {
+  it('retries on HTTP 429 and succeeds on the second try', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('rate limited', { status: 429 }))
+      .mockResolvedValueOnce(jsonResponse({ rows: [{ row: makeRow('a__1') }] }));
+    const sleep = vi.fn(async () => undefined);
+    const fetcher = new HttpHfFetcher({
+      fetchImpl,
+      retryBackoffMs: [25],
+      minRequestIntervalMs: 0,
+      sleep,
+    });
+
+    const row = await fetcher.fetchTaskRow({ hf_dataset: 'd', hf_split: 's', instance_id: 'a__1' });
+
+    expect(row.instance_id).toBe('a__1');
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(25);
+  });
+
+  it('honors Retry-After for retryable responses', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('rate limited', {
+        status: 429,
+        headers: { 'Retry-After': '2' },
+      }))
+      .mockResolvedValueOnce(jsonResponse({ rows: [{ row: makeRow('a__1') }] }));
+    const sleep = vi.fn(async () => undefined);
+    const fetcher = new HttpHfFetcher({
+      fetchImpl,
+      retryBackoffMs: [25],
+      minRequestIntervalMs: 0,
+      sleep,
+    });
+
+    await fetcher.fetchTaskRow({ hf_dataset: 'd', hf_split: 's', instance_id: 'a__1' });
+
+    expect(sleep).toHaveBeenCalledWith(2000);
+  });
+
+  it('serializes requests through the shared throttle', async () => {
+    const events: string[] = [];
+    let releaseFirst!: () => void;
+    const firstRequest = new Promise<Response>((resolve) => {
+      releaseFirst = () => {
+        events.push('first released');
+        resolve(jsonResponse({ rows: [{ row: makeRow('a__1') }] }));
+      };
+    });
+    const fetchImpl = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        events.push('first fetch');
+        return firstRequest;
+      })
+      .mockImplementationOnce(async () => {
+        events.push('second fetch');
+        return jsonResponse({ rows: [{ row: makeRow('b__2') }] });
+      });
+    const sleep = vi.fn(async () => undefined);
+    const fetcherA = new HttpHfFetcher({ fetchImpl, minRequestIntervalMs: 10, sleep });
+    const fetcherB = new HttpHfFetcher({ fetchImpl, minRequestIntervalMs: 10, sleep });
+
+    const first = fetcherA.fetchTaskRow({ hf_dataset: 'd', hf_split: 's', instance_id: 'a__1' });
+    const second = fetcherB.fetchTaskRow({ hf_dataset: 'd', hf_split: 's', instance_id: 'b__2' });
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    try {
+      expect(events).toEqual(['first fetch']);
+    } finally {
+      releaseFirst();
+    }
+
+    await Promise.all([first, second]);
+
+    expect(events).toEqual(['first fetch', 'first released', 'second fetch']);
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep.mock.calls[0]?.[0]).toBeGreaterThan(0);
+  });
+
   it('retries on transient HTTP 5xx and succeeds on the third try', async () => {
     let calls = 0;
     const fetchImpl = (async () => {
@@ -164,7 +244,7 @@ describe('HttpHfFetcher — retry budget for transient failures', () => {
         rows: [{ row: makeRow('a__1') }],
       }), { status: 200 });
     }) as unknown as typeof fetch;
-    const fetcher = new HttpHfFetcher({ fetchImpl, retryBackoffMs: [1, 2, 4] });
+    const fetcher = new HttpHfFetcher({ fetchImpl, retryBackoffMs: [1, 2, 4], minRequestIntervalMs: 0 });
     const row = await fetcher.fetchTaskRow({ hf_dataset: 'd', hf_split: 's', instance_id: 'a__1' });
     expect(row.instance_id).toBe('a__1');
     expect(calls).toBe(3);
@@ -176,7 +256,7 @@ describe('HttpHfFetcher — retry budget for transient failures', () => {
       calls += 1;
       return new Response('', { status: 503 });
     }) as unknown as typeof fetch;
-    const fetcher = new HttpHfFetcher({ fetchImpl, retryBackoffMs: [1, 2, 4] });
+    const fetcher = new HttpHfFetcher({ fetchImpl, retryBackoffMs: [1, 2, 4], minRequestIntervalMs: 0 });
     await expect(
       fetcher.fetchTaskRow({ hf_dataset: 'd', hf_split: 's', instance_id: 'a__1' }),
     ).rejects.toThrow(/503/);
@@ -189,7 +269,7 @@ describe('HttpHfFetcher — retry budget for transient failures', () => {
       calls += 1;
       return new Response('', { status: 404 });
     }) as unknown as typeof fetch;
-    const fetcher = new HttpHfFetcher({ fetchImpl, retryBackoffMs: [1, 2, 4] });
+    const fetcher = new HttpHfFetcher({ fetchImpl, retryBackoffMs: [1, 2, 4], minRequestIntervalMs: 0 });
     await expect(
       fetcher.fetchTaskRow({ hf_dataset: 'd', hf_split: 's', instance_id: 'a__1' }),
     ).rejects.toThrow(/404/);

--- a/client/test/solver-types/swe-rebench-v2-generator-cooldown.test.ts
+++ b/client/test/solver-types/swe-rebench-v2-generator-cooldown.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -276,6 +276,7 @@ describe('swe-rebench-v2 generator — admissionMode: required', () => {
       artifactCid: 'bafy-vetted-pool-cid',
       evalSemanticsVersion: EVAL_SEMANTICS_VERSION,
     });
+    expect(task?.context?.['vettedPoolRef']).toBeUndefined();
   });
 
   it('uses the published artifact pool, not unpublished local scorable entries', async () => {
@@ -312,6 +313,50 @@ describe('swe-rebench-v2 generator — admissionMode: required', () => {
 
     expect(task?.spec).toMatchObject({ instance_id: 'org__repo-2' });
     expect(task?.eligibility?.['vettedPoolRef']).toEqual(ref);
+  });
+
+  it('caches the write-once vetted-pool publication after first resolution', async () => {
+    const artifact: SweRebenchV2VettedPoolArtifact = {
+      schemaVersion: 'swe-rebench-v2-vetted-pool.v1',
+      evalSemanticsVersion: EVAL_SEMANTICS_VERSION,
+      generatedAt: '2026-05-22T00:00:00.000Z',
+      entries: [
+        {
+          instance_id: 'org__repo-1',
+          scorable: true,
+          reason: 'gold-patch-resolves',
+          checkedAt: '2026-05-14T00:00:00Z',
+        },
+        {
+          instance_id: 'org__repo-2',
+          scorable: true,
+          reason: 'gold-patch-resolves',
+          checkedAt: '2026-05-14T00:00:01Z',
+        },
+      ],
+    };
+    const ref = createVettedPoolArtifactRef({
+      manifestCid: launchedRecord().manifestCid,
+      artifactCid: 'bafy-existing-vetted-pool',
+      artifactHash: hashVettedPoolArtifact(artifact),
+      evalSemanticsVersion: EVAL_SEMANTICS_VERSION,
+      publishedAt: '2026-05-22T00:00:00.000Z',
+    });
+    await writeVettedPoolArtifactPublication({ stateDir, ref, artifact });
+
+    const gen = makeTestGenerator({
+      stateDir,
+      admissionMode: 'required',
+      N_max_postings_per_task: 1,
+    });
+
+    const first = await gen();
+    unlinkSync(join(stateDir, 'vetted-pool-artifact-publication.json'));
+    const second = await gen();
+
+    expect(first?.spec).toMatchObject({ instance_id: 'org__repo-1' });
+    expect(second?.spec).toMatchObject({ instance_id: 'org__repo-2' });
+    expect(second?.eligibility?.['vettedPoolRef']).toEqual(ref);
   });
 
   it('falls back to python-floor when admissionMode is python-floor and no validation data exists', async () => {

--- a/client/test/solver-types/swe-rebench-v2-generator-cooldown.test.ts
+++ b/client/test/solver-types/swe-rebench-v2-generator-cooldown.test.ts
@@ -5,7 +5,14 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { makeSweRebenchV2GeneratorForLaunchedRecord } from '../../src/solver-types/swe-rebench-v2.js';
 import type { AdmissionMode } from '../../src/solver-types/_swe-rebench-v2-validated-pool.js';
-import { ValidatedPoolStore, EVAL_SEMANTICS_VERSION } from '../../src/solver-types/_swe-rebench-v2-validated-pool.js';
+import {
+  ValidatedPoolStore,
+  EVAL_SEMANTICS_VERSION,
+  createVettedPoolArtifactRef,
+  hashVettedPoolArtifact,
+  writeVettedPoolArtifactPublication,
+  type SweRebenchV2VettedPoolArtifact,
+} from '../../src/solver-types/_swe-rebench-v2-validated-pool.js';
 import type { LaunchedSolverNetRecord } from '../../src/solvernets/store.js';
 import type { PoolTask } from '../../src/solver-types/_swe-rebench-v2-pool.js';
 
@@ -201,10 +208,19 @@ describe('swe-rebench-v2 generator — admissionMode: required', () => {
     stateDir = tmpDir();
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-14T10:00:00.000Z'));
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: true,
-      json: async () => ({ splits: [{ split: '2026_02' }] }),
-    } as Response);
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (init?.method === 'POST' || url.includes('/api/v0/add')) {
+        return {
+          status: 200,
+          text: async () => `${JSON.stringify({ Hash: 'bafy-vetted-pool-cid' })}\n`,
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({ splits: [{ split: '2026_02' }] }),
+      } as Response;
+    });
   });
 
   afterEach(() => {
@@ -233,6 +249,69 @@ describe('swe-rebench-v2 generator — admissionMode: required', () => {
     const gen = makeTestGenerator({ stateDir, admissionMode: 'required' });
     const task = await gen();
     expect(task?.spec).toMatchObject({ instance_id: 'org__repo-1' });
+  });
+
+  it('publishes the local scorable pool before posting and stamps the artifact ref', async () => {
+    const store = new ValidatedPoolStore({ stateDir });
+    await store.record(
+      'org__repo-1',
+      {
+        scorable: true,
+        reason: 'gold-patch-resolves',
+        checkedAt: '2026-05-14T00:00:00Z',
+        rowHash: 'sha256:' + '1'.repeat(64),
+        imageDigest: 'sha256:' + 'a'.repeat(64),
+      },
+      EVAL_SEMANTICS_VERSION,
+    );
+    const gen = makeTestGenerator({ stateDir, admissionMode: 'required' });
+
+    const task = await gen();
+
+    expect(task?.spec).toMatchObject({ instance_id: 'org__repo-1' });
+    expect(task?.eligibility?.['vettedPoolRef']).toMatchObject({
+      schemaVersion: 'solvernet.artifact-ref.v1',
+      manifestCid: launchedRecord().manifestCid,
+      artifactType: 'swe-rebench-v2-vetted-pool.v1',
+      artifactCid: 'bafy-vetted-pool-cid',
+      evalSemanticsVersion: EVAL_SEMANTICS_VERSION,
+    });
+  });
+
+  it('uses the published artifact pool, not unpublished local scorable entries', async () => {
+    const store = new ValidatedPoolStore({ stateDir });
+    await store.record(
+      'org__repo-1',
+      { scorable: true, reason: 'locally validated only', checkedAt: '2026-05-14T00:00:00Z' },
+      EVAL_SEMANTICS_VERSION,
+    );
+    const artifact: SweRebenchV2VettedPoolArtifact = {
+      schemaVersion: 'swe-rebench-v2-vetted-pool.v1',
+      evalSemanticsVersion: EVAL_SEMANTICS_VERSION,
+      generatedAt: '2026-05-22T00:00:00.000Z',
+      entries: [
+        {
+          instance_id: 'org__repo-2',
+          scorable: true,
+          reason: 'gold-patch-resolves',
+          checkedAt: '2026-05-14T00:00:01Z',
+        },
+      ],
+    };
+    const ref = createVettedPoolArtifactRef({
+      manifestCid: launchedRecord().manifestCid,
+      artifactCid: 'bafy-existing-vetted-pool',
+      artifactHash: hashVettedPoolArtifact(artifact),
+      evalSemanticsVersion: EVAL_SEMANTICS_VERSION,
+      publishedAt: '2026-05-22T00:00:00.000Z',
+    });
+    await writeVettedPoolArtifactPublication({ stateDir, ref, artifact });
+
+    const gen = makeTestGenerator({ stateDir, admissionMode: 'required' });
+    const task = await gen();
+
+    expect(task?.spec).toMatchObject({ instance_id: 'org__repo-2' });
+    expect(task?.eligibility?.['vettedPoolRef']).toEqual(ref);
   });
 
   it('falls back to python-floor when admissionMode is python-floor and no validation data exists', async () => {

--- a/client/test/solver-types/swe-rebench-v2-validated-pool.test.ts
+++ b/client/test/solver-types/swe-rebench-v2-validated-pool.test.ts
@@ -7,6 +7,10 @@ import {
   filterToScorablePool,
   validatePoolInstances,
   EVAL_SEMANTICS_VERSION,
+  exportScorableVettedPoolArtifact,
+  hashVettedPoolArtifact,
+  loadVettedPoolArtifactScorableEntries,
+  sweRebenchV2VettedPoolArtifactMetadataKey,
 } from '../../src/solver-types/_swe-rebench-v2-validated-pool.js';
 import { computeRowHash } from '../../src/solver-types/_swe-rebench-v2-substrate.js';
 import type { PoolTask } from '../../src/solver-types/_swe-rebench-v2-pool.js';
@@ -107,6 +111,76 @@ describe('filterToScorablePool', () => {
     ];
     const { pool: out } = filterToScorablePool(inferred, null, 'python-floor');
     expect(out.map((t) => t.instance_id)).toEqual(['a__inferred_py']);
+  });
+});
+
+describe('swe-rebench-v2 vetted pool artifact helpers', () => {
+  it('exports only scorable entries with grading substrate metadata and stable hash', async () => {
+    const dir = tmpDir();
+    const store = new ValidatedPoolStore({ stateDir: dir });
+    await store.record(
+      'org__repo-2',
+      {
+        scorable: true,
+        reason: 'gold-patch-resolves',
+        checkedAt: '2026-05-14T00:00:02Z',
+        rowHash: 'sha256:' + '2'.repeat(64),
+        imageName: 'swerebenchv2/repo-2:latest',
+        imageDigest: 'sha256:' + 'b'.repeat(64),
+        upstreamEvalCommit: '2'.repeat(40),
+      },
+      EVAL_SEMANTICS_VERSION,
+    );
+    await store.record(
+      'org__repo-1',
+      {
+        scorable: true,
+        reason: 'gold-patch-resolves',
+        checkedAt: '2026-05-14T00:00:01Z',
+        rowHash: 'sha256:' + '1'.repeat(64),
+        imageName: 'swerebenchv2/repo-1:latest',
+        imageDigest: 'sha256:' + 'a'.repeat(64),
+        upstreamEvalCommit: '1'.repeat(40),
+      },
+      EVAL_SEMANTICS_VERSION,
+    );
+    await store.record(
+      'org__repo-bad',
+      {
+        scorable: false,
+        reason: 'gold-patch-not-resolved',
+        checkedAt: '2026-05-14T00:00:03Z',
+      },
+      EVAL_SEMANTICS_VERSION,
+    );
+
+    const artifact = await exportScorableVettedPoolArtifact(store, EVAL_SEMANTICS_VERSION, {
+      generatedAt: '2026-05-22T00:00:00.000Z',
+    });
+
+    expect(artifact).toMatchObject({
+      schemaVersion: 'swe-rebench-v2-vetted-pool.v1',
+      evalSemanticsVersion: EVAL_SEMANTICS_VERSION,
+      generatedAt: '2026-05-22T00:00:00.000Z',
+    });
+    expect(artifact.entries.map((e) => e.instance_id)).toEqual(['org__repo-1', 'org__repo-2']);
+    expect(artifact.entries[0]).toMatchObject({
+      instance_id: 'org__repo-1',
+      reason: 'gold-patch-resolves',
+      rowHash: 'sha256:' + '1'.repeat(64),
+      imageName: 'swerebenchv2/repo-1:latest',
+      imageDigest: 'sha256:' + 'a'.repeat(64),
+      upstreamEvalCommit: '1'.repeat(40),
+    });
+
+    const entries = loadVettedPoolArtifactScorableEntries(artifact);
+    expect(entries.ids).toEqual(new Set(['org__repo-1', 'org__repo-2']));
+    expect(entries.byId.get('org__repo-2')?.imageDigest).toBe('sha256:' + 'b'.repeat(64));
+    expect(hashVettedPoolArtifact(artifact)).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(hashVettedPoolArtifact({ ...artifact, entries: [...artifact.entries].reverse() }))
+      .toBe(hashVettedPoolArtifact(artifact));
+    expect(sweRebenchV2VettedPoolArtifactMetadataKey('bafy-manifest'))
+      .toBe('solvernet-artifact:bafy-manifest:swe-rebench-v2-vetted-pool');
   });
 });
 
@@ -374,6 +448,60 @@ describe('validatePoolInstances — populates substrate fields', () => {
       upstreamEvalCommit: '0123456789abcdef0123456789abcdef01234567',
     });
     expect(entry!.rowHash).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  it('uses the runner-carried imageDigest when cleanup pruned the local image before post-eval inspection', async () => {
+    const dir = tmpDir();
+    const store = new ValidatedPoolStore({ stateDir: dir });
+    const carriedDigest = 'sha256:' + 'f'.repeat(64);
+
+    const summary = await validatePoolInstances(
+      [poolTask('a__1')],
+      {
+        fetcher: {
+          fetchTaskRow: async () => ({
+            instance_id: 'a__1',
+            repo: 'acme/widget',
+            image_name: 'acme/widget:latest',
+            FAIL_TO_PASS: ['t::a'],
+            PASS_TO_PASS: ['t::b'],
+            test_patch: 'diff b',
+            install_config: { install: ['pip install .'], test_cmd: ['pytest'], log_parser: 'parse_log_pytest' },
+          }),
+        },
+        runner: {
+          runEval: async () => ({
+            passed_match: true,
+            passed: ['t::a'],
+            failed: [],
+            log: '',
+            exitCode: 0,
+            imageDigest: carriedDigest,
+          }),
+        },
+        store,
+        semanticsVersion: EVAL_SEMANTICS_VERSION,
+        upstreamRepoDir: '/fake/upstream',
+        commandRunner: async (bin, args) => {
+          if (bin === 'docker' && args[0] === 'image') {
+            return { exitCode: 1, stdout: '', stderr: 'No such image: acme/widget:latest' };
+          }
+          if (bin === 'git' && args[0] === 'rev-parse') {
+            return { exitCode: 0, stdout: '0123456789abcdef0123456789abcdef01234567\n', stderr: '' };
+          }
+          return { exitCode: 1, stdout: '', stderr: 'unexpected' };
+        },
+      },
+    );
+
+    expect(summary).toMatchObject({ checked: 1, scorable: 1, unscorable: 0 });
+    const entry = await store.getEntry('a__1', EVAL_SEMANTICS_VERSION);
+    expect(entry).toMatchObject({
+      scorable: true,
+      reason: 'gold-patch-resolves',
+      imageName: 'acme/widget:latest',
+      imageDigest: carriedDigest,
+    });
   });
 
   it('records the entry as unscorable when imageDigest cannot be resolved (required mode)', async () => {

--- a/client/test/store/store.test.ts
+++ b/client/test/store/store.test.ts
@@ -28,6 +28,52 @@ describe('Store', () => {
     expect(store.getShutdownState()).toBe('clean');
   });
 
+  it('persists unresolved transaction submissions for replacement fee recovery', () => {
+    store.recordTxSubmission({
+      chainId: 84532,
+      from: '0x1111111111111111111111111111111111111111',
+      nonce: 7,
+      hash: `0x${'11'.repeat(32)}`,
+      logicalTx: 'safe.execTransaction',
+      submittedAtMs: 1_000,
+      fees: {
+        maxFeePerGas: 100n,
+        maxPriorityFeePerGas: 10n,
+      },
+      to: '0x2222222222222222222222222222222222222222',
+      value: 0n,
+      data: '0x1234',
+    });
+
+    expect(store.getTxSubmission({
+      chainId: 84532,
+      from: '0x1111111111111111111111111111111111111111',
+      nonce: 7,
+    })).toMatchObject({
+      hash: `0x${'11'.repeat(32)}`,
+      logicalTx: 'safe.execTransaction',
+      fees: {
+        maxFeePerGas: 100n,
+        maxPriorityFeePerGas: 10n,
+      },
+      data: '0x1234',
+      resolvedAtMs: null,
+    });
+
+    store.markTxSubmissionResolved({
+      chainId: 84532,
+      from: '0x1111111111111111111111111111111111111111',
+      nonce: 7,
+      resolvedAtMs: 2_000,
+    });
+
+    expect(store.getTxSubmission({
+      chainId: 84532,
+      from: '0x1111111111111111111111111111111111111111',
+      nonce: 7,
+    })?.resolvedAtMs).toBe(2_000);
+  });
+
   it('aggregates own activity and config rows', () => {
     store.recordOwnActivity('r1', 'delivered');
     store.recordOwnActivity('r2', 'evaluated');

--- a/client/test/tx-retry.test.ts
+++ b/client/test/tx-retry.test.ts
@@ -6,6 +6,7 @@ import {
   recoverStuckNonceIfNeeded,
   viemSendTransactionWithRetry,
   withRecoverableRetry,
+  withNonceLedger,
   viemFeeOverridesForAttempt,
   waitForContractCode,
 } from '../src/tx-retry.js';
@@ -320,6 +321,87 @@ describe('tx-retry', () => {
     });
   });
 
+  describe('withNonceLedger', () => {
+    it('resolves chain/from/nonce once and records submissions through the provided ledger', async () => {
+      const from = '0x1111111111111111111111111111111111111111' as const;
+      const ledger = createMemoryTxSubmissionLedger();
+      await ledger.recordTxSubmission({
+        chainId: 84532,
+        from,
+        nonce: 7,
+        hash: `0x${'11'.repeat(32)}`,
+        logicalTx: 'previous',
+        submittedAtMs: 1_000,
+        fees: {
+          maxFeePerGas: 100n,
+          maxPriorityFeePerGas: 10n,
+        },
+      });
+      const publicClient = {
+        getChainId: vi.fn().mockResolvedValue(84532),
+        getTransactionCount: vi.fn().mockResolvedValue(7),
+        estimateFeesPerGas: vi.fn().mockResolvedValue({
+          maxFeePerGas: 80n,
+          maxPriorityFeePerGas: 8n,
+        }),
+        getGasPrice: vi.fn(),
+      };
+
+      const result = await withNonceLedger(
+        {
+          publicClient: publicClient as never,
+          ledger,
+          from,
+        },
+        async (nonceLedger) => {
+          expect(nonceLedger.chainId).toBe(84532);
+          expect(nonceLedger.from).toBe(from);
+          expect(nonceLedger.nonce).toBe(7);
+
+          const feeResult = await nonceLedger.feeResultForAttempt(1, {
+            forceEstimate: true,
+          });
+          expect(feeResult).toMatchObject({
+            kind: 'eip1559',
+            overrides: {
+              maxFeePerGas: 115n,
+              maxPriorityFeePerGas: 12n,
+            },
+          });
+
+          await nonceLedger.recordSubmitted({
+            hash: `0x${'22'.repeat(32)}`,
+            logicalTx: 'helper.test',
+            fees: feeResult.snapshot,
+            to: '0x2222222222222222222222222222222222222222',
+            value: 1n,
+            data: '0x1234',
+            submittedAtMs: 2_000,
+          });
+          await nonceLedger.markResolved(3_000);
+          return 'ok';
+        },
+      );
+
+      expect(result).toBe('ok');
+      expect(publicClient.getChainId).toHaveBeenCalledTimes(1);
+      expect(publicClient.getTransactionCount).toHaveBeenCalledWith({
+        address: from,
+        blockTag: 'pending',
+      });
+      const submitted = await ledger.getTxSubmission({ chainId: 84532, from, nonce: 7 });
+      expect(submitted).toMatchObject({
+        hash: `0x${'22'.repeat(32)}`,
+        logicalTx: 'helper.test',
+        resolvedAtMs: 3_000,
+        fees: {
+          maxFeePerGas: 115n,
+          maxPriorityFeePerGas: 12n,
+        },
+      });
+    });
+  });
+
   describe('stuck nonce recovery', () => {
     it('detects an old unresolved nonce and clears it with a bumped self-transfer', async () => {
       const from = '0x1111111111111111111111111111111111111111' as const;
@@ -360,10 +442,12 @@ describe('tx-retry', () => {
         walletClient,
         ledger,
         from,
+        chainId: 84532,
         staleAfterMs: 30_000,
         nowMs: 61_000,
       });
 
+      expect(publicClient.getChainId).not.toHaveBeenCalled();
       expect(result?.recoveryHash).toBe(`0x${'22'.repeat(32)}`);
       expect(sendTransaction).toHaveBeenCalledWith({
         account: walletClient.account,

--- a/client/test/tx-retry.test.ts
+++ b/client/test/tx-retry.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  createMemoryTxSubmissionLedger,
   flattenErrorMessage,
   isRecoverableTransactionError,
+  recoverStuckNonceIfNeeded,
+  viemSendTransactionWithRetry,
   withRecoverableRetry,
   viemFeeOverridesForAttempt,
   waitForContractCode,
@@ -244,6 +247,134 @@ describe('tx-retry', () => {
       const o = await viemFeeOverridesForAttempt(publicClient as never, 2);
       expect('maxFeePerGas' in o && o.maxFeePerGas).toBe(130n);
       expect('maxPriorityFeePerGas' in o && o.maxPriorityFeePerGas).toBe(13n);
+    });
+
+    it('bumps EIP-1559 replacement fees from the previous submitted fee when the fresh estimate is lower', async () => {
+      const publicClient = {
+        estimateFeesPerGas: vi.fn().mockResolvedValue({
+          maxFeePerGas: 90n,
+          maxPriorityFeePerGas: 9n,
+        }),
+        getGasPrice: vi.fn(),
+      };
+      const o = await viemFeeOverridesForAttempt(publicClient as never, 1, {
+        previousFees: {
+          maxFeePerGas: 100n,
+          maxPriorityFeePerGas: 10n,
+        },
+      });
+      expect(o).toEqual({
+        maxFeePerGas: 115n,
+        maxPriorityFeePerGas: 12n,
+      });
+    });
+
+    it('bumps legacy replacement gasPrice from the previous submitted fee when the fresh estimate is lower', async () => {
+      const publicClient = {
+        estimateFeesPerGas: vi.fn().mockRejectedValue(new Error('legacy chain')),
+        getGasPrice: vi.fn().mockResolvedValue(90n),
+      };
+      const o = await viemFeeOverridesForAttempt(publicClient as never, 1, {
+        previousFees: { gasPrice: 100n },
+      });
+      expect(o).toEqual({ gasPrice: 115n });
+    });
+  });
+
+  describe('viemSendTransactionWithRetry', () => {
+    const account = {
+      address: '0x1111111111111111111111111111111111111111',
+    } as const;
+
+    it('pins an explicit EOA nonce across replacement retries', async () => {
+      const publicClient = {
+        getChainId: vi.fn().mockResolvedValue(84532),
+        getTransactionCount: vi.fn().mockResolvedValue(7),
+        estimateFeesPerGas: vi.fn().mockResolvedValue({
+          maxFeePerGas: 100n,
+          maxPriorityFeePerGas: 10n,
+        }),
+        getGasPrice: vi.fn(),
+      };
+      const sendTransaction = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('replacement transaction underpriced'))
+        .mockResolvedValueOnce(`0x${'aa'.repeat(32)}`);
+
+      await expect(
+        viemSendTransactionWithRetry(
+          { sendTransaction },
+          publicClient as never,
+          {
+            account,
+            to: '0x2222222222222222222222222222222222222222',
+            value: 1n,
+          },
+          { maxAttempts: 2, baseDelayMs: 1, maxDelayMs: 1 },
+        ),
+      ).resolves.toBe(`0x${'aa'.repeat(32)}`);
+
+      expect(sendTransaction).toHaveBeenCalledTimes(2);
+      expect(sendTransaction.mock.calls[0]![0].nonce).toBe(7);
+      expect(sendTransaction.mock.calls[1]![0].nonce).toBe(7);
+    });
+  });
+
+  describe('stuck nonce recovery', () => {
+    it('detects an old unresolved nonce and clears it with a bumped self-transfer', async () => {
+      const from = '0x1111111111111111111111111111111111111111' as const;
+      const ledger = createMemoryTxSubmissionLedger();
+      await ledger.recordTxSubmission({
+        chainId: 84532,
+        from,
+        nonce: 7,
+        hash: `0x${'11'.repeat(32)}`,
+        logicalTx: 'safe.execTransaction',
+        submittedAtMs: 1_000,
+        fees: {
+          maxFeePerGas: 100n,
+          maxPriorityFeePerGas: 10n,
+        },
+      });
+      const publicClient = {
+        getChainId: vi.fn().mockResolvedValue(84532),
+        getTransactionCount: vi
+          .fn()
+          .mockResolvedValueOnce(8)
+          .mockResolvedValueOnce(7),
+        estimateFeesPerGas: vi.fn().mockResolvedValue({
+          maxFeePerGas: 80n,
+          maxPriorityFeePerGas: 8n,
+        }),
+        getGasPrice: vi.fn(),
+        waitForTransactionReceipt: vi.fn().mockResolvedValue({ status: 'success' }),
+      };
+      const sendTransaction = vi.fn().mockResolvedValue(`0x${'22'.repeat(32)}`);
+      const walletClient = {
+        account: { address: from },
+        sendTransaction,
+      };
+
+      const result = await recoverStuckNonceIfNeeded({
+        publicClient: publicClient as never,
+        walletClient,
+        ledger,
+        from,
+        staleAfterMs: 30_000,
+        nowMs: 61_000,
+      });
+
+      expect(result?.recoveryHash).toBe(`0x${'22'.repeat(32)}`);
+      expect(sendTransaction).toHaveBeenCalledWith({
+        account: walletClient.account,
+        to: from,
+        value: 0n,
+        nonce: 7,
+        maxFeePerGas: 115n,
+        maxPriorityFeePerGas: 12n,
+      });
+      const resolved = await ledger.getTxSubmission({ chainId: 84532, from, nonce: 7 });
+      expect(resolved?.resolvedAtMs).toBe(61_000);
     });
   });
 });

--- a/docs/superpowers/specs/2026-05-22-swe-rebench-vetted-pool-artifact-design.md
+++ b/docs/superpowers/specs/2026-05-22-swe-rebench-vetted-pool-artifact-design.md
@@ -1,0 +1,74 @@
+# SWE-Rebench V2 Vetted Pool Artifact Design
+
+Issue: #478
+Date: 2026-05-22
+Status: implementation target for `feat/478-vetted-pool`
+
+## Decision
+
+The swe-rebench-v2 launcher owns expensive vetting. It exports the local
+`validated-pool.json` scorable entries into a canonical JSON artifact, pins that
+artifact to IPFS, and publishes a SolverNet-scoped mutable pointer for the
+current launch. The generator and evaluators consume that published pool; they
+do not run gold-patch validation on the posting or grading hot path.
+
+## Artifact
+
+The pool artifact contains only entries admitted as `scorable: true` for the
+current `evalSemanticsVersion`. Each entry includes the instance id and the
+grading substrate metadata already recorded by validation: `rowHash`,
+`imageName`, `imageDigest`, `upstreamEvalCommit`, `reason`, and `checkedAt`.
+
+The artifact hash is `sha256:` over the artifact's RFC 8785 canonical JSON. This
+hash is included in the pointer and lets consumers verify that the IPFS body
+matches the launcher's advertised pool.
+
+## Pointer
+
+Metadata key:
+
+```text
+solvernet-artifact:<manifestCid>:swe-rebench-v2-vetted-pool
+```
+
+Pointer payload:
+
+```json
+{
+  "schemaVersion": "solvernet.artifact-ref.v1",
+  "manifestCid": "<SolverNet manifest CID>",
+  "artifactType": "swe-rebench-v2-vetted-pool.v1",
+  "artifactCid": "<IPFS CID>",
+  "artifactHash": "sha256:<canonical artifact hash>",
+  "evalSemanticsVersion": "<version>",
+  "publishedAt": "<ISO timestamp>"
+}
+```
+
+The intended durable read path is the existing ERC-8004 metadata/indexer
+plumbing keyed by the metadata key above. For this branch's current testnet
+acceptance path, the launcher also stamps the full pointer into each posted
+task's eligibility. That gives evaluators a deterministic direct pointer even
+before indexer support for generic SolverNet artifacts is complete.
+
+## Runtime Rules
+
+- `validate-pool` remains the producer of local admission facts.
+- The launcher generator exports and publishes the scorable subset when it has
+  local admission data but no current publication ref.
+- The generator selects candidates only from the published artifact's scorable
+  ids and stamps the pointer into posted task eligibility.
+- The evaluator requires launcher-posted tasks to carry a pool pointer, fetches
+  and verifies that artifact, and admits only instances present in it.
+- Evaluators trust the launcher's vetting. They may still check the task is in
+  the artifact and, when available, that the artifact hash matches, but they do
+  not independently re-run gold-patch validation.
+- Legacy tasks without a pool pointer may continue using the prior local
+  `validated-pool.json` admission path so old in-flight tasks do not break.
+
+## Non-Goals
+
+This branch does not implement broad indexer discovery for generic artifact
+metadata. The task-stamped pointer is the working end-to-end path; the metadata
+key and payload are specified so a follow-up can make the indexer-backed lookup
+the default read path without changing task semantics.


### PR DESCRIPTION
## Summary

Closes #478.

- Adds the swe-rebench-v2 vetted pool artifact spec and helper schema/hash/publication utilities.
- Publishes the launcher-local scorable pool to IPFS when no publication exists, persists the publication locally, and stamps `eligibility.vettedPoolRef` on generated tasks.
- Changes the evaluator to trust launcher-published pool refs for launcher-posted tasks, while keeping the old local `validated-pool.json` admission path for legacy tasks without a ref.

## Test Plan

- `cd client && yarn vitest run test/solver-types/swe-rebench-v2-validated-pool.test.ts test/solver-types/swe-rebench-v2-generator-cooldown.test.ts test/harnesses/impls/swe-rebench-v2-evaluator/harness.test.ts`
- `cd client && yarn typecheck`
- `cd client && yarn build`
- `cd client && yarn test`

## Notes

The fully working branch path is the pragmatic direct task-stamped artifact ref. The spec reserves the SolverNet/ERC-8004 metadata key shape (`solvernet-artifact:<manifestCid>:swe-rebench-v2-vetted-pool`) for indexer-backed discovery follow-up.
