### PR TITLE
fix(operator): warn when joinedSolverNets entry silently skips claim registration

### DIFF
--- a/client/src/solver-nets/registry.ts
+++ b/client/src/solver-nets/registry.ts
@@ -252,10 +252,20 @@ export async function registerJoinedNet(
   cid: string,
   joined: JoinedSolverNetConfig,
 ): Promise<void> {
-  if (!joined.contract) return;
+  if (!joined.contract) {
+    console.warn(
+      `[solver-nets] joinedSolverNets[${cid}] missing contract field — entry will not participate in claim flow`,
+    );
+    return;
+  }
   const solverType = `${joined.contract.id}.${joined.contract.version}`;
   const contract = getSolverNetContract(joined.contract);
-  if (!contract) return;
+  if (!contract) {
+    console.warn(
+      `[solver-nets] joinedSolverNets[${cid}] contract ${solverType} did not resolve to a known SolverNet — entry will not participate in claim flow`,
+    );
+    return;
+  }
   const roles = rolesFromJoinedConfig(joined);
   if (roles.length === 0) return;
   const disabledDefaults = joined.disabledDefaultPlugins ?? [];

--- a/client/test/solver-nets/registry-register-joined.test.ts
+++ b/client/test/solver-nets/registry-register-joined.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   SolverNetRegistry,
   loadSolverNets,
@@ -34,5 +34,50 @@ describe('registerJoinedNet', () => {
     const live = new SolverNetRegistry();
     await registerJoinedNet(live, CID, { ...joined, contract: undefined });
     expect(live.list()).toEqual([]);
+  });
+
+  describe('diagnostic warnings on silent skip', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('warns (missing contract field) and does not register when contract is absent', async () => {
+      const live = new SolverNetRegistry();
+      await registerJoinedNet(live, CID, { ...joined, contract: undefined });
+
+      expect(live.list()).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const msg = String(warnSpy.mock.calls[0][0]);
+      expect(msg).toMatch(/missing contract field/);
+      expect(msg).toContain(CID);
+    });
+
+    it('warns (did not resolve) and does not register when contract is unknown', async () => {
+      const live = new SolverNetRegistry();
+      await registerJoinedNet(live, CID, {
+        ...joined,
+        contract: { id: 'not-a-real-solvernet', version: 'v99' },
+      });
+
+      expect(live.list()).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const msg = String(warnSpy.mock.calls[0][0]);
+      expect(msg).toMatch(/did not resolve/);
+      expect(msg).toContain(CID);
+    });
+
+    it('does not warn on the happy path with a resolvable contract', async () => {
+      const live = new SolverNetRegistry();
+      await registerJoinedNet(live, CID, joined);
+
+      expect(live.list().length).toBeGreaterThan(0);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary

A `joinedSolverNets` config entry missing (or carrying an unresolvable) `contract` field was silently skipped by `registerJoinedNet` — the SolverNet appeared in the static catalog and harness-readiness registry but never registered into the claim flow, with **no log and no error**. Operators using a hand-written / template config (e.g. the Railway-hosted daemon in #661) appeared correctly in the dashboard but never claimed a task, discovering the problem only when evicted.

This keeps `contract` optional in the schema (making it required would hard-fail the whole daemon boot and break the legitimate mid-onboarding partial entries the SPA writes) and instead emits a distinct, cid-bearing `console.warn` before each of the two early-returns in `registerJoinedNet`:
- missing `contract` field, and
- `contract` present but not resolvable to a known SolverNet.

Investigated acceptance-criterion (3): the SPA `JoinFlow` already derives `contract` from the manifest and sends it on `POST /v1/operator/join/:cid` (JoinFlow.tsx / JoinFlow.test.tsx), so the dashboard-driven join path already populates `contract`. The failure is specific to hand-written/template configs, which the new warn now surfaces.

## Test plan

- Regression tests in `client/test/solver-nets/registry-register-joined.test.ts` (spy on `console.warn`):
  - missing `contract` → zero registrations + warn matching `/missing contract field/` with the cid
  - unresolvable `contract` → zero registrations + warn matching `/did not resolve/` with the cid
  - happy path (resolvable `swe-rebench-v2/v1`) → registers and does NOT warn
- `yarn vitest run test/solver-nets/registry-register-joined.test.ts` → 5/5 pass
- `yarn typecheck` → 0 errors

Closes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)