### PR TITLE
release: v0.1.8 — 5 release-readiness fixes (Tier 3 loop proven on-chain)

### DIFF
--- a/.codex/skills/review-pr
+++ b/.codex/skills/review-pr
@@ -1,0 +1,1 @@
+../../.claude/skills/review-pr

--- a/.cursor/skills/review-pr
+++ b/.cursor/skills/review-pr
@@ -1,0 +1,1 @@
+../../.claude/skills/review-pr

--- a/client/package.json
+++ b/client/package.json
@@ -94,6 +94,7 @@
     "stolas": "tsx test/e2e/stolas.ts",
     "substrate:adopt": "tsx scripts/release/substrate-adopt.ts",
     "substrate:copy": "tsx scripts/release/substrate-copy.ts",
+    "substrate:provision": "tsx scripts/release/substrate-provision.ts",
     "substrate:reap": "tsx scripts/release/substrate-reap.ts",
     "substrate:topup": "tsx scripts/release/substrate-topup.ts",
     "substrate:verify": "tsx scripts/release/substrate-verify.ts",

--- a/client/scripts/release/substrate-provision.test.ts
+++ b/client/scripts/release/substrate-provision.test.ts
@@ -1,0 +1,228 @@
+// client/scripts/release/substrate-provision.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  provisionSubstrate,
+  buildRpcChain,
+  rpcChainIsHealthy,
+  DEFAULT_SOLVE_HARNESS,
+  DEFAULT_SOLVE_MODEL,
+  EVALUATOR_STATE_DIR_NAME,
+  type CheckResult,
+} from './substrate-provision.js';
+import { DEFAULT_TESTNET_RPC_URLS } from '../../src/config.js';
+
+const ADDR = (n: number): string => `0x${n.toString(16).padStart(40, '0')}`;
+
+function manifestFixture(opName: string, overrides: { rpcUrl?: string; fleetSafe?: string } = {}): unknown {
+  return {
+    substrateVersion: '1',
+    createdAt: new Date().toISOString(),
+    adoptedFrom: '/tmp/source',
+    name: opName,
+    shape: 'current',
+    role: 'participant',
+    network: 'base-sepolia',
+    operator: {
+      masterAddress: ADDR(1),
+      fleetAgentId: '42',
+      fleetSafeAddress: overrides.fleetSafe ?? ADDR(2),
+      fleetStage: 'staked',
+      serviceId: 7,
+      serviceStep: 'complete',
+      agentEoa: ADDR(3),
+      safeAddress: ADDR(2),
+      mechAddress: ADDR(4),
+      stakingAddress: ADDR(5),
+      identityRegistry: ADDR(6),
+    },
+    config: {
+      apiPort: 7331,
+      rpcUrl: overrides.rpcUrl ?? DEFAULT_TESTNET_RPC_URLS[0],
+      joinedSolverNets: ['QmManifestCidA'],
+    },
+  };
+}
+
+interface SetupOpts {
+  rpcUrl?: string | string[];
+  harness?: string;
+  model?: string;
+  roles?: string[];
+  manifestRpcUrl?: string;
+  withEvaluatorState?: boolean;
+  withPool?: boolean;
+}
+
+async function setupHome(root: string, opName: string, o: SetupOpts = {}): Promise<string> {
+  const opDir = path.join(root, 'operators', opName);
+  const jinn = path.join(opDir, '.jinn-client');
+  await fs.mkdir(path.join(jinn, 'earning'), { recursive: true });
+
+  await fs.writeFile(
+    path.join(opDir, 'manifest.json'),
+    JSON.stringify(manifestFixture(opName, { rpcUrl: o.manifestRpcUrl }), null, 2) + '\n',
+  );
+  await fs.writeFile(
+    path.join(jinn, 'config.json'),
+    JSON.stringify(
+      {
+        apiPort: 7331,
+        rpcUrl: o.rpcUrl ?? DEFAULT_TESTNET_RPC_URLS[0], // single endpoint = drift by default
+        joinedSolverNets: {
+          QmManifestCidA: {
+            manifestCid: 'QmManifestCidA',
+            name: 'swe-net',
+            roles: o.roles ?? ['solver'],
+            harness: o.harness ?? 'hermes-agent', // drift from claude-code-learner by default
+            model: o.model ?? 'deepseek/deepseek-v4-flash',
+            plugins: [],
+          },
+        },
+      },
+      null,
+      2,
+    ) + '\n',
+  );
+  await fs.writeFile(
+    path.join(jinn, 'earning', 'earning_state.json'),
+    JSON.stringify({ fleet_agent_id: '42', fleet_safe_address: ADDR(2), chain: 'base-sepolia' }, null, 2) + '\n',
+  );
+  return opDir;
+}
+
+function byId(checks: CheckResult[], id: CheckResult['id']): CheckResult {
+  const c = checks.find((x) => x.id === id);
+  if (!c) throw new Error(`no check ${id}`);
+  return c;
+}
+
+const credsPresent = async () => true;
+const credsMissing = async () => false;
+
+describe('substrate-provision doctor', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'substrate-provision-test-'));
+  });
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('rpcChainIsHealthy / buildRpcChain agree on the canonical chain', () => {
+    expect(rpcChainIsHealthy(DEFAULT_TESTNET_RPC_URLS[0])).toBe(false); // single string = drift
+    expect(rpcChainIsHealthy([DEFAULT_TESTNET_RPC_URLS[0]])).toBe(false); // missing slot
+    expect(rpcChainIsHealthy(buildRpcChain())).toBe(true);
+    const paid = buildRpcChain('https://paid.example');
+    expect(paid[0]).toBe('https://paid.example');
+    expect(rpcChainIsHealthy(paid)).toBe(true);
+  });
+
+  it('detects all five drift categories without mutating files (detect-only)', async () => {
+    const opDir = await setupHome(root, 'op-a');
+    const cfgBefore = await fs.readFile(path.join(opDir, '.jinn-client', 'config.json'), 'utf-8');
+
+    const res = await provisionSubstrate('op-a', {
+      substrateRoot: root,
+      skipOnChain: true,
+      isEvaluator: true,
+      hasHarnessCreds: credsMissing,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(byId(res.checks, 'rpc-fallback-chain').status).toBe('drift');
+    expect(byId(res.checks, 'harness-config').status).toBe('drift');
+    expect(byId(res.checks, 'evaluator-role').status).toBe('drift');
+    expect(byId(res.checks, 'evaluator-harness-state').status).toBe('drift');
+    expect(byId(res.checks, 'admission-pool').status).toBe('drift');
+    expect(byId(res.checks, 'harness-creds').status).toBe('drift');
+
+    // detect-only must not write
+    expect(await fs.readFile(path.join(opDir, '.jinn-client', 'config.json'), 'utf-8')).toBe(cfgBefore);
+  });
+
+  it('repairs RPC chain, harness config, evaluator role, harness state, and admission pool', async () => {
+    const opDir = await setupHome(root, 'op-b');
+
+    const res = await provisionSubstrate('op-b', {
+      substrateRoot: root,
+      repair: true,
+      skipOnChain: true,
+      isEvaluator: true,
+      hasHarnessCreds: credsPresent,
+    });
+
+    expect(res.ok).toBe(true);
+    expect(byId(res.checks, 'rpc-fallback-chain').status).toBe('repaired');
+    expect(byId(res.checks, 'harness-config').status).toBe('repaired');
+    expect(byId(res.checks, 'evaluator-role').status).toBe('repaired');
+    expect(byId(res.checks, 'evaluator-harness-state').status).toBe('repaired');
+    expect(byId(res.checks, 'admission-pool').status).toBe('repaired');
+
+    const cfg = JSON.parse(await fs.readFile(path.join(opDir, '.jinn-client', 'config.json'), 'utf-8'));
+    expect(Array.isArray(cfg.rpcUrl)).toBe(true);
+    expect(cfg.rpcUrl).toEqual(DEFAULT_TESTNET_RPC_URLS);
+    const entry = cfg.joinedSolverNets.QmManifestCidA;
+    // HarnessNameSchema is not applied here (raw config rewrite) — the doctor
+    // writes the configured alias verbatim; the daemon canonicalises on load.
+    expect(entry.harness).toBe(DEFAULT_SOLVE_HARNESS);
+    expect(entry.model).toBe(DEFAULT_SOLVE_MODEL);
+    expect(entry.roles).toContain('evaluator');
+    expect(entry.roles).toContain('solver');
+
+    const stateDir = path.join(opDir, '.jinn-client', 'engine', 'impl-state', EVALUATOR_STATE_DIR_NAME);
+    const state = JSON.parse(await fs.readFile(path.join(stateDir, 'state.json'), 'utf-8'));
+    expect(state.enabled).toBe(true);
+    const pool = JSON.parse(await fs.readFile(path.join(stateDir, 'validated-pool.json'), 'utf-8'));
+    expect(pool.schemaVersion).toBe('swe-rebench-v2-validated-pool.v1');
+    expect(pool.entries).toEqual({});
+  });
+
+  it('is idempotent — a second repair run reports ok with no further repairs', async () => {
+    await setupHome(root, 'op-b');
+    await provisionSubstrate('op-b', { substrateRoot: root, repair: true, skipOnChain: true, isEvaluator: true, hasHarnessCreds: credsPresent });
+
+    const second = await provisionSubstrate('op-b', { substrateRoot: root, repair: true, skipOnChain: true, isEvaluator: true, hasHarnessCreds: credsPresent });
+    expect(second.ok).toBe(true);
+    const repaired = second.checks.filter((c) => c.status === 'repaired');
+    expect(repaired).toHaveLength(0);
+    for (const c of second.checks) {
+      expect(['ok', 'skipped']).toContain(c.status);
+    }
+  });
+
+  it('harness-creds drift can never be auto-repaired (no synthesised login)', async () => {
+    await setupHome(root, 'op-a');
+    const res = await provisionSubstrate('op-a', { substrateRoot: root, repair: true, skipOnChain: true, hasHarnessCreds: credsMissing });
+    const creds = byId(res.checks, 'harness-creds');
+    expect(creds.status).toBe('drift');
+    expect(res.ok).toBe(false);
+  });
+
+  it('prepends a paid RPC key to the testnet chain when provided', async () => {
+    const opDir = await setupHome(root, 'op-a');
+    await provisionSubstrate('op-a', { substrateRoot: root, repair: true, skipOnChain: true, paidRpcUrl: 'https://alchemy.example', hasHarnessCreds: credsPresent });
+    const cfg = JSON.parse(await fs.readFile(path.join(opDir, '.jinn-client', 'config.json'), 'utf-8'));
+    expect(cfg.rpcUrl[0]).toBe('https://alchemy.example');
+    expect(cfg.rpcUrl).toContain(DEFAULT_TESTNET_RPC_URLS[0]);
+    // manifest single-endpoint stays the head slot (paid key)
+    const manifest = JSON.parse(await fs.readFile(path.join(opDir, 'manifest.json'), 'utf-8'));
+    expect(manifest.config.rpcUrl).toBe('https://alchemy.example');
+  });
+
+  it('skips evaluator-only checks for a non-evaluator op', async () => {
+    await setupHome(root, 'op-a', { roles: ['solver'] });
+    const res = await provisionSubstrate('op-a', { substrateRoot: root, skipOnChain: true, hasHarnessCreds: credsPresent });
+    expect(res.checks.find((c) => c.id === 'evaluator-role')).toBeUndefined();
+    expect(res.checks.find((c) => c.id === 'admission-pool')).toBeUndefined();
+  });
+
+  it('returns a skipped result with no crash when manifest is missing', async () => {
+    const res = await provisionSubstrate('op-missing', { substrateRoot: root, skipOnChain: true, hasHarnessCreds: credsPresent });
+    expect(res.ok).toBe(false);
+    expect(res.checks[0].status).toBe('skipped');
+  });
+});

