### PR TITLE
feat(harness-layer): distill staged/install — install from staging without re-distilling

### DIFF
--- a/client/packages/harness-layer/src/cli.ts
+++ b/client/packages/harness-layer/src/cli.ts
@@ -71,6 +71,7 @@ import {
   DEFAULT_MODEL as DEFAULT_CLAUDE_DISTILL_MODEL,
 } from './distill-llm.js';
 import { createLocalDistiller, createLocalSkillSink } from './distiller.js';
+import { parseSkillMarkdown, type SkillPackage } from './skill-package.js';
 import {
   DEFAULT_DISTILL_MODE_PATH,
   readDistillMode,
@@ -95,6 +96,7 @@ import {
   renderRecorded,
   renderEmpty,
   renderRunSummary,
+  renderSkillsPanel,
   renderReview,
   renderFailure,
   renderResumeNothing,
@@ -234,6 +236,14 @@ Commands:
                                                  Pure reads — never prompts, spends, or writes.
   distill runs [--limit N] [--json]              Recorded runs, newest-first (one record per run
                                                  outcome: ok / partial / empty).
+  distill staged [--out <dir>] [--json]          Skills waiting in the staging area (<out>-staged):
+                                                 name, what each helps with, provenance. Read-only.
+  distill install [<name> ...] [--all] [--out <dir>] [--json]
+                                                 Install previously STAGED skills into the active
+                                                 dir — no distillation, no consent gate, no LLM
+                                                 calls; these are artifacts an earlier LOCAL run
+                                                 already produced. Installed staged copies are
+                                                 removed (staging holds only what's not installed).
   distill eval-prep [--limit N] [--out <dir>] [--json] [--meta] [--select-only]
                     [--group-cap N] [--concurrency N] [--force] [--retry-errors]
                     [--models gpt-5.4-mini,gpt-5.5]
@@ -431,6 +441,48 @@ function countSkillDirs(dir: string): number {
   return count;
 }
 
+/**
+ * Parse every staged skill under `stagingDir` (#1536). An unparseable
+ * SKILL.md is skipped with a stderr warning — one bad artifact must not
+ * hide the rest of the staging area.
+ */
+function listStaged(stagingDir: string): SkillPackage[] {
+  if (!existsSync(stagingDir)) return [];
+  const pkgs: SkillPackage[] = [];
+  for (const entry of readdirSync(stagingDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const md = join(stagingDir, entry.name, 'SKILL.md');
+    if (!existsSync(md)) continue;
+    try {
+      pkgs.push(parseSkillMarkdown(readFileSync(md, 'utf-8')));
+    } catch (err) {
+      console.warn(`[distill] skipping unparseable staged skill ${entry.name}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  return pkgs;
+}
+
+/**
+ * Install skills into the active dir and remove their staged copies — the
+ * single install path (#1536), shared by the inline run flow and the
+ * `distill install` subverb, so staging always holds exactly what is not
+ * installed. NO LLM calls, NO consent gate: these are artifacts an earlier
+ * consented LOCAL run already produced.
+ */
+async function installStagedSkills(
+  pkgs: SkillPackage[],
+  stagingDir: string,
+  activeDir: string,
+): Promise<Array<{ name: string; path: string }>> {
+  const sink = createLocalSkillSink(activeDir);
+  const installed: Array<{ name: string; path: string }> = [];
+  for (const pkg of pkgs) {
+    await sink(pkg);
+    rmSync(join(stagingDir, pkg.name), { recursive: true, force: true });
+    installed.push({ name: pkg.name, path: join(activeDir, pkg.name, 'SKILL.md') });
+  }
+  return installed;
+}
 function ask(rl: ReturnType<typeof createInterface>, q: string): Promise<string> {
   return new Promise((resolve) => rl.question(q, (a) => resolve(a)));
 }
@@ -958,6 +1010,7 @@ export async function runJinnLayerCli(
         install: { type: 'string' },
         progress: { type: 'string' },
         'cluster-timeout': { type: 'string' },
+        all: { type: 'boolean', default: false },
         models: { type: 'string' },
         'max-clusters': { type: 'string' },
         'max-contrastive': { type: 'string' },
@@ -1118,10 +1171,69 @@ export async function runJinnLayerCli(
     };
     const emptyFacts = { clusterCount: 0, published: [], rejectedCount: 0, errorCount: 0, installed: [] };
 
+    // Subverbs (#1535 status/runs, #1536 staged/install). Routed before the
+    // mode machinery: none of them prompt or spend, and only `install` writes
+    // (moving already-produced artifacts out of staging).
     const sub = parsed.positionals[0];
-    if (sub !== undefined && sub !== 'runs' && sub !== 'status') {
-      writer.write(`error: unknown distill subcommand ${JSON.stringify(sub)} (expected: run, runs, status)\n\n${USAGE}`);
+    if (sub !== undefined && sub !== 'runs' && sub !== 'status' && sub !== 'staged' && sub !== 'install') {
+      writer.write(`error: unknown distill subcommand ${JSON.stringify(sub)} (expected: run, runs, status, staged, install)\n\n${USAGE}`);
       return 2;
+    }
+    if (sub === 'staged') {
+      const activeDir = (parsed.values.out as string | undefined) ?? DEFAULT_SKILLS_INSTALL_DIR;
+      const stagingDir = stagingDirFor(activeDir);
+      const staged = listStaged(stagingDir);
+      if (json) {
+        writer.write(
+          JSON.stringify(staged.map((p) => ({ name: p.name, description: p.description, provenance: p.jinn.provenance }))) + '\n',
+        );
+      } else if (staged.length === 0) {
+        writer.write(`nothing staged in ${stagingDir}\n`);
+      } else {
+        const skills: RenderedSkill[] = staged.map((p) => ({
+          name: p.name,
+          installed: false,
+          provenance: p.jinn.provenance,
+          helpsWith: p.description,
+        }));
+        writer.write(renderSkillsPanel(skills, 'staged — waiting for install') + '\n');
+        writer.write(`install with: distill install <name> · distill install --all\n`);
+      }
+      return 0;
+    }
+
+    if (sub === 'install') {
+      const activeDir = (parsed.values.out as string | undefined) ?? DEFAULT_SKILLS_INSTALL_DIR;
+      const stagingDir = stagingDirFor(activeDir);
+      const names = parsed.positionals.slice(1);
+      const all = parsed.values.all as boolean;
+      if (names.length === 0 && !all) {
+        writer.write(`error: distill install needs skill <name>(s) or --all\n\n${USAGE}`);
+        return 2;
+      }
+      const staged = listStaged(stagingDir);
+      const byName = new Map(staged.map((p) => [p.name, p]));
+      let chosen: SkillPackage[];
+      if (all) {
+        chosen = staged;
+      } else {
+        const unknown = names.filter((n) => !byName.has(n));
+        if (unknown.length > 0) {
+          const available = staged.length > 0 ? staged.map((p) => p.name).join(', ') : 'nothing staged';
+          writer.write(`error: not staged: ${unknown.join(', ')} (staged: ${available})\n`);
+          return 2;
+        }
+        chosen = names.map((n) => byName.get(n)!);
+      }
+      const installed = await installStagedSkills(chosen, stagingDir, activeDir);
+      if (json) {
+        writer.write(JSON.stringify({ installed, stagingDir, activeDir }) + '\n');
+      } else if (installed.length === 0) {
+        writer.write(`nothing staged in ${stagingDir}\n`);
+      } else {
+        writer.write(installed.map((s) => `installed  ${s.name}  →  ${s.path}`).join('\n') + '\n');
+      }
+      return 0;
     }
     if (sub === 'runs') {
       const limN = Number.parseInt(parsed.values.limit as string, 10);
@@ -1420,12 +1532,11 @@ export async function runJinnLayerCli(
 
     // Install the chosen skills into the active dir via the existing local sink,
     // and clear their staged copies so staging holds only what's not installed.
-    const activeSink = createLocalSkillSink(activeDir);
-    for (const p of published) {
-      if (!installNames.has(p.pkg.name)) continue;
-      await activeSink(p.pkg);
-      rmSync(join(stagingDir, p.pkg.name), { recursive: true, force: true });
-    }
+    await installStagedSkills(
+      published.filter((p) => installNames.has(p.pkg.name)).map((p) => p.pkg),
+      stagingDir,
+      activeDir,
+    );
 
     if (json) {
       writer.write(JSON.stringify({

--- a/client/packages/harness-layer/test/cli.test.ts
+++ b/client/packages/harness-layer/test/cli.test.ts
@@ -2488,3 +2488,125 @@ describe('jinn-layer distill run log + status/runs subverbs (#1535)', () => {
     expect(JSON.parse(runsOutput.out())).toEqual([]);
   });
 });
+
+describe('jinn-layer distill staged/install — install from staging (#1536)', () => {
+  beforeEach(() => {
+    const modePath = tmpModeFile();
+    writeDistillMode('local', modePath);
+    process.env['JINN_LAYER_DISTILL_MODE_PATH'] = modePath;
+  });
+  afterEach(() => {
+    delete process.env['JINN_LAYER_DISTILL_MODE_PATH'];
+  });
+
+  /** A distill port that fails loudly if the subverbs ever invoke the LLM. */
+  const forbiddenDistill = async (): Promise<DistillLLMOutput> => {
+    throw new Error('distill install/staged must never invoke the distiller');
+  };
+
+  async function stageOne(outDir: string, name = 'orm-fanout-dedup'): Promise<string> {
+    const capturesDir = capturesDirWith(ownCapture());
+    const w = capture();
+    const code = await runJinnLayerCli(
+      ['distill', '--captures', capturesDir, '--out', outDir, '--install', 'none', '--json'],
+      { writer: w.writer, distillDeps: stubDistillDeps({ distill: async () => ({ ...VALID_DISTILL, name }) }) },
+    );
+    expect(code).toBe(0);
+    return capturesDir;
+  }
+
+  it('distill staged --json lists staged skills with name, description, and provenance', async () => {
+    const outDir = mkdtempSync(join(tmpdir(), 'jinn-distill-out-'));
+    await stageOne(outDir);
+    const { writer, out } = capture();
+    const code = await runJinnLayerCli(
+      ['distill', 'staged', '--out', outDir, '--json'],
+      { writer, distillDeps: { distill: forbiddenDistill } },
+    );
+    expect(code).toBe(0);
+    const staged = JSON.parse(out());
+    expect(staged).toHaveLength(1);
+    expect(staged[0].name).toBe('orm-fanout-dedup');
+    expect(typeof staged[0].description).toBe('string');
+    expect(staged[0].provenance.some((r: string) => r.startsWith('local-capture:'))).toBe(true);
+  });
+
+  it('distill staged on an empty staging dir returns [] / a clear message', async () => {
+    const outDir = mkdtempSync(join(tmpdir(), 'jinn-distill-out-'));
+    const { writer, out } = capture();
+    const code = await runJinnLayerCli(
+      ['distill', 'staged', '--out', outDir, '--json'],
+      { writer, distillDeps: { distill: forbiddenDistill } },
+    );
+    expect(code).toBe(0);
+    expect(JSON.parse(out())).toEqual([]);
+  });
+
+  it('distill install --all installs every staged skill with zero LLM calls and empties staging', async () => {
+    const outDir = mkdtempSync(join(tmpdir(), 'jinn-distill-out-'));
+    await stageOne(outDir);
+    const { writer, out } = capture();
+    const code = await runJinnLayerCli(
+      ['distill', 'install', '--all', '--out', outDir, '--json'],
+      { writer, distillDeps: { distill: forbiddenDistill } },
+    );
+    expect(code).toBe(0);
+    const result = JSON.parse(out());
+    expect(result.installed).toHaveLength(1);
+    expect(result.installed[0].name).toBe('orm-fanout-dedup');
+    // Installed into the active dir, staged copy removed.
+    const md = readFileSync(join(outDir, 'orm-fanout-dedup', 'SKILL.md'), 'utf-8');
+    expect(parseSkillMarkdown(md).name).toBe('orm-fanout-dedup');
+    expect(existsSync(join(outDir + '-staged', 'orm-fanout-dedup'))).toBe(false);
+  });
+
+  it('distill install <name> installs just that skill from a previous run', async () => {
+    const outDir = mkdtempSync(join(tmpdir(), 'jinn-distill-out-'));
+    await stageOne(outDir, 'skill-one');
+    const { writer } = capture();
+    const code = await runJinnLayerCli(
+      ['distill', 'install', 'skill-one', '--out', outDir, '--json'],
+      { writer, distillDeps: { distill: forbiddenDistill } },
+    );
+    expect(code).toBe(0);
+    expect(existsSync(join(outDir, 'skill-one', 'SKILL.md'))).toBe(true);
+  });
+
+  it('does not read the mode file — install works on a virgin mode (no consent gate)', async () => {
+    const outDir = mkdtempSync(join(tmpdir(), 'jinn-distill-out-'));
+    await stageOne(outDir);
+    const virginMode = join(mkdtempSync(join(tmpdir(), 'jinn-virgin-')), 'distill.json');
+    await withEnv({ JINN_LAYER_DISTILL_MODE_PATH: virginMode }, async () => {
+      const { writer } = capture();
+      const code = await runJinnLayerCli(
+        ['distill', 'install', '--all', '--out', outDir, '--json'],
+        { writer, distillDeps: { distill: forbiddenDistill } },
+      );
+      expect(code).toBe(0);
+    });
+    expect(existsSync(virginMode)).toBe(false);
+  });
+
+  it('an unknown name exits 2 and lists what is staged', async () => {
+    const outDir = mkdtempSync(join(tmpdir(), 'jinn-distill-out-'));
+    await stageOne(outDir, 'real-skill');
+    const { writer, out } = capture();
+    const code = await runJinnLayerCli(
+      ['distill', 'install', 'nope', '--out', outDir, '--json'],
+      { writer, distillDeps: { distill: forbiddenDistill } },
+    );
+    expect(code).toBe(2);
+    expect(out()).toContain('real-skill');
+  });
+
+  it('install with neither names nor --all exits 2', async () => {
+    const outDir = mkdtempSync(join(tmpdir(), 'jinn-distill-out-'));
+    const { writer, out } = capture();
+    const code = await runJinnLayerCli(
+      ['distill', 'install', '--out', outDir],
+      { writer, distillDeps: { distill: forbiddenDistill } },
+    );
+    expect(code).toBe(2);
+    expect(out()).toMatch(/--all|<name>/);
+  });
+});


### PR DESCRIPTION
Closes #1536. Parent epic #1486. **Stacked on #1544**; retarget as the stack merges.

## What

- `distill staged [--out][--json]` — read-only list of the staging area: name, what each skill helps with, provenance refs. Unparseable staged SKILL.md files are skipped with a stderr warning.
- `distill install [<name> ...] [--all] [--out][--json]` — installs previously staged skills into the active dir. **No LLM calls, no consent gate, no mode read** (verified by a test that injects a distill port that throws if invoked, and by asserting the mode file is never created on a virgin machine). `--all` is a flag, not a magic name. Unknown names exit 2 listing what is staged; bare `install` with neither names nor `--all` exits 2.
- The inline run-flow install and the subverb now share one `installStagedSkills` helper — the "staging holds exactly what's not installed" invariant lives in one place.

## Verification

TDD: 7 new tests first (staged list round-trip, empty staging, install --all with zero distiller invocations + staging emptied, install <name> from a previous run, virgin-mode no-consent install, unknown name exit 2 + listing, missing args exit 2). Full harness-layer suite: 439 passed. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)