### PR TITLE
feat(spa): copy identity addresses

### DIFF
--- a/client/src/dashboard/spa/src/pages/overview/IdentityCard.test.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/IdentityCard.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Router } from 'wouter';
 import { memoryLocation } from 'wouter/memory-location';
@@ -31,6 +31,23 @@ function wrap(ui: JSX.Element): JSX.Element {
 }
 
 describe('IdentityCard', () => {
+  const originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+  const originalExecCommand = Object.getOwnPropertyDescriptor(document, 'execCommand');
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalClipboard) {
+      Object.defineProperty(navigator, 'clipboard', originalClipboard);
+    } else {
+      Object.defineProperty(navigator, 'clipboard', { configurable: true, value: undefined });
+    }
+    if (originalExecCommand) {
+      Object.defineProperty(document, 'execCommand', originalExecCommand);
+    } else {
+      Reflect.deleteProperty(document, 'execCommand');
+    }
+  });
+
   it('exposes data-testid="identity-card" on the root region', () => {
     render(wrap(<IdentityCard {...defaultProps()} />));
     expect(screen.getByTestId('identity-card')).toBeTruthy();
@@ -67,6 +84,102 @@ describe('IdentityCard', () => {
     const card = screen.getByTestId('identity-card');
     // Four '—' placeholders, one per missing stat.
     expect(card.querySelectorAll('[data-testid="identity-stat-empty"]').length).toBe(4);
+    expect(screen.queryByTestId('identity-master-address')).toBeNull();
+    expect(screen.queryByTestId('identity-safe-address')).toBeNull();
+    expect(screen.queryByRole('button', { name: /copy full master address/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /copy full safe address/i })).toBeNull();
+  });
+
+  it('copies the full Master address when clicked', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(wrap(<IdentityCard {...defaultProps()} />));
+    fireEvent.click(screen.getByRole('button', { name: /copy full master address/i }));
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(defaultProps().masterAddress),
+    );
+  });
+
+  it('copies the full Safe address when clicked', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(wrap(<IdentityCard {...defaultProps()} />));
+    fireEvent.click(screen.getByRole('button', { name: /copy full safe address/i }));
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(defaultProps().safeAddress),
+    );
+  });
+
+  it('falls back to execCommand copy when Clipboard API is unavailable', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: undefined,
+    });
+    const execCommand = vi.fn(() => {
+      expect((document.activeElement as HTMLTextAreaElement).value).toBe(defaultProps().masterAddress);
+      return true;
+    });
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: execCommand,
+    });
+
+    render(wrap(<IdentityCard {...defaultProps()} />));
+    fireEvent.click(screen.getByRole('button', { name: /copy full master address/i }));
+
+    await waitFor(() => expect(execCommand).toHaveBeenCalledWith('copy'));
+  });
+
+  it('falls back to execCommand copy when Clipboard API rejects', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('clipboard denied'));
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    const execCommand = vi.fn(() => {
+      expect((document.activeElement as HTMLTextAreaElement).value).toBe(defaultProps().safeAddress);
+      return true;
+    });
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: execCommand,
+    });
+
+    render(wrap(<IdentityCard {...defaultProps()} />));
+    fireEvent.click(screen.getByRole('button', { name: /copy full safe address/i }));
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(defaultProps().safeAddress),
+    );
+    await waitFor(() => expect(execCommand).toHaveBeenCalledWith('copy'));
+  });
+
+  it('does not report copied when execCommand fallback fails', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: undefined,
+    });
+    const execCommand = vi.fn().mockReturnValue(false);
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: execCommand,
+    });
+
+    render(wrap(<IdentityCard {...defaultProps()} />));
+    fireEvent.click(screen.getByRole('button', { name: /copy full master address/i }));
+
+    await waitFor(() => expect(execCommand).toHaveBeenCalledWith('copy'));
+    expect(screen.queryByText('Copied')).toBeNull();
   });
 
   it('surfaces a binding-pending chip when a service has agentId but is not bound', () => {

--- a/client/src/dashboard/spa/src/pages/overview/IdentityCard.tsx
+++ b/client/src/dashboard/spa/src/pages/overview/IdentityCard.tsx
@@ -42,6 +42,34 @@ function EmptyDash(): JSX.Element {
   return <span data-testid="identity-stat-empty" className={emptyValue}>—</span>;
 }
 
+async function copyToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {
+      // Fall through to the legacy path below.
+    }
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  textarea.setSelectionRange(0, text.length);
+  try {
+    if (document.execCommand('copy') !== true) {
+      throw new Error('Copy command failed');
+    }
+  } finally {
+    textarea.remove();
+  }
+}
+
 function Stat({ label, children }: { label: string; children: ReactNode }): JSX.Element {
   return (
     <div className="flex flex-col gap-1">
@@ -56,14 +84,25 @@ function AddressStat({ label, address, testId }: {
   address: string | null;
   testId: string;
 }): JSX.Element {
+  const copy = (): void => {
+    if (!address) return;
+    void copyToClipboard(address).catch(() => {});
+  };
+
   return (
     <Stat label={label}>
       {address ? (
         <Tooltip>
           <TooltipTrigger asChild>
-            <span data-testid={testId} tabIndex={0} className={`cursor-help ${statValue}`}>
+            <button
+              type="button"
+              data-testid={testId}
+              aria-label={`Copy full ${label} address`}
+              onClick={copy}
+              className={`cursor-copy border-0 bg-transparent p-0 text-left ${statValue}`}
+            >
               {trunc(address)}
-            </span>
+            </button>
           </TooltipTrigger>
           <TooltipContent>{address}</TooltipContent>
         </Tooltip>


### PR DESCRIPTION
## Summary
- Make the Overview Identity card Master and Safe addresses clickable copy controls while preserving the compact truncated display and full-address tooltip.
- Use `navigator.clipboard.writeText` when available and an `execCommand('copy')` textarea fallback when Clipboard API is unavailable or rejects.
- Keep missing-address placeholders non-clickable and cover success/fallback/failure paths in component tests.

## Test Plan
- `NODE_OPTIONS=--preserve-symlinks corepack yarn vitest run src/dashboard/spa/src/pages/overview/IdentityCard.test.tsx src/dashboard/spa/src/pages/Overview.test.tsx` with Node 22
- `corepack yarn build:spa` with Node 22

## Notes
- Local Node 20.14 hit an existing jsdom ESM/CJS loader issue before collecting SPA tests; Node 22 ran the SPA tests successfully.
