### PR TITLE
fix(cli): only auto-open browser on jinn run's first-ever launch (#804)

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -10,9 +10,13 @@ Jinn protocol client. Runs a headless daemon that participates in the Jinn train
 Running `jinn run` opens a browser to `http://127.0.0.1:7331`
 with the operator panel — Status, Visibility (live event stream), Setup
 (bootstrap state machine), and an embedded Claude Code session in Auto Mode
-(when available).
+(when available). Auto-open only happens on the first-ever launch (tracked
+by a marker file), so restarting the daemon doesn't accumulate fresh
+browser tabs.
 
-To suppress auto-open: `jinn run --no-ui`.
+To force the panel open on a later launch: `jinn run --ui`.
+
+To suppress auto-open entirely: `jinn run --no-ui` (wins over `--ui`).
 
 To open the panel manually for an already-running daemon: `jinn ui`.
 

--- a/client/src/cli/commands/run.ts
+++ b/client/src/cli/commands/run.ts
@@ -127,7 +127,7 @@ export function createRunCommand(deps: RunDeps = PRODUCTION_DEPS): CommandModule
     name: 'run',
     summary: 'Start the daemon in the foreground; stops on SIGINT/SIGTERM',
     helpText: `Usage: jinn run [--human] [--config <path>] [--password-fd <fd>] [--no-ui]
-                [--no-daemon] [--funding-timeout <duration>] [--json-progress]
+                [--ui] [--no-daemon] [--funding-timeout <duration>] [--json-progress]
 
 Long-running. Starts the creator, harness, and delivery-watcher
 loops and runs until the process receives SIGINT or SIGTERM. Before
@@ -138,12 +138,18 @@ By default, stdout emits a single machine-readable startup record and
 all progress / runtime logs go to stderr. Use \`--human\` for a concise
 terminal summary instead.
 
-By default, the operator panel is opened in your default browser once the
-daemon's API server is up. Pass \`--no-ui\` to suppress this.
+The operator panel is only auto-opened in your default browser on the
+first-ever launch (tracked by a marker file), so restarting the daemon
+doesn't accumulate fresh browser tabs. Use \`jinn ui\` to reopen it any
+time. Pass \`--ui\` to force a browser open on this launch even after the
+first; pass \`--no-ui\` to suppress auto-open entirely — \`--no-ui\` wins
+if both are given.
 
 Flags:
   --human                Print a concise terminal summary instead of JSON.
-  --no-ui                Suppress automatic browser open (default: open the operator panel).
+  --no-ui                Suppress automatic browser open. Overrides --ui.
+  --ui                   Force the operator panel open even after the first
+                         launch (normally auto-open only happens once).
   --no-daemon            Stop after bootstrap completes; do not start daemon
                          loops. Emits a JSON summary on stdout and exits 0.
   --funding-timeout <d>  Bound the wait when the wallet needs funding. Accepts
@@ -156,6 +162,7 @@ Examples:
   jinn run
   jinn run --human
   jinn run --no-ui
+  jinn run --ui
   jinn run --no-daemon --json
   jinn run --funding-timeout 30m --json-progress
   printf '%s\n' secret | jinn run --password-fd 0
@@ -174,6 +181,7 @@ Failure example (funding gate):
           options: {
             ...COMMON_FLAGS,
             'no-ui': { type: 'boolean', default: false },
+            ui: { type: 'boolean', default: false },
             'no-daemon': { type: 'boolean', default: false },
             'funding-timeout': { type: 'string' },
             'json-progress': { type: 'boolean', default: false },
@@ -288,6 +296,13 @@ Failure example (funding gate):
       // can honour it. The flag itself stays for backwards compat.
       if (parsed.values['no-ui'] as boolean) {
         process.env['JINN_NO_UI'] = '1';
+      }
+
+      // Translate --ui into JINN_FORCE_UI so main() re-opens the browser even
+      // after the first-launch marker exists (issue #804). JINN_NO_UI still
+      // wins over this if both are set — see ui-auto-open-gate.ts.
+      if (parsed.values.ui as boolean) {
+        process.env['JINN_FORCE_UI'] = '1';
       }
 
       // Translate --funding-timeout into JINN_FUNDING_TIMEOUT_MS so main()'s

--- a/client/src/cli/ui-auto-open-gate.ts
+++ b/client/src/cli/ui-auto-open-gate.ts
@@ -1,0 +1,27 @@
+/**
+ * First-launch UI auto-open gate (issue #804).
+ *
+ * `jinn run` used to call `openBrowser()` unconditionally on every launch, so
+ * every restart during a dogfooding session opened a fresh browser tab and
+ * stale tabs accumulated. This predicate is the single source of truth for
+ * whether main.ts should auto-open the browser and/or write the "first
+ * launch happened" marker file this run.
+ *
+ * `noUi` (JINN_NO_UI=1 / `--no-ui`) wins outright over `forceUi` (JINN_FORCE_UI=1
+ * / `--ui`): headless mode never opens a browser and never writes the marker.
+ * Otherwise, open when forced or when the marker doesn't exist yet
+ * (first-ever launch); write the marker whenever it didn't already exist.
+ */
+export function decideUiAutoOpen(opts: {
+  noUi: boolean;
+  forceUi: boolean;
+  markerExists: boolean;
+}): { shouldOpen: boolean; shouldWriteMarker: boolean } {
+  if (opts.noUi) {
+    return { shouldOpen: false, shouldWriteMarker: false };
+  }
+  return {
+    shouldOpen: opts.forceUi || !opts.markerExists,
+    shouldWriteMarker: !opts.markerExists,
+  };
+}

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -35,6 +35,7 @@ import { CapturePublishUnavailableError } from './api/captures.js';
 import { invalidatePredictionOperatorStatusCache } from './api/gather-status.js';
 import type { LauncherGeneratorStateSnapshot } from './api/launcher-status.js';
 import { ensureUiToken } from './api/ui-token.js';
+import { decideUiAutoOpen } from './cli/ui-auto-open-gate.js';
 import { getFileLogger, closeFileLogger } from './observability/file-logger.js';
 import { emitProgress } from './observability/progress.js';
 import { hashImplStateDir } from './harnesses/freeze.js';
@@ -994,10 +995,28 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     `http://127.0.0.1:${setupApiServer.port}/?k=${handshakeKey}`;
   // Auto-open the operator panel as soon as the setup-mode API is up so the
   // operator can watch bootstrap progress (including the funding wait, which
