### PR TITLE
feat(815): post-merge follow-ups for AI-units ceiling

### DIFF
--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -25,6 +25,7 @@ import type { FleetState } from '../earning/types.js';
 import { displayFleetServiceIndex } from '../earning/fleet-display-index.js';
 import {
   assembleStatusV1,
+  type AiUnitsPausedWindow,
   type GatheredStatusRaw,
   type ServiceBalanceErrorEntry,
   type StatusV1Response,
@@ -906,14 +907,16 @@ export async function gatherStatusForApi(
         // Block-preferred precedence — mirrors the daemon gate
         // (`src/daemon/ai-units-gate.ts`): when both windows are over, the
         // binding window is the block (issue #830, item 2).
-        const pausedWindow: 'block' | 'week' | null = overBlock ? 'block' : overWeek ? 'week' : null;
+        const pausedWindow: AiUnitsPausedWindow = overBlock ? 'block' : overWeek ? 'week' : null;
         // The true "claims resume at" instant for the week window (issue
-        // #830, item 1) — null when the week window is under cap, in which
-        // case the fixed `now + 7d` fallback is used since the value isn't
-        // operator-relevant.
-        const weekResetsAt =
-          store.weekWindowResumeAt(credentialId, aiUnitsCfg.capPerWeekUsdMicros, now) ??
-          weekResetsAtFallback;
+        // #830, item 1) — only computed when actually paused on the week
+        // window; otherwise the fixed `now + 7d` fallback is used since the
+        // value isn't operator-relevant (and querying it would cost an
+        // unconditional per-credential row scan on every status poll).
+        const weekResetsAt = overWeek
+          ? (store.weekWindowResumeAt(credentialId, aiUnitsCfg.capPerWeekUsdMicros, now) ??
+            weekResetsAtFallback)
+          : weekResetsAtFallback;
         return {
           credentialId,
           // #1006: legacy unit fields, derived from USD via the peg.

--- a/client/src/api/gather-status.ts
+++ b/client/src/api/gather-status.ts
@@ -888,7 +888,7 @@ export async function gatherStatusForApi(
   if (aiUnitsCfg) {
     const now = new Date();
     const blockResetsAt = blockResetsAtUtc(now).toISOString();
-    const weekResetsAt = weekResetsAtUtc(now).toISOString();
+    const weekResetsAtFallback = weekResetsAtUtc(now).toISOString();
     // Dedupe credentials across manifests — multiple SolverNets on the same
     // credential share one row.
     const uniqueCredentials = new Set(Object.values(aiUnitsCfg.manifestCredentials));
@@ -900,9 +900,20 @@ export async function gatherStatusForApi(
       credentials: [...uniqueCredentials].map((credentialId) => {
         const block = store.usdMicrosThisBlock(credentialId, now);
         const week = store.usdMicrosThisWeek(credentialId, now);
-        const paused =
-          block.usdMicros >= aiUnitsCfg.capPerBlockUsdMicros ||
-          week.usdMicros >= aiUnitsCfg.capPerWeekUsdMicros;
+        const overBlock = block.usdMicros >= aiUnitsCfg.capPerBlockUsdMicros;
+        const overWeek = week.usdMicros >= aiUnitsCfg.capPerWeekUsdMicros;
+        const paused = overBlock || overWeek;
+        // Block-preferred precedence — mirrors the daemon gate
+        // (`src/daemon/ai-units-gate.ts`): when both windows are over, the
+        // binding window is the block (issue #830, item 2).
+        const pausedWindow: 'block' | 'week' | null = overBlock ? 'block' : overWeek ? 'week' : null;
+        // The true "claims resume at" instant for the week window (issue
+        // #830, item 1) — null when the week window is under cap, in which
+        // case the fixed `now + 7d` fallback is used since the value isn't
+        // operator-relevant.
+        const weekResetsAt =
+          store.weekWindowResumeAt(credentialId, aiUnitsCfg.capPerWeekUsdMicros, now) ??
+          weekResetsAtFallback;
         return {
           credentialId,
           // #1006: legacy unit fields, derived from USD via the peg.
@@ -928,6 +939,7 @@ export async function gatherStatusForApi(
           // first cost row lands in the window (fresh node or just-reset 7d
           // window), so this can transiently under-report the live credential.
           active: week.usdMicros > 0,
+          pausedWindow,
           blockResetsAt,
           weekResetsAt,
         };

--- a/client/src/api/status-build.ts
+++ b/client/src/api/status-build.ts
@@ -42,6 +42,9 @@ export interface SpendStatus {
   credentials: SpendCredentialRow[];
 }
 
+/** The AI-units window a paused credential is binding on, or `null` when not paused. */
+export type AiUnitsPausedWindow = 'block' | 'week' | null;
+
 /** Per-credential AI-units row exposed on /v1/status (issues #815, #1004). */
 export interface AiUnitsCredentialRow {
   credentialId: string;
@@ -83,7 +86,7 @@ export interface AiUnitsCredentialRow {
    * cap). `null` when not paused. Lets the SPA render the pause reason
    * without re-deriving the precedence locally (issue #830, item 2).
    */
-  pausedWindow: 'block' | 'week' | null;
+  pausedWindow: AiUnitsPausedWindow;
   /** ISO timestamp of the next 6h block boundary (00:00 / 06:00 / 12:00 / 18:00 UTC). */
   blockResetsAt: string;
   /**

--- a/client/src/api/status-build.ts
+++ b/client/src/api/status-build.ts
@@ -76,9 +76,25 @@ export interface AiUnitsCredentialRow {
    * enrolled one in the /v1/status footprint (issue #891).
    */
   active: boolean;
+  /**
+   * The binding window when `paused` is true, using the same
+   * block-preferred precedence as the daemon gate
+   * (`src/daemon/ai-units-gate.ts`: block wins when both windows are over
+   * cap). `null` when not paused. Lets the SPA render the pause reason
+   * without re-deriving the precedence locally (issue #830, item 2).
+   */
+  pausedWindow: 'block' | 'week' | null;
   /** ISO timestamp of the next 6h block boundary (00:00 / 06:00 / 12:00 / 18:00 UTC). */
   blockResetsAt: string;
-  /** ISO timestamp of the next 7d window reset. */
+  /**
+   * ISO timestamp claims resume for the 7d window. When the week window is
+   * over cap, this is the accurate rolling-window resume instant (the
+   * moment the oldest in-window spend ages out enough to drop the sum back
+   * under the cap — see `Store.weekWindowResumeAt`). When the week window
+   * is under cap, this falls back to the coarse `weekResetsAtUtc(now)`
+   * (`now + 7d`) instant, which is not operator-relevant in that case
+   * (issue #830, item 1).
+   */
   weekResetsAt: string;
 }
 

--- a/client/src/dashboard/spa/src/pages/AiUnitsPauseAlert.test.tsx
+++ b/client/src/dashboard/spa/src/pages/AiUnitsPauseAlert.test.tsx
@@ -146,4 +146,33 @@ describe('AiUnitsPauseAlert', () => {
     expect(screen.getByTestId('ai-units-pause-alert-a:k').textContent).toMatch(/6h/);
     expect(screen.getByTestId('ai-units-pause-alert-b:k').textContent).toMatch(/7d|week/i);
   });
+
+  it('prefers the gate-sourced pausedWindow over local derivation when they disagree (#830)', () => {
+    // unitsThisBlock >= capPerBlock would locally derive "block", but the
+    // daemon gate says the binding window is actually "week" — the
+    // gate-sourced field must win.
+    render(
+      <AiUnitsPauseAlert
+        aiUnits={{
+          credentials: [
+            {
+              credentialId: 'c:k',
+              unitsThisBlock: 100,
+              unitsThisWeek: 2800,
+              capPerBlock: 100,
+              capPerWeek: 2800,
+              paused: true,
+              pausedWindow: 'week',
+              blockResetsAt: '2026-05-28T18:00:00.000Z',
+              weekResetsAt: '2026-06-04T13:00:00.000Z',
+            },
+          ],
+        }}
+      />,
+    );
+    const alert = screen.getByTestId('ai-units-pause-alert-c:k');
+    expect(alert.textContent).toMatch(/7d|week/i);
+    expect(alert.textContent).not.toMatch(/6h/);
+    expect(alert.textContent).toContain('13:00 UTC'); // formatUtc(weekResetsAt)
+  });
 });

--- a/client/src/dashboard/spa/src/pages/AiUnitsPauseAlert.tsx
+++ b/client/src/dashboard/spa/src/pages/AiUnitsPauseAlert.tsx
@@ -26,6 +26,14 @@ export interface AiUnitsStatusRow {
    * field (see the `?? true` default at the use site).
    */
   active?: boolean;
+  /**
+   * The binding window the daemon gate is actually pausing on
+   * (block-preferred precedence), from the /v1/status feed. Optional for
+   * backward-compat with daemons that predate the field (see the
+   * `?? (unitsThisBlock >= capPerBlock ? 'block' : 'week')` fallback at the
+   * use site) — issue #830, item 2.
+   */
+  pausedWindow?: 'block' | 'week' | null;
   blockResetsAt: string;
   weekResetsAt: string;
 }
@@ -54,9 +62,12 @@ export function AiUnitsPauseAlert({ aiUnits }: AiUnitsPauseAlertProps): JSX.Elem
   return (
     <div className="flex flex-col gap-2">
       {paused.map((row) => {
-        // Pick the binding window — whichever sum has actually reached its cap.
-        const blockHit = row.unitsThisBlock >= row.capPerBlock;
-        const window: 'block' | 'week' = blockHit ? 'block' : 'week';
+        // Prefer the gate-sourced binding window (issue #830, item 2) — it
+        // reflects the daemon's actual block-preferred precedence and can't
+        // disagree with it. Fall back to local derivation only for daemons
+        // predating the `pausedWindow` field.
+        const window: 'block' | 'week' =
+          row.pausedWindow ?? (row.unitsThisBlock >= row.capPerBlock ? 'block' : 'week');
         const resumeAt = window === 'block' ? row.blockResetsAt : row.weekResetsAt;
         const windowLabel = window === 'block' ? '6h' : '7d';
         // A paused credential is by definition the active one; default to active

--- a/client/src/spend/ai-units.ts
+++ b/client/src/spend/ai-units.ts
@@ -90,7 +90,7 @@ function unitsToUsdMicros(units: number): number {
 /** 6h block in milliseconds — UTC blocks start at 00:00 / 06:00 / 12:00 / 18:00. */
 const SIX_HOUR_BLOCK_MS = 6 * 60 * 60 * 1_000;
 /** 7 days in milliseconds — UTC-aligned. */
-const SEVEN_DAY_MS = 7 * 24 * 60 * 60 * 1_000;
+export const SEVEN_DAY_MS = 7 * 24 * 60 * 60 * 1_000;
 
 /**
  * Project the AI-unit cost of one task for a harness/model combination.

--- a/client/src/spend/ai-units.ts
+++ b/client/src/spend/ai-units.ts
@@ -253,7 +253,18 @@ export function blockIdUtc(now: Date): string {
   return blockStartUtc(now).toISOString();
 }
 
-/** Reset instant for the 7-day window — `now + (boundary - elapsed)`. We use rolling 7d here. */
+/**
+ * Coarse fallback reset instant for the 7-day window: `now + 7d`. This is
+ * NOT the true "claims resume at" instant for a paused week window — the
+ * window is rolling, so it sheds its oldest rows continuously rather than
+ * resetting all at once at a fixed point 7 days out. When a credential is
+ * actually paused on the week window, `Store.weekWindowResumeAt` computes
+ * the accurate resume instant (the moment the oldest in-window spend ages
+ * out enough to drop the sum back under the cap); callers should prefer
+ * that and fall back to this fixed instant only when the week window is
+ * under cap (in which case the value isn't operator-relevant). See issue
+ * #830.
+ */
 export function weekResetsAtUtc(now: Date): Date {
   return new Date(now.getTime() + SEVEN_DAY_MS);
 }

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -11,6 +11,9 @@ import type { TaskRunReadModel } from '../types/task-run-read-model.js';
 import type { TxSubmissionKey, TxSubmissionLedgerEntry } from '../tx-retry.js';
 import { normalizeEnvelopeRole, type Role } from '../types/envelope.js';
 
+/** 7 days in milliseconds — mirrors `SEVEN_DAY_MS` in `spend/ai-units.ts`. */
+const SEVEN_DAY_MS = 7 * 24 * 60 * 60 * 1_000;
+
 export interface ActivityEventInput {
   ts: string | null;
   kind: string;
@@ -1483,6 +1486,48 @@ export class Store {
   ): { usdMicros: number; estimated: boolean } {
     const weekStart = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1_000).toISOString();
     return this.sumUsdMicros(credentialId, weekStart, undefined);
+  }
+
+  /**
+   * The true "claims resume at" instant for the rolling 7-day window
+   * (issue #830, item 1). `weekResetsAtUtc(now)` (`now + 7d`) is a fixed
+   * instant that overstates the wait — a rolling window sheds its oldest
+   * rows continuously, not all at once. This walks the in-window rows
+   * oldest-to-newest, subtracting each from the running total, and returns
+   * the instant the remaining sum first drops below `capUsdMicros` (that
+   * row's `ts + 7d`). Returns `null` when the window is already under cap
+   * (not paused on the week window — the fixed-instant fallback is used by
+   * the caller in that case, since the value isn't operator-relevant).
+   */
+  weekWindowResumeAt(credentialId: string, capUsdMicros: number, now: Date = new Date()): string | null {
+    const weekStart = new Date(now.getTime() - SEVEN_DAY_MS).toISOString();
+    const rows = this.db
+      .prepare(
+        `SELECT ts, COALESCE(actual_cost_usd_micros, estimated_cost_usd_micros, 0) AS usdMicros
+         FROM activity_events
+         WHERE credential_id = @cid
+           AND ts IS NOT NULL AND ts >= @weekStart AND ts < @now
+           AND claim_status IN ('claimed', 'delivered')
+         ORDER BY ts ASC`,
+      )
+      .all({ cid: credentialId, weekStart, now: now.toISOString() }) as {
+      ts: string;
+      usdMicros: number;
+    }[];
+
+    let remaining = rows.reduce((sum, r) => sum + r.usdMicros, 0);
+    if (remaining < capUsdMicros) return null;
+
+    for (const row of rows) {
+      remaining -= row.usdMicros;
+      if (remaining < capUsdMicros) {
+        return new Date(new Date(row.ts).getTime() + SEVEN_DAY_MS).toISOString();
+      }
+    }
+    // Degenerate: dropping every row still doesn't clear the cap — resume
+    // once the newest row itself ages out.
+    const last = rows[rows.length - 1];
+    return new Date(new Date(last.ts).getTime() + SEVEN_DAY_MS).toISOString();
   }
 
   /** Shared COALESCE-sum + estimate-flag query for the USD accumulators. */

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -10,9 +10,7 @@ import { TASK_RUNS_SCHEMA, TaskRunPersistence } from '../harnesses/engine/persis
 import type { TaskRunReadModel } from '../types/task-run-read-model.js';
 import type { TxSubmissionKey, TxSubmissionLedgerEntry } from '../tx-retry.js';
 import { normalizeEnvelopeRole, type Role } from '../types/envelope.js';
-
-/** 7 days in milliseconds — mirrors `SEVEN_DAY_MS` in `spend/ai-units.ts`. */
-const SEVEN_DAY_MS = 7 * 24 * 60 * 60 * 1_000;
+import { SEVEN_DAY_MS } from '../spend/ai-units.js';
 
 export interface ActivityEventInput {
   ts: string | null;
@@ -1518,16 +1516,16 @@ export class Store {
     let remaining = rows.reduce((sum, r) => sum + r.usdMicros, 0);
     if (remaining < capUsdMicros) return null;
 
+    // Guaranteed to return inside this loop: `remaining` starts >=
+    // `capUsdMicros` (checked above) and strictly decreases each iteration,
+    // reaching 0 after the last row — which is always < capUsdMicros.
     for (const row of rows) {
       remaining -= row.usdMicros;
       if (remaining < capUsdMicros) {
         return new Date(new Date(row.ts).getTime() + SEVEN_DAY_MS).toISOString();
       }
     }
-    // Degenerate: dropping every row still doesn't clear the cap — resume
-    // once the newest row itself ages out.
-    const last = rows[rows.length - 1];
-    return new Date(new Date(last.ts).getTime() + SEVEN_DAY_MS).toISOString();
+    throw new Error('unreachable: weekWindowResumeAt loop must return before exhausting rows');
   }
 
   /** Shared COALESCE-sum + estimate-flag query for the USD accumulators. */

--- a/client/test/spend/ai-units.test.ts
+++ b/client/test/spend/ai-units.test.ts
@@ -8,6 +8,7 @@
  * peg.
  */
 import { describe, expect, it, vi } from 'vitest';
+import { estimateModelCost } from '../../src/harnesses/cost-estimates.js';
 import {
   GPT_5_4_MINI_USD_PER_BLOCK,
   REFERENCE_CEILING,
@@ -31,6 +32,11 @@ describe('AI-units calibration', () => {
   it('GPT_5_4_MINI_USD_PER_BLOCK is a positive number (the AI-unit peg)', () => {
     expect(typeof GPT_5_4_MINI_USD_PER_BLOCK).toBe('number');
     expect(GPT_5_4_MINI_USD_PER_BLOCK).toBeGreaterThan(0);
+  });
+
+  it('pins the Haiku worked example against peg/rate drift (issue #830, item 3)', () => {
+    // 50k input * $0.001/1k + 20k output * $0.005/1k = 0.05 + 0.10 = 0.15 USD.
+    expect(estimateModelCost('claude-haiku-4-5-20251001')?.usd).toBeCloseTo(0.15, 4);
   });
 });
 

--- a/client/test/store/ai-units-week-resume.test.ts
+++ b/client/test/store/ai-units-week-resume.test.ts
@@ -1,0 +1,101 @@
+/**
+ * weekWindowResumeAt — the true "claims resume at" instant for the rolling
+ * 7-day AI-units window (issue #830, item 1). Unlike `weekResetsAtUtc`
+ * (always `now + 7d`, a fixed instant that doesn't reflect the rolling
+ * window shedding its oldest rows continuously), this walks the in-window
+ * rows oldest-to-newest and returns the instant the running total first
+ * drops back under the cap.
+ */
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Store } from '../../src/store/store.js';
+
+function freshStore(): Store {
+  return new Store(join(mkdtempSync(join(tmpdir(), 'ai-units-week-resume-')), 'jinn.db'));
+}
+
+const SEVEN_DAY_MS = 7 * 24 * 60 * 60 * 1_000;
+
+describe('weekWindowResumeAt', () => {
+  let store: Store;
+  afterEach(() => store?.close());
+
+  it('returns null when the window sum is under cap', () => {
+    store = freshStore();
+    const now = new Date('2026-05-28T13:00:00.000Z');
+    const recent = new Date(now.getTime() - 1 * 24 * 60 * 60 * 1000);
+    store.recordActivityEvent({
+      ts: recent.toISOString(),
+      kind: 'claimed',
+      requestId: 'req-1',
+      credentialId: 'anthropic:api-key',
+      claimStatus: 'delivered',
+      actualCostUsdMicros: 100_000,
+    });
+    expect(store.weekWindowResumeAt('anthropic:api-key', 500_000, now)).toBeNull();
+  });
+
+  it('resume = oldest.ts + 7d when a single oldest row over cap', () => {
+    store = freshStore();
+    const now = new Date('2026-05-28T13:00:00.000Z');
+    const oldest = new Date(now.getTime() - 6 * 24 * 60 * 60 * 1000);
+    store.recordActivityEvent({
+      ts: oldest.toISOString(),
+      kind: 'claimed',
+      requestId: 'req-1',
+      credentialId: 'anthropic:api-key',
+      claimStatus: 'delivered',
+      actualCostUsdMicros: 1_000_000, // over the 500_000 cap alone
+    });
+    const resumeAt = store.weekWindowResumeAt('anthropic:api-key', 500_000, now);
+    expect(resumeAt).toBe(new Date(oldest.getTime() + SEVEN_DAY_MS).toISOString());
+  });
+
+  it('resume requires dropping the two oldest rows', () => {
+    store = freshStore();
+    const now = new Date('2026-05-28T13:00:00.000Z');
+    const oldest = new Date(now.getTime() - 6 * 24 * 60 * 60 * 1000);
+    const middle = new Date(now.getTime() - 4 * 24 * 60 * 60 * 1000);
+    const newest = new Date(now.getTime() - 1 * 24 * 60 * 60 * 1000);
+    // total = 600_000, cap = 500_000.
+    // Drop oldest (200_000) -> remaining 400_000 < cap -> resume at oldest+7d.
+    store.recordActivityEvent({
+      ts: oldest.toISOString(),
+      kind: 'claimed',
+      requestId: 'req-1',
+      credentialId: 'anthropic:api-key',
+      claimStatus: 'delivered',
+      actualCostUsdMicros: 200_000,
+    });
+    store.recordActivityEvent({
+      ts: middle.toISOString(),
+      kind: 'claimed',
+      requestId: 'req-2',
+      credentialId: 'anthropic:api-key',
+      claimStatus: 'delivered',
+      actualCostUsdMicros: 250_000,
+    });
+    store.recordActivityEvent({
+      ts: newest.toISOString(),
+      kind: 'claimed',
+      requestId: 'req-3',
+      credentialId: 'anthropic:api-key',
+      claimStatus: 'delivered',
+      actualCostUsdMicros: 150_000,
+    });
+    // total = 600_000 >= cap(500_000). Drop oldest (200_000) -> remaining
+    // 400_000 < 500_000 cap already. So resume = oldest + 7d.
+    const resumeAt = store.weekWindowResumeAt('anthropic:api-key', 500_000, now);
+    expect(resumeAt).toBe(new Date(oldest.getTime() + SEVEN_DAY_MS).toISOString());
+
+    // Now raise the cap so dropping just the oldest isn't enough: total 600_000,
+    // cap 450_000. Drop oldest -> remaining 400_000 < 450_000 -> still oldest+7d
+    // (dropping one row is enough here too). Use a cap that forces two drops:
+    // cap = 380_000. Drop oldest -> remaining 400_000 >= 380_000 (not enough).
+    // Drop middle too -> remaining 150_000 < 380_000 -> resume = middle + 7d.
+    const resumeAt2 = store.weekWindowResumeAt('anthropic:api-key', 380_000, now);
+    expect(resumeAt2).toBe(new Date(middle.getTime() + SEVEN_DAY_MS).toISOString());
+  });
+});


### PR DESCRIPTION
## Summary
Three small, independently-landable follow-ups from the #815 post-merge review (AI-units ceiling):

1. **`weekResetsAt` reflects the rolling window, not a fixed `now + 7d`.** New `Store.weekWindowResumeAt()` computes the true "claims resume at" instant — the moment the oldest in-window rows age out far enough that the 7d spend sum drops back under the weekly cap (binding row's `ts + 7d`). `gather-status.ts` uses it when the credential is paused on the week window; falls back to the coarse `now + 7d` otherwise. Field name unchanged (semantics corrected) to avoid SPA/test churn.
2. **The UI binding-window picker can no longer disagree with the gate.** New `pausedWindow: 'block' | 'week' | null` field on the `/v1/status` AI-units row, computed with the daemon gate's block-preferred precedence (`overBlock ? 'block' : overWeek ? 'week' : null`). `AiUnitsPauseAlert` reads it directly (`row.pausedWindow ?? local-derivation` for daemon backcompat) instead of re-deriving from `unitsThisBlock >= capPerBlock`.
3. **Haiku worked-example regression test** in `test/spend/ai-units.test.ts` pinning `estimateModelCost('claude-haiku-4-5-20251001').usd ≈ 0.15` to catch cost-table peg/rate drift.

Reviewed independently (approve, no blockers) and security-reviewed (no findings). `/simplify` applied (shared `SEVEN_DAY_MS`/`AiUnitsPausedWindow` reuse, gated the extra query behind `overWeek`).

Two structural findings surfaced during review were deliberately deferred as out-of-scope for this Low-effort follow-up: (a) extracting the block-preferred precedence into a shared predicate reused by both `gather-status.ts` and `daemon/ai-units-gate.ts`; (b) importing `AiUnitsPausedWindow` into the SPA to replace its inlined union. Worth a future issue.

## Test plan
- New store unit tests (`test/store/ai-units-week-resume.test.ts`): under-cap → null; single oldest row over cap → `ts+7d`; multi-row requiring multiple drops.
- Updated `AiUnitsPauseAlert.test.tsx`: gate-sourced `pausedWindow: 'week'` wins over a local `unitsThisBlock >= capPerBlock` derivation (the disagreement case).
- New Haiku worked-example assertion.
- `yarn typecheck`, full `yarn test`, and `yarn build` green locally.

Closes #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)