### PR TITLE
fix(hermes-agent): honor JINN_HERMES_MODEL/PROVIDER over per-SolverNet model config (#543)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,8 @@ Config file first, env var override. File at `~/.jinn-client/config.json` or `--
 |------------------|--------------------------|-----------------------------------|
 | rpcUrl           | BASE_RPC_URL/JINN_RPC_URL| mainnet (default fallback chain): `["https://mainnet.base.org", …4 more]` · testnet (default fallback chain): `["https://base-sepolia.publicnode.com", …3 more, "https://sepolia.base.org"]` (≥5 free providers per chain, #911) |
 | claudeModel      | JINN_CLAUDE_MODEL        | claude-haiku-4-5-20251001         |
+| hermesModel      | JINN_HERMES_MODEL        | per-SolverNet config (env wins over SolverNet config) |
+| hermesProvider   | JINN_HERMES_PROVIDER     | per-SolverNet config (env wins; ignored when a base_url/custom endpoint is set) |
 | claudePath       | JINN_CLAUDE_PATH         | claude                            |
 | pollIntervalMs   | JINN_POLL_INTERVAL_MS    | 5000                              |
 | apiPort          | JINN_API_PORT            | 7331                              |

--- a/client/src/harnesses/impls/hermes-agent/bootstrap.ts
+++ b/client/src/harnesses/impls/hermes-agent/bootstrap.ts
@@ -92,6 +92,12 @@ export interface WritePerTaskConfigInputs {
    * in tests.
    */
   seedFrom?: string;
+  /**
+   * OS environment for reading JINN_HERMES_MODEL / JINN_HERMES_PROVIDER
+   * precedence overrides. Defaults to process.env at the read site; injected
+   * in tests to set precedence cases without mutating global env.
+   */
+  processEnv?: NodeJS.ProcessEnv;
 }
 
 function seedOperatorState(hermesHome: string, seedFrom: string): void {
@@ -265,9 +271,14 @@ export function writePerTaskHermesConfig(inputs: WritePerTaskConfigInputs): void
 
   const operator = inputs.seedFrom ? readOperatorConfigYaml(inputs.seedFrom) : {};
   const snippet = hermesConfigFromSolverPlugins(inputs.solverPluginRoots, inputs.env);
+  const envSource = inputs.processEnv ?? process.env;
+  const envModel = envSource['JINN_HERMES_MODEL']?.trim() || undefined;
+  const envProvider = envSource['JINN_HERMES_PROVIDER']?.trim() || undefined;
+  const model = envModel ?? inputs.model;
+  const provider = inputs.baseUrl ? inputs.provider : (envProvider ?? inputs.provider);
   const merged = mergePerTaskConfig(operator, snippet, {
-    model: inputs.model,
-    provider: inputs.provider,
+    model,
+    provider,
     baseUrl: inputs.baseUrl,
     workingDir: inputs.workingDir,
   });

--- a/client/test/harnesses/impls/hermes-agent/bootstrap.test.ts
+++ b/client/test/harnesses/impls/hermes-agent/bootstrap.test.ts
@@ -446,6 +446,91 @@ describe('writePerTaskHermesConfig', () => {
     });
   });
 
+  // JINN_HERMES_MODEL / JINN_HERMES_PROVIDER (daemon OS env) must win over the
+  // per-SolverNet config value (`inputs.model` / `inputs.provider`), which wins
+  // over ~/.hermes/config.yaml. Precedence bug #543: the SolverNet config value
+  // silently won because writePerTaskHermesConfig stamped `inputs.model` directly.
+  describe('JINN_HERMES_MODEL / JINN_HERMES_PROVIDER env precedence', () => {
+    it('uses the env vars when no per-SolverNet model/provider is supplied', () => {
+      const home = mkdtempSync(join(tmpdir(), 'hermes-home-'));
+      try {
+        writePerTaskHermesConfig({
+          hermesHome: home,
+          workingDir: '/work',
+          solverPluginRoots: [],
+          env: { daemonApiUrl: 'http://127.0.0.1:7331', daemonApiToken: 'tok', corpusEnv: {} },
+          processEnv: { JINN_HERMES_MODEL: 'env-model', JINN_HERMES_PROVIDER: 'env-provider' },
+        });
+        const cfg = readConfig(home);
+        expect(cfg.model.default).toBe('env-model');
+        expect(cfg.model.provider).toBe('env-provider');
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
+    it('uses the per-SolverNet config value when no env vars are set', () => {
+      const home = mkdtempSync(join(tmpdir(), 'hermes-home-'));
+      try {
+        writePerTaskHermesConfig({
+          hermesHome: home,
+          workingDir: '/work',
+          model: 'config-model',
+          provider: 'config-provider',
+          solverPluginRoots: [],
+          env: { daemonApiUrl: 'http://127.0.0.1:7331', daemonApiToken: 'tok', corpusEnv: {} },
+          processEnv: {},
+        });
+        const cfg = readConfig(home);
+        expect(cfg.model.default).toBe('config-model');
+        expect(cfg.model.provider).toBe('config-provider');
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
+    it('prefers the env vars over the per-SolverNet config value', () => {
+      const home = mkdtempSync(join(tmpdir(), 'hermes-home-'));
+      try {
+        writePerTaskHermesConfig({
+          hermesHome: home,
+          workingDir: '/work',
+          model: 'config-model',
+          provider: 'config-provider',
+          solverPluginRoots: [],
+          env: { daemonApiUrl: 'http://127.0.0.1:7331', daemonApiToken: 'tok', corpusEnv: {} },
+          processEnv: { JINN_HERMES_MODEL: 'env-model', JINN_HERMES_PROVIDER: 'env-provider' },
+        });
+        const cfg = readConfig(home);
+        expect(cfg.model.default).toBe('env-model');
+        expect(cfg.model.provider).toBe('env-provider');
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
+    it('keeps the custom-endpoint provider when a base_url is set (env provider does not override)', () => {
+      const home = mkdtempSync(join(tmpdir(), 'hermes-home-'));
+      try {
+        writePerTaskHermesConfig({
+          hermesHome: home,
+          workingDir: '/work',
+          model: 'qwen2.5-coder:7b',
+          provider: 'custom',
+          baseUrl: 'http://127.0.0.1:11434/v1',
+          solverPluginRoots: [],
+          env: { daemonApiUrl: 'http://127.0.0.1:7331', daemonApiToken: 'tok', corpusEnv: {} },
+          processEnv: { JINN_HERMES_PROVIDER: 'env-provider' },
+        });
+        const cfg = readConfig(home);
+        expect(cfg.model.provider).toBe('custom');
+        expect(cfg.model.base_url).toBe('http://127.0.0.1:11434/v1');
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+  });
+
   it('skips seeding when seedFrom equals hermesHome or does not exist', () => {
     const taskHome = mkdtempSync(join(tmpdir(), 'hermes-task-'));
     try {

--- a/client/test/harnesses/impls/hermes-agent/bootstrap.test.ts
+++ b/client/test/harnesses/impls/hermes-agent/bootstrap.test.ts
@@ -509,6 +509,26 @@ describe('writePerTaskHermesConfig', () => {
       }
     });
 
+    it('ignores empty/whitespace env vars and preserves the per-SolverNet config value', () => {
+      const home = mkdtempSync(join(tmpdir(), 'hermes-home-'));
+      try {
+        writePerTaskHermesConfig({
+          hermesHome: home,
+          workingDir: '/work',
+          model: 'config-model',
+          provider: 'config-provider',
+          solverPluginRoots: [],
+          env: { daemonApiUrl: 'http://127.0.0.1:7331', daemonApiToken: 'tok', corpusEnv: {} },
+          processEnv: { JINN_HERMES_MODEL: '   ', JINN_HERMES_PROVIDER: '' },
+        });
+        const cfg = readConfig(home);
+        expect(cfg.model.default).toBe('config-model');
+        expect(cfg.model.provider).toBe('config-provider');
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
     it('keeps the custom-endpoint provider when a base_url is set (env provider does not override)', () => {
       const home = mkdtempSync(join(tmpdir(), 'hermes-home-'));
       try {

--- a/docs/operator/rotating-harness-keys.md
+++ b/docs/operator/rotating-harness-keys.md
@@ -45,6 +45,8 @@ OPENROUTER_API_KEY=sk-or-...
 
 For OAuth / pooled credentials, run `hermes login`; it writes `~/.hermes/auth/` and `~/.hermes/auth.json`, which the daemon seeds per Task.
 
+Model / provider precedence: `JINN_HERMES_MODEL` / `JINN_HERMES_PROVIDER` in the daemon env win over the per-SolverNet config value, which wins over `~/.hermes/config.yaml`. When `JINN_HERMES_BASE_URL` (a local OpenAI-compatible endpoint) is set the provider stays `custom` regardless of `JINN_HERMES_PROVIDER`; the model name is still env-overridable.
+
 > Note on the rotate subcommand: a `hermes auth add` subcommand could **not** be confirmed in the harness code as shipped. The verified surfaces are `hermes login` (OAuth), the `~/.hermes/.env` file (provider key), and `hermes auth list` (used by the readiness probe). For an explicit add/rotate subcommand, run `hermes --help` against your installed version rather than relying on an unverified command.
 
 ## client/.env is dev-only


### PR DESCRIPTION
**Recovered stranded work.** An autopilot session implemented #543 and committed to `fix/543-hermes-agent-jinn-hermes-model-jinn-hermes-provider-env-vars` but terminated before opening a PR — the worktree was about to be reclaimed, so this surfaces the commits for review rather than losing them.

Commits authored by the autopilot session; opened as a **draft**, unvetted by me — **CI + review still required**. Do not merge until green + reviewed.

Closes #543.