### PR TITLE
fix(daemon): successful on-chain deliveries persisted as FAILED due to desired_state_id NOT NULL constraint

### DIFF
--- a/client/src/cli/commands/backfill-failed-deliveries.ts
+++ b/client/src/cli/commands/backfill-failed-deliveries.ts
@@ -7,16 +7,23 @@
  * the legacy `artifacts.desired_state_id NOT NULL` column (fixed in #511,
  * commit 65de316e8). The engine's error-classification catch turned that
  * throw into a FAILED run even though the on-chain delivery had already
- * landed. This command scans historical FAILED rows, checks each recorded
- * `deliveryTxHash`'s receipt, and reclassifies the ones whose delivery
- * succeeded. No wallet/password is required — this only reads chain state
- * and writes to the local SQLite DB.
+ * landed. This command scans historical FAILED rows whose `failureReason`
+ * carries the `artifacts.desired_state_id` constraint signature, checks
+ * each candidate's recorded `deliveryTxHash` receipt as secondary
+ * confirmation, and reclassifies the ones whose delivery succeeded.
+ * `deliveryTxHash` + a successful receipt alone is NOT sufficient grounds —
+ * see the scoping note in the harness module below. No wallet/password is
+ * required — this only reads chain state and writes to the local SQLite DB.
+ *
+ * Caveat: reclassified rows have no `artifacts` row and no ERC-8004
+ * metadata anchor (that write is exactly what failed) — this command does
+ * not reconstruct either, it only corrects `task_runs.state`.
  *
  * See `client/src/harnesses/engine/backfill-failed-deliveries.ts` and
  * `client/src/harnesses/engine/persistence.ts#reclassifyFailedAsComplete`.
  */
 
-import type { CommandContext, CommandModule } from '../command.js';
+import type { BaseCommandDeps, CommandContext, CommandModule } from '../command.js';
 import { COMMON_FLAGS, parseCommandArgs } from '../command.js';
 import { emitResult } from '../output.js';
 import { emitEnvelope } from '../../errors/envelope.js';
