### PR TITLE
feat(hermes): support local provider base URLs

### DIFF
--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -22,6 +22,7 @@ import { TaskSchema, parseTask } from './types/task.js';
 import type { Task } from './types/task.js';
 import { canonicalHarnessName, CLAUDE_CODE_HARNESS } from './harnesses/names.js';
 import { parseRpcUrls } from './rpc/transport.js';
+import { canonicalLocalHttpBaseUrl } from './local-provider-url.js';
 
 // ── Schema ──────────────────────────────────────────────────────────────────
 
@@ -125,6 +126,23 @@ export const JinnConfigSchema = z.object({
 
   /** Hermes provider (e.g. 'anthropic'). */
   hermesProvider: z.string().optional(),
+
+  /** Local OpenAI-compatible Hermes base URL, e.g. http://127.0.0.1:11434/v1 for Ollama. */
+  hermesBaseUrl: z
+    .string()
+    .url()
+    .transform((value, ctx) => {
+      const canonical = canonicalLocalHttpBaseUrl(value);
+      if (!canonical) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'hermesBaseUrl must be a local HTTP(S) URL',
+        });
+        return z.NEVER;
+      }
+      return canonical;
+    })
+    .optional(),
 
   /**
    * Timeout in ms for `hermes doctor` health-check runs.
@@ -894,6 +912,7 @@ export function loadConfig(configPath?: string): JinnConfig {
   if (env['JINN_HERMES_PATH'])       merged.hermesPath = env['JINN_HERMES_PATH'];
   if (env['JINN_HERMES_MODEL'])      merged.hermesModel = env['JINN_HERMES_MODEL'];
   if (env['JINN_HERMES_PROVIDER'])   merged.hermesProvider = env['JINN_HERMES_PROVIDER'];
+  if (env['JINN_HERMES_BASE_URL'])   merged.hermesBaseUrl = env['JINN_HERMES_BASE_URL'];
   if (env['JINN_HERMES_DOCTOR_TIMEOUT_MS']) {
     merged.hermesDoctorTimeoutMs = parseInt(env['JINN_HERMES_DOCTOR_TIMEOUT_MS'], 10);
   }
@@ -1286,6 +1305,7 @@ const TRACKED_ENV_VARS = [
   'JINN_HERMES_PATH',
   'JINN_HERMES_MODEL',
   'JINN_HERMES_PROVIDER',
+  'JINN_HERMES_BASE_URL',
   'JINN_HERMES_DOCTOR_TIMEOUT_MS',
   'JINN_RUNTIME_MODE',
   'JINN_PEERS',

--- a/client/src/harnesses/impls/hermes-agent/adapter.ts
+++ b/client/src/harnesses/impls/hermes-agent/adapter.ts
@@ -67,6 +67,7 @@ export interface HermesHarnessAdapterConfig {
   hermesPath?: string;
   hermesModel?: string;
   hermesProvider?: string;
+  hermesBaseUrl?: string;
   daemonApiUrl: string;
   daemonApiToken: string;
   corpusEnv: ConfigBuilderEnv['corpusEnv'];
@@ -105,6 +106,7 @@ export class HermesHarnessAdapter {
   private readonly hermesPath: string;
   private readonly hermesModel: string | undefined;
   private readonly hermesProvider: string | undefined;
+  private readonly hermesBaseUrl: string | undefined;
   private readonly daemonApiUrl: string;
   private readonly daemonApiToken: string;
   private readonly corpusEnv: ConfigBuilderEnv['corpusEnv'];
@@ -116,6 +118,7 @@ export class HermesHarnessAdapter {
     this.hermesPath = config.hermesPath ?? 'hermes';
     this.hermesModel = config.hermesModel;
     this.hermesProvider = config.hermesProvider;
+    this.hermesBaseUrl = config.hermesBaseUrl;
     this.daemonApiUrl = config.daemonApiUrl;
     this.daemonApiToken = config.daemonApiToken;
     this.corpusEnv = config.corpusEnv;
@@ -128,10 +131,10 @@ export class HermesHarnessAdapter {
   async runTask(inputs: TaskSessionInputs): Promise<void> {
     const hermesHome = inputs.implStateDir;
     const model = inputs.model ?? inputs.claudeModel ?? this.hermesModel;
-    // Provider resolution: explicit `hermesProvider` wins. If unset, fall back
-    // to inference from the model id format. See `inferProviderFromModelId`
-    // above + gh #293 / #295.
-    const provider = this.hermesProvider ?? inferProviderFromModelId(model);
+    // Provider resolution: local OpenAI-compatible endpoints must use Hermes'
+    // custom provider. Otherwise, explicit `hermesProvider` wins, then model-id
+    // inference. See `inferProviderFromModelId` above + gh #293 / #295.
+    const provider = this.hermesBaseUrl ? 'custom' : (this.hermesProvider ?? inferProviderFromModelId(model));
 
     // Step 1: bootstrap — seed auth from the operator's home, write config.yaml + .env.
     //
@@ -149,6 +152,7 @@ export class HermesHarnessAdapter {
       workingDir: inputs.workingDir,
       model,
       provider,
+      baseUrl: this.hermesBaseUrl,
       solverPluginRoots: inputs.pluginRoots ?? [],
       env: {
         storePath: this.storePath,

--- a/client/src/harnesses/impls/hermes-agent/adapter.ts
+++ b/client/src/harnesses/impls/hermes-agent/adapter.ts
@@ -130,7 +130,7 @@ export class HermesHarnessAdapter {
 
   async runTask(inputs: TaskSessionInputs): Promise<void> {
     const hermesHome = inputs.implStateDir;
-    const model = inputs.model ?? inputs.claudeModel ?? this.hermesModel;
+    const model = this.hermesBaseUrl ? this.hermesModel : (inputs.model ?? inputs.claudeModel ?? this.hermesModel);
     // Provider resolution: local OpenAI-compatible endpoints must use Hermes'
     // custom provider. Otherwise, explicit `hermesProvider` wins, then model-id
     // inference. See `inferProviderFromModelId` above + gh #293 / #295.

--- a/client/src/harnesses/impls/hermes-agent/bootstrap.ts
+++ b/client/src/harnesses/impls/hermes-agent/bootstrap.ts
@@ -183,6 +183,7 @@ function mergePerTaskConfig(
     if (opts.provider) jinnModel.provider = opts.provider;
     if (opts.baseUrl) jinnModel.base_url = opts.baseUrl;
     const merged: Record<string, unknown> = { ...opModel, ...jinnModel };
+    if (opts.baseUrl && !opts.model) delete merged.default;
     const opMaxTokens = typeof opModel.max_tokens === 'number' ? opModel.max_tokens : undefined;
     merged.max_tokens = opMaxTokens != null
       ? Math.min(opMaxTokens, JINN_HERMES_MAX_TOKENS_CAP)

--- a/client/src/harnesses/impls/hermes-agent/bootstrap.ts
+++ b/client/src/harnesses/impls/hermes-agent/bootstrap.ts
@@ -81,6 +81,7 @@ export interface WritePerTaskConfigInputs {
   workingDir: string;
   model?: string;
   provider?: string;
+  baseUrl?: string;
   solverPluginRoots: readonly string[];
   env: ConfigBuilderEnv;
   /**
@@ -165,7 +166,7 @@ function readOperatorConfigYaml(seedFrom: string): Record<string, unknown> {
 function mergePerTaskConfig(
   operator: Record<string, unknown>,
   jinn: HermesConfigSnippet,
-  opts: { model?: string; provider?: string; workingDir: string },
+  opts: { model?: string; provider?: string; baseUrl?: string; workingDir: string },
 ): Record<string, unknown> {
   const out: Record<string, unknown> = { ...operator };
 
@@ -175,11 +176,12 @@ function mergePerTaskConfig(
   // JINN_HERMES_MAX_TOKENS_CAP (operators may pin lower, never higher).
   // See the JINN_HERMES_MAX_TOKENS_CAP docstring for the OpenRouter
   // pre-billing rationale (production bug, 2026-05-23).
-  if (opts.model || opts.provider || isObj(out.model)) {
+  if (opts.model || opts.provider || opts.baseUrl || isObj(out.model)) {
     const opModel = isObj(out.model) ? out.model : {};
     const jinnModel: Record<string, unknown> = {};
     if (opts.model) jinnModel.default = opts.model;
     if (opts.provider) jinnModel.provider = opts.provider;
+    if (opts.baseUrl) jinnModel.base_url = opts.baseUrl;
     const merged: Record<string, unknown> = { ...opModel, ...jinnModel };
     const opMaxTokens = typeof opModel.max_tokens === 'number' ? opModel.max_tokens : undefined;
     merged.max_tokens = opMaxTokens != null
@@ -265,6 +267,7 @@ export function writePerTaskHermesConfig(inputs: WritePerTaskConfigInputs): void
   const merged = mergePerTaskConfig(operator, snippet, {
     model: inputs.model,
     provider: inputs.provider,
+    baseUrl: inputs.baseUrl,
     workingDir: inputs.workingDir,
   });
   writeFileSync(

--- a/client/src/harnesses/impls/hermes-agent/harness.ts
+++ b/client/src/harnesses/impls/hermes-agent/harness.ts
@@ -12,6 +12,9 @@ import {
   DEFAULT_OPENROUTER_CREDIT_FLOOR_USD,
   type OpenRouterCreditConfig,
 } from '../../../api/hermes-doctor-endpoint.js';
+import { isLocalHttpBaseUrl, urlAtBasePath } from '../../../local-provider-url.js';
+
+const DEFAULT_HERMES_PROVIDER_PROBE_TIMEOUT_MS = 2_000;
 
 export interface HermesHarnessConfig {
   adapter: HermesHarnessAdapter;
@@ -20,6 +23,12 @@ export interface HermesHarnessConfig {
   hermesPath?: string;
   /** Timeout for the `hermes doctor` probe. Defaults to 30s. */
   hermesDoctorTimeoutMs?: number;
