### PR TITLE
feat(jinn-agent): payoff surface + distill discoverability

### DIFF
--- a/apps/jinn-agent/hermes_cli/tips.py
+++ b/apps/jinn-agent/hermes_cli/tips.py
@@ -521,6 +521,11 @@ _JINN_TIPS = [
     and len(_jinn_rebrand_tip(_tip)) <= 150
 ]
 
+# Jinn-layer features with no upstream tip to rebrand (mono #1551).
+_JINN_TIPS.append(
+    "Distill your recent work into reusable skills, fully on this machine — /jinn distill"
+)
+
 _upstream_get_random_tip = get_random_tip
 
 

--- a/apps/jinn-agent/plugins/jinn/__init__.py
+++ b/apps/jinn-agent/plugins/jinn/__init__.py
@@ -45,6 +45,10 @@ _veto_lock = threading.Lock()
 _vetoed_tasks: Set[str] = set()
 _session_hint_shown: Set[str] = set()
 
+# Distilled-skill use counts at session start; the session-end payoff surface
+# reports only skills used during this session.
+_distill_usage_snapshot: Dict[str, int] = {}
+
 # Test seam: overridable subprocess runner (None = real jinn-layer binary).
 _runner: Optional[jinn_layer.Runner] = None
 
@@ -251,6 +255,8 @@ def _on_session_start(session_id: str = "", platform: str = "", **_: Any) -> Non
         distill.reattach_watcher(sink=_user_line)
     except Exception:
         pass
+    global _distill_usage_snapshot
+    _distill_usage_snapshot = distill.snapshot_usage()
     if consent.consent_decided():
         return
     if session_id in _session_hint_shown:
@@ -417,6 +423,14 @@ def _on_session_end(
     output_tokens: Optional[int] = None,
     **_: Any,
 ) -> None:
+    # Usage is native local telemetry, so show payoff independently of sharing
+    # consent and before any capture-path early return.
+    try:
+        for line in distill.payoff_lines(_distill_usage_snapshot):
+            _user_line(line)
+    except Exception:
+        pass
+
     # Local capture is unconditional (mono#1714); only the share step is gated.
     share_enabled = consent.share_enabled()
     # Record the skills loadout + token fallback (host forward, mono #1662) —
