### PR TITLE
feat(jinn-agent): wire splash corpus reachability + contribution counts (#1420)

### DIFF
--- a/apps/jinn-agent/hermes_cli/banner.py
+++ b/apps/jinn-agent/hermes_cli/banner.py
@@ -365,11 +365,11 @@ def gather_splash_state() -> Dict[str, object]:
       - contribution: real consent state — ``unset`` omits the line,
         ``accepted`` → on, ``declined`` → off.
 
-    Degraded (no cheap sync fork source — see the PR data-wiring notes):
-      - corpus reachability + count: needs a ``jinn-layer corpus`` call.
-        A real source exists but not synchronously; wiring it is follow-up
-        Jinn-Network/mono#1420, so this stays ``checking…`` for now (not a bug).
-      - contribution_count: needs a ``jinn-layer ledger`` call.
+    Wired via the background prefetch (non-blocking, ``timeout=0.0``):
+      - corpus reachability + count and contribution_count come from
+        ``prefetch_splash_reads()`` (jinn-layer corpus search + ledger). Until
+        the prefetch resolves the read yields None and corpus honestly stays
+        ``checking…`` — the settle can't shift layout (label-column-fixed).
 
     Omitted (no source at all in the fork — the line is not rendered):
       - node status + vessel: the harness has no local node/vessel concept
@@ -401,11 +401,23 @@ def gather_splash_state() -> Dict[str, object]:
     except Exception:
         pass  # No consent module → treat as pre-consent, omit the line.
 
-    # corpus: no cheap synchronous source yet → left unresolved (checking…).
-    # A real corpus source exists but not synchronously; wiring it (reachability
-    # + envelope count without blocking the paint) is follow-up
-    # Jinn-Network/mono#1420. Until then this line honestly reads checking… —
-    # it is not a bug. node: key never set → line omitted (see _status_lines).
+    # Corpus + contribution count — reuse the prefetched reads; never block.
+    # Un-prefetched / not-yet-resolved → None → corpus stays checking… (paint
+    # never shifts layout: the status strings are label-column-fixed). node:
+    # key never set → line omitted (see _status_lines).
+    try:
+        reads = get_splash_reads(timeout=0.0)
+    except Exception:
+        reads = None
+    if reads is not None:
+        if "corpus" in reads:
+            state["corpus"] = reads["corpus"]
+        if "corpus_count" in reads:
+            state["corpus_count"] = reads["corpus_count"]
+        # contribution_count only when contribution is on (renderer degrades to
+        # 'on · traces published' without a count otherwise).
+        if state.get("contribution") == "on" and "contribution_count" in reads:
+            state["contribution_count"] = reads["contribution_count"]
     return state
 
 
@@ -885,6 +897,81 @@ def get_update_result(timeout: float = 0.5) -> Optional[int]:
     """Get result of prefetched check. Returns None if not ready."""
     _update_check_done.wait(timeout=timeout)
     return _update_result
+
+
+# =========================================================================
+# Non-blocking splash reads (corpus reachability+count, contribution count)
+# =========================================================================
+
+_splash_result: Optional[Dict[str, object]] = None
+_splash_reads_done = threading.Event()
+
+
+def _read_contribution_count() -> Optional[int]:
+    """Published-trace count via jinn-layer ``ledger --json``, or None.
+
+    Mirrors ``/jinn ledger``'s "N published" (ledger_view.render_ledger) and
+    the ``onboarding.ledger_nonempty`` degrade rule: any layer error /
+    unparseable output / unrecognised shape → None (never a false count, never
+    raise). Stored raw — consent-gating is applied at merge time in
+    ``gather_splash_state``.
+    """
+    try:
+        from plugins.jinn import jinn_layer, ledger_view
+        code, out = jinn_layer.ledger_json()
+        if code != 0:
+            return None
+        rows = ledger_view.rows_from_json(json.loads(out))
+        if rows is None:
+            return None
+        return sum(1 for r in rows if r.get("state") not in ("vetoed", "failed"))
+    except Exception:
+        return None
+
+
+def _read_corpus() -> Dict[str, object]:
+    """Corpus reachability+count via ``corpus search '' --limit 500 --json``.
+
+    exit 0 + a parseable JSON array → connected + len(hits); anything else →
+    unreachable. NOTE: corpus_count is capped at the ``--limit`` (500) — the
+    only corpus verb is ``search`` (no total-count/stats verb in harness-layer),
+    so this is exact at testnet scale and under-reports past 500 records. A real
+    total-count verb is the follow-up if/when mainnet scale demands it.
+    """
+    try:
+        from plugins.jinn import jinn_layer
+        code, out = jinn_layer.corpus_search("", limit=500, as_json=True)
+        if code == 0:
+            hits = json.loads(out)
+            if isinstance(hits, list):
+                return {"corpus": "connected", "corpus_count": len(hits)}
+    except Exception:
+        pass
+    return {"corpus": "unreachable"}
+
+
+def prefetch_splash_reads():
+    """Kick both splash subprocess reads in a background daemon thread."""
+    def _run():
+        global _splash_result
+        result: Dict[str, object] = {}
+        try:
+            result.update(_read_corpus())
+            cc = _read_contribution_count()
+            if cc is not None:
+                result["contribution_count"] = cc
+        except Exception:
+            pass  # never raise — publish whatever resolved, honest checking… for the rest
+        _splash_result = result
+        _splash_reads_done.set()
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+
+
+def get_splash_reads(timeout: float = 0.0) -> Optional[Dict[str, object]]:
+    """Result of the prefetched reads, or None if unresolved. Never blocks at 0.0."""
+    _splash_reads_done.wait(timeout=timeout)
+    return _splash_result
 
 
 # =========================================================================

--- a/apps/jinn-agent/hermes_cli/banner.py
+++ b/apps/jinn-agent/hermes_cli/banner.py
@@ -924,7 +924,7 @@ def _read_contribution_count() -> Optional[int]:
         rows = ledger_view.rows_from_json(json.loads(out))
         if rows is None:
             return None
-        return sum(1 for r in rows if r.get("state") not in ("vetoed", "failed"))
+        return ledger_view.published_count(rows)
     except Exception:
         return None
 

--- a/apps/jinn-agent/hermes_cli/main.py
+++ b/apps/jinn-agent/hermes_cli/main.py
@@ -2320,9 +2320,10 @@ def cmd_chat(args):
     # competes for CPU on single-core devices, so keep it opt-in there.
     if _termux_should_prefetch_update_check():
         try:
-            from hermes_cli.banner import prefetch_update_check
+            from hermes_cli.banner import prefetch_update_check, prefetch_splash_reads
 
             prefetch_update_check()
+            prefetch_splash_reads()
         except Exception:
             pass
 

--- a/apps/jinn-agent/plugins/jinn/jinn_layer.py
+++ b/apps/jinn-agent/plugins/jinn/jinn_layer.py
@@ -136,9 +136,7 @@ def corpus_search(
     the one production caller (``plugins/jinn/__init__.py``) that already passes
     ``runner=`` by keyword stays backward-compatible.
     """
-    args = ["corpus", "search", query]
-    if limit is not None:
-        args += ["--limit", str(limit)]
+    args = ["corpus", "search", query, "--limit", str(limit)]
     if as_json:
         args.append("--json")
     return run(args, runner)

--- a/apps/jinn-agent/plugins/jinn/jinn_layer.py
+++ b/apps/jinn-agent/plugins/jinn/jinn_layer.py
@@ -122,8 +122,26 @@ def ledger_json(runner: Optional[Runner] = None) -> Tuple[int, str]:
     return run(["ledger", "--json"], runner)
 
 
-def corpus_search(query: str, runner: Optional[Runner] = None) -> Tuple[int, str]:
-    return run(["corpus", "search", query], runner)
+def corpus_search(
+    query: str,
+    *,
+    limit: int = 500,
+    as_json: bool = True,
+    runner: Optional[Runner] = None,
+) -> Tuple[int, str]:
+    """Corpus search. The CLI owns clamping ([1,500]) and ``""`` = all records.
+
+    ``as_json`` emits ``--json`` (harness-layer prints ``JSON.stringify(hits)``,
+    a JSON array); ``limit`` emits ``--limit N``. Keyword-only past ``query`` so
+    the one production caller (``plugins/jinn/__init__.py``) that already passes
+    ``runner=`` by keyword stays backward-compatible.
+    """
+    args = ["corpus", "search", query]
+    if limit is not None:
+        args += ["--limit", str(limit)]
+    if as_json:
+        args.append("--json")
+    return run(args, runner)
 
 
 def contract(runner: Optional[Runner] = None) -> Tuple[int, str]:

--- a/apps/jinn-agent/plugins/jinn/ledger_view.py
+++ b/apps/jinn-agent/plugins/jinn/ledger_view.py
@@ -219,6 +219,16 @@ def render_ledger(
     return "\n".join(out)
 
 
+def published_count(rows: Sequence[Dict[str, object]]) -> int:
+    """Number of published rows — the canonical "N published" definition.
+
+    Published = any row whose ``state`` is neither ``vetoed`` nor ``failed``.
+    Single source of truth for the count ``render_ledger`` shows and the splash
+    line mirrors, so the two never drift.
+    """
+    return sum(1 for r in rows if r.get("state") not in ("vetoed", "failed"))
+
+
 def rows_from_json(payload: object) -> Optional[List[Dict[str, object]]]:
     """Coerce a parsed ``jinn-layer ledger --json`` payload into render rows.
 

--- a/apps/jinn-agent/tests/plugins/test_jinn_layer.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_layer.py
@@ -1,0 +1,46 @@
+"""jinn-layer wrapper argv tests (Jinn-Network/mono#1420).
+
+The splash corpus reachability+count read depends on ``corpus_search``
+emitting ``--limit`` and ``--json``. These assert the exact argv the wrapper
+hands the runner (a fake callable capturing the full argv, ``binary()`` at
+index 0).
+"""
+
+from __future__ import annotations
+
+from plugins.jinn import jinn_layer
+
+
+def test_corpus_search_emits_limit_and_json_flags():
+    captured = []
+
+    def runner(argv):
+        captured.append(argv)
+        return 0, "[]"
+
+    code, out = jinn_layer.corpus_search("", limit=500, as_json=True, runner=runner)
+    assert code == 0
+    assert out == "[]"
+    assert captured[0][1:] == ["corpus", "search", "", "--limit", "500", "--json"]
+
+
+def test_corpus_search_query_only_default_still_json():
+    captured = []
+
+    def runner(argv):
+        captured.append(argv)
+        return 0, "[]"
+
+    jinn_layer.corpus_search("tdd", runner=runner)
+    assert captured[0][1:] == ["corpus", "search", "tdd", "--limit", "500", "--json"]
+
+
+def test_corpus_search_no_json_omits_flag():
+    captured = []
+
+    def runner(argv):
+        captured.append(argv)
+        return 0, ""
+
+    jinn_layer.corpus_search("q", as_json=False, runner=runner)
+    assert captured[0][1:] == ["corpus", "search", "q", "--limit", "500"]

--- a/apps/jinn-agent/tests/plugins/test_jinn_splash.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_splash.py
@@ -18,11 +18,23 @@ surface is re-derivable from these tests.
 from __future__ import annotations
 
 import re
+import threading
 
 import pytest
 
 from hermes_cli import banner
 from hermes_cli.banner import _FB, _TC, render_jinn_splash
+
+
+@pytest.fixture(autouse=True)
+def _reset_splash_globals():
+    """Snapshot+restore the splash-reads module globals so no test leaks a
+    resolved read into the honest-``checking…`` cases (#1420)."""
+    prev_r, prev_e = banner._splash_result, banner._splash_reads_done
+    banner._splash_result = None
+    banner._splash_reads_done = threading.Event()
+    yield
+    banner._splash_result, banner._splash_reads_done = prev_r, prev_e
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -328,3 +340,49 @@ def test_gather_state_contribution_follows_consent(monkeypatch, tmp_path):
 
     consent.save_state(False)
     assert banner.gather_splash_state().get("contribution") == "off"
+
+
+# ── splash reads prefetch (#1420) ────────────────────────────────────────────
+
+
+def _resolve(**payload):
+    banner._splash_result = payload
+    banner._splash_reads_done.set()
+
+
+def test_get_splash_reads_returns_none_when_unprefetched():
+    assert banner.get_splash_reads(timeout=0.0) is None  # AC3 non-blocking
+
+
+def test_resolved_connected_populates_corpus_and_count(monkeypatch):
+    monkeypatch.delenv("JINN_NETWORK", raising=False)
+    _resolve(corpus="connected", corpus_count=42)
+    state = banner.gather_splash_state()
+    assert state["corpus"] == "connected"
+    assert state["corpus_count"] == 42  # AC1
+
+
+def test_resolved_unreachable_sets_corpus_no_count(monkeypatch):
+    monkeypatch.delenv("JINN_NETWORK", raising=False)
+    _resolve(corpus="unreachable")
+    state = banner.gather_splash_state()
+    assert state["corpus"] == "unreachable"
+    assert "corpus_count" not in state  # AC1
+
+
+def test_contribution_count_only_when_on(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from plugins.jinn import consent
+
+    consent.save_state(consent.ACCEPTED)
+    _resolve(contribution_count=7)
+    assert banner.gather_splash_state()["contribution_count"] == 7  # AC2
+
+
+def test_contribution_count_suppressed_when_off(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from plugins.jinn import consent
+
+    consent.save_state(consent.DECLINED)
+    _resolve(contribution_count=7)
+    assert "contribution_count" not in banner.gather_splash_state()  # AC2 gate

--- a/apps/jinn-agent/tests/plugins/test_jinn_splash.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_splash.py
@@ -374,7 +374,7 @@ def test_contribution_count_only_when_on(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     from plugins.jinn import consent
 
-    consent.save_state(consent.ACCEPTED)
+    consent.save_state(True)
     _resolve(contribution_count=7)
     assert banner.gather_splash_state()["contribution_count"] == 7  # AC2
 
@@ -383,6 +383,6 @@ def test_contribution_count_suppressed_when_off(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     from plugins.jinn import consent
 
-    consent.save_state(consent.DECLINED)
+    consent.save_state(False)
     _resolve(contribution_count=7)
     assert "contribution_count" not in banner.gather_splash_state()  # AC2 gate

--- a/apps/jinn-agent/tui_gateway/server.py
+++ b/apps/jinn-agent/tui_gateway/server.py
@@ -117,9 +117,10 @@ def _thread_panic_hook(args):
 threading.excepthook = _thread_panic_hook
 
 try:
-    from hermes_cli.banner import prefetch_update_check
+    from hermes_cli.banner import prefetch_update_check, prefetch_splash_reads
 
     prefetch_update_check()
+    prefetch_splash_reads()
 except Exception:
     pass
 


### PR DESCRIPTION
**Recovered stranded work.** An autopilot session implemented #1420 and committed to `feat/1420-splash-wire-corpus-reachability-count-and-contribution-count` but terminated before opening a PR — the worktree was about to be reclaimed, so this surfaces the commits for review rather than losing them.

Commits authored by the autopilot session; opened as a **draft**, unvetted by me — **CI + review still required**. Do not merge until green + reviewed.

Closes #1420.