+  /** Local OpenAI-compatible Hermes base URL. */
+  hermesBaseUrl?: string;
+  /** Timeout (ms) for probing the local OpenAI-compatible provider. */
+  hermesProviderProbeTimeoutMs?: number;
+  /** Test hook for the local provider readiness probe. */
+  hermesProviderFetch?: typeof fetch;
   /**
    * Per-task OpenRouter credit floor in USD. Below this, `isReady()` reports
    * not-ready with a top-up nextStep. Defaults to
@@ -54,6 +63,9 @@ export class HermesHarness implements Harness {
   private readonly adapter: HermesHarnessAdapter;
   private readonly hermesPath: string | undefined;
   private readonly hermesDoctorTimeoutMs: number | undefined;
+  private readonly hermesBaseUrl: string | undefined;
+  private readonly hermesProviderProbeTimeoutMs: number;
+  private readonly hermesProviderFetch: typeof fetch;
   private readonly openrouterCreditFloorUsd: number;
   private readonly creditProbe: (config: OpenRouterCreditConfig) => Promise<Awaited<ReturnType<typeof probeOpenRouterCredit>>>;
 
@@ -62,6 +74,10 @@ export class HermesHarness implements Harness {
     this.version = config.version ?? '0.1.0';
     this.hermesPath = config.hermesPath;
     this.hermesDoctorTimeoutMs = config.hermesDoctorTimeoutMs;
+    this.hermesBaseUrl = config.hermesBaseUrl;
+    this.hermesProviderProbeTimeoutMs =
+      config.hermesProviderProbeTimeoutMs ?? DEFAULT_HERMES_PROVIDER_PROBE_TIMEOUT_MS;
+    this.hermesProviderFetch = config.hermesProviderFetch ?? fetch;
     this.openrouterCreditFloorUsd = config.openrouterCreditFloorUsd ?? DEFAULT_OPENROUTER_CREDIT_FLOOR_USD;
     this.creditProbe = config.creditProbe ?? probeOpenRouterCredit;
   }
@@ -73,6 +89,9 @@ export class HermesHarness implements Harness {
    *   - `installed: false` → binary not on PATH → ready=false with install
    *     nextStep so the operator sees an actionable message instead of
    *     N/N failed claims (#330).
+   *   - `JINN_HERMES_BASE_URL` set → binary exists and the configured local
+   *     OpenAI-compatible provider answers `/models` → ready=true. This mode
+   *     deliberately bypasses the OpenRouter-specific auth/credit gates.
    *   - `exitCode !== 0` → binary exists but `hermes doctor` reports a
    *     configuration problem (e.g. provider not signed in) → ready=false
    *     with a nextStep that points at the SPA precheck panel.
@@ -82,9 +101,10 @@ export class HermesHarness implements Harness {
    *     openrouter` directly. `auth list` reads the credential pool, so it
    *     recognises API-key credentials (the normal `OPENROUTER_API_KEY`
    *     setup) as well as OAuth — unlike `auth status`, which only reflects
-   *     interactive-OAuth-login state. Hermes is OpenRouter-only, so an
-   *     OpenRouter with no usable credential means Hermes has no model
-   *     provider and every claim would burn (#332/#330/#348).
+   *     interactive-OAuth-login state. In the default Jinn/Hermes path,
+   *     Hermes uses OpenRouter, so an OpenRouter with no usable credential
+   *     means Hermes has no model provider and every claim would burn
+   *     (#332/#330/#348).
    *   - OpenRouter credential is present but credit is exhausted → ready=false.
    *     Production bug, 2026-05-23: `auth list openrouter` reported the
    *     api_key credential as healthy, but every solve attempt for the day
@@ -113,6 +133,19 @@ export class HermesHarness implements Harness {
         },
       };
     }
+    if (this.hermesBaseUrl) {
+      if (!isLocalHttpBaseUrl(this.hermesBaseUrl)) {
+        return {
+          ready: false,
+          reason: 'hermes base URL must be local',
+          nextStep: {
+            description:
+              'Use a local Hermes provider URL such as http://127.0.0.1:11434/v1 or unset JINN_HERMES_BASE_URL.',
+          },
+        };
+      }
+      return this.probeLocalHermesProvider(this.hermesBaseUrl);
+    }
     if (result.exitCode !== 0) {
       const stderr = result.stderr.trim();
       const stdout = result.stdout.trim();
@@ -127,8 +160,9 @@ export class HermesHarness implements Harness {
       };
     }
     // Third gate: `hermes doctor` exits 0 even when every model provider is
-    // logged out. Hermes is OpenRouter-only, so probe OpenRouter auth
-    // directly — a logged-out OpenRouter means Hermes cannot run a task.
+    // logged out. The default Jinn/Hermes path relies on OpenRouter, so probe
+    // OpenRouter auth directly — a logged-out OpenRouter means Hermes cannot
+    // run a task.
     const auth = await probeHermesAuthStatus('openrouter', config);
     if (!auth.authed) {
       return {
@@ -162,6 +196,43 @@ export class HermesHarness implements Harness {
       };
     }
     return { ready: true };
+  }
+
+  private async probeLocalHermesProvider(baseUrl: string): Promise<ReadyStatus> {
+    const modelsUrl = urlAtBasePath(baseUrl, 'models');
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.hermesProviderProbeTimeoutMs);
+    try {
+      const response = await this.hermesProviderFetch(modelsUrl, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer jinn-local' },
+        signal: controller.signal,
+      });
+      if (response.ok) return { ready: true };
+      return {
+        ready: false,
+        reason: `local Hermes provider /models returned HTTP ${response.status}`,
+        nextStep: {
+          description:
+            'Start the local OpenAI-compatible provider and verify its /v1/models endpoint responds.',
+        },
+      };
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      const reason = err instanceof Error && err.name === 'AbortError'
+        ? 'local Hermes provider /models probe timed out'
+        : `local Hermes provider unavailable${detail ? `: ${detail}` : ''}`;
+      return {
+        ready: false,
+        reason,
+        nextStep: {
+          description:
+            'Start the local OpenAI-compatible provider and verify its /v1/models endpoint responds.',
+        },
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
   }
 
   supports(spec: { solverType: string; role?: 'restoration' | 'evaluation' }): boolean {

--- a/client/src/harnesses/impls/index.ts
+++ b/client/src/harnesses/impls/index.ts
@@ -110,6 +110,8 @@ export interface HarnessEnv {
   hermesModel?: string;
   /** Hermes provider (e.g. 'anthropic'). */
   hermesProvider?: string;
