### PR TITLE
fix(ci): build shared contribution store before hermetic tests

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -73,7 +73,7 @@
     "typecheck": "yarn build:sdk && yarn build:plugin && yarn build:harness-layer-store && tsc --noEmit && yarn typecheck:harness-layer",
     "lint:no-late-mount": "node scripts/check-no-late-route-mount.mjs",
     "test": "yarn build:sdk && yarn build:plugin && yarn build:harness-layer-store && vitest run",
-    "test:hermetic": "yarn build:sdk && vitest run --config vitest.hermetic.config.ts",
+    "test:hermetic": "yarn build:sdk && yarn build:plugin && yarn build:harness-layer-store && vitest run --config vitest.hermetic.config.ts",
     "smoke:build-anvil-snapshot": "vitest run test/scripts/build-anvil-snapshot-entrypoint.test.ts",
     "test:watch": "vitest",
     "test:claude-prediction": "yarn build && JINN_TEST_CLAUDE_PREDICTION=1 vitest run test/harnesses/impls/claude-mcp-prediction/isolation.test.ts",


### PR DESCRIPTION
The Stage 1 contribution bridge introduced a generated shared-store runtime that the normal client test/build entrypoints already build. The hermetic entrypoint omitted those prerequisites, so PR #1748 failed before its suites could execute.

This makes `test:hermetic` build the plugin and harness-layer store before invoking Vitest, keeping local and CI hermetic runs aligned.

Refs #1661

Verification:
- `yarn test:hermetic` now builds `dist/harness-layer/contribution-store.js` and no longer reports the missing-module failure.
- The local run proceeds to contract-dependent tests; those require the workflow's separate contracts/indexer setup and are covered by this PR's GitHub gate.