### PR TITLE
test(chain): drop structurally racy port-allocator uniqueness test

### DIFF
--- a/client/test/_support/chain/port-allocator.test.ts
+++ b/client/test/_support/chain/port-allocator.test.ts
@@ -12,10 +12,4 @@ describe('allocateAnvilPort', () => {
       s.listen(port, '127.0.0.1', () => s.close(() => resolve()));
     });
   });
-
-  it('returns different ports on repeated calls', async () => {
-    const a = await allocateAnvilPort();
-    const b = await allocateAnvilPort();
-    expect(a).not.toBe(b);
-  });
 });


### PR DESCRIPTION
## Summary
`allocateAnvilPort()` binds to `:0`, reads the kernel-assigned port, then closes the socket before returning. A subsequent call can therefore legitimately receive the same port — so the `'returns different ports on repeated calls'` test asserted a premise that cannot hold, and flaked CI (it blocked PR #705, a docs-only diff). This drops that test. The remaining `'returns a listenable port'` test covers the function's actual contract; the allocator source is unchanged.

## Test plan
- `yarn vitest run test/_support/chain/port-allocator.test.ts` → passes (1 test)
- `yarn typecheck` → clean

Closes #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)