+  /** Local OpenAI-compatible Hermes base URL. */
+  hermesBaseUrl?: string;
   /** Timeout (ms) for the `hermes doctor` probe in HermesHarness.isReady. */
   hermesDoctorTimeoutMs?: number;
 }
@@ -272,6 +274,7 @@ export function buildHarnesses(env: HarnessEnv): Harness[] {
     hermesPath: env.hermesPath,
     hermesModel: env.hermesModel,
     hermesProvider: env.hermesProvider,
+    hermesBaseUrl: env.hermesBaseUrl,
     daemonApiUrl: env.daemonApiUrl ?? 'http://127.0.0.1:7331',
     daemonApiToken: env.daemonApiToken ?? '',
     storePath: env.storePath,
@@ -280,6 +283,7 @@ export function buildHarnesses(env: HarnessEnv): Harness[] {
   out.push(new HermesHarness({
     adapter: hermesAdapter,
     ...(env.hermesPath !== undefined ? { hermesPath: env.hermesPath } : {}),
+    ...(env.hermesBaseUrl !== undefined ? { hermesBaseUrl: env.hermesBaseUrl } : {}),
     ...(env.hermesDoctorTimeoutMs !== undefined ? { hermesDoctorTimeoutMs: env.hermesDoctorTimeoutMs } : {}),
   }));
 

--- a/client/src/local-provider-url.ts
+++ b/client/src/local-provider-url.ts
@@ -1,0 +1,27 @@
+import { isIP } from 'node:net';
+
+export function canonicalLocalHttpBaseUrl(value: string): string | undefined {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return undefined;
+    if (url.username || url.password) return undefined;
+    if (url.search || url.hash) return undefined;
+    const hostname = url.hostname.toLowerCase();
+    const isLocal =
+      hostname === 'localhost' ||
+      hostname === '[::1]' ||
+      hostname === '::1' ||
+      (isIP(hostname) === 4 && hostname.startsWith('127.'));
+    return isLocal ? url.toString() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function isLocalHttpBaseUrl(value: string): boolean {
+  return canonicalLocalHttpBaseUrl(value) !== undefined;
+}
+
+export function urlAtBasePath(baseUrl: string, path: string): string {
+  return new URL(path, baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`).toString();
+}

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -2000,6 +2000,7 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     hermesPath: config.hermesPath,
     hermesModel: config.hermesModel,
     hermesProvider: config.hermesProvider,
+    hermesBaseUrl: config.hermesBaseUrl,
     hermesDoctorTimeoutMs: config.hermesDoctorTimeoutMs,
     codexPath: config.codexPath,
     codexDoctorTimeoutMs: config.codexDoctorTimeoutMs,

--- a/client/test/config.test.ts
+++ b/client/test/config.test.ts
@@ -1206,6 +1206,7 @@ describe('hermes config keys', () => {
     'JINN_HERMES_PATH',
     'JINN_HERMES_MODEL',
     'JINN_HERMES_PROVIDER',
+    'JINN_HERMES_BASE_URL',
     'JINN_HERMES_DOCTOR_TIMEOUT_MS',
   ] as const;
   const saved: Record<string, string | undefined> = {};
@@ -1233,18 +1234,60 @@ describe('hermes config keys', () => {
       hermesPath: '/usr/local/bin/hermes',
       hermesModel: 'anthropic/claude-opus-4.6',
       hermesProvider: 'anthropic',
+      hermesBaseUrl: 'http://127.0.0.1:11434/v1',
     });
     const cfg = loadConfig(configPath);
     expect(cfg.hermesPath).toBe('/usr/local/bin/hermes');
     expect(cfg.hermesModel).toBe('anthropic/claude-opus-4.6');
     expect(cfg.hermesProvider).toBe('anthropic');
+    expect(cfg.hermesBaseUrl).toBe('http://127.0.0.1:11434/v1');
   });
 
   it('env vars override hermes config values', async () => {
     const configPath = await writeConfigFile({ network: 'testnet' });
     process.env['JINN_HERMES_PATH'] = '/opt/hermes/bin/hermes';
+    process.env['JINN_HERMES_BASE_URL'] = 'http://localhost:11434/v1';
     const cfg = loadConfig(configPath);
     expect(cfg.hermesPath).toBe('/opt/hermes/bin/hermes');
+    expect(cfg.hermesBaseUrl).toBe('http://localhost:11434/v1');
+  });
+
+  it.each([
+    ['http://2130706433:11434/v1', 'http://127.0.0.1:11434/v1'],
+    ['http://127.0.0.1:11434\\@api.openai.com/v1', 'http://127.0.0.1:11434/@api.openai.com/v1'],
+  ])('canonicalizes Hermes local provider base URL before use: %s', async (input, expected) => {
+    const configPath = await writeConfigFile({
+      network: 'testnet',
+      hermesBaseUrl: input,
+    });
+
+    const cfg = loadConfig(configPath);
+
+    expect(cfg.hermesBaseUrl).toBe(expected);
+  });
+
+  it.each([
+    'https://api.openai.com/v1',
+    'http://user:pass@127.0.0.1:11434/v1',
+    'http://127.0.0.1:11434/v1?api_key=secret',
+    'http://127.0.0.1:11434/v1#secret',
+  ])('rejects unsafe Hermes local provider base URLs: %s', async (hermesBaseUrl) => {
+    const configPath = await writeConfigFile({
+      network: 'testnet',
+      hermesBaseUrl,
+    });
+
+    let caught: any;
+    try {
+      loadConfig(configPath);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught?.code).toBe('config_invalid');
+    const issues: Array<{ path: string; message: string }> = caught.details?.issues ?? [];
+    expect(issues.some((issue) =>
+      issue.path === 'hermesBaseUrl' && /must be a local/i.test(issue.message)
+    )).toBe(true);
   });
 });
 

--- a/client/test/harnesses/impls/hermes-agent/adapter.test.ts
+++ b/client/test/harnesses/impls/hermes-agent/adapter.test.ts
@@ -1,6 +1,6 @@
 // client/test/harnesses/impls/hermes-agent/adapter.test.ts
 import { EventEmitter } from 'node:events';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -158,6 +158,7 @@ describe('HermesHarnessAdapter', () => {
       const adapter = new HermesHarnessAdapter({
         hermesPath: '/bin/fake-hermes',
         operatorHermesHome: home,
+        hermesModel: 'qwen2.5-coder:7b',
         hermesProvider: 'openrouter',
         hermesBaseUrl: 'http://127.0.0.1:11434/v1',
         daemonApiUrl: 'http://127.0.0.1:7331',
@@ -169,9 +170,7 @@ describe('HermesHarnessAdapter', () => {
         }) as any,
       });
 
-      const taskInputs = inputs(work, home);
-      taskInputs.model = 'qwen2.5-coder:7b';
-      await adapter.runTask(taskInputs);
+      await adapter.runTask(inputs(work, home));
 
       expect(spawnCalls).toHaveLength(1);
       const call = spawnCalls[0];
@@ -184,6 +183,132 @@ describe('HermesHarnessAdapter', () => {
       expect(cfg.model.default).toBe('qwen2.5-coder:7b');
       expect(cfg.model.provider).toBe('custom');
       expect(cfg.model.base_url).toBe('http://127.0.0.1:11434/v1');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(work, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers configured local model over SolverNet catalog model when local provider URL is configured', async () => {
+    const spawnCalls: SpawnCall[] = [];
+    const home = mkdtempSync(join(tmpdir(), 'hermes-home-'));
+    const work = mkdtempSync(join(tmpdir(), 'hermes-wd-'));
+
+    try {
+      const adapter = new HermesHarnessAdapter({
+        hermesPath: '/bin/fake-hermes',
+        operatorHermesHome: home,
+        hermesModel: 'qwen2.5-coder:7b',
+        hermesBaseUrl: 'http://127.0.0.1:11434/v1',
+        daemonApiUrl: 'http://127.0.0.1:7331',
+        daemonApiToken: 'tok',
+        corpusEnv: {},
+        _spawnFn: vi.fn((command: string, args: string[], options: any) => {
+          spawnCalls.push({ command, args, options });
+          return fakeHermesChild() as any;
+        }) as any,
+      });
+
+      const taskInputs = inputs(work, home);
+      taskInputs.model = 'anthropic/claude-opus-4.7';
+      await adapter.runTask(taskInputs);
+
+      expect(spawnCalls).toHaveLength(1);
+      const call = spawnCalls[0];
+      expect(call.args).toContain('--model');
+      expect(call.args).toContain('qwen2.5-coder:7b');
+      expect(call.args).not.toContain('anthropic/claude-opus-4.7');
+      expect(call.args).toContain('--provider');
+      expect(call.args).toContain('custom');
+
+      const cfg = yamlParse(readFileSync(join(home, 'config.yaml'), 'utf8')) as any;
+      expect(cfg.model.default).toBe('qwen2.5-coder:7b');
+      expect(cfg.model.provider).toBe('custom');
+      expect(cfg.model.base_url).toBe('http://127.0.0.1:11434/v1');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(work, { recursive: true, force: true });
+    }
+  });
+
+  it('does not pass SolverNet catalog model to local provider without a local model override', async () => {
+    const spawnCalls: SpawnCall[] = [];
+    const operatorHome = mkdtempSync(join(tmpdir(), 'hermes-operator-home-'));
+    const taskHome = mkdtempSync(join(tmpdir(), 'hermes-task-home-'));
+    const work = mkdtempSync(join(tmpdir(), 'hermes-wd-'));
+
+    try {
+      writeFileSync(
+        join(operatorHome, 'config.yaml'),
+        'model:\n  default: anthropic/claude-opus-4.7\n  provider: openrouter\n',
+        'utf8',
+      );
+
+      const adapter = new HermesHarnessAdapter({
+        hermesPath: '/bin/fake-hermes',
+        operatorHermesHome: operatorHome,
+        hermesBaseUrl: 'http://127.0.0.1:11434/v1',
+        daemonApiUrl: 'http://127.0.0.1:7331',
+        daemonApiToken: 'tok',
+        corpusEnv: {},
+        _spawnFn: vi.fn((command: string, args: string[], options: any) => {
+          spawnCalls.push({ command, args, options });
+          return fakeHermesChild() as any;
+        }) as any,
+      });
+
+      const taskInputs = inputs(work, taskHome);
+      taskInputs.model = 'anthropic/claude-opus-4.7';
+      await adapter.runTask(taskInputs);
+
+      expect(spawnCalls).toHaveLength(1);
+      const call = spawnCalls[0];
+      expect(call.args).not.toContain('--model');
+      expect(call.args).not.toContain('anthropic/claude-opus-4.7');
+      expect(call.args).toContain('--provider');
+      expect(call.args).toContain('custom');
+
+      const cfg = yamlParse(readFileSync(join(taskHome, 'config.yaml'), 'utf8')) as any;
+      expect(cfg.model.default).toBeUndefined();
+      expect(cfg.model.provider).toBe('custom');
+      expect(cfg.model.base_url).toBe('http://127.0.0.1:11434/v1');
+    } finally {
+      rmSync(operatorHome, { recursive: true, force: true });
+      rmSync(taskHome, { recursive: true, force: true });
+      rmSync(work, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps SolverNet catalog model precedence when no local provider URL is configured', async () => {
+    const spawnCalls: SpawnCall[] = [];
+    const home = mkdtempSync(join(tmpdir(), 'hermes-home-'));
+    const work = mkdtempSync(join(tmpdir(), 'hermes-wd-'));
+
+    try {
+      const adapter = new HermesHarnessAdapter({
+        hermesPath: '/bin/fake-hermes',
+        operatorHermesHome: home,
+        hermesModel: 'qwen2.5-coder:7b',
+        daemonApiUrl: 'http://127.0.0.1:7331',
+        daemonApiToken: 'tok',
+        corpusEnv: {},
+        _spawnFn: vi.fn((command: string, args: string[], options: any) => {
+          spawnCalls.push({ command, args, options });
+          return fakeHermesChild() as any;
+        }) as any,
+      });
+
+      const taskInputs = inputs(work, home);
+      taskInputs.model = 'anthropic/claude-opus-4.7';
+      await adapter.runTask(taskInputs);
+
+      expect(spawnCalls).toHaveLength(1);
+      const call = spawnCalls[0];
+      expect(call.args).toContain('--model');
+      expect(call.args).toContain('anthropic/claude-opus-4.7');
+      expect(call.args).not.toContain('qwen2.5-coder:7b');
+      expect(call.args).toContain('--provider');
+      expect(call.args).toContain('openrouter');
     } finally {
       rmSync(home, { recursive: true, force: true });
       rmSync(work, { recursive: true, force: true });

--- a/client/test/harnesses/impls/hermes-agent/adapter.test.ts
+++ b/client/test/harnesses/impls/hermes-agent/adapter.test.ts
@@ -1,10 +1,11 @@
 // client/test/harnesses/impls/hermes-agent/adapter.test.ts
 import { EventEmitter } from 'node:events';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it, vi } from 'vitest';
+import { parse as yamlParse } from 'yaml';
 import { HermesHarnessAdapter } from '../../../../src/harnesses/impls/hermes-agent/adapter.js';
 import type { TaskSessionInputs } from '../../../../src/harnesses/impls/learner/types.js';
 
@@ -142,6 +143,47 @@ describe('HermesHarnessAdapter', () => {
       const call = spawnCalls[0];
       expect(call.args).toContain('--provider');
       expect(call.args).toContain('openrouter');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(work, { recursive: true, force: true });
+    }
+  });
+
+  it('uses Hermes custom provider and writes base_url when a local provider URL is configured', async () => {
+    const spawnCalls: SpawnCall[] = [];
+    const home = mkdtempSync(join(tmpdir(), 'hermes-home-'));
+    const work = mkdtempSync(join(tmpdir(), 'hermes-wd-'));
+
+    try {
+      const adapter = new HermesHarnessAdapter({
+        hermesPath: '/bin/fake-hermes',
+        operatorHermesHome: home,
+        hermesProvider: 'openrouter',
+        hermesBaseUrl: 'http://127.0.0.1:11434/v1',
+        daemonApiUrl: 'http://127.0.0.1:7331',
+        daemonApiToken: 'tok',
+        corpusEnv: {},
+        _spawnFn: vi.fn((command: string, args: string[], options: any) => {
+          spawnCalls.push({ command, args, options });
+          return fakeHermesChild() as any;
+        }) as any,
+      });
+
+      const taskInputs = inputs(work, home);
+      taskInputs.model = 'qwen2.5-coder:7b';
+      await adapter.runTask(taskInputs);
+
+      expect(spawnCalls).toHaveLength(1);
+      const call = spawnCalls[0];
+      expect(call.args).toContain('--model');
+      expect(call.args).toContain('qwen2.5-coder:7b');
+      expect(call.args).toContain('--provider');
+      expect(call.args).toContain('custom');
+
+      const cfg = yamlParse(readFileSync(join(home, 'config.yaml'), 'utf8')) as any;
+      expect(cfg.model.default).toBe('qwen2.5-coder:7b');
+      expect(cfg.model.provider).toBe('custom');
+      expect(cfg.model.base_url).toBe('http://127.0.0.1:11434/v1');
     } finally {
       rmSync(home, { recursive: true, force: true });
       rmSync(work, { recursive: true, force: true });

--- a/client/test/harnesses/impls/hermes-agent/bootstrap.test.ts
+++ b/client/test/harnesses/impls/hermes-agent/bootstrap.test.ts
@@ -64,6 +64,32 @@ describe('writePerTaskHermesConfig', () => {
     }
   });
 
+  it('writes a local OpenAI-compatible base_url when supplied by Jinn', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hermes-home-'));
+    try {
+      writePerTaskHermesConfig({
+        hermesHome: home,
+        workingDir: '/work',
+        model: 'qwen2.5-coder:7b',
+        provider: 'custom',
+        baseUrl: 'http://127.0.0.1:11434/v1',
+        solverPluginRoots: [],
+        env: {
+          daemonApiUrl: 'http://127.0.0.1:7331',
+          daemonApiToken: 'tok',
+          corpusEnv: {},
+        },
+      });
+
+      const cfg = readConfig(home);
+      expect(cfg.model.default).toBe('qwen2.5-coder:7b');
+      expect(cfg.model.provider).toBe('custom');
+      expect(cfg.model.base_url).toBe('http://127.0.0.1:11434/v1');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   it('writes .env with daemon credentials', () => {
     const home = mkdtempSync(join(tmpdir(), 'hermes-home-'));
     try {

--- a/client/test/harnesses/impls/hermes-agent/is-ready.test.ts
+++ b/client/test/harnesses/impls/hermes-agent/is-ready.test.ts
@@ -136,6 +136,79 @@ describe('HermesHarness.isReady', () => {
     expect(result.nextStep?.description).toMatch(/install/i);
   });
 
+  it('uses a local OpenAI-compatible provider instead of OpenRouter gates when hermesBaseUrl is configured', async () => {
+    vi.mocked(probeHermesDoctor).mockReturnValue({
+      installed: true,
+      exitCode: 1,
+      stdout: '',
+      stderr: 'no OpenRouter provider configured',
+    });
+    const providerFetch = vi.fn(async () => new Response(JSON.stringify({ data: [] }), { status: 200 }));
+    const h = new HermesHarness({
+      adapter: fakeAdapter as any,
+      hermesBaseUrl: 'http://127.0.0.1:11434/v1',
+      hermesProviderFetch: providerFetch as typeof fetch,
+    });
+
+    const result = await h.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+
+    expect(result.ready).toBe(true);
+    expect(providerFetch).toHaveBeenCalledWith(
+      'http://127.0.0.1:11434/v1/models',
+      expect.objectContaining({
+        method: 'GET',
+        headers: { Authorization: 'Bearer jinn-local' },
+      }),
+    );
+    expect(probeHermesAuthStatus).not.toHaveBeenCalled();
+    expect(probeOpenRouterCredit).not.toHaveBeenCalled();
+  });
+
+  it('reports not-ready when the configured local provider does not answer /models', async () => {
+    vi.mocked(probeHermesDoctor).mockReturnValue({
+      installed: true,
+      exitCode: 0,
+      stdout: 'ok',
+      stderr: '',
+    });
+    const providerFetch = vi.fn(async () => new Response('missing', { status: 404 }));
+    const h = new HermesHarness({
+      adapter: fakeAdapter as any,
+      hermesBaseUrl: 'http://127.0.0.1:11434/v1',
+      hermesProviderFetch: providerFetch as typeof fetch,
+    });
+
+    const result = await h.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+
+    expect(result.ready).toBe(false);
+    expect(result.reason).toMatch(/\/models returned HTTP 404/i);
+    expect(probeHermesAuthStatus).not.toHaveBeenCalled();
+    expect(probeOpenRouterCredit).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-local hermesBaseUrl before probing provider auth', async () => {
+    vi.mocked(probeHermesDoctor).mockReturnValue({
+      installed: true,
+      exitCode: 0,
+      stdout: 'ok',
+      stderr: '',
+    });
+    const providerFetch = vi.fn();
+    const h = new HermesHarness({
+      adapter: fakeAdapter as any,
+      hermesBaseUrl: 'https://api.openai.com/v1',
+      hermesProviderFetch: providerFetch as typeof fetch,
+    });
+
+    const result = await h.isReady!({ solverType: 'swe-rebench-v2.v1', role: 'restoration' });
+
+    expect(result.ready).toBe(false);
+    expect(result.reason).toMatch(/base URL must be local/i);
+    expect(providerFetch).not.toHaveBeenCalled();
+    expect(probeHermesAuthStatus).not.toHaveBeenCalled();
+    expect(probeOpenRouterCredit).not.toHaveBeenCalled();
+  });
+
   it('returns ready=false with config nextStep when hermes doctor exit != 0', async () => {
     vi.mocked(probeHermesDoctor).mockResolvedValue({
       installed: true,


### PR DESCRIPTION
## Summary
- Add Hermes local provider URL config so operators can route Hermes to local OpenAI-compatible endpoints such as Ollama.
- Force local provider runs through Hermes `custom` provider and prevent SolverNet/catalog remote model IDs from being passed to local endpoints.
- Add regression coverage for local model override, local no-model inheritance, remote catalog precedence, URL validation, readiness, and config plumbing.

## Test Plan
- `yarn vitest run test/config.test.ts test/harnesses/impls/hermes-agent/bootstrap.test.ts test/harnesses/impls/hermes-agent/adapter.test.ts test/harnesses/impls/hermes-agent/is-ready.test.ts test/harnesses/impls/build-harnesses.test.ts`

## Notes
- This is a fresh PR after #423 was merged and reverted by #607 for process/code-owner review gating, not because the local-provider approach was reported faulty.