@@ -41,8 +48,8 @@ function humanResult(payload: BackfillFailedDeliveriesResult & { dryRun: boolean
     payload.dryRun ? 'Failed-delivery backfill (dry run) complete.' : 'Failed-delivery backfill complete.',
   ];
   lines.push(`  reclassified: ${payload.reclassified.length}`);
-  for (const requestId of payload.reclassified) {
-    lines.push(`    ${requestId}`);
+  for (const r of payload.reclassified) {
+    lines.push(`    ${r.requestId} — was: ${r.originalFailureReason ?? '(no failure reason recorded)'}`);
   }
   lines.push(`  skipped:      ${payload.skipped.length}`);
   for (const s of payload.skipped) {
@@ -75,9 +82,7 @@ async function defaultRunBackfill(
   }
 }
 
-export interface BackfillFailedDeliveriesCommandDeps {
-  loadConfig: typeof defaultLoadConfig;
-  getConfigPathFromArgs: typeof defaultGetConfigPathFromArgs;
+export interface BackfillFailedDeliveriesCommandDeps extends BaseCommandDeps {
   runBackfill: typeof defaultRunBackfill;
 }
 
@@ -178,11 +183,18 @@ export function createBackfillFailedDeliveriesCommand(
     summary: 'Reclassify FAILED runs as COMPLETE when their delivery tx actually succeeded (#506)',
     helpText: `Usage: jinn backfill-failed-deliveries [--dry-run] [--human] [--config <path>]
 
-Scans FAILED task_runs for a recorded deliveryTxHash, checks its on-chain
-receipt, and reclassifies rows whose delivery transaction succeeded as
-COMPLETE. Rows with no deliveryTxHash, a reverted receipt, or an RPC error
-are left FAILED and reported separately. Idempotent — already-COMPLETE rows
-are never touched, and re-running finds nothing left to reclassify.
+Scans FAILED task_runs whose failure reason matches the #506
+artifacts.desired_state_id constraint signature, checks each candidate's
+recorded deliveryTxHash receipt as secondary confirmation, and reclassifies
+rows whose delivery transaction succeeded as COMPLETE. Rows with a
+non-matching failure reason, no deliveryTxHash, a reverted receipt, or an
+RPC error are left FAILED and reported separately. Idempotent —
+already-COMPLETE rows are never touched, and re-running finds nothing left
+to reclassify.
+
+Reclassified rows have no artifacts row and no ERC-8004 metadata anchor
+(that write is exactly what failed) — this command does not reconstruct
+either, it only corrects task_runs.state.
 
 No wallet or password is required.
 

--- a/client/src/cli/commands/backfill-failed-deliveries.ts
+++ b/client/src/cli/commands/backfill-failed-deliveries.ts
@@ -1,0 +1,198 @@
+/**
+ * `jinn backfill-failed-deliveries` — reclassify FAILED task_runs as
+ * COMPLETE when their on-chain delivery transaction actually succeeded
+ * (#506).
+ *
+ * Background: `insertArtifact()` used to throw on databases still carrying
+ * the legacy `artifacts.desired_state_id NOT NULL` column (fixed in #511,
+ * commit 65de316e8). The engine's error-classification catch turned that
+ * throw into a FAILED run even though the on-chain delivery had already
+ * landed. This command scans historical FAILED rows, checks each recorded
+ * `deliveryTxHash`'s receipt, and reclassifies the ones whose delivery
+ * succeeded. No wallet/password is required — this only reads chain state
+ * and writes to the local SQLite DB.
+ *
+ * See `client/src/harnesses/engine/backfill-failed-deliveries.ts` and
+ * `client/src/harnesses/engine/persistence.ts#reclassifyFailedAsComplete`.
+ */
+
+import type { CommandContext, CommandModule } from '../command.js';
+import { COMMON_FLAGS, parseCommandArgs } from '../command.js';
+import { emitResult } from '../output.js';
+import { emitEnvelope } from '../../errors/envelope.js';
+import {
+  loadConfig as defaultLoadConfig,
+  getConfigPathFromArgs as defaultGetConfigPathFromArgs,
+} from '../../config.js';
+import { Store } from '../../store/store.js';
+import { TaskRunPersistence } from '../../harnesses/engine/persistence.js';
+import {
+  backfillFailedDeliveries as defaultBackfillFailedDeliveries,
+  type BackfillFailedDeliveriesResult,
+} from '../../harnesses/engine/backfill-failed-deliveries.js';
+import { createJinnPublicClient, type JinnOnchainNetwork } from '../../earning/viem-clients.js';
+
+function envelopeDebug(env: NodeJS.ProcessEnv): boolean {
+  return env['JINN_DEBUG'] === '1';
+}
+
+function humanResult(payload: BackfillFailedDeliveriesResult & { dryRun: boolean }): string {
+  const lines: string[] = [
+    payload.dryRun ? 'Failed-delivery backfill (dry run) complete.' : 'Failed-delivery backfill complete.',
+  ];
+  lines.push(`  reclassified: ${payload.reclassified.length}`);
+  for (const requestId of payload.reclassified) {
+    lines.push(`    ${requestId}`);
+  }
+  lines.push(`  skipped:      ${payload.skipped.length}`);
+  for (const s of payload.skipped) {
+    lines.push(`    ${s.requestId} — ${s.reason}`);
+  }
+  lines.push(`  failed:       ${payload.failed.length}`);
+  for (const f of payload.failed) {
+    lines.push(`    ${f.requestId} — ${f.error}`);
+  }
+  return lines.join('\n');
+}
+
+export interface RunBackfillFailedDeliveriesArgs {
+  dbPath: string;
+  rpcUrls: readonly string[];
+  network: JinnOnchainNetwork;
+  dryRun: boolean;
+}
+
+async function defaultRunBackfill(
+  args: RunBackfillFailedDeliveriesArgs,
+): Promise<BackfillFailedDeliveriesResult> {
+  const store = new Store(args.dbPath);
+  try {
+    const persistence = new TaskRunPersistence(store.db);
+    const publicClient = createJinnPublicClient(args.rpcUrls, args.network);
+    return await defaultBackfillFailedDeliveries({ persistence, publicClient, dryRun: args.dryRun });
+  } finally {
+    store.close();
+  }
+}
+
+export interface BackfillFailedDeliveriesCommandDeps {
+  loadConfig: typeof defaultLoadConfig;
+  getConfigPathFromArgs: typeof defaultGetConfigPathFromArgs;
+  runBackfill: typeof defaultRunBackfill;
+}
+
+const PRODUCTION_DEPS: BackfillFailedDeliveriesCommandDeps = {
+  loadConfig: defaultLoadConfig,
+  getConfigPathFromArgs: defaultGetConfigPathFromArgs,
+  runBackfill: defaultRunBackfill,
+};
+
+export function createBackfillFailedDeliveriesCommand(
+  deps: BackfillFailedDeliveriesCommandDeps = PRODUCTION_DEPS,
+): CommandModule {
+  async function run(ctx: CommandContext): Promise<void> {
+    let json = false;
+    let human = false;
+    let configPath: string | undefined;
+    let dryRun = false;
+
+    try {
+      const parsed = parseCommandArgs(ctx.argv, {
+        ...COMMON_FLAGS,
+        'dry-run': { type: 'boolean' as const, default: false },
+      });
+      json = Boolean(parsed.values.json);
+      human = Boolean(parsed.values.human);
+      dryRun = Boolean(parsed.values['dry-run']);
+      configPath =
+        typeof parsed.values.config === 'string' && parsed.values.config.length > 0
+          ? parsed.values.config
+          : undefined;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      emitEnvelope(
+        {
+          code: 'invalid_invocation',
+          message: 'Invalid command-line arguments.',
+          hint: 'Run `jinn backfill-failed-deliveries --help` for supported flags.',
+          exampleCli: 'jinn backfill-failed-deliveries --dry-run --json',
+          details: { field: 'argv', expected: message },
+        },
+        { writer: ctx.writer, exit: ctx.exit },
+      );
+      return;
+    }
+
+    const config = deps.loadConfig(configPath);
+    const network: JinnOnchainNetwork = config.network === 'testnet' ? 'base-sepolia' : 'base';
+
+    let result: BackfillFailedDeliveriesResult;
+    try {
+      result = await deps.runBackfill({
+        dbPath: config.dbPath,
+        rpcUrls: config.rpcUrls,
+        network,
+        dryRun,
+      });
+    } catch (err) {
+      const cause = err instanceof Error ? err.message : String(err);
+      const details: Record<string, unknown> = { cause };
+      if (envelopeDebug(ctx.env) && err instanceof Error && err.stack) {
+        details.stack = err.stack;
+      }
+      emitEnvelope(
+        {
+          code: 'fatal',
+          message:
+            err instanceof Error && err.message.trim().length > 0
+              ? err.message
+              : 'Failed-delivery backfill failed with an unexpected error.',
+          details,
+        },
+        { writer: ctx.writer, exit: ctx.exit },
+      );
+      return;
+    }
+
+    const payload = {
+      schemaVersion: 1 as const,
+      generatedAt: new Date().toISOString(),
+      dryRun,
+      reclassified: result.reclassified,
+      skipped: result.skipped,
+      failed: result.failed,
+    };
+
+    emitResult(payload, (v) => humanResult(v as typeof payload), {
+      json,
+      human,
+      writer: ctx.writer,
+      stdoutIsTty: ctx.stdoutIsTty,
+      noColor: Boolean(ctx.env['NO_COLOR']),
+    });
+    ctx.exit(0);
+  }
+
+  return {
+    name: 'backfill-failed-deliveries',
+    summary: 'Reclassify FAILED runs as COMPLETE when their delivery tx actually succeeded (#506)',
+    helpText: `Usage: jinn backfill-failed-deliveries [--dry-run] [--human] [--config <path>]
+
+Scans FAILED task_runs for a recorded deliveryTxHash, checks its on-chain
+receipt, and reclassifies rows whose delivery transaction succeeded as
+COMPLETE. Rows with no deliveryTxHash, a reverted receipt, or an RPC error
+are left FAILED and reported separately. Idempotent — already-COMPLETE rows
+are never touched, and re-running finds nothing left to reclassify.
+
+No wallet or password is required.
+
+Examples:
+  jinn backfill-failed-deliveries --dry-run
+  jinn backfill-failed-deliveries --json
+`,
+    run,
+  };
+}
+
+const command: CommandModule = createBackfillFailedDeliveriesCommand();
+export default command;

--- a/client/src/cli/index.ts
+++ b/client/src/cli/index.ts
@@ -35,6 +35,7 @@ import keysCommand from './commands/keys-backup.js';
 import updateCommand from './commands/update.js';
 import mcpCommand from './commands/mcp.js';
 import migrateAgentIdCommand from './commands/migrate-agent-id.js';
+import backfillFailedDeliveriesCommand from './commands/backfill-failed-deliveries.js';
 import conformanceCommand from './commands/conformance.js';
 import createCommand from './commands/create.js';
 import uiCommand from './commands/ui.js';
@@ -71,6 +72,7 @@ const COMMANDS: CommandModule[] = [
   updateCommand,
   mcpCommand,
   migrateAgentIdCommand,
+  backfillFailedDeliveriesCommand,
   conformanceCommand,
   createCommand,
   uiCommand,

--- a/client/src/harnesses/engine/backfill-failed-deliveries.ts
+++ b/client/src/harnesses/engine/backfill-failed-deliveries.ts
@@ -1,0 +1,77 @@
+/**
+ * Administrative backfill (#506): scan FAILED task_runs for ones whose
+ * delivery transaction actually landed on-chain and reclassify them as
+ * COMPLETE.
+ *
+ * Background: `insertArtifact()` used to throw on databases still carrying
+ * the legacy `artifacts.desired_state_id NOT NULL` column (fixed in #511).
+ * The engine's error path (`_runTransition` catch → `_classifyAndMarkTerminal`
+ * → `markFailed()`) turned that throw into a FAILED run even though the
+ * on-chain delivery — the thing that actually matters for reward eligibility
+ * — had already succeeded. This backfill corrects the historical DB rows
+ * left behind by that bug; it does not change any live engine behaviour.
+ */
+
+import type { PublicClient } from 'viem';
+import { TaskRunPersistence } from './persistence.js';
+import { TaskRunState } from './state.js';
+
+export interface BackfillFailedDeliveriesDeps {
+  persistence: TaskRunPersistence;
+  /** Only `.getTransactionReceipt` is used. */
+  publicClient: PublicClient;
+  /** When true, report what would be reclassified without writing to the DB. Default false. */
+  dryRun?: boolean;
+}
+
+export interface BackfillFailedDeliveriesResult {
+  /** Request IDs reclassified FAILED → COMPLETE (or that would be, under dryRun). */
+  reclassified: string[];
+  /** Request IDs left FAILED because their delivery didn't succeed (or has no tx hash). */
+  skipped: Array<{ requestId: string; reason: string }>;
+  /** Request IDs whose receipt lookup errored — left FAILED, not retried within this run. */
+  failed: Array<{ requestId: string; error: string }>;
+}
+
+export async function backfillFailedDeliveries(
+  deps: BackfillFailedDeliveriesDeps,
+): Promise<BackfillFailedDeliveriesResult> {
+  const { persistence, publicClient, dryRun = false } = deps;
+  const result: BackfillFailedDeliveriesResult = { reclassified: [], skipped: [], failed: [] };
+
+  const failedRuns = persistence.getByState(TaskRunState.FAILED);
+  for (const run of failedRuns) {
+    if (!run.deliveryTxHash) {
+      result.skipped.push({ requestId: run.requestId, reason: 'no deliveryTxHash recorded' });
+      continue;
+    }
+
+    let receipt;
+    try {
+      receipt = await publicClient.getTransactionReceipt({
+        hash: run.deliveryTxHash as `0x${string}`,
+      });
+    } catch (err) {
+      result.failed.push({
+        requestId: run.requestId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      continue;
+    }
+
+    if (receipt.status !== 'success') {
+      result.skipped.push({
+        requestId: run.requestId,
+        reason: `delivery tx did not succeed (status=${receipt.status})`,
+      });
+      continue;
+    }
+
+    if (!dryRun) {
+      persistence.reclassifyFailedAsComplete(run.requestId);
+    }
+    result.reclassified.push(run.requestId);
+  }
+
+  return result;
+}

--- a/client/src/harnesses/engine/backfill-failed-deliveries.ts
+++ b/client/src/harnesses/engine/backfill-failed-deliveries.ts
@@ -9,12 +9,42 @@
  * → `markFailed()`) turned that throw into a FAILED run even though the
  * on-chain delivery — the thing that actually matters for reward eligibility
  * — had already succeeded. This backfill corrects the historical DB rows
- * left behind by that bug; it does not change any live engine behaviour.
+ * left behind by that bug; it does not change any live engine behavior.
+ *
+ * Scope: a FAILED row is only a reclassification candidate when its
+ * `failureReason` carries the `artifacts.desired_state_id` NOT NULL
+ * constraint signature (see `DESIRED_STATE_ID_FAILURE_SIGNATURE` below).
+ * A `deliveryTxHash` + successful receipt alone is NOT sufficient — the
+ * daemon persists `deliveryTxHash` after `deliverToMarketplace` lands but
+ * *before* `claimDelivery` runs (crash-recovery design, see
+ * `client/src/harnesses/engine/delivery.ts`), so a row that genuinely failed
+ * at the `claimDelivery` step also carries a `deliveryTxHash` with a
+ * successful receipt — reclassifying it would hide a real failure. The
+ * receipt check below is a secondary confirmation, applied only after the
+ * failure-reason signature already narrows the candidate set to the #506
+ * bug.
+ *
+ * Caveat: because the failure in every #506 case happened at the
+ * `insertArtifact()` step, reclassified rows have no corresponding
+ * `artifacts` row and no ERC-8004 on-chain metadata anchor — that write is
+ * exactly what failed. This backfill does not attempt to reconstruct either;
+ * it only corrects `task_runs.state`.
  */
 
 import type { PublicClient } from 'viem';
 import { TaskRunPersistence } from './persistence.js';
 import { TaskRunState } from './state.js';
+
+/**
+ * Substring present in every `failureReason` produced by the #506 bug.
+ * The raw SqliteError message is exactly
+ * `NOT NULL constraint failed: artifacts.desired_state_id`; `markFailed`
+ * persists it verbatim when invoked from `_runTransition`'s 'transition'
+ * context, or prefixed with `recovery: ` when invoked from the 'recovery'
+ * context (see `_classifyAndMarkTerminal` in engine.ts). This substring
+ * survives both forms.
+ */
+const DESIRED_STATE_ID_FAILURE_SIGNATURE = 'artifacts.desired_state_id';
 
 export interface BackfillFailedDeliveriesDeps {
   persistence: TaskRunPersistence;
@@ -25,9 +55,9 @@ export interface BackfillFailedDeliveriesDeps {
 }
 
 export interface BackfillFailedDeliveriesResult {
-  /** Request IDs reclassified FAILED → COMPLETE (or that would be, under dryRun). */
-  reclassified: string[];
-  /** Request IDs left FAILED because their delivery didn't succeed (or has no tx hash). */
+  /** Rows reclassified FAILED → COMPLETE (or that would be, under dryRun). */
+  reclassified: Array<{ requestId: string; originalFailureReason: string | null }>;
+  /** Request IDs left FAILED because they aren't #506 candidates, or their delivery didn't succeed. */
   skipped: Array<{ requestId: string; reason: string }>;
   /** Request IDs whose receipt lookup errored — left FAILED, not retried within this run. */
   failed: Array<{ requestId: string; error: string }>;
@@ -41,6 +71,14 @@ export async function backfillFailedDeliveries(
 
   const failedRuns = persistence.getByState(TaskRunState.FAILED);
   for (const run of failedRuns) {
+    if (!run.failureReason || !run.failureReason.includes(DESIRED_STATE_ID_FAILURE_SIGNATURE)) {
+      result.skipped.push({
+        requestId: run.requestId,
+        reason: 'failure reason does not match the desired_state_id constraint signature',
+      });
+      continue;
+    }
+
     if (!run.deliveryTxHash) {
       result.skipped.push({ requestId: run.requestId, reason: 'no deliveryTxHash recorded' });
       continue;
@@ -67,10 +105,17 @@ export async function backfillFailedDeliveries(
       continue;
     }
 
-    if (!dryRun) {
-      persistence.reclassifyFailedAsComplete(run.requestId);
+    if (dryRun) {
+      result.reclassified.push({ requestId: run.requestId, originalFailureReason: run.failureReason });
+      continue;
     }
-    result.reclassified.push(run.requestId);
+
+    const wrote = persistence.reclassifyFailedAsComplete(run.requestId);
+    if (wrote) {
+      result.reclassified.push({ requestId: run.requestId, originalFailureReason: run.failureReason });
+    } else {
+      result.skipped.push({ requestId: run.requestId, reason: 'row state changed concurrently' });
+    }
   }
 
   return result;

--- a/client/src/harnesses/engine/persistence.ts
+++ b/client/src/harnesses/engine/persistence.ts
@@ -741,6 +741,32 @@ export class TaskRunPersistence {
   }
 
   /**
+   * Administrative backfill (#506): reclassify a FAILED row as COMPLETE when
+   * its on-chain delivery actually landed — the run failed only because a
+   * downstream persistence step (e.g. the legacy `desired_state_id` NOT NULL
+   * insertArtifact throw, fixed in #511) threw after the delivery tx was
+   * already broadcast and confirmed.
+   *
+   * Deliberately bypasses `assertValidTransition` — there is no FAILED →
+   * COMPLETE edge in the state machine, and there shouldn't be one; this is
+   * an out-of-band operator-invoked correction driven by on-chain evidence
+   * (a successful transaction receipt), not a transition the engine itself
+   * would ever perform. Idempotent: returns `false` and makes no change if
+   * the row is missing or not currently FAILED.
+   */
+  reclassifyFailedAsComplete(requestId: string): boolean {
+    const existing = this.getByRequestId(requestId);
+    if (!existing || existing.state !== 'FAILED') return false;
+    const now = Date.now();
+    const result = this.db.prepare(`
+      UPDATE task_runs
+      SET state = 'COMPLETE', state_updated_at = ?, failure_reason = NULL, failure_at = NULL
+      WHERE request_id = ? AND state = 'FAILED'
+    `).run(now, requestId);
+    return result.changes > 0;
+  }
+
+  /**
    * Mark a task RACE_LOST with a reason (valid from any non-terminal state).
    * Peer to `markFailed`, semantically distinct: the run never produced
    * operator-attributable work — another operator pruned the on-chain slot

--- a/client/test/cli/commands/backfill-failed-deliveries.test.ts
+++ b/client/test/cli/commands/backfill-failed-deliveries.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createBackfillFailedDeliveriesCommand,
+  type BackfillFailedDeliveriesCommandDeps,
+} from '../../../src/cli/commands/backfill-failed-deliveries.js';
+import type { CommandContext } from '../../../src/cli/command.js';
+
+function makeCommandCtx(opts: { argv?: string[]; env?: NodeJS.ProcessEnv } = {}): {
+  ctx: CommandContext;
+  writes: string[];
+  exits: number[];
+} {
+  const writes: string[] = [];
+  const exits: number[] = [];
+  const ctx: CommandContext = {
+    argv: opts.argv ?? [],
+    stdoutIsTty: false,
+    writer: { write: (s: string) => { writes.push(s); return true; } },
+    exit: (code: number) => { exits.push(code); },
+    env: opts.env ?? {},
+  };
+  return { ctx, writes, exits };
+}
+
+const defaultConfig = {
+  dbPath: '/tmp/jinn.db',
+  network: 'testnet',
+  rpcUrl: 'http://127.0.0.1:8545',
+  rpcUrls: ['http://127.0.0.1:8545'],
+};
+
+interface FakeDepsOverrides {
+  backfillResult?: {
+    reclassified: string[];
+    skipped: Array<{ requestId: string; reason: string }>;
+    failed: Array<{ requestId: string; error: string }>;
+  };
+  backfillThrows?: Error;
+  captureRunArgs?: (args: any) => void;
+}
+
+function makeFakeDeps(overrides: FakeDepsOverrides = {}): BackfillFailedDeliveriesCommandDeps {
+  return {
+    loadConfig: () => defaultConfig as any,
+    getConfigPathFromArgs: () => undefined,
+    runBackfill: async (args: any) => {
+      overrides.captureRunArgs?.(args);
+      if (overrides.backfillThrows) throw overrides.backfillThrows;
+      return overrides.backfillResult ?? { reclassified: [], skipped: [], failed: [] };
+    },
+  };
+}
+
+describe('backfill-failed-deliveries command', () => {
+  it('parses and dispatches with empty result; emits JSON by default', async () => {
+    const cmd = createBackfillFailedDeliveriesCommand(makeFakeDeps());
+    const { ctx, writes, exits } = makeCommandCtx();
+    await cmd.run(ctx);
+    expect(exits).toEqual([0]);
+    const line = writes.join('').trim();
+    expect(line.startsWith('{')).toBe(true);
+    const payload = JSON.parse(line);
+    expect(payload.schemaVersion).toBe(1);
+    expect(payload.dryRun).toBe(false);
+    expect(payload.reclassified).toEqual([]);
+    expect(payload.skipped).toEqual([]);
+    expect(payload.failed).toEqual([]);
+  });
+
+  it('passes through reclassified/skipped/failed counts to the JSON payload', async () => {
+    const cmd = createBackfillFailedDeliveriesCommand(
+      makeFakeDeps({
+        backfillResult: {
+          reclassified: ['req-1'],
+          skipped: [{ requestId: 'req-2', reason: 'no deliveryTxHash recorded' }],
+          failed: [{ requestId: 'req-3', error: 'boom' }],
+        },
+      }),
+    );
+    const { ctx, writes, exits } = makeCommandCtx();
+    await cmd.run(ctx);
+    expect(exits).toEqual([0]);
+    const payload = JSON.parse(writes.join('').trim());
+    expect(payload.reclassified).toEqual(['req-1']);
+    expect(payload.skipped).toEqual([{ requestId: 'req-2', reason: 'no deliveryTxHash recorded' }]);
+    expect(payload.failed).toEqual([{ requestId: 'req-3', error: 'boom' }]);
+  });
+
+  it('renders human output when --human is passed', async () => {
+    const cmd = createBackfillFailedDeliveriesCommand(
+      makeFakeDeps({
+        backfillResult: {
+          reclassified: ['req-1'],
+          skipped: [],
+          failed: [],
+        },
+      }),
+    );
+    const { ctx, writes, exits } = makeCommandCtx({ argv: ['--human'] });
+    await cmd.run(ctx);
+    expect(exits).toEqual([0]);
+    const out = writes.join('');
+    expect(out).toContain('reclassified: 1');
+    expect(out).toContain('req-1');
+  });
+
+  it('emits fatal envelope when the backfill throws', async () => {
+    const cmd = createBackfillFailedDeliveriesCommand(
+      makeFakeDeps({ backfillThrows: new Error('rpc dead') }),
+    );
+    const { ctx, writes, exits } = makeCommandCtx();
+    await cmd.run(ctx);
+    const env = JSON.parse(writes.join('').trim());
+    expect(env.code).toBe('fatal');
+    expect(env.message).toContain('rpc dead');
+    expect(exits[0]).not.toBe(0);
+  });
+
+  it('forwards --dry-run through to runBackfill and the JSON payload', async () => {
+    let captured: any;
+    const cmd = createBackfillFailedDeliveriesCommand(
+      makeFakeDeps({ captureRunArgs: (a) => { captured = a; } }),
+    );
+    const { ctx, writes } = makeCommandCtx({ argv: ['--dry-run'] });
+    await cmd.run(ctx);
+    expect(captured.dryRun).toBe(true);
+    const payload = JSON.parse(writes.join('').trim());
+    expect(payload.dryRun).toBe(true);
+  });
+
+  it('forwards dbPath + rpcUrls + resolved network to runBackfill', async () => {
+    let captured: any;
+    const cmd = createBackfillFailedDeliveriesCommand(
+      makeFakeDeps({ captureRunArgs: (a) => { captured = a; } }),
+    );
+    const { ctx } = makeCommandCtx();
+    await cmd.run(ctx);
+    expect(captured.dbPath).toBe('/tmp/jinn.db');
+    expect(captured.rpcUrls).toEqual(['http://127.0.0.1:8545']);
+    expect(captured.network).toBe('base-sepolia'); // testnet -> base-sepolia
+    expect(captured.dryRun).toBe(false);
+  });
+});

--- a/client/test/cli/commands/backfill-failed-deliveries.test.ts
+++ b/client/test/cli/commands/backfill-failed-deliveries.test.ts
@@ -31,7 +31,7 @@ const defaultConfig = {
 
 interface FakeDepsOverrides {
   backfillResult?: {
-    reclassified: string[];
+    reclassified: Array<{ requestId: string; originalFailureReason: string | null }>;
     skipped: Array<{ requestId: string; reason: string }>;
     failed: Array<{ requestId: string; error: string }>;
   };
@@ -71,7 +71,7 @@ describe('backfill-failed-deliveries command', () => {
     const cmd = createBackfillFailedDeliveriesCommand(
       makeFakeDeps({
         backfillResult: {
-          reclassified: ['req-1'],
+          reclassified: [{ requestId: 'req-1', originalFailureReason: 'NOT NULL constraint failed: artifacts.desired_state_id' }],
           skipped: [{ requestId: 'req-2', reason: 'no deliveryTxHash recorded' }],
           failed: [{ requestId: 'req-3', error: 'boom' }],
         },
@@ -81,7 +81,9 @@ describe('backfill-failed-deliveries command', () => {
     await cmd.run(ctx);
     expect(exits).toEqual([0]);
     const payload = JSON.parse(writes.join('').trim());
-    expect(payload.reclassified).toEqual(['req-1']);
+    expect(payload.reclassified).toEqual([
+      { requestId: 'req-1', originalFailureReason: 'NOT NULL constraint failed: artifacts.desired_state_id' },
+    ]);
     expect(payload.skipped).toEqual([{ requestId: 'req-2', reason: 'no deliveryTxHash recorded' }]);
     expect(payload.failed).toEqual([{ requestId: 'req-3', error: 'boom' }]);
   });
@@ -90,7 +92,7 @@ describe('backfill-failed-deliveries command', () => {
     const cmd = createBackfillFailedDeliveriesCommand(
       makeFakeDeps({
         backfillResult: {
-          reclassified: ['req-1'],
+          reclassified: [{ requestId: 'req-1', originalFailureReason: 'NOT NULL constraint failed: artifacts.desired_state_id' }],
           skipped: [],
           failed: [],
         },
@@ -102,6 +104,7 @@ describe('backfill-failed-deliveries command', () => {
     const out = writes.join('');
     expect(out).toContain('reclassified: 1');
     expect(out).toContain('req-1');
+    expect(out).toContain('NOT NULL constraint failed: artifacts.desired_state_id');
   });
 
   it('emits fatal envelope when the backfill throws', async () => {

--- a/client/test/harnesses/engine/backfill-failed-deliveries.test.ts
+++ b/client/test/harnesses/engine/backfill-failed-deliveries.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for the #506 backfill: FAILED task_runs whose delivery tx actually
+ * landed on-chain get reclassified as COMPLETE.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { PublicClient } from 'viem';
+import { Store } from '../../../src/store/store.js';
+import { TaskRunPersistence, type PersistedTaskRunInput } from '../../../src/harnesses/engine/persistence.js';
+import { TaskRunState } from '../../../src/harnesses/engine/state.js';
+import { backfillFailedDeliveries } from '../../../src/harnesses/engine/backfill-failed-deliveries.js';
+
+function makeInput(requestId: string, overrides: Partial<PersistedTaskRunInput> = {}): PersistedTaskRunInput {
+  return {
+    requestId,
+    taskCid: 'bafyabc123',
+    onchainCreationTx: '0xdeadbeef',
+    onchainCreationBlock: 1000,
+    solverType: 'portfolio.v0',
+    windowStartTs: Date.now() - 60_000,
+    windowEndTs: Date.now() + 86_400_000,
+    task: { id: requestId, description: 'test' },
+    ...overrides,
+  };
+}
+
+/** Walk a fresh row through to a FAILED terminal state, optionally with a deliveryTxHash. */
+function seedFailed(
+  p: TaskRunPersistence,
+  requestId: string,
+  opts: { deliveryTxHash?: string } = {},
+): void {
+  p.insertDiscovered(makeInput(requestId));
+  p.transition(requestId, TaskRunState.CLAIMED);
+  p.transition(requestId, TaskRunState.WAITING);
+  p.transition(requestId, TaskRunState.PRE_SNAPSHOT);
+  p.transition(requestId, TaskRunState.RUNNING);
+  p.transition(requestId, TaskRunState.POST_SNAPSHOT);
+  p.transition(requestId, TaskRunState.PACKAGING);
+  p.transition(requestId, TaskRunState.DELIVERING, {
+    deliveryTxHash: opts.deliveryTxHash ?? null,
+  });
+  p.markFailed(requestId, 'insertArtifact threw: NOT NULL constraint failed');
+}
+
+describe('backfillFailedDeliveries', () => {
+  let store: Store;
+  let persistence: TaskRunPersistence;
+
+  beforeEach(() => {
+    store = new Store(':memory:');
+    persistence = new TaskRunPersistence(store.db);
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  it('reclassifies a FAILED row as COMPLETE when the delivery tx succeeded', async () => {
+    seedFailed(persistence, 'req-success', { deliveryTxHash: '0xaaa' });
+    const publicClient = {
+      getTransactionReceipt: vi.fn().mockResolvedValue({ status: 'success' }),
+    } as unknown as PublicClient;
+
+    const result = await backfillFailedDeliveries({ persistence, publicClient });
+
+    expect(result.reclassified).toEqual(['req-success']);
+    expect(result.skipped).toEqual([]);
+    expect(result.failed).toEqual([]);
+    expect(persistence.getByRequestId('req-success')!.state).toBe(TaskRunState.COMPLETE);
+  });
+
+  it('skips a FAILED row with no deliveryTxHash', async () => {
+    seedFailed(persistence, 'req-no-hash');
+    const publicClient = {
+      getTransactionReceipt: vi.fn(),
+    } as unknown as PublicClient;
+
+    const result = await backfillFailedDeliveries({ persistence, publicClient });
+
+    expect(result.reclassified).toEqual([]);
+    expect(result.skipped).toEqual([{ requestId: 'req-no-hash', reason: expect.any(String) }]);
+    expect(publicClient.getTransactionReceipt).not.toHaveBeenCalled();
+    expect(persistence.getByRequestId('req-no-hash')!.state).toBe(TaskRunState.FAILED);
+  });
+
+  it('skips a FAILED row whose delivery tx reverted', async () => {
+    seedFailed(persistence, 'req-reverted', { deliveryTxHash: '0xbbb' });
+    const publicClient = {
+      getTransactionReceipt: vi.fn().mockResolvedValue({ status: 'reverted' }),
+    } as unknown as PublicClient;
+
+    const result = await backfillFailedDeliveries({ persistence, publicClient });
+
+    expect(result.reclassified).toEqual([]);
+    expect(result.skipped).toEqual([{ requestId: 'req-reverted', reason: expect.any(String) }]);
+    expect(persistence.getByRequestId('req-reverted')!.state).toBe(TaskRunState.FAILED);
+  });
+
+  it('records an RPC rejection as failed and keeps processing the rest of the batch', async () => {
+    seedFailed(persistence, 'req-rpc-down', { deliveryTxHash: '0xccc' });
+    seedFailed(persistence, 'req-healthy', { deliveryTxHash: '0xddd' });
+    const getTransactionReceipt = vi.fn().mockImplementation(async ({ hash }: { hash: string }) => {
+      if (hash === '0xccc') throw new Error('RPC unavailable');
+      return { status: 'success' };
+    });
+    const publicClient = { getTransactionReceipt } as unknown as PublicClient;
+
+    const result = await backfillFailedDeliveries({ persistence, publicClient });
+
+    expect(result.failed).toEqual([{ requestId: 'req-rpc-down', error: expect.stringContaining('RPC unavailable') }]);
+    expect(result.reclassified).toEqual(['req-healthy']);
+    expect(persistence.getByRequestId('req-rpc-down')!.state).toBe(TaskRunState.FAILED);
+    expect(persistence.getByRequestId('req-healthy')!.state).toBe(TaskRunState.COMPLETE);
+  });
+
+  it('does not touch COMPLETE rows', async () => {
+    persistence.insertDiscovered(makeInput('req-complete'));
+    persistence.transition('req-complete', TaskRunState.CLAIMED);
+    persistence.transition('req-complete', TaskRunState.WAITING);
+    persistence.transition('req-complete', TaskRunState.PRE_SNAPSHOT);
+    persistence.transition('req-complete', TaskRunState.RUNNING);
+    persistence.transition('req-complete', TaskRunState.POST_SNAPSHOT);
+    persistence.transition('req-complete', TaskRunState.PACKAGING);
+    persistence.transition('req-complete', TaskRunState.DELIVERING, { deliveryTxHash: '0xeee' });
+    persistence.transition('req-complete', TaskRunState.COMPLETE);
+    const publicClient = {
+      getTransactionReceipt: vi.fn().mockResolvedValue({ status: 'success' }),
+    } as unknown as PublicClient;
+
+    const result = await backfillFailedDeliveries({ persistence, publicClient });
+
+    expect(result.reclassified).toEqual([]);
+    expect(result.skipped).toEqual([]);
+    expect(result.failed).toEqual([]);
+    expect(publicClient.getTransactionReceipt).not.toHaveBeenCalled();
+    expect(persistence.getByRequestId('req-complete')!.state).toBe(TaskRunState.COMPLETE);
+  });
+
+  it('dryRun: true reports reclassification without writing to the DB', async () => {
+    seedFailed(persistence, 'req-dry-run', { deliveryTxHash: '0xfff' });
+    const publicClient = {
+      getTransactionReceipt: vi.fn().mockResolvedValue({ status: 'success' }),
+    } as unknown as PublicClient;
+
+    const result = await backfillFailedDeliveries({ persistence, publicClient, dryRun: true });
+
+    expect(result.reclassified).toEqual(['req-dry-run']);
+    expect(persistence.getByRequestId('req-dry-run')!.state).toBe(TaskRunState.FAILED);
+  });
+
+  it('is idempotent — a second run reclassifies nothing further', async () => {
+    seedFailed(persistence, 'req-idempotent', { deliveryTxHash: '0x111' });
+    const publicClient = {
+      getTransactionReceipt: vi.fn().mockResolvedValue({ status: 'success' }),
+    } as unknown as PublicClient;
+
+    const first = await backfillFailedDeliveries({ persistence, publicClient });
+    expect(first.reclassified).toEqual(['req-idempotent']);
+
+    const second = await backfillFailedDeliveries({ persistence, publicClient });
+    expect(second.reclassified).toEqual([]);
+    expect(second.skipped).toEqual([]);
+    expect(second.failed).toEqual([]);
+  });
+});

--- a/client/test/harnesses/engine/backfill-failed-deliveries.test.ts
+++ b/client/test/harnesses/engine/backfill-failed-deliveries.test.ts
@@ -24,11 +24,20 @@ function makeInput(requestId: string, overrides: Partial<PersistedTaskRunInput> 
   };
 }
 
-/** Walk a fresh row through to a FAILED terminal state, optionally with a deliveryTxHash. */
+/** The #506 failure-reason signature the backfill scopes its candidate filter to. */
+const DESIRED_STATE_ID_REASON = 'NOT NULL constraint failed: artifacts.desired_state_id';
+
+/**
+ * Walk a fresh row through to a FAILED terminal state, optionally with a
+ * deliveryTxHash. Defaults `failureReason` to the #506 bug signature so
+ * seeded rows are backfill candidates by default; pass a different
+ * `failureReason` to simulate a genuinely-failed row (e.g. a claimDelivery
+ * revert) that happens to also carry a deliveryTxHash + success receipt.
+ */
 function seedFailed(
   p: TaskRunPersistence,
   requestId: string,
-  opts: { deliveryTxHash?: string } = {},
+  opts: { deliveryTxHash?: string; failureReason?: string } = {},
 ): void {
   p.insertDiscovered(makeInput(requestId));
   p.transition(requestId, TaskRunState.CLAIMED);
@@ -40,7 +49,7 @@ function seedFailed(
   p.transition(requestId, TaskRunState.DELIVERING, {
     deliveryTxHash: opts.deliveryTxHash ?? null,
   });
-  p.markFailed(requestId, 'insertArtifact threw: NOT NULL constraint failed');
+  p.markFailed(requestId, opts.failureReason ?? DESIRED_STATE_ID_REASON);
 }
 
 describe('backfillFailedDeliveries', () => {
@@ -64,10 +73,59 @@ describe('backfillFailedDeliveries', () => {
 
     const result = await backfillFailedDeliveries({ persistence, publicClient });
 
-    expect(result.reclassified).toEqual(['req-success']);
+    expect(result.reclassified).toEqual([
+      { requestId: 'req-success', originalFailureReason: DESIRED_STATE_ID_REASON },
+    ]);
     expect(result.skipped).toEqual([]);
     expect(result.failed).toEqual([]);
     expect(persistence.getByRequestId('req-success')!.state).toBe(TaskRunState.COMPLETE);
+    // The UPDATE clears failure fields on a genuinely-COMPLETE row — the
+    // original reason is preserved only in the command's output, not the row.
+    expect(persistence.getByRequestId('req-success')!.failureReason).toBeNull();
+  });
+
+  it('skips a FAILED row with a matching deliveryTxHash + success receipt but a non-matching failure reason (#506 review finding 1)', async () => {
+    // A row that failed at claimDelivery (step 2) after deliverToMarketplace
+    // (step 1) already persisted deliveryTxHash — genuinely failed, not the
+    // #506 desired_state_id bug. Must not be reclassified.
+    seedFailed(persistence, 'req-other-failure', {
+      deliveryTxHash: '0xaaa',
+      failureReason: 'execution reverted: TCMaxVerdictsReached',
+    });
+    const publicClient = {
+      getTransactionReceipt: vi.fn().mockResolvedValue({ status: 'success' }),
+    } as unknown as PublicClient;
+
+    const result = await backfillFailedDeliveries({ persistence, publicClient });
+
+    expect(result.reclassified).toEqual([]);
+    expect(result.skipped).toEqual([
+      {
+        requestId: 'req-other-failure',
+        reason: 'failure reason does not match the desired_state_id constraint signature',
+      },
+    ]);
+    expect(publicClient.getTransactionReceipt).not.toHaveBeenCalled();
+    expect(persistence.getByRequestId('req-other-failure')!.state).toBe(TaskRunState.FAILED);
+  });
+
+  it('skips a FAILED row whose failure reason carries the recovery: prefix but still matches the signature', async () => {
+    // _classifyAndMarkTerminal stamps `recovery: ${reason}` when invoked from
+    // the recovery context — the substring check must survive that wrapping.
+    seedFailed(persistence, 'req-recovery-prefixed', {
+      deliveryTxHash: '0xbeef',
+      failureReason: `recovery: ${DESIRED_STATE_ID_REASON}`,
+    });
+    const publicClient = {
+      getTransactionReceipt: vi.fn().mockResolvedValue({ status: 'success' }),
+    } as unknown as PublicClient;
+
+    const result = await backfillFailedDeliveries({ persistence, publicClient });
+
+    expect(result.reclassified).toEqual([
+      { requestId: 'req-recovery-prefixed', originalFailureReason: `recovery: ${DESIRED_STATE_ID_REASON}` },
+    ]);
+    expect(persistence.getByRequestId('req-recovery-prefixed')!.state).toBe(TaskRunState.COMPLETE);
   });
 
   it('skips a FAILED row with no deliveryTxHash', async () => {
@@ -109,7 +167,9 @@ describe('backfillFailedDeliveries', () => {
     const result = await backfillFailedDeliveries({ persistence, publicClient });
 
     expect(result.failed).toEqual([{ requestId: 'req-rpc-down', error: expect.stringContaining('RPC unavailable') }]);
-    expect(result.reclassified).toEqual(['req-healthy']);
+    expect(result.reclassified).toEqual([
+      { requestId: 'req-healthy', originalFailureReason: DESIRED_STATE_ID_REASON },
+    ]);
     expect(persistence.getByRequestId('req-rpc-down')!.state).toBe(TaskRunState.FAILED);
     expect(persistence.getByRequestId('req-healthy')!.state).toBe(TaskRunState.COMPLETE);
   });
@@ -145,7 +205,9 @@ describe('backfillFailedDeliveries', () => {
 
     const result = await backfillFailedDeliveries({ persistence, publicClient, dryRun: true });
 
-    expect(result.reclassified).toEqual(['req-dry-run']);
+    expect(result.reclassified).toEqual([
+      { requestId: 'req-dry-run', originalFailureReason: DESIRED_STATE_ID_REASON },
+    ]);
     expect(persistence.getByRequestId('req-dry-run')!.state).toBe(TaskRunState.FAILED);
   });
 
@@ -156,11 +218,30 @@ describe('backfillFailedDeliveries', () => {
     } as unknown as PublicClient;
 
     const first = await backfillFailedDeliveries({ persistence, publicClient });
-    expect(first.reclassified).toEqual(['req-idempotent']);
+    expect(first.reclassified).toEqual([
+      { requestId: 'req-idempotent', originalFailureReason: DESIRED_STATE_ID_REASON },
+    ]);
 
     const second = await backfillFailedDeliveries({ persistence, publicClient });
     expect(second.reclassified).toEqual([]);
     expect(second.skipped).toEqual([]);
     expect(second.failed).toEqual([]);
+  });
+
+  it('skips (does not push to reclassified) when reclassifyFailedAsComplete reports a concurrent state change (#506 review finding 2)', async () => {
+    seedFailed(persistence, 'req-concurrent', { deliveryTxHash: '0x222' });
+    const publicClient = {
+      getTransactionReceipt: vi.fn().mockResolvedValue({ status: 'success' }),
+    } as unknown as PublicClient;
+    // Simulate another writer flipping the row out of FAILED between our
+    // getByState() read and the UPDATE — reclassifyFailedAsComplete's WHERE
+    // clause guard reports this by returning false without writing.
+    const reclassifySpy = vi.spyOn(persistence, 'reclassifyFailedAsComplete').mockReturnValue(false);
+
+    const result = await backfillFailedDeliveries({ persistence, publicClient });
+
+    expect(reclassifySpy).toHaveBeenCalledWith('req-concurrent');
+    expect(result.reclassified).toEqual([]);
+    expect(result.skipped).toEqual([{ requestId: 'req-concurrent', reason: 'row state changed concurrently' }]);
   });
 });

--- a/client/test/harnesses/engine/engine-packaging.test.ts
+++ b/client/test/harnesses/engine/engine-packaging.test.ts
@@ -6,9 +6,10 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import Database from 'better-sqlite3';
 import { Store } from '../../../src/store/store.js';
 import {
   TaskEngine,
@@ -267,6 +268,69 @@ describe('Engine packaging integration', () => {
     const artifact = store.getArtifactByRequestId(requestId, 'restoration-result');
     expect(artifact).not.toBeNull();
     expect(artifact!.outcome).toBe('SUCCESS');
+  });
+
+  it('deliver() persists COMPLETE (not FAILED) against a legacy desired_state_id NOT NULL artifacts schema (regression #506)', async () => {
+    // Issue #506: a successful on-chain delivery was persisted as FAILED
+    // because insertArtifact() threw on a legacy NOT NULL column, and the
+    // engine's _runTransition catch → _classifyAndMarkTerminal → markFailed()
+    // flipped the run to FAILED. process() must resolve and land COMPLETE.
+    const dir = mkdtempSync(join(tmpdir(), 'jinn-legacy-engine-'));
+    const dbPath = join(dir, 'jinn.db');
+    const legacy = new Database(dbPath);
+    legacy.exec(`
+      CREATE TABLE config (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+      CREATE TABLE artifacts (
+        id TEXT PRIMARY KEY,
+        desired_state_id TEXT NOT NULL,
+        request_id TEXT NOT NULL,
+        title TEXT NOT NULL,
+        content TEXT,
+        tags TEXT NOT NULL DEFAULT '[]',
+        outcome TEXT NOT NULL CHECK (outcome IN ('SUCCESS', 'FAILURE', 'UNKNOWN')),
+        remote INTEGER NOT NULL DEFAULT 0,
+        owner_address TEXT,
+        endpoint TEXT,
+        price TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `);
+    legacy.close();
+
+    const legacyStore = new Store(dbPath);
+    const legacyTmp = mkTmp();
+    const legacyEngine = new TestEngine(makeOpts(legacyStore, legacyTmp));
+    try {
+      const requestId = 'req-legacy-deliver';
+      await legacyEngine.observe(makeInput(requestId, legacyTmp));
+      const p = legacyEngine.testPersistence;
+      p.transition(requestId, TaskRunState.CLAIMED);
+      p.transition(requestId, TaskRunState.WAITING);
+      p.transition(requestId, TaskRunState.PRE_SNAPSHOT);
+      p.transition(requestId, TaskRunState.RUNNING);
+      p.transition(requestId, TaskRunState.POST_SNAPSHOT);
+      p.transition(requestId, TaskRunState.PACKAGING);
+      p.transition(requestId, TaskRunState.DELIVERING, {
+        manifestCid: 'bafymanifest123',
+        evidenceHash: '0xaabbccdd00000000000000000000000000000000000000000000000000000000',
+      });
+
+      await legacyEngine.process(requestId);
+      const intent = legacyEngine.testPersistence.getByRequestId(requestId);
+      expect(intent!.state).toBe(TaskRunState.COMPLETE);
+      expect(intent!.deliveryTxHash).toBe('0xdeliverytx');
+
+      const artifact = legacyStore.getArtifactByRequestId(requestId, 'restoration-result');
+      expect(artifact).not.toBeNull();
+      expect(artifact!.outcome).toBe('SUCCESS');
+    } finally {
+      legacyStore.close();
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(legacyTmp, { recursive: true, force: true });
+    }
   });
 
   it('pack() throws when safeAddress is not configured', async () => {

--- a/client/test/harnesses/engine/engine-packaging.test.ts
+++ b/client/test/harnesses/engine/engine-packaging.test.ts
@@ -6,10 +6,9 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import Database from 'better-sqlite3';
 import { Store } from '../../../src/store/store.js';
 import {
   TaskEngine,
@@ -18,6 +17,7 @@ import {
 } from '../../../src/harnesses/engine/engine.js';
 import { TaskRunPersistence, type PersistedTaskRunInput } from '../../../src/harnesses/engine/persistence.js';
 import { TaskRunState } from '../../../src/harnesses/engine/state.js';
+import { createLegacyArtifactsSchemaDb } from '../../helpers/legacy-artifacts-schema.js';
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
@@ -275,30 +275,7 @@ describe('Engine packaging integration', () => {
     // because insertArtifact() threw on a legacy NOT NULL column, and the
     // engine's _runTransition catch → _classifyAndMarkTerminal → markFailed()
     // flipped the run to FAILED. process() must resolve and land COMPLETE.
-    const dir = mkdtempSync(join(tmpdir(), 'jinn-legacy-engine-'));
-    const dbPath = join(dir, 'jinn.db');
-    const legacy = new Database(dbPath);
-    legacy.exec(`
-      CREATE TABLE config (
-        key TEXT PRIMARY KEY,
-        value TEXT NOT NULL
-      );
-      CREATE TABLE artifacts (
-        id TEXT PRIMARY KEY,
-        desired_state_id TEXT NOT NULL,
-        request_id TEXT NOT NULL,
-        title TEXT NOT NULL,
-        content TEXT,
-        tags TEXT NOT NULL DEFAULT '[]',
-        outcome TEXT NOT NULL CHECK (outcome IN ('SUCCESS', 'FAILURE', 'UNKNOWN')),
-        remote INTEGER NOT NULL DEFAULT 0,
-        owner_address TEXT,
-        endpoint TEXT,
-        price TEXT,
-        created_at TEXT NOT NULL DEFAULT (datetime('now'))
-      );
-    `);
-    legacy.close();
+    const { dir, dbPath } = createLegacyArtifactsSchemaDb('jinn-legacy-engine-');
 
     const legacyStore = new Store(dbPath);
     const legacyTmp = mkTmp();

--- a/client/test/helpers/legacy-artifacts-schema.ts
+++ b/client/test/helpers/legacy-artifacts-schema.ts
@@ -1,0 +1,44 @@
+import Database from 'better-sqlite3';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Creates a fresh SQLite file at a temp path with the pre-Task-native-IDs
+ * (#406) `artifacts` schema, where `desired_state_id` is `TEXT NOT NULL`.
+ * `Store`'s startup migration (`ensureArtifactsTaskColumns`) detects this
+ * legacy column and `insertArtifact` mirrors `task_id` into it (#511) —
+ * tests exercising that path, or guarding its regression (#506), open a
+ * `Store` against the path this returns.
+ *
+ * Does not open a `Store` itself and does not create the caller's temp
+ * directory — only the DB file's schema. Callers are responsible for
+ * cleaning up the returned directory.
+ */
+export function createLegacyArtifactsSchemaDb(dirPrefix: string): { dir: string; dbPath: string } {
+  const dir = mkdtempSync(join(tmpdir(), dirPrefix));
+  const dbPath = join(dir, 'jinn.db');
+  const legacy = new Database(dbPath);
+  legacy.exec(`
+    CREATE TABLE config (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+    CREATE TABLE artifacts (
+      id TEXT PRIMARY KEY,
+      desired_state_id TEXT NOT NULL,
+      request_id TEXT NOT NULL,
+      title TEXT NOT NULL,
+      content TEXT,
+      tags TEXT NOT NULL DEFAULT '[]',
+      outcome TEXT NOT NULL CHECK (outcome IN ('SUCCESS', 'FAILURE', 'UNKNOWN')),
+      remote INTEGER NOT NULL DEFAULT 0,
+      owner_address TEXT,
+      endpoint TEXT,
+      price TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+  legacy.close();
+  return { dir, dbPath };
+}

--- a/client/test/store/store.test.ts
+++ b/client/test/store/store.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Store } from '../../src/store/store.js';
+import { createLegacyArtifactsSchemaDb } from '../helpers/legacy-artifacts-schema.js';
 
 describe('Store', () => {
   let store: Store;
@@ -160,30 +161,7 @@ describe('Store', () => {
     // because insertArtifact() threw on this legacy NOT NULL column, and the
     // engine's error path flipped the run to FAILED. Guard against a
     // regression of that throw.
-    const dir = mkdtempSync(join(tmpdir(), 'jinn-legacy-insert-'));
-    const dbPath = join(dir, 'jinn.db');
-    const legacy = new Database(dbPath);
-    legacy.exec(`
-      CREATE TABLE config (
-        key TEXT PRIMARY KEY,
-        value TEXT NOT NULL
-      );
-      CREATE TABLE artifacts (
-        id TEXT PRIMARY KEY,
-        desired_state_id TEXT NOT NULL,
-        request_id TEXT NOT NULL,
-        title TEXT NOT NULL,
-        content TEXT,
-        tags TEXT NOT NULL DEFAULT '[]',
-        outcome TEXT NOT NULL CHECK (outcome IN ('SUCCESS', 'FAILURE', 'UNKNOWN')),
-        remote INTEGER NOT NULL DEFAULT 0,
-        owner_address TEXT,
-        endpoint TEXT,
-        price TEXT,
-        created_at TEXT NOT NULL DEFAULT (datetime('now'))
-      );
-    `);
-    legacy.close();
+    const { dbPath } = createLegacyArtifactsSchemaDb('jinn-legacy-insert-');
 
     const legacyStore = new Store(dbPath);
     try {

--- a/client/test/store/store.test.ts
+++ b/client/test/store/store.test.ts
@@ -155,6 +155,58 @@ describe('Store', () => {
     }
   });
 
+  it('insertArtifact succeeds against a legacy desired_state_id NOT NULL schema (regression #506)', () => {
+    // Issue #506: a successful on-chain delivery was persisted as FAILED
+    // because insertArtifact() threw on this legacy NOT NULL column, and the
+    // engine's error path flipped the run to FAILED. Guard against a
+    // regression of that throw.
+    const dir = mkdtempSync(join(tmpdir(), 'jinn-legacy-insert-'));
+    const dbPath = join(dir, 'jinn.db');
+    const legacy = new Database(dbPath);
+    legacy.exec(`
+      CREATE TABLE config (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+      CREATE TABLE artifacts (
+        id TEXT PRIMARY KEY,
+        desired_state_id TEXT NOT NULL,
+        request_id TEXT NOT NULL,
+        title TEXT NOT NULL,
+        content TEXT,
+        tags TEXT NOT NULL DEFAULT '[]',
+        outcome TEXT NOT NULL CHECK (outcome IN ('SUCCESS', 'FAILURE', 'UNKNOWN')),
+        remote INTEGER NOT NULL DEFAULT 0,
+        owner_address TEXT,
+        endpoint TEXT,
+        price TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `);
+    legacy.close();
+
+    const legacyStore = new Store(dbPath);
+    try {
+      expect(() =>
+        legacyStore.insertArtifact({
+          id: 'art-legacy-insert-1',
+          taskId: 'task-legacy-1',
+          requestId: 'req-legacy-1',
+          title: 'Restoration result',
+          content: 'content',
+          tags: ['restoration-result'],
+          outcome: 'SUCCESS',
+        }),
+      ).not.toThrow();
+
+      const results = legacyStore.searchArtifacts({ taskId: 'task-legacy-1' });
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('art-legacy-insert-1');
+    } finally {
+      legacyStore.close();
+    }
+  });
+
   it('stores durable task post records', () => {
     store.upsertTaskPostRecord({
       creatorSafeAddress: '0x00112233445566778899AABbCCdDeeFf00112233',


### PR DESCRIPTION
## Summary

Issue #506: solve runs whose delivery landed on-chain (status 0x1) showed as FAILED in the operator dashboard. Root cause: on SQLite databases created before the artifacts-schema change, `insertArtifact()` threw `NOT NULL constraint failed: artifacts.desired_state_id` during the post-delivery write, and the engine's error fallback flipped the just-completed run to FAILED.

The schema-level production fix already landed on `next` in 65de316e8 (PR #511): `Store.hasLegacyDesiredStateId` detection + mirroring `task_id` into the legacy column. This PR delivers the remaining acceptance criteria:

- **Regression tests** (previously missing): a store-level test that `insertArtifact()` succeeds against a legacy `desired_state_id NOT NULL` schema, and an engine-level test driving the full `deliver()` walk on a legacy-schema DB asserting the run lands COMPLETE, not FAILED. Both were empirically confirmed to fail with the exact original error when the 65de316e8 fix is reverted.
- **Backfill**: `jinn backfill-failed-deliveries` — a one-shot, idempotent CLI command that re-classifies historical FAILED rows to COMPLETE. Scoped tightly to this bug's signature: a row is only a candidate when its `failure_reason` contains `artifacts.desired_state_id` (covers the raw and `recovery: `-prefixed forms), and its `deliveryTxHash` receipt is independently re-verified as `status: success`. The scoping matters because the delivery flow persists the tx hash after `deliverToMarketplace` but before `claimDelivery` — a receipt-only condition would wrongly reclassify genuine claim-step failures. Supports `--dry-run`; reports `reclassified` (with each row's original failure reason, preserving the audit trail), `skipped` (with reasons), and `failed` (per-row RPC errors, isolated).
- **Known caveat (documented in CLI help + module docblock)**: reclassified rows have no `artifacts` row and no ERC-8004 anchor — the artifact write is exactly what failed for them; the backfill does not reconstruct either.

## Test plan

- `client/test/store/store.test.ts` — insertArtifact regression on legacy schema.
- `client/test/harnesses/engine/engine-packaging.test.ts` — end-to-end deliver() regression on legacy schema (COMPLETE, delivery tx hash set, restoration-result artifact present).
- `client/test/harnesses/engine/backfill-failed-deliveries.test.ts` — 10 cases: success reclassify, no-hash skip, reverted-receipt skip, non-matching-signature skip (claim-step failure shape), recovery-prefix match, RPC-error isolation with batch continuation, COMPLETE rows untouched, dry-run no-write, idempotency, concurrent-state-change skip.
- `client/test/cli/commands/backfill-failed-deliveries.test.ts` — JSON envelope, counts, --human rendering, fatal envelope, --dry-run forwarding.
- Full suite: `yarn typecheck` clean; `yarn test` green (715 files / 6189 tests); `yarn build` clean.

## Remaining acceptance item (operator-side)

Manual verify against the running operator (the four txs from the issue showing `succeeded` after re-bootstrap) requires the operator's live daemon and DB — run `jinn backfill-failed-deliveries --dry-run` first, review the candidate list, then run without the flag and re-check the dashboard. Not automatable from this PR.

Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)