### PR TITLE
fix(harness): name missing deliverable, not .orient/summary.json, on empty run

### DIFF
--- a/client/src/harnesses/impls/learner/harvest.ts
+++ b/client/src/harnesses/impls/learner/harvest.ts
@@ -564,6 +564,17 @@ export async function harvestOutput(workingDir: string, phaseRange?: string, tas
   // unless a typed SolverNet payload is already present. In the typed-payload
   // path, phase artifacts are useful learner telemetry, but the payload is the
   // delivery contract the engine needs to package and settle.
+  const phasesCompleted = detectCompletedPhases(workingDir);
+
+  // No solution payload AND no phase artifacts at all: the run produced nothing.
+  // Fail on the real cause (the missing deliverable) rather than naming a phase
+  // telemetry file (e.g. .orient/summary.json), which is a misleading symptom.
+  if (!typedPayload && phasesCompleted.length === 0 && requiredPhases.size > 0) {
+    throw new Error(
+      'harness produced no solution payload and no phase artifacts; the run appears empty (did the harness execute?)',
+    );
+  }
+
   const validated = new Map<Phase, Record<string, unknown>>();
   for (const phase of REQUIRED_PHASES[range]) {
     const path = join(workingDir, `.${phase}`, PHASE_PRIMARY_ARTIFACT[phase]);
@@ -575,7 +586,6 @@ export async function harvestOutput(workingDir: string, phaseRange?: string, tas
     if (artifact) validated.set(phase, artifact);
   }
 
-  const phasesCompleted = detectCompletedPhases(workingDir);
   const gating: Record<string, unknown> = { phasesCompleted };
 
   // Read a phase's primary artifact for optional gating-field extraction.

--- a/client/test/harnesses/impls/learner/harvest.test.ts
+++ b/client/test/harnesses/impls/learner/harvest.test.ts
@@ -166,6 +166,25 @@ describe('harvestOutput', () => {
     expect((out.solutionPayload as Record<string, unknown>).patch).toContain('old = False');
   });
 
+  // ── Empty run — no payload, no phase artifacts (#814) ───────────────────────
+
+  it('empty run: no typed payload and no phase artifacts — names the missing deliverable, not .orient/summary.json', async () => {
+    // The harness produced nothing: no solution-payload.json and no phase dirs.
+    // The error must be deliverable-oriented, not phase-telemetry-oriented.
+    await expect(harvestOutput(workingDir, 'full')).rejects.toThrow(/appears empty/);
+    await expect(harvestOutput(workingDir, 'full')).rejects.not.toThrow(/\.orient\/summary\.json/);
+  });
+
+  it('partial run: some phase artifacts present but a required primary missing — still throws Required artifact missing', async () => {
+    // A non-required phase (orient) produced artifacts, so the run is not empty,
+    // but post-execute requires debrief whose primary artifact is absent.
+    writePhaseArtifact(workingDir, 'orient', 'summary.json', { topics: [] });
+    const requiredPath = join(workingDir, '.debrief', 'analysis.json');
+    await expect(harvestOutput(workingDir, 'post-execute')).rejects.toThrow(
+      `Required artifact missing: ${requiredPath}`,
+    );
+  });
+
   // ── Optional artifact handling (warn, don't throw) ──────────────────────────
 
   it('does not throw when optional artifact is absent; logs a warning', async () => {


### PR DESCRIPTION
## Summary
`harvestOutput` (client/src/harnesses/impls/learner/harvest.ts) failed a task with `Required artifact missing: <workdir>/.orient/summary.json` when the harness actually produced **no deliverable at all**. `.orient/summary.json` is phase telemetry, not the delivery contract — the real cause (e.g. missing API key so the harness never ran) was hidden behind a telemetry-artifact message, costing real debugging time during M1 burn-in prep.

The fix hoists `detectCompletedPhases(workingDir)` above the required-phase validation loop and adds an early guard: when there is no typed solution payload **and** no phase produced any artifacts (and the phase range actually requires phases), `harvestOutput` now throws:

> harness produced no solution payload and no phase artifacts; the run appears empty (did the harness execute?)

Existing behavior is preserved:
- **Answer present** ⇒ phase artifacts stay optional ⇒ pass (unchanged).
- **Partial run** (some phase produced artifacts, one required primary artifact missing) ⇒ still throws the specific `Required artifact missing: <path>`.
- **solve-only frozen mode** (`REQUIRED_PHASES` empty) is unaffected — the guard is scoped with `requiredPhases.size > 0`.

## Test plan
- Regression test 1: no typed payload + no phase dirs ⇒ rejects with `/appears empty/` and does **not** name `.orient/summary.json`. (Confirmed failing before the fix, passing after.)
- Regression test 2: no typed payload + a non-required phase dir populated but the required `.execute`/`.debrief` artifact missing ⇒ still rejects with `Required artifact missing: <path>`.
- Case 3 (typed payload present + phase artifacts absent ⇒ resolves) already covered by the existing suite.
- `test/harnesses/impls/learner/harvest.test.ts`: 42/42 pass. Typecheck green.

Closes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)