### PR TITLE
feat(version-check): surface available client upgrades to operators (#641)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,6 +310,7 @@ Config file first, env var override. File at `~/.jinn-client/config.json` or `--
 | _(none — env-only)_  | JINN_EVAL_DISK_FLOOR_GB | 20 (free-disk floor in GB before each swe-rebench-v2 eval round; below it the runner prunes Docker and aborts the run cleanly if still short) |
 | _(none — env-only)_  | JINN_NET_LIVENESS_WEBHOOK_URL | unset — generic incoming-webhook URL (Slack-compatible) for the cron-driven net-liveness probe (#1044, `yarn net-liveness`, `docs/runbooks/net-liveness.md`). Unset → NO-OP: the probe still classifies and logs, it just never posts. |
 | _(none — env-only)_  | JINN_NET_LIVENESS_THRESHOLD_MINUTES | 30 — staleness threshold (minutes) for the net-liveness probe; converted to Base block-space at 30 blocks/min. |
+| _(none — env-only)_  | JINN_VERSION_CHECK | enabled (default). Gates the start-time npm-registry check (#641) that logs one line when a newer `@jinn-network/client` has been published and backs the dashboard's `update_available` banner. Opt out with `0` / `false` / `no` / empty. Best-effort — a registry outage degrades silently, never gates boot. |
 
 `JINN_PASSWORD` is env-only — never in config files.
 

--- a/client/OPERATOR-APP-SPEC.md
+++ b/client/OPERATOR-APP-SPEC.md
@@ -297,7 +297,7 @@ Components raise state messages locally. The Notifications component is the unio
 - `harness_not_ready`
 - `bootstrap_blocked`
 - `restart_required`
-- `update_available`
+- `update_available` — a newer `@jinn-network/client` has been published. Backed by the daemon's start-time (and 6-hourly) npm-registry check (#641), surfaced on `/v1/status` as `latestVersion` (with the running `version`) and derived when the two differ. Gated by `JINN_VERSION_CHECK` (default enabled; opt out with `0`/`false`/`no`/empty). Severity: info.
 - `rpc_unreachable`
 - `rpc_all_failed` — every slot in the RPC fallback chain has failed (`AllRpcsFailedError`). Severity: action_required. The masked host list is included.
 - `rpc_primary_degraded` — slot 0 returned HTTP 429 / 5xx during the boot probe or steady-state traffic; a secondary slot served. Severity: informational.

--- a/client/OPERATOR-APP-SPEC.md
+++ b/client/OPERATOR-APP-SPEC.md
@@ -297,7 +297,7 @@ Components raise state messages locally. The Notifications component is the unio
 - `harness_not_ready`
 - `bootstrap_blocked`
 - `restart_required`
-- `update_available` — a newer `@jinn-network/client` has been published. Backed by the daemon's start-time (and 6-hourly) npm-registry check (#641), surfaced on `/v1/status` as `latestVersion` (with the running `version`) and derived when the two differ. Gated by `JINN_VERSION_CHECK` (default enabled; opt out with `0`/`false`/`no`/empty). Severity: info.
+- `update_available` — a newer `@jinn-network/client` has been published. Backed by the daemon's start-time (and 6-hourly) npm-registry check (#641), surfaced on `/v1/status` as `latestVersion` (with the running `version`). The daemon makes the semver comparison: `latestVersion` holds the latest published version **only when it is strictly newer than the running `version`, else `null`**. The banner derives directly from a non-null `latestVersion`. Gated by `JINN_VERSION_CHECK` (default enabled; opt out with `0`/`false`/`no`/empty). Severity: info.
 - `rpc_unreachable`
 - `rpc_all_failed` — every slot in the RPC fallback chain has failed (`AllRpcsFailedError`). Severity: action_required. The masked host list is included.
 - `rpc_primary_degraded` — slot 0 returned HTTP 429 / 5xx during the boot probe or steady-state traffic; a secondary slot served. Severity: informational.

--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -43,6 +43,7 @@ import {
 import { gatherTaskRunsStatus, applyOutcomes } from './task-runs-build.js';
 import type { DiscoveryAPI, VerdictTallyResult } from '../discovery/types.js';
 import { gatherLoopCompletion, gatherImplStateCadence } from './loop-completion-build.js';
+import { buildInfo } from '../build-info.js';
 import type { BalanceCacheEntry } from '../store/store.js';
 import {
   buildPredictionOperatorStatus,
@@ -186,6 +187,14 @@ export interface StatusGatherConfig {
    * and sqlite-only contexts omit it ⇒ `null` (issue #441).
    */
   passwordRotation?: PasswordRotationConfig;
+  /**
+   * Optional getter for the latest published `@jinn-network/client` version
+   * (issue #641). Threaded by `main.ts` as a holder deref so the start-time
+   * npm-registry check can back-fill `/v1/status.latestVersion` once it
+   * resolves. Best-effort: returning `null` (or throwing) leaves
+   * `latestVersion` null — the SPA simply doesn't show the update banner.
+   */
+  latestVersion?: () => string | null;
   /**
    * Resolved DiscoveryAPI, threaded by `server.ts`. When present, the async
    * status path enriches each COMPLETE solve run's task-relative `outcome`
@@ -659,8 +668,20 @@ export async function gatherGatheredStatusRaw(
     );
   }
 
+  // Version-check surface (issue #641). `version` is always this build's
+  // implVersion; `latestVersion` is a best-effort deref of the npm-registry
+  // getter — any failure degrades to null (no banner), never throws.
+  let latestVersion: string | null = null;
+  try {
+    latestVersion = status?.latestVersion?.() ?? null;
+  } catch {
+    latestVersion = null;
+  }
+
   const baseRaw: GatheredStatusRaw = {
     shutdownState,
+    version: buildInfo.implVersion,
+    latestVersion,
     daemonRuntime: readDaemonRuntime(status?.earningDir),
     daemonStartedAt,
     passwordRotationAt: resolvePasswordRotationAt(status?.passwordRotation),

--- a/client/src/api/status-build.ts
+++ b/client/src/api/status-build.ts
@@ -19,6 +19,7 @@ import {
   type CostSurfaceStatus,
 } from '../spend/cost-surface-status.js';
 import { DEFAULT_MASTER_ETH_DAILY_WEI } from '../earning/master-gas.js';
+import { buildInfo } from '../build-info.js';
 
 export type StatusHintsScope = 'full' | 'sqlite_only';
 
@@ -89,6 +90,16 @@ export interface AiUnitsStatus {
 export interface GatheredStatusRaw {
   /** sqlite_only: only SQLite-backed fields (e2e / API without fleet context). */
   hintsScope?: StatusHintsScope;
+  /**
+   * Running client version (issue #641). Absent ⇒ the assembler falls back to
+   * `buildInfo.implVersion`.
+   */
+  version?: string;
+  /**
+   * Latest published `@jinn-network/client` version from the npm registry, or
+   * `null` when the check hasn't resolved / is disabled (issue #641).
+   */
+  latestVersion?: string | null;
   shutdownState: string | null;
   daemonRuntime?: {
     pidPath: string;
@@ -195,6 +206,15 @@ export interface GatheredStatusRaw {
 
 export interface StatusV1Response {
   statusMode: 'full' | 'sqlite_only';
+  /** Running client version (issue #641). */
+  version: string;
+  /**
+   * Latest published `@jinn-network/client` version from the npm registry, or
+   * `null` when the start-time check hasn't resolved / is disabled. The SPA's
+   * `useNotifications` adapter fires `update_available` when it differs from
+   * `version` (issue #641).
+   */
+  latestVersion: string | null;
   daemon: {
     shutdownState: string | null;
     startedAt: string | null;
@@ -537,6 +557,8 @@ export function assembleStatusV1(raw: GatheredStatusRaw): StatusV1Response {
 
   return {
     statusMode: mode,
+    version: raw.version ?? buildInfo.implVersion,
+    latestVersion: raw.latestVersion ?? null,
     daemon: {
       shutdownState: raw.shutdownState,
       startedAt: raw.daemonStartedAt ?? null,

--- a/client/src/dashboard/spa/src/notifications/derive.test.ts
+++ b/client/src/dashboard/spa/src/notifications/derive.test.ts
@@ -83,6 +83,23 @@ describe('deriveNotifications', () => {
     expect(out.map(n => n.kind)).toContain('update_available');
   });
 
+  it('does not emit update_available when latestVersion is undefined (null on the wire)', () => {
+    const { latestVersion: _drop, ...rest } = baseState.status;
+    const out = deriveNotifications({
+      ...baseState,
+      status: rest,
+    });
+    expect(out.map(n => n.kind)).not.toContain('update_available');
+  });
+
+  it('does not emit update_available when latestVersion equals daemonVersion', () => {
+    const out = deriveNotifications({
+      ...baseState,
+      status: { ...baseState.status, daemonVersion: '0.1.5', latestVersion: '0.1.5' },
+    });
+    expect(out.map(n => n.kind)).not.toContain('update_available');
+  });
+
   it('does not duplicate categories (each canonical kind emits at most once)', () => {
     const out = deriveNotifications({
       ...baseState,

--- a/client/src/dashboard/spa/src/notifications/useNotifications.test.ts
+++ b/client/src/dashboard/spa/src/notifications/useNotifications.test.ts
@@ -105,3 +105,29 @@ describe('mapStatusToDeriveInput gas gate boundary (#1296, handbook AI workflow 
     expect(l2!.empty).toBe(true);
   });
 });
+
+describe('mapStatusToDeriveInput — version check (#641)', () => {
+  it('maps version + latestVersion into daemonVersion + latestVersion', () => {
+    const mapped = mapStatusToDeriveInput(
+      { version: '0.1.8', latestVersion: '0.2.0' },
+      {},
+      false,
+    );
+    expect(mapped.daemonVersion).toBe('0.1.8');
+    expect(mapped.latestVersion).toBe('0.2.0');
+  });
+
+  it('maps a null latestVersion to undefined (banner stays silent)', () => {
+    expect(
+      mapStatusToDeriveInput({ version: '0.1.8', latestVersion: null }, {}, false)
+        .latestVersion,
+    ).toBeUndefined();
+    expect(
+      mapStatusToDeriveInput({ version: '0.1.8' }, {}, false).latestVersion,
+    ).toBeUndefined();
+  });
+
+  it('defaults daemonVersion to 0.0.0 when version is absent', () => {
+    expect(mapStatusToDeriveInput({}, {}, false).daemonVersion).toBe('0.0.0');
+  });
+});

--- a/client/src/dashboard/spa/src/notifications/useNotifications.test.tsx
+++ b/client/src/dashboard/spa/src/notifications/useNotifications.test.tsx
@@ -115,6 +115,61 @@ describe('useNotifications', () => {
     expect(() => result.current).not.toThrow();
   });
 
+  // ── update_available wire mapping (issue #641) ─────────────────────────
+  // The daemon reports the running build as `/v1/status.version` and the newest
+  // published `@jinn-network/client` as `/v1/status.latestVersion` (string when
+  // strictly newer, null otherwise). `mapStatusToDeriveInput` normalises these
+  // into the deriver's `daemonVersion` / `latestVersion`. These tests pin the
+  // wire mapping against the real /v1/status shape (the deriver's own emit rule
+  // is pinned separately in derive.test.ts).
+
+  it('emits update_available when /v1/status.latestVersion is strictly newer than version', async () => {
+    apiMocks.getStatus.mockResolvedValue({
+      masterGas: { balanceWei: '0' },
+      fleet: { services: [] },
+      version: '0.1.6',
+      latestVersion: '0.1.8',
+    });
+    apiMocks.getBootstrap.mockResolvedValue({
+      mode: 'running',
+      joinedSolverNets: { 'bafkreic-x': {} },
+    });
+
+    const { result } = renderHook(() => useNotifications(), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(result.current.map(n => n.kind)).toContain('update_available'),
+    );
+    const update = result.current.find(n => n.kind === 'update_available');
+    expect(update?.severity).toBe('info');
+    expect(update?.message).toContain('0.1.8');
+    expect(update?.message).toContain('0.1.6');
+  });
+
+  it('does not emit update_available when /v1/status.latestVersion is null', async () => {
+    apiMocks.getStatus.mockResolvedValue({
+      masterGas: { balanceWei: '0' },
+      fleet: { services: [] },
+      version: '0.1.6',
+      latestVersion: null,
+    });
+    apiMocks.getBootstrap.mockResolvedValue({
+      mode: 'running',
+      joinedSolverNets: { 'bafkreic-x': {} },
+    });
+
+    const { result } = renderHook(() => useNotifications(), {
+      wrapper: makeWrapper(),
+    });
+
+    // funding_low fires from the zero-balance default; wait for it so the hook
+    // has settled before asserting the negative.
+    await waitFor(() => expect(result.current.map(n => n.kind)).toContain('funding_low'));
+    expect(result.current.map(n => n.kind)).not.toContain('update_available');
+  });
+
   it('does not create claim notifications from collector pending rewards', async () => {
     apiMocks.getStatus.mockResolvedValue({
       masterGas: {

--- a/client/src/dashboard/spa/src/notifications/useNotifications.test.tsx
+++ b/client/src/dashboard/spa/src/notifications/useNotifications.test.tsx
@@ -164,9 +164,10 @@ describe('useNotifications', () => {
       wrapper: makeWrapper(),
     });
 
-    // funding_low fires from the zero-balance default; wait for it so the hook
-    // has settled before asserting the negative.
-    await waitFor(() => expect(result.current.map(n => n.kind)).toContain('funding_low'));
+    // Wait until the status fetch has settled before asserting the negative.
+    // Current gas-runway semantics do not manufacture a funding notification
+    // from a status fixture that omits the threshold/runway fields.
+    await waitFor(() => expect(apiMocks.getStatus).toHaveBeenCalled());
     expect(result.current.map(n => n.kind)).not.toContain('update_available');
   });
 

--- a/client/src/dashboard/spa/src/notifications/useNotifications.ts
+++ b/client/src/dashboard/spa/src/notifications/useNotifications.ts
@@ -132,8 +132,12 @@ export function mapStatusToDeriveInput(
     // this default keeps rpc_unreachable from double-firing through the deriver.
     rpc: { reachable: true },
     restartPending,
+    // `version` + `latestVersion` are now populated by the daemon's start-time
+    // npm-registry check (#641). A `string` latestVersion that differs from
+    // daemonVersion fires the `update_available` banner via the deriver; a
+    // null/absent value maps to undefined so the banner stays silent.
     daemonVersion: String(s.version ?? '0.0.0'),
-    latestVersion: undefined,
+    latestVersion: typeof s.latestVersion === 'string' ? s.latestVersion : undefined,
     services: fleetServices.map((svc: any) => ({
       safeBound: svc?.safeBoundToAgent !== false,
     })),

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -121,6 +121,14 @@ import {
   summarizeFallbackChain,
 } from './preflight/rpc-network.js';
 import { apiPortFailureMessage, checkApiPortAvailable } from './preflight/api-port.js';
+import {
+  fetchLatestVersion,
+  getRunningVersion,
+  isNewerVersion,
+  isVersionCheckEnabled,
+  formatUpdateLogLine,
+  VERSION_CHECK_INTERVAL_MS,
+} from './preflight/version-check.js';
 import { openBrowser } from './cli/open-browser.js';
 
 if (process.env['JINN_LOAD_DEV_ENV'] === '1' || process.env['NODE_ENV'] === 'development') {
@@ -544,6 +552,11 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
   const joinApplierHolder: {
     current: import('./daemon/join-applier.js').JoinApplier | undefined;
   } = { current: undefined };
+
+  // #641: latest published `@jinn-network/client` version, back-filled by the
+  // start-time npm-registry check below. `/v1/status.latestVersion` reads this
+  // via the `latestVersion` getter threaded into the ApiServer status config.
+  const latestVersionHolder: { current: string | null } = { current: null };
 
   // hjex.6: retry signal for the bootstrap halt-and-resume loop.
   // When a SetupBootstrapHalted is caught (fatal non-funding error or funding
@@ -2138,6 +2151,9 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
         source: passwordResolution.source,
         filePath: passwordResolution.filePath,
       },
+      // #641: back-fills /v1/status.latestVersion from the start-time
+      // npm-registry check (populated after the daemon-running line below).
+      latestVersion: () => latestVersionHolder.current,
       spendCaps: spendCap?.caps,
       aiUnits,
     },
@@ -2333,12 +2349,15 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
   // flow (they were created in setup-mode before bootstrap), so we close
   // them explicitly after Daemon.stop() completes.
   let shutdownPromise: Promise<void> | null = null;
+  // #641: recurring npm-registry version check; cleared on shutdown.
+  let versionCheckTimer: ReturnType<typeof setInterval> | null = null;
   const shutdown = async (signal: string) => {
     if (shutdownPromise) return shutdownPromise;
     shutdownPromise = (async () => {
       let exitCode = 0;
       console.log(`\n[main] Received ${signal}, shutting down...`);
       try {
+        if (versionCheckTimer) clearInterval(versionCheckTimer);
         harnessReadinessRegistry.stop();
         await daemon.stop();
         await setupApiServer.close().catch(() => undefined);
@@ -2392,6 +2411,31 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     throw error;
   }
   console.log(`[main] Daemon running. Dashboard: http://127.0.0.1:${config.apiPort}`);
+
+  // #641: start-time (and recurring) npm-registry version check. Fire-and-forget
+  // — never awaited, never rejects into boot. When a newer client is published
+  // it logs one line and back-fills the dashboard's update_available banner via
+  // `latestVersionHolder`. Opt out with JINN_VERSION_CHECK=0.
+  if (isVersionCheckEnabled(process.env)) {
+    const refreshVersionCheck = async (): Promise<void> => {
+      try {
+        const latest = await fetchLatestVersion();
+        if (!latest) return;
+        latestVersionHolder.current = latest;
+        if (isNewerVersion(getRunningVersion(), latest)) {
+          console.log(formatUpdateLogLine(latest));
+        }
+      } catch {
+        // Advisory only — a registry hiccup must never disturb the daemon.
+      }
+    };
+    void refreshVersionCheck();
+    versionCheckTimer = setInterval(() => {
+      void refreshVersionCheck();
+    }, VERSION_CHECK_INTERVAL_MS);
+    versionCheckTimer.unref();
+  }
+
   return {
     schemaVersion: 1,
     generatedAt: new Date().toISOString(),

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -2420,10 +2420,17 @@ export async function main(): Promise<DaemonStartupInfo | SetupHaltedInfo | void
     const refreshVersionCheck = async (): Promise<void> => {
       try {
         const latest = await fetchLatestVersion();
-        if (!latest) return;
-        latestVersionHolder.current = latest;
-        if (isNewerVersion(getRunningVersion(), latest)) {
+        if (latest && isNewerVersion(getRunningVersion(), latest)) {
+          // Only surface a value when the published latest is genuinely newer
+          // than the running build. The dashboard banner derives directly from
+          // a non-null `latestVersion`, so this keeps the log and the banner on
+          // the same semver strictly-greater check.
+          latestVersionHolder.current = latest;
           console.log(formatUpdateLogLine(latest));
+        } else {
+          // Not newer (equal, older, or unfetchable) — clear any prior value so
+          // a stale tick can't linger as a false upgrade signal.
+          latestVersionHolder.current = null;
         }
       } catch {
         // Advisory only — a registry hiccup must never disturb the daemon.

--- a/client/src/preflight/version-check.ts
+++ b/client/src/preflight/version-check.ts
@@ -3,13 +3,7 @@
  *
  * The daemon does not surface that a newer `@jinn-network/client` has been
  * published, so operators run stale dashboards. This module supplies the pure,
- * unit-testable pieces main.ts composes into a fire-and-forget check:
- *
- *   - `getRunningVersion()`      — the version this process is running
- *   - `isVersionCheckEnabled()`  — the `JINN_VERSION_CHECK` opt-out gate
- *   - `fetchLatestVersion()`     — best-effort GET of the npm `latest` dist-tag
- *   - `isNewerVersion()`         — semver compare (never throws)
- *   - `formatUpdateLogLine()`    — the one-line "update available" log message
+ * unit-testable pieces main.ts composes into a fire-and-forget check.
  *
  * Nothing here throws: a registry outage, a malformed response, or an
  * unparseable version degrades to `null` / `false`. The check is advisory.
@@ -74,14 +68,8 @@ export async function fetchLatestVersion(
     });
     if (!res.ok) return null;
     const body: unknown = await res.json();
-    if (
-      body &&
-      typeof body === 'object' &&
-      typeof (body as { version?: unknown }).version === 'string'
-    ) {
-      return (body as { version: string }).version;
-    }
-    return null;
+    const version = (body as { version?: unknown })?.version;
+    return typeof version === 'string' ? version : null;
   } catch {
     return null;
   } finally {

--- a/client/src/preflight/version-check.ts
+++ b/client/src/preflight/version-check.ts
@@ -1,0 +1,107 @@
+/**
+ * Start-time npm-registry version check (issue #641).
+ *
+ * The daemon does not surface that a newer `@jinn-network/client` has been
+ * published, so operators run stale dashboards. This module supplies the pure,
+ * unit-testable pieces main.ts composes into a fire-and-forget check:
+ *
+ *   - `getRunningVersion()`      — the version this process is running
+ *   - `isVersionCheckEnabled()`  — the `JINN_VERSION_CHECK` opt-out gate
+ *   - `fetchLatestVersion()`     — best-effort GET of the npm `latest` dist-tag
+ *   - `isNewerVersion()`         — semver compare (never throws)
+ *   - `formatUpdateLogLine()`    — the one-line "update available" log message
+ *
+ * Nothing here throws: a registry outage, a malformed response, or an
+ * unparseable version degrades to `null` / `false`. The check is advisory.
+ */
+
+import semver from 'semver';
+import { buildInfo } from '../build-info.js';
+
+/** npm `latest` dist-tag endpoint for the published client package. */
+const REGISTRY_LATEST_URL =
+  'https://registry.npmjs.org/@jinn-network/client/latest';
+
+/** Default abort timeout for the registry fetch (ms). */
+const DEFAULT_TIMEOUT_MS = 2500;
+
+/** Poll cadence for the recurring background refresh (6 hours). */
+export const VERSION_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+/** The version this process is running (from the build-time package version). */
+export function getRunningVersion(): string {
+  return buildInfo.implVersion;
+}
+
+/**
+ * Whether the start-time version check is enabled. Default-on; opt out via
+ * `JINN_VERSION_CHECK` set to `0` / `false` / `no` / empty (case-insensitive,
+ * whitespace-trimmed). Mirrors the inverted-boolean pattern used for
+ * `JINN_RUN_LEGACY_MIGRATIONS` in config.ts.
+ */
+export function isVersionCheckEnabled(
+  env: Record<string, string | undefined>,
+): boolean {
+  const raw = env['JINN_VERSION_CHECK'];
+  if (raw === undefined) return true;
+  const v = raw.trim().toLowerCase();
+  return !(v === '0' || v === 'false' || v === 'no' || v === '');
+}
+
+export interface FetchLatestVersionOptions {
+  /** Injectable fetch for testing; defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch;
+  /** Abort timeout in ms; defaults to 2500. */
+  timeoutMs?: number;
+}
+
+/**
+ * Best-effort read of the latest published version from the npm registry.
+ * Returns the version string, or `null` on any failure (non-200, malformed
+ * body, network error, abort/timeout). Never throws.
+ */
+export async function fetchLatestVersion(
+  opts: FetchLatestVersionOptions = {},
+): Promise<string | null> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(REGISTRY_LATEST_URL, {
+      signal: controller.signal,
+      headers: { accept: 'application/json' },
+    });
+    if (!res.ok) return null;
+    const body: unknown = await res.json();
+    if (
+      body &&
+      typeof body === 'object' &&
+      typeof (body as { version?: unknown }).version === 'string'
+    ) {
+      return (body as { version: string }).version;
+    }
+    return null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * True when `latest` is strictly newer than `running`. The dev placeholder
+ * (`0.0.0-dev`) sorts below any real release, so a dev build reports an update
+ * as available. Unparseable inputs yield `false` (never throws).
+ */
+export function isNewerVersion(running: string, latest: string): boolean {
+  const r = semver.coerce(running);
+  const l = semver.coerce(latest);
+  if (!r || !l) return false;
+  return semver.gt(l, r);
+}
+
+/** One-line "update available" log message. */
+export function formatUpdateLogLine(latest: string): string {
+  return `[version] v${latest} of @jinn-network/client is available — run \`jinn update\` and restart to pick it up`;
+}

--- a/client/test/api/gather-status.test.ts
+++ b/client/test/api/gather-status.test.ts
@@ -459,6 +459,46 @@ describe('gatherStatusForApi', () => {
     });
   });
 
+  it('reports running version and null latestVersion when no getter is supplied (#641)', async () => {
+    const { gatherStatusForApi } = await import('../../src/api/gather-status.js');
+    const { buildInfo } = await import('../../src/build-info.js');
+
+    await withTempStore(async (store) => {
+      const status = await gatherStatusForApi(store, undefined);
+      expect(status.version).toBe(buildInfo.implVersion);
+      expect(status.latestVersion).toBeNull();
+    });
+  });
+
+  it('threads latestVersion from the getter, and null when it throws (#641)', async () => {
+    mockStatusRpc();
+    const { gatherStatusForApi } = await import('../../src/api/gather-status.js');
+
+    await withTempStore(async (store) => {
+      const ok = await gatherStatusForApi(store, {
+        earningDir: mkdtempSync(join(tmpdir(), 'jinn-status-test-')),
+        rpcUrl: 'http://127.0.0.1:0',
+        network: 'testnet' as const,
+        pollIntervalMs: 5000,
+        rewardClaimIntervalMs: 0,
+        latestVersion: () => '9.9.9',
+      });
+      expect(ok.latestVersion).toBe('9.9.9');
+
+      const thrown = await gatherStatusForApi(store, {
+        earningDir: mkdtempSync(join(tmpdir(), 'jinn-status-test-')),
+        rpcUrl: 'http://127.0.0.1:0',
+        network: 'testnet' as const,
+        pollIntervalMs: 5000,
+        rewardClaimIntervalMs: 0,
+        latestVersion: () => {
+          throw new Error('holder not ready');
+        },
+      });
+      expect(thrown.latestVersion).toBeNull();
+    });
+  });
+
   it('threads status.harness from the harnessReadiness getter when supplied', async () => {
     mockStatusRpc();
     const { gatherStatusForApi } = await import('../../src/api/gather-status.js');

--- a/client/test/api/status-build.test.ts
+++ b/client/test/api/status-build.test.ts
@@ -5,6 +5,7 @@ import {
   type GatheredStatusRaw,
 } from '../../src/api/status-build.js';
 import type { FleetState } from '../../src/earning/types.js';
+import { buildInfo } from '../../src/build-info.js';
 
 function minimalFleet(overrides: Partial<FleetState> = {}): FleetState {
   return {
@@ -352,6 +353,31 @@ describe('assembleStatusV1', () => {
     expect(j.taskRuns?.totals.solutions).toBe(0);
     expect(j.taskRuns?.totals.verdicts).toBe(0);
     expect(j.taskRuns?.inFlight[0]?.solverType).toBe('swe-rebench-v2.v1');
+  });
+
+  it('projects version + latestVersion (#641)', () => {
+    const base: GatheredStatusRaw = {
+      shutdownState: 'running',
+      dbPath: '/tmp/x.db',
+      activityCounts: {},
+      recentActivity: [],
+      lastRewardClaimTickAt: null,
+      rewardClaimIntervalMs: 0,
+      fleet: null,
+      rpc: { ok: true },
+      master: { address: null },
+      pollIntervalMs: 5000,
+      masterDailyEstimateWei: '1000',
+    };
+    // Explicit version + latestVersion pass through verbatim.
+    const withBoth = assembleStatusV1({ ...base, version: '0.1.8', latestVersion: '0.2.0' });
+    expect(withBoth.version).toBe('0.1.8');
+    expect(withBoth.latestVersion).toBe('0.2.0');
+
+    // Absent latestVersion → null; absent version → buildInfo fallback.
+    const withNeither = assembleStatusV1(base);
+    expect(withNeither.latestVersion).toBeNull();
+    expect(withNeither.version).toBe(buildInfo.implVersion);
   });
 });
 

--- a/client/test/dashboard/update-available-notification.e2e.test.ts
+++ b/client/test/dashboard/update-available-notification.e2e.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Acceptance-test for issue #641: surface the `update_available` notification
+ * in the operator dashboard SPA when the daemon reports a newer published
+ * `@jinn-network/client`.
+ *
+ * This is the Stage 7 (testing-jinn-app) regression. The unit tests in
+ * `useNotifications.test.tsx` (wire → deriver adapter) and `derive.test.ts`
+ * (pure deriver) pin the mapping; this E2E exercises the full SPA wiring:
+ * - the daemon's `/v1/status` snapshot carrying `version` + `latestVersion`
+ * - `mapStatusToDeriveInput` normalising those into the deriver's
+ *   `daemonVersion` / `latestVersion` fields
+ * - `deriveNotifications` emitting the `update_available` kind only when
+ *   `latestVersion` is a string strictly differing from `daemonVersion`
+ * - the `NotificationsList` rendering the info banner
+ *
+ * The banner is a pure function of the `/v1/status` payload (unlike the
+ * SSE-driven `claim_failed` kind), so both cases just override the `/v1/status`
+ * route AFTER `mockDaemonApi` and assert on the rendered banner.
+ *
+ * Acceptance criteria (from issue #641):
+ *   (1) newer `latestVersion` than `version` ⇒ `update_available` banner shows.
+ *   (2) `latestVersion: null` (or equal to version) ⇒ NO banner.
+ */
+import { test, expect } from '@playwright/test';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { mkdtempSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  mockDaemonApi,
+  DEFAULT_STATUS_PAYLOAD,
+} from './helpers/mock-daemon-api';
+
+const PORT = 17335;
+
+let daemon: ChildProcess | null = null;
+let homeDir = '';
+let handshakeUrl: string | null = null;
+
+test.beforeAll(async () => {
+  homeDir = mkdtempSync(join(tmpdir(), 'jinn-update-available-e2e-'));
+  const distBin = join(process.cwd(), 'dist', 'bin', 'jinn.js');
+  if (!existsSync(distBin)) {
+    throw new Error(`dist/bin/jinn.js missing — run \`yarn build\` first`);
+  }
+  daemon = spawn('node', [distBin, 'run', '--no-ui'], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      HOME: homeDir,
+      JINN_PASSWORD: 'test-password',
+      JINN_API_PORT: String(PORT),
+      BASE_RPC_URL: 'http://127.0.0.1:65000',
+      JINN_NETWORK: 'testnet',
+      JINN_DISABLE_TESTNET_FAUCET: '1',
+    },
+    stdio: 'pipe',
+  });
+
+  const onChunk = (chunk: Buffer): void => {
+    const text = chunk.toString('utf-8');
+    const m = /UI handshake URL:\s+(\S+)/.exec(text);
+    if (m && !handshakeUrl) handshakeUrl = m[1];
+  };
+  daemon.stderr?.on('data', onChunk);
+  daemon.stdout?.on('data', onChunk);
+
+  for (let i = 0; i < 60; i++) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${PORT}/v1/bootstrap`, {
+        headers: { 'x-jinn-ui-token': 'unused' },
+      });
+      if (res.status === 200 || res.status === 401) return;
+    } catch {
+      // not yet
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error('daemon never came up on test port');
+});
+
+test.afterAll(async () => {
+  if (daemon && !daemon.killed) {
+    daemon.kill('SIGTERM');
+    await new Promise((r) => setTimeout(r, 500));
+    if (!daemon.killed) daemon.kill('SIGKILL');
+  }
+});
+
+/**
+ * Override the `/v1/status` route with a payload carrying the given `version`
+ * and `latestVersion`. Registered AFTER `mockDaemonApi` so it wins (Playwright
+ * checks routes in reverse-registration order).
+ */
+async function overrideStatusVersions(
+  page: import('@playwright/test').Page,
+  version: string,
+  latestVersion: string | null,
+): Promise<void> {
+  await page.route(
+    (url) => url.pathname === '/v1/status',
+    (route) =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...DEFAULT_STATUS_PAYLOAD,
+          version,
+          latestVersion,
+        }),
+      }),
+  );
+}
+
+test('update_available banner shows when latestVersion is strictly newer than version (issue #641)', async ({ page }) => {
+  await mockDaemonApi(page);
+  await overrideStatusVersions(page, '0.1.6', '0.1.8');
+
+  await page.goto(handshakeUrl ?? `http://127.0.0.1:${PORT}/`);
+
+  const updateItem = page.locator('[data-kind="update_available"]');
+  await expect(updateItem).toBeVisible({ timeout: 15_000 });
+  await expect(updateItem).toHaveAttribute('data-severity', 'info');
+  // Message follows deriveNotifications():
+  //   "Daemon <latest> available (running <current>)."
+  await expect(updateItem).toContainText('0.1.8');
+  await expect(updateItem).toContainText('0.1.6');
+});
+
+test('no update_available banner when latestVersion is null (issue #641)', async ({ page }) => {
+  await mockDaemonApi(page);
+  await overrideStatusVersions(page, '0.1.6', null);
+
+  await page.goto(handshakeUrl ?? `http://127.0.0.1:${PORT}/`);
+
+  // Wait for a snapshot-derived notification to render (the default mocked
+  // /v1/status reports zero gas → funding_low). Once that's visible we know the
+  // deriver has run, so the absence of update_available is a real negative,
+  // not a not-yet-rendered race.
+  await expect(page.locator('[data-kind="funding_low"]')).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.locator('[data-kind="update_available"]')).toHaveCount(0);
+});

--- a/client/test/preflight/version-check.test.ts
+++ b/client/test/preflight/version-check.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getRunningVersion,
+  isVersionCheckEnabled,
+  fetchLatestVersion,
+  isNewerVersion,
+  formatUpdateLogLine,
+  VERSION_CHECK_INTERVAL_MS,
+} from '../../src/preflight/version-check.js';
+import { buildInfo } from '../../src/build-info.js';
+
+describe('getRunningVersion', () => {
+  it('returns buildInfo.implVersion', () => {
+    expect(getRunningVersion()).toBe(buildInfo.implVersion);
+  });
+});
+
+describe('isVersionCheckEnabled', () => {
+  it('defaults on when the var is unset', () => {
+    expect(isVersionCheckEnabled({})).toBe(true);
+  });
+
+  it('is on for truthy strings', () => {
+    expect(isVersionCheckEnabled({ JINN_VERSION_CHECK: '1' })).toBe(true);
+    expect(isVersionCheckEnabled({ JINN_VERSION_CHECK: 'true' })).toBe(true);
+    expect(isVersionCheckEnabled({ JINN_VERSION_CHECK: 'yes' })).toBe(true);
+  });
+
+  it('is off for the opt-out strings', () => {
+    expect(isVersionCheckEnabled({ JINN_VERSION_CHECK: '0' })).toBe(false);
+    expect(isVersionCheckEnabled({ JINN_VERSION_CHECK: 'false' })).toBe(false);
+    expect(isVersionCheckEnabled({ JINN_VERSION_CHECK: 'no' })).toBe(false);
+    expect(isVersionCheckEnabled({ JINN_VERSION_CHECK: '' })).toBe(false);
+  });
+
+  it('is case-insensitive and trims whitespace', () => {
+    expect(isVersionCheckEnabled({ JINN_VERSION_CHECK: ' FALSE ' })).toBe(false);
+    expect(isVersionCheckEnabled({ JINN_VERSION_CHECK: ' No ' })).toBe(false);
+  });
+});
+
+describe('fetchLatestVersion', () => {
+  function okFetch(body: unknown): typeof fetch {
+    return (async () => ({
+      ok: true,
+      status: 200,
+      json: async () => body,
+    })) as unknown as typeof fetch;
+  }
+
+  it('returns the version on a 200 with a well-formed body', async () => {
+    const result = await fetchLatestVersion({ fetchImpl: okFetch({ version: '1.2.3' }) });
+    expect(result).toBe('1.2.3');
+  });
+
+  it('returns null on a non-200 response', async () => {
+    const fetchImpl = (async () => ({
+      ok: false,
+      status: 503,
+      json: async () => ({ version: '1.2.3' }),
+    })) as unknown as typeof fetch;
+    expect(await fetchLatestVersion({ fetchImpl })).toBeNull();
+  });
+
+  it('returns null when .version is missing or malformed', async () => {
+    expect(await fetchLatestVersion({ fetchImpl: okFetch({}) })).toBeNull();
+    expect(await fetchLatestVersion({ fetchImpl: okFetch({ version: 42 }) })).toBeNull();
+    expect(await fetchLatestVersion({ fetchImpl: okFetch('not json') })).toBeNull();
+  });
+
+  it('returns null (never throws) when fetch rejects', async () => {
+    const fetchImpl = (async () => {
+      throw new Error('network down');
+    }) as unknown as typeof fetch;
+    await expect(fetchLatestVersion({ fetchImpl })).resolves.toBeNull();
+  });
+
+  it('returns null when the request aborts / times out', async () => {
+    const fetchImpl = ((_url: string, opts?: { signal?: AbortSignal }) =>
+      new Promise((_resolve, reject) => {
+        opts?.signal?.addEventListener('abort', () =>
+          reject(Object.assign(new Error('aborted'), { name: 'AbortError' })),
+        );
+      })) as unknown as typeof fetch;
+    await expect(
+      fetchLatestVersion({ fetchImpl, timeoutMs: 1 }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe('isNewerVersion', () => {
+  it('is true when latest > running', () => {
+    expect(isNewerVersion('0.1.8', '0.2.0')).toBe(true);
+    expect(isNewerVersion('1.0.0', '1.0.1')).toBe(true);
+  });
+
+  it('is false when latest equals or is older than running', () => {
+    expect(isNewerVersion('0.2.0', '0.2.0')).toBe(false);
+    expect(isNewerVersion('0.2.0', '0.1.9')).toBe(false);
+  });
+
+  it('treats the dev placeholder as older than any real release', () => {
+    expect(isNewerVersion('0.0.0-dev', '0.1.0')).toBe(true);
+  });
+
+  it('is false (never throws) for unparseable inputs', () => {
+    expect(isNewerVersion('not-a-version', '1.0.0')).toBe(false);
+    expect(isNewerVersion('1.0.0', 'garbage')).toBe(false);
+  });
+});
+
+describe('formatUpdateLogLine', () => {
+  it('names the version and the upgrade command', () => {
+    expect(formatUpdateLogLine('1.2.3')).toBe(
+      '[version] v1.2.3 of @jinn-network/client is available — run `jinn update` and restart to pick it up',
+    );
+  });
+});
+
+describe('VERSION_CHECK_INTERVAL_MS', () => {
+  it('is a positive interval', () => {
+    expect(VERSION_CHECK_INTERVAL_MS).toBeGreaterThan(0);
+  });
+});

--- a/client/test/preflight/version-check.test.ts
+++ b/client/test/preflight/version-check.test.ts
@@ -99,6 +99,12 @@ describe('isNewerVersion', () => {
     expect(isNewerVersion('0.2.0', '0.1.9')).toBe(false);
   });
 
+  it('is false when the running build is a canary ahead of the registry latest (#641)', () => {
+    // The holder must stay null here so the dashboard banner does not advertise
+    // a downgrade (registry latest) as an upgrade over a newer local canary.
+    expect(isNewerVersion('0.2.0-canary.1', '0.1.9')).toBe(false);
+  });
+
   it('treats the dev placeholder as older than any real release', () => {
     expect(isNewerVersion('0.0.0-dev', '0.1.0')).toBe(true);
   });


### PR DESCRIPTION
## Summary
The daemon did not surface that a newer `@jinn-network/client` had been published, so operators ran stale dashboards without knowing an update existed (issue #641 — not a publishing bug, a DX gap).

This adds a start-time (and 6-hourly) npm-registry version check:
- **New `client/src/preflight/version-check.ts`** — GETs `https://registry.npmjs.org/@jinn-network/client/latest`, compares with `semver`, never throws, `AbortController` timeout, returns `null` on any failure. Gated by `JINN_VERSION_CHECK` (default on; opt out with `0`/`false`/`no`/empty).
- **Startup log** — one line when a strictly-newer version exists, pointing at `jinn update` + restart. Fire-and-forget, so it can never block or crash boot.
- **Dashboard banner** — `/v1/status` now carries `version` + `latestVersion` (populated only when strictly newer than the running build), feeding the *existing* `update_available` notification pipeline — no new component. The banner and the log fire on the identical semver check, so an operator on a build ahead of `latest` (e.g. a canary) never sees a false downgrade banner.
- **Resource-safe** — the recurring check is `.unref()`'d and cleared on shutdown; the 5s status poll reads a cached holder and never hits npm.
- **Docs** — `CLAUDE.md` env-var table + `client/OPERATOR-APP-SPEC.md` §2.10.

Out of scope (untouched): auto-update on startup, publish-pipeline changes, and the separate `jinn update`-doesn't-stop-the-daemon issue.

## Test plan
- `client/test/preflight/version-check.test.ts` — `fetchLatestVersion` (200 / non-200 / malformed / rejects / timeout-abort), `isVersionCheckEnabled` opt-out strings, `isNewerVersion` (newer / equal / older / `0.0.0-dev` / canary-ahead / unparseable), `formatUpdateLogLine`.
- `status-build.test.ts` + `gather-status.test.ts` — `version` always populated, `latestVersion` threaded from the getter (and null when it throws).
- SPA: `useNotifications.test.tsx` + `derive.test.ts` — wire mapping and deriver positives/negatives; `client/test/dashboard/update-available-notification.e2e.test.ts` — Playwright mocked-daemon render (newer→banner, null→no banner).
- `yarn typecheck` + `yarn test` + `yarn build` all green locally.

Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)