### PR TITLE
feat(codex): support local OpenAI-compatible provider

### DIFF
--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -33,6 +33,7 @@ function isLocalCodexBaseUrl(value: string): boolean {
     const url = new URL(value);
     if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
     if (url.username || url.password) return false;
+    if (url.search || url.hash) return false;
     const hostname = url.hostname.toLowerCase();
     if (hostname === 'localhost') return true;
     if (hostname === '[::1]' || hostname === '::1') return true;

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -15,6 +15,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { isIP } from 'node:net';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { z } from 'zod';
@@ -26,6 +27,20 @@ import { parseRpcUrls } from './rpc/transport.js';
 // ── Schema ──────────────────────────────────────────────────────────────────
 
 const HarnessNameSchema = z.string().transform((name) => canonicalHarnessName(name));
+
+function isLocalCodexBaseUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+    if (url.username || url.password) return false;
+    const hostname = url.hostname.toLowerCase();
+    if (hostname === 'localhost') return true;
+    if (hostname === '[::1]' || hostname === '::1') return true;
+    return isIP(hostname) === 4 && hostname.startsWith('127.');
+  } catch {
+    return false;
+  }
+}
 
 export const JinnConfigSchema = z.object({
   /**
@@ -134,6 +149,16 @@ export const JinnConfigSchema = z.object({
 
   /** Path to the `codex` executable. Defaults to `codex` when unset. */
   codexPath: z.string().optional(),
+
+  /** Default Codex model when a SolverNet does not specify one. */
+  codexModel: z.string().optional(),
+
+  /** Local Codex provider base URL, e.g. http://127.0.0.1:11434/v1 for Ollama. */
+  codexBaseUrl: z
+    .string()
+    .url()
+    .refine(isLocalCodexBaseUrl, 'codexBaseUrl must be a local HTTP(S) URL')
+    .optional(),
 
   /**
    * Timeout in ms for `codex --version` health-check runs.
@@ -884,6 +909,8 @@ export function loadConfig(configPath?: string): JinnConfig {
     merged.hermesDoctorTimeoutMs = parseInt(env['JINN_HERMES_DOCTOR_TIMEOUT_MS'], 10);
   }
   if (env['JINN_CODEX_PATH'])        merged.codexPath = env['JINN_CODEX_PATH'];
+  if (env['JINN_CODEX_MODEL'])       merged.codexModel = env['JINN_CODEX_MODEL'];
+  if (env['JINN_CODEX_BASE_URL'])    merged.codexBaseUrl = env['JINN_CODEX_BASE_URL'];
   if (env['JINN_CODEX_DOCTOR_TIMEOUT_MS']) {
     merged.codexDoctorTimeoutMs = parseInt(env['JINN_CODEX_DOCTOR_TIMEOUT_MS'], 10);
   }
@@ -1273,6 +1300,10 @@ const TRACKED_ENV_VARS = [
   'JINN_HERMES_MODEL',
   'JINN_HERMES_PROVIDER',
   'JINN_HERMES_DOCTOR_TIMEOUT_MS',
+  'JINN_CODEX_PATH',
+  'JINN_CODEX_MODEL',
+  'JINN_CODEX_BASE_URL',
+  'JINN_CODEX_DOCTOR_TIMEOUT_MS',
   'JINN_RUNTIME_MODE',
   'JINN_PEERS',
   'JINN_DISCOVERY_MODE',

--- a/client/src/harnesses/impls/index.ts
+++ b/client/src/harnesses/impls/index.ts
@@ -69,6 +69,8 @@ export interface HarnessEnv {
   codexPath?: string;
   /** Default Codex model when a SolverNet does not specify one. */
   codexModel?: string;
+  /** Local OpenAI-compatible Codex provider base URL. */
+  codexBaseUrl?: string;
   /**
    * Timeout (ms) for the `codex --version` probe in the Codex variant of
    * `LearnerHarness.isReady`.
@@ -253,6 +255,7 @@ export function buildHarnesses(env: HarnessEnv): Harness[] {
   const codexLearnerAdapter = new CodexCodeHarnessAdapter({
     codexPath: env.codexPath,
     codexModel: env.codexModel,
+    codexBaseUrl: env.codexBaseUrl,
     storePath: env.storePath,
     daemonApiUrl: env.daemonApiUrl,
     daemonApiToken: env.daemonApiToken,
@@ -263,6 +266,8 @@ export function buildHarnesses(env: HarnessEnv): Harness[] {
     adapter: codexLearnerAdapter,
     claudePath: env.claudePath,
     ...(env.codexPath !== undefined ? { codexPath: env.codexPath } : {}),
+    ...(env.codexModel !== undefined ? { codexModel: env.codexModel } : {}),
+    ...(env.codexBaseUrl !== undefined ? { codexBaseUrl: env.codexBaseUrl } : {}),
     ...(env.codexDoctorTimeoutMs !== undefined
       ? { codexDoctorTimeoutMs: env.codexDoctorTimeoutMs }
       : {}),

--- a/client/src/harnesses/impls/learner/adapters/codex-code.ts
+++ b/client/src/harnesses/impls/learner/adapters/codex-code.ts
@@ -217,6 +217,7 @@ export class CodexCodeHarnessAdapter implements HarnessAdapter {
    */
   async runTask(inputs: TaskSessionInputs, pluginRoot: string): Promise<void> {
     const prompt = buildInitialPrompt(inputs);
+    const usingLocalProvider = this.codexBaseUrl !== undefined && isLocalCodexBaseUrl(this.codexBaseUrl);
     const baseEnv = {
       IMPL_STATE_DIR: inputs.implStateDir,
       WORKING_DIR: inputs.workingDir,
@@ -240,6 +241,7 @@ export class CodexCodeHarnessAdapter implements HarnessAdapter {
       JINN_CORPUS_CHAIN_ID: this.corpusEnv?.chainId != null ? String(this.corpusEnv.chainId) : '',
       JINN_CORPUS_IDENTITY_REGISTRY_ADDRESS: this.corpusEnv?.identityRegistryAddress ?? '',
       JINN_CORPUS_FROM_BLOCK: this.corpusEnv?.fromBlock != null ? String(this.corpusEnv.fromBlock) : '',
+      ...(usingLocalProvider && !process.env['OPENAI_API_KEY'] ? { OPENAI_API_KEY: 'jinn-local' } : {}),
       ...(inputs.adapterEnv ?? {}),
     };
     const env = buildAgentEnv(baseEnv);

--- a/client/src/harnesses/impls/learner/adapters/codex-code.ts
+++ b/client/src/harnesses/impls/learner/adapters/codex-code.ts
@@ -111,6 +111,7 @@ export function isLocalCodexBaseUrl(value: string): boolean {
     const url = new URL(value);
     if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
     if (url.username || url.password) return false;
+    if (url.search || url.hash) return false;
     const hostname = url.hostname.toLowerCase();
     if (hostname === 'localhost') return true;
     if (hostname === '[::1]' || hostname === '::1') return true;
@@ -217,6 +218,7 @@ export class CodexCodeHarnessAdapter implements HarnessAdapter {
    */
   async runTask(inputs: TaskSessionInputs, pluginRoot: string): Promise<void> {
     const prompt = buildInitialPrompt(inputs);
+    const providerConfigArgs = codexProviderConfigArgs(this.codexBaseUrl);
     const usingLocalProvider = this.codexBaseUrl !== undefined && isLocalCodexBaseUrl(this.codexBaseUrl);
     const baseEnv = {
       IMPL_STATE_DIR: inputs.implStateDir,
@@ -241,8 +243,8 @@ export class CodexCodeHarnessAdapter implements HarnessAdapter {
       JINN_CORPUS_CHAIN_ID: this.corpusEnv?.chainId != null ? String(this.corpusEnv.chainId) : '',
       JINN_CORPUS_IDENTITY_REGISTRY_ADDRESS: this.corpusEnv?.identityRegistryAddress ?? '',
       JINN_CORPUS_FROM_BLOCK: this.corpusEnv?.fromBlock != null ? String(this.corpusEnv.fromBlock) : '',
-      ...(usingLocalProvider && !process.env['OPENAI_API_KEY'] ? { OPENAI_API_KEY: 'jinn-local' } : {}),
       ...(inputs.adapterEnv ?? {}),
+      ...(usingLocalProvider ? { OPENAI_API_KEY: 'jinn-local' } : {}),
     };
     const env = buildAgentEnv(baseEnv);
 
@@ -280,7 +282,7 @@ export class CodexCodeHarnessAdapter implements HarnessAdapter {
       '-m',
       inputs.model ?? inputs.claudeModel ?? this.codexModel,
     ];
-    for (const configArg of codexProviderConfigArgs(this.codexBaseUrl)) {
+    for (const configArg of providerConfigArgs) {
       args.push('-c', configArg);
     }
     for (const configArg of prepared.configArgs) {

--- a/client/src/harnesses/impls/learner/adapters/codex-code.ts
+++ b/client/src/harnesses/impls/learner/adapters/codex-code.ts
@@ -1,5 +1,6 @@
 import { spawn, spawnSync, type ChildProcess, type SpawnOptions } from 'node:child_process';
 import { accessSync, constants, createWriteStream, mkdirSync } from 'node:fs';
+import { isIP } from 'node:net';
 import { dirname, join, resolve } from 'node:path';
 import { finished } from 'node:stream/promises';
 import { fileURLToPath } from 'node:url';
@@ -9,6 +10,7 @@ import type { HarnessAdapter, TaskSessionInputs } from '../types.js';
 export interface CodexCodeHarnessAdapterConfig {
   codexPath?: string;
   codexModel?: string;
+  codexBaseUrl?: string;
   storePath?: string;
   daemonApiUrl?: string;
   daemonApiToken?: string;
@@ -27,6 +29,7 @@ export interface CodexCodeHarnessAdapterConfig {
 }
 
 const DEFAULT_CODEX_MODEL = 'gpt-5.4-mini';
+const LOCAL_CODEX_PROVIDER = 'jinn-local';
 const MACOS_CODEX_APP_BINARY = '/Applications/Codex.app/Contents/Resources/codex';
 
 const ENV_ALLOWLIST = [
@@ -91,6 +94,49 @@ function taskContextJson(inputs: TaskSessionInputs): string {
   }
 }
 
+function codexConfigPath(parts: string[]): string {
+  return parts.map((part) =>
+    /^[A-Za-z0-9_-]+$/.test(part)
+      ? part
+      : `"${part.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+  ).join('.');
+}
+
+function codexConfigValue(value: string): string {
+  return JSON.stringify(value);
+}
+
+export function isLocalCodexBaseUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+    if (url.username || url.password) return false;
+    const hostname = url.hostname.toLowerCase();
+    if (hostname === 'localhost') return true;
+    if (hostname === '[::1]' || hostname === '::1') return true;
+    return isIP(hostname) === 4 && hostname.startsWith('127.');
+  } catch {
+    return false;
+  }
+}
+
+function codexProviderConfigArgs(baseUrl: string | undefined): string[] {
+  const normalizedBaseUrl = baseUrl?.trim();
+  if (!normalizedBaseUrl) return [];
+  if (normalizedBaseUrl && !isLocalCodexBaseUrl(normalizedBaseUrl)) {
+    throw new Error('codex-code adapter: codexBaseUrl must be local; remote custom providers are not supported');
+  }
+
+  const args = [`model_provider=${codexConfigValue(LOCAL_CODEX_PROVIDER)}`];
+  if (normalizedBaseUrl) {
+    const prefix = ['model_providers', LOCAL_CODEX_PROVIDER];
+    args.push(`${codexConfigPath([...prefix, 'name'])}=${codexConfigValue(LOCAL_CODEX_PROVIDER)}`);
+    args.push(`${codexConfigPath([...prefix, 'base_url'])}=${codexConfigValue(normalizedBaseUrl)}`);
+    args.push(`${codexConfigPath([...prefix, 'wire_api'])}=${codexConfigValue('responses')}`);
+  }
+  return args;
+}
+
 /**
  * Construct the initial task prompt for the Codex Code agent.
  *
@@ -138,6 +184,7 @@ export class CodexCodeHarnessAdapter implements HarnessAdapter {
 
   private readonly codexPath: string;
   private readonly codexModel: string;
+  private readonly codexBaseUrl: string | undefined;
   private readonly storePath: string | undefined;
   private readonly daemonApiUrl: string | undefined;
   private readonly daemonApiToken: string | undefined;
@@ -149,6 +196,7 @@ export class CodexCodeHarnessAdapter implements HarnessAdapter {
   constructor(config: CodexCodeHarnessAdapterConfig = {}) {
     this.codexPath = config.codexPath ?? defaultCodexPath();
     this.codexModel = config.codexModel ?? DEFAULT_CODEX_MODEL;
+    this.codexBaseUrl = config.codexBaseUrl;
     this.storePath = config.storePath;
     this.daemonApiUrl = config.daemonApiUrl;
     this.daemonApiToken = config.daemonApiToken;
@@ -230,6 +278,9 @@ export class CodexCodeHarnessAdapter implements HarnessAdapter {
       '-m',
       inputs.model ?? inputs.claudeModel ?? this.codexModel,
     ];
+    for (const configArg of codexProviderConfigArgs(this.codexBaseUrl)) {
+      args.push('-c', configArg);
+    }
     for (const configArg of prepared.configArgs) {
       args.push('-c', configArg);
     }

--- a/client/src/harnesses/impls/learner/harness.ts
+++ b/client/src/harnesses/impls/learner/harness.ts
@@ -14,6 +14,7 @@ import { resolvePluginRoot } from './plugin-path.js';
 import { harvestOutput } from './harvest.js';
 import { buildClaudeIsReady } from '../../../preflight/claude-auth.js';
 import { probeCodexDoctor } from '../../../api/codex-doctor-endpoint.js';
+import { isLocalCodexBaseUrl } from './adapters/codex-code.js';
 
 /**
  * `Harness` shell. Bridges the engine's dispatch contract
@@ -30,6 +31,7 @@ export class LearnerHarness implements Harness {
   private readonly pluginRoot: string;
   private readonly claudePath: string;
   private readonly codexPath: string | undefined;
+  private readonly codexBaseUrl: string | undefined;
   private readonly codexDoctorTimeoutMs: number | undefined;
   private readonly runtimeMode: 'bare' | 'container' | 'docker-compose';
 
@@ -40,6 +42,7 @@ export class LearnerHarness implements Harness {
     this.pluginRoot = config.pluginRoot ?? resolvePluginRoot();
     this.claudePath = config.claudePath ?? 'claude';
     this.codexPath = config.codexPath;
+    this.codexBaseUrl = config.codexBaseUrl;
     this.codexDoctorTimeoutMs = config.codexDoctorTimeoutMs;
     this.runtimeMode = config.runtimeMode ?? 'bare';
   }
@@ -80,6 +83,8 @@ export class LearnerHarness implements Harness {
    *     failed claims (#348).
    *   - `exitCode !== 0` → binary exists but `codex --version` failed →
    *     ready=false pointing at the Codex precheck panel.
+   *   - local `codexBaseUrl` → binary runs and the local sidecar owns auth, so
+   *     Codex auth is not required.
    *   - `authStatus: 'not_configured'` → binary runs but no `OPENAI_API_KEY`
    *     and no `codex login` session → ready=false with a sign-in nextStep.
    *   - `authStatus: 'expired'` → an `auth.json` is present but its OAuth
@@ -116,6 +121,20 @@ export class LearnerHarness implements Harness {
         nextStep: {
           description:
             'Run `codex --version` locally to surface the problem, or open the Codex precheck panel in the operator dashboard.',
+          url: '/api/codex/doctor',
+        },
+      };
+    }
+    if (this.codexBaseUrl) {
+      if (isLocalCodexBaseUrl(this.codexBaseUrl)) {
+        return { ready: true };
+      }
+      return {
+        ready: false,
+        reason: 'codex base URL must be local',
+        nextStep: {
+          description:
+            'Use a local Codex provider URL such as http://127.0.0.1:11434/v1 or unset JINN_CODEX_BASE_URL.',
           url: '/api/codex/doctor',
         },
       };

--- a/client/src/harnesses/impls/learner/harness.ts
+++ b/client/src/harnesses/impls/learner/harness.ts
@@ -16,6 +16,8 @@ import { buildClaudeIsReady } from '../../../preflight/claude-auth.js';
 import { probeCodexDoctor } from '../../../api/codex-doctor-endpoint.js';
 import { isLocalCodexBaseUrl } from './adapters/codex-code.js';
 
+const DEFAULT_CODEX_PROVIDER_PROBE_TIMEOUT_MS = 2_000;
+
 /**
  * `Harness` shell. Bridges the engine's dispatch contract
  * (`await impl.run(ctx)`) into the harness adapter + markdown plugin.
@@ -33,6 +35,8 @@ export class LearnerHarness implements Harness {
   private readonly codexPath: string | undefined;
   private readonly codexBaseUrl: string | undefined;
   private readonly codexDoctorTimeoutMs: number | undefined;
+  private readonly codexProviderProbeTimeoutMs: number;
+  private readonly codexProviderFetch: typeof fetch;
   private readonly runtimeMode: 'bare' | 'container' | 'docker-compose';
 
   constructor(config: LearnerHarnessConfig) {
@@ -44,6 +48,9 @@ export class LearnerHarness implements Harness {
     this.codexPath = config.codexPath;
     this.codexBaseUrl = config.codexBaseUrl;
     this.codexDoctorTimeoutMs = config.codexDoctorTimeoutMs;
+    this.codexProviderProbeTimeoutMs =
+      config.codexProviderProbeTimeoutMs ?? DEFAULT_CODEX_PROVIDER_PROBE_TIMEOUT_MS;
+    this.codexProviderFetch = config.codexProviderFetch ?? fetch;
     this.runtimeMode = config.runtimeMode ?? 'bare';
   }
 
@@ -93,7 +100,7 @@ export class LearnerHarness implements Harness {
    *     operator with a leftover file is not treated as ready (#366).
    *   - otherwise → ready=true.
    */
-  private codexIsReady(): ReadyStatus {
+  private async codexIsReady(): Promise<ReadyStatus> {
     const config: { codexPath?: string; codexDoctorTimeoutMs?: number } = {};
     if (this.codexPath !== undefined) config.codexPath = this.codexPath;
     if (this.codexDoctorTimeoutMs !== undefined) {
@@ -127,7 +134,7 @@ export class LearnerHarness implements Harness {
     }
     if (this.codexBaseUrl) {
       if (isLocalCodexBaseUrl(this.codexBaseUrl)) {
-        return { ready: true };
+        return this.probeLocalCodexProvider(this.codexBaseUrl);
       }
       return {
         ready: false,
@@ -162,6 +169,46 @@ export class LearnerHarness implements Harness {
       };
     }
     return { ready: true };
+  }
+
+  private async probeLocalCodexProvider(baseUrl: string): Promise<ReadyStatus> {
+    const providerRoot = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+    const modelsUrl = new URL('models', providerRoot).toString();
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.codexProviderProbeTimeoutMs);
+    try {
+      const response = await this.codexProviderFetch(modelsUrl, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer jinn-local' },
+        signal: controller.signal,
+      });
+      if (response.ok) return { ready: true };
+      return {
+        ready: false,
+        reason: `local Codex provider /models returned HTTP ${response.status}`,
+        nextStep: {
+          description:
+            'Start the local OpenAI-compatible provider and verify its /v1/models endpoint responds.',
+          url: '/api/codex/doctor',
+        },
+      };
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      const reason = err instanceof Error && err.name === 'AbortError'
+        ? 'local Codex provider /models probe timed out'
+        : `local Codex provider unavailable${detail ? `: ${detail}` : ''}`;
+      return {
+        ready: false,
+        reason,
+        nextStep: {
+          description:
+            'Start the local OpenAI-compatible provider and verify its /v1/models endpoint responds.',
+          url: '/api/codex/doctor',
+        },
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
   }
 
   supports(spec: { solverType: string; role?: 'restoration' | 'evaluation' }): boolean {

--- a/client/src/harnesses/impls/learner/types.ts
+++ b/client/src/harnesses/impls/learner/types.ts
@@ -130,6 +130,10 @@ export interface LearnerHarnessConfig {
    * passed to `probeCodexDoctor()`. Defaults to 'codex' (from PATH).
    */
   codexPath?: string;
+  /** Default Codex model when a SolverNet does not specify one. */
+  codexModel?: string;
+  /** Local OpenAI-compatible Codex provider base URL. */
+  codexBaseUrl?: string;
   /**
    * Timeout (ms) for the `codex --version` probe in the Codex variant's
    * `isReady()`. Defaults to 30s.

--- a/client/src/harnesses/impls/learner/types.ts
+++ b/client/src/harnesses/impls/learner/types.ts
@@ -139,4 +139,8 @@ export interface LearnerHarnessConfig {
    * `isReady()`. Defaults to 30s.
    */
   codexDoctorTimeoutMs?: number;
+  /** Timeout (ms) for probing a local OpenAI-compatible Codex provider. */
+  codexProviderProbeTimeoutMs?: number;
+  /** Test hook for the local provider readiness probe. */
+  codexProviderFetch?: typeof fetch;
 }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1950,6 +1950,8 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     hermesProvider: config.hermesProvider,
     hermesDoctorTimeoutMs: config.hermesDoctorTimeoutMs,
     codexPath: config.codexPath,
+    codexModel: config.codexModel,
+    codexBaseUrl: config.codexBaseUrl,
     codexDoctorTimeoutMs: config.codexDoctorTimeoutMs,
   })) {
     implRegistry.register(impl);

--- a/client/test/config.test.ts
+++ b/client/test/config.test.ts
@@ -1338,6 +1338,28 @@ describe('codex local provider config keys', () => {
       issue.path === 'codexBaseUrl' && /must be a local/i.test(issue.message)
     )).toBe(true);
   });
+
+  it.each([
+    'http://127.0.0.1:11434/v1?api_key=secret',
+    'http://127.0.0.1:11434/v1#secret',
+  ])('rejects Codex provider base URLs with query or fragment: %s', async (codexBaseUrl) => {
+    const configPath = await writeConfigFile({
+      network: 'testnet',
+      codexBaseUrl,
+    });
+
+    let caught: any;
+    try {
+      loadConfig(configPath);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught?.code).toBe('config_invalid');
+    const issues: Array<{ path: string; message: string }> = caught.details?.issues ?? [];
+    expect(issues.some((issue) =>
+      issue.path === 'codexBaseUrl' && /must be a local/i.test(issue.message)
+    )).toBe(true);
+  });
 });
 
 describe('migrateLegacySolverNets', () => {

--- a/client/test/config.test.ts
+++ b/client/test/config.test.ts
@@ -1248,6 +1248,98 @@ describe('hermes config keys', () => {
   });
 });
 
+describe('codex local provider config keys', () => {
+  const dirs: string[] = [];
+  const CODEX_ENV_KEYS = [
+    'JINN_CODEX_MODEL',
+    'JINN_CODEX_BASE_URL',
+  ] as const;
+  const saved: Record<string, string | undefined> = {};
+  for (const k of CODEX_ENV_KEYS) saved[k] = process.env[k];
+
+  afterEach(async () => {
+    for (const k of CODEX_ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  async function writeConfigFile(contents: Record<string, unknown>): Promise<string> {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'jinn-codex-config-'));
+    dirs.push(dir);
+    const configPath = path.join(dir, 'config.json');
+    await writeFile(configPath, JSON.stringify(contents, null, 2));
+    return configPath;
+  }
+
+  it('loads local Codex provider config from file', async () => {
+    const configPath = await writeConfigFile({
+      network: 'testnet',
+      codexModel: 'llama3.1',
+      codexBaseUrl: 'http://127.0.0.1:11434/v1',
+    });
+
+    const cfg = loadConfig(configPath);
+
+    expect(cfg.codexModel).toBe('llama3.1');
+    expect(cfg.codexBaseUrl).toBe('http://127.0.0.1:11434/v1');
+  });
+
+  it('env vars override Codex provider config values', async () => {
+    const configPath = await writeConfigFile({
+      network: 'testnet',
+      codexModel: 'gpt-5.4-mini',
+      codexBaseUrl: 'http://127.0.0.1:11434/v1',
+    });
+    process.env['JINN_CODEX_MODEL'] = 'qwen2.5-coder';
+    process.env['JINN_CODEX_BASE_URL'] = 'http://localhost:1234/v1';
+
+    const cfg = loadConfig(configPath);
+
+    expect(cfg.codexModel).toBe('qwen2.5-coder');
+    expect(cfg.codexBaseUrl).toBe('http://localhost:1234/v1');
+  });
+
+  it('rejects remote Codex provider base URLs', async () => {
+    const configPath = await writeConfigFile({
+      network: 'testnet',
+      codexBaseUrl: 'https://api.openai.com/v1',
+    });
+
+    let caught: any;
+    try {
+      loadConfig(configPath);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught?.code).toBe('config_invalid');
+    const issues: Array<{ path: string; message: string }> = caught.details?.issues ?? [];
+    expect(issues.some((issue) =>
+      issue.path === 'codexBaseUrl' && /must be a local/i.test(issue.message)
+    )).toBe(true);
+  });
+
+  it('rejects credentials embedded in Codex provider base URLs', async () => {
+    const configPath = await writeConfigFile({
+      network: 'testnet',
+      codexBaseUrl: 'http://user:pass@127.0.0.1:11434/v1',
+    });
+
+    let caught: any;
+    try {
+      loadConfig(configPath);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught?.code).toBe('config_invalid');
+    const issues: Array<{ path: string; message: string }> = caught.details?.issues ?? [];
+    expect(issues.some((issue) =>
+      issue.path === 'codexBaseUrl' && /must be a local/i.test(issue.message)
+    )).toBe(true);
+  });
+});
+
 describe('migrateLegacySolverNets', () => {
   it('migrates a single legacy solverNets entry into joinedSolverNets keyed by `legacy:<name>`', () => {
     const raw: Record<string, unknown> = {

--- a/client/test/harnesses/impls/build-harnesses.test.ts
+++ b/client/test/harnesses/impls/build-harnesses.test.ts
@@ -1,7 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { buildHarnesses } from '../../../src/harnesses/impls/index.js';
 import { CLAUDE_CODE_HARNESS, CODEX_HARNESS } from '../../../src/harnesses/names.js';
+import { probeCodexDoctor } from '../../../src/api/codex-doctor-endpoint.js';
 import type { Harness } from '../../../src/harnesses/types.js';
+
+vi.mock('../../../src/api/codex-doctor-endpoint.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../src/api/codex-doctor-endpoint.js')>();
+  return {
+    ...actual,
+    probeCodexDoctor: vi.fn(),
+  };
+});
 
 const ENV = {
   stub: true as const,
@@ -75,5 +85,25 @@ describe('buildHarnesses — external impls + disabledNames', () => {
     });
     expect(impls.some((impl) => impl.name === CODEX_HARNESS)).toBe(false);
     expect(impls.some((impl) => impl.name === CLAUDE_CODE_HARNESS)).toBe(true);
+  });
+
+  it('threads local Codex provider config into the Codex harness readiness', async () => {
+    vi.mocked(probeCodexDoctor).mockReturnValue({
+      installed: true,
+      authenticated: false,
+      authStatus: 'not_configured',
+      exitCode: 0,
+      stdout: 'codex 1.2.3',
+      stderr: '',
+    });
+    const impls = buildHarnesses({
+      ...ENV,
+      codexBaseUrl: 'http://127.0.0.1:11434/v1',
+    });
+    const codex = impls.find((impl) => impl.name === CODEX_HARNESS);
+
+    expect(codex).toBeDefined();
+    await expect(codex!.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' }))
+      .resolves.toEqual({ ready: true });
   });
 });

--- a/client/test/harnesses/impls/build-harnesses.test.ts
+++ b/client/test/harnesses/impls/build-harnesses.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { buildHarnesses } from '../../../src/harnesses/impls/index.js';
 import { CLAUDE_CODE_HARNESS, CODEX_HARNESS } from '../../../src/harnesses/names.js';
 import { probeCodexDoctor } from '../../../src/api/codex-doctor-endpoint.js';
@@ -19,6 +19,10 @@ const ENV = {
   claudePath: 'claude',
   claudeModel: 'claude-haiku-4-5-20251001',
 };
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 function makeFake(name: string): Harness {
   return {
@@ -96,6 +100,7 @@ describe('buildHarnesses — external impls + disabledNames', () => {
       stdout: 'codex 1.2.3',
       stderr: '',
     });
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ data: [] }), { status: 200 })));
     const impls = buildHarnesses({
       ...ENV,
       codexBaseUrl: 'http://127.0.0.1:11434/v1',

--- a/client/test/harnesses/impls/learner/codex-code-adapter.test.ts
+++ b/client/test/harnesses/impls/learner/codex-code-adapter.test.ts
@@ -361,6 +361,8 @@ describe('CodexCodeHarnessAdapter', () => {
   });
 
   it('passes local Codex provider config for Ollama-compatible endpoints', async () => {
+    const previousOpenAiKey = process.env['OPENAI_API_KEY'];
+    delete process.env['OPENAI_API_KEY'];
     const calls: SpawnCall[] = [];
     const spawnFn = vi.fn((command: string, args: string[], options: { env?: NodeJS.ProcessEnv; cwd?: string }) => {
       calls.push({ command, args, options });
@@ -407,7 +409,10 @@ describe('CodexCodeHarnessAdapter', () => {
         '-c',
         'model_providers.jinn-local.wire_api="responses"',
       ]));
+      expect(calls[0]!.options.env?.OPENAI_API_KEY).toBe('jinn-local');
     } finally {
+      if (previousOpenAiKey === undefined) delete process.env['OPENAI_API_KEY'];
+      else process.env['OPENAI_API_KEY'] = previousOpenAiKey;
       rmSync(workingDir, { recursive: true, force: true });
       rmSync(implStateDir, { recursive: true, force: true });
     }

--- a/client/test/harnesses/impls/learner/codex-code-adapter.test.ts
+++ b/client/test/harnesses/impls/learner/codex-code-adapter.test.ts
@@ -362,7 +362,7 @@ describe('CodexCodeHarnessAdapter', () => {
 
   it('passes local Codex provider config for Ollama-compatible endpoints', async () => {
     const previousOpenAiKey = process.env['OPENAI_API_KEY'];
-    delete process.env['OPENAI_API_KEY'];
+    process.env['OPENAI_API_KEY'] = 'real-openai-key';
     const calls: SpawnCall[] = [];
     const spawnFn = vi.fn((command: string, args: string[], options: { env?: NodeJS.ProcessEnv; cwd?: string }) => {
       calls.push({ command, args, options });
@@ -524,6 +524,82 @@ describe('CodexCodeHarnessAdapter', () => {
     } finally {
       rmSync(workingDir, { recursive: true, force: true });
       rmSync(implStateDir, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    'http://127.0.0.1:11434/v1?api_key=secret',
+    'http://127.0.0.1:11434/v1#secret',
+  ])('rejects Codex provider URLs with query or fragment before spawning: %s', async (codexBaseUrl) => {
+    const spawnFn = vi.fn();
+    const workingDir = mkdtempSync(join(tmpdir(), 'jinn-codex-url-secret-work-'));
+    const implStateDir = mkdtempSync(join(tmpdir(), 'jinn-codex-url-secret-state-'));
+    try {
+      const adapter = new CodexCodeHarnessAdapter({
+        codexPath: 'codex-test',
+        codexBaseUrl,
+        clientRoot: '/client/root',
+        _spawnFn: spawnFn as never,
+        _runSessionStartHook: false,
+      });
+
+      await expect(adapter.runTask({
+        taskId: 'swe-rebench-task-restoration',
+        requestId: '0x' + '7'.repeat(64),
+        solverType: 'swe-rebench-v2.v1',
+        taskBody: sweTask() as never,
+        implStateDir,
+        workingDir,
+        pluginRoots: [sweRuntimePluginRoot, networkToolsPluginRoot],
+        windowStartTs: 1,
+        windowEndTs: 2,
+        msUntilEndTs: 1,
+        mode: 'train',
+        abort: new AbortController().signal,
+      }, learnerPluginRoot)).rejects.toThrow(/codexBaseUrl must be local/i);
+      expect(spawnFn).not.toHaveBeenCalled();
+    } finally {
+      rmSync(workingDir, { recursive: true, force: true });
+      rmSync(implStateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects invalid Codex provider URLs before running session-start hooks', async () => {
+    const spawnFn = vi.fn();
+    const workingDir = mkdtempSync(join(tmpdir(), 'jinn-codex-url-prehook-work-'));
+    const implStateDir = mkdtempSync(join(tmpdir(), 'jinn-codex-url-prehook-state-'));
+    const pluginRoot = mkdtempSync(join(tmpdir(), 'jinn-codex-url-prehook-plugin-'));
+    const markerPath = join(pluginRoot, 'hook-ran');
+    try {
+      mkdirSync(join(pluginRoot, 'hooks'), { recursive: true });
+      writeFileSync(join(pluginRoot, 'hooks', 'session-start'), `#!/usr/bin/env bash\ntouch "${markerPath}"\n`);
+      const adapter = new CodexCodeHarnessAdapter({
+        codexPath: 'codex-test',
+        codexBaseUrl: 'http://127.0.0.1:11434/v1?api_key=secret',
+        clientRoot: '/client/root',
+        _spawnFn: spawnFn as never,
+      });
+
+      await expect(adapter.runTask({
+        taskId: 'swe-rebench-task-restoration',
+        requestId: '0x' + '7'.repeat(64),
+        solverType: 'swe-rebench-v2.v1',
+        taskBody: sweTask() as never,
+        implStateDir,
+        workingDir,
+        pluginRoots: [sweRuntimePluginRoot, networkToolsPluginRoot],
+        windowStartTs: 1,
+        windowEndTs: 2,
+        msUntilEndTs: 1,
+        mode: 'train',
+        abort: new AbortController().signal,
+      }, pluginRoot)).rejects.toThrow(/codexBaseUrl must be local/i);
+      expect(spawnFn).not.toHaveBeenCalled();
+      expect(existsSync(markerPath)).toBe(false);
+    } finally {
+      rmSync(workingDir, { recursive: true, force: true });
+      rmSync(implStateDir, { recursive: true, force: true });
+      rmSync(pluginRoot, { recursive: true, force: true });
     }
   });
 

--- a/client/test/harnesses/impls/learner/codex-code-adapter.test.ts
+++ b/client/test/harnesses/impls/learner/codex-code-adapter.test.ts
@@ -360,6 +360,59 @@ describe('CodexCodeHarnessAdapter', () => {
     }
   });
 
+  it('passes local Codex provider config for Ollama-compatible endpoints', async () => {
+    const calls: SpawnCall[] = [];
+    const spawnFn = vi.fn((command: string, args: string[], options: { env?: NodeJS.ProcessEnv; cwd?: string }) => {
+      calls.push({ command, args, options });
+      return fakeCodexChild();
+    });
+    const workingDir = mkdtempSync(join(tmpdir(), 'jinn-codex-ollama-work-'));
+    const implStateDir = mkdtempSync(join(tmpdir(), 'jinn-codex-ollama-state-'));
+    try {
+      const adapter = new CodexCodeHarnessAdapter({
+        codexPath: 'codex-test',
+        codexModel: 'llama3.1',
+        codexBaseUrl: 'http://127.0.0.1:11434/v1',
+        clientRoot: '/client/root',
+        _spawnFn: spawnFn as never,
+        _runSessionStartHook: false,
+      });
+
+      await adapter.runTask({
+        taskId: 'swe-rebench-task-restoration',
+        requestId: '0x' + '7'.repeat(64),
+        solverType: 'swe-rebench-v2.v1',
+        taskBody: sweTask() as never,
+        implStateDir,
+        workingDir,
+        pluginRoots: [sweRuntimePluginRoot, networkToolsPluginRoot],
+        windowStartTs: 1,
+        windowEndTs: 2,
+        msUntilEndTs: 1,
+        mode: 'train',
+        abort: new AbortController().signal,
+      }, learnerPluginRoot);
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]!.args).toEqual(expect.arrayContaining([
+        '--ignore-user-config',
+        '-m',
+        'llama3.1',
+        '-c',
+        'model_provider="jinn-local"',
+        '-c',
+        'model_providers.jinn-local.name="jinn-local"',
+        '-c',
+        'model_providers.jinn-local.base_url="http://127.0.0.1:11434/v1"',
+        '-c',
+        'model_providers.jinn-local.wire_api="responses"',
+      ]));
+    } finally {
+      rmSync(workingDir, { recursive: true, force: true });
+      rmSync(implStateDir, { recursive: true, force: true });
+    }
+  });
+
   it('closes stdin even when the child errors before reading the prompt (#675)', async () => {
     let captured: FakeCodexChild | undefined;
     const spawnFn = vi.fn(() => {
@@ -395,6 +448,74 @@ describe('CodexCodeHarnessAdapter', () => {
 
       expect(captured).toBeDefined();
       expect(captured!.stdin.end).toHaveBeenCalledTimes(1);
+    } finally {
+      rmSync(workingDir, { recursive: true, force: true });
+      rmSync(implStateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects non-local Codex provider URLs before spawning', async () => {
+    const spawnFn = vi.fn();
+    const workingDir = mkdtempSync(join(tmpdir(), 'jinn-codex-remote-work-'));
+    const implStateDir = mkdtempSync(join(tmpdir(), 'jinn-codex-remote-state-'));
+    try {
+      const adapter = new CodexCodeHarnessAdapter({
+        codexPath: 'codex-test',
+        codexBaseUrl: 'https://api.openai.com/v1',
+        clientRoot: '/client/root',
+        _spawnFn: spawnFn as never,
+        _runSessionStartHook: false,
+      });
+
+      await expect(adapter.runTask({
+        taskId: 'swe-rebench-task-restoration',
+        requestId: '0x' + '7'.repeat(64),
+        solverType: 'swe-rebench-v2.v1',
+        taskBody: sweTask() as never,
+        implStateDir,
+        workingDir,
+        pluginRoots: [sweRuntimePluginRoot, networkToolsPluginRoot],
+        windowStartTs: 1,
+        windowEndTs: 2,
+        msUntilEndTs: 1,
+        mode: 'train',
+        abort: new AbortController().signal,
+      }, learnerPluginRoot)).rejects.toThrow(/codexBaseUrl must be local/i);
+      expect(spawnFn).not.toHaveBeenCalled();
+    } finally {
+      rmSync(workingDir, { recursive: true, force: true });
+      rmSync(implStateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects Codex provider URLs with embedded credentials before spawning', async () => {
+    const spawnFn = vi.fn();
+    const workingDir = mkdtempSync(join(tmpdir(), 'jinn-codex-url-creds-work-'));
+    const implStateDir = mkdtempSync(join(tmpdir(), 'jinn-codex-url-creds-state-'));
+    try {
+      const adapter = new CodexCodeHarnessAdapter({
+        codexPath: 'codex-test',
+        codexBaseUrl: 'http://user:pass@127.0.0.1:11434/v1',
+        clientRoot: '/client/root',
+        _spawnFn: spawnFn as never,
+        _runSessionStartHook: false,
+      });
+
+      await expect(adapter.runTask({
+        taskId: 'swe-rebench-task-restoration',
+        requestId: '0x' + '7'.repeat(64),
+        solverType: 'swe-rebench-v2.v1',
+        taskBody: sweTask() as never,
+        implStateDir,
+        workingDir,
+        pluginRoots: [sweRuntimePluginRoot, networkToolsPluginRoot],
+        windowStartTs: 1,
+        windowEndTs: 2,
+        msUntilEndTs: 1,
+        mode: 'train',
+        abort: new AbortController().signal,
+      }, learnerPluginRoot)).rejects.toThrow(/codexBaseUrl must be local/i);
+      expect(spawnFn).not.toHaveBeenCalled();
     } finally {
       rmSync(workingDir, { recursive: true, force: true });
       rmSync(implStateDir, { recursive: true, force: true });

--- a/client/test/harnesses/impls/learner/codex-is-ready.test.ts
+++ b/client/test/harnesses/impls/learner/codex-is-ready.test.ts
@@ -86,6 +86,62 @@ describe('LearnerHarness.isReady — Codex variant (#348)', () => {
     expect(result.nextStep?.description).toMatch(/sign in|OPENAI_API_KEY|codex login/i);
   });
 
+  it('returns ready=true for local Codex provider when binary is installed without OpenAI auth', async () => {
+    vi.mocked(probeCodexDoctor).mockReturnValue({
+      installed: true,
+      authenticated: false,
+      authStatus: 'not_configured',
+      exitCode: 0,
+      stdout: 'codex 1.2.3',
+      stderr: '',
+    });
+    const harness = new LearnerHarness({
+      name: CODEX_HARNESS,
+      adapter: new NoOpAdapter(),
+      codexBaseUrl: 'http://127.0.0.1:11434/v1',
+    });
+    const result = await harness.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+    expect(result.ready).toBe(true);
+  });
+
+  it('still requires the Codex binary for local provider readiness', async () => {
+    vi.mocked(probeCodexDoctor).mockReturnValue({
+      installed: false,
+      authenticated: false,
+      authStatus: 'not_configured',
+      exitCode: null,
+      stdout: '',
+      stderr: '',
+    });
+    const harness = new LearnerHarness({
+      name: CODEX_HARNESS,
+      adapter: new NoOpAdapter(),
+      codexBaseUrl: 'http://127.0.0.1:11434/v1',
+    });
+    const result = await harness.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+    expect(result.ready).toBe(false);
+    expect(result.reason).toMatch(/not installed/i);
+  });
+
+  it('does not skip Codex auth for remote provider URLs', async () => {
+    vi.mocked(probeCodexDoctor).mockReturnValue({
+      installed: true,
+      authenticated: false,
+      authStatus: 'not_configured',
+      exitCode: 0,
+      stdout: 'codex 1.2.3',
+      stderr: '',
+    });
+    const harness = new LearnerHarness({
+      name: CODEX_HARNESS,
+      adapter: new NoOpAdapter(),
+      codexBaseUrl: 'https://api.openai.com/v1',
+    });
+    const result = await harness.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+    expect(result.ready).toBe(false);
+    expect(result.reason).toMatch(/base URL must be local/i);
+  });
+
   // #366: a stale/expired auth.json must not read as ready. The reason MUST
   // be distinct from the not-configured case so the operator sees a
   // re-login hint rather than a first-time sign-in hint.

--- a/client/test/harnesses/impls/learner/codex-is-ready.test.ts
+++ b/client/test/harnesses/impls/learner/codex-is-ready.test.ts
@@ -95,13 +95,63 @@ describe('LearnerHarness.isReady — Codex variant (#348)', () => {
       stdout: 'codex 1.2.3',
       stderr: '',
     });
+    const providerFetch = vi.fn(async () => new Response(JSON.stringify({ data: [] }), { status: 200 }));
     const harness = new LearnerHarness({
       name: CODEX_HARNESS,
       adapter: new NoOpAdapter(),
       codexBaseUrl: 'http://127.0.0.1:11434/v1',
+      codexProviderFetch: providerFetch as typeof fetch,
     });
     const result = await harness.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
     expect(result.ready).toBe(true);
+    expect(providerFetch).toHaveBeenCalledWith('http://127.0.0.1:11434/v1/models', expect.objectContaining({
+      method: 'GET',
+    }));
+  });
+
+  it('returns ready=false for local Codex provider when /models is unreachable', async () => {
+    vi.mocked(probeCodexDoctor).mockReturnValue({
+      installed: true,
+      authenticated: false,
+      authStatus: 'not_configured',
+      exitCode: 0,
+      stdout: 'codex 1.2.3',
+      stderr: '',
+    });
+    const providerFetch = vi.fn(async () => {
+      throw new Error('connect ECONNREFUSED 127.0.0.1:11434');
+    });
+    const harness = new LearnerHarness({
+      name: CODEX_HARNESS,
+      adapter: new NoOpAdapter(),
+      codexBaseUrl: 'http://127.0.0.1:11434/v1',
+      codexProviderFetch: providerFetch as typeof fetch,
+    });
+    const result = await harness.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+    expect(result.ready).toBe(false);
+    expect(result.reason).toMatch(/provider unavailable/i);
+    expect(result.nextStep?.description).toMatch(/local OpenAI-compatible provider/i);
+  });
+
+  it('returns ready=false for local Codex provider when /models is not OK', async () => {
+    vi.mocked(probeCodexDoctor).mockReturnValue({
+      installed: true,
+      authenticated: false,
+      authStatus: 'not_configured',
+      exitCode: 0,
+      stdout: 'codex 1.2.3',
+      stderr: '',
+    });
+    const providerFetch = vi.fn(async () => new Response('nope', { status: 404 }));
+    const harness = new LearnerHarness({
+      name: CODEX_HARNESS,
+      adapter: new NoOpAdapter(),
+      codexBaseUrl: 'http://127.0.0.1:11434/v1',
+      codexProviderFetch: providerFetch as typeof fetch,
+    });
+    const result = await harness.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+    expect(result.ready).toBe(false);
+    expect(result.reason).toMatch(/HTTP 404/i);
   });
 
   it('still requires the Codex binary for local provider readiness', async () => {


### PR DESCRIPTION
## Summary

Adds a local OpenAI-compatible provider path for the Codex harness so operators can point Codex at a local sidecar such as Ollama.

This keeps the change scoped to Codex configuration/runtime wiring:

- adds `JINN_CODEX_BASE_URL`, `JINN_CODEX_MODEL`, and `JINN_CODEX_DOCTOR_TIMEOUT_MS` config/env support
- restricts custom Codex provider URLs to local loopback URLs and rejects embedded credentials
- wires the Codex adapter to pass a local `jinn-local` provider using the Responses API
- treats local Codex providers as ready without OpenAI auth, while still requiring the Codex CLI binary
- injects a dummy `OPENAI_API_KEY` for local providers when no real key is present, because the Codex CLI requires the configured env key even for local endpoints

## Testing

- `yarn vitest run test/harnesses/impls/learner/codex-code-adapter.test.ts test/harnesses/impls/learner/codex-is-ready.test.ts test/config.test.ts test/harnesses/impls/build-harnesses.test.ts`
- Local Docker smoke test with Ollama ROCm sidecar:
  - `/v1/chat/completions` returned `DIRECT_LLM_OK`
  - `/v1/responses` returned `WARMED_OK`
  - `codex exec` inside the Jinn daemon container returned `DAEMON_CODEX_OK`
  - `ollama ps` showed `qwen2.5-coder:7b` running on `100% GPU`

## Notes

This PR does not add deployment files or Docker Compose changes. Local sidecar deployment remains operator-managed.
