### PR TITLE
feat(plugin): render canonical contribution states

### DIFF
--- a/apps/jinn-agent/plugins/jinn/__init__.py
+++ b/apps/jinn-agent/plugins/jinn/__init__.py
@@ -572,9 +572,31 @@ def _handle_jinn(command_args: str = "", session_id: str = "", task_id: str = ""
         return f"preview failed:\n{out}"
 
     if sub == "ledger":
-        # Prefer structured rows (design 1b columns + tier chips + retry
-        # sub-line + exact empty state). Degrade to the layer's raw text when
-        # the installed layer predates `ledger --json`.
+        # Prefer canonical contribution-store rows. A layer that predates the
+        # command falls back to the legacy publication-receipt ledger.
+        ccode, cout = jinn_layer.contribution_ledger_json(runner=_runner)
+        if ccode == 0:
+            try:
+                reply = jinn_layer.parse_process_response(cout)
+            except ValueError:
+                reply = None
+            if isinstance(reply, dict):
+                if reply.get("status") == "unavailable":
+                    return f"contribution ledger unavailable:\n{reply.get('reason', 'details unavailable')}"
+                rows = ledger_view.rows_from_json(reply.get("value"))
+                if rows is not None:
+                    rendered = ledger_view.render_ledger(
+                        rows, enabled=consent.share_enabled()
+                    )
+                    if reply.get("status") == "degraded":
+                        rendered += (
+                            "\n\ncontribution state degraded — "
+                            + str(reply.get("reason") or "details unavailable")
+                        )
+                    return rendered
+
+        # Prefer structured legacy rows (design 1b columns + tier chips +
+        # exact empty state), then degrade to the layer's raw text.
         jcode, jout = jinn_layer.ledger_json(runner=_runner)
         if jcode == 0:
             try:

--- a/apps/jinn-agent/plugins/jinn/jinn_layer.py
+++ b/apps/jinn-agent/plugins/jinn/jinn_layer.py
@@ -121,6 +121,10 @@ def contribution_preview(
     return run(args, runner)
 
 
+def contribution_ledger_json(runner: Optional[Runner] = None) -> Tuple[int, str]:
+    return run(["contribution", "ledger", "--json"], runner)
+
+
 def contribution_disable(runner: Optional[Runner] = None) -> Tuple[int, str]:
     return run(["contribution", "disable", "--json"], runner)
 

--- a/apps/jinn-agent/plugins/jinn/ledger_view.py
+++ b/apps/jinn-agent/plugins/jinn/ledger_view.py
@@ -9,7 +9,9 @@ retained-local retry sub-line, and the exact empty-state copy.
 
 Rows are dicts with keys: ``time``, ``task``, ``env``, ``anchor``, ``tier``
 (one of ``user-accepted`` | ``tests-passed`` | ``evaluator-verified``), and an
-optional ``state`` (``queued`` | ``minted`` | ``vetoed`` | ``failed``).
+optional ``state``. Canonical contribution rows use ``recorded``, ``minted``,
+``preview-required``, ``queued``, ``published``, ``vetoed``, or ``rejected``;
+legacy receipt rows omit the state when published and may use ``failed``.
 Colours reuse the #1417 splash palette via ``style``.
 
 The renderer is pure and snapshot-testable. ``/jinn ledger`` calls it when the
@@ -52,8 +54,17 @@ FAILED_LABEL = "publish failed — retained locally"
 # like the vetoed row.
 RECORDED_LABEL = "recorded"
 MINTED_LABEL = "minted"
+QUEUED_LABEL = "queued"
+PREVIEW_REQUIRED_LABEL = "preview required"
+REJECTED_LABEL = "rejected (local)"
 
-_LOCAL_STATE_LABELS = {"queued": RECORDED_LABEL, "minted": MINTED_LABEL}
+_LOCAL_STATE_LABELS = {
+    "recorded": RECORDED_LABEL,
+    "minted": MINTED_LABEL,
+    "queued": QUEUED_LABEL,
+    "preview-required": PREVIEW_REQUIRED_LABEL,
+    "rejected": REJECTED_LABEL,
+}
 
 
 def _cell(text: Optional[str], w: int, align_right: bool = False) -> str:
@@ -84,7 +95,8 @@ def _row(pal, rst: str, r: Dict[str, object]) -> str:
     if state in _LOCAL_STATE_LABELS:
         env = dim(_cell("—", _COL["env"]))
         anc = dim(_cell("—", _COL["anchor"]))
-        return f"{time}  {task}  {env}  {anc}  {sky(_LOCAL_STATE_LABELS[state])}"
+        chip = red if state == "rejected" else amber if state == "preview-required" else sky
+        return f"{time}  {task}  {env}  {anc}  {chip(_LOCAL_STATE_LABELS[state])}"
 
     if state == "failed":
         env = sky(_cell(r.get("env"), _COL["env"]))
@@ -172,7 +184,9 @@ def render_ledger(
     red = lambda s: _style.wrap(pal, rst, "red", s)
 
     published = sum(
-        1 for r in rows if r.get("state") not in ("vetoed", "failed", "queued", "minted")
+        1
+        for r in rows
+        if r.get("state") is None or r.get("state") == "published"
     )
     vetoed = sum(1 for r in rows if r.get("state") == "vetoed")
     retained = sum(1 for r in rows if r.get("state") == "failed")

--- a/apps/jinn-agent/tests/plugins/test_jinn_layer_verbs.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_layer_verbs.py
@@ -40,14 +40,16 @@ def test_session_end_writes_one_complete_request_to_stdin():
     ]
 
 
-def test_contribution_preview_and_disable_use_versioned_json_commands():
+def test_contribution_preview_ledger_and_disable_use_versioned_json_commands():
     runner = StdinRunner()
 
     assert jinn_layer.contribution_preview(acknowledge=True, runner=runner)[0] == 0
+    assert jinn_layer.contribution_ledger_json(runner=runner)[0] == 0
     assert jinn_layer.contribution_disable(runner=runner)[0] == 0
 
     assert runner.calls == [
         ([jinn_layer.binary(), "contribution", "preview", "--ack", "--json"], None),
+        ([jinn_layer.binary(), "contribution", "ledger", "--json"], None),
         ([jinn_layer.binary(), "contribution", "disable", "--json"], None),
     ]
 

--- a/apps/jinn-agent/tests/plugins/test_jinn_ledger_mint_states.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_ledger_mint_states.py
@@ -1,11 +1,4 @@
-"""Ledger contribution-state projection foundation (Jinn-Network/mono#1664, AC1).
-
-The contribution enum is ``queued | minted | published | vetoed``. The render
-layer is the only place a human-facing LABEL is chosen: ``queued`` renders as
-``recorded`` (it has not left the machine yet), ``minted`` as ``minted``, and
-the raw enum spelling ``queued`` never leaks to the terminal. ``published``
-rows keep the existing tier chip; ``vetoed`` keeps ``vetoed (local only)``.
-"""
+"""Ledger projection over the canonical contribution-store state axes."""
 
 from __future__ import annotations
 
@@ -32,21 +25,25 @@ def _truecolor(monkeypatch):
 def _mixed_rows():
     return [
         {"time": "05-26 06:41", "task": "fix flaky retry", "env": "env-8f21c2",
-         "anchor": "0x7a2f…c019", "tier": "tests-passed"},   # published (tier chip)
+         "anchor": "0x7a2f…c019", "tier": "tests-passed", "state": "published"},
         {"time": "05-26 06:40", "task": "add pagination", "state": "minted"},
         {"time": "05-26 06:39", "task": "tidy imports", "state": "queued"},
+        {"time": "05-26 06:38", "task": "new candidate", "state": "recorded"},
+        {"time": "05-26 06:37", "task": "await preview", "state": "preview-required"},
+        {"time": "05-26 06:36", "task": "not reproducible", "state": "rejected"},
         {"time": "05-26 06:38", "task": "refactor auth", "state": "vetoed"},
     ]
 
 
-def test_queued_renders_as_recorded_chip_not_raw_enum():
+def test_recorded_and_queued_render_as_distinct_truthful_states():
     plain = _plain(ledger_view.render_ledger([
+        {"time": "05-26 06:38", "task": "new candidate", "state": "recorded"},
         {"time": "05-26 06:39", "task": "tidy imports", "state": "queued"},
     ]))
     assert ledger_view.RECORDED_LABEL == "recorded"
     assert "recorded" in plain
-    # The raw enum spelling never reaches the terminal.
-    assert "queued" not in plain
+    assert ledger_view.QUEUED_LABEL == "queued"
+    assert "queued" in plain
 
 
 def test_minted_renders_as_minted_chip():
@@ -61,7 +58,7 @@ def test_recorded_and_minted_projection_hides_env_and_anchor_values():
     # The renderer foundation treats recorded/minted rows as local: envelope
     # and anchor are placeholders, never adapter-supplied values.
     sentinels = {
-        "queued": ("QENV7", "QANCHOR9"),
+        "recorded": ("QENV7", "QANCHOR9"),
         "minted": ("MENV7", "MANCHOR9"),
     }
     for state, (env_sentinel, anchor_sentinel) in sentinels.items():
@@ -88,11 +85,14 @@ def test_non_string_state_is_ignored_by_projection_renderer():
 
 def test_all_states_render_their_labels_together():
     plain = _plain(ledger_view.render_ledger(_mixed_rows()))
+    assert "1 published" in plain
     assert "recorded" in plain
     assert "minted" in plain
+    assert "queued" in plain
+    assert "preview required" in plain
+    assert "rejected (local)" in plain
     assert "tests-passed" in plain          # published row keeps its tier chip
     assert "vetoed (local only)" in plain
-    assert "queued" not in plain            # enum never leaks
 
 
 def test_rows_from_json_passes_state_through():

--- a/apps/jinn-agent/tests/plugins/test_jinn_plugin.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_plugin.py
@@ -17,6 +17,7 @@ jinn = importlib.import_module("plugins.jinn")
 consent = importlib.import_module("plugins.jinn.consent")
 capture_buffer = importlib.import_module("plugins.jinn.capture_buffer")
 session_bridge = importlib.import_module("plugins.jinn.session_bridge")
+jinn_layer = importlib.import_module("plugins.jinn.jinn_layer")
 
 
 class RunnerSpy:
@@ -375,15 +376,19 @@ def test_corpus_command_delegates_to_layer(isolated_home):
 # ── Ledger: structured render vs degrade (mono#1418) ─────────────────────────
 
 def test_ledger_renders_structured_rows_from_json(isolated_home):
-    # `jinn-layer ledger --json` yields rows → the design 1b table.
+    # The canonical contribution ledger yields rows → the design 1b table.
     rows = [
         {"time": "05-26 06:41", "task": "fix retry", "envelope": "env-8f21c2",
-         "anchor": "0x7a2f…c019", "tier": "tests-passed"},
+         "anchor": "0x7a2f…c019", "tier": "tests-passed", "state": "published"},
         {"time": "05-25 22:41", "task": "refactor auth", "state": "vetoed"},
     ]