--- a/client/scripts/release/substrate-provision.ts
+++ b/client/scripts/release/substrate-provision.ts
@@ -1,0 +1,465 @@
+/**
+ * substrate-provision — idempotent doctor for gold op-substrate homes.
+ *
+ * Issue #531 (v0.1.8 release-readiness sweep): getting release-readiness
+ * Tier 2/3 to a real green repeatedly required the same operator-local,
+ * one-time fixes to the gold homes (`~/jinn-dev/operators/op-{a,b}`).
+ * None of it is repo state — it is operator-local substrate setup that was
+ * discovered ad hoc and re-done by hand every run. This doctor detects and
+ * (with `--repair`) fixes that drift idempotently so Tier 2/3 is reproducible
+ * on any machine and is a prerequisite for ever running it autonomously / in CI.
+ *
+ * The five recurring drift categories (all hit as manual one-offs):
+ *   1. RPC fallback chain     — config.rpcUrl must be a multi-provider chain
+ *                               (testnet default DEFAULT_TESTNET_RPC_URLS, with
+ *                               an optional paid key prepended), NOT a single
+ *                               quota-limited endpoint. The manifest's single
+ *                               config.rpcUrl (read by substrate-verify via one
+ *                               `http()`) must be a working endpoint — kept as
+ *                               the first slot of the chain.
+ *   2. fleet_safe consistency — manifest.operator.fleetSafeAddress and
+ *                               earning_state.fleet_safe_address must equal the
+ *                               on-chain IdentityRegistry.getAgentWallet(fleetAgentId).
+ *                               A stale value fails substrate-verify.
+ *   3. Harness config         — each joinedSolverNets entry must use a learner
+ *                               harness with CLI-session auth (default
+ *                               claude-code-learner / claude-haiku-4-5) so the
+ *                               per-SolverNet readiness gate does not gate ALL
+ *                               of an op's claims for want of an API key.
+ *   4. Evaluator role + pool  — the evaluator op needs the `evaluator` role on
+ *                               its joinedSolverNets entry, the evaluator harness
+ *                               state seeded, and a validated-pool.json admission
+ *                               file (without it every swe-rebench-v2 task fails
+ *                               admission as `admission_missing_or_unscorable`).
+ *   5. Harness creds          — the configured solve harness's credential must be
+ *                               present (CLI session for claude-code-learner; an
+ *                               auth.json / API key for codex / hermes), else the
+ *                               readiness gate gates all claims.
+ *
+ * Design: a doctor, not a from-scratch provisioner. It never bootstraps a wallet
+ * or touches funds — `substrate-adopt` / the earning bootstrap own that. It only
+ * reconciles the post-bootstrap substrate to a Tier-2/3-ready resting state.
+ * Detect-only by default; pass `--repair` to apply fixes.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { createPublicClient, http, parseAbi, type Address } from 'viem';
+import { goldPath } from './substrate-paths.js';
+import { loadManifestSafe, type Manifest } from './types.js';
+import { chainForNetwork } from './substrate-verify.js';
+import { DEFAULT_TESTNET_RPC_URLS } from '../../src/config.js';
+import { canonicalHarnessName } from '../../src/harnesses/names.js';
+import { EVAL_SEMANTICS_VERSION } from '../../src/solver-types/_swe-rebench-v2-validated-pool.js';
+
+const IDENTITY_REGISTRY_ABI = parseAbi([
+  'function getAgentWallet(uint256 agentId) view returns (address)',
+]);
+
+/** The team's chosen swe-rebench solve harness — CLI session auth, no API key. */
+export const DEFAULT_SOLVE_HARNESS = 'claude-code-learner';
+export const DEFAULT_SOLVE_MODEL = 'claude-haiku-4-5-20251001';
+/** Directory name (under engine/impl-state) where the evaluator harness keeps
+ *  its state.json and the validated-pool.json admission file. Mirrors the
+ *  `name` of SweRebenchV2EvaluatorHarness and main.ts's implStateDir join. */
+export const EVALUATOR_STATE_DIR_NAME = 'swe-rebench-v2-evaluator';
+const EVALUATOR_STATE_FILE = 'state.json';
+const ADMISSION_FILE = 'validated-pool.json';
+const ADMISSION_SCHEMA_VERSION = 'swe-rebench-v2-validated-pool.v1';
+
+export type CheckStatus = 'ok' | 'drift' | 'repaired' | 'skipped';
+
+export interface CheckResult {
+  /** Stable id for the drift category. */
+  id:
+    | 'rpc-fallback-chain'
+    | 'manifest-rpc-endpoint'
+    | 'fleet-safe-consistency'
+    | 'harness-config'
+    | 'evaluator-role'
+    | 'evaluator-harness-state'
+    | 'admission-pool'
+    | 'harness-creds';
+  status: CheckStatus;
+  detail: string;
+}
+
+export interface ProvisionResult {
+  opName: string;
+  /** true if, after this run, the home has no remaining drift. */
+  ok: boolean;
+  checks: CheckResult[];
+}
+
+export interface ProvisionOptions {
+  substrateRoot?: string;
+  /** false = detect only (default); true = apply repairs. */
+  repair?: boolean;
+  /** Skip the on-chain fleet_safe reconcile (offline / unit tests). */
+  skipOnChain?: boolean;
+  /** Treat this op as the evaluator (needs evaluator role + harness state + pool). */
+  isEvaluator?: boolean;
+  /** Solve harness to enforce on joinedSolverNets entries. */
+  harness?: string;
+  /** Model to enforce on joinedSolverNets entries. */
+  model?: string;
+  /** Optional paid RPC key to PREPEND to the testnet fallback chain. */
+  paidRpcUrl?: string;
+  /**
+   * Predicate that reports whether the configured solve harness's credential
+   * is present. Injectable so the unit test does not depend on the host's
+   * `~/.claude` / `~/.codex`. Defaults to a filesystem probe.
+   */
+  hasHarnessCreds?: (harness: string) => Promise<boolean>;
+}
+
+interface OperatorConfig {
+  rpcUrl?: string | string[];
+  apiPort?: number;
+  joinedSolverNets?: Record<string, JoinedSolverNetEntry>;
+  [k: string]: unknown;
+}
+
+interface JoinedSolverNetEntry {
+  manifestCid?: string;
+  name?: string;
+  roles?: string[];
+  harness?: string;
+  model?: string;
+  [k: string]: unknown;
+}
+
+interface EarningState {
+  fleet_agent_id?: string;
+  fleet_safe_address?: string;
+  fleet_identity_registry?: string;
+  [k: string]: unknown;
+}
+
+async function readJson<T>(p: string): Promise<T | null> {
+  try {
+    return JSON.parse(await fs.readFile(p, 'utf-8')) as T;
+  } catch {
+    return null;
+  }
+}
+
+async function writeJson(p: string, value: unknown): Promise<void> {
+  await fs.mkdir(path.dirname(p), { recursive: true });
+  await fs.writeFile(p, JSON.stringify(value, null, 2) + '\n');
+}
+
+/** The canonical testnet fallback chain, optionally with a paid key prepended. */
+export function buildRpcChain(paidRpcUrl?: string): string[] {
+  const base = [...DEFAULT_TESTNET_RPC_URLS];
+  if (paidRpcUrl && paidRpcUrl.trim() && !base.includes(paidRpcUrl.trim())) {
+    return [paidRpcUrl.trim(), ...base];
+  }
+  return base;
+}
+
+/** True if `rpcUrl` is already a multi-provider chain whose slots cover the
+ *  canonical testnet defaults (a single string, or an array missing a default
+ *  slot, is drift). */
+export function rpcChainIsHealthy(rpcUrl: string | string[] | undefined): boolean {
+  if (!Array.isArray(rpcUrl)) return false;
+  if (rpcUrl.length < 2) return false;
+  return DEFAULT_TESTNET_RPC_URLS.every((u) => rpcUrl.includes(u));
+}
+
+/**
+ * Default harness-creds probe. claude-code-learner authenticates via the
+ * `claude` CLI session (`~/.claude` or a logged-in CLI), so its presence is a
+ * best-effort directory probe; codex needs `~/.codex/auth.json` (or an
+ * OPENAI_API_KEY); hermes needs OPENROUTER_API_KEY.
+ */
+async function defaultHasHarnessCreds(harness: string): Promise<boolean> {
+  const canonical = canonicalHarnessName(harness);
+  const home = process.env.HOME ?? '';
+  if (canonical === 'claude-code') {
+    if (process.env.ANTHROPIC_API_KEY) return true;
+    return fs.stat(path.join(home, '.claude')).then(() => true).catch(() => false);
+  }
+  if (canonical === 'codex') {
+    if (process.env.OPENAI_API_KEY) return true;
+    const codexHome = process.env.CODEX_HOME ?? path.join(home, '.codex');
+    return fs.stat(path.join(codexHome, 'auth.json')).then(() => true).catch(() => false);
+  }
+  if (canonical === 'hermes-agent') {
+    return Boolean(process.env.OPENROUTER_API_KEY);
+  }
+  return true;
+}
+
+export async function provisionSubstrate(opName: string, opts: ProvisionOptions = {}): Promise<ProvisionResult> {
+  const repair = opts.repair ?? false;
+  const harness = opts.harness ?? DEFAULT_SOLVE_HARNESS;
+  const model = opts.model ?? DEFAULT_SOLVE_MODEL;
+  const hasHarnessCreds = opts.hasHarnessCreds ?? defaultHasHarnessCreds;
+  const checks: CheckResult[] = [];
+
+  const opDir = goldPath(opName, opts.substrateRoot);
+  const jinnDir = path.join(opDir, '.jinn-client');
+  const cfgPath = path.join(jinnDir, 'config.json');
+  const earningPath = path.join(jinnDir, 'earning', 'earning_state.json');
+  const implStateRoot = path.join(jinnDir, 'engine', 'impl-state');
+
+  const loaded = await loadManifestSafe(opDir);
+  if (!loaded.ok) {
+    checks.push({ id: 'rpc-fallback-chain', status: 'skipped', detail: loaded.error });
+    return { opName, ok: false, checks };
+  }
+  const manifest = loaded.manifest;
+
+  const cfg = (await readJson<OperatorConfig>(cfgPath)) ?? {};
+  let cfgDirty = false;
+
+  // ── 1. RPC fallback chain (config.rpcUrl) ──────────────────────────────
+  {
+    if (rpcChainIsHealthy(cfg.rpcUrl)) {
+      checks.push({ id: 'rpc-fallback-chain', status: 'ok', detail: `chain of ${(cfg.rpcUrl as string[]).length} providers` });
+    } else if (repair) {
+      cfg.rpcUrl = buildRpcChain(opts.paidRpcUrl);
+      cfgDirty = true;
+      checks.push({ id: 'rpc-fallback-chain', status: 'repaired', detail: `set ${(cfg.rpcUrl as string[]).length}-provider chain` });
+    } else {
+      const shape = Array.isArray(cfg.rpcUrl) ? `array(${cfg.rpcUrl.length})` : typeof cfg.rpcUrl;
+      checks.push({ id: 'rpc-fallback-chain', status: 'drift', detail: `config.rpcUrl is ${shape}, want multi-provider chain` });
+    }
+  }
+
+  // ── 1b. Manifest RPC endpoint (single working http() endpoint) ─────────
+  {
+    const chain = Array.isArray(cfg.rpcUrl) ? cfg.rpcUrl : rpcChainIsHealthy(cfg.rpcUrl) ? cfg.rpcUrl : buildRpcChain(opts.paidRpcUrl);
+    const want = (Array.isArray(chain) ? chain[0] : chain) ?? DEFAULT_TESTNET_RPC_URLS[0];
+    if (manifest.config.rpcUrl === want) {
+      checks.push({ id: 'manifest-rpc-endpoint', status: 'ok', detail: `manifest endpoint = ${want}` });
+    } else if (repair) {
+      manifest.config.rpcUrl = want;
+      await writeJson(path.join(opDir, 'manifest.json'), manifest);
+      checks.push({ id: 'manifest-rpc-endpoint', status: 'repaired', detail: `manifest endpoint → ${want}` });
+    } else {
+      checks.push({ id: 'manifest-rpc-endpoint', status: 'drift', detail: `manifest endpoint ${manifest.config.rpcUrl} != head ${want}` });
+    }
+  }
+
+  // ── 2. fleet_safe consistency (on-chain reconcile) ─────────────────────
+  await checkFleetSafe(opName, manifest, earningPath, opDir, checks, { repair, skipOnChain: opts.skipOnChain ?? false });
+
+  // ── 3 + 4. Harness config + evaluator role across joinedSolverNets ─────
+  {
+    const joined = cfg.joinedSolverNets ?? {};
+    const entries = Object.entries(joined);
+    if (entries.length === 0) {
+      checks.push({ id: 'harness-config', status: 'skipped', detail: 'no joinedSolverNets entries' });
+    } else {
+      let harnessDrift = 0;
+      let harnessRepaired = 0;
+      let roleDrift = 0;
+      let roleRepaired = 0;
+      for (const [, entry] of entries) {
+        const wantCanonical = canonicalHarnessName(harness);
+        const haveCanonical = entry.harness ? canonicalHarnessName(entry.harness) : undefined;
+        if (haveCanonical !== wantCanonical || entry.model !== model) {
+          if (repair) {
+            entry.harness = harness;
+            entry.model = model;
+            cfgDirty = true;
+            harnessRepaired++;
+          } else {
+            harnessDrift++;
+          }
+        }
+        if (opts.isEvaluator) {
+          const roles = Array.isArray(entry.roles) ? entry.roles : [];
+          if (!roles.includes('evaluator')) {
+            if (repair) {
+              entry.roles = Array.from(new Set([...roles, 'evaluator']));
+              if (entry.roles.length === 1) entry.roles = ['solver', 'evaluator'];
+              cfgDirty = true;
+              roleRepaired++;
+            } else {
+              roleDrift++;
+            }
+          }
+        }
+      }
+      checks.push(summarize('harness-config', entries.length, harnessDrift, harnessRepaired, `harness=${harness} model=${model}`));
+      if (opts.isEvaluator) {
+        checks.push(summarize('evaluator-role', entries.length, roleDrift, roleRepaired, 'evaluator role on entry'));
+      }
+    }
+  }
+
+  // ── 4b. Evaluator harness state seed ───────────────────────────────────
+  if (opts.isEvaluator) {
+    const statePath = path.join(implStateRoot, EVALUATOR_STATE_DIR_NAME, EVALUATOR_STATE_FILE);
+    const existing = await readJson<{ enabled?: boolean }>(statePath);
+    if (existing?.enabled === true) {
+      checks.push({ id: 'evaluator-harness-state', status: 'ok', detail: 'evaluator harness enabled' });
+    } else if (repair) {
+      await writeJson(statePath, {
+        schemaVersion: 'swe-rebench-v2-evaluator-state.v1',
+        enabled: true,
+        enabledAt: new Date().toISOString(),
+        upstreamRepoDir: path.join(implStateRoot, EVALUATOR_STATE_DIR_NAME, 'upstream'),
+      });
+      checks.push({ id: 'evaluator-harness-state', status: 'repaired', detail: 'seeded enabled state.json' });
+    } else {
+      checks.push({ id: 'evaluator-harness-state', status: 'drift', detail: 'evaluator harness state missing/not enabled' });
+    }
+
+    // ── 4c. Admission pool (validated-pool.json must exist & be parseable) ─
+    const poolPath = path.join(implStateRoot, EVALUATOR_STATE_DIR_NAME, ADMISSION_FILE);
+    const pool = await readJson<{ schemaVersion?: string; evalSemanticsVersion?: string }>(poolPath);
+    const poolValid = pool?.schemaVersion === ADMISSION_SCHEMA_VERSION && pool?.evalSemanticsVersion === EVAL_SEMANTICS_VERSION;
+    if (poolValid) {
+      checks.push({ id: 'admission-pool', status: 'ok', detail: `pool present (semantics v${EVAL_SEMANTICS_VERSION})` });
+    } else if (repair) {
+      // Seed an empty admission file at the current semantics version. The
+      // operator still runs `jinn solver-nets validate-pool` to populate it;
+      // this guarantees the file exists & parses so admission lookups return a
+      // clean empty set rather than crashing, and the verify step can assert it.
+      await writeJson(poolPath, {
+        schemaVersion: ADMISSION_SCHEMA_VERSION,
+        evalSemanticsVersion: EVAL_SEMANTICS_VERSION,
+        updatedAt: new Date().toISOString(),
+        entries: {},
+      });
+      checks.push({ id: 'admission-pool', status: 'repaired', detail: `seeded empty pool (semantics v${EVAL_SEMANTICS_VERSION}) — run validate-pool to populate` });
+    } else {
+      checks.push({ id: 'admission-pool', status: 'drift', detail: 'validated-pool.json missing or wrong semantics version' });
+    }
+  }
+
+  // ── 5. Harness creds present for the configured solve harness ──────────
+  {
+    const present = await hasHarnessCreds(harness);
+    if (present) {
+      checks.push({ id: 'harness-creds', status: 'ok', detail: `${harness} credential present` });
+    } else {
+      // Creds cannot be synthesised — repair cannot manufacture a login. Always
+      // report drift so the operator seeds them (codex login / claude login /
+      // OPENROUTER_API_KEY).
+      checks.push({ id: 'harness-creds', status: 'drift', detail: `${harness} credential missing — log in / set the key, cannot auto-repair` });
+    }
+  }
+
+  if (cfgDirty && repair) {
+    await writeJson(cfgPath, cfg);
+  }
+
+  const ok = checks.every((c) => c.status === 'ok' || c.status === 'repaired' || c.status === 'skipped');
+  return { opName, ok, checks };
+}
+
+function summarize(
+  id: CheckResult['id'],
+  total: number,
+  drift: number,
+  repaired: number,
+  what: string,
+): CheckResult {
+  if (repaired > 0) return { id, status: 'repaired', detail: `${repaired}/${total} entries set ${what}` };
+  if (drift > 0) return { id, status: 'drift', detail: `${drift}/${total} entries need ${what}` };
+  return { id, status: 'ok', detail: `all ${total} entries: ${what}` };
+}
+
+async function checkFleetSafe(
+  opName: string,
+  manifest: Manifest,
+  earningPath: string,
+  opDir: string,
+  checks: CheckResult[],
+  opts: { repair: boolean; skipOnChain: boolean },
+): Promise<void> {
+  if (manifest.shape !== 'current' || manifest.operator.fleetAgentId === null) {
+    checks.push({ id: 'fleet-safe-consistency', status: 'skipped', detail: 'pre-fleet shape or no fleetAgentId' });
+    return;
+  }
+  if (opts.skipOnChain) {
+    checks.push({ id: 'fleet-safe-consistency', status: 'skipped', detail: 'on-chain check skipped' });
+    return;
+  }
+
+  const client = createPublicClient({
+    chain: chainForNetwork(manifest.network),
+    transport: http(manifest.config.rpcUrl),
+  });
+  let bound: string;
+  try {
+    bound = await client.readContract({
+      address: manifest.operator.identityRegistry as Address,
+      abi: IDENTITY_REGISTRY_ABI,
+      functionName: 'getAgentWallet',
+      args: [BigInt(manifest.operator.fleetAgentId)],
+    });
+  } catch (err) {
+    checks.push({ id: 'fleet-safe-consistency', status: 'skipped', detail: `getAgentWallet read failed: ${(err as Error).message}` });
+    return;
+  }
+
+  const earning = (await readJson<EarningState>(earningPath)) ?? {};
+  const manifestStale = manifest.operator.fleetSafeAddress?.toLowerCase() !== bound.toLowerCase();
+  const earningStale = (earning.fleet_safe_address ?? '').toLowerCase() !== bound.toLowerCase();
+
+  if (!manifestStale && !earningStale) {
+    checks.push({ id: 'fleet-safe-consistency', status: 'ok', detail: `fleetSafe == on-chain ${bound}` });
+    return;
+  }
+  if (opts.repair) {
+    manifest.operator.fleetSafeAddress = bound;
+    await writeJson(path.join(opDir, 'manifest.json'), manifest);
+    earning.fleet_safe_address = bound;
+    await writeJson(earningPath, earning);
+    checks.push({ id: 'fleet-safe-consistency', status: 'repaired', detail: `fleetSafe → on-chain ${bound}` });
+  } else {
+    checks.push({
+      id: 'fleet-safe-consistency',
+      status: 'drift',
+      detail: `manifest=${manifest.operator.fleetSafeAddress} earning=${earning.fleet_safe_address} on-chain=${bound}`,
+    });
+  }
+}
+
+function parseArgs(argv: string[]): { opName?: string; opts: ProvisionOptions } {
+  const opts: ProvisionOptions = {};
+  let opName: string | undefined;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--repair') opts.repair = true;
+    else if (a === '--skip-on-chain') opts.skipOnChain = true;
+    else if (a === '--evaluator') opts.isEvaluator = true;
+    else if (a === '--harness') opts.harness = argv[++i];
+    else if (a === '--model') opts.model = argv[++i];
+    else if (a === '--paid-rpc-url') opts.paidRpcUrl = argv[++i];
+    else if (a === '--substrate-root') opts.substrateRoot = argv[++i];
+    else if (!a.startsWith('--')) opName = a;
+  }
+  return { opName, opts };
+}
+
+async function cliMain(): Promise<void> {
+  const { opName, opts } = parseArgs(process.argv.slice(2));
+  if (!opName) {
+    console.error(
+      'usage: substrate-provision <op-name> [--repair] [--evaluator] [--skip-on-chain]\n' +
+        '         [--harness <name>] [--model <id>] [--paid-rpc-url <url>] [--substrate-root <dir>]\n' +
+        '\n' +
+        'Detect-only by default; pass --repair to apply idempotent fixes.\n' +
+        'Do NOT run against live ~/jinn-dev/operators homes during a release run\n' +
+        'without --skip-on-chain awareness — use --substrate-root for a copy.',
+    );
+    process.exit(2);
+  }
+  const result = await provisionSubstrate(opName, opts);
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(result.ok ? 0 : 1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  cliMain().catch((err) => {
+    console.error(err);
+    process.exit(2);
+  });
+}

--- a/client/src/adapters/mech/contracts.ts
+++ b/client/src/adapters/mech/contracts.ts
@@ -181,34 +181,34 @@ async function restakeEvictedService(
   });
 }
 
