### PR TITLE
fix(dashboard): remove decorative gold gradient on Onboarding active-phase row

### DIFF
--- a/client/src/dashboard/spa/src/styles/globals.css
+++ b/client/src/dashboard/spa/src/styles/globals.css
@@ -168,10 +168,13 @@ textarea:focus-visible {
 }
 
 /* `data-status="active"` row treatment for the Onboarding phase list —
-   the active phase row gets a subtle gold gradient wash. Co-located with
-   the keyframes since they share the same surface. */
+   the active phase row is marked with a flat low-opacity gold tint plus a
+   gold left-border accent (a deliberate active-state signal, not a decorative
+   gradient wash — see BRAND.md content non-negotiables). Co-located with the
+   keyframes since they share the same surface. */
 .phase-row[data-status='active'] {
-  background: linear-gradient(90deg, rgba(220, 184, 102, 0.04) 0%, transparent 60%);
+  background: rgba(220, 184, 102, 0.05);
+  box-shadow: inset 2px 0 0 0 var(--accent-gold);
   transition: background 320ms ease;
 }
 

--- a/client/src/dashboard/spa/src/styles/globals.gradient.test.ts
+++ b/client/src/dashboard/spa/src/styles/globals.gradient.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// Regression guard for issue #519: BRAND.md / CLAUDE.md §Design System forbid
+// decorative gradients ("Never use gradients as decoration" — protection
+// gradients over imagery are the only exception). The dashboard rework had
+// introduced a decorative gold linear-gradient wash on the active Onboarding
+// phase row. This test pins that no decoratively-used gradient re-enters the
+// SPA globals.css.
+const globalsCss = readFileSync(
+  fileURLToPath(new URL('./globals.css', import.meta.url)),
+  'utf8',
+);
+
+describe('globals.css brand non-negotiables', () => {
+  it('contains no decorative linear/radial gradient', () => {
+    expect(globalsCss).not.toMatch(/linear-gradient|radial-gradient/i);
+  });
+});


### PR DESCRIPTION
## Summary

BRAND.md content non-negotiables and CLAUDE.md §Design System forbid decorative gradients ("Never use gradients as decoration" — protection gradients over imagery are the only exception). The dashboard rework had introduced a 4%-opacity gold `linear-gradient` wash on the active Onboarding phase row (`client/src/dashboard/spa/src/styles/globals.css`).

This replaces it with a **flat low-opacity gold tint** plus a **gold left-border accent** (`inset box-shadow`, so no layout shift), sourced from the existing `--accent-gold` DESIGN token. The treatment reads as a deliberate active-state signal rather than a decorative gradient wash.

## Test plan

- Regression guard `globals.gradient.test.ts` asserts no decoratively-used `linear-gradient`/`radial-gradient` remains in globals.css (written first, confirmed red against the old wash, now green).
- Onboarding component suite (23 tests) still passes — `data-status="active"` behavior preserved.

Acceptance criteria met: decorative gradient replaced with a non-gradient token-consistent active-row treatment; no decorative gradient remains in globals.css.

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)