-    isolated_home.out = json.dumps(rows)
+    isolated_home.out = json.dumps({
+        "contractVersion": 1,
+        "status": "ok",
+        "value": {"rows": rows},
+    })
     out = jinn._handle_jinn(command_args="ledger")
-    assert isolated_home.calls[0][1:3] == ["ledger", "--json"]
+    assert isolated_home.calls[0][1:4] == ["contribution", "ledger", "--json"]
     assert "TIER" in out
     assert "tests-passed" in out
     assert "vetoed (local only)" in out
@@ -396,8 +401,26 @@ def test_ledger_degrades_to_raw_text_when_json_unavailable(isolated_home):
     out = jinn._handle_jinn(command_args="ledger")
     assert out == "PLAIN LEDGER TEXT (no --json support)"
     # Both the --json probe and the plain ledger were attempted.
+    assert ["contribution", "ledger", "--json"] in [c[1:4] for c in isolated_home.calls]
     assert ["ledger", "--json"] in [c[1:3] for c in isolated_home.calls]
     assert any(c[1:] == ["ledger"] for c in isolated_home.calls)
+
+
+def test_ledger_reports_canonical_store_unavailable_without_manufacturing_empty_state(
+    isolated_home,
+):
+    isolated_home.out = json.dumps({
+        "contractVersion": 1,
+        "status": "unavailable",
+        "reason": "contribution store offline",
+    })
+
+    out = jinn._handle_jinn(command_args="ledger")
+
+    assert out == "contribution ledger unavailable:\ncontribution store offline"
+    assert isolated_home.calls == [[
+        jinn_layer.binary(), "contribution", "ledger", "--json"
+    ]]
 
 
 def test_preview_with_no_pending_shows_example_fixture(isolated_home):
