### PR TITLE
feat(jinn-agent): /jinn distill — splash, status hub, where setter

### DIFF
--- a/apps/jinn-agent/plugins/jinn/__init__.py
+++ b/apps/jinn-agent/plugins/jinn/__init__.py
@@ -533,6 +533,8 @@ _JINN_HELP = (
     "  /jinn skills install <ref>   install a corpus-published skill into the agent's skills\n"
     "  /jinn skills list            jinn-installed skills\n"
     "  /jinn skills uninstall <slug>  remove a jinn-installed skill\n"
+    "  /jinn distill   local distillation — your captures into reusable skills\n"
+    "  /jinn distill where local|defer|off   set where distillation runs\n"
 )
 
 
@@ -717,6 +719,11 @@ def _handle_jinn(command_args: str = "", session_id: str = "", task_id: str = ""
         if not installed:
             return "No jinn-installed skills. /corpus <query> to find some, then /jinn skills install <ref>."
         return "\n".join(f"{row['slug']}  ({row['ref'] or 'ref unknown'})" for row in installed)
+
+    if sub == "distill":
+        # Local distillation (mono #1538) — all logic + rendering in distill.py;
+        # this dispatch stays a one-liner like the other module-backed verbs.
+        return distill.handle_command(parts[1:], runner=_runner)
 
     if sub == "veto":
         if not buf.has_steps(task_id, session_id):

--- a/apps/jinn-agent/plugins/jinn/distill.py
+++ b/apps/jinn-agent/plugins/jinn/distill.py
@@ -36,7 +36,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from . import jinn_layer
+from . import consent, jinn_layer
 
 Runner = Callable[[List[str]], Tuple[int, str]]
 
@@ -234,3 +234,133 @@ def write_episode_fallback(episode: Dict[str, Any]) -> Optional[Path]:
                     pass
     except Exception:
         return None
+
+
+# ── /jinn distill — the in-session surface (mono #1538) ─────────────────────
+#
+# All handlers return stateless strings (input() would deadlock the TUI; the
+# two-step pattern from /jinn consent covers anything that needs confirming).
+# First-run detection is facts-over-flags (onboarding.py precedent): the FACT
+# is `mode == "unset"` from the layer's status read; the only stored flag is
+# that the splash was shown.
+
+UPDATE_LAYER_LINE = (
+    "The Jinn layer here doesn't know distillation yet — update it:\n"
+    "  npm install -g @jinn-network/client@canary"
+)
+
+
+def ux_flags_path() -> Path:
+    return consent.get_hermes_home() / "jinn" / "distill-ux.json"
+
+
+def load_ux_flags() -> Dict[str, object]:
+    """Pure seen-flags only — never mode, consent, or run state."""
+    path = ux_flags_path()
+    if not path.exists():
+        return {"splash_shown": False, "payoff_invited": False}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return {
+            "splash_shown": bool(data.get("splash_shown", False)),
+            "payoff_invited": bool(data.get("payoff_invited", False)),
+        }
+    except Exception:
+        return {"splash_shown": False, "payoff_invited": False}
+
+
+def mark_ux_flag(name: str) -> None:
+    if name not in ("splash_shown", "payoff_invited"):
+        raise ValueError(f"unknown distill ux flag: {name}")
+    flags = load_ux_flags()
+    flags[name] = True
+    path = ux_flags_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(flags, indent=2) + "\n", encoding="utf-8")
+
+
+def render_splash(status: Dict[str, Any]) -> str:
+    count = status.get("capturesCount", 0)
+    provider = status.get("distillProvider", "claude")
+    model = status.get("distillModel", "")
+    return "\n".join(
+        [
+            "◇ distill — turn your own work into reusable skills",
+            "",
+            "  As you work, completed tasks are reserved on this machine as",
+            f"  captures ({count} so far). A distillation run reads them and writes",
+            "  SKILL.md files the agent picks up on later tasks — fully locally:",
+            "  nothing is published, nothing leaves this machine.",
+            "",
+            f"  distiller   {provider} · {model}",
+            "              (the frontier model that WRITES the skills — distinct",
+            "              from the runtime model your sessions run on)",
+            "",
+            "  start one   /jinn distill start",
+            "  or decide later — captures keep accruing either way.",
+        ]
+    )
+
+
+def render_hub(status: Dict[str, Any]) -> str:
+    mode = status.get("mode", "unset")
+    captures = status.get("capturesCount", 0)
+    uncovered = status.get("uncoveredCount", 0)
+    staged = status.get("stagedCount", 0)
+    installed = status.get("installedCount", 0)
+    provider = status.get("distillProvider", "claude")
+    model = status.get("distillModel", "")
+    last = status.get("lastRun")
+    if isinstance(last, dict):
+        last_line = (
+            f"{last.get('startedAt', '?')}  {last.get('outcome', '?')} — "
+            f"{len(last.get('published', []) or [])} distilled, {len(last.get('installed', []) or [])} installed"
+        )
+    else:
+        last_line = "never · /jinn distill start"
+    lines = [
+        "◇ distill",
+        f"  mode        {mode}",
+        f"  captures    {uncovered} of {captures} not yet distilled",
+        f"  staged      {staged}" + ("  → /jinn distill review" if staged else ""),
+        f"  installed   {installed}",
+        f"  distiller   {provider} · {model}",
+        f"  last run    {last_line}",
+    ]
+    return "\n".join(lines)
+
+
+def handle_command(parts: List[str], runner: Optional[Runner] = None) -> str:
+    """`/jinn distill ...` — dispatch on the first word after `distill`."""
+    action = parts[0] if parts else ""
+
+    if action == "where":
+        mode = parts[1] if len(parts) > 1 else ""
+        if mode not in ("local", "defer", "off"):
+            return "usage: /jinn distill where local|defer|off"
+        code, out = jinn_layer.run(["distill", "--where", mode, "--json"], runner)
+        if code != 0:
+            return out.strip() or UPDATE_LAYER_LINE
+        cached_mode(runner, refresh=True)
+        behaviour = {
+            "local": "runs happen here when you start them",
+            "defer": "captures keep accruing; nothing runs",
+            "off": "captures stop being reserved for distillation",
+        }[mode]
+        return f"distill mode recorded: {mode} — {behaviour}."
+
+    if action == "":
+        status = distill_status(runner)
+        if status is None:
+            return UPDATE_LAYER_LINE
+        cached_mode(runner, refresh=True)
+        if status.get("mode") == "unset" and not load_ux_flags()["splash_shown"]:
+            mark_ux_flag("splash_shown")
+            return render_splash(status)
+        return render_hub(status)
+
+    return (
+        "/jinn distill — local distillation\n"
+        "  /jinn distill                 status (first run: what this is)\n"
+        "  /jinn distill where local|defer|off   set where it runs\n"
+    )

