### PR TITLE
feat(harness-layer): persistent + discoverable distiller-model selection (#1496)

### DIFF
--- a/client/packages/harness-layer/src/cli.ts
+++ b/client/packages/harness-layer/src/cli.ts
@@ -74,7 +74,9 @@ import { createLocalDistiller, createLocalSkillSink } from './distiller.js';
 import { parseSkillMarkdown, type SkillPackage } from './skill-package.js';
 import {
   DEFAULT_DISTILL_MODE_PATH,
+  readDistillDefaults,
   readDistillMode,
+  writeDistillDefaults,
   writeDistillMode,
   type DistillMode,
 } from './distill-mode.js';
@@ -1134,20 +1136,38 @@ export async function runJinnLayerCli(
     const endedEmpty = () =>
       progress?.runEnd({ outcome: 'empty', clusterCount: 0, published: [], rejectedCount: 0, errorCount: 0, installed: [] });
 
+    const modePath = distillModePath();
+    const persisted = readDistillDefaults(modePath);
+
     // Distiller provider + model — the arbitrage knob. The model resolved here
     // WRITES the skills; it is deliberately distinct from the cheap runtime
     // model each capture ran under (`environment.model`), which `distill` never
-    // touches. Resolution: --distiller-model > JINN_DISTILL_MODEL > provider default.
-    const rawProvider = (parsed.values.distiller as string | undefined) ?? process.env['JINN_DISTILL_PROVIDER'] ?? 'claude';
+    // touches. Resolution: flag > env > persisted default > provider default.
+    const rawProvider =
+      (parsed.values.distiller as string | undefined) ??
+      process.env['JINN_DISTILL_PROVIDER'] ??
+      persisted.distiller ??
+      'claude';
     const distillProvider = parseDistillProvider(rawProvider);
     if (!distillProvider) {
       writer.write(`error: distiller must be "claude" or "codex" (got ${JSON.stringify(rawProvider)})\n\n${USAGE}`);
       return 2;
     }
     const defaultDistillModel = distillProvider === 'codex' ? DEFAULT_CODEX_MODEL : DEFAULT_CLAUDE_DISTILL_MODEL;
+    // The persisted model belongs to the persisted provider. If the effective
+    // provider was overridden away from it by a flag/env, the persisted model
+    // no longer applies — fall to the new provider's default instead.
+    const providerOverridden =
+      (parsed.values.distiller as string | undefined) !== undefined ||
+      process.env['JINN_DISTILL_PROVIDER'] !== undefined;
+    const persistedModel =
+      providerOverridden && persisted.distiller !== undefined && persisted.distiller !== distillProvider
+        ? undefined
+        : persisted.distillerModel;
     const distillModel =
       (parsed.values['distiller-model'] as string | undefined) ??
       process.env['JINN_DISTILL_MODEL'] ??
+      persistedModel ??
       defaultDistillModel;
     const clusterTimeoutMs = resolveClusterTimeoutMs(parsed.values['cluster-timeout'] as string | undefined);
     if (typeof clusterTimeoutMs === 'object') {
@@ -1157,7 +1177,6 @@ export async function runJinnLayerCli(
     const distill =
       dd.distill ?? (dd.distillerFactory ?? defaultDistillerFactory)(distillProvider, distillModel, clusterTimeoutMs).distill;
 
-    const modePath = distillModePath();
     const runsPath = process.env['JINN_LAYER_DISTILL_RUNS_PATH'] ?? DEFAULT_DISTILL_RUNS_PATH;
     const logRun = (
       outcome: DistillRunRecord['outcome'],

--- a/client/packages/harness-layer/src/cli.ts
+++ b/client/packages/harness-layer/src/cli.ts
@@ -69,6 +69,7 @@ import {
   createCodexMetaDistiller,
   DEFAULT_CODEX_MODEL,
   DEFAULT_MODEL as DEFAULT_CLAUDE_DISTILL_MODEL,
+  DISTILLER_CATALOG,
 } from './distill-llm.js';
 import { createLocalDistiller, createLocalSkillSink } from './distiller.js';
 import { parseSkillMarkdown, type SkillPackage } from './skill-package.js';
@@ -864,7 +865,8 @@ export async function runJinnLayerCli(
   const isSkillsInstall = verb === 'skills' && subverb === 'install';
   const isDistillRun = verb === 'distill' && subverb === 'run';
   const isDistillEvalPrep = verb === 'distill' && subverb === 'eval-prep';
-  const isDistill = verb === 'distill' && !isDistillRun && !isDistillEvalPrep;
+  const isDistillModels = verb === 'distill' && subverb === 'models';
+  const isDistill = verb === 'distill' && !isDistillRun && !isDistillEvalPrep && !isDistillModels;
   const isDeriveEnv = verb === 'derive-env';
   const isContract = verb === 'contract';
   const isSessionPickup = verb === 'session' && subverb === 'pickup';
@@ -873,7 +875,7 @@ export async function runJinnLayerCli(
   const isContributionPreview = verb === 'contribution' && subverb === 'preview';
   const isContributionLedger = verb === 'contribution' && subverb === 'ledger';
   const isContributionDisable = verb === 'contribution' && subverb === 'disable';
-  if (!isCorpus && !isCapturePreview && !isLedger && !isPublish && !isSeed && !isSkillsInstall && !isDistillRun && !isDistillEvalPrep && !isDistill && !isDeriveEnv && !isContract && !isSessionPickup && !isSessionEnd && !isHistory && !isContributionPreview && !isContributionLedger && !isContributionDisable) {
+  if (!isCorpus && !isCapturePreview && !isLedger && !isPublish && !isSeed && !isSkillsInstall && !isDistillRun && !isDistillEvalPrep && !isDistillModels && !isDistill && !isDeriveEnv && !isContract && !isSessionPickup && !isSessionEnd && !isHistory && !isContributionPreview && !isContributionLedger && !isContributionDisable) {
     writer.write(USAGE);
     return verb === undefined || verb === 'help' || verb === '--help' ? 0 : 2;
   }
@@ -1115,6 +1117,33 @@ export async function runJinnLayerCli(
     return result.errors.length > 0 ? 1 : 0;
   }
 
+  if (isDistillModels) {
+    const json = parsed.values.json as boolean;
+    const persisted = readDistillDefaults(distillModePath());
+    // Resolve exactly as a run would (minus per-run model-vs-provider nuance):
+    // flag > env > persisted > provider default, so the marked row is what a
+    // bare `distill` would actually use.
+    const rawProvider =
+      (parsed.values.distiller as string | undefined) ??
+      process.env['JINN_DISTILL_PROVIDER'] ??
+      persisted.distiller ??
+      'claude';
+    const provider = parseDistillProvider(rawProvider) ?? 'claude';
+    const defaultModel = provider === 'codex' ? DEFAULT_CODEX_MODEL : DEFAULT_CLAUDE_DISTILL_MODEL;
+    const model =
+      (parsed.values['distiller-model'] as string | undefined) ??
+      process.env['JINN_DISTILL_MODEL'] ??
+      persisted.distillerModel ??
+      defaultModel;
+    const resolved = { provider, model };
+    if (json) {
+      writer.write(JSON.stringify({ catalog: DISTILLER_CATALOG, resolved }) + '\n');
+    } else {
+      writer.write(renderDistillerModels({ catalog: DISTILLER_CATALOG, resolved }) + '\n');
+    }
+    return 0;
+  }
+
   if (isDistill) {
     const dd = opts.distillDeps ?? {};
     const json = parsed.values.json as boolean;
@@ -1330,7 +1359,7 @@ export async function runJinnLayerCli(
         }
         patch.distillerModel = setModel;
       }
-      writeDistilDefaults(patch, modePath);
+      writeDistillDefaults(patch, modePath);
       writer.write((json ? JSON.stringify(patch) : renderDistillerSet(patch)) + '\n');
       return 0;
     }

--- a/client/packages/harness-layer/src/cli.ts
+++ b/client/packages/harness-layer/src/cli.ts
@@ -94,6 +94,8 @@ import {
   renderPreview,
   renderConfirmLocal,
   renderModeSet,
+  renderDistillerSet,
+  renderDistillerModels,
   renderDeferredRun,
   renderRecorded,
   renderEmpty,
@@ -1005,6 +1007,8 @@ export async function runJinnLayerCli(
         meta: { type: 'boolean', default: false },
         distiller: { type: 'string' },
         'distiller-model': { type: 'string' },
+        'set-distiller': { type: 'string' },
+        'set-distiller-model': { type: 'string' },
         captures: { type: 'string' },
         'local-only': { type: 'boolean', default: false },
         where: { type: 'string' },
@@ -1302,6 +1306,32 @@ export async function runJinnLayerCli(
       }
       writeDistillMode(whereFlag, modePath);
       writer.write((json ? JSON.stringify({ where: whereFlag }) : renderModeSet(whereFlag)) + '\n');
+      return 0;
+    }
+
+    // 1496 — `--set-distiller[-model]`: the persistent distiller default setter.
+    // Scriptable, non-interactive; records the default and echoes it, runs nothing.
+    const setProvider = parsed.values['set-distiller'] as string | undefined;
+    const setModel = parsed.values['set-distiller-model'] as string | undefined;
+    if (setProvider !== undefined || setModel !== undefined) {
+      const patch: { distiller?: DistillProvider; distillerModel?: string } = {};
+      if (setProvider !== undefined) {
+        const provider = parseDistillProvider(setProvider);
+        if (!provider) {
+          writer.write(`error: distiller must be "claude" or "codex" (got ${JSON.stringify(setProvider)})\n\n${USAGE}`);
+          return 2;
+        }
+        patch.distiller = provider;
+      }
+      if (setModel !== undefined) {
+        if (setModel === '') {
+          writer.write(`error: --set-distiller-model must be a non-empty model id\n\n${USAGE}`);
+          return 2;
+        }
+        patch.distillerModel = setModel;
+      }
+      writeDistilDefaults(patch, modePath);
+      writer.write((json ? JSON.stringify(patch) : renderDistillerSet(patch)) + '\n');
       return 0;
     }
 

--- a/client/packages/harness-layer/src/distill-llm.ts
+++ b/client/packages/harness-layer/src/distill-llm.ts
@@ -55,6 +55,41 @@ export class DistillTimeoutError extends Error {
   }
 }
 
+/** One row of the discoverable distiller catalog (`distill models`). */
+export interface DistillerCatalogEntry {
+  provider: 'claude' | 'codex';
+  model: string;
+  /** `local` runs on this machine; `hosted` sends captures off-machine (none yet). */
+  execution: 'local' | 'hosted';
+  cost: string;
+  privacy: string;
+  isDefault?: boolean;
+}
+
+/**
+ * The static, honest catalog of runnable distillers. Every entry is `local`
+ * today — no hosted distiller exists (both ports spawn a local CLI). The models
+ * reference `DEFAULT_MODEL` / `DEFAULT_CODEX_MODEL` directly so the catalog and
+ * the provider defaults cannot drift.
+ */
+export const DISTILLER_CATALOG: readonly DistillerCatalogEntry[] = [
+  {
+    provider: 'claude',
+    model: DEFAULT_MODEL,
+    execution: 'local',
+    cost: 'high (frontier pass)',
+    privacy: 'local — captures never leave the machine',
+    isDefault: true,
+  },
+  {
+    provider: 'codex',
+    model: DEFAULT_CODEX_MODEL,
+    execution: 'local',
+    cost: 'high (frontier pass)',
+    privacy: 'local — captures never leave the machine',
+  },
+];
+
 const DISTILL_OUTPUT_SCHEMA = {
   type: 'object',
   additionalProperties: false,

--- a/client/packages/harness-layer/src/distill-mode.ts
+++ b/client/packages/harness-layer/src/distill-mode.ts
@@ -50,6 +50,32 @@ function isDistillMode(value: unknown): value is DistillMode {
   return typeof value === 'string' && (MODES as readonly string[]).includes(value);
 }
 
+/** The two distiller providers the persisted default may name. */
+export type DistillDefaultProvider = 'claude' | 'codex';
+
+/** The persisted per-axis distiller defaults, sibling to `where`. */
+export interface DistillDefaults {
+  distiller?: DistillDefaultProvider;
+  distillerModel?: string;
+}
+
+const PROVIDERS: readonly DistillDefaultProvider[] = ['claude', 'codex'];
+
+function isDefaultProvider(value: unknown): value is DistillDefaultProvider {
+  return typeof value === 'string' && (PROVIDERS as readonly string[]).includes(value);
+}
+
+/** Parse the whole doc off disk once; a missing/malformed file is `{}`. */
+function readDoc(path: string): Record<string, unknown> {
+  if (!existsSync(path)) return {};
+  try {
+    const doc = JSON.parse(readFileSync(path, 'utf-8')) as unknown;
+    return typeof doc === 'object' && doc !== null ? (doc as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
 /**
  * Read the recorded mode. A missing file, malformed JSON, or a `where` value
  * that is not one of the three modes all read as `unset` — the fail-safe that
@@ -72,12 +98,8 @@ export function readDistillMode(
     }
     return 'unset';
   }
-  try {
-    const doc = JSON.parse(readFileSync(path, 'utf-8')) as { where?: unknown };
-    return isDistillMode(doc.where) ? doc.where : 'unset';
-  } catch {
-    return 'unset';
-  }
+  const doc = readDoc(path);
+  return isDistillMode(doc.where) ? doc.where : 'unset';
 }
 
 /**
@@ -86,6 +108,38 @@ export function readDistillMode(
  * write identically.
  */
 export function writeDistillMode(mode: DistillMode, path: string = DEFAULT_DISTILL_MODE_PATH): void {
+  const doc = readDoc(path);
+  doc.where = mode;
   mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, JSON.stringify({ where: mode }, null, 2) + '\n', { encoding: 'utf-8' });
+  writeFileSync(path, JSON.stringify(doc, null, 2) + '\n', { encoding: 'utf-8' });
+}
+
+/**
+ * Read the persisted distiller defaults. Same fail-safe as `readDistillMode`:
+ * an unrecognised `distiller` or a non-string `distillerModel` reads as absent,
+ * so a corrupt field falls back to the provider default rather than erroring.
+ */
+export function readDistillDefaults(path: string = DEFAULT_DISTILL_MODE_PATH): DistillDefaults {
+  const doc = readDoc(path);
+  const out: DistillDefaults = {};
+  if (isDefaultProvider(doc.distiller)) out.distiller = doc.distiller;
+  if (typeof doc.distillerModel === 'string' && doc.distillerModel !== '') {
+    out.distillerModel = doc.distillerModel;
+  }
+  return out;
+}
+
+/**
+ * Merge the given distiller-default patch into the doc, preserving `where` and
+ * any default not named in the patch. Writes the same pretty JSON shape.
+ */
+export function writeDistillDefaults(
+  patch: DistillDefaults,
+  path: string = DEFAULT_DISTILL_MODE_PATH,
+): void {
+  const doc = readDoc(path);
+  if (patch.distiller !== undefined) doc.distiller = patch.distiller;
+  if (patch.distillerModel !== undefined) doc.distillerModel = patch.distillerModel;
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(doc, null, 2) + '\n', { encoding: 'utf-8' });
 }

--- a/client/packages/harness-layer/src/distill-render.ts
+++ b/client/packages/harness-layer/src/distill-render.ts
@@ -16,6 +16,7 @@
 const BIN = 'jinn-layer';
 
 import type { DistillMode } from './distill-mode.js';
+import type { DistillerCatalogEntry } from './distill-llm.js';
 
 function plural(n: number, one: string): string {
   return `${n} ${one}${n === 1 ? '' : 's'}`;
@@ -140,6 +141,48 @@ export function renderModeSet(mode: DistillMode): string {
     case 'off':
       return `distill: mode set to off. Captures are not reserved for distillation.`;
   }
+}
+
+/** One-line echo after `distill --set-distiller[-model]` records a default. */
+export function renderDistillerSet(o: { distiller?: 'claude' | 'codex'; distillerModel?: string }): string {
+  const parts: string[] = [];
+  if (o.distiller !== undefined) parts.push(`provider ${o.distiller}`);
+  if (o.distillerModel !== undefined) parts.push(`model ${o.distillerModel}`);
+  return `distill: default distiller set — ${parts.join(', ')}. Applies to future runs; a per-run --distiller[-model] flag still wins.`;
+}
+
+/**
+ * `distill models` — the discoverable catalog. One row per runnable distiller
+ * with its execution/cost/privacy attributes; the currently-resolved default
+ * is marked with the word `(default)` (never a glyph).
+ */
+export function renderDistillerModels(o: {
+  catalog: readonly DistillerCatalogEntry[];
+  resolved: { provider: string; model: string };
+}): string {
+  const iw = 74;
+  const rows = o.catalog.map((e) => {
+    const isResolved = e.provider === o.resolved.provider && e.model === o.resolved.model;
+    const mark = isResolved ? ' (default)' : '';
+    return boxLine(
+      iw,
+      `${e.provider.padEnd(8)}${e.execution.padEnd(8)}${e.cost.padEnd(22)}${e.model}${mark}`,
+    );
+  });
+  const panel = [
+    boxTop(iw, 'distillers · the model that writes your skills'),
+    boxLine(iw, `${'provider'.padEnd(8)}${'run'.padEnd(8)}${'cost'.padEnd(22)}model`),
+    ...rows,
+    boxBot(iw),
+  ].join('\n');
+  return [
+    panel,
+    '',
+    ...o.catalog.map((e) => `  ${e.model} — ${e.privacy}`),
+    '',
+    `  Set a default  ·  ${BIN} distill --set-distiller <provider>  |  --set-distiller-model <model>`,
+    `  Override once  ·  ${BIN} distill --distiller <provider>  |  --distiller-model <model>`,
+  ].join('\n');
 }
 
 /** 1c — what a bare `distill` prints while the mode is defer: it runs nothing. */

--- a/client/packages/harness-layer/test/cli.test.ts
+++ b/client/packages/harness-layer/test/cli.test.ts
@@ -13,7 +13,12 @@ import type { AttemptRef, BridgeEvidence } from '../src/bridge.js';
 import type { DistillCluster, DistillLLMOutput, MetaDistillLLMOutput } from '../src/distill.js';
 import type { MetaCluster } from '../src/cluster.js';
 import { parseSkillMarkdown } from '../src/skill-package.js';
-import { readDistillMode, writeDistillMode } from '../src/distill-mode.js';
+import {
+  readDistillDefaults,
+  readDistillMode,
+  writeDistillDefaults,
+  writeDistillMode,
+} from '../src/distill-mode.js';
 import { assertAttemptedClusterIds, attemptRecordFileName } from '../src/eval-prep.js';
 
 /** A distinct temp mode file for a test (env-injected via JINN_LAYER_DISTILL_MODE_PATH). */
@@ -188,6 +193,91 @@ describe('jinn-layer CLI', () => {
     const code = await runJinnLayerCli(['bogus'], { layer, writer });
     expect(code).not.toBe(0);
     expect(out()).toContain('Usage');
+  });
+});
+
+describe('jinn-layer distill — persisted distiller default (resolution order, #1496)', () => {
+  /** A distill dep that records the (provider, model) the factory was built with. */
+  function recordingFactory(calls: Array<{ provider: string; model: string }>): DistillCliDeps {
+    return {
+      distillerFactory: (provider, model) => {
+        calls.push({ provider, model });
+        return { distill: async () => VALID_DISTILL, metaDistill: async () => { throw new Error('unused'); } };
+      },
+    };
+  }
+
+  it('uses the persisted distiller + model when no flag or env is set', async () => {
+    const modePath = tmpModeFile();
+    writeDistillMode('local', modePath);
+    writeDistillDefaults({ distiller: 'codex', distillerModel: 'gpt-5.5-custom' }, modePath);
+    const calls: Array<{ provider: string; model: string }> = [];
+    await withEnv(
+      { JINN_LAYER_DISTILL_MODE_PATH: modePath, JINN_DISTILL_PROVIDER: undefined, JINN_DISTILL_MODEL: undefined },
+      async () => {
+        const { writer } = capture();
+        const code = await runJinnLayerCli(
+          ['distill', '--captures', capturesDirWith(ownCapture()), '--out', mkdtempSync(join(tmpdir(), 'o-')), '--install', 'all'],
+          { writer, distillDeps: recordingFactory(calls) },
+        );
+        expect(code).toBe(0);
+        expect(calls).toEqual([{ provider: 'codex', model: 'gpt-5.5-custom' }]);
+      },
+    );
+  });
+
+  it('a per-run --distiller flag overrides the persisted default', async () => {
+    const modePath = tmpModeFile();
+    writeDistillMode('local', modePath);
+    writeDistillDefaults({ distiller: 'codex', distillerModel: 'gpt-5.5-custom' }, modePath);
+    const calls: Array<{ provider: string; model: string }> = [];
+    await withEnv(
+      { JINN_LAYER_DISTILL_MODE_PATH: modePath, JINN_DISTILL_PROVIDER: undefined, JINN_DISTILL_MODEL: undefined },
+      async () => {
+        const { writer } = capture();
+        await runJinnLayerCli(
+          ['distill', '--distiller', 'claude', '--captures', capturesDirWith(ownCapture()), '--out', mkdtempSync(join(tmpdir(), 'o-')), '--install', 'all'],
+          { writer, distillDeps: recordingFactory(calls) },
+        );
+        expect(calls).toEqual([{ provider: 'claude', model: 'claude-opus-4-8' }]);
+      },
+    );
+  });
+
+  it('env overrides the persisted default but loses to a flag', async () => {
+    const modePath = tmpModeFile();
+    writeDistillMode('local', modePath);
+    writeDistillDefaults({ distiller: 'codex', distillerModel: 'gpt-persisted' }, modePath);
+    const calls: Array<{ provider: string; model: string }> = [];
+    await withEnv(
+      { JINN_LAYER_DISTILL_MODE_PATH: modePath, JINN_DISTILL_PROVIDER: 'claude', JINN_DISTILL_MODEL: 'model-from-env' },
+      async () => {
+        const { writer } = capture();
+        await runJinnLayerCli(
+          ['distill', '--captures', capturesDirWith(ownCapture()), '--out', mkdtempSync(join(tmpdir(), 'o-')), '--install', 'all'],
+          { writer, distillDeps: recordingFactory(calls) },
+        );
+        expect(calls).toEqual([{ provider: 'claude', model: 'model-from-env' }]);
+      },
+    );
+  });
+
+  it('a corrupt persisted distiller falls back to the provider default (fail-safe)', async () => {
+    const modePath = tmpModeFile();
+    writeDistillMode('local', modePath);
+    writeFileSync(modePath, JSON.stringify({ where: 'local', distiller: 'bogus', distillerModel: 5 }));
+    const calls: Array<{ provider: string; model: string }> = [];
+    await withEnv(
+      { JINN_LAYER_DISTILL_MODE_PATH: modePath, JINN_DISTILL_PROVIDER: undefined, JINN_DISTILL_MODEL: undefined },
+      async () => {
+        const { writer } = capture();
+        await runJinnLayerCli(
+          ['distill', '--captures', capturesDirWith(ownCapture()), '--out', mkdtempSync(join(tmpdir(), 'o-')), '--install', 'all'],
+          { writer, distillDeps: recordingFactory(calls) },
+        );
+        expect(calls).toEqual([{ provider: 'claude', model: 'claude-opus-4-8' }]);
+      },
+    );
   });
 });
 

--- a/client/packages/harness-layer/test/cli.test.ts
+++ b/client/packages/harness-layer/test/cli.test.ts
@@ -2700,3 +2700,75 @@ describe('jinn-layer distill staged/install — install from staging (#1536)', (
     expect(out()).toMatch(/--all|<name>/);
   });
 });
+
+describe('jinn-layer distil — persistent distiller setter (#1496)', () => {
+  it('--set-distiller persists the provider and runs nothing', async () => {
+    const modePath = tmpModeFile();
+    const seen: string[] = [];
+    await withEnv({ JINN_LAYER_DISTIL_MODE_PATH: modePath }, async () => {
+      const { writer, out } = capture();
+      const code = await runJinnLayerCli(
+        ['distil', '--set-distiller', 'codex', '--captures', capturesDirWith(ownCapture())],
+        { writer, distilDeps: { distill: async (c: DistillCluster) => { seen.push(...c.instanceIds); return VALID_DISTILL; } } },
+      );
+      expect(code).toBe(0);
+      expect(seen).toEqual([]); // setter only — never ran
+      expect(readDistilDefaults(modePath)).toEqual({ distiller: 'codex' });
+      expect(out()).toMatch(/codex/);
+    });
+  });
+
+  it('--set-distiller-model persists the model and runs nothing', async () => {
+    const modePath = tmpModeFile();
+    await withEnv({ JINN_LAYER_DISTIL_MODE_PATH: modePath }, async () => {
+      const { writer, out } = capture();
+      const code = await runJinnLayerCli(['distil', '--set-distiller-model', 'claude-opus-4-9'], { writer, distilDeps: stubDistilDeps() });
+      expect(code).toBe(0);
+      expect(readDistilDefaults(modePath)).toEqual({ distillerModel: 'claude-opus-4-9' });
+      expect(out()).toContain('claude-opus-4-9');
+    });
+  });
+
+  it('accepts both flags in one call and writes both', async () => {
+    const modePath = tmpModeFile();
+    await withEnv({ JINN_LAYER_DISTIL_MODE_PATH: modePath }, async () => {
+      const { writer } = capture();
+      const code = await runJinnLayerCli(
+        ['distil', '--set-distiller', 'codex', '--set-distiller-model', 'gpt-5.5'],
+        { writer, distilDeps: stubDistilDeps() },
+      );
+      expect(code).toBe(0);
+      expect(readDistilDefaults(modePath)).toEqual({ distiller: 'codex', distillerModel: 'gpt-5.5' });
+    });
+  });
+
+  it('rejects an unknown --set-distiller provider with exit 2 and writes nothing', async () => {
+    const modePath = tmpModeFile();
+    await withEnv({ JINN_LAYER_DISTIL_MODE_PATH: modePath }, async () => {
+      const { writer, out } = capture();
+      const code = await runJinnLayerCli(['distil', '--set-distiller', 'gpt'], { writer, distilDeps: stubDistilDeps() });
+      expect(code).toBe(2);
+      expect(out()).toContain('distiller must be "claude" or "codex"');
+      expect(readDistilDefaults(modePath)).toEqual({});
+    });
+  });
+
+  it('rejects an empty --set-distiller-model with exit 2 and writes nothing', async () => {
+    const modePath = tmpModeFile();
+    await withEnv({ JINN_LAYER_DISTIL_MODE_PATH: modePath }, async () => {
+      const { writer } = capture();
+      const code = await runJinnLayerCli(['distil', '--set-distiller-model', ''], { writer, distilDeps: stubDistilDeps() });
+      expect(code).toBe(2);
+      expect(readDistilDefaults(modePath)).toEqual({});
+    });
+  });
+
+  it('--set-distiller --json emits the persisted patch', async () => {
+    const modePath = tmpModeFile();
+    await withEnv({ JINN_LAYER_DISTIL_MODE_PATH: modePath }, async () => {
+      const { writer, out } = capture();
+      await runJinnLayerCli(['distil', '--set-distiller', 'codex', '--json'], { writer, distilDeps: stubDistilDeps() });
+      expect(JSON.parse(out())).toEqual({ distiller: 'codex' });
+    });
+  });
+});

--- a/client/packages/harness-layer/test/cli.test.ts
+++ b/client/packages/harness-layer/test/cli.test.ts
@@ -19,6 +19,7 @@ import {
   writeDistillDefaults,
   writeDistillMode,
 } from '../src/distill-mode.js';
+import { DISTILLER_CATALOG } from '../src/distill-llm.js';
 import { assertAttemptedClusterIds, attemptRecordFileName } from '../src/eval-prep.js';
 
 /** A distinct temp mode file for a test (env-injected via JINN_LAYER_DISTILL_MODE_PATH). */
@@ -2701,74 +2702,132 @@ describe('jinn-layer distill staged/install — install from staging (#1536)', (
   });
 });
 
-describe('jinn-layer distil — persistent distiller setter (#1496)', () => {
+describe('jinn-layer distill — persistent distiller setter (#1496)', () => {
   it('--set-distiller persists the provider and runs nothing', async () => {
     const modePath = tmpModeFile();
     const seen: string[] = [];
-    await withEnv({ JINN_LAYER_DISTIL_MODE_PATH: modePath }, async () => {
+    await withEnv({ JINN_LAYER_DISTILL_MODE_PATH: modePath }, async () => {
       const { writer, out } = capture();
       const code = await runJinnLayerCli(
-        ['distil', '--set-distiller', 'codex', '--captures', capturesDirWith(ownCapture())],
-        { writer, distilDeps: { distill: async (c: DistillCluster) => { seen.push(...c.instanceIds); return VALID_DISTILL; } } },
+        ['distill', '--set-distiller', 'codex', '--captures', capturesDirWith(ownCapture())],
+        { writer, distillDeps: { distill: async (c: DistillCluster) => { seen.push(...c.instanceIds); return VALID_DISTILL; } } },
       );
       expect(code).toBe(0);
       expect(seen).toEqual([]); // setter only — never ran
-      expect(readDistilDefaults(modePath)).toEqual({ distiller: 'codex' });
+      expect(readDistillDefaults(modePath)).toEqual({ distiller: 'codex' });
       expect(out()).toMatch(/codex/);
     });
   });
 
   it('--set-distiller-model persists the model and runs nothing', async () => {
     const modePath = tmpModeFile();
-    await withEnv({ JINN_LAYER_DISTIL_MODE_PATH: modePath }, async () => {
+    await withEnv({ JINN_LAYER_DISTILL_MODE_PATH: modePath }, async () => {
       const { writer, out } = capture();
-      const code = await runJinnLayerCli(['distil', '--set-distiller-model', 'claude-opus-4-9'], { writer, distilDeps: stubDistilDeps() });
+      const code = await runJinnLayerCli(['distill', '--set-distiller-model', 'claude-opus-4-9'], { writer, distillDeps: stubDistillDeps() });
       expect(code).toBe(0);
-      expect(readDistilDefaults(modePath)).toEqual({ distillerModel: 'claude-opus-4-9' });
+      expect(readDistillDefaults(modePath)).toEqual({ distillerModel: 'claude-opus-4-9' });
       expect(out()).toContain('claude-opus-4-9');
     });
   });
 
   it('accepts both flags in one call and writes both', async () => {
     const modePath = tmpModeFile();
-    await withEnv({ JINN_LAYER_DISTIL_MODE_PATH: modePath }, async () => {
+    await withEnv({ JINN_LAYER_DISTILL_MODE_PATH: modePath }, async () => {
       const { writer } = capture();
       const code = await runJinnLayerCli(
-        ['distil', '--set-distiller', 'codex', '--set-distiller-model', 'gpt-5.5'],
-        { writer, distilDeps: stubDistilDeps() },
+        ['distill', '--set-distiller', 'codex', '--set-distiller-model', 'gpt-5.5'],
+        { writer, distillDeps: stubDistillDeps() },
       );
       expect(code).toBe(0);
-      expect(readDistilDefaults(modePath)).toEqual({ distiller: 'codex', distillerModel: 'gpt-5.5' });
+      expect(readDistillDefaults(modePath)).toEqual({ distiller: 'codex', distillerModel: 'gpt-5.5' });
     });
   });
 
   it('rejects an unknown --set-distiller provider with exit 2 and writes nothing', async () => {
     const modePath = tmpModeFile();
-    await withEnv({ JINN_LAYER_DISTIL_MODE_PATH: modePath }, async () => {
+    await withEnv({ JINN_LAYER_DISTILL_MODE_PATH: modePath }, async () => {
       const { writer, out } = capture();
-      const code = await runJinnLayerCli(['distil', '--set-distiller', 'gpt'], { writer, distilDeps: stubDistilDeps() });
+      const code = await runJinnLayerCli(['distill', '--set-distiller', 'gpt'], { writer, distillDeps: stubDistillDeps() });
       expect(code).toBe(2);
       expect(out()).toContain('distiller must be "claude" or "codex"');
-      expect(readDistilDefaults(modePath)).toEqual({});
+      expect(readDistillDefaults(modePath)).toEqual({});
     });
   });
 
   it('rejects an empty --set-distiller-model with exit 2 and writes nothing', async () => {
     const modePath = tmpModeFile();
-    await withEnv({ JINN_LAYER_DISTIL_MODE_PATH: modePath }, async () => {
+    await withEnv({ JINN_LAYER_DISTILL_MODE_PATH: modePath }, async () => {
       const { writer } = capture();
-      const code = await runJinnLayerCli(['distil', '--set-distiller-model', ''], { writer, distilDeps: stubDistilDeps() });
+      const code = await runJinnLayerCli(['distill', '--set-distiller-model', ''], { writer, distillDeps: stubDistillDeps() });
       expect(code).toBe(2);
-      expect(readDistilDefaults(modePath)).toEqual({});
+      expect(readDistillDefaults(modePath)).toEqual({});
     });
   });
 
   it('--set-distiller --json emits the persisted patch', async () => {
     const modePath = tmpModeFile();
-    await withEnv({ JINN_LAYER_DISTIL_MODE_PATH: modePath }, async () => {
+    await withEnv({ JINN_LAYER_DISTILL_MODE_PATH: modePath }, async () => {
       const { writer, out } = capture();
-      await runJinnLayerCli(['distil', '--set-distiller', 'codex', '--json'], { writer, distilDeps: stubDistilDeps() });
+      await runJinnLayerCli(['distill', '--set-distiller', 'codex', '--json'], { writer, distillDeps: stubDistillDeps() });
       expect(JSON.parse(out())).toEqual({ distiller: 'codex' });
+    });
+  });
+});
+
+describe('jinn-layer distill models — discovery (#1496)', () => {
+  it('lists every catalog model with execution/cost/privacy attributes', async () => {
+    const { writer, out } = capture();
+    const code = await runJinnLayerCli(['distill', 'models'], { writer, distillDeps: stubDistillDeps() });
+    expect(code).toBe(0);
+    for (const e of DISTILLER_CATALOG) {
+      expect(out()).toContain(e.model);
+      expect(out()).toContain(e.execution);
+    }
+    expect(out()).toMatch(/frontier pass/); // cost
+    expect(out()).toMatch(/local/); // privacy/execution
+  });
+
+  it('marks the resolved default (persisted default wins the marker)', async () => {
+    const modePath = tmpModeFile();
+    writeDistillDefaults({ distiller: 'codex', distillerModel: 'gpt-5.5' }, modePath);
+    await withEnv(
+      { JINN_LAYER_DISTILL_MODE_PATH: modePath, JINN_DISTILL_PROVIDER: undefined, JINN_DISTILL_MODEL: undefined },
+      async () => {
+        const { writer, out } = capture();
+        await runJinnLayerCli(['distill', 'models'], { writer, distillDeps: stubDistillDeps() });
+        const gptLine = out().split('\n').find((l) => l.includes('gpt-5.5'));
+        expect(gptLine).toMatch(/default/i);
+      },
+    );
+  });
+
+  it('--json emits the catalog array and the resolved selection', async () => {
+    const modePath = tmpModeFile();
+    await withEnv(
+      { JINN_LAYER_DISTILL_MODE_PATH: modePath, JINN_DISTILL_PROVIDER: undefined, JINN_DISTILL_MODEL: undefined },
+      async () => {
+        const { writer, out } = capture();
+        const code = await runJinnLayerCli(['distill', 'models', '--json'], { writer, distillDeps: stubDistillDeps() });
+        expect(code).toBe(0);
+        const parsed = JSON.parse(out());
+        expect(parsed.catalog).toHaveLength(DISTILLER_CATALOG.length);
+        expect(parsed.resolved).toEqual({ provider: 'claude', model: 'claude-opus-4-8' });
+      },
+    );
+  });
+
+  it('a bare distill is NOT treated as models (run path intact)', async () => {
+    // Regression guard: bare distil with an empty captures dir still runs the
+    // normal path (No eligible captures), not the models catalog.
+    const modePath = tmpModeFile();
+    writeDistillMode('local', modePath);
+    await withEnv({ JINN_LAYER_DISTILL_MODE_PATH: modePath }, async () => {
+      const { writer, out } = capture();
+      const emptyDir = mkdtempSync(join(tmpdir(), 'jinn-captures-empty-'));
+      const code = await runJinnLayerCli(['distill', '--captures', emptyDir], { writer, distillDeps: stubDistillDeps() });
+      expect(code).toBe(0);
+      expect(out()).toContain('No eligible captures');
+      expect(out()).not.toMatch(/frontier pass/);
     });
   });
 });

--- a/client/packages/harness-layer/test/distill-llm.test.ts
+++ b/client/packages/harness-layer/test/distill-llm.test.ts
@@ -6,6 +6,8 @@ import {
   createCodexDistiller,
   createCodexMetaDistiller,
   DEFAULT_CODEX_MODEL,
+  DEFAULT_MODEL,
+  DISTILLER_CATALOG,
   buildMetaDistillInput,
   type ChildLike,
   type SpawnLike,
@@ -340,5 +342,26 @@ describe('per-cluster subprocess timeout (#1534)', () => {
     const meta = createClaudeMetaDistiller({ spawnImpl: spawn, timeoutMs: 30 });
     await expect(meta(metaCluster)).rejects.toThrow(/timed out after 30ms/);
     expect(child.killed).toContain('SIGKILL');
+  });
+});
+
+describe('distiller catalog', () => {
+  it('lists exactly the two runnable providers, both local', () => {
+    expect(DISTILLER_CATALOG.map((e) => e.provider)).toEqual(['claude', 'codex']);
+    expect(DISTILLER_CATALOG.every((e) => e.execution === 'local')).toBe(true);
+  });
+
+  it('mirrors the hard-coded provider default models (cannot drift)', () => {
+    const claude = DISTILLER_CATALOG.find((e) => e.provider === 'claude');
+    const codex = DISTILLER_CATALOG.find((e) => e.provider === 'codex');
+    expect(claude?.model).toBe(DEFAULT_MODEL);
+    expect(codex?.model).toBe(DEFAULT_CODEX_MODEL);
+  });
+
+  it('marks the claude default entry and carries cost + privacy prose', () => {
+    const claude = DISTILLER_CATALOG.find((e) => e.provider === 'claude');
+    expect(claude?.isDefault).toBe(true);
+    expect(claude?.cost).toBeTruthy();
+    expect(claude?.privacy).toMatch(/local/i);
   });
 });

--- a/client/packages/harness-layer/test/distill-mode.test.ts
+++ b/client/packages/harness-layer/test/distill-mode.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { readDistillMode, writeDistillMode } from '../src/distill-mode.js';
+import {
+  readDistillDefaults,
+  readDistillMode,
+  writeDistillDefaults,
+  writeDistillMode,
+} from '../src/distill-mode.js';
 
 function tmpModePath(): string {
   return join(mkdtempSync(join(tmpdir(), 'jinn-distill-mode-')), 'distill.json');
@@ -58,5 +63,58 @@ describe('distill mode store', () => {
     writeDistillMode('local', path);
     writeFileSync(legacy, JSON.stringify({ where: 'off' }));
     expect(readDistillMode(path, legacy)).toBe('local');
+  });
+});
+
+describe('distill defaults store (distiller + distillerModel)', () => {
+  it('reads empty defaults when the file is absent', () => {
+    expect(readDistillDefaults(tmpModePath())).toEqual({});
+  });
+
+  it('reads empty defaults when the file is malformed JSON', () => {
+    const path = tmpModePath();
+    writeFileSync(path, '{ not valid');
+    expect(readDistillDefaults(path)).toEqual({});
+  });
+
+  it('drops an unrecognised distiller provider (fail-safe → absent)', () => {
+    const path = tmpModePath();
+    writeFileSync(path, JSON.stringify({ distiller: 'gpt', distillerModel: 'x' }));
+    expect(readDistillDefaults(path)).toEqual({ distillerModel: 'x' });
+  });
+
+  it('drops a non-string distillerModel (fail-safe → absent)', () => {
+    const path = tmpModePath();
+    writeFileSync(path, JSON.stringify({ distiller: 'claude', distillerModel: 42 }));
+    expect(readDistillDefaults(path)).toEqual({ distiller: 'claude' });
+  });
+
+  it('round-trips distiller and distillerModel', () => {
+    const path = tmpModePath();
+    writeDistillDefaults({ distiller: 'codex', distillerModel: 'gpt-5.5' }, path);
+    expect(readDistillDefaults(path)).toEqual({ distiller: 'codex', distillerModel: 'gpt-5.5' });
+  });
+
+  it('merges defaults without clobbering an existing where mode', () => {
+    const path = tmpModePath();
+    writeDistillMode('local', path);
+    writeDistillDefaults({ distiller: 'codex' }, path);
+    expect(readDistillMode(path)).toBe('local');
+    expect(readDistillDefaults(path)).toEqual({ distiller: 'codex' });
+  });
+
+  it('writeDistillMode preserves already-set distiller defaults', () => {
+    const path = tmpModePath();
+    writeDistillDefaults({ distiller: 'codex', distillerModel: 'gpt-5.5' }, path);
+    writeDistillMode('off', path);
+    expect(readDistillMode(path)).toBe('off');
+    expect(readDistillDefaults(path)).toEqual({ distiller: 'codex', distillerModel: 'gpt-5.5' });
+  });
+
+  it('merges a partial patch without dropping the other default', () => {
+    const path = tmpModePath();
+    writeDistillDefaults({ distiller: 'claude', distillerModel: 'claude-opus-4-8' }, path);
+    writeDistillDefaults({ distillerModel: 'claude-opus-4-9' }, path);
+    expect(readDistillDefaults(path)).toEqual({ distiller: 'claude', distillerModel: 'claude-opus-4-9' });
   });
 });

--- a/client/packages/harness-layer/test/distill-render.test.ts
+++ b/client/packages/harness-layer/test/distill-render.test.ts
@@ -10,8 +10,11 @@ import {
   renderReview,
   renderFailure,
   renderResumeNothing,
+  renderDistillerSet,
+  renderDistillerModels,
   type RenderedSkill,
 } from '../src/distill-render.js';
+import { DISTILLER_CATALOG } from '../src/distill-llm.js';
 
 /** The two hard rules apply to every string this surface prints. */
 const EMOJI = /\p{Extended_Pictographic}/u;
@@ -260,5 +263,51 @@ describe('distill render — nothing to resume (1c/1d)', () => {
   it('says all captures are already distilled', () => {
     const s = renderResumeNothing({ captureCount: 6 });
     expect(s).toMatch(/already distilled|nothing to resume/i);
+  });
+});
+
+describe('distill render — distiller setter echo', () => {
+  it('echoes the provider when only the provider is set', () => {
+    const s = renderDistillerSet({ distiller: 'codex' });
+    expect(s).toMatch(/codex/);
+    expect(s).toMatch(/distiller/i);
+    expect(s).not.toMatch(EMOJI);
+  });
+  it('echoes the model when only the model is set', () => {
+    const s = renderDistillerSet({ distillerModel: 'gpt-5.5' });
+    expect(s).toContain('gpt-5.5');
+    expect(s).not.toMatch(EMOJI);
+  });
+  it('echoes both when both are set', () => {
+    const s = renderDistillerSet({ distiller: 'claude', distillerModel: 'claude-opus-4-8' });
+    expect(s).toMatch(/claude/);
+    expect(s).toContain('claude-opus-4-8');
+  });
+});
+
+describe('distill render — distiller catalog (discovery)', () => {
+  const s = renderDistillerModels({
+    catalog: DISTILLER_CATALOG,
+    resolved: { provider: 'claude', model: 'claude-opus-4-8' },
+  });
+
+  it('lists every catalog model with its execution/cost/privacy attributes', () => {
+    for (const e of DISTILLER_CATALOG) {
+      expect(s).toContain(e.model);
+      expect(s).toContain(e.execution);
+    }
+    expect(s).toMatch(/local/);
+    expect(s).toMatch(/frontier pass/);
+  });
+
+  it('marks the currently-resolved default with a word, not a glyph', () => {
+    const line = s.split('\n').find((l) => l.includes('claude-opus-4-8'));
+    expect(line).toMatch(/default/i);
+    expect(s).not.toMatch(EMOJI);
+  });
+
+  it('does not mark a non-resolved model as default', () => {
+    const line = s.split('\n').find((l) => l.includes('gpt-5.5'));
+    expect(line).not.toMatch(/\(default\)/);
   });
 });


### PR DESCRIPTION
**Recovered stranded work.** An autopilot session implemented #1496 and committed to `feat/1496-feat-harness-layer-persistent-discoverable-distiller-model-s` but terminated before opening a PR — the worktree was about to be reclaimed, so this surfaces the commits for review rather than losing them.

Commits authored by the autopilot session; opened as a **draft**, unvetted by me — **CI + review still required**. Do not merge until green + reviewed.

Closes #1496.