### PR TITLE
chore: back-merge #322 docs into next (restore main-next ancestry)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,18 @@ In rough order:
 3. **[`BRAND.md`](BRAND.md)** — voice, headless-brand posture, content non-negotiables. Read before any user-facing copy.
 4. Canonical docs as needed: [`SPEC.md`](SPEC.md), [`THESIS.md`](THESIS.md), [`GROWTH.md`](GROWTH.md), [`GLOSSARY.md`](GLOSSARY.md).
 
+## Contributing shape
+
+Jinn has no canonical implementation. The client and frontend in this repo are *one* implementation of the protocol. Contributing to Jinn can take any of several shapes — all welcomed:
+
+- **Contributing to this implementation**: bug fixes, features, refactors, docs. See the work-shape table below.
+- **Building an alternative implementation**: an alternative client, frontend, explorer, operator UI, or broadcast bot. Fork freely. Add your implementation to the known-instances list in the README when it's ready (open a PR with the entry).
+- **Running infrastructure**: hosting a frontend mirror, running a community chat room, running a broadcast bot instance under your own account. Add it to the README's community-run surfaces list.
+- **Design input**: open a [Discussion](https://github.com/Jinn-Network/mono/discussions) on protocol design, governance scope, documentation, or any canonical artifact. We actively want this input. No formal RFC process — Discussions and PRs are the input mechanism.
+- **Articulating an alternative narrative**: [`BRAND.md`](BRAND.md), [`THESIS.md`](THESIS.md), [`GROWTH.md`](GROWTH.md) are *the current articulating contributor entity's* narrative, not the protocol's. If you disagree, articulate your own — the protocol doesn't privilege ours.
+
+The only thing we ask: don't structurally privilege your contribution above others. The posture is plurality; contributions that try to install themselves as canonical defeat it. See [Discussion #316](https://github.com/Jinn-Network/mono/discussions/316) for the full statement of this posture.
+
 ## How work is shaped
 
 Jinn engineering recognises seven shapes of work plus one emergency sub-flow, keyed to Conventional Commits prefixes:


### PR DESCRIPTION
## Why

PR #322 (a 12-line CONTRIBUTING.md addition) was accidentally merged into `main` instead of `next` (merge commit `ba837bf`). This broke the repo invariant that **`main` must always be an ancestor of `next`** (`.github/workflows/main-next-ancestor-check.yml`), which would fail-loud the next Monday `promote-main.yml` fast-forward.

A plain `git revert` would *not* fix this — it adds another commit on `main` not on `next`, widening the divergence. The sanctioned remedy for "commit on `main` not on `next`" is the back-merge procedure in `docs/runbooks/hotfix.md` step 9.

## What

Back-merges `origin/main` into `next` via a real merge commit, bringing `ba837bf` into `next`'s ancestry. After this lands, `main` is once again an ancestor of `next` and the daily ancestor-check + Monday promotion pass. The docs change ends up on `next`, where #322 was meant to target.

## ⚠️ Merge method

**Must be merged as a "Create a merge commit"** — squash or rebase merge would drop `ba837bf` from ancestry and leave the invariant broken.

## Net diff

`CONTRIBUTING.md` +12 lines (the original #322 change). No other changes.