--- a/apps/jinn-agent/tests/plugins/test_jinn_distill_command.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_distill_command.py
@@ -1,0 +1,156 @@
+"""/jinn distill — splash, status hub, where setter (mono #1538).
+
+First-run detection is facts-over-flags: the FACT is `mode == "unset"` from
+`distill status`; the only stored flag is `splash_shown`. All handlers return
+stateless strings — no blocking input in the TUI.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+jinn = importlib.import_module("plugins.jinn")
+capture_buffer = importlib.import_module("plugins.jinn.capture_buffer")
+distill = importlib.import_module("plugins.jinn.distill")
+
+
+def make_status(**over):
+    status = {
+        "mode": "unset",
+        "capturesCount": 3,
+        "uncoveredCount": 2,
+        "stagedCount": 0,
+        "installedCount": 0,
+        "distillProvider": "claude",
+        "distillModel": "claude-opus-4-8",
+        "lastRun": None,
+    }
+    status.update(over)
+    return status
+
+
+class LayerRunner:
+    """Answers distill status/--where; records every call."""
+
+    def __init__(self, status=None, status_code: int = 0):
+        self.calls: list[list[str]] = []
+        self.status = status if status is not None else make_status()
+        self.status_code = status_code
+
+    def __call__(self, argv: list[str]) -> tuple[int, str]:
+        self.calls.append(argv)
+        if argv[1:3] == ["distill", "status"]:
+            if self.status_code != 0:
+                return self.status_code, "unknown distill subcommand"
+            return 0, json.dumps(self.status)
+        if argv[1:2] == ["distill"] and "--where" in argv:
+            mode = argv[argv.index("--where") + 1]
+            self.status = dict(self.status, mode=mode)
+            return 0, json.dumps({"where": mode})
+        return 0, "ok"
+
+
+@pytest.fixture(autouse=True)
+def isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("JINN_LAYER_CAPTURES_DIR", str(tmp_path / "captures"))
+    capture_buffer.reset()
+    distill.reset()
+    yield
+    jinn._runner = None
+
+
+def _distill(args: str = "") -> str:
+    return jinn._handle_jinn(command_args=("distill " + args).strip(), session_id="s1", task_id="t1")
+
+
+def test_first_run_shows_the_splash_and_marks_it_seen():
+    jinn._runner = LayerRunner(make_status(mode="unset", capturesCount=3))
+    out = _distill()
+    assert "distill" in out.lower()
+    assert "on this machine" in out or "locally" in out.lower()
+    assert "claude-opus-4-8" in out, "the resolved distiller model is shown (display only, #1496)"
+    assert "3" in out, "current reserved-capture count"
+    assert "/jinn distill start" in out
+    assert distill.load_ux_flags()["splash_shown"] is True
+
+
+def test_second_call_shows_the_status_hub_not_the_splash():
+    jinn._runner = LayerRunner(make_status(mode="unset"))
+    first = _distill()
+    second = _distill()
+    assert first != second
+    assert "mode" in second.lower()
+
+
+def test_hub_reflects_the_status_read():
+    distill.mark_ux_flag("splash_shown")
+    jinn._runner = LayerRunner(
+        make_status(
+            mode="local",
+            capturesCount=7,
+            uncoveredCount=4,
+            stagedCount=2,
+            installedCount=1,
+            lastRun={
+                "startedAt": "2026-07-10T12:00:00.000Z",
+                "outcome": "ok",
+                "published": ["retry-backoff-patterns"],
+                "installed": [],
+            },
+        )
+    )
+    out = _distill()
+    assert "local" in out
+    assert "4" in out and "7" in out, "uncovered/total captures"
+    assert "2 staged" in out or "staged      2" in out.replace("\n", " ") or "staged 2" in out
+    assert "/jinn distill review" in out
+    assert "ok" in out
+
+
+def test_where_sets_the_mode_via_the_layer_and_refreshes_the_cache():
+    runner = LayerRunner(make_status(mode="unset"))
+    jinn._runner = runner
+    out = _distill("where defer")
+    where_calls = [c for c in runner.calls if "--where" in c]
+    assert where_calls and where_calls[0][1:] == ["distill", "--where", "defer", "--json"]
+    assert "defer" in out
+    # The cache follows: gating now sees the recorded mode without a new process-wide stale value.
+    assert distill.cached_mode(runner) == "defer"
+
+
+def test_where_off_mentions_captures_stop_being_reserved():
+    jinn._runner = LayerRunner(make_status(mode="local"))
+    out = _distill("where off")
+    assert "reserv" in out.lower() or "captures" in out.lower()
+
+
+def test_where_rejects_unknown_modes_without_calling_the_layer():
+    runner = LayerRunner()
+    jinn._runner = runner
+    out = _distill("where sideways")
+    assert "local" in out and "defer" in out and "off" in out, "usage names the three modes"
+    assert [c for c in runner.calls if "--where" in c] == []
+
+
+def test_layer_without_distill_verbs_points_at_the_canary_update():
+    jinn._runner = LayerRunner(status_code=2)
+    out = _distill()
+    assert "@canary" in out or "update" in out.lower()
+
+
+def test_handlers_never_call_blocking_input(monkeypatch):
+    def boom(*a, **k):  # pragma: no cover - the assertion is that it is never hit
+        raise AssertionError("input() must never run in the TUI path")
+
+    monkeypatch.setattr("builtins.input", boom)
+    jinn._runner = LayerRunner()
+    _distill()
+    _distill("where defer")
+
+
+def test_jinn_help_mentions_the_distill_family():
+    assert "/jinn distill" in jinn._JINN_HELP


### PR DESCRIPTION
Closes #1538. Parent epic #1486. **Stacked on #1546** (captures tee); retarget to `next` as the stack merges. Runtime dependency: `distill status` / `--where` (#1544, #1541).

## What

- `distill` branch in `_handle_jinn` — a one-line dispatch; logic + rendering live in `plugins/jinn/distill.py` (module-backed verb pattern, like `skills_install`/`ledger_view`).
- **First-run splash** — facts-over-flags (onboarding precedent): fact = `mode == "unset"` from the layer status read; stored flag = `splash_shown` in `$HERMES_HOME/jinn/distill-ux.json`. Splash: what distillation is, runs fully on this machine, the resolved distiller model (display only — persistent selection stays #1496), reserved-capture count, `→ /jinn distill start`.
- **Status hub** thereafter: mode · uncovered/total captures · staged (→ `/jinn distill review`) · installed · distiller · last run.
- **`/jinn distill where local|defer|off`** — shells the layer's `--where` setter, refreshes the process mode cache (the F1 tee gate follows immediately), echoes the behaviour per mode.
- Old layer without the verbs → `@canary` update pointer. `_JINN_HELP` updated.

## Verification

TDD: 9 pytest cases first — splash on virgin machine + flag persistence, hub on second call, hub reflects status fields, where→layer call + cache refresh, `where off` copy, unknown mode rejected without a layer call, old-layer degrade message, no-`input()` guard, help text. Full jinn suite: 209 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)