### PR TITLE
fix(daemon): gate evaluation-opportunity scan on evaluator role

### DIFF
--- a/client/src/adapters/mech/adapter.ts
+++ b/client/src/adapters/mech/adapter.ts
@@ -248,6 +248,23 @@ export class MechAdapter implements ExecutionAdapter {
     this.store = store;
   }
 
+  /**
+   * Whether this operator participates as an evaluator. Undefined ⇒ enabled
+   * (opt-out default). Gates evaluation-opportunity ingest, boot rehydrate, and
+   * per-cycle scan (#547).
+   */
+  private get evaluatorEnabled(): boolean {
+    return this.config.evaluatorEnabled !== false;
+  }
+
+  /**
+   * Enable the evaluator role at runtime after a live SolverNet join (a join
+   * never removes a role, so turning it back off is never needed). #547.
+   */
+  public setEvaluatorEnabled(enabled: boolean): void {
+    this.config.evaluatorEnabled = enabled;
+  }
+
   async initialize(): Promise<void> {
     const chain = this.config.chainId === 84532 ? baseSepolia : base;
     const clients = createClients(
@@ -278,7 +295,13 @@ export class MechAdapter implements ExecutionAdapter {
 
     // Recover pending state from on-chain events
     if (this.store) {
-      this.loadPendingEvaluationSolutions();
+      // #547: only rehydrate the evaluation-opportunity set for evaluators.
+      // recoverPendingState recovers this operator's own in-flight restoration
+      // claims (router cursor + TaskCreated scan), not the evaluation set, so it
+      // stays unguarded.
+      if (this.evaluatorEnabled) {
+        this.loadPendingEvaluationSolutions();
+      }
       await this.recoverPendingState(blockNumber);
     } else {
       const fromBlock = this.onchainScanFromBlock(blockNumber);
@@ -1046,6 +1069,7 @@ export class MechAdapter implements ExecutionAdapter {
   }
 
   private async *retryPendingEvaluationSolutions(): AsyncIterable<TaskAnnouncement> {
+    if (!this.evaluatorEnabled) return; // #547: non-evaluators never scan.
     let processed = 0;
     for (const [requestId, solution] of Array.from(this.pendingEvaluationSolutions)) {
       // Yield to the event loop periodically so a large backlog of pending
@@ -1090,9 +1114,13 @@ export class MechAdapter implements ExecutionAdapter {
           const fromBlock = this.requestBlockCursor + 1n;
           const logs = await this.getRouterLogsInChunks(fromBlock, currentBlock);
 
-          const submittedSolutions = decodeSolutionDeliveryClaimedLogs(logs);
-          for (const solution of submittedSolutions) {
-            this.rememberPendingEvaluationSolution(solution);
+          // #547: only evaluators ingest delivery-claimed logs into the
+          // pending-evaluation set. Restoration discovery below is unaffected.
+          if (this.evaluatorEnabled) {
+            const submittedSolutions = decodeSolutionDeliveryClaimedLogs(logs);
+            for (const solution of submittedSolutions) {
+              this.rememberPendingEvaluationSolution(solution);
+            }
           }
 
           const joinedManifestDigests = this.joinedManifestDigestSet();

--- a/client/src/adapters/mech/types.ts
+++ b/client/src/adapters/mech/types.ts
@@ -51,6 +51,16 @@ export interface MechAdapterConfig {
   /** Base mainnet V1, Phase 1b V2, or Task-native V3 delivery claim ABI. */
   routerClaimDeliveryVariant: 'v1' | 'v2' | 'v3';
   evictionRecovery?: EvictionRecoveryConfig;
+  /**
+   * Whether this operator holds the `evaluator` role in a joined SolverNet.
+   * Omitted ⇒ enabled (opt-out default): a bare construction site keeps the
+   * historical scan-everything behaviour. Production callers (main.ts,
+   * join-applier.ts) always pass an explicit boolean. Gates three surfaces:
+   * ingest of delivery-claimed logs into the pending-evaluation set, the boot
+   * rehydrate of that set, and the per-cycle scan of evaluation opportunities.
+   * Ref #547.
+   */
+  evaluatorEnabled?: boolean;
 }
 
 export const MECH_MARKETPLACE_ABI = [

--- a/client/src/daemon/join-applier.ts
+++ b/client/src/daemon/join-applier.ts
@@ -32,6 +32,11 @@ export interface JoinApplierDeps {
   registry: SolverNetRegistry;
   /** The in-memory operator config block (kept consistent for launcher reads). */
   config: { joinedSolverNets?: Record<string, JoinedSolverNetConfig> };
+  /**
+   * #547: flip the MechAdapter's evaluator gate on live when an evaluator-role
+   * join lands. A join never removes a role, so there is no "off" counterpart.
+   */
+  enableEvaluator?: () => void;
 }
 
 export type JoinApplier = (entry: JoinedSolverNetConfig) => Promise<void>;
@@ -45,6 +50,9 @@ export function createJoinApplier(deps: JoinApplierDeps): JoinApplier {
     if (entry.roles.includes('solver') && !deps.taskDiscovery.solverNetManifestCids.includes(cid)) {
       deps.taskDiscovery.solverNetManifestCids.push(cid);
     }
+
+    // #547: an evaluator-role join enables the adapter's evaluation scan live.
+    if (entry.roles.includes('evaluator')) deps.enableEvaluator?.();
 
     // (b) engine eligibility view.
     deps.view.set(cid, { roles: entry.roles });

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1306,6 +1306,12 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     .filter((entry) => entry.roles.includes('solver'))
     .map((entry) => entry.manifestCid);
 
+  // #547: only scan/ingest evaluation opportunities when this operator holds the
+  // evaluator role in at least one joined SolverNet. The join applier flips this
+  // on live via adapter.setEvaluatorEnabled(true).
+  const evaluatorEnabled = Object.values(config.joinedSolverNets ?? {})
+    .some((entry) => entry.roles.includes('evaluator'));
+
   // ── DiscoveryAPI construction ─────────────────────────────────────────────
   // Build the shared DiscoveryAPI used by MechAdapter (task discovery),
   // the SolverNet registry client (lifecycle status), and the corpus library
@@ -1387,6 +1393,7 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     routerClaimDeliveryVariant: CHAIN_CONFIG.routerClaimDeliveryVersion,
     evictionRecovery,
     taskDiscovery,
+    evaluatorEnabled,
   }, sharedStore);
 
   // ── TaskEngine wiring ─────────────────────────────────────────────────
@@ -2277,6 +2284,7 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     readiness: harnessReadinessRegistry,
     registry: solverNetRegistry,
     config,
+    enableEvaluator: () => adapter.setEvaluatorEnabled(true),
   });
 
   if (config.watchdogAutoRestart) {

--- a/client/test/adapters/mech/adapter.test.ts
+++ b/client/test/adapters/mech/adapter.test.ts
@@ -1173,6 +1173,104 @@ describe('MechAdapter TaskCoordinator flow', () => {
     await adapter.stop();
   });
 
+  it('does not scan evaluation opportunities when the operator is not an evaluator (#547)', async () => {
+    const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+    const { canClaimEvaluation, decodeSolutionDeliveryClaimedLogs } = await import('../../../src/adapters/mech/contracts.js');
+    const solverSafe = ('0x' + '66'.repeat(20)) as `0x${string}`;
+
+    // Seed a delivery-claimed log. A persistent mock (not `Once`) keeps the queue
+    // empty for the tests that follow — the ingest gate means this is never
+    // consumed, and a leftover `Once` value would leak into a later test. Reset
+    // to the module default at the end.
+    vi.mocked(decodeSolutionDeliveryClaimedLogs).mockReturnValue([{
+      taskId: '1',
+      attemptIndex: 0,
+      requestId: REQUEST_ID,
+      operator: solverSafe,
+      transactionHash: TX_HASH,
+      blockNumber: 333,
+    }]);
+
+    const adapter = new MechAdapter({ ...TEST_CONFIG, evaluatorEnabled: false });
+    await adapter.initialize();
+    (adapter as any).publicClient.getBlockNumber = vi.fn().mockResolvedValue(101n);
+    (adapter as any).publicClient.getLogs = vi.fn().mockResolvedValue([{ data: '0x', topics: [] }]);
+    (adapter as any).requestBlockCursor = 100n;
+
+    const gen = adapter.watchForTasks()[Symbol.asyncIterator]();
+    // Drive exactly one poll cycle. With no restoration or evaluation work the
+    // cycle completes without yielding; race it against a microtask so the test
+    // never hangs on the outer while loop.
+    const step = gen.next();
+    await Promise.race([step, new Promise((resolve) => setImmediate(resolve))]);
+
+    expect(canClaimEvaluation).not.toHaveBeenCalled();
+    expect((adapter as any).pendingEvaluationSolutions.size).toBe(0);
+
+    await adapter.stop();
+    await step;
+    vi.mocked(decodeSolutionDeliveryClaimedLogs).mockReturnValue([]);
+  });
+
+  it('scans evaluation opportunities when the operator is an evaluator (#547)', async () => {
+    const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+    const {
+      canClaimEvaluation,
+      decodeSolutionDeliveryClaimedLogs,
+      getMarketplaceRequestDeliveryMech,
+    } = await import('../../../src/adapters/mech/contracts.js');
+    const { fetchFromIpfs, fetchSignedTaskFromIpfs } = await import('../../../src/adapters/mech/ipfs.js');
+    const solverSafe = ('0x' + '66'.repeat(20)) as `0x${string}`;
+    const solverMech = ('0x' + '77'.repeat(20)) as `0x${string}`;
+
+    vi.mocked(decodeSolutionDeliveryClaimedLogs).mockReturnValueOnce([{
+      taskId: '1',
+      attemptIndex: 0,
+      requestId: REQUEST_ID,
+      operator: solverSafe,
+      transactionHash: TX_HASH,
+      blockNumber: 333,
+    }]);
+    vi.mocked(getMarketplaceRequestDeliveryMech).mockResolvedValueOnce(solverMech);
+    vi.mocked(fetchFromIpfs).mockResolvedValueOnce({ data: 'solution payload' });
+    vi.mocked(fetchSignedTaskFromIpfs).mockResolvedValueOnce(signedTask({ id: 'watched-task' }));
+
+    const adapter = new MechAdapter({ ...TEST_CONFIG, evaluatorEnabled: true });
+    await adapter.initialize();
+    (adapter as any).publicClient.getBlockNumber = vi.fn().mockResolvedValue(101n);
+    (adapter as any).publicClient.getLogs = vi.fn().mockResolvedValue([{ data: '0x', topics: [] }]);
+    (adapter as any).requestBlockCursor = 100n;
+
+    const gen = adapter.watchForTasks()[Symbol.asyncIterator]();
+    const { value } = await gen.next();
+
+    expect(value).toMatchObject({ taskId: `evaluation:1:0:${REQUEST_ID}` });
+    expect(canClaimEvaluation).toHaveBeenCalled();
+
+    await adapter.stop();
+  });
+
+  it('does not rehydrate persisted evaluation opportunities on boot when not an evaluator (#547)', async () => {
+    const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
+    const store = makeConfigStore({
+      mech_pending_evaluation_solutions_v1: JSON.stringify([{
+        taskId: '1',
+        attemptIndex: 0,
+        requestId: REQUEST_ID,
+        operator: ('0x' + '66'.repeat(20)),
+        transactionHash: TX_HASH,
+        blockNumber: 333,
+      }]),
+    });
+
+    const adapter = new MechAdapter({ ...TEST_CONFIG, evaluatorEnabled: false }, store as never);
+    await adapter.initialize();
+
+    expect((adapter as any).pendingEvaluationSolutions.size).toBe(0);
+
+    await adapter.stop();
+  });
+
   it('drops stale evaluation opportunities before yielding them to the daemon', async () => {
     const { MechAdapter } = await import('../../../src/adapters/mech/adapter.js');
     const {

--- a/client/test/daemon/join-applier.test.ts
+++ b/client/test/daemon/join-applier.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createJoinApplier } from '../../src/daemon/join-applier.js';
 import { SolverNetRegistry } from '../../src/solver-nets/registry.js';
 import { createMutableJoinedSolverNetsView } from '../../src/harnesses/engine/engine.js';
@@ -96,6 +96,30 @@ describe('createJoinApplier', () => {
     const status = readiness.isReadyForClaim(CID);
     expect(status.reason ?? '').not.toContain('not in joinedSolverNets');
     expect(status.ready).toBe(true);
+  });
+
+  it('flips the evaluator gate on live for an evaluator-role join, but not for a solver-only join (#547)', async () => {
+    const { HarnessReadinessRegistry } = await import('../../src/harnesses/readiness-registry.js');
+    const readiness = new HarnessReadinessRegistry({ harnessesByName: {}, joinedHarnessesByCid: {} });
+    await readiness.refreshNow();
+
+    const makeApplier = (enableEvaluator: () => void) =>
+      createJoinApplier({
+        taskDiscovery: { solverNetManifestCids: [] as string[] },
+        view: createMutableJoinedSolverNetsView({}),
+        readiness,
+        registry: new SolverNetRegistry(),
+        config: {},
+        enableEvaluator,
+      });
+
+    const solverEnable = vi.fn();
+    await makeApplier(solverEnable)({ ...joined, roles: ['solver'] });
+    expect(solverEnable).not.toHaveBeenCalled();
+
+    const evaluatorEnable = vi.fn();
+    await makeApplier(evaluatorEnable)({ ...joined, roles: ['solver', 'evaluator'] });
+    expect(evaluatorEnable).toHaveBeenCalledOnce();
   });
 
   it('is idempotent on the cid set (re-apply does not duplicate)', async () => {


### PR DESCRIPTION
## Summary

The daemon iterated the full historical evaluation-opportunity backlog on **every** poll cycle even for operators whose joined-SolverNet roles are `["solver"]` and never `evaluator`. Each opportunity fanned out chain reads (`canEvaluate` and friends) that could never produce an actionable claim — wasted RPC budget and added substrate RPC pressure (the class of load that took the indexer down on 2026-05-20).

This gates all three evaluation surfaces behind a single `evaluatorEnabled` flag on `MechAdapter`:

- **Boot rehydrate** — `loadPendingEvaluationSolutions()` is skipped for non-evaluators. `recoverPendingState` (own in-flight *restoration* claims via router cursor / TaskCreated scan) stays unguarded.
- **Per-cycle ingest** — delivery-claimed logs are only decoded into the pending-evaluation set when `evaluatorEnabled`. Restoration discovery is untouched.
- **Per-cycle scan** — `retryPendingEvaluationSolutions()` returns early for non-evaluators (covers both `watchForTasks` call sites via the one guard).

`MechAdapterConfig.evaluatorEnabled` is **opt-out** (undefined ⇒ enabled) so bare/CLI construction sites keep historical behaviour; production callers (`main.ts`) pass an explicit boolean derived from `joinedSolverNets` roles. A live evaluator-role join flips the gate on via `setEvaluatorEnabled(true)`, wired through the join-applier's new `enableEvaluator` dep. A join never removes a role, so no "off" path exists.

## Test plan

- `client/test/adapters/mech/adapter.test.ts` — solver-only (`evaluatorEnabled: false`) asserts `canClaimEvaluation` is never called and `pendingEvaluationSolutions` stays empty (the acceptance criterion); a paired evaluator (`true`) test asserts a real `evaluation:…` announcement is yielded so the gate is load-bearing, not a no-op; a boot-rehydrate test asserts persisted opportunities are not rehydrated for non-evaluators.
- `client/test/daemon/join-applier.test.ts` — asserts `enableEvaluator` fires for an evaluator-role join and never for a solver-only join (closes a review-flagged coverage gap on the live-flip mechanism).
- `yarn typecheck` green; both test files pass (58 + 5).

## Reviewer notes

- Independent review: **approve**, nothing blocking. Traced the second `new MechAdapter` site (`cli/execution-context.ts`) — it drives `jinn tasks submit` only and never calls `watchForTasks`, so its default-enabled flag is inert.
- Security review: **no security-relevant issues** — this is an internal behavior gate, not an auth boundary; self-eval prevention and claim eligibility remain enforced on-chain.
- Known functional edge (out of scope, fails **closed**): the request-block cursor advances while the gate is disabled, so an operator that turns evaluator on *live* mid-run will not rehydrate solutions delivered during the disabled window. It fails closed (fewer opportunities, never unauthorized) and the common case (evaluator role present at boot) is unaffected.

Closes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)