@@ -571,6 +585,13 @@ def _handle_jinn(command_args: str = "", session_id: str = "", task_id: str = ""
         pending = _latest_pending()
         if pending:
             lines.append(f"pending trace: {pending}")
+        d_status = distill.distill_status(_runner)
+        if d_status:
+            lines.append(
+                f"distill: {d_status.get('mode', 'unset')} — "
+                f"{d_status.get('uncoveredCount', 0)} capture(s) not yet distilled, "
+                f"{d_status.get('stagedCount', 0)} staged, {d_status.get('installedCount', 0)} installed"
+            )
         return "\n".join(lines)
 
     if sub == "consent":

--- a/apps/jinn-agent/plugins/jinn/distill.py
+++ b/apps/jinn-agent/plugins/jinn/distill.py
@@ -472,6 +472,81 @@ def reattach_watcher(sink: Optional[Sink] = None) -> None:
     _archive_current("died")
 
 
+# ── Payoff surface (mono #1550) ──────────────────────────────────────────────
+#
+# The join: the harness's usage sidecar ($HERMES_HOME/skills/.usage.json,
+# keyed by skill NAME, bumped by the native skill tools) × the .jinn-ref
+# markers whose ref starts with `local-distill:`. Sessions snapshot at start,
+# diff at end, and print one ◇ line per used distilled skill (cap 3).
+
+PAYOFF_LINE_CAP = 3
+
+
+def _distilled_markers() -> Dict[str, int]:
+    """name → provenance_count for installed skills with a local-distill ref."""
+    out: Dict[str, int] = {}
+    directory = skills_install.skills_dir()
+    if not directory.exists():
+        return out
+    for child in directory.iterdir():
+        marker = child / ".jinn-ref"
+        if not (child.is_dir() and marker.exists()):
+            continue
+        try:
+            data = json.loads(marker.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        ref = str(data.get("ref", ""))
+        if not ref.startswith("local-distill:"):
+            continue
+        count = data.get("provenance_count")
+        out[child.name] = int(count) if isinstance(count, int) else 0
+    return out
+
+
+def _read_usage() -> Dict[str, Dict[str, Any]]:
+    """The upstream usage sidecar, read directly (never written here)."""
+    path = skills_install.skills_dir() / ".usage.json"
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def snapshot_usage() -> Dict[str, int]:
+    """use_count per installed DISTILLED skill, at session start."""
+    usage = _read_usage()
+    snapshot: Dict[str, int] = {}
+    for name in _distilled_markers():
+        rec = usage.get(name)
+        count = rec.get("use_count") if isinstance(rec, dict) else 0
+        snapshot[name] = int(count) if isinstance(count, int) else 0
+    return snapshot
+
+
+def payoff_lines(snapshot: Dict[str, int]) -> List[str]:
+    """◇ lines for distilled skills used since `snapshot` (cap 3). Never raises."""
+    try:
+        markers = _distilled_markers()
+        usage = _read_usage()
+        lines: List[str] = []
+        for name, provenance_count in sorted(markers.items()):
+            rec = usage.get(name)
+            count = rec.get("use_count") if isinstance(rec, dict) else 0
+            count = int(count) if isinstance(count, int) else 0
+            if count > snapshot.get(name, 0):
+                sources = f"{provenance_count} of your captures" if provenance_count else "your captures"
+                lines.append(f"◇ skill used — {name} · distilled from {sources}")
+            if len(lines) >= PAYOFF_LINE_CAP:
+                break
+        return lines
+    except Exception:
+        return []
+
+
 # ── /jinn distill — the in-session surface (mono #1538) ─────────────────────
 #
 # All handlers return stateless strings (input() would deadlock the TUI; the
@@ -687,6 +762,34 @@ def handle_command(parts: List[str], runner: Optional[Runner] = None) -> str:
                 pass
             lines.append(f"installed  {name}  →  {row.get('path', '')}")
         lines.append("The agent's skill loader picks these up from here.")
+        # First install: one-time invitation to close the loop (mono #1550).
+        if not load_ux_flags()["payoff_invited"]:
+            mark_ux_flag("payoff_invited")
+            lines.append("")
+            lines.append(
+                "try one: run a task like the ones these came from — the agent"
+                " picks the skills up automatically, and you'll see a"
+                " ◇ skill used line when it does."
+            )
+        return "\n".join(lines)
+
+    if action == "skills":
+        markers = _distilled_markers()
+        usage = _read_usage()
+        status = distill_status(runner) or {}
+        staged_count = status.get("stagedCount", 0)
+        if not markers and not staged_count:
+            return "no distilled skills yet — /jinn distill start runs a distillation over your captures"
+        lines = ["◇ distilled skills"]
+        for name, provenance_count in sorted(markers.items()):
+            rec = usage.get(name) if isinstance(usage.get(name), dict) else {}
+            count = rec.get("use_count", 0)
+            last = rec.get("last_used_at") or "never"
+            lines.append(f"  {name}")
+            lines.append(f"    used   {count}x · last {last}")
+            lines.append(f"    from   {provenance_count} of your captures")
+        if staged_count:
+            lines.append(f"  staged      {staged_count}  → /jinn distill review")
         return "\n".join(lines)
 
     if action == "where":
@@ -721,5 +824,6 @@ def handle_command(parts: List[str], runner: Optional[Runner] = None) -> str:
         "  /jinn distill stop            end the live run (staged skills kept)\n"
         "  /jinn distill review          the staged skills — what each helps with, where it came from\n"
         "  /jinn distill install <name>|all   install staged skills (no re-distillation)\n"
+        "  /jinn distill skills          the distilled skillset with usage\n"
         "  /jinn distill where local|defer|off   set where it runs\n"
     )

--- a/apps/jinn-agent/plugins/jinn/distill.py
+++ b/apps/jinn-agent/plugins/jinn/distill.py
@@ -81,9 +81,17 @@ def episodes_dir() -> Path:
 
 
 def distill_status(runner: Optional[Runner] = None) -> Optional[Dict[str, Any]]:
-    """One `distill status --json` read; None when the layer lacks the verb."""
+    """One `distill status --json` read; None when the layer lacks the verb.
+
+    Scoped with `--out` to the harness's native skills dir — the plugin
+    installs there, so coverage/staged/installed must count against it, not
+    the layer's default dir (otherwise the hub shows stale numbers after a
+    run — e2e finding).
+    """
     try:
-        code, out = jinn_layer.run(["distill", "status", "--json"], runner)
+        code, out = jinn_layer.run(
+            ["distill", "status", "--json", "--out", str(skills_install.skills_dir())], runner
+        )
     except Exception:
         return None
     if code != 0:

--- a/apps/jinn-agent/tests/plugins/test_jinn_distill_command.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_distill_command.py
@@ -154,3 +154,16 @@ def test_handlers_never_call_blocking_input(monkeypatch):
 
 def test_jinn_help_mentions_the_distill_family():
     assert "/jinn distill" in jinn._JINN_HELP
+
+
+def test_status_reads_are_scoped_to_the_native_skills_dir():
+    # The plugin installs into $HERMES_HOME/skills — status must count
+    # coverage/staged/installed against THAT dir, not the layer default,
+    # or the hub shows stale numbers after a run (e2e finding).
+    runner = LayerRunner(make_status())
+    jinn._runner = runner
+    _distill()
+    status_calls = [c for c in runner.calls if c[1:3] == ["distill", "status"]]
+    assert status_calls, "hub reads status"
+    for call in status_calls:
+        assert "--out" in call, f"status call missing --out: {call}"

--- a/apps/jinn-agent/tests/plugins/test_jinn_distill_payoff.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_distill_payoff.py
@@ -1,0 +1,154 @@
+"""Payoff surface + discoverability (mono #1550, #1551).
+
+The join: $HERMES_HOME/skills/.usage.json (upstream sidecar, keyed by skill
+NAME) × .jinn-ref markers carrying a `local-distill:` ref. Sessions diff
+usage between start and end; each used distilled skill emits one ambient
+◇ line (cap 3). The invitation shows once, after the first install.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+jinn = importlib.import_module("plugins.jinn")
+distill = importlib.import_module("plugins.jinn.distill")
+skills_install = importlib.import_module("plugins.jinn.skills_install")
+
+
+@pytest.fixture(autouse=True)
+def isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    distill.reset()
+    yield
+    jinn._runner = None
+
+
+def _install_distilled(name: str, provenance_count: int = 2, use_count: int = 0) -> None:
+    d = skills_install.skills_dir() / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text(f"# {name}\n")
+    (d / ".jinn-ref").write_text(
+        json.dumps({"ref": f"local-distill:{name}", "provenance": [], "provenance_count": provenance_count}) + "\n"
+    )
+    _set_usage(name, use_count)
+
+
+def _set_usage(name: str, use_count: int) -> None:
+    usage_path = skills_install.skills_dir() / ".usage.json"
+    usage = json.loads(usage_path.read_text()) if usage_path.exists() else {}
+    usage[name] = {"use_count": use_count, "last_used_at": f"2026-07-10T12:00:0{use_count}.000Z"}
+    usage_path.parent.mkdir(parents=True, exist_ok=True)
+    usage_path.write_text(json.dumps(usage))
+
+
+def test_used_distilled_skill_emits_one_payoff_line():
+    _install_distilled("retry-backoff-patterns", provenance_count=2, use_count=1)
+    snapshot = distill.snapshot_usage()
+    _set_usage("retry-backoff-patterns", 2)
+    lines = distill.payoff_lines(snapshot)
+    assert len(lines) == 1
+    assert "retry-backoff-patterns" in lines[0]
+    assert "2" in lines[0], "how many of the operator's captures it came from"
+    assert lines[0].startswith("◇ skill used")
+
+
+def test_no_usage_delta_means_silence():
+    _install_distilled("retry-backoff-patterns", use_count=3)
+    snapshot = distill.snapshot_usage()
+    assert distill.payoff_lines(snapshot) == []
+
+
+def test_non_distilled_skills_are_ignored(tmp_path):
+    # A corpus-installed skill (different ref scheme) and a user skill (no marker).
+    d = skills_install.skills_dir() / "corpus-skill"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text("# corpus-skill\n")
+    (d / ".jinn-ref").write_text(json.dumps({"ref": "bafy-corpus-ref"}) + "\n")
+    u = skills_install.skills_dir() / "user-skill"
+    u.mkdir(parents=True, exist_ok=True)
+    (u / "SKILL.md").write_text("# user-skill\n")
+    snapshot = distill.snapshot_usage()
+    _set_usage("corpus-skill", 5)
+    _set_usage("user-skill", 5)
+    assert distill.payoff_lines(snapshot) == []
+
+
+def test_payoff_lines_cap_at_three():
+    for i in range(5):
+        _install_distilled(f"skill-{i}", use_count=0)
+    snapshot = distill.snapshot_usage()
+    for i in range(5):
+        _set_usage(f"skill-{i}", 1)
+    assert len(distill.payoff_lines(snapshot)) == 3
+
+
+def test_session_end_prints_payoff_lines(monkeypatch, capsys):
+    # No capture path in play: mode off, consent unset — the payoff lines
+    # print regardless (usage is the harness's own telemetry).
+    jinn._runner = lambda argv: (0, json.dumps({"mode": "off"})) if argv[1:3] == ["distill", "status"] else (0, "ok")
+    _install_distilled("retry-backoff-patterns", provenance_count=2, use_count=0)
+    jinn._on_session_start(session_id="s1")
+    _set_usage("retry-backoff-patterns", 1)
+    jinn._on_session_end(session_id="s1", task_id="t1", completed=True, interrupted=False)
+    err = capsys.readouterr().err
+    assert "◇ skill used" in err
+    assert "retry-backoff-patterns" in err
+
+
+def test_invitation_shows_once_after_first_install():
+    class InstallRunner:
+        def __call__(self, argv):
+            if argv[1:3] == ["distill", "staged"]:
+                return 0, json.dumps([{"name": "s1", "description": "d", "provenance": ["local-capture:a"]}])
+            if argv[1:3] == ["distill", "install"]:
+                out_dir = Path(argv[argv.index("--out") + 1])
+                (out_dir / "s1").mkdir(parents=True, exist_ok=True)
+                (out_dir / "s1" / "SKILL.md").write_text("# s1\n")
+                return 0, json.dumps({"installed": [{"name": "s1", "path": str(out_dir / "s1" / "SKILL.md")}]})
+            return 0, "ok"
+
+    jinn._runner = InstallRunner()
+    first = jinn._handle_jinn(command_args="distill install all", session_id="s", task_id="t")
+    assert "try" in first.lower(), "first install invites a similar task"
+    second = jinn._handle_jinn(command_args="distill install all", session_id="s", task_id="t")
+    assert "try" not in second.lower(), "the invitation is one-time"
+
+
+# ── Discoverability (#1551) ──────────────────────────────────────────────────
+
+
+def test_distill_skills_view_shows_usage():
+    _install_distilled("retry-backoff-patterns", provenance_count=2, use_count=4)
+
+    class StatusRunner:
+        def __call__(self, argv):
+            if argv[1:3] == ["distill", "status"]:
+                return 0, json.dumps({"mode": "local", "stagedCount": 1})
+            return 0, "ok"
+
+    jinn._runner = StatusRunner()
+    out = jinn._handle_jinn(command_args="distill skills", session_id="s", task_id="t")
+    assert "retry-backoff-patterns" in out
+    assert "4" in out, "use count is shown"
+    assert "1 staged" in out or "staged      1" in out.replace("\n", " ") or "staged 1" in out
+
+
+def test_jinn_status_includes_a_distill_line():
+    class StatusRunner:
+        def __call__(self, argv):
+            if argv[1:3] == ["distill", "status"]:
+                return 0, json.dumps({"mode": "defer", "uncoveredCount": 3, "capturesCount": 5, "stagedCount": 0, "installedCount": 0})
+            return 0, "ok"
+
+    jinn._runner = StatusRunner()
+    out = jinn._handle_jinn(command_args="status", session_id="s", task_id="t")
+    assert "distill" in out.lower()
+
+
+def test_tips_mention_distill():
+    tips = importlib.import_module("hermes_cli.tips")
+    assert any("/jinn distill" in tip for tip in tips._JINN_TIPS)


### PR DESCRIPTION
Closes #1550. Closes #1551. Parent epic #1486. **Stacked on #1549** (top of the stack); retarget as the stack merges.

## What

**Payoff (#1550)** — "see the distilled skills being used":
- Session start snapshots use counts for installed skills whose `.jinn-ref` carries a `local-distill:` ref (join key = skill name, matching the upstream `.usage.json` sidecar the native skill tools bump — read-only here).
- Session end diffs and prints `◇ skill used — <name> · distilled from N of your captures` per used skill (cap 3; silence when nothing was used; independent of capture/consent — usage is the harness's own telemetry; never raises into a session end).
- One-time invitation after the first install (`payoff_invited` seen-flag): run a task like the ones the skills came from.

**Discoverability (#1551)**:
- `/jinn distill skills` — the skillset view: per-skill use count, last used, provenance count, plus the staged count → review pointer.
- `/jinn status` gains a one-line distill summary (mode, uncovered captures, staged, installed).
- One `_JINN_TIPS` entry (tips.py is a JINN.md-owned file).

## Verification

TDD: 9 pytest cases first — payoff line on usage delta, silence on none, non-distilled skills ignored (corpus refs + markerless user skills), the cap, end-to-end session-start→end emission, one-time invitation, skills view with usage, status line, tip presence. Full jinn suite: 237 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)