### PR TITLE
feat(jinn-agent): /jinn distill review + install from staging

### DIFF
--- a/apps/jinn-agent/plugins/jinn/distill.py
+++ b/apps/jinn-agent/plugins/jinn/distill.py
@@ -611,6 +611,84 @@ def handle_command(parts: List[str], runner: Optional[Runner] = None) -> str:
     if action == "stop":
         return stop_run()
 
+    if action == "review":
+        code, out = jinn_layer.run(
+            ["distill", "staged", "--json", "--out", str(skills_install.skills_dir())], runner
+        )
+        if code != 0:
+            return out.strip() or UPDATE_LAYER_LINE
+        try:
+            staged = json.loads(out)
+        except ValueError:
+            return UPDATE_LAYER_LINE
+        if not staged:
+            return "nothing staged — /jinn distill start runs a distillation over your captures"
+        lines = ["◇ distilled skills — staged, waiting for your choice", ""]
+        for skill in staged:
+            name = skill.get("name", "?")
+            provenance = skill.get("provenance") or []
+            sources = ", ".join(str(p).replace("local-capture:", "") for p in provenance)
+            lines.append(f"  {name}")
+            lines.append(f"    helps  {skill.get('description', '')}")
+            lines.append(f"    from   {len(provenance)} capture(s): {sources}")
+            lines.append("")
+        lines.append("  install with  /jinn distill install <name> · /jinn distill install all")
+        return "\n".join(lines)
+
+    if action == "install":
+        target = parts[1] if len(parts) > 1 else ""
+        if not target:
+            return "usage: /jinn distill install <name>|all"
+        skills_dir = skills_install.skills_dir()
+        # Read the staged provenance FIRST — the install below clears the
+        # staged copies, and the marker (payoff join, uninstall guard) needs it.
+        staged_code, staged_out = jinn_layer.run(
+            ["distill", "staged", "--json", "--out", str(skills_dir)], runner
+        )
+        provenance_by_name: Dict[str, List[str]] = {}
+        if staged_code == 0:
+            try:
+                for skill in json.loads(staged_out):
+                    provenance_by_name[str(skill.get("name"))] = list(skill.get("provenance") or [])
+            except ValueError:
+                pass
+        selector = ["--all"] if target == "all" else [target]
+        code, out = jinn_layer.run(
+            ["distill", "install", *selector, "--json", "--out", str(skills_dir)], runner
+        )
+        if code != 0:
+            return out.strip() or UPDATE_LAYER_LINE
+        try:
+            result = json.loads(out)
+        except ValueError:
+            return UPDATE_LAYER_LINE
+        installed = result.get("installed") or []
+        if not installed:
+            return "nothing staged — /jinn distill start runs a distillation over your captures"
+        lines = []
+        for row in installed:
+            name = str(row.get("name"))
+            provenance = provenance_by_name.get(name, [])
+            marker = skills_dir / name / ".jinn-ref"
+            try:
+                marker.parent.mkdir(parents=True, exist_ok=True)
+                marker.write_text(
+                    json.dumps(
+                        {
+                            "ref": f"local-distill:{name}",
+                            "provenance": provenance,
+                            "provenance_count": len(provenance),
+                        }
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+            except OSError:
+                pass
+            lines.append(f"installed  {name}  →  {row.get('path', '')}")
+        lines.append("The agent's skill loader picks these up from here.")
+        return "\n".join(lines)
+
     if action == "where":
         mode = parts[1] if len(parts) > 1 else ""
         if mode not in ("local", "defer", "off"):
@@ -641,5 +719,7 @@ def handle_command(parts: List[str], runner: Optional[Runner] = None) -> str:
         "  /jinn distill                 status (first run: what this is)\n"
         "  /jinn distill start           run one (two-step: start → start confirm)\n"
         "  /jinn distill stop            end the live run (staged skills kept)\n"
+        "  /jinn distill review          the staged skills — what each helps with, where it came from\n"
+        "  /jinn distill install <name>|all   install staged skills (no re-distillation)\n"
         "  /jinn distill where local|defer|off   set where it runs\n"
     )

--- a/apps/jinn-agent/tests/plugins/test_jinn_distill_install.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_distill_install.py
@@ -1,0 +1,131 @@
+"""/jinn distill review + install from staging (mono #1540).
+
+review renders the layer's staged list (name · helps · from); install moves
+staged skills into $HERMES_HOME/skills via the layer (zero LLM calls) and
+writes the .jinn-ref marker so list/uninstall and the marker-gated delete
+guard keep working, and the payoff join (F5) has provenance to read.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+jinn = importlib.import_module("plugins.jinn")
+distill = importlib.import_module("plugins.jinn.distill")
+skills_install = importlib.import_module("plugins.jinn.skills_install")
+
+STAGED = [
+    {
+        "name": "retry-backoff-patterns",
+        "description": "Use when a flaky external call needs retries. Not for: pure functions.",
+        "provenance": ["local-capture:own-1", "local-capture:own-2"],
+    },
+    {
+        "name": "vitest-fixture-hygiene",
+        "description": "Use when fixtures leak state between tests. Not for: e2e suites.",
+        "provenance": ["local-capture:own-3"],
+    },
+]
+
+
+class LayerRunner:
+    """Answers distill staged/install; records calls; writes installed SKILL.md files."""
+
+    def __init__(self, staged=None, install_code: int = 0):
+        self.calls: list[list[str]] = []
+        self.staged = STAGED if staged is None else staged
+        self.install_code = install_code
+
+    def __call__(self, argv: list[str]) -> tuple[int, str]:
+        self.calls.append(argv)
+        if argv[1:3] == ["distill", "staged"]:
+            return 0, json.dumps(self.staged)
+        if argv[1:3] == ["distill", "install"]:
+            if self.install_code != 0:
+                return self.install_code, "error: not staged: nope (staged: retry-backoff-patterns)"
+            out_dir = Path(argv[argv.index("--out") + 1])
+            chosen = self.staged if "--all" in argv else [s for s in self.staged if s["name"] in argv]
+            installed = []
+            for s in chosen:
+                d = out_dir / s["name"]
+                d.mkdir(parents=True, exist_ok=True)
+                (d / "SKILL.md").write_text(f"# {s['name']}\n")
+                installed.append({"name": s["name"], "path": str(d / "SKILL.md")})
+            return 0, json.dumps({"installed": installed, "stagingDir": str(out_dir) + "-staged", "activeDir": str(out_dir)})
+        if argv[1:3] == ["distill", "status"]:
+            return 0, json.dumps({"mode": "local"})
+        return 0, "ok"
+
+
+@pytest.fixture(autouse=True)
+def isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    distill.reset()
+    yield
+    jinn._runner = None
+
+
+def _cmd(args: str, runner) -> str:
+    jinn._runner = runner
+    return jinn._handle_jinn(command_args=("distill " + args).strip(), session_id="s", task_id="t")
+
+
+def test_review_renders_name_helps_and_provenance():
+    runner = LayerRunner()
+    out = _cmd("review", runner)
+    staged_calls = [c for c in runner.calls if c[1:3] == ["distill", "staged"]]
+    assert staged_calls and "--out" in staged_calls[0], "review reads the staging next to the native skills dir"
+    assert "retry-backoff-patterns" in out
+    assert "flaky external call" in out
+    assert "own-1" in out or "2 capture" in out, "provenance is shown"
+    assert "/jinn distill install" in out
+
+
+def test_review_with_nothing_staged_points_at_start():
+    out = _cmd("review", LayerRunner(staged=[]))
+    assert "nothing staged" in out.lower()
+    assert "/jinn distill start" in out
+
+
+def test_install_all_installs_via_the_layer_and_writes_markers():
+    runner = LayerRunner()
+    out = _cmd("install all", runner)
+    install_calls = [c for c in runner.calls if c[1:3] == ["distill", "install"]]
+    assert install_calls and "--all" in install_calls[0]
+    assert "retry-backoff-patterns" in out and "vitest-fixture-hygiene" in out
+
+    marker = skills_install.skills_dir() / "retry-backoff-patterns" / ".jinn-ref"
+    data = json.loads(marker.read_text())
+    assert data["ref"] == "local-distill:retry-backoff-patterns"
+    assert data["provenance"] == ["local-capture:own-1", "local-capture:own-2"]
+    assert data["provenance_count"] == 2
+
+    # The marker keeps the existing list/uninstall surface working unchanged.
+    slugs = [row["slug"] for row in skills_install.list_installed()]
+    assert "retry-backoff-patterns" in slugs
+
+
+def test_install_one_by_name():
+    runner = LayerRunner()
+    out = _cmd("install vitest-fixture-hygiene", runner)
+    install_calls = [c for c in runner.calls if c[1:3] == ["distill", "install"]]
+    assert "vitest-fixture-hygiene" in install_calls[0] and "--all" not in install_calls[0]
+    assert "vitest-fixture-hygiene" in out
+    assert not (skills_install.skills_dir() / "retry-backoff-patterns" / ".jinn-ref").exists()
+
+
+def test_install_surfaces_the_layer_error_for_unknown_names():
+    out = _cmd("install nope", LayerRunner(install_code=2))
+    assert "not staged" in out
+    assert "retry-backoff-patterns" in out
+
+
+def test_install_without_a_target_shows_usage():
+    runner = LayerRunner()
+    out = _cmd("install", runner)
+    assert "usage" in out.lower()
+    assert [c for c in runner.calls if c[1:3] == ["distill", "install"]] == []


### PR DESCRIPTION
Closes #1540. Parent epic #1486. **Stacked on #1548**; retarget as the stack merges. Runtime dependency: `distill staged`/`install` subverbs (#1545).

## What

- **`/jinn distill review`** — renders the staging area forward (name · helps · from-your-captures) via `distill staged --json --out $HERMES_HOME/skills`; empty staging points at `start`.
- **`/jinn distill install <name>|all`** — shells `distill install` (zero LLM calls; the layer owns the move and the staging-holds-only-what's-not-installed invariant), then writes the `.jinn-ref` marker per installed skill: `{"ref": "local-distill:<name>", "provenance": [...], "provenance_count": N}`. The marker keeps `skills list`/`uninstall` and the marker-gated delete guard working unchanged, and gives the payoff surface (F5) its provenance join. Staged provenance is read **before** installing (the install clears staged copies).
- Single-step — install is not a spend (consistent with `/jinn skills install`). Installed skills land where the hermes native skill loader reads.

## Verification

TDD: 6 pytest cases first — review rendering (helps + provenance + instructions), empty-staging pointer, install-all with marker contents + `list_installed` compatibility, install-one leaves others unmarked, layer error surfaced for unknown names, usage on missing target. Full jinn suite: 228 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)