### PR TITLE
chore(ci): cache client node_modules in hermetic gate to avoid onnxruntime CDN fetch

### DIFF
--- a/.github/workflows/hermetic-gate.yml
+++ b/.github/workflows/hermetic-gate.yml
@@ -88,12 +88,18 @@ jobs:
       # a warm run restores it and `--immutable` reconciles without re-running the
       # postinstall — CDN is never contacted (AC-1). A cold run (miss on a changed
       # `client/yarn.lock`) may fall back to the CDN fetch once, then primes the
-      # cache for subsequent warm runs (AC-2).
+      # cache for subsequent warm runs (AC-2). The `restore-keys` prefix lets a
+      # run whose `client/yarn.lock` changed for an unrelated reason still restore
+      # the prior `node_modules` as a base tree — `--immutable` reconciles only the
+      # deltas against it instead of a cold CDN fetch (a genuinely bumped
+      # onnxruntime version would still re-fetch, which is unavoidable).
       - name: Cache client node_modules (holds onnxruntime-node prebuilt binary)
         uses: actions/cache@v4
         with:
           path: client/node_modules
           key: ${{ runner.os }}-client-nodemodules-${{ hashFiles('client/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-client-nodemodules-
 
       - name: Install client deps
         working-directory: client

--- a/.github/workflows/hermetic-gate.yml
+++ b/.github/workflows/hermetic-gate.yml
@@ -79,6 +79,22 @@ jobs:
         with:
           version: nightly-1c7c4bebce1e075989780fd401bf6bffcb424746
 
+      # A gate named *hermetic* must not hit a third-party CDN per run. `client`
+      # depends (via @huggingface/transformers) on onnxruntime-node, whose
+      # postinstall downloads a prebuilt native `.node` binary from an external
+      # CDN — that fetch flaked (ETIMEDOUT) and red-gated PR #1622 (#1697).
+      # Cache `client/node_modules` specifically: with `nodeLinker: node-modules`
+      # the downloaded binary lives inside node_modules (not the yarn cache), so
+      # a warm run restores it and `--immutable` reconciles without re-running the
+      # postinstall — CDN is never contacted (AC-1). A cold run (miss on a changed
+      # `client/yarn.lock`) may fall back to the CDN fetch once, then primes the
+      # cache for subsequent warm runs (AC-2).
+      - name: Cache client node_modules (holds onnxruntime-node prebuilt binary)
+        uses: actions/cache@v4
+        with:
+          path: client/node_modules
+          key: ${{ runner.os }}-client-nodemodules-${{ hashFiles('client/yarn.lock') }}
+
       - name: Install client deps
         working-directory: client
         run: yarn install --immutable


### PR DESCRIPTION
## Summary

The "Hermetic gate (deterministic, snapshot)" job runs `yarn install --immutable` in `client/`, which triggers `onnxruntime-node@1.24.3` (pulled transitively by `@huggingface/transformers`, used by the trajectory scrub detector) to download a prebuilt native `.node` binary from an external CDN at install time. On 2026-07-12 that fetch flaked (`AggregateError [ETIMEDOUT] connect ETIMEDOUT 150.171.109.149:443`) and red-gated PR #1622 — a network flake on a gate whose entire premise is that a red is always a real code regression.

This adds a single `actions/cache@v4` step caching `client/node_modules`, keyed on `client/yarn.lock`, placed immediately before "Install client deps". With `nodeLinker: node-modules` the downloaded binary lives inside `node_modules` (not the yarn cache), so:

- **Warm run** (AC-1): `node_modules` — including the already-downloaded binary and yarn's `.yarn-state.yml` build state — is restored, so `yarn install --immutable` reconciles without re-running the postinstall. The CDN is never contacted.
- **Cold run** (AC-2): a cache miss falls back to the CDN fetch once, install succeeds, and the cache is primed for subsequent warm runs.

A `restore-keys` prefix lets a run whose `client/yarn.lock` changed for an unrelated reason still restore the prior `node_modules` as a base and reconcile only the deltas, rather than paying a cold CDN fetch (a genuinely bumped onnxruntime version would still re-fetch — unavoidable).

## Test plan

CI-workflow-only change; no runtime code path is touched, and the repo has no workflow-assertion test harness (per the Low-chore SOP, none was invented). Verified by:
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/hermetic-gate.yml'))"` → YAML OK
- Confirmed the cache step is ordered before "Install client deps" and correctly keyed on `client/yarn.lock`.

The behavioral outcome (warm run skips the CDN) is validated by the gate's own subsequent runs on this branch and after merge.

Closes #1697

🤖 Generated with [Claude Code](https://claude.com/claude-code)