-  // is the whole point of starting the API early). Suppressed by setting
-  // JINN_NO_UI=1 — `jinn run --no-ui` translates the flag into this env var.
-  if (process.env['JINN_NO_UI'] !== '1') {
+  // is the whole point of starting the API early). Only on the first-ever
+  // launch (tracked by a marker file) — otherwise every restart during a
+  // dogfooding session opens a fresh browser tab and stale tabs accumulate
+  // (issue #804). `jinn run --no-ui` / JINN_NO_UI=1 always suppresses;
+  // `jinn run --ui` / JINN_FORCE_UI=1 forces a reopen even past first launch.
+  const uiOpenedMarkerPath = join(config.earningDir, '.ui-opened');
+  const uiAutoOpenDecision = decideUiAutoOpen({
+    noUi: process.env['JINN_NO_UI'] === '1',
+    forceUi: process.env['JINN_FORCE_UI'] === '1',
+    markerExists: existsSync(uiOpenedMarkerPath),
+  });
+  if (uiAutoOpenDecision.shouldOpen) {
     openBrowser(process.env['JINN_UI_HANDSHAKE_URL']!);
+  } else if (process.env['JINN_NO_UI'] !== '1') {
+    console.log(
+      `[main] Dashboard ready at http://127.0.0.1:${setupApiServer.port} — ` +
+        `run 'jinn ui' to open it (auto-open suppressed after first launch; use --ui to force)`,
+    );
+  }
+  if (uiAutoOpenDecision.shouldWriteMarker) {
+    mkdirSync(dirname(uiOpenedMarkerPath), { recursive: true });
+    writeFileSyncMain(uiOpenedMarkerPath, new Date().toISOString() + '\n');
   }
   console.log(
     `[main] Setup-mode API up (mode=${setupController.mode()}). ` +

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1001,22 +1001,31 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
   // (issue #804). `jinn run --no-ui` / JINN_NO_UI=1 always suppresses;
   // `jinn run --ui` / JINN_FORCE_UI=1 forces a reopen even past first launch.
   const uiOpenedMarkerPath = join(config.earningDir, '.ui-opened');
+  const noUi = process.env['JINN_NO_UI'] === '1';
+  const forceUi = process.env['JINN_FORCE_UI'] === '1';
   const uiAutoOpenDecision = decideUiAutoOpen({
-    noUi: process.env['JINN_NO_UI'] === '1',
-    forceUi: process.env['JINN_FORCE_UI'] === '1',
+    noUi,
+    forceUi,
     markerExists: existsSync(uiOpenedMarkerPath),
   });
   if (uiAutoOpenDecision.shouldOpen) {
     openBrowser(process.env['JINN_UI_HANDSHAKE_URL']!);
-  } else if (process.env['JINN_NO_UI'] !== '1') {
+  } else if (!noUi) {
     console.log(
       `[main] Dashboard ready at http://127.0.0.1:${setupApiServer.port} — ` +
         `run 'jinn ui' to open it (auto-open suppressed after first launch; use --ui to force)`,
     );
   }
   if (uiAutoOpenDecision.shouldWriteMarker) {
-    mkdirSync(dirname(uiOpenedMarkerPath), { recursive: true });
-    writeFileSyncMain(uiOpenedMarkerPath, new Date().toISOString() + '\n');
+    try {
+      mkdirSync(dirname(uiOpenedMarkerPath), { recursive: true });
+      writeFileSyncMain(uiOpenedMarkerPath, new Date().toISOString() + '\n');
+    } catch (err) {
+      console.warn(
+        `[main] Failed to write UI-opened marker at ${uiOpenedMarkerPath}: ` +
+          (err instanceof Error ? err.message : String(err)),
+      );
+    }
   }
   console.log(
     `[main] Setup-mode API up (mode=${setupController.mode()}). ` +

--- a/client/test/cli/run-no-ui.test.ts
+++ b/client/test/cli/run-no-ui.test.ts
@@ -75,6 +75,44 @@ describe('jinn run --no-ui', () => {
   });
 });
 
+describe('jinn run --ui (issue #804)', () => {
+  const FORCE_UI_KEY = 'JINN_FORCE_UI' as const;
+  let snapshot: string | undefined;
+  beforeEach(() => {
+    snapshot = process.env[FORCE_UI_KEY];
+    delete process.env[FORCE_UI_KEY];
+  });
+  afterEach(() => {
+    if (snapshot === undefined) delete process.env[FORCE_UI_KEY];
+    else process.env[FORCE_UI_KEY] = snapshot;
+  });
+
+  it('--ui sets JINN_FORCE_UI=1', async () => {
+    const fakeDeps = makeFakeDeps();
+    const run = createRunCommand(fakeDeps);
+    const { ctx, exits } = makeCommandCtx({
+      argv: ['--ui', '--json'],
+      env: { JINN_PASSWORD: 'test' },
+    });
+    await run.run(ctx);
+    expect(exits).not.toContain(11);
+    expect(process.env['JINN_FORCE_UI']).toBe('1');
+    expect(fakeDeps.mainFn).toHaveBeenCalled();
+  });
+
+  it('without --ui, JINN_FORCE_UI is not set', async () => {
+    const fakeDeps = makeFakeDeps();
+    const run = createRunCommand(fakeDeps);
+    const { ctx, exits } = makeCommandCtx({
+      argv: ['--json'],
+      env: { JINN_PASSWORD: 'test' },
+    });
+    await run.run(ctx);
+    expect(exits).not.toContain(11);
+    expect(process.env['JINN_FORCE_UI']).toBeUndefined();
+  });
+});
+
 describe('jinn run flags (A4 quickstart parity)', () => {
   // Snapshot + restore the env vars these tests mutate via process.env.
   // run.ts's translation block writes JINN_FUNDING_TIMEOUT_MS / JINN_NO_DAEMON
@@ -84,6 +122,7 @@ describe('jinn run flags (A4 quickstart parity)', () => {
     'JINN_NO_DAEMON',
     'JINN_JSON_PROGRESS',
     'JINN_NO_UI',
+    'JINN_FORCE_UI',
   ] as const;
   const snapshot: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
   beforeEach(() => {

--- a/client/test/cli/ui-auto-open-gate.test.ts
+++ b/client/test/cli/ui-auto-open-gate.test.ts
@@ -10,10 +10,10 @@
  * Rules:
  *  - `noUi` (JINN_NO_UI=1) wins outright: never open, never write the marker.
  *  - Otherwise open when forced (`--ui`) or when the marker doesn't exist yet
- *    (first-ever launch).
- *  - Write the marker whenever it didn't already exist (so the first launch
- *    is recorded even under a headless / no-ui run, and every later run sees
- *    an existing marker).
+ *    (first-ever launch); write the marker whenever it didn't already exist.
+ *  - Because `noUi` short-circuits before the marker is considered, a run
+ *    under JINN_NO_UI=1 never writes it — a later non-headless run still
+ *    counts as first-ever and opens once.
  */
 import { describe, it, expect } from 'vitest';
 import { decideUiAutoOpen } from '../../src/cli/ui-auto-open-gate.js';

--- a/client/test/cli/ui-auto-open-gate.test.ts
+++ b/client/test/cli/ui-auto-open-gate.test.ts
@@ -1,0 +1,66 @@
+/**
+ * First-launch UI auto-open gate (issue #804).
+ *
+ * `jinn run` used to call `openBrowser()` unconditionally on every launch,
+ * so every restart during a dogfooding session opened a fresh browser tab
+ * and stale tabs accumulated. `decideUiAutoOpen()` is the single source of
+ * truth for whether main.ts should auto-open the browser and/or write the
+ * "first launch happened" marker file this run.
+ *
+ * Rules:
+ *  - `noUi` (JINN_NO_UI=1) wins outright: never open, never write the marker.
+ *  - Otherwise open when forced (`--ui`) or when the marker doesn't exist yet
+ *    (first-ever launch).
+ *  - Write the marker whenever it didn't already exist (so the first launch
+ *    is recorded even under a headless / no-ui run, and every later run sees
+ *    an existing marker).
+ */
+import { describe, it, expect } from 'vitest';
+import { decideUiAutoOpen } from '../../src/cli/ui-auto-open-gate.js';
+
+describe('decideUiAutoOpen', () => {
+  it('first-ever launch (no marker, no flags): opens and writes the marker', () => {
+    expect(
+      decideUiAutoOpen({ noUi: false, forceUi: false, markerExists: false }),
+    ).toEqual({ shouldOpen: true, shouldWriteMarker: true });
+  });
+
+  it('subsequent launch (marker present, no flags): does NOT open — the bug fix', () => {
+    expect(
+      decideUiAutoOpen({ noUi: false, forceUi: false, markerExists: true }),
+    ).toEqual({ shouldOpen: false, shouldWriteMarker: false });
+  });
+
+  it('--ui forces open even when the marker is present', () => {
+    expect(
+      decideUiAutoOpen({ noUi: false, forceUi: true, markerExists: true }),
+    ).toEqual({ shouldOpen: true, shouldWriteMarker: false });
+  });
+
+  it('--ui on a first-ever launch still opens and writes the marker', () => {
+    expect(
+      decideUiAutoOpen({ noUi: false, forceUi: true, markerExists: false }),
+    ).toEqual({ shouldOpen: true, shouldWriteMarker: true });
+  });
+
+  it('JINN_NO_UI=1 suppresses open on first-ever launch and does not write the marker', () => {
+    expect(
+      decideUiAutoOpen({ noUi: true, forceUi: false, markerExists: false }),
+    ).toEqual({ shouldOpen: false, shouldWriteMarker: false });
+  });
+
+  it('JINN_NO_UI=1 suppresses open on a later launch too', () => {
+    expect(
+      decideUiAutoOpen({ noUi: true, forceUi: false, markerExists: true }),
+    ).toEqual({ shouldOpen: false, shouldWriteMarker: false });
+  });
+
+  it('JINN_NO_UI=1 wins over --ui (no-ui overrides force-ui)', () => {
+    expect(
+      decideUiAutoOpen({ noUi: true, forceUi: true, markerExists: false }),
+    ).toEqual({ shouldOpen: false, shouldWriteMarker: false });
+    expect(
+      decideUiAutoOpen({ noUi: true, forceUi: true, markerExists: true }),
+    ).toEqual({ shouldOpen: false, shouldWriteMarker: false });
+  });
+});


### PR DESCRIPTION
## Summary

`jinn run` unconditionally called `openBrowser(handshakeUrl)` on every launch, so every daemon restart during a dogfooding session opened another browser tab; stale tabs (dead per-launch `?k=` handshake keys) accumulate and silently 401 with no signal which tab is live (#804).

This change gates auto-open behind a first-launch marker:

- New pure decision function `client/src/cli/ui-auto-open-gate.ts` — `decideUiAutoOpen({ noUi, forceUi, markerExists })`. `JINN_NO_UI=1` wins outright; otherwise open on first-ever launch (no marker) or when forced.
- `client/src/main.ts` writes marker `<earningDir>/.ui-opened` on first launch (try/catch-guarded — a failed write never blocks startup) and, when auto-open is suppressed, logs a one-line hint pointing at `jinn ui` / `--ui`.
- New `jinn run --ui` flag (`JINN_FORCE_UI=1`) force-opens regardless of the marker. `--no-ui` still overrides everything.
- `jinn ui`, `open-browser.ts`, and UI-token persistence are untouched — the persisted `jinn_ui_token` cookie is why existing tabs keep working across restarts, and `jinn ui` remains the deliberate reopen path.

Trade-offs accepted (per issue's recommended smallest fix): if the operator closes all tabs, auto-open does not resume — `jinn ui` or `--ui` is the reopen path. Marker is scoped per `earningDir` (per operator identity). Known narrow edge: two concurrent first launches sharing an `earningDir` can each open a tab (TOCTOU on the marker); accepted as out of scope.

## Test plan

- Regression test first (TDD): `client/test/cli/ui-auto-open-gate.test.ts` — full `noUi × forceUi × markerExists` truth table (8/8 combinations), including the exact bug scenario (marker present → no auto-open).
- `client/test/cli/run-no-ui.test.ts` — `--ui` → `JINN_FORCE_UI=1` flag translation, alongside existing `--no-ui` coverage.
- `yarn typecheck`, full `yarn test`, and `yarn build` green locally.
- Independent review: APPROVE, all 7 acceptance criteria verified. Security review: no findings. Non-blocking follow-up noted by review: no integration test exercises the `main.ts` wiring block itself (pure gate + flag translation are covered).

Closes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)