+/**
+ * Run a protocol-loop action (createTask / claim* / deliver). Staking is
+ * ORTHOGONAL to this loop: JinnRouterV3 has no staking gate on these calls, so
+ * an evicted service can still post, claim and deliver. The former
+ * eviction-recovery behaviour — on any action failure, read staking state and,
+ * if evicted, fire an inline `distributor.reStake()` then retry — was not just
+ * unnecessary, it was actively HARMFUL: when the reStake itself reverts (these
+ * services re-evict faster than `minStakingDuration`, so reStake routinely
+ * reverts on-chain), `restakeEvictedService` throws `reStake failed for service
+ * N`, which REPLACES the action's real error and propagates up as the failure.
+ * That broke the solve/deliver tick in T3.1 — op-b completed zero solves while
+ * its delivery path turned every transient hiccup into a fatal `reStake failed
+ * for service 56`. Reward-eligibility re-staking is handled out-of-band by the
+ * background EvictionLoop (daemon.ts); the protocol loop must never depend on
+ * it. (#773 — completes the eviction removal that dropped the UI/API surface
+ * but missed this hot-path coupling.)
+ *
+ * `_publicClient`/`_recovery`/`_label` are retained in the signature so the many
+ * call sites and their `evictionRecovery` plumbing stay unchanged; they are
+ * intentionally unused.
+ */
 export async function withEvictionRecovery<T>(
-  publicClient: PublicClient,
-  recovery: EvictionRecoveryConfig | undefined,
-  label: string,
+  _publicClient: PublicClient,
+  _recovery: EvictionRecoveryConfig | undefined,
+  _label: string,
   action: () => Promise<T>,
 ): Promise<T> {
-  try {
-    return await action();
-  } catch (err) {
-    if (!recovery) throw err;
-
-    let stakingState: number;
-    try {
-      stakingState = await readStakingState(publicClient, recovery);
-    } catch (stateErr) {
-      console.error(
-        `[staking-recovery] ${label}: could not check staking state after failed action; ` +
-        `preserving original error. state check error: ${flattenErrorMessage(stateErr)}`,
-      );
-      throw err;
-    }
-    if (stakingState !== EVICTED_STAKING_STATE) {
-      throw err;
-    }
-
-    await restakeEvictedService(publicClient, recovery, label);
-    return action();
-  }
+  return action();
 }
 
 export async function submitTask(

--- a/client/src/cli/commands/solver-nets.ts
+++ b/client/src/cli/commands/solver-nets.ts
@@ -543,6 +543,15 @@ Output flags:
         if (s.highestYieldBlocker) {
           lines.push(`Highest-yield unscorable blocker: ${s.highestYieldBlocker}`);
         }
+        // #806: gold-patch-not-resolved entries whose PASS_TO_PASS tests broke
+        // (p2p_broke > 0) are usually an environment/setup problem, not a
+        // non-resolving gold patch — a chase-able, recoverable capacity blocker.
+        const p2pBroke = s.byReason.find((b) => b.reason === 'gold-patch-not-resolved:p2p-broke');
+        if (p2pBroke && p2pBroke.count > 0) {
+          lines.push(
+            `Candidate capacity blocker: ${p2pBroke.count} gold-patch-not-resolved entr${p2pBroke.count === 1 ? 'y' : 'ies'} broke PASS_TO_PASS (environment/setup problem, likely recoverable — investigate before treating as non-resolving patches)`,
+          );
+        }
         if (s.freshness.status === 'stale') {
           lines.push(`Freshness: stale — ${s.freshness.reason}`);
           lines.push(`  run: ${s.freshness.cli}`);

--- a/client/src/daemon/jinn-claim-loop.ts
+++ b/client/src/daemon/jinn-claim-loop.ts
@@ -37,14 +37,14 @@
  */
 
 import type { Address, Hex, PublicClient, WalletClient } from 'viem';
-import { getAddress } from 'viem';
+import { encodeFunctionData, getAddress } from 'viem';
 import { isOperationalServiceStep } from '../earning/types.js';
 import { base, baseSepolia } from 'viem/chains';
 import type { FleetStateStore } from '../earning/store.js';
 import type { Store } from '../store/store.js';
 import { emitEvent } from '../observability/emit-event.js';
 import { displayFleetServiceIndex } from '../earning/fleet-display-index.js';
-import { waitForTransactionReceiptWithRetry } from '../tx-retry.js';
+import { viemSendTransactionWithRetry, waitForTransactionReceiptWithRetry } from '../tx-retry.js';
 import { CLAIM_TICKET_TOPIC0, JINN_CLAIM_EMITTER_ABI } from '../earning/contracts.js';
 import {
   fetchLatestClaimTicket,
@@ -261,14 +261,33 @@ export class JinnClaimLoop {
     const account = this.config.l2Wallet.account;
     if (!account) throw new Error('L2 wallet has no account configured');
 
-    const { request } = await this.config.l2Client.simulateContract({
+    // Pre-flight: surface a revert before we broadcast.
+    await this.config.l2Client.simulateContract({
       address: this.config.claimEmitterAddress,
       abi: JINN_CLAIM_EMITTER_ABI,
       functionName: 'emitClaim',
       args: [serviceId],
       account,
     });
-    const hash = await this.config.l2Wallet.writeContract(request);
+
+    // Broadcast through the shared per-EOA nonce ledger (issue #525). emitClaim
+    // is sent from the AGENT EOA — the same EOA the creator/claim/deliver Safe
+    // txs use. A raw `walletClient.writeContract` here auto-fills the nonce from
+    // `getTransactionCount(pending)` OUTSIDE the broadcast lock, so on testnet
+    // (where this loop is enabled by default and fires immediately at startup)
+    // it races the creator's first `createTask` and both pick the same nonce →
+    // "nonce too low". Routing via viemSendTransactionWithRetry serializes the
+    // nonce-read→broadcast against every other agent-EOA broadcaster.
+    const data = encodeFunctionData({
+      abi: JINN_CLAIM_EMITTER_ABI,
+      functionName: 'emitClaim',
+      args: [serviceId],
+    });
+    const hash = await viemSendTransactionWithRetry(this.config.l2Wallet, this.config.l2Client, {
+      account,
+      to: this.config.claimEmitterAddress,
+      data,
+    });
     await waitForTransactionReceiptWithRetry(this.config.l2Client, hash);
     return hash;
   }

--- a/client/src/erc8004/identity.ts
+++ b/client/src/erc8004/identity.ts
@@ -49,9 +49,19 @@
  *      — claimDelivery is authoritative").
  */
 
-import { encodeAbiParameters, type Hex, type PublicClient, type WalletClient } from 'viem';
+import {
+  encodeAbiParameters,
+  encodeFunctionData,
+  type Hex,
+  type PublicClient,
+  type WalletClient,
+} from 'viem';
 import type { EnvelopeRef } from '../corpus/types.js';
 import type { DiscoveryAPI } from '../discovery/types.js';
+import {
+  viemSendTransactionWithRetry,
+  type TxRetryWalletClient,
+} from '../tx-retry.js';
 import {
   IDENTITY_REGISTRY_SET_METADATA_ABI,
   PAYLOAD_TUPLE,
@@ -503,14 +513,30 @@ export class IdentityPublisher {
       throw new Error('IdentityPublisher: walletClient has no chain configured');
     }
 
-    const txHash = await this.walletClient.writeContract({
-      address: this.identityRegistryAddress,
+    // Route through viemSendTransactionWithRetry so this EOA-direct setMetadata
+    // tx shares the per-EOA broadcast lock + nonce ledger + recoverable-retry
+    // with the Safe-mediated loops (creator / claim / deliver) and
+    // eviction-recovery that broadcast from the SAME agent EOA. Sending a raw
+    // writeContract here let viem auto-fill the nonce from the pending count,
+    // which raced those loops and reverted "nonce too low" — the #525 launch
+    // stall. encodeFunctionData reproduces the exact calldata writeContract
+    // would have built.
+    const data = encodeFunctionData({
       abi: IDENTITY_REGISTRY_SET_METADATA_ABI,
       functionName: 'setMetadata',
       args: [this.agentId, metadataKey, metadataValue],
-      account,
-      chain,
     });
+    const txHash = await viemSendTransactionWithRetry(
+      this.walletClient as unknown as TxRetryWalletClient,
+      this.publicClient,
+      {
+        account,
+        to: this.identityRegistryAddress,
+        data,
+        value: 0n,
+      },
+      { logicalTx: 'erc8004.setMetadata' },
+    );
 
     // Best-effort confirmation. We surface the blockNumber so callers can
     // record a verifiable on-chain reference; if the receipt query fails

--- a/client/src/harnesses/impls/hermes-agent/harness.ts
+++ b/client/src/harnesses/impls/hermes-agent/harness.ts
@@ -1,5 +1,7 @@
 // client/src/harnesses/impls/hermes-agent/harness.ts
 import type { Harness, HarnessContext, ReadyStatus, Solution } from '../../types.js';
+import type { Task } from '../../../types/task.js';
+import { vettedPoolRefSemanticsMismatch } from '../../../solver-types/_swe-rebench-v2-validated-pool.js';
 import { HERMES_AGENT_HARNESS } from '../../names.js';
 import type { HermesHarnessAdapter } from './adapter.js';
 import { harvestOutput } from '../learner/harvest.js';
@@ -167,6 +169,19 @@ export class HermesHarness implements Harness {
     // Evaluation is not supported: Hermes has no evaluator-side plugins
     // (verdict signing, checker contracts).
     return spec.role !== 'evaluation' && spec.solverType === 'swe-rebench-v2.v1';
+  }
+
+  /**
+   * gh #300 — solver-side ghost-task admission (Tier 1, zero-fetch).
+   * Reject tasks whose on-chain `vettedPoolRef` announces an
+   * `evalSemanticsVersion` no local evaluator could grade. Fails open when the
+   * ref is absent (recency floor guards ref-less ghosts). See
+   * `spec/2026-05-29-ghost-task-admission-symmetric-gate.md`.
+   */
+  async canAttempt(task: Task): Promise<{ ok: true } | { ok: false; reason: string }> {
+    const mismatch = vettedPoolRefSemanticsMismatch(task.eligibility);
+    if (mismatch) return { ok: false, reason: mismatch };
+    return { ok: true };
   }
 
   async run(ctx: HarnessContext): Promise<Solution> {

--- a/client/src/harnesses/impls/learner/harness.ts
+++ b/client/src/harnesses/impls/learner/harness.ts
@@ -4,6 +4,8 @@ import type {
   ReadyStatus,
   Solution,
 } from '../../types.js';
+import type { Task } from '../../../types/task.js';
+import { vettedPoolRefSemanticsMismatch } from '../../../solver-types/_swe-rebench-v2-validated-pool.js';
 import { CLAUDE_CODE_HARNESS, CODEX_HARNESS, canonicalHarnessName } from '../../names.js';
 import type {
   HarnessAdapter,
@@ -178,6 +180,20 @@ export class LearnerHarness implements Harness {
       return false;
     }
     return true;
+  }
+
+  /**
+   * gh #300 — solver-side ghost-task admission (Tier 1, zero-fetch).
+   * Reject tasks whose on-chain `vettedPoolRef` announces an
+   * `evalSemanticsVersion` no local evaluator could grade (the swe-rebench-v2
+   * ghost class). Fails open when the ref is absent, so non-swe-rebench-v2
+   * SolverTypes the learner also serves are unaffected. See
+   * `spec/2026-05-29-ghost-task-admission-symmetric-gate.md`.
+   */
+  async canAttempt(task: Task): Promise<{ ok: true } | { ok: false; reason: string }> {
+    const mismatch = vettedPoolRefSemanticsMismatch(task.eligibility);
+    if (mismatch) return { ok: false, reason: mismatch };
+    return { ok: true };
   }
 
   async run(ctx: HarnessContext): Promise<Solution> {

--- a/client/src/solver-types/_swe-rebench-v2-validated-pool.ts
+++ b/client/src/solver-types/_swe-rebench-v2-validated-pool.ts
@@ -424,6 +424,42 @@ export function vettedPoolArtifactRefFromEligibility(eligibility: Record<string,
   return parseVettedPoolArtifactRef(raw);
 }
 
+/**
+ * gh #300 — solver-side ghost-task admission, Tier 1 (zero-fetch).
+ *
+ * Returns a human-readable reason string when the task's on-chain
+ * `vettedPoolRef` announces an `evalSemanticsVersion` that no local evaluator
+ * could grade under the current {@link EVAL_SEMANTICS_VERSION}, otherwise
+ * `null`. This is the symmetric counterpart to the evaluator's hard gate in
+ * `loadPublishedPoolRow` (swe-rebench-v2-evaluator/harness.ts): the evaluator
+ * already rejects semantics-skewed tasks at verdict time; this lets the
+ * solver reject them at claim time instead of burning compute on a task its
+ * own evaluator will refuse to score.
+ *
+ * Deliberately **fails open when the ref is absent** (returns `null`): pre-
+ * `vettedPoolRef` and `python-floor` tasks carry no ref and are still guarded
+ * by the recency floor (`DEFAULT_TASK_DISCOVERY_FROM_BLOCK`). Closing those
+ * fail-closed is a network-wide behavioural change deferred to Tier 2 (see
+ * `spec/2026-05-29-ghost-task-admission-symmetric-gate.md`). A malformed ref
+ * surfaces as a mismatch reason rather than throwing, so the claim path never
+ * crashes on a bad ref.
+ */
+export function vettedPoolRefSemanticsMismatch(
+  eligibility: Record<string, unknown> | undefined,
+): string | null {
+  let ref: SolverNetArtifactRef | null;
+  try {
+    ref = vettedPoolArtifactRefFromEligibility(eligibility);
+  } catch (err) {
+    return `vettedPoolRef invalid: ${err instanceof Error ? err.message : String(err)}`;
+  }
+  if (!ref) return null; // no ref → fail open (recency floor guards these)
+  if (ref.evalSemanticsVersion !== EVAL_SEMANTICS_VERSION) {
+    return `vettedPoolRef evalSemanticsVersion=${ref.evalSemanticsVersion} cannot be graded under local EVAL_SEMANTICS_VERSION=${EVAL_SEMANTICS_VERSION} (ghost task, gh #300)`;
+  }
+  return null;
+}
+
 export class ValidatedPoolStore {
   private readonly file: string;
   private cache: ValidatedPoolFile | null = null;

--- a/client/src/solver-types/_swe-rebench-v2-validated-pool.ts
+++ b/client/src/solver-types/_swe-rebench-v2-validated-pool.ts
@@ -512,13 +512,33 @@ export class ValidatedPoolStore {
 }
 
 /**
+ * Histogram bucket for gold-patch-not-resolved entries whose PASS_TO_PASS
+ * tests broke (`p2p_broke > 0`). These are usually an environment/setup
+ * problem (missing system deps, a pytest/plugin version mismatch) rather
+ * than a non-resolving gold patch — a chase-able evaluator-capacity blocker,
+ * the same shape as `ungradeable:pytest_missing`. See issue #806.
+ */
+export const GOLD_PATCH_NOT_RESOLVED_P2P_BROKE_REASON = 'gold-patch-not-resolved:p2p-broke';
+
+/**
  * Collapse a stored `reason` string into a histogram bucket. Diagnostic
  * detail (`(f2p X, p2p_broke Y)`, the verbatim HF 429 message) is kept on
  * the entry for debugging, but the bucket name is what matters for the
  * #493 reason-histogram CLI. Unknown reasons pass through unchanged.
+ *
+ * Per #806, `gold-patch-not-resolved` is split by PASS_TO_PASS breakage:
+ * entries with `p2p_broke > 0` map to a distinct
+ * `gold-patch-not-resolved:p2p-broke` bucket (environment broke — chase-able),
+ * while `p2p_broke == 0` keeps the base bucket (patch genuinely doesn't
+ * resolve — leave alone). The split is display-only; the per-entry `reason`
+ * string keeps the full `(f2p X, p2p_broke Y)` detail.
  */
 export function normalizeReason(reason: string): string {
-  if (reason.startsWith('gold-patch-not-resolved')) return 'gold-patch-not-resolved';
+  if (reason.startsWith('gold-patch-not-resolved')) {
+    const p2pBroke = reason.match(/p2p_broke (\d+)/);
+    if (p2pBroke && Number(p2pBroke[1]) > 0) return GOLD_PATCH_NOT_RESOLVED_P2P_BROKE_REASON;
+    return 'gold-patch-not-resolved';
+  }
   if (reason.startsWith('transient:HF-429:')) return 'transient:HF-429';
   // Pre-#578 legacy: 429s recorded as `error:HF datasets-server returned 429 for ...`.
   if (/^error:HF datasets-server returned 429\b/.test(reason)) return 'error:HF-429';

--- a/client/src/solvernets/daemon-init.ts
+++ b/client/src/solvernets/daemon-init.ts
@@ -78,7 +78,11 @@ import type { LaunchedSolverNetRecord, SolverNetStore } from './store.js';
 
 // Import viem types lazily-named — keep the runtime import scoped so unit
 // tests don't pay viem startup cost when they pass mocked publishers.
-import type { PublicClient, WalletClient } from 'viem';
+import { encodeFunctionData, type PublicClient, type WalletClient } from 'viem';
+import {
+  viemSendTransactionWithRetry,
+  type TxRetryWalletClient,
+} from '../tx-retry.js';
 
 // Noop SubgraphClient used by launch/lifecycle state-machine recovery paths
 // (mempool-drop detection) until a real subgraph extension is wired (Task 25).
@@ -497,15 +501,31 @@ export function createMetadataPublisherFromViem(args: {
       if (!chain) {
         throw new Error('createMetadataPublisherFromViem: walletClient has no chain configured');
       }
-      const txHash = await args.walletClient.writeContract({
-        address: args.identityRegistryAddress,
+      // Route through viemSendTransactionWithRetry so this launch/lifecycle
+      // setMetadata shares the per-EOA broadcast lock + nonce ledger + retry
+      // with the Safe-mediated loops (creator / claim / deliver) and
+      // eviction-recovery that broadcast from the SAME agent EOA. A raw
+      // writeContract here let viem auto-fill the nonce from the pending count,
+      // which raced those loops and reverted "nonce too low" — the #525 launch
+      // stall. (Sibling to the IdentityPublisher fix in a4a52ca2;
+      // encodeFunctionData reproduces the exact calldata writeContract built.)
+      const data = encodeFunctionData({
         abi: IDENTITY_REGISTRY_SET_METADATA_ABI,
         functionName: 'setMetadata',
         // viem's bytes input accepts `0x`-prefixed hex; convert from Uint8Array.
         args: [BigInt(agentId), key, uint8ArrayToHex(value)],
-        account,
-        chain,
       });
+      const txHash = await viemSendTransactionWithRetry(
+        args.walletClient as unknown as TxRetryWalletClient,
+        args.publicClient,
+        {
+          account,
+          to: args.identityRegistryAddress,
+          data,
+          value: 0n,
+        },
+        { logicalTx: 'solvernet.setMetadata' },
+      );
       const receipt = await args.publicClient.waitForTransactionReceipt({ hash: txHash });
       return {
         txHash,

--- a/client/src/trajectory/transcript-watcher.ts
+++ b/client/src/trajectory/transcript-watcher.ts
@@ -44,6 +44,7 @@
 
 import * as fs from 'node:fs/promises';
 import { resolve as resolvePath } from 'node:path';
+import { once } from 'node:events';
 import chokidar, { type FSWatcher } from 'chokidar';
 import type { TranscriptEvent, TranscriptParser } from './transcript-parsers/types.js';
 import { ClaudeCodeJsonlParser } from './transcript-parsers/claude-code-jsonl.js';
@@ -256,6 +257,16 @@ export async function startTranscriptWatcher(
 
   watcher.on('add', enqueue);
   watcher.on('change', enqueue);
+
+  // Resolve only once chokidar has finished its initial scan and bound the
+  // underlying OS watches. With `awaitWriteFinish` enabled, chokidar does not
+  // process `add`/`change` events until `ready` has fired (see chokidar's
+  // `_emit` guard on `_readyEmitted`), so returning the watcher before `ready`
+  // means appends made immediately after `startTranscriptWatcher` can be
+  // silently dropped. Awaiting `ready` makes detection deterministic — the
+  // caller is guaranteed a live watcher — instead of racing fs-watch setup
+  // latency against a fixed polling budget (the root of #304's CI flake).
+  await once(watcher, 'ready');
 
   async function handleChange(state: SourceState): Promise<void> {
     if (shuttingDown) return;

--- a/client/src/tx-retry.ts
+++ b/client/src/tx-retry.ts
@@ -367,6 +367,62 @@ export interface WithNonceLedgerArgs {
   staleAfterMs?: number;
 }
 
+// ── Per-EOA broadcast serialization (issue #525 nonce-collision) ─────────────
+//
+// Multiple daemon subsystems broadcast transactions from the SAME agent EOA:
+//   - executeSafeTransaction (creator / claim / deliver loops, Safe-mediated)
+//   - IdentityPublisher.setMetadata (launch + per-execution anchors)
+//   - eviction-recovery distributor.reStake
+//
+// Each independently reads the EOA's `pending` transaction count to choose a
+// nonce. When two run concurrently they read the SAME pending nonce, assign it
+// to two different transactions, and the second to land reverts "nonce too
+// low". The per-Safe lock in adapters/mech/safe.ts only serializes Safe txs
+// sharing one Safe — it does not cover the EOA shared across these distinct
+// broadcast mechanisms.
+//
+// This per-EOA mutex serializes the nonce-read → broadcast → record critical
+// section across ALL broadcasters that route through `withNonceLedger`
+// (executeSafeTransaction and viemSendTransactionWithRetry). It is keyed by the
+// lowercased `from` address so two different EOAs never block each other, and
+// it tolerates the `fn` rejecting (the lock is always released in `finally`).
+const eoaBroadcastLocks = new Map<string, Promise<unknown>>();
+
+/**
+ * Run `fn` while holding an exclusive per-EOA broadcast lock. Concurrent calls
+ * for the same `from` address are serialized; calls for different addresses
+ * proceed in parallel. The returned promise resolves/rejects with `fn`'s
+ * result, and the lock is released whether `fn` succeeds or throws.
+ *
+ * Exported for tests and for non-ledger broadcast paths that still need to
+ * share the EOA serialization (e.g. a raw `writeContract` that opts in).
+ */
+export async function withEoaBroadcastLock<T>(
+  from: Address,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const key = from.toLowerCase();
+  // Chain onto any in-flight broadcast for this EOA. We await the prior
+  // promise's settlement (success OR failure) before proceeding, so a failed
+  // predecessor never deadlocks its successors.
+  const prior = eoaBroadcastLocks.get(key) ?? Promise.resolve();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  // The stored promise resolves when THIS holder releases — successors await it.
+  eoaBroadcastLocks.set(key, gate);
+  await prior.catch(() => { /* predecessor failure must not block the queue */ });
+  try {
+    return await fn();
+  } finally {
+    release();
+    // Clean up the map entry if we are the tail of the queue, so the Map does
+    // not grow unbounded across many EOAs over a long-lived daemon.
+    if (eoaBroadcastLocks.get(key) === gate) {
+      eoaBroadcastLocks.delete(key);
+    }
+  }
+}
+
 export function createMemoryTxSubmissionLedger(): TxSubmissionLedger {
   const entries = new Map<string, TxSubmissionLedgerEntry>();
   const keyFor = (key: TxSubmissionKey) =>
@@ -674,6 +730,16 @@ function withoutFeeOverrides<T extends TxFeeSnapshot>(tx: T): Omit<T, keyof TxFe
 }
 
 export async function withNonceLedger<T>(
+  args: WithNonceLedgerArgs,
+  fn: (context: NonceLedgerContext) => Promise<T>,
+): Promise<T> {
+  // Serialize the whole nonce-read → send → record section per EOA so two
+  // concurrent broadcasters from the same `from` address cannot read the same
+  // `pending` nonce and collide ("nonce too low"). See `withEoaBroadcastLock`.
+  return withEoaBroadcastLock(args.from, () => withNonceLedgerInner(args, fn));
+}
+
+async function withNonceLedgerInner<T>(
   args: WithNonceLedgerArgs,
   fn: (context: NonceLedgerContext) => Promise<T>,
 ): Promise<T> {

--- a/client/test/adapters/mech/eviction-recovery.test.ts
+++ b/client/test/adapters/mech/eviction-recovery.test.ts
@@ -36,17 +36,19 @@ function makeMasterWalletClient(): WalletClient {
   } as unknown as WalletClient;
 }
 
-describe('eviction-triggered restake recovery', () => {
+describe('staking decoupled from the protocol loop (#773)', () => {
   beforeEach(() => {
     vi.mocked(executeSafeTransaction).mockReset();
   });
 
-  it('restakes an evicted service and retries the failed Safe action once', async () => {
+  it('does NOT inline-restake an evicted service — the claim proceeds, no distributor.reStake', async () => {
+    // Service is EVICTED (state 2). JinnRouterV3 has no staking gate, so the
+    // claim must still go through, and the protocol loop must NOT broadcast a
+    // distributor.reStake — that inline reStake (when it reverts) was masking
+    // the real action error and breaking solve/deliver ticks in T3.1.
     const publicClient = makePublicClient(2);
     const masterWalletClient = makeMasterWalletClient();
-    vi.mocked(executeSafeTransaction)
-      .mockRejectedValueOnce(new Error('execution reverted: GS013'))
-      .mockResolvedValueOnce('0xclaim' as Hex);
+    vi.mocked(executeSafeTransaction).mockResolvedValueOnce('0xclaim' as Hex);
 
     const txHash = await claimDelivery(
       publicClient,
@@ -64,17 +66,12 @@ describe('eviction-triggered restake recovery', () => {
     );
 
     expect(txHash).toBe('0xclaim');
-    expect(executeSafeTransaction).toHaveBeenCalledTimes(2);
-    expect(masterWalletClient.sendTransaction).toHaveBeenCalledTimes(1);
-    expect(masterWalletClient.sendTransaction).toHaveBeenCalledWith(
-      expect.objectContaining({
-        to: DISTRIBUTOR_ADDRESS,
-        gas: 1_500_000n,
-      }),
-    );
+    expect(executeSafeTransaction).toHaveBeenCalledTimes(1);
+    // The decisive regression assertion: no inline reStake, ever.
+    expect(masterWalletClient.sendTransaction).not.toHaveBeenCalled();
   });
 
-  it('preserves the original error when the service is not evicted', async () => {
+  it('propagates the original action error without restaking', async () => {
     const publicClient = makePublicClient(1);
     const masterWalletClient = makeMasterWalletClient();
     vi.mocked(executeSafeTransaction).mockRejectedValueOnce(new Error('RequestNotFound'));

--- a/client/test/cli/solver-nets-validate-pool-report.test.ts
+++ b/client/test/cli/solver-nets-validate-pool-report.test.ts
@@ -86,6 +86,49 @@ describe('solver-nets validate-pool-report', () => {
     expect(out).toMatch(/highest[- ]yield.*ungradeable:pytest_missing/i);
   });
 
+  it('--human surfaces the p2p-broke split and names it as a candidate capacity blocker (#806)', async () => {
+    const dir = tmpDir();
+    seedValidatedPool(dir, {
+      'a__1': { scorable: true, reason: 'gold-patch-resolves' },
+      // p2p intact — genuinely-hard / mislabeled, leave alone.
+      'a__2': { scorable: false, reason: 'gold-patch-not-resolved (f2p 1, p2p_broke 0)' },
+      // p2p broke — environment problem, chase-able capacity blocker.
+      'a__3': { scorable: false, reason: 'gold-patch-not-resolved (f2p 0, p2p_broke 53)' },
+      'a__4': { scorable: false, reason: 'gold-patch-not-resolved (f2p 0, p2p_broke 7)' },
+    });
+    const made = makeCommandCtx({
+      argv: ['validate-pool-report', 'swe-rebench-v2', '--human'],
+      env: { JINN_SWE_REBENCH_V2_STATE_DIR: dir },
+    });
+    await solverNetsCommand.run(made.ctx);
+    expect(made.exits).toEqual([]);
+    const out = made.writes.join('');
+    // The two shapes appear in distinct histogram buckets.
+    expect(out).toContain('gold-patch-not-resolved:p2p-broke');
+    expect(out).toContain('gold-patch-not-resolved');
+    // The p2p-broke count is called out as a candidate (recoverable) capacity blocker.
+    expect(out).toMatch(/capacity blocker/i);
+    expect(out).toMatch(/2\b/); // the 2 p2p-broke entries
+    expect(out).toMatch(/environment/i);
+  });
+
+  it('--human omits the p2p-broke capacity-blocker callout when no entries broke PASS_TO_PASS (#806)', async () => {
+    const dir = tmpDir();
+    seedValidatedPool(dir, {
+      'a__1': { scorable: true, reason: 'gold-patch-resolves' },
+      'a__2': { scorable: false, reason: 'gold-patch-not-resolved (f2p 1, p2p_broke 0)' },
+    });
+    const made = makeCommandCtx({
+      argv: ['validate-pool-report', 'swe-rebench-v2', '--human'],
+      env: { JINN_SWE_REBENCH_V2_STATE_DIR: dir },
+    });
+    await solverNetsCommand.run(made.ctx);
+    expect(made.exits).toEqual([]);
+    const out = made.writes.join('');
+    expect(out).not.toContain('gold-patch-not-resolved:p2p-broke');
+    expect(out).not.toMatch(/capacity blocker/i);
+  });
+
   it('fails cleanly with a "stale" / "absent" message when validated-pool.json is missing', async () => {
     const dir = tmpDir(); // empty
     const made = makeCommandCtx({

--- a/client/test/daemon/jinn-claim-loop.test.ts
+++ b/client/test/daemon/jinn-claim-loop.test.ts
@@ -125,6 +125,11 @@ function mockL2Client(opts: { emitTxHash?: `0x${string}`; emitBlock?: bigint } =
 function mockL2Wallet() {
   return {
     account: { address: AGENT },
+    // emitOnL2 routes through viemSendTransactionWithRetry → sendTransaction so
+    // its broadcast shares the per-EOA nonce ledger with the creator/claim Safe
+    // txs (issue #525). writeContract is retained but must NOT be used for the
+    // emit anymore — see the "routes the emit through the nonce ledger" test.
+    sendTransaction: vi.fn(async (_req: any) => '0xaabb'),
     writeContract: vi.fn(async (req: any) => req.hash ?? '0xaabb'),
   } as any;
 }
@@ -189,7 +194,8 @@ describe('JinnClaimLoop', () => {
 
       expect(result).toMatchObject({ ticks: 1, emits: 1, submits: 0, errors: 0 });
       expect(l2Client.simulateContract).toHaveBeenCalledTimes(1);
-      expect(l2Wallet.writeContract).toHaveBeenCalledTimes(1);
+      expect(l2Wallet.sendTransaction).toHaveBeenCalledTimes(1);
+      expect(l2Wallet.writeContract).not.toHaveBeenCalled();
       expect(l2Client.getLogs).toHaveBeenCalledTimes(1);
       expect((l2Client.getLogs as any).mock.calls[0][0]).toMatchObject({
         toBlock: 'latest',

--- a/client/test/dashboard/helpers/mock-daemon-api.ts
+++ b/client/test/dashboard/helpers/mock-daemon-api.ts
@@ -79,6 +79,26 @@ export const DEFAULT_EVENTS = {
   events: [],
 } as const;
 
+/** Minimal activity-events page — empty list, no cursor, no counts. */
+export const DEFAULT_ACTIVITY_EVENTS = {
+  events: [],
+  nextCursor: null,
+  counts: {},
+} as const;
+
+/** Single activity-event row for the /v1/activity-events/:id detail route. */
+export const MOCK_ACTIVITY_EVENT_ROW = {
+  id: 1,
+  ts: new Date().toISOString(),
+  kind: 'task_posted',
+  requestId: null,
+  serviceIndex: 1,
+  txHash: null,
+  solverType: 'prediction.v1',
+  outcome: 'ok',
+  detail: null,
+} as const;
+
 /** Minimal operator execution-data (artifacts) list — includes all required response fields. */
 export const DEFAULT_OPERATOR_ARTIFACTS = {
   schemaVersion: 1 as const,
@@ -364,5 +384,22 @@ export async function mockDaemonApi(page: Page, _opts: MockDaemonApiOptions = {}
     (url) => url.pathname.startsWith('/v1/events/'),
     (route) =>
       route.fulfill({ contentType: 'application/json', body: JSON.stringify(DEFAULT_EVENTS) }),
+  );
+
+  // ---- Activity events (persistent lifecycle stream — /v1/activity-events) ----
+  // The Events list + EventDetail pages call /v1/activity-events[ /:id ]. Without
+  // a mock these fall through to the real daemon and 401 (auth cookie not set in
+  // the mocked context) — same failure mode the /v1/events mock above guards.
+  // Register the per-id prefix BEFORE the exact list route so the exact match
+  // wins (Playwright checks last-registered first).
+  await page.route(
+    (url) => url.pathname.startsWith('/v1/activity-events/'),
+    (route) =>
+      route.fulfill({ contentType: 'application/json', body: JSON.stringify(MOCK_ACTIVITY_EVENT_ROW) }),
+  );
+  await page.route(
+    (url) => url.pathname === '/v1/activity-events',
+    (route) =>
+      route.fulfill({ contentType: 'application/json', body: JSON.stringify(DEFAULT_ACTIVITY_EVENTS) }),
   );
 }

--- a/client/test/dashboard/multi-op/fixtures/two-substrate-ops.ts
+++ b/client/test/dashboard/multi-op/fixtures/two-substrate-ops.ts
@@ -25,6 +25,11 @@ export const test = base.extend<TwoSubstrateOpsFixtures>({
       // events from the IdentityRegistry directly over their (fork) RPC, so the
       // SolverNet op-a just launched is discoverable within one refresh cycle.
       extraEnv: { JINN_DISCOVERY_MODE: 'onchain' },
+      // Both daemons share one in-process mock IPFS so op-a's launch-time
+      // manifest pin is fetchable by op-b's catalog enrichment. Without this,
+      // op-a pins to its own registry and op-b can't read the body back, so the
+      // catalog row is skipped and "op-b sees op-a's SolverNet" times out.
+      sharedMockIpfs: true,
     });
     try {
       await use(handle);

--- a/client/test/dashboard/multi-op/fixtures/two-substrate-ops.ts
+++ b/client/test/dashboard/multi-op/fixtures/two-substrate-ops.ts
@@ -15,6 +15,16 @@ export const test = base.extend<TwoSubstrateOpsFixtures>({
       // collisions under parallel runs: tier-2-helpers tests 7740-7743,
       // T2.1 7750-7751, T2.2 7760-7761, T2.3 7770-7771.
       portBase: 7770,
+      // Drive discovery off the Anvil fork, not the real testnet Ponder indexer.
+      // T2.3 launches a SolverNet on a *fresh fork* (setupTier2Scenario forks
+      // Base Sepolia) and then asserts op-b discovers it in the catalog. The
+      // default testnet discovery mode is `http` against the shared indexer,
+      // which indexes real Base Sepolia and will NEVER see a fork-only launch —
+      // so op-b's catalog stays empty and the "op-b sees catalog" wait times
+      // out. `onchain` makes both daemons' catalog refresh read MetadataSet
+      // events from the IdentityRegistry directly over their (fork) RPC, so the
+      // SolverNet op-a just launched is discoverable within one refresh cycle.
+      extraEnv: { JINN_DISCOVERY_MODE: 'onchain' },
     });
     try {
       await use(handle);

--- a/client/test/dashboard/multi-op/launcher-join-flow.e2e.test.ts
+++ b/client/test/dashboard/multi-op/launcher-join-flow.e2e.test.ts
@@ -2,7 +2,14 @@
 import { test, expect } from './fixtures/two-substrate-ops';
 
 test('T2.3 — op-a launches, op-b joins, both observe each other', async ({ browser, opAUrl, opBUrl }) => {
-  test.setTimeout(5 * 60 * 1000);
+  // 8 min: this drives TWO substrate daemons against a Base Sepolia Anvil fork
+  // through a full launcher-create → launch → cross-operator catalog-discovery →
+  // join → observe flow. Several legs are gated on independent ~30s daemon
+  // cadences (op-a's Launcher list load, op-a's on-chain launch, op-b's catalog
+  // refresh) that stack on the fork, and the original 5-min budget was below
+  // their realistic sum. Every step is gated by its own inner assertion, so the
+  // wider budget gives a genuinely-progressing flow room without masking a hang.
+  test.setTimeout(8 * 60 * 1000);
 
   const opACtx = await browser.newContext();
   const opBCtx = await browser.newContext();
@@ -12,6 +19,9 @@ test('T2.3 — op-a launches, op-b joins, both observe each other', async ({ bro
   try {
     // ===== op-a: Launcher Create wizard =====
     await opAPage.goto(opAUrl);
+    // First load sets the jinn_ui_token cookie from the `?k=` handshake URL, so
+    // later same-origin navigations (e.g. /launcher/launched) need no query param.
+    const opAOrigin = new URL(opAPage.url()).origin;
     await opAPage.getByRole('link', { name: /launcher/i }).click();
     // The "Create SolverNet" CTA on the Launcher list page is a shadcn
     // `<Button asChild><Link>…</Link></Button>`, so it renders as an <a>
@@ -52,23 +62,59 @@ test('T2.3 — op-a launches, op-b joins, both observe each other', async ({ bro
     // Wait for state machine to reach 'launched'
     await expect(opAPage.getByText(/launched/i).first()).toBeVisible({ timeout: 120000 });
     const manifestCid = await opAPage.getByTestId('manifest-cid').textContent({ timeout: 10000 });
+    // The shared mock IPFS returns a base32 CIDv1-raw (`bafkrei…`), matching the
+    // real Autonolas registry's multibase form. The StatusHeader truncates the
+    // CID for display, so match the prefix only — what matters is that a real
+    // CIDv1 rendered, not a placeholder.
     expect(manifestCid).toMatch(/^bafkrei/);
 
     // ===== op-b: Catalog sees op-a's SolverNet =====
+    // First load establishes the jinn_ui_token cookie (from the `?k=` handshake
+    // URL), so later same-origin navigations don't need the query param.
     await opBPage.goto(opBUrl);
-    await opBPage.getByRole('link', { name: /operator/i }).click();
-    await opBPage.getByRole('button', { name: /browse catalog/i }).click();
+    const opBOrigin = new URL(opBPage.url()).origin;
 
-    // Allow indexer + SPA polling lag (~30s).
-    await expect(opBPage.getByText(solverNetName)).toBeVisible({ timeout: 60000 });
+    // Drive directly to the catalog route and reload on a tight cadence until
+    // op-a's SolverNet appears. The reload serves two purposes:
+    //   1. op-b's substrate daemon re-runs FleetBootstrapper + eviction-recovery
+    //      against the fork at startup; `/v1/bootstrap` reads earning_state.json
+    //      from disk, which can transiently read non-`complete` while recovery
+    //      runs, briefly gating the SPA on the Onboarding screen. A reload after
+    //      the daemon settles re-evaluates the gate and lands on the operating
+    //      shell. (Clicking nav links instead would hang on Onboarding.)
+    //   2. op-b's catalog row only surfaces after op-b's daemon catalog
+    //      refresher (≤30s) enriches op-a's manifest from the shared mock IPFS;
+    //      each reload forces an immediate fresh `/v1/solvernets/registry` fetch
+    //      rather than waiting behind the SPA's in-page 30s poll.
+    // Not a blind timeout bump — the inner getByText is the real gate; if the
+    // row never enriches the loop still fails.
+    await expect(async () => {
+      await opBPage.goto(`${opBOrigin}/operator/registry`);
+      await expect(opBPage.getByText(solverNetName)).toBeVisible({ timeout: 5000 });
+    }).toPass({ timeout: 180000, intervals: [4000] });
 
     // ===== op-b joins =====
-    await opBPage.getByText(solverNetName).click();
-    await opBPage.getByRole('button', { name: /^join$/i }).click();
-    await expect(opBPage.getByText(/restart required/i)).toBeVisible({ timeout: 10000 });
+    // The catalog card's join CTA is a shadcn `<Button asChild><Link>Join</Link>`
+    // → an <a role="link"> (data-testid registry-join-cta), not a <button>; the
+    // prior `getByRole('button', {name:/^join$/i})` matched nothing and hung.
+    // Target the CTA by test id, which routes to the multi-step JoinFlow.
+    await opBPage.getByTestId('registry-join-cta').first().click();
+    // JoinFlow is a multi-step form: pick a role, then submit. Choose the
+    // evaluator role — PredictionV1Evaluator is deterministic and always
+    // ready, so it never trips the solver-harness readiness gate that would
+    // disable the submit button. Fall back to solver if evaluator isn't open.
+    const evaluatorOption = opBPage.locator('[data-testid="join-role-option"][data-role="evaluator"]');
+    const roleToggle = (await evaluatorOption.count()) > 0
+      ? evaluatorOption
+      : opBPage.locator('[data-testid="join-role-option"]').first();
+    await roleToggle.click();
+    await opBPage.getByTestId('join-flow-submit').click();
+    // Success surface (#333) shows the SolverNet just joined + the restart hint.
+    await expect(opBPage.getByTestId('join-flow-success')).toBeVisible({ timeout: 30000 });
+    await expect(opBPage.getByTestId('join-flow-success-restart')).toBeVisible({ timeout: 5000 });
 
     // ===== op-a sees op-b's join =====
-    await opAPage.goto(`${opAUrl}/launcher/launched`);
+    await opAPage.goto(`${opAOrigin}/launcher/launched`);
     await opAPage.getByText(solverNetName).click();
 
     // The launched dashboard now surfaces an `operator-count` element

--- a/client/test/dashboard/multi-op/launcher-join-flow.e2e.test.ts
+++ b/client/test/dashboard/multi-op/launcher-join-flow.e2e.test.ts
@@ -13,7 +13,15 @@ test('T2.3 — op-a launches, op-b joins, both observe each other', async ({ bro
     // ===== op-a: Launcher Create wizard =====
     await opAPage.goto(opAUrl);
     await opAPage.getByRole('link', { name: /launcher/i }).click();
-    await opAPage.getByRole('button', { name: /create solvernet/i }).click();
+    // The "Create SolverNet" CTA on the Launcher list page is a shadcn
+    // `<Button asChild><Link>…</Link></Button>`, so it renders as an <a>
+    // (role="link"), not a <button> — in BOTH render paths (the EmptyState
+    // button and the populated-list header CTA). The prior
+    // `getByRole('button', { name: /create solvernet/i })` matched nothing and
+    // hung the full 300s Playwright budget (mis-filed as #525 "flake-timing";
+    // it was a deterministic selector mismatch, not a slow flow). Match the
+    // link role so the selector works regardless of which path renders.
+    await opAPage.getByRole('link', { name: /create solvernet/i }).click();
 
     const solverNetName = `t23-${Date.now()}`;
 
@@ -29,8 +37,13 @@ test('T2.3 — op-a launches, op-b joins, both observe each other', async ({ bro
     await opAPage.getByLabel(/cadence/i).fill('60000');
     await opAPage.getByRole('button', { name: /next/i }).click();
 
-    // Step 4: Configure Pricing
-    await opAPage.getByLabel(/price/i).fill('100');
+    // Step 4: Configure Pricing. The wizard now has two distinct price inputs
+    // (solution + verdict); `getByLabel(/price/i)` matched both and resolved to
+    // an ambiguous locator that never became actionable. Target each input by
+    // its stable test id. validatePricing requires at least one positive price,
+    // so set both.
+    await opAPage.getByTestId('launcher-create-solutionPriceWei').fill('100000000000000');
+    await opAPage.getByTestId('launcher-create-verdictPriceWei').fill('50000000000000');
     await opAPage.getByRole('button', { name: /next/i }).click();
 
     // Step 5: Review and Launch

--- a/client/test/e2e/_daemon-harness-helpers.ts
+++ b/client/test/e2e/_daemon-harness-helpers.ts
@@ -607,6 +607,47 @@ function parseMultipartBody(body: Buffer, contentType: string): Buffer | null {
   return null;
 }
 
+// RFC4648 base32 (no padding), lowercase — the multibase 'b' alphabet IPFS
+// uses for CIDv1. Mirrors the inverse of `base32Decode` in
+// src/adapters/mech/ipfs.ts.
+const MOCK_BASE32_ALPHABET = 'abcdefghijklmnopqrstuvwxyz234567';
+
+function base32EncodeNoPad(bytes: Uint8Array): string {
+  let bits = 0;
+  let value = 0;
+  let out = '';
+  for (const b of bytes) {
+    value = (value << 8) | b;
+    bits += 8;
+    while (bits >= 5) {
+      out += MOCK_BASE32_ALPHABET[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) {
+    out += MOCK_BASE32_ALPHABET[(value << (5 - bits)) & 31];
+  }
+  return out;
+}
+
+/**
+ * Build a CIDv1-raw base32 string (`b…`, e.g. `bafkrei…`) from a sha256 hex
+ * digest — the same multibase form the real Autonolas registry returns and
+ * the form the daemon's production CID validation (`CID_SHAPE_REGEX` in
+ * api/solvernets-endpoints.ts) accepts. Bytes: version 0x01, codec 0x55 (raw),
+ * multihash 0x12 (sha2-256) 0x20 (32-byte length) + digest.
+ */
+function cidv1RawBase32FromSha256Hex(sha256hex: string): string {
+  const digest = new Uint8Array(sha256hex.match(/.{2}/g)!.map((h) => parseInt(h, 16)));
+  const cidBytes = new Uint8Array(4 + digest.length);
+  cidBytes[0] = 0x01; // CIDv1
+  cidBytes[1] = 0x55; // raw codec
+  cidBytes[2] = 0x12; // sha2-256
+  cidBytes[3] = 0x20; // 32 bytes
+  cidBytes.set(digest, 4);
+  return `b${base32EncodeNoPad(cidBytes)}`;
+}
+
 export async function startMockIpfsServer(): Promise<MockIpfsServer> {
   // Map from CID path (e.g. `f01551220{hex}`) → serialised JSON string.
   const store = new Map<string, string>();
@@ -645,14 +686,24 @@ export async function startMockIpfsServer(): Promise<MockIpfsServer> {
             fileBytes = body;
           }
           const sha256hex = createHash('sha256').update(fileBytes).digest('hex');
-          const cidPath = `f01551220${sha256hex}`;
+          // Return a base32 CIDv1 (`bafkrei…`) — the multibase form the real
+          // Autonolas registry returns and that the daemon's production CID
+          // validation accepts (CID_SHAPE_REGEX only admits `Qm…`/`b…`). The
+          // SolverNet launch persists this Hash as `manifestCid`; returning the
+          // legacy base16 (`f01551220…`) form made `GET /v1/solvernets/registry/:cid`
+          // 400 (invalid_cid) so the catalog could not enrich a fork-launched
+          // SolverNet (T2.3). Store under the base32 key (what the daemon will
+          // GET back) plus the legacy base16 raw/dag-pb keys so digest-derived
+          // gateway fetches (T2.2 / daemon-harness-cycle, which address content
+          // by on-chain digest as `f01551220{digest}`) keep resolving.
+          const cidB32 = cidv1RawBase32FromSha256Hex(sha256hex);
           const serialised = fileBytes.toString('utf8');
-          store.set(cidPath, serialised);
-          // Also store under dag-pb variant so gateway fetches succeed either way.
+          store.set(cidB32, serialised);
+          store.set(`f01551220${sha256hex}`, serialised);
           store.set(`f01701220${sha256hex}`, serialised);
-          console.log(`[mock-ipfs] uploaded cid=${cidPath} bytes=${fileBytes.length}`);
+          console.log(`[mock-ipfs] uploaded cid=${cidB32} bytes=${fileBytes.length}`);
           res.writeHead(200, { 'content-type': 'application/json' });
-          res.end(JSON.stringify({ Hash: cidPath, Size: fileBytes.length, Name: 'content.json' }));
+          res.end(JSON.stringify({ Hash: cidB32, Size: fileBytes.length, Name: 'content.json' }));
           return;
         }
 

--- a/client/test/e2e/_daemon-harness-helpers.ts
+++ b/client/test/e2e/_daemon-harness-helpers.ts
@@ -1045,6 +1045,21 @@ export async function postPredictionV1Task(
   creatorPrivKey: `0x${string}`,
   mockIpfs: MockIpfsServer,
   v3Env: TaskV3Env,
+  /**
+   * Optional on-chain policy overrides.
+   *
+   * - `disallowSolverSelfEvaluation` — when true, the TaskCoordinator reverts
+   *   `claimEvaluation` if the evaluator equals the solution attempt's operator
+   *   (TaskCoordinator.sol §432-433). Multi-operator scenarios (T2.2) set this
+   *   so the solver (op-a) cannot win the evaluation-claim race against the
+   *   dedicated evaluator (op-b): with `requiredVerdicts: 1`, whichever operator
+   *   claims first settles the single verdict, and if op-a wins, op-b can never
+   *   settle (TCMaxVerdictsReached) — making `waitForVerdict(evaluator=op-b)`
+   *   time out non-deterministically. Defaults to `false` to preserve the
+   *   single-operator consumer (`daemon-harness-cycle.ts`), which never waits
+   *   for a verdict and so is unaffected either way.
+   */
+  opts: { disallowSolverSelfEvaluation?: boolean } = {},
 ): Promise<PostedPredictionTask> {
   const rpcUrl = fixture.anvil.rpcUrl;
   const routerAddress = v3Env.routerAddress;
@@ -1179,7 +1194,7 @@ export async function postPredictionV1Task(
       passThreshold: 1,
       evaluationDeadline: BigInt(chainNowSec + 1_200),
       maxVerdictsPerEvaluator: 1,
-      disallowSolverSelfEvaluation: false,
+      disallowSolverSelfEvaluation: opts.disallowSolverSelfEvaluation ?? false,
     },
   };
 

--- a/client/test/erc8004/identity-publisher.test.ts
+++ b/client/test/erc8004/identity-publisher.test.ts
@@ -7,9 +7,10 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import type { Hex, PublicClient, WalletClient } from 'viem';
+import { decodeFunctionData, type Hex, type PublicClient, type WalletClient } from 'viem';
 import {
   IdentityPublisher,
+  IDENTITY_REGISTRY_SET_METADATA_ABI,
   PayloadValidationError,
   buildMetadataKey,
   encodeExecutionPayload,
@@ -18,6 +19,31 @@ import {
   type ExecutionPayload,
   type ExecutionPayloadV2,
 } from '../../src/erc8004/identity.js';
+
+/**
+ * Decode the calldata of a `setMetadata` send-tx mock call back to the
+ * `{ address, functionName, args }` shape the assertions check.
+ *
+ * IdentityPublisher now routes setMetadata through
+ * `viemSendTransactionWithRetry` (per-EOA broadcast lock + nonce ledger, the
+ * #525 nonce-collision fix), so the calldata arrives ABI-encoded in `data`
+ * rather than as discrete `writeContract` args.
+ */
+function decodeSetMetadataCall(call: { to: Hex; data: Hex }): {
+  address: string;
+  functionName: string;
+  args: readonly [bigint, string, Hex];
+} {
+  const decoded = decodeFunctionData({
+    abi: IDENTITY_REGISTRY_SET_METADATA_ABI,
+    data: call.data,
+  });
+  return {
+    address: call.to,
+    functionName: decoded.functionName,
+    args: decoded.args as unknown as readonly [bigint, string, Hex],
+  };
+}
 
 // ── Spec test vectors (payload-schema §8) ─────────────────────────────────────
 
@@ -232,13 +258,13 @@ describe('buildMetadataKey', () => {
 // ── publishContent — calldata + lifecycle ─────────────────────────────────────
 
 function makeMocks(overrides?: {
-  writeContractImpl?: (...args: unknown[]) => Promise<Hex>;
+  sendTransactionImpl?: (...args: unknown[]) => Promise<Hex>;
   waitImpl?: (...args: unknown[]) => Promise<unknown>;
 }) {
-  const writeContract = vi
+  const sendTransaction = vi
     .fn<[unknown], Promise<Hex>>()
     .mockImplementation(
-      overrides?.writeContractImpl as (...args: unknown[]) => Promise<Hex> ??
+      overrides?.sendTransactionImpl as (...args: unknown[]) => Promise<Hex> ??
         (() => Promise.resolve('0xfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed' as Hex)),
     );
   const waitForTransactionReceipt = vi.fn().mockImplementation(
@@ -250,12 +276,23 @@ function makeMocks(overrides?: {
   const walletClient = {
     account,
     chain,
-    writeContract,
+    sendTransaction,
   } as unknown as WalletClient;
+  // The publicClient methods below back viemSendTransactionWithRetry's nonce
+  // ledger + fee estimation. getTransactionCount returns a stable value so the
+  // first attempt's pinned nonce is deterministic and stuck-nonce recovery is a
+  // no-op (pending === latest).
   const publicClient = {
     waitForTransactionReceipt,
+    getChainId: vi.fn().mockResolvedValue(8453),
+    getTransactionCount: vi.fn().mockResolvedValue(0),
+    estimateFeesPerGas: vi.fn().mockResolvedValue({
+      maxFeePerGas: 100n,
+      maxPriorityFeePerGas: 10n,
+    }),
+    getGasPrice: vi.fn().mockResolvedValue(50n),
   } as unknown as PublicClient;
-  return { walletClient, publicClient, writeContract, waitForTransactionReceipt };
+  return { walletClient, publicClient, sendTransaction, waitForTransactionReceipt };
 }
 
 describe('IdentityPublisher.publishContent', () => {
@@ -263,7 +300,7 @@ describe('IdentityPublisher.publishContent', () => {
   const AGENT_ID = 42n;
 
   it('calls setMetadata with correct address, args, and ABI-encoded value', async () => {
-    const { walletClient, publicClient, writeContract, waitForTransactionReceipt } = makeMocks();
+    const { walletClient, publicClient, sendTransaction, waitForTransactionReceipt } = makeMocks();
 
     const publisher = new IdentityPublisher({
       identityRegistryAddress: REGISTRY,
@@ -280,14 +317,10 @@ describe('IdentityPublisher.publishContent', () => {
     });
 
     expect(txHash).toMatch(/^0x[0-9a-f]{64}$/);
-    expect(writeContract).toHaveBeenCalledTimes(1);
+    expect(sendTransaction).toHaveBeenCalledTimes(1);
     expect(waitForTransactionReceipt).toHaveBeenCalledTimes(1);
 
-    const call = writeContract.mock.calls[0]![0] as {
-      address: string;
-      functionName: string;
-      args: [bigint, string, Hex];
-    };
+    const call = decodeSetMetadataCall(sendTransaction.mock.calls[0]![0] as { to: Hex; data: Hex });
     expect(call.address).toBe(REGISTRY);
     expect(call.functionName).toBe('setMetadata');
     expect(call.args[0]).toBe(AGENT_ID);
@@ -296,7 +329,7 @@ describe('IdentityPublisher.publishContent', () => {
   });
 
   it('uses "evaluation:" prefix when kind=evaluation', async () => {
-    const { walletClient, publicClient, writeContract } = makeMocks();
+    const { walletClient, publicClient, sendTransaction } = makeMocks();
     const publisher = new IdentityPublisher({
       identityRegistryAddress: REGISTRY,
       agentId: AGENT_ID,
@@ -310,13 +343,13 @@ describe('IdentityPublisher.publishContent', () => {
       payload: VECTOR_A_INPUT,
     });
 
-    const call = writeContract.mock.calls[0]![0] as { args: [bigint, string, Hex] };
+    const call = decodeSetMetadataCall(sendTransaction.mock.calls[0]![0] as { to: Hex; data: Hex });
     expect(call.args[1]).toBe('evaluation:bafyverdict002');
     expect(call.args[2]).toBe(VECTOR_A_EXPECTED);
   });
 
   it('propagates PayloadValidationError on bad payload (no contract call)', async () => {
-    const { walletClient, publicClient, writeContract } = makeMocks();
+    const { walletClient, publicClient, sendTransaction } = makeMocks();
     const publisher = new IdentityPublisher({
       identityRegistryAddress: REGISTRY,
       agentId: AGENT_ID,
@@ -336,12 +369,14 @@ describe('IdentityPublisher.publishContent', () => {
       }),
     ).rejects.toBeInstanceOf(PayloadValidationError);
 
-    expect(writeContract).not.toHaveBeenCalled();
+    expect(sendTransaction).not.toHaveBeenCalled();
   });
 
-  it('propagates writeContract errors to the caller', async () => {
+  it('propagates send-transaction errors to the caller', async () => {
     const { walletClient, publicClient } = makeMocks({
-      writeContractImpl: () => Promise.reject(new Error('rpc unreachable')),
+      // A non-recoverable error so the retry wrapper surfaces it immediately
+      // rather than burning the retry budget on a transient classification.
+      sendTransactionImpl: () => Promise.reject(new Error('insufficient funds: rpc unreachable')),
     });
     const publisher = new IdentityPublisher({
       identityRegistryAddress: REGISTRY,
@@ -378,7 +413,7 @@ describe('IdentityPublisher.publishContentV2', () => {
   const AGENT_ID = 42n;
 
   it('uses "evaluation:" prefix when kind=evaluation (jinn-mono-n93o)', async () => {
-    const { walletClient, publicClient, writeContract, waitForTransactionReceipt } = makeMocks();
+    const { walletClient, publicClient, sendTransaction, waitForTransactionReceipt } = makeMocks();
     const publisher = new IdentityPublisher({
       identityRegistryAddress: REGISTRY,
       agentId: AGENT_ID,
@@ -394,14 +429,10 @@ describe('IdentityPublisher.publishContentV2', () => {
     });
 
     expect(txHash).toMatch(/^0x[0-9a-f]{64}$/);
-    expect(writeContract).toHaveBeenCalledTimes(1);
+    expect(sendTransaction).toHaveBeenCalledTimes(1);
     expect(waitForTransactionReceipt).toHaveBeenCalledTimes(1);
 
-    const call = writeContract.mock.calls[0]![0] as {
-      address: string;
-      functionName: string;
-      args: [bigint, string, Hex];
-    };
+    const call = decodeSetMetadataCall(sendTransaction.mock.calls[0]![0] as { to: Hex; data: Hex });
     expect(call.address).toBe(REGISTRY);
     expect(call.functionName).toBe('setMetadata');
     expect(call.args[0]).toBe(AGENT_ID);
@@ -410,7 +441,7 @@ describe('IdentityPublisher.publishContentV2', () => {
   });
 
   it('uses "envelope:" prefix when kind=envelope (back-compat regression)', async () => {
-    const { walletClient, publicClient, writeContract } = makeMocks();
+    const { walletClient, publicClient, sendTransaction } = makeMocks();
     const publisher = new IdentityPublisher({
       identityRegistryAddress: REGISTRY,
       agentId: AGENT_ID,
@@ -424,7 +455,7 @@ describe('IdentityPublisher.publishContentV2', () => {
       payload: V2_VECTOR_INPUT,
     });
 
-    const call = writeContract.mock.calls[0]![0] as { args: [bigint, string, Hex] };
+    const call = decodeSetMetadataCall(sendTransaction.mock.calls[0]![0] as { to: Hex; data: Hex });
     expect(call.args[1]).toBe('envelope:bafyenvelope004');
   });
 });

--- a/client/test/harnesses/impls/hermes-agent/harness.test.ts
+++ b/client/test/harnesses/impls/hermes-agent/harness.test.ts
@@ -3,6 +3,32 @@ import { describe, expect, it, vi } from 'vitest';
 import { HermesHarness } from '../../../../src/harnesses/impls/hermes-agent/harness.js';
 import { HERMES_AGENT_HARNESS } from '../../../../src/harnesses/names.js';
 import type { HarnessContext } from '../../../../src/harnesses/types.js';
+import type { Task } from '../../../../src/types/task.js';
+import {
+  EVAL_SEMANTICS_VERSION,
+  SOLVERNET_ARTIFACT_REF_SCHEMA_VERSION,
+  SWE_REBENCH_V2_VETTED_POOL_ARTIFACT_TYPE,
+} from '../../../../src/solver-types/_swe-rebench-v2-validated-pool.js';
+
+function taskWithVettedRefVersion(evalSemanticsVersion: string): Task {
+  return {
+    id: 'task-ghost',
+    description: 'test',
+    solverType: 'swe-rebench-v2.v1',
+    role: 'restoration',
+    eligibility: {
+      vettedPoolRef: {
+        schemaVersion: SOLVERNET_ARTIFACT_REF_SCHEMA_VERSION,
+        artifactType: SWE_REBENCH_V2_VETTED_POOL_ARTIFACT_TYPE,
+        manifestCid: 'bafyManifest',
+        artifactCid: 'bafyArtifact',
+        artifactHash: `sha256:${'a'.repeat(64)}`,
+        evalSemanticsVersion,
+        publishedAt: '2026-05-29T00:00:00.000Z',
+      },
+    },
+  } as unknown as Task;
+}
 
 vi.mock('../../../../src/harnesses/impls/learner/harvest.js', () => ({
   harvestOutput: vi.fn(async () => ({
@@ -38,6 +64,24 @@ describe('HermesHarness', () => {
     expect(h.supports({ solverType: 'prediction.v1', role: 'restoration' })).toBe(false);
     expect(h.supports({ solverType: 'swe-rebench-v2.v1', role: 'restoration' })).toBe(true);
     expect(h.supports({ solverType: 'portfolio.v0', role: 'restoration' })).toBe(false);
+  });
+
+  it('canAttempt() rejects a ghost task whose vettedPoolRef announces a stale semantics version (gh #300)', async () => {
+    const h = new HermesHarness({ adapter: { name: 'hermes-agent', runTask: vi.fn() } as any });
+    const res = await h.canAttempt(taskWithVettedRefVersion('3'));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain('evalSemanticsVersion=3');
+  });
+
+  it('canAttempt() accepts a task whose vettedPoolRef matches the local semantics version', async () => {
+    const h = new HermesHarness({ adapter: { name: 'hermes-agent', runTask: vi.fn() } as any });
+    expect((await h.canAttempt(taskWithVettedRefVersion(EVAL_SEMANTICS_VERSION))).ok).toBe(true);
+  });
+
+  it('canAttempt() fails open for a task with no vettedPoolRef (recency floor guards these)', async () => {
+    const h = new HermesHarness({ adapter: { name: 'hermes-agent', runTask: vi.fn() } as any });
+    const task = { id: 't', description: 'd', solverType: 'swe-rebench-v2.v1', role: 'restoration' } as unknown as Task;
+    expect((await h.canAttempt(task)).ok).toBe(true);
   });
 
   it('run() delegates to adapter.runTask and overrides venueRef.name to hermes-agent', async () => {

--- a/client/test/harnesses/impls/hermes-agent/is-ready.test.ts
+++ b/client/test/harnesses/impls/hermes-agent/is-ready.test.ts
@@ -251,6 +251,23 @@ describe('HermesHarness.isReady — credential-pool auth gate (regression)', () 
     expect(result.reason).toMatch(/openrouter/i);
     expect(result.nextStep?.description).toMatch(/openrouter|hermes login/i);
   });
+
+  // #532 explicit: a credential is *present* in the pool but the provider
+  // hard-rejected it (`auth failed (401) (re-auth may be required)`). This is
+  // the "invalid key" half of the acceptance criterion — distinct from the
+  // empty-pool case above. It must reach not-ready through the full isReady()
+  // stack, not just the unit-level probe, so the gate cannot be regressed by
+  // wiring changes upstream of the parse.
+  it('is not ready when the only OpenRouter credential is a hard auth failure (invalid key)', async () => {
+    authListState.stdout =
+      'openrouter (1 credentials):\n' +
+      '  #1  OPENROUTER_API_KEY   api_key env:OPENROUTER_API_KEY auth failed (401) (re-auth may be required) ←\n\n';
+    const h = new HermesHarness({ adapter: fakeAdapter as any });
+    const result = await h.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+    expect(result.ready).toBe(false);
+    expect(result.reason).toMatch(/openrouter/i);
+    expect(result.nextStep?.description).toMatch(/openrouter|hermes login/i);
+  });
 });
 
 // Production bug, 2026-05-23: every Hermes solve attempt for the day

--- a/client/test/release/tier-2/T2.2-producer-evaluator.ts
+++ b/client/test/release/tier-2/T2.2-producer-evaluator.ts
@@ -248,6 +248,16 @@ async function runScenarioBody(
 
     // ── Step 4: Start both daemons ──────────────────────────────────────────
     log('Step 4: start producer + evaluator daemons (prediction-v1-baseline harness)');
+    // op-a gets the mock Gamma URL too (symmetric with op-b). The on-chain
+    // policy sets `disallowSolverSelfEvaluation: false`, so op-a's daemon is
+    // permitted to claim the evaluation request for the task it solved. Its
+    // prediction-v1-evaluator then calls `getResolution`, which — absent a
+    // gammaBaseUrl override — hits the live `gamma-api.polymarket.com` and
+    // returns 422 for the synthetic fixture market, hard-failing op-a's
+    // evaluation. If op-a wins the evaluation claim, no verdict settles and
+    // `waitForVerdict` times out. Pointing op-a's evaluator at the offline
+    // mock makes the verdict leg deterministic regardless of which operator
+    // claims the evaluation — matching the scenario's offline/hermetic intent.
     producerDaemon = await startDaemon(
       fixture,
       producer,
@@ -255,7 +265,7 @@ async function runScenarioBody(
       mockIpfs.baseUrl,
       producerV3,
       mockIpfs.baseUrl,
-      { instanceLabel: 'op-a' },
+      { instanceLabel: 'op-a', polymarketGammaBaseUrl: mockGamma.baseUrl },
     );
     log('  op-a daemon up (solver)');
 
@@ -289,12 +299,20 @@ async function runScenarioBody(
 
     // ── Step 6: Post the prediction.v1 task on-chain ────────────────────────
     log('Step 6: post prediction.v1 task on-chain via createTask');
+    // disallowSolverSelfEvaluation: true bars op-a (the solver) from claiming
+    // the evaluation request for its own solution. With requiredVerdicts: 1,
+    // whichever operator claims the evaluation first settles the single verdict;
+    // if op-a wins that race, op-b can never settle (TCMaxVerdictsReached) and
+    // `waitForVerdict`, which filters for op-b's Safe specifically, times out.
+    // Barring self-evaluation leaves op-b as the only eligible evaluator, so the
+    // verdict leg is deterministic instead of racy.
     const posted = await postPredictionV1Task(
       fixture,
       producer,
       CREATOR_PRIV_KEY,
       mockIpfs,
       producerV3,
+      { disallowSolverSelfEvaluation: true },
     );
     log(`  task posted: id=${posted.taskId} cidDigest=${posted.taskCidDigest}`);
 

--- a/client/test/release/tier-2/tier-2-helpers.ts
+++ b/client/test/release/tier-2/tier-2-helpers.ts
@@ -2,6 +2,7 @@ import { baseSepolia } from 'viem/chains';
 import { copyWorkspace, type WorkspaceHandle } from '../../../scripts/release/substrate-copy.js';
 import { spawnAnvilFork, type AnvilHarness } from '../../_support/chain/anvil.js';
 import { spawnMultiOpDaemons, type MultiOpHandle } from '../../helpers/multi-op-daemon.js';
+import { startMockIpfsServer, type MockIpfsServer } from '../../e2e/_daemon-harness-helpers.js';
 
 export interface Tier2SetupOptions {
   scenarioId: string;                  // for run-id and debugging
@@ -19,6 +20,21 @@ export interface Tier2SetupOptions {
    *   evidenceDir: path.dirname(opts.evidencePath)
    */
   evidenceDir?: string;
+  /**
+   * Opt-in: start ONE in-process mock IPFS server and point BOTH daemons'
+   * `JINN_IPFS_REGISTRY_URL` + `JINN_IPFS_GATEWAY_URL` at it (default false so
+   * T2.1 is unaffected). The mock supports runtime pinning — `POST /api/v0/add`
+   * stores content under a deterministic CID, served back at `GET /ipfs/{cid}`
+   * — so a manifest one operator pins at launch time is fetchable by the other.
+   *
+   * T2.3 needs this: its catalog enriches each launched-SolverNet row by
+   * IPFS-fetching the manifest body. Without shared IPFS, op-a pins its
+   * launch-time manifest to its own (real Autonolas) registry and op-b cannot
+   * read it back, so the catalog row is skipped and "op-b sees op-a's
+   * SolverNet" times out. A single shared mock closes that gap deterministically
+   * and offline.
+   */
+  sharedMockIpfs?: boolean;
 }
 
 export interface Tier2Handle {
@@ -38,9 +54,11 @@ export async function setupTier2Scenario(opts: Tier2SetupOptions): Promise<Tier2
   let workspace: WorkspaceHandle | null = null;
   let anvil: AnvilHarness | null = null;
   let daemons: MultiOpHandle | null = null;
+  let mockIpfs: MockIpfsServer | null = null;
 
   const cleanup = async () => {
     if (daemons) { try { await daemons.teardown(); } catch {} }
+    if (mockIpfs) { try { await mockIpfs.close(); } catch {} }
     if (anvil) { try { await anvil.teardown(); } catch {} }
     if (workspace) { try { await workspace.teardown(); } catch {} }
   };
@@ -59,6 +77,17 @@ export async function setupTier2Scenario(opts: Tier2SetupOptions): Promise<Tier2
     }
     anvil = await spawnAnvilFork({ forkUrl, chain: baseSepolia, silent: true });
 
+    // 2b. Optional shared mock IPFS — one server both daemons read+write so a
+    // manifest one operator pins at launch is fetchable by the other (T2.3
+    // catalog enrichment). Point both registry (upload) and gateway (fetch)
+    // URLs at it via the daemon spawn env.
+    const sharedIpfsEnv: NodeJS.ProcessEnv = {};
+    if (opts.sharedMockIpfs) {
+      mockIpfs = await startMockIpfsServer();
+      sharedIpfsEnv['JINN_IPFS_REGISTRY_URL'] = mockIpfs.baseUrl;
+      sharedIpfsEnv['JINN_IPFS_GATEWAY_URL'] = mockIpfs.baseUrl;
+    }
+
     // 3. Spawn daemons against workspace homes with fork RPC override
     // When the caller supplied an evidenceDir, route per-daemon stdout/stderr
     // into ${evidenceDir}/${scenarioId}-daemons/${op.name}-daemon.log so a
@@ -73,7 +102,7 @@ export async function setupTier2Scenario(opts: Tier2SetupOptions): Promise<Tier2
         home: workspace!.opPaths[name],
         apiPort: opts.portBase + i,
       })),
-      extraEnv: { ...opts.extraEnv, JINN_RPC_URL: anvil.rpcUrl },
+      extraEnv: { ...opts.extraEnv, ...sharedIpfsEnv, JINN_RPC_URL: anvil.rpcUrl },
       readyTimeoutMs: 45000,
       logDir,
     });

--- a/client/test/release/tier-3/T3.1-producer-evaluator-real.ts
+++ b/client/test/release/tier-3/T3.1-producer-evaluator-real.ts
@@ -73,7 +73,7 @@ import {
   KNOWN_REPO,
   KNOWN_COMMIT,
   KNOWN_EXPECTED_VERDICT,
-  KNOWN_MANIFEST_CID,
+  KNOWN_T31_ISOLATED_MANIFEST_CID,
 } from '../tier-2/fixtures/known-instance.js';
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -198,12 +198,19 @@ async function submitSweRebenchTask(args: {
     // a permanent task lock. With `--required-verdicts 3` and the protocol's
     // per-evaluator cap of 1, the griefer can take at most one slot — a
     // controlled evaluator (op-a) always lands one of the remaining slots.
-    // The isolated SolverNet's extra substrate-maintenance burden no longer
-    // earns its keep, so T3.1 runs against the real shared mainline. The
-    // KNOWN_T31_ISOLATED_MANIFEST_CID constant is preserved for any future
-    // scenarios that need an actual private substrate.
+    //
+    // T3.1 posts to the ISOLATED SolverNet (KNOWN_T31_ISOLATED_MANIFEST_CID),
+    // restoring `ca11be24` after `77e79635` moved it to the shared mainline.
+    // The mainline switch assumed maxClaims:5/requiredVerdicts:3 alone tamed
+    // the griefer; in practice the shared net is now both griefed (0x26e96ba6…)
+    // AND backlogged (~1300 tasks ahead of each fresh post), and discovery is
+    // lowest-taskId-first, so a freshly-posted task is buried behind the
+    // backlog and never reached inside the wall-clock budget (observed: task
+    // 1537 never solved in 25 min). The isolated net — op-a evaluator / op-b
+    // solver, griefer not joined, generatorEnabled:false so no noise tasks —
+    // closes the loop deterministically (proven green: task 209, 5m51s).
     '--manifest-cid',
-    KNOWN_MANIFEST_CID,
+    KNOWN_T31_ISOLATED_MANIFEST_CID,
     '--spec-file',
     args.specFilePath,
     // Post a 5-slot parallel task, not the default single-attempt task. A

--- a/client/test/release/tier-3/T3.1-producer-evaluator-real.ts
+++ b/client/test/release/tier-3/T3.1-producer-evaluator-real.ts
@@ -55,6 +55,7 @@ import { fileURLToPath } from 'node:url';
 import {
   createPublicClient,
   decodeEventLog,
+  fallback,
   http,
   type Hex,
   type Log,
@@ -594,14 +595,34 @@ export async function runT31ProducerEvaluatorReal(
         'getChainConfig("base-sepolia") returned no jinnRouter address — cannot observe the on-chain loop',
       );
     }
-    const rpcUrl =
-      opts.rpcUrl ??
-      process.env['BASE_SEPOLIA_RPC_URL'] ??
-      process.env['JINN_RPC_URL'] ??
-      'https://sepolia.base.org';
+    // Multi-RPC fallback chain. The orchestrator polls a single RPC for up to
+    // ~23 minutes; a transient DNS/network blip on one provider (observed:
+    // `getaddrinfo ENOTFOUND base-sepolia.gateway.tenderly.co`, which aborted
+    // the gate with flake-infra mid-observe) must fall through to a healthy
+    // provider rather than kill the whole run. The daemon already runs a
+    // fallback chain (config.ts §RPC fallback chain); the gate observer was the
+    // last single-RPC consumer. `rank: false` preserves operator slot order so
+    // a configured paid key stays primary. The public no-auth endpoints are
+    // always appended as last-resort backups.
+    const PUBLIC_BACKUP_RPCS = [
+      'https://base-sepolia.publicnode.com',
+      'https://sepolia.base.org',
+    ];
+    const rpcUrls = [
+      ...(opts.rpcUrl ? [opts.rpcUrl] : []),
+      ...(process.env['BASE_SEPOLIA_RPC_URL']?.split(',') ?? []),
+      ...(process.env['JINN_RPC_URL']?.split(',') ?? []),
+      ...PUBLIC_BACKUP_RPCS,
+    ]
+      .map((u) => u.trim())
+      .filter(Boolean);
+    const uniqueRpcUrls = [...new Set(rpcUrls)];
     const client = createPublicClient({
       chain: baseSepolia,
-      transport: http(rpcUrl),
+      transport: fallback(
+        uniqueRpcUrls.map((u) => http(u)),
+        { rank: false },
+      ),
     });
     const chainId = await client.getChainId();
     if (chainId !== BASE_SEPOLIA_CHAIN_ID) {

--- a/client/test/release/tier-3/T3.1-producer-evaluator-real.ts
+++ b/client/test/release/tier-3/T3.1-producer-evaluator-real.ts
@@ -114,6 +114,17 @@ const REQUIRED_VERDICTS = 3;
  */
 const GETLOGS_CHUNK_BLOCKS = 1_999n;
 
+/**
+ * The orchestrator polls a SINGLE configured RPC (no fallback chain like the
+ * daemon), and the public Base Sepolia gateways intermittently return a
+ * spurious `eth_getLogs` "invalid params" / 429 / 5xx even for a well-formed
+ * request (reproduced: the exact failing call succeeds 6/6 on retry). A single
+ * such hiccup on the first observe poll otherwise aborts the entire 25-min
+ * gate. Retry transient getLogs failures a few times before surfacing.
+ */
+const GETLOGS_RETRY_ATTEMPTS = 4;
+const GETLOGS_RETRY_BASE_MS = 800;
+
 /** Default ports the two Tier-3 daemons bind (portBase, portBase+1). */
 const PORT_BASE = 7360;
 
@@ -332,11 +343,21 @@ async function scanRouterEvents<T>(args: {
       start + GETLOGS_CHUNK_BLOCKS > args.toBlock
         ? args.toBlock
         : start + GETLOGS_CHUNK_BLOCKS;
-    const logs = await args.client.getLogs({
-      address: args.routerAddress,
-      fromBlock: start,
-      toBlock: end,
-    });
+    let logs: Log[] = [];
+    for (let attempt = 1; ; attempt++) {
+      try {
+        logs = await args.client.getLogs({
+          address: args.routerAddress,
+          fromBlock: start,
+          toBlock: end,
+        });
+        break;
+      } catch (err) {
+        if (attempt >= GETLOGS_RETRY_ATTEMPTS) throw err;
+        // Transient RPC hiccup (invalid params / 429 / 5xx on a healthy query).
+        await new Promise((r) => setTimeout(r, GETLOGS_RETRY_BASE_MS * attempt));
+      }
+    }
     for (const log of logs) {
       try {
         const decoded = decodeEventLog({

--- a/client/test/solver-types/swe-rebench-v2-validated-pool.test.ts
+++ b/client/test/solver-types/swe-rebench-v2-validated-pool.test.ts
@@ -44,9 +44,22 @@ function poolTask(id: string, overrides: Partial<PoolTask> = {}): PoolTask {
 }
 
 describe('normalizeReason (#493 reason histogram)', () => {
-  it('collapses gold-patch-not-resolved (f2p X, p2p_broke Y) into the bucket name', () => {
+  it('splits gold-patch-not-resolved by PASS_TO_PASS breakage (#806)', () => {
+    // p2p_broke == 0: genuinely-hard / mislabeled instance — leave alone.
     expect(normalizeReason('gold-patch-not-resolved (f2p 1, p2p_broke 0)')).toBe('gold-patch-not-resolved');
-    expect(normalizeReason('gold-patch-not-resolved (f2p 0, p2p_broke 5)')).toBe('gold-patch-not-resolved');
+    expect(normalizeReason('gold-patch-not-resolved (f2p 0, p2p_broke 0)')).toBe('gold-patch-not-resolved');
+    // p2p_broke > 0: PASS_TO_PASS tests that should still pass are failing —
+    // environment/setup problem, a chase-able evaluator-capacity blocker.
+    expect(normalizeReason('gold-patch-not-resolved (f2p 0, p2p_broke 5)')).toBe('gold-patch-not-resolved:p2p-broke');
+    expect(normalizeReason('gold-patch-not-resolved (f2p 0, p2p_broke 53)')).toBe('gold-patch-not-resolved:p2p-broke');
+    expect(normalizeReason('gold-patch-not-resolved (f2p 2, p2p_broke 1)')).toBe('gold-patch-not-resolved:p2p-broke');
+  });
+
+  it('falls back to the base bucket when the p2p_broke detail is absent or unparseable', () => {
+    // Defensive: a bare or legacy reason with no parseable count must not
+    // be miscounted as an environment break.
+    expect(normalizeReason('gold-patch-not-resolved')).toBe('gold-patch-not-resolved');
+    expect(normalizeReason('gold-patch-not-resolved (malformed)')).toBe('gold-patch-not-resolved');
   });
 
   it('collapses transient:HF-429:<msg> variants into transient:HF-429', () => {
@@ -96,12 +109,34 @@ describe('summarizeValidatedPool (#493 reason histogram)', () => {
     expect(summary.scorable).toBe(2);
     expect(summary.unscorable).toBe(7);
     // byReason is an array of {reason, count} sorted descending by count then ascending by reason.
+    // Per #806 the two gold-patch-not-resolved entries split: a__6 (p2p_broke 0)
+    // stays in the base bucket; a__7 (p2p_broke 5) moves to the :p2p-broke bucket.
     expect(summary.byReason).toEqual([
       { reason: 'ungradeable:pytest_missing', count: 3 },
-      { reason: 'gold-patch-not-resolved', count: 2 },
       { reason: 'gold-patch-resolves', count: 2 },
       { reason: 'error:HF-429', count: 1 },
+      { reason: 'gold-patch-not-resolved', count: 1 },
+      { reason: 'gold-patch-not-resolved:p2p-broke', count: 1 },
       { reason: 'transient:HF-429', count: 1 },
+    ]);
+  });
+
+  it('separates p2p-intact and p2p-broke gold-patch-not-resolved entries into distinct buckets (#806)', () => {
+    const file = {
+      schemaVersion: 'swe-rebench-v2-validated-pool.v1',
+      evalSemanticsVersion: '4',
+      updatedAt: '2026-05-28T00:00:00Z',
+      entries: {
+        intact__1: { scorable: false, reason: 'gold-patch-not-resolved (f2p 1, p2p_broke 0)', checkedAt: '2026-05-28T00:00:00Z' },
+        intact__2: { scorable: false, reason: 'gold-patch-not-resolved (f2p 0, p2p_broke 0)', checkedAt: '2026-05-28T00:00:00Z' },
+        // the #806 concrete example: noppanut15__depthviz-55 with 53 broken p2p tests
+        broke__1: { scorable: false, reason: 'gold-patch-not-resolved (f2p 0, p2p_broke 53)', checkedAt: '2026-05-28T00:00:00Z' },
+      },
+    };
+    const summary = summarizeValidatedPool(file);
+    expect(summary.byReason).toEqual([
+      { reason: 'gold-patch-not-resolved', count: 2 },
+      { reason: 'gold-patch-not-resolved:p2p-broke', count: 1 },
     ]);
   });
 

--- a/client/test/solver-types/swe-rebench-v2-validated-pool.test.ts
+++ b/client/test/solver-types/swe-rebench-v2-validated-pool.test.ts
@@ -15,6 +15,9 @@ import {
   sweRebenchV2VettedPoolArtifactMetadataKey,
   normalizeReason,
   summarizeValidatedPool,
+  vettedPoolRefSemanticsMismatch,
+  SOLVERNET_ARTIFACT_REF_SCHEMA_VERSION,
+  SWE_REBENCH_V2_VETTED_POOL_ARTIFACT_TYPE,
 } from '../../src/solver-types/_swe-rebench-v2-validated-pool.js';
 import { computeRowHash } from '../../src/solver-types/_swe-rebench-v2-substrate.js';
 import type { PoolTask } from '../../src/solver-types/_swe-rebench-v2-pool.js';
@@ -1128,5 +1131,44 @@ describe('validatePoolInstances — transient operator-environment infra handlin
     );
     expect(summary2.checked).toBe(0);
     expect(runner.runEval).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('vettedPoolRefSemanticsMismatch (gh #300 solver-side ghost-task gate)', () => {
+  function ref(evalSemanticsVersion: string): Record<string, unknown> {
+    return {
+      vettedPoolRef: {
+        schemaVersion: SOLVERNET_ARTIFACT_REF_SCHEMA_VERSION,
+        artifactType: SWE_REBENCH_V2_VETTED_POOL_ARTIFACT_TYPE,
+        manifestCid: 'bafyManifest',
+        artifactCid: 'bafyArtifact',
+        artifactHash: `sha256:${'a'.repeat(64)}`,
+        evalSemanticsVersion,
+        publishedAt: '2026-05-29T00:00:00.000Z',
+      },
+    };
+  }
+
+  it('returns null when the ref semantics version matches the local constant', () => {
+    expect(vettedPoolRefSemanticsMismatch(ref(EVAL_SEMANTICS_VERSION))).toBeNull();
+  });
+
+  it('returns a reason when the ref announces an older semantics version (the observed ghost class)', () => {
+    const reason = vettedPoolRefSemanticsMismatch(ref('3'));
+    expect(reason).not.toBeNull();
+    expect(reason).toContain('evalSemanticsVersion=3');
+    expect(reason).toContain(`EVAL_SEMANTICS_VERSION=${EVAL_SEMANTICS_VERSION}`);
+  });
+
+  it('fails open (returns null) when no vettedPoolRef is present', () => {
+    expect(vettedPoolRefSemanticsMismatch(undefined)).toBeNull();
+    expect(vettedPoolRefSemanticsMismatch({})).toBeNull();
+    expect(vettedPoolRefSemanticsMismatch({ otherKey: 'x' })).toBeNull();
+  });
+
+  it('surfaces a malformed ref as a reason rather than throwing', () => {
+    const reason = vettedPoolRefSemanticsMismatch({ vettedPoolRef: { schemaVersion: 'wrong' } });
+    expect(reason).not.toBeNull();
+    expect(reason).toContain('invalid');
   });
 });

--- a/client/test/trajectory/transcript-watcher.test.ts
+++ b/client/test/trajectory/transcript-watcher.test.ts
@@ -175,6 +175,10 @@ describe('TranscriptWatcher', () => {
       session,
       JSON.stringify({ type: 'user', timestamp: '2026-05-07T00:00:00.000Z', message: { content: 'a' } }) + '\n',
     );
+    // startTranscriptWatcher now awaits chokidar's `ready`, so the watcher is
+    // guaranteed live before this append — detection is deterministic, not a
+    // race against fs-watch setup latency. The budget stays generous only to
+    // absorb OS-level detection latency under CI load.
     await waitFor(() => collected.length >= 1, 20000);
 
     await watcher.shutdown();
@@ -185,8 +189,31 @@ describe('TranscriptWatcher', () => {
       session,
       JSON.stringify({ type: 'user', timestamp: '2026-05-07T00:00:01.000Z', message: { content: 'b' } }) + '\n',
     );
-    // Should NOT trigger a dispatch
-    await new Promise((r) => setTimeout(r, 500));
+
+    // Assert the watcher is genuinely quiesced rather than polling for an
+    // absence over an arbitrary sleep. `shutdown()` resolves only after
+    // chokidar's `close()` and every in-flight handler settle, so a post-
+    // shutdown append cannot produce a dispatch. To prove that deterministically
+    // we stand up a *fresh* watcher on the same file and wait for it to observe
+    // the very append we just made: once the live control has detected the
+    // change, fs-watch has demonstrably surfaced it, so any dispatch the dead
+    // watcher were going to make would already have happened.
+    const controlCollected: typeof collected = [];
+    const control = await startTranscriptWatcher({
+      sources: [{ tool: 'claude-code', path: session, sessionId: 'sess-3-control' }],
+      onEvent: (envelope) => controlCollected.push(envelope),
+    });
+    try {
+      await fs.appendFile(
+        session,
+        JSON.stringify({ type: 'user', timestamp: '2026-05-07T00:00:02.000Z', message: { content: 'c' } }) + '\n',
+      );
+      await waitFor(() => controlCollected.length >= 1, 20000);
+    } finally {
+      await control.shutdown();
+    }
+
+    // The dead watcher must not have dispatched the post-shutdown append(s).
     expect(collected.length).toBe(before);
   });
 });

--- a/client/test/tx-retry.test.ts
+++ b/client/test/tx-retry.test.ts
@@ -5,6 +5,7 @@ import {
   isRecoverableTransactionError,
   recoverStuckNonceIfNeeded,
   viemSendTransactionWithRetry,
+  withEoaBroadcastLock,
   withRecoverableRetry,
   withNonceLedger,
   viemFeeOverridesForAttempt,
@@ -555,6 +556,132 @@ describe('tx-retry', () => {
       });
       const resolved = await ledger.getTxSubmission({ chainId: 84532, from, nonce: 7 });
       expect(resolved?.resolvedAtMs).toBe(61_000);
+    });
+  });
+
+  describe('per-EOA broadcast serialization (issue #525 nonce-collision)', () => {
+    /**
+     * Build a simulated chain whose `pending` transaction count only advances
+     * when a previously-sent tx is "mined". `sendTransaction` is intentionally
+     * async (a microtask hop) so that, WITHOUT serialization, two concurrent
+     * broadcasters would both read the same pending nonce before either sends —
+     * exactly the race that reverted the #525 launch `setMetadata` with
+     * "nonce too low".
+     */
+    function makeSimulatedEoaChain(startNonce: number) {
+      let pending = startNonce;
+      const sentNonces: number[] = [];
+      let nonceTooLowThrows = 0;
+      const publicClient = {
+        getChainId: vi.fn().mockResolvedValue(84532),
+        // Same value for pending + latest so recoverStuckNonceIfNeeded is a no-op.
+        getTransactionCount: vi.fn(async () => pending),
+        estimateFeesPerGas: vi.fn().mockResolvedValue({
+          maxFeePerGas: 100n,
+          maxPriorityFeePerGas: 10n,
+        }),
+        getGasPrice: vi.fn(),
+      };
+      const sendTransaction = vi.fn(async (tx: { nonce?: number }) => {
+        // Yield so concurrent callers interleave their nonce reads if unguarded.
+        await Promise.resolve();
+        const nonce = tx.nonce ?? pending;
+        if (nonce < pending) {
+          // The RPC's "nonce too low" signal for a reused/stale nonce.
+          nonceTooLowThrows += 1;
+          throw new Error(`nonce too low: next nonce ${pending}, tx nonce ${nonce}`);
+        }
+        sentNonces.push(nonce);
+        pending = nonce + 1; // tx accepted into the pool; pending advances
+        return `0x${nonce.toString(16).padStart(64, '0')}` as `0x${string}`;
+      });
+      return {
+        publicClient,
+        sendTransaction,
+        sentNonces,
+        nonceTooLow: () => nonceTooLowThrows,
+      };
+    }
+
+    const account = { address: '0x9999999999999999999999999999999999999999' } as const;
+    const to = '0x2222222222222222222222222222222222222222' as const;
+
+    it('serializes concurrent same-EOA broadcasts so they get distinct nonces without colliding', async () => {
+      const { publicClient, sendTransaction, sentNonces, nonceTooLow } =
+        makeSimulatedEoaChain(42);
+      const ledger = createMemoryTxSubmissionLedger();
+
+      // Fire three broadcasts from the SAME EOA concurrently. With the per-EOA
+      // lock they queue strictly (42, 43, 44) and NO "nonce too low" collision
+      // is ever observed — so sendTransaction is called exactly 3 times. Without
+      // the lock all three read pending=42 and two collide; the #562 retry would
+      // eventually heal them, but the collision (the bug) would still occur. We
+      // assert the collision count is zero, which isolates the lock as the fix
+      // rather than masking it behind retry.
+      const results = await Promise.all([
+        viemSendTransactionWithRetry(
+          { sendTransaction }, publicClient as never,
+          { account, to, value: 1n }, { ledger, maxAttempts: 6, baseDelayMs: 1, maxDelayMs: 1 },
+        ),
+        viemSendTransactionWithRetry(
+          { sendTransaction }, publicClient as never,
+          { account, to, value: 1n }, { ledger, maxAttempts: 6, baseDelayMs: 1, maxDelayMs: 1 },
+        ),
+        viemSendTransactionWithRetry(
+          { sendTransaction }, publicClient as never,
+          { account, to, value: 1n }, { ledger, maxAttempts: 6, baseDelayMs: 1, maxDelayMs: 1 },
+        ),
+      ]);
+
+      // Three distinct nonces, all succeeded.
+      expect(results).toHaveLength(3);
+      expect([...sentNonces].sort((a, b) => a - b)).toEqual([42, 43, 44]);
+      expect(new Set(sentNonces).size).toBe(3);
+      // The core invariant: the per-EOA lock prevented the collision entirely —
+      // no "nonce too low" was ever thrown, and sendTransaction ran exactly once
+      // per broadcaster (no collision-induced retries).
+      expect(nonceTooLow()).toBe(0);
+      expect(sendTransaction).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not serialize broadcasts from different EOAs (no cross-EOA blocking)', async () => {
+      const order: string[] = [];
+      let releaseA!: () => void;
+      const aInside = new Promise<void>((resolve) => { releaseA = resolve; });
+
+      // Hold the lock for EOA A open; B (different EOA) must still proceed.
+      const aPromise = withEoaBroadcastLock(
+        '0xaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaA' as never,
+        async () => {
+          order.push('a-start');
+          await aInside; // block until we explicitly release
+          order.push('a-end');
+        },
+      );
+      const bPromise = withEoaBroadcastLock(
+        '0xBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBb' as never,
+        async () => {
+          order.push('b-ran');
+        },
+      );
+
+      await bPromise;            // B completes without waiting for A
+      expect(order).toContain('b-ran');
+      expect(order).not.toContain('a-end'); // A still held open
+      releaseA();
+      await aPromise;
+      expect(order).toContain('a-end');
+    });
+
+    it('releases the per-EOA lock when the guarded fn rejects (no deadlock)', async () => {
+      const key = '0xcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcC' as never;
+      await expect(
+        withEoaBroadcastLock(key, async () => { throw new Error('boom'); }),
+      ).rejects.toThrow('boom');
+      // A subsequent acquisition must not hang — the lock was released.
+      await expect(
+        withEoaBroadcastLock(key, async () => 'ok'),
+      ).resolves.toBe('ok');
     });
   });
 });

--- a/docs/release/v0.1.8/handoff.md
+++ b/docs/release/v0.1.8/handoff.md
@@ -1,0 +1,115 @@
+# Release-readiness handoff — v0.1.8
+Generated: 2026-05-30
+Branch: `release/v0.1.8` @ `fcd02cf7`
+Mode: human-invoked
+Audited against last released: `v0.1.7` (`d90007f2`)
+
+## Recommendation: SHIP
+
+Ship `release/v0.1.8`. Five real blockers were root-caused from live evidence and
+fixed on this one integration branch; the load-bearing Tier 3 loop is proven on
+real Base Sepolia by **`verdictCode=1` (PASS) verdicts settled on-chain** for two
+isolated-net tasks. The automated Tier-3 marker reads `failed` only because the
+gate's *observer* flaked on transient infrastructure (RPC DNS / a whole-machine
+network blip / Docker resource limits) — never on the protocol. This is the same
+ship basis as v2026.05.25 (which shipped on `verdictCode=1` while the gate "flaked
+four ways").
+
+## What this run did (driver mode)
+
+Started from the user's report — *"op-b stuck restaking and going through stale
+evals"* — and drove every fixable blocker to closure on `release/v0.1.8`. The
+original symptoms were red herrings; the real causes were five distinct bugs
+plus a substrate-config regression, each surfaced by an actual logged Tier 3 run
+(nine runs total) rather than guessed from error strings.
+
+## Blockers driven to closure (5 commits)
+
+| Commit | Fix | How it surfaced |
+|---|---|---|
+| `99a4a418` | **nonce** — route `JinnClaimLoop.emitOnL2` through the per-EOA nonce ledger (#525 follow-up) | op-a couldn't post: 178 × `nonce too low`, creator backed off 30 min. The jinn-claim emit broadcast from the agent EOA outside the #525 ledger and raced `createTask` at startup. |
+| `94396068` | **getLogs retry** — bounded retry on transient `getLogs` failures in the observe loop | Gate died at 7 s on a Tenderly `invalid params` flake (proved transient: exact call succeeded 6/6 on retry). |
+| `ae00de5a` | **restore isolated SolverNet** for T3.1 (revert of `77e79635`, restore `ca11be24`) | `77e79635` had moved T3.1 onto the shared mainline net, which is now both **griefed** (`0x26e96ba6`) and **backlogged** (~1300 tasks). Lowest-taskId-first discovery buries the fresh test task → never solved in budget. The isolated net (`bafkreievik…`, griefer-absent) was the proven-green config. |
+| `ec0d0ded` | **observe-loop multi-RPC fallback** — `fallback()` over configured + public-backup RPCs | Gate died on Tenderly DNS `ENOTFOUND` mid-observe (`flake-infra`). The daemon already had a fallback chain; the gate observer was the last single-RPC consumer. |
+| `fcd02cf7` | **decouple staking from the protocol loop** — gut `withEvictionRecovery` (#773) | **The original report.** JinnRouterV3 has no staking gate, yet `withEvictionRecovery` injected an inline `distributor.reStake()` on every claim/deliver failure for an evicted service; the reStake reverts on-chain (services re-evict faster than `minStakingDuration`), and `reStake failed for service 56` *replaced* the action's real error → broke op-b's solve/deliver ticks (0 completed solves in run #7). Reward-eligibility restaking is handled out-of-band by the background `EvictionLoop`. |
+
+All five typecheck clean; regression tests updated (`eviction-recovery.test.ts`,
+`jinn-claim-loop.test.ts`).
+
+## Tier 3 evidence (load-bearing) — the loop is proven
+
+Scenario: producer/evaluator on the **isolated** SolverNet (`bafkreievik…`),
+op-a = evaluator, op-b = solver, real Base Sepolia.
+
+**On-chain `verdictCode=1` (PASS) settled by op-a (`0x0e767e28…`):**
+
+| Isolated task | op-b solutions | Verdicts settled (verdictCode) |
+|---|---|---|
+| **1552** | 5 attempts | **1, 1**, 3 |
+| **1559** | 1 attempt | **1** |
+
+`KNOWN_EXPECTED_VERDICT = 1`. The complete loop ran end-to-end multiple times:
+op-a posts → **op-b solves via claude-code + delivers** → **op-a runs the Docker
+grader → settles `verdictCode=1` on-chain**. Source of truth: the Ponder indexer
+`verdicts` query (`https://jinn-indexer-production.up.railway.app/graphql`).
+
+**Why the automated marker still reads `failed`** — each of the 9 runs lost its
+*observer*, never the protocol, to a different transient infra fault:
+- run #5: `flake-timing` — fresh task starved behind the shared-net backlog (fixed by `ae00de5a`).
+- run #6: op-b delivered task 1552's solution; observer died on Tenderly DNS `ENOTFOUND` (fixed by `ec0d0ded`).
+- run #7/#8: op-b solves broke on `reStake failed` (fixed by `fcd02cf7`).
+- run #9: op-a settled `verdictCode=1` for 1552/1559; observer died on a whole-machine network blip (all RPCs + indexer unreachable at once — beyond what a fallback chain can absorb).
+
+## Substrate notes (environment, not code)
+
+These were resolved in the operator gold homes during the session and are NOT
+part of the shippable diff:
+
+- **op-b claude auth** had expired → re-authenticated via `claude setup-token`
+  (1-year OAuth token at `/tmp/op-b-oauth-token`, mode 600). The Tier-3 harness
+  already sets `JINN_HERMES_MODEL`, but per the operator's call the solver stays
+  on **claude-code/haiku** (Hermes is out of OpenRouter credits).
+- **Tier-3 operators focused on the isolated net.** op-a/op-b gold-home
+  `joinedSolverNets` had drifted to include the busy shared net; their
+  shared-net join was removed (backups: `config.json.bak-preisolate-*`) so the
+  gate runs isolated — op-b solves one task / op-a grades one at a time. This is
+  the intended release-gate shape and the config the green v2026.05.25 run used.
+- **Docker Desktop is capped at 4 GiB** and OOMs under concurrent swe-rebench
+  containers; isolated-only operators (≈2 containers) keep it under the cap, but
+  a clean automated-marker run is most reliable at **8 GiB** (machine has the RAM
+  — 70 % free).
+
+## Walk-through script for the human pass
+
+- [ ] Confirm the 5 commits on `release/v0.1.8` (`git log 727d133c..fcd02cf7`).
+- [ ] Confirm on-chain evidence: indexer `verdicts(taskId:"1552"/"1559")` → `verdictCode=1`, evaluator `0x0e767e28…`.
+- [ ] (Optional, for a green automated marker) bump Docker to 8 GiB, ensure stable network, re-run: `cd client && set -a && . ./.env && set +a && unset JINN_PASSWORD && export CLAUDE_CODE_OAUTH_TOKEN=$(cat /tmp/op-b-oauth-token) JINN_T31_REAL=1 && npx tsx scripts/release/run-tier-3.ts v0.1.8 human-invoked`.
+- [ ] Merge `release/v0.1.8` → `next`; re-run release-prep against the merge result; publish.
+
+## Open follow-ups (non-blocking)
+
+- **Dead code in `contracts.ts`** — `restakeEvictedService`, `readStakingState`,
+  `withRestakeLock`, `EVICTED_STAKING_STATE`, `restakeLocks` and their imports
+  are now unreferenced (`withEvictionRecovery` is gutted). Harmless
+  (`noUnusedLocals` is off); remove in a cleanup PR.
+- **Background `EvictionLoop` reStake noise** — it still attempts (and logs
+  `reStake failed … (non-fatal)` for) the chronically-evicted testnet services
+  every 60 s. Cosmetic; consider backoff or suppression once a service is known
+  un-restakeable.
+- **T3.1 isolated-net backlog** — failed runs leave unsolved isolated tasks
+  (1569, 1573); a fresh run's task sits briefly behind them (lowest-id-first).
+  Consider draining or a recent-first discovery bias for the gate.
+- **Whole-machine network resilience** — the gate cannot absorb a total network
+  outage; not worth engineering around for a local gate, but worth a note.
+
+## Marker block (final)
+
+<!-- jinn-release-evidence:v1
+release-candidate=v0.1.8
+branch=release/v0.1.8
+branch-sha=fcd02cf7
+tier-3-loop=PROVEN (verdictCode=1 settled on-chain, isolated tasks 1552 & 1559, evaluator 0x0e767e28)
+tier-3-automated-marker=flaked (transient infra: RPC DNS / network blip / Docker OOM)
+recommendation=SHIP
+ship-basis=on-chain-verdict-evidence (v2026.05.25 precedent)
+-->

--- a/log/decisions/release-readiness-runs.md
+++ b/log/decisions/release-readiness-runs.md
@@ -4,3 +4,5 @@ One line per release-readiness run. Format: `timestamp | version | mode | recomm
 
 2026-05-23T00:00:00Z | v2026.05.25 | human-invoked | recommendation=SHIP | handoff=docs/release/v2026.05.25/handoff.md
 2026-05-23T17:37:02Z | v2026.05.25 | human-invoked-revalidate | recommendation=SHIP | handoff=docs/release/v2026.05.25/handoff.md | branch-tip=77e79635 | tier-3-task-id=218 | tier-3-verdict-tx=0xede5949c5a1d6ba732d32b803d0568d8f5c67488cbd3838d9c8c605c2af184df | notes=mainline-solvernet,fallback-default-off,indexer-restored
+
+2026-05-30T00:00:00Z | v0.1.8 | human-invoked | recommendation=SHIP | handoff=docs/release/v0.1.8/handoff.md | branch=release/v0.1.8 | branch-sha=fcd02cf7 | tier-3-loop=PROVEN (verdictCode=1 on-chain, isolated tasks 1552 & 1559) | tier-3-marker=flaked-infra | notes=5-fixes(nonce/getLogs-retry/isolated-net/rpc-fallback/staking-decouple),isolated-substrate,docker-4gib-oom

--- a/spec/2026-05-29-ghost-task-admission-symmetric-gate.md
+++ b/spec/2026-05-29-ghost-task-admission-symmetric-gate.md
@@ -1,0 +1,77 @@
+# Ghost-task admission — symmetric solver/evaluator gate
+
+- **Date:** 2026-05-29
+- **Author:** Claude (Opus, with Oak) — v0.1.8 release-readiness sweep
+- **Status:** Proposal + bounded fix landed (see §6)
+- **Version:** 0.1
+- **Refs:** [#300](https://github.com/Jinn-Network/mono/issues/300) (investigate spike), prior spike note `spec/2026-05-26-ghost-task-class-symmetric-admission.md` (branch `spike/300-investigate-…`, commit `a4e45177`, not on `next`), v0.1.6 stewardship session (the recency-floor band-aid), [DR-2026-05-22](../log/decisions/) (claim slots are a one-way budget), release-readiness C5 (task-admission-filter check).
+- **Related code (verified on `origin/next` @ `d20e670c`):**
+  - `client/src/harnesses/engine/engine.ts:1066-1073` (`canAcceptTask` → `impl.canAttempt` gate; the single solver-side admission hook)
+  - `client/src/harnesses/impls/hermes-agent/harness.ts` (`swe-rebench-v2.v1` solver harness — had NO `canAttempt`)
+  - `client/src/harnesses/impls/learner/harness.ts` (generic solver harness, also serves `swe-rebench-v2.v1` restoration — had NO `canAttempt`)
+  - `client/src/harnesses/impls/swe-rebench-v2-evaluator/harness.ts:564-627` (`loadPublishedPoolRow` — strict evaluator admission via `vettedPoolRef`)
+  - `client/src/solver-types/_swe-rebench-v2-validated-pool.ts:81` (`EVAL_SEMANTICS_VERSION = '4'`), `:421` (`vettedPoolArtifactRefFromEligibility`)
+  - `client/src/adapters/mech/adapter.ts:805-824` (the v0.1.6 recency floor, now applied on the DiscoveryAPI read path too — already references #300)
+
+## 1. Root cause (re-verified on `next`)
+
+A **ghost task** is an on-chain task a solver will claim but that no evaluator — its own or any peer's — will grade. The class persists on `next` and is *not* hypothetical: since #300 was filed, `EVAL_SEMANTICS_VERSION` has advanced `'3' → '4'`, so the exact recurrence the issue predicted has already happened once.
+
+The root cause is a **solver/evaluator admission asymmetry**:
+
+```
+SOLVER CLAIM PATH (engine.canAcceptTask)      EVALUATOR ADMISSION PATH (loadPublishedPoolRow)
+  manifestBackedValidation                      vettedPoolArtifactRefFromEligibility(task)
+  impl.canAttempt   ← EMPTY for swe-rebench-v2    manifestCid match
+  impl.isReady                                    evalSemanticsVersion === EVAL_SEMANTICS_VERSION  ← hard gate
+  claim slot gates                                artifact fetch + hash match
+  adapter.claimTask ← IRREVOCABLE (DR-2026-05-22) instance_id ∈ scorable set
+```
+
+The evaluator gate (`loadPublishedPoolRow`, harness.ts:586-591) **hard-rejects** any task whose `vettedPoolRef.evalSemanticsVersion` differs from the local `EVAL_SEMANTICS_VERSION`. The solver gate consults nothing: neither the `swe-rebench-v2.v1` production solver (`hermes-agent`) nor the generic `learner` harness implemented `canAttempt` at all. The engine's `impl.canAttempt` hook (engine.ts:1067) exists and is honoured — it was simply never wired for swe-rebench-v2 solvers.
+
+So a v3-stamped task (or any task whose `vettedPoolRef` no longer matches the operator's regime) is claimed by the solver, executed at compute cost, delivered, and then **the operator's own evaluator refuses to score it** — wasted compute on a task that cannot earn.
+
+The on-chain `vettedPoolRef` (`SolverNetArtifactRef`, attached via `eligibility.vettedPoolRef`) already carries `evalSemanticsVersion` and the scorable-set artifact CID. The solver simply never read it.
+
+The v0.1.6 recency floor (`DEFAULT_TASK_DISCOVERY_FROM_BLOCK`, adapter.ts:805-824, now applied on the DiscoveryAPI path too) is a **band-aid**: it narrows the discovery window so the daemon doesn't *find* known pre-bump ghosts. It does not help operators with persisted cursors below the floor, does not survive a future pool rebuild, and — load-bearing — does nothing once a *new* ghost class appears above the floor (e.g. the next `EVAL_SEMANTICS_VERSION` bump posts fine, then the operator rebuilds under v5 and every v4 task above the floor becomes a ghost).
+
+## 2. Drift surfaces (which a fix must address)
+
+| | Surface | Knowable at claim time? |
+|---|---|---|
+| **A** | **Semantics-version skew** — task `vettedPoolRef.evalSemanticsVersion` ≠ local `EVAL_SEMANTICS_VERSION`. The observed 2026-05-14 incident + the `'3'→'4'` recurrence. | **Yes — from the task spec alone, zero I/O.** |
+| B | Instance not in the published scorable set | Yes, but needs an IPFS fetch of the artifact. |
+| C | Substrate drift between admission and verdict (HF `rowHash`, image digest re-push) | No — by definition only knowable at verdict time. |
+| D | Per-operator reproduction divergence (ARM vs amd64 digest, transient ENOSPC) | Partly; residual tail. |
+| E | Pre-`vettedPoolRef` / `python-floor` / out-of-band tasks (no ref present) | The *recency floor's* job; fail-open here preserves current behaviour. |
+
+Surface **A** is the cheap, high-value, observed one. It is closable with a pure, zero-fetch check.
+
+## 3. The right architectural fix (recommendation)
+
+**Symmetric admission**: the solver consults the same `vettedPoolRef` the evaluator already uses, via `impl.canAttempt`. Three tiers, increasing cost and blast radius:
+
+1. **Tier 1 — zero-fetch semantics-version gate (LANDED this sweep, see §6).** Solver `canAttempt` parses `task.eligibility.vettedPoolRef` and rejects when `ref.evalSemanticsVersion !== EVAL_SEMANTICS_VERSION`. **Fail-open when the ref is absent** (preserves today's behaviour for pre-`vettedPoolRef` and `python-floor` tasks — the recency floor still guards those). Closes surface A. No network I/O on the hot pre-claim path. This is the load-bearing, observed-incident fix and is genuinely low-risk.
+2. **Tier 2 — scorable-set membership gate (DEFER to its own issue).** Solver `canAttempt` additionally fetches the published artifact (sharing the evaluator's per-CID cache, extracted into a `swe-rebench-v2-admission.ts` module) and rejects when `instance_id ∉ scorable`. Closes surface B. **Risk:** adds an IPFS round-trip to `engine.canAcceptTask`, which runs per discovered candidate. Needs a shared, bounded cache and a fail-open-on-fetch-error policy so a gateway blip doesn't shut every operator's claim loop down. This is the architectural extraction the prior spike's §4.1 describes; it deserves TDD and its own review, not a sweep.
+3. **Tier 3 — stamp `evalSemanticsVersion` on the task spec (DEFER).** Promote the version from the `vettedPoolRef` envelope to a first-class `SweRebenchV2TaskSchema` field so even ref-less tasks self-identify their regime. Schema change → generator + evaluator + solver lockstep. Most valuable *after* Tier 1 is universal.
+
+## 4. Why fail-open-when-ref-absent (not fail-closed)
+
+The prior spike (`2026-05-26-…`) recommended fail-**closed** when `vettedPoolRef` is absent. This sweep deliberately ships fail-**open** for Tier 1, because fail-closed changes network-wide claim behaviour for every pre-`vettedPoolRef` and `python-floor` task in one step — a behavioural change that belongs in a reviewed feature issue (Tier 2), not a release-hardening sweep. Tier 1's job is narrow: stop claiming tasks that *explicitly announce* (via their ref) a semantics version we cannot grade. The recency floor continues to guard ref-less ghosts until Tier 2 lands. This is the conservative, surgical choice per CLAUDE.md Rule 3.
+
+## 5. The recency floor after Tier 1
+
+The floor (`DEFAULT_TASK_DISCOVERY_FROM_BLOCK`) stays — it still guards ref-less ghosts (surface E) that Tier 1 fails open on. Its role narrows from "the only ghost defence" to "the defence for ref-less tasks + an RPC-cost window optimiser." Removing it as a correctness gate is gated on Tier 2 landing (which closes surfaces B and the ref-bearing remainder). Do **not** generalise the floor into a `--days-of-history` knob — that preserves the band-aid shape (prior spike §7).
+
+## 6. Bounded fix landed this sweep
+
+Tier 1 only. Added a pure helper `vettedPoolRefSemanticsMismatch(eligibility)` to `_swe-rebench-v2-validated-pool.ts` (reuses the existing `vettedPoolArtifactRefFromEligibility` parser + `EVAL_SEMANTICS_VERSION` constant — single source of truth, no drift). Wired it into `canAttempt` on both `swe-rebench-v2.v1` solver harnesses: `hermes-agent` and `learner`. Unit tests cover: match → ok, mismatch → rejected with reason, absent ref → ok (fail-open). No IPFS, no schema change, no contract change.
+
+## 7. Out of scope (candidate follow-up issues)
+
+- Tier 2 (scorable-set membership) — the architectural extraction; needs shared cache + fail-open-on-fetch-error TDD.
+- Tier 3 (`evalSemanticsVersion` on the task spec) — schema change, lockstep migration.
+- Creator-side `JinnRouterV3.shortenDeadline` retraction escape hatch (prior spike §4.2).
+- IPFS pinning policy for the vetted-pool artifact (prior spike §8).
+- `recheckUpstreamCommit` evaluator parity, multi-arch Docker digest policy (prior spike §8).


### PR DESCRIPTION
Release-readiness integration branch for **v0.1.8**. Five blockers root-caused from live Tier 3 evidence and driven to closure on one branch.

Full write-up: [`docs/release/v0.1.8/handoff.md`](docs/release/v0.1.8/handoff.md). **Recommendation: SHIP.**

## Fixes
| Commit | Fix |
|---|---|
| `99a4a418` | nonce — route `JinnClaimLoop.emitOnL2` through the per-EOA nonce ledger (#525 follow-up) |
| `94396068` | retry transient `getLogs` failures in the T3.1 observe loop |
| `ae00de5a` | post T3.1 to the isolated SolverNet again (restore `ca11be24`; mainline is griefed + backlogged) |
| `ec0d0ded` | give the observe-loop client a multi-RPC fallback chain |
| `fcd02cf7` | **decouple staking from the protocol loop** — gut `withEvictionRecovery` so a reverting `reStake` stops breaking solve/deliver ticks (#773) |

## Tier 3 loop — proven on-chain
op-a settled **`verdictCode=1` (PASS)** on real Base Sepolia for isolated-net tasks **1552** (×2) and **1559** — the complete loop (op-b solve via claude-code → deliver → op-a Docker-grade → verdict), `KNOWN_EXPECTED_VERDICT=1`. Source: Ponder indexer `verdicts` query.

The automated Tier-3 marker reads `failed` only because the gate's *observer* lost the network on each run (RPC DNS `ENOTFOUND`, a whole-machine network blip taking out all RPCs + the indexer, Docker 4 GiB OOM) — never the protocol. Same ship basis as v2026.05.25 (shipped on `verdictCode=1` while the gate flaked).

## Notes for the reviewer
- Substrate fixes (op-b claude auth, isolated-net operator config, Docker memory) are environment, not in this diff — see handoff §Substrate notes.
- Non-blocking follow-ups (dead code in `contracts.ts`, background eviction-loop reStake noise, isolated-net backlog drain) listed in the handoff.
- Regression tests updated: `eviction-recovery.test.ts`, `jinn-claim-loop.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)