@@ -477,7 +500,6 @@ def test_jinn_layer_not_found_points_at_canary_tag():
     """mono#1382: bare `npm install -g @jinn-network/client` installs latest,
     which has no jinn-layer bin until stable >= 0.1.10 — the error must name
     the canary tag."""
-    jinn_layer = importlib.import_module("plugins.jinn.jinn_layer")
     code, out = jinn_layer._default_runner(["definitely-not-a-real-binary-xyz"])
     assert code == 127
     assert "@jinn-network/client@canary" in out

--- a/client/packages/harness-layer/src/adapters/contribution-adapter.ts
+++ b/client/packages/harness-layer/src/adapters/contribution-adapter.ts
@@ -59,6 +59,10 @@ export function createContributionAdapter(deps: ContributionAdapterDeps): Contri
         const entries = (await store.list()).map((record): ContributionLedgerEntry => ({
           recordId: record.recordId,
           sourceId: record.candidate.sourceId,
+          createdAt: record.candidate.createdAt,
+          verifiabilityTier: record.candidate.testRuns.some((run) => run.exitCode === 0)
+            ? 'tests-passed'
+            : 'user-accepted',
           repositorySlug: record.candidate.repositorySlug,
           baseCommit: record.candidate.baseCommit,
           localState: record.localState,

--- a/client/packages/harness-layer/src/cli.ts
+++ b/client/packages/harness-layer/src/cli.ts
@@ -39,6 +39,7 @@ import {
   SessionEndRequestV1Schema,
   SessionPickupRequestV1Schema,
   envelope as processEnvelope,
+  contributionLedgerRow,
   sessionEndEnvelope,
   trackingCorpus,
 } from './process-contract.js';
@@ -135,6 +136,7 @@ Commands:
   session end                                     Read a complete EpisodeV1 request on stdin
   contribution preview [--ack] --json             Show the next sanitized first-share preview;
                                                    --ack records the one-time acknowledgement
+  contribution ledger --json                      Show privacy-safe canonical contribution states
   contribution disable --json                     Disable every unpublished authorization
   corpus search "<query>" [--limit N] [--json]   Search corpus records (substring match on
                                                  solverType / role / artifactType / refs)
@@ -811,8 +813,9 @@ export async function runJinnLayerCli(
   const isSessionPickup = verb === 'session' && subverb === 'pickup';
   const isSessionEnd = verb === 'session' && subverb === 'end';
   const isContributionPreview = verb === 'contribution' && subverb === 'preview';
+  const isContributionLedger = verb === 'contribution' && subverb === 'ledger';
   const isContributionDisable = verb === 'contribution' && subverb === 'disable';
-  if (!isCorpus && !isCapturePreview && !isLedger && !isPublish && !isSeed && !isSkillsInstall && !isDistillRun && !isDistillEvalPrep && !isDistill && !isDeriveEnv && !isContract && !isSessionPickup && !isSessionEnd && !isContributionPreview && !isContributionDisable) {
+  if (!isCorpus && !isCapturePreview && !isLedger && !isPublish && !isSeed && !isSkillsInstall && !isDistillRun && !isDistillEvalPrep && !isDistill && !isDeriveEnv && !isContract && !isSessionPickup && !isSessionEnd && !isContributionPreview && !isContributionLedger && !isContributionDisable) {
     writer.write(USAGE);
     return verb === undefined || verb === 'help' || verb === '--help' ? 0 : 2;
   }
@@ -869,6 +872,27 @@ export async function runJinnLayerCli(
       writer.write(`${JSON.stringify(processEnvelope('ok', result.value))}\n`);
     } else if (result.status === 'degraded') {
       writer.write(`${JSON.stringify(processEnvelope('degraded', result.value, result.reason))}\n`);
+    } else {
+      writer.write(`${JSON.stringify(processEnvelope('unavailable', undefined, result.reason))}\n`);
+    }
+    return 0;
+  }
+
+  if (isContributionLedger) {
+    if (rest.length !== 1 || rest[0] !== '--json') {
+      writer.write('error: invalid contribution ledger command; use contribution ledger --json\n');
+      return 2;
+    }
+    const result = await createJinnPlugin(buildPluginDepsFromEnv(opts.pluginOverrides ?? {}))
+      .contributionLedger();
+    if (result.status === 'ok') {
+      writer.write(`${JSON.stringify(processEnvelope('ok', {
+        rows: result.value.map(contributionLedgerRow),
+      }))}\n`);
+    } else if (result.status === 'degraded') {
+      writer.write(`${JSON.stringify(processEnvelope('degraded', {
+        rows: (result.value ?? []).map(contributionLedgerRow),
+      }, result.reason))}\n`);
     } else {
       writer.write(`${JSON.stringify(processEnvelope('unavailable', undefined, result.reason))}\n`);
     }

--- a/client/packages/harness-layer/src/index.ts
+++ b/client/packages/harness-layer/src/index.ts
@@ -268,4 +268,6 @@ export {
   type SessionEndRequestV1,
   type SessionPickupEnvelope,
   type SessionPickupRequestV1,
+  contributionLedgerRow,
+  type ContributionLedgerRowV1,
 } from './process-contract.js';

--- a/client/packages/harness-layer/src/process-contract.ts
+++ b/client/packages/harness-layer/src/process-contract.ts
@@ -6,6 +6,7 @@ import {
   PickupConfigSchema,
   SessionActivityFactsSchema,
   type FirstTurnPickupResult,
+  type ContributionLedgerEntry,
   type JinnPluginDeps,
   type SessionEndResult,
 } from '@jinn-network/plugin';
@@ -107,3 +108,32 @@ export function trackingCorpus(deps: JinnPluginDeps): {
 }
 
 export type SessionPickupEnvelope = ProcessEnvelope<FirstTurnPickupResult>;
+
+export interface ContributionLedgerRowV1 {
+  time: string;
+  task: string;
+  env: string | null;
+  anchor: string | null;
+  tier: 'user-accepted' | 'tests-passed';
+  state: ContributionLedgerEntry['status'];
+}
+
+function displayTimestamp(value: string): string {
+  const match = /^\d{4}-(\d{2})-(\d{2})T(\d{2}):(\d{2})/u.exec(value);
+  return match ? `${match[1]}-${match[2]} ${match[3]}:${match[4]}` : value;
+}
+
+/** Persistence-safe terminal projection. Local IDs and candidate evidence do not cross it. */
+export function contributionLedgerRow(entry: ContributionLedgerEntry): ContributionLedgerRowV1 {
+  const published = entry.status === 'published';
+  const repository = entry.repositorySlug ?? 'repository unavailable';
+  const commit = entry.baseCommit ? entry.baseCommit.slice(0, 8) : 'commit unavailable';
+  return {
+    time: displayTimestamp(entry.createdAt),
+    task: `${repository} @ ${commit}`,
+    env: published ? entry.mintRef ?? null : null,
+    anchor: published ? entry.publicationRef ?? null : null,
+    tier: entry.verifiabilityTier,
+    state: entry.status,
+  };
+}

--- a/client/packages/harness-layer/test/process-contract.test.ts
+++ b/client/packages/harness-layer/test/process-contract.test.ts
@@ -9,8 +9,14 @@ import {
   InMemoryLocalLearningPort,
   InMemorySkillsPort,
 } from '@jinn-network/plugin/testing';
-import { unavailable, type EpisodeV1, type JinnPluginDeps } from '@jinn-network/plugin';
+import {
+  unavailable,
+  type ContributionCandidateV1,
+  type EpisodeV1,
+  type JinnPluginDeps,
+} from '@jinn-network/plugin';
 import { runJinnLayerCli } from '../src/cli.js';
+import { ContributionStore } from '../src/contribution-store.js';
 import {
   MineableTraceStore,
   resolveMineableStateDir,
@@ -102,6 +108,7 @@ describe('jinn-layer process contract v1', () => {
     ['contract', ['contract', 'unexpected']],
     ['session pickup', ['session', 'pickup', '--unexpected']],
     ['session end', ['session', 'end', '--unexpected']],
+    ['contribution ledger', ['contribution', 'ledger', '--unexpected']],
   ])('rejects extra arguments on the %s interface', async (_label, argv) => {
     const out = capture();
     expect(await runJinnLayerCli(argv, {
@@ -373,6 +380,31 @@ describe('jinn-layer process contract v1', () => {
         publicationState: 'disabled',
         candidate: { sourceId: 'episode-host-1' },
       });
+
+      const ledgerOut = capture();
+      expect(await runJinnLayerCli(['contribution', 'ledger', '--json'], {
+        writer: ledgerOut.writer,
+        pluginOverrides: {
+          corpus: new InMemoryCorpusPort([]),
+          localLearning: new InMemoryLocalLearningPort(),
+          skills: new InMemorySkillsPort(),
+        },
+      })).toBe(0);
+      expect(JSON.parse(ledgerOut.output())).toEqual({
+        contractVersion: 1,
+        status: 'ok',
+        value: {
+          rows: [{
+            time: '07-15 12:02',
+            task: 'Jinn-Network/mono @ 01234567',
+            env: null,
+            anchor: null,
+            tier: 'tests-passed',
+            state: 'recorded',
+          }],
+        },
+      });
+      expect(ledgerOut.output()).not.toMatch(/episode-host-1|acceptedDiff|diff --git|skillEvents/);
     } finally {
       if (previousEpisodes === undefined) delete process.env['JINN_LAYER_EPISODES_DIR'];
       else process.env['JINN_LAYER_EPISODES_DIR'] = previousEpisodes;
@@ -380,6 +412,104 @@ describe('jinn-layer process contract v1', () => {
       else process.env['JINN_MINEABLE_STATE_DIR'] = previousMineable;
       rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  it('projects every real contribution-store transition without requiring a sidecar', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'jinn-contribution-ledger-'));
+    const previousMineable = process.env['JINN_MINEABLE_STATE_DIR'];
+    process.env['JINN_MINEABLE_STATE_DIR'] = root;
+    const base = request().contributionCandidate as ContributionCandidateV1;
+    const candidate = (
+      sourceId: string,
+      publishMinedTasksConsent: boolean,
+      minute: string,
+    ): ContributionCandidateV1 => ({
+      ...base,
+      sourceId,
+      publishMinedTasksConsent,
+      createdAt: `2026-07-15T12:${minute}:00.000Z`,
+    });
+    try {
+      const store = new ContributionStore({ stateDir: root });
+      await store.record(candidate('recorded-local-id', false, '01'));
+      await store.record(candidate('minted-local-id', false, '02'));
+      await store.markMinted('minted-local-id', 'mint:local-only');
+      await store.record(candidate('preview-local-id', true, '03'));
+
+      const previewOut = capture();
+      expect(await runJinnLayerCli(['contribution', 'ledger', '--json'], {
+        writer: previewOut.writer,
+        pluginOverrides: {
+          corpus: new InMemoryCorpusPort([]),
+          localLearning: new InMemoryLocalLearningPort(),
+          skills: new InMemorySkillsPort(),
+        },
+      })).toBe(0);
+      expect(JSON.parse(previewOut.output()).value.rows.map((row: { state: string }) => row.state))
+        .toEqual(['recorded', 'minted', 'preview-required']);
+
+      await store.authorize('preview-local-id', '2026-07-15T12:04:00.000Z');
+      await store.record(candidate('queued-local-id', true, '04'));
+      await store.record(candidate('published-local-id', true, '05'));
+      await store.markMinted('published-local-id', 'mint:published');
+      await store.markPublished('published-local-id', 'ipfs://published');
+      await store.record(candidate('vetoed-local-id', true, '06'), undefined, {
+        publicationState: 'vetoed',
+      });
+      await store.record(candidate('rejected-local-id', false, '07'));
+      await store.markRejected('rejected-local-id', 'not reproducible');
+
+      const out = capture();
+      expect(await runJinnLayerCli(['contribution', 'ledger', '--json'], {
+        writer: out.writer,
+        pluginOverrides: {
+          corpus: new InMemoryCorpusPort([]),
+          localLearning: new InMemoryLocalLearningPort(),
+          skills: new InMemorySkillsPort(),
+        },
+      })).toBe(0);
+
+      const reply = JSON.parse(out.output());
+      expect(reply.status).toBe('ok');
+      expect(reply.value.rows.map((row: { state: string }) => row.state)).toEqual([
+        'recorded',
+        'minted',
+        'queued',
+        'queued',
+        'published',
+        'vetoed',
+        'rejected',
+      ]);
+      expect(reply.value.rows[4]).toMatchObject({
+        env: 'mint:published',
+        anchor: 'ipfs://published',
+        state: 'published',
+      });
+      expect(out.output()).not.toMatch(/-local-id|acceptedDiff|diff --git|skillEvents/);
+    } finally {
+      if (previousMineable === undefined) delete process.env['JINN_MINEABLE_STATE_DIR'];
+      else process.env['JINN_MINEABLE_STATE_DIR'] = previousMineable;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('reports an unavailable contribution store as product state, not a command failure', async () => {
+    const base = new InMemoryContributionPort();
+    const contribution = {
+      ...base,
+      async ledger() { return unavailable('contribution store offline'); },
+    } as JinnPluginDeps['contribution'];
+    const out = capture();
+
+    expect(await runJinnLayerCli(['contribution', 'ledger', '--json'], {
+      writer: out.writer,
+      pluginOverrides: memoryDeps({ contribution }),
+    })).toBe(0);
+    expect(JSON.parse(out.output())).toEqual({
+      contractVersion: 1,
+      status: 'unavailable',
+      reason: 'contribution store offline',
+    });
   });
 
   it('returns unavailable with the typed persistence result when evidence did not persist', async () => {

--- a/packages/plugin/src/plugin.ts
+++ b/packages/plugin/src/plugin.ts
@@ -7,7 +7,7 @@
 
 /// <reference types="node" />
 import { randomUUID } from 'node:crypto';
-import type { ContributionPort } from './ports/contribution-port.js';
+import type { ContributionLedgerEntry, ContributionPort } from './ports/contribution-port.js';
 import type { CorpusPort } from './ports/corpus-port.js';
 import type { EvidencePort } from './ports/evidence-port.js';
 import type { LocalLearningPort } from './ports/local-learning-port.js';
@@ -428,6 +428,7 @@ export interface JinnPlugin {
   history(): Promise<HistoryResult>;
   explain(sessionRef: string): Promise<SessionExplanation>;
   previewContribution(acknowledge?: boolean): Promise<PortResult<ContributionPreview | null>>;
+  contributionLedger(): Promise<PortResult<ContributionLedgerEntry[]>>;
   disableContributionPublication(): Promise<PortResult<{ recordIds: string[] }>>;
 }
 
@@ -447,6 +448,13 @@ export function createJinnPlugin(deps: JinnPluginDeps): JinnPlugin {
     },
     previewContribution(acknowledge = false): Promise<PortResult<ContributionPreview | null>> {
       return previewContribution(deps, acknowledge);
+    },
+    async contributionLedger(): Promise<PortResult<ContributionLedgerEntry[]>> {
+      try {
+        return await deps.contribution.ledger();
+      } catch (error) {
+        return unavailable(`contribution ledger failed: ${errorReason(error)}`);
+      }
     },
     async disableContributionPublication(): Promise<PortResult<{ recordIds: string[] }>> {
       if (!deps.contribution.disableUnpublished) {

--- a/packages/plugin/src/ports/contribution-port.ts
+++ b/packages/plugin/src/ports/contribution-port.ts
@@ -26,6 +26,8 @@ export interface ContributionStatusSnapshot extends ContributionState {
 export interface ContributionLedgerEntry extends ContributionStatusSnapshot {
   recordId: string;
   sourceId: string;
+  createdAt: string;
+  verifiabilityTier: 'user-accepted' | 'tests-passed';
   /** Sanitized repository facts used by the local first-share preview. */
   repositorySlug?: string;
   baseCommit?: string;

--- a/packages/plugin/src/testing/contract-kits.ts
+++ b/packages/plugin/src/testing/contract-kits.ts
@@ -99,6 +99,8 @@ export function describeContributionPortContract(makeAdapter: () => Contribution
         expect(ledgerResult.value).toContainEqual({
           recordId: recordResult.value.recordId,
           sourceId: 'episode-1',
+          createdAt: '2026-07-15T12:00:00.000Z',
+          verifiabilityTier: 'user-accepted',
           repositorySlug: 'Jinn-Network/mono',
           baseCommit: '0123456789abcdef',
           localState: 'recorded',

--- a/packages/plugin/src/testing/in-memory-contribution.ts
+++ b/packages/plugin/src/testing/in-memory-contribution.ts
@@ -46,6 +46,10 @@ export class InMemoryContributionPort implements ContributionPort {
     return ok([...this.records.entries()].map(([recordId, record]) => ({
       recordId,
       sourceId: record.candidate.sourceId,
+      createdAt: record.candidate.createdAt,
+      verifiabilityTier: record.candidate.testRuns.some((run) => run.exitCode === 0)
+        ? 'tests-passed' as const
+        : 'user-accepted' as const,
       repositorySlug: record.candidate.repositorySlug,
       baseCommit: record.candidate.baseCommit,
       ...snapshot(record.state),

--- a/packages/plugin/test/history-forward-states.test.ts
+++ b/packages/plugin/test/history-forward-states.test.ts
@@ -25,6 +25,10 @@ class StubContributionPort implements ContributionPort {
     this.entries.push({
       recordId,
       sourceId: candidate.sourceId,
+      createdAt: candidate.createdAt,
+      verifiabilityTier: candidate.testRuns.some((run) => run.exitCode === 0)
+        ? 'tests-passed'
+        : 'user-accepted',
       localState: 'recorded',
       publicationState: candidate.publishMinedTasksConsent ? 'preview-required' : 'disabled',
       status: candidate.publishMinedTasksConsent ? 'preview-required' : 'recorded',
@@ -67,20 +71,25 @@ function buildPlugin(evidence: InMemoryEvidencePort, contribution: ContributionP
 describe('plugin.history — two-axis contribution-state projection', () => {
   it('projects local and publication states onto their derived user-facing status', async () => {
     const evidence = new InMemoryEvidencePort();
+    const facts = {
+      createdAt: '2026-07-15T12:00:00.000Z',
+      verifiabilityTier: 'user-accepted' as const,
+    };
     const states: Array<Omit<ContributionLedgerEntry, 'recordId' | 'sourceId'>> = [
-      { localState: 'recorded', publicationState: 'disabled', status: 'recorded' },
-      { localState: 'minted', publicationState: 'disabled', status: 'minted', mintRef: 'mint-1' },
-      { localState: 'rejected', publicationState: 'disabled', status: 'rejected' },
-      { localState: 'recorded', publicationState: 'preview-required', status: 'preview-required' },
-      { localState: 'minted', publicationState: 'queued', status: 'queued', mintRef: 'mint-2' },
+      { ...facts, localState: 'recorded', publicationState: 'disabled', status: 'recorded' },
+      { ...facts, localState: 'minted', publicationState: 'disabled', status: 'minted', mintRef: 'mint-1' },
+      { ...facts, localState: 'rejected', publicationState: 'disabled', status: 'rejected' },
+      { ...facts, localState: 'recorded', publicationState: 'preview-required', status: 'preview-required' },
+      { ...facts, localState: 'minted', publicationState: 'queued', status: 'queued', mintRef: 'mint-2' },
       {
+        ...facts,
         localState: 'minted',
         publicationState: 'published',
         status: 'published',
         mintRef: 'mint-3',
         publicationRef: 'publication-1',
       },
-      { localState: 'recorded', publicationState: 'vetoed', status: 'vetoed' },
+      { ...facts, localState: 'recorded', publicationState: 'vetoed', status: 'vetoed' },
     ];
     const ledger: ContributionLedgerEntry[] = [];
     for (const state of states) {

--- a/packages/plugin/test/plugin/complete-session.test.ts
+++ b/packages/plugin/test/plugin/complete-session.test.ts
@@ -207,6 +207,8 @@ describe('JinnPlugin.completeSession()', () => {
       value: [{
         recordId: 'record-1',
         sourceId: 'episode-complete',
+        createdAt: '2026-07-15T12:01:00.000Z',
+        verifiabilityTier: 'tests-passed',
         repositorySlug: 'Jinn-Network/mono',
         baseCommit: '0123456789abcdef',
         localState: 'recorded',

--- a/packages/plugin/test/ports/contribution-port.test.ts
+++ b/packages/plugin/test/ports/contribution-port.test.ts
@@ -64,6 +64,8 @@ describe('InMemoryContributionPort forward states', () => {
       value: [{
         recordId: recorded.value.recordId,
         sourceId: 'episode-forward',
+        createdAt: '2026-07-15T12:00:00.000Z',
+        verifiabilityTier: 'user-accepted',
         repositorySlug: 'Jinn-Network/mono',
         baseCommit: '0123456789abcdef',
         localState: 'minted',


### PR DESCRIPTION
## Product outcome

`/jinn ledger` now renders the real shared contribution store rather than a synthetic or process-local projection. A captured session can be inspected through recorded, preview-required, minted, queued, published, vetoed, or rejected states even when the daemon sidecar is absent.

## User-facing state table

| Canonical state | User label | Public refs shown |
|---|---|---|
| recorded | recorded | none |
| preview-required | preview required | none |
| minted | minted | none |
| queued | queued | none |
| published | tier chip | mint + publication refs |
| vetoed | vetoed (local only) | none |
| rejected | rejected (local) | none |

## Boundaries and privacy

- Adds `JinnPlugin.contributionLedger()` and `jinn-layer contribution ledger --json`.
- Projects only timestamp, public repository/base commit, tier, derived state, and published refs.
- Never exposes local record/source IDs, trajectory, accepted diff/gold, failures, skills, or holdouts.
- Keeps the legacy receipt ledger as an old-binary fallback only.

## Verification

- Plugin: typecheck, 22 files / 114 tests, build.
- Harness layer: typecheck plus 3 focused files / 28 tests.
- Python plugin: 4 files / 65 tests.
- Real shared-store integration covers session-end write, daemon-readable record, preview acknowledgement, all state transitions, absent sidecar, and privacy projection.

Closes #1664