### PR TITLE
feat(plugin): derive Stage 1 session history

### DIFF
--- a/apps/jinn-agent/plugins/jinn/__init__.py
+++ b/apps/jinn-agent/plugins/jinn/__init__.py
@@ -30,6 +30,7 @@ from typing import Any, Dict, Optional, Set
 from . import capture_buffer as buf
 from . import consent
 from . import distill
+from . import history_view
 from . import jinn_layer
 from . import ledger_view
 from . import onboarding
@@ -474,6 +475,7 @@ _JINN_HELP = (
     "  /jinn status    consent + capture state\n"
     "  /jinn consent   run the consent flow\n"
     "  /jinn preview   inspect a retained legacy capture, or a labelled example\n"
+    "  /jinn history   sessions derived from episodes, contributions, and local skills\n"
     "  /jinn ledger    the contribution ledger — what left this machine\n"
     "  /jinn veto      withhold the current task (recorded locally, never published)\n"
     "  /jinn skills install <ref>   install a corpus-published skill into the agent's skills\n"
@@ -570,6 +572,29 @@ def _handle_jinn(command_args: str = "", session_id: str = "", task_id: str = ""
             consent.mark_previewed()
             return out + "\n\nlegacy preview only — this retained file will not auto-publish."
         return f"preview failed:\n{out}"
+
+    if sub == "history":
+        code, out = jinn_layer.history_json(runner=_runner)
+        if code != 0:
+            return f"history unavailable:\n{out}"
+        try:
+            reply = jinn_layer.parse_process_response(out)
+        except ValueError as exc:
+            return f"history unavailable:\n{exc}"
+        if reply.get("status") == "unavailable":
+            reason = history_view.safe_text(reply.get("reason"), "details unavailable")
+            return f"history unavailable:\n{reason}"
+        value = reply.get("value")
+        entries = value.get("entries") if isinstance(value, dict) else None
+        if not isinstance(entries, list):
+            return "history unavailable:\njinn-layer response omitted history entries"
+        rendered = history_view.render_history(entries)
+        if reply.get("status") == "degraded":
+            rendered += (
+                "\n\nhistory degraded — "
+                + history_view.safe_text(reply.get("reason"), "details unavailable")
+            )
+        return rendered
 
     if sub == "ledger":
         # Prefer canonical contribution-store rows. A layer that predates the

--- a/apps/jinn-agent/plugins/jinn/history_view.py
+++ b/apps/jinn-agent/plugins/jinn/history_view.py
@@ -1,0 +1,108 @@
+"""Pure terminal renderer for history derived by the canonical Jinn layer."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import re
+from typing import Any, Dict, Iterable, List
+
+from . import style
+
+_ANSI_SEQUENCE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def safe_text(value: object, fallback: str = "unavailable") -> str:
+    if not isinstance(value, str) or not value.strip():
+        return fallback
+    return style.sanitise(_ANSI_SEQUENCE.sub("", value.strip()))
+
+
+def _time(value: object) -> str:
+    raw = safe_text(value, "")
+    if not raw:
+        return "unknown time"
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return raw
+    return parsed.strftime("%m-%d %H:%M")
+
+
+def _knowledge(entry: Dict[str, Any]) -> str:
+    surfaced = entry.get("knowledgeSurfaced")
+    used = entry.get("knowledgeUsed")
+    if not isinstance(surfaced, int) or not isinstance(used, int):
+        return "knowledge unavailable"
+    return f"knowledge {surfaced} surfaced · {used} used"
+
+
+def _eligibility(value: object) -> str:
+    if not isinstance(value, dict) or not isinstance(value.get("eligible"), bool):
+        return "eligibility unavailable"
+    label = "eligible" if value["eligible"] else "not eligible"
+    reason = safe_text(value.get("reason"), "")
+    return f"eligibility {label}" + (f" — {reason}" if reason else "")
+
+
+def _contribution(value: object) -> str:
+    if not isinstance(value, dict):
+        return "contribution unavailable"
+    status = safe_text(value.get("status"), "unavailable")
+    line = f"contribution {status}"
+    anchor = safe_text(value.get("anchorRef"), "")
+    return line + (f" · {anchor}" if anchor else "")
+
+
+def _skills(value: object) -> List[str]:
+    if value is None:
+        return ["local skills unavailable"]
+    if not isinstance(value, list):
+        return ["local skills unavailable"]
+    if not value:
+        return ["local skills none"]
+
+    labels: List[str] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        ref = safe_text(item.get("ref"), "")
+        state = safe_text(item.get("state"), "unavailable")
+        if ref.startswith("local-skill:"):
+            ref = ref[len("local-skill:") :]
+        if ref:
+            labels.append(f"{ref} ({state})")
+    return ["local skills " + ", ".join(labels)] if labels else ["local skills unavailable"]
+
+
+def render_history(entries: Iterable[Dict[str, Any]]) -> str:
+    """Render canonical session history without inventing missing facts."""
+    rows = [entry for entry in entries if isinstance(entry, dict)]
+    if not rows:
+        return (
+            "No Jinn sessions captured yet. Complete ordinary work with Jinn "
+            "enabled to build local history."
+        )
+
+    pal, rst = style.palette()
+    title = style.wrap(
+        pal,
+        rst,
+        "fg",
+        f"Jinn history · {len(rows)} session" + ("s" if len(rows) != 1 else ""),
+    )
+    rendered = [title]
+    for entry in rows:
+        captured = _time(entry.get("capturedAt"))
+        summary = safe_text(entry.get("taskSummary"), "untitled session")
+        capture = safe_text(entry.get("captureStatus"), "unavailable")
+        rendered.extend(
+            [
+                "",
+                style.wrap(pal, rst, "dim", captured) + "  " + summary,
+                "  " + _knowledge(entry) + f" · capture {capture}",
+                "  " + _eligibility(entry.get("eligibility")),
+                "  " + _contribution(entry.get("contributionState")),
+                *("  " + line for line in _skills(entry.get("distilledSkills"))),
+            ]
+        )
+    return "\n".join(rendered)

--- a/apps/jinn-agent/plugins/jinn/jinn_layer.py
+++ b/apps/jinn-agent/plugins/jinn/jinn_layer.py
@@ -129,6 +129,11 @@ def contribution_disable(runner: Optional[Runner] = None) -> Tuple[int, str]:
     return run(["contribution", "disable", "--json"], runner)
 
 
+def history_json(runner: Optional[Runner] = None) -> Tuple[int, str]:
+    """Read history derived from canonical layer-owned evidence."""
+    return run(["history", "--json"], runner)
+
+
 def parse_process_response(raw: str) -> Dict[str, Any]:
     try:
         parsed = json.loads(raw)

--- a/apps/jinn-agent/tests/plugins/test_jinn_history.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_history.py
@@ -1,0 +1,135 @@
+"""Derived Stage 1 history rendering and command wiring."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import re
+
+import pytest
+
+jinn = importlib.import_module("plugins.jinn")
+history_view = importlib.import_module("plugins.jinn.history_view")
+jinn_layer = importlib.import_module("plugins.jinn.jinn_layer")
+
+_ANSI = re.compile(r"\033\[[0-9;]*m")
+
+
+def _plain(value: str) -> str:
+    return _ANSI.sub("", value)
+
+
+@pytest.fixture(autouse=True)
+def _plain_terminal(monkeypatch):
+    monkeypatch.setenv("NO_COLOR", "1")
+
+
+def _entry(**overrides):
+    value = {
+        "sessionId": "session-1",
+        "capturedAt": "2026-07-15T12:00:00.000Z",
+        "taskSummary": "Fix the retry bridge",
+        "knowledgeSurfaced": 2,
+        "knowledgeUsed": 1,
+        "captureStatus": "captured",
+        "eligibility": {
+            "eligible": True,
+            "reason": "accepted diff on a public repository",
+            "checkedAt": "2026-07-15T12:01:00.000Z",
+        },
+        "contributionState": {"status": "queued"},
+        "distilledSkills": [
+            {"ref": "local-skill:retry-budget", "state": "installed"},
+            {"ref": "local-skill:test-first", "state": "staged"},
+        ],
+    }
+    value.update(overrides)
+    return value
+
+
+def test_history_renders_real_session_facts_and_skill_state():
+    out = _plain(history_view.render_history([_entry()]))
+    assert "Jinn history · 1 session" in out
+    assert "Fix the retry bridge" in out
+    assert "2 surfaced · 1 used" in out
+    assert "eligible" in out
+    assert "contribution queued" in out
+    assert "retry-budget (installed)" in out
+    assert "test-first (staged)" in out
+
+
+def test_history_renders_unavailable_facts_instead_of_zeroes():
+    out = _plain(history_view.render_history([_entry(
+        knowledgeSurfaced=None,
+        knowledgeUsed=None,
+        eligibility=None,
+        contributionState={"status": "unavailable"},
+        distilledSkills=None,
+    )]))
+    assert "knowledge unavailable" in out
+    assert "eligibility unavailable" in out
+    assert "contribution unavailable" in out
+    assert "local skills unavailable" in out
+    assert "0 surfaced" not in out
+
+
+def test_history_empty_state_is_explicit():
+    assert "No Jinn sessions captured yet" in _plain(history_view.render_history([]))
+
+
+def test_jinn_history_uses_the_versioned_layer_command(monkeypatch):
+    calls = []
+
+    def runner(argv):
+        calls.append(argv)
+        return 0, json.dumps({
+            "contractVersion": 1,
+            "status": "ok",
+            "value": {"entries": [_entry()]},
+        })
+
+    monkeypatch.setattr(jinn, "_runner", runner)
+    out = _plain(jinn._handle_jinn(command_args="history"))
+    assert calls == [[jinn_layer.binary(), "history", "--json"]]
+    assert "Fix the retry bridge" in out
+
+
+def test_jinn_history_preserves_degraded_reason(monkeypatch):
+    def runner(_argv):
+        return 0, json.dumps({
+            "contractVersion": 1,
+            "status": "degraded",
+            "reason": "contribution: contribution store offline",
+            "value": {"entries": [_entry(contributionState={"status": "unavailable"})]},
+        })
+
+    monkeypatch.setattr(jinn, "_runner", runner)
+    out = _plain(jinn._handle_jinn(command_args="history"))
+    assert "contribution unavailable" in out
+    assert "history degraded — contribution: contribution store offline" in out
+
+
+def test_jinn_history_sanitises_layer_supplied_fields(monkeypatch):
+    def runner(_argv):
+        return 0, json.dumps({
+            "contractVersion": 1,
+            "status": "degraded",
+            "reason": "store\n\033[31mspoofed",
+            "value": {"entries": [_entry(
+                taskSummary="task\n\033[31mspoofed",
+                contributionState={"status": "published", "anchorRef": "anchor-1"},
+            )]},
+        })
+
+    monkeypatch.setattr(jinn, "_runner", runner)
+    out = jinn._handle_jinn(command_args="history")
+    assert "taskspoofed" in out
+    assert "storespoofed" in out
+    assert "anchor-1" in out
+    assert "\033[31m" not in out
+
+
+def test_jinn_history_reports_missing_layer_as_unavailable(monkeypatch):
+    monkeypatch.setattr(jinn, "_runner", lambda _argv: (127, "jinn-layer: not found"))
+    out = jinn._handle_jinn(command_args="history")
+    assert out == "history unavailable:\njinn-layer: not found"

--- a/apps/jinn-agent/tests/plugins/test_jinn_layer_verbs.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_layer_verbs.py
@@ -40,14 +40,16 @@ def test_session_end_writes_one_complete_request_to_stdin():
     ]
 
 
-def test_contribution_preview_ledger_and_disable_use_versioned_json_commands():
+def test_history_contribution_preview_ledger_and_disable_use_versioned_json_commands():
     runner = StdinRunner()
 
+    assert jinn_layer.history_json(runner=runner)[0] == 0
     assert jinn_layer.contribution_preview(acknowledge=True, runner=runner)[0] == 0
     assert jinn_layer.contribution_ledger_json(runner=runner)[0] == 0
     assert jinn_layer.contribution_disable(runner=runner)[0] == 0
 
     assert runner.calls == [
+        ([jinn_layer.binary(), "history", "--json"], None),
         ([jinn_layer.binary(), "contribution", "preview", "--ack", "--json"], None),
         ([jinn_layer.binary(), "contribution", "ledger", "--json"], None),
         ([jinn_layer.binary(), "contribution", "disable", "--json"], None),

--- a/client/packages/harness-layer/src/adapters/local-learning-adapter.ts
+++ b/client/packages/harness-layer/src/adapters/local-learning-adapter.ts
@@ -7,7 +7,12 @@
  * The returned object exposes `awaitRun(runId)` beyond the port surface so
  * tests can observe the terminal state deterministically (no timers).
  */
-import type { LocalLearningPort, LocalLearningRun, PortResult } from '@jinn-network/plugin';
+import type {
+  LocalLearningPort,
+  LocalLearningRun,
+  LocalLearningSkill,
+  PortResult,
+} from '@jinn-network/plugin';
 import { ok, unavailable } from '@jinn-network/plugin';
 import type { CapturedTask } from '../capture.js';
 import type { Distiller } from '../distiller.js';
@@ -16,6 +21,8 @@ export interface LocalLearningAdapterDeps {
   distiller: Distiller;
   /** Resolve episodeIds → the captures the distiller consumes. */
   loadCaptures: (episodeIds: string[]) => Promise<CapturedTask[]>;
+  /** Read durable skill state; unlike process-local run state this survives CLI invocations. */
+  listSkills?: () => Promise<LocalLearningSkill[]>;
 }
 
 /** The port plus a test-only completion handle. */
@@ -59,6 +66,15 @@ export function createLocalLearningAdapter(deps: LocalLearningAdapterDeps): Loca
 
     async list(): Promise<PortResult<LocalLearningRun[]>> {
       return ok([...runs.values()]);
+    },
+
+    async skills(): Promise<PortResult<LocalLearningSkill[]>> {
+      if (!deps.listSkills) return unavailable('local skill provenance is unavailable');
+      try {
+        return ok(await deps.listSkills());
+      } catch (error) {
+        return unavailable(`local skill provenance failed: ${String(error)}`);
+      }
     },
 
     async awaitRun(runId: string): Promise<void> {

--- a/client/packages/harness-layer/src/cli.ts
+++ b/client/packages/harness-layer/src/cli.ts
@@ -134,6 +134,7 @@ Commands:
   contract --json                                 Print process contract version 1
   session pickup                                  Read a v1 pickup request on stdin
   session end                                     Read a complete EpisodeV1 request on stdin
+  history --json                                  Derive local session history from canonical stores
   contribution preview [--ack] --json             Show the next sanitized first-share preview;
                                                    --ack records the one-time acknowledgement
   contribution ledger --json                      Show privacy-safe canonical contribution states
@@ -812,10 +813,11 @@ export async function runJinnLayerCli(
   const isContract = verb === 'contract';
   const isSessionPickup = verb === 'session' && subverb === 'pickup';
   const isSessionEnd = verb === 'session' && subverb === 'end';
+  const isHistory = verb === 'history';
   const isContributionPreview = verb === 'contribution' && subverb === 'preview';
   const isContributionLedger = verb === 'contribution' && subverb === 'ledger';
   const isContributionDisable = verb === 'contribution' && subverb === 'disable';
-  if (!isCorpus && !isCapturePreview && !isLedger && !isPublish && !isSeed && !isSkillsInstall && !isDistillRun && !isDistillEvalPrep && !isDistill && !isDeriveEnv && !isContract && !isSessionPickup && !isSessionEnd && !isContributionPreview && !isContributionLedger && !isContributionDisable) {
+  if (!isCorpus && !isCapturePreview && !isLedger && !isPublish && !isSeed && !isSkillsInstall && !isDistillRun && !isDistillEvalPrep && !isDistill && !isDeriveEnv && !isContract && !isSessionPickup && !isSessionEnd && !isHistory && !isContributionPreview && !isContributionLedger && !isContributionDisable) {
     writer.write(USAGE);
     return verb === undefined || verb === 'help' || verb === '--help' ? 0 : 2;
   }
@@ -858,6 +860,22 @@ export async function runJinnLayerCli(
     } catch (error) {
       return interfaceError(writer, error);
     }
+  }
+
+  if (isHistory) {
+    if (subverb !== '--json' || rest.length !== 0) {
+      writer.write('error: invalid history command; use jinn-layer history --json\n');
+      return 2;
+    }
+    const result = await createJinnPlugin(buildPluginDepsFromEnv(opts.pluginOverrides ?? {}))
+      .history();
+    const status = result.unavailable ? 'unavailable' : result.degraded ? 'degraded' : 'ok';
+    writer.write(`${JSON.stringify(processEnvelope(
+      status,
+      { entries: result.entries },
+      result.reason,
+    ))}\n`);
+    return 0;
   }
 
   if (isContributionPreview) {

--- a/client/packages/harness-layer/src/distill-captures.ts
+++ b/client/packages/harness-layer/src/distill-captures.ts
@@ -3,6 +3,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { parseCapturedTask, type CapturedTask } from './capture.js';
 import { parseSkillMarkdown } from './skill-package.js';
+import type { LocalLearningSkill } from '@jinn-network/plugin';
 
 /** Own-captures dir the rung-1 `distill` loop reads by default. */
 export const DEFAULT_CAPTURES_DIR = join(homedir(), '.jinn-client', 'harness-layer', 'captures');
@@ -39,6 +40,43 @@ export function loadRecentCaptures(dir: string, limit: number): CapturedTask[] {
 /** Staging directory beside the active generated-skill directory. */
 export function stagingDirFor(activeDir: string): string {
   return `${activeDir.replace(/[/\\]+$/, '')}-staged`;
+}
+
+/** Derive local skill history from the canonical active/staged SKILL.md files. */
+export function localSkillProvenance(
+  activeDir: string,
+  stagedDir: string = stagingDirFor(activeDir),
+): LocalLearningSkill[] {
+  const skills = new Map<string, LocalLearningSkill>();
+  const scan = (dir: string, state: LocalLearningSkill['state']): void => {
+    if (!existsSync(dir)) return;
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const md = join(dir, entry.name, 'SKILL.md');
+      if (!existsSync(md)) continue;
+      try {
+        const pkg = parseSkillMarkdown(readFileSync(md, 'utf-8'));
+        const sourceSessionIds = pkg.jinn.provenance
+          .map((ref) => /^local-capture:(.+)$/.exec(ref)?.[1])
+          .filter((sessionId): sessionId is string => Boolean(sessionId));
+        if (sourceSessionIds.length === 0) continue;
+        const ref = `local-skill:${pkg.name}`;
+        const existing = skills.get(ref);
+        if (existing?.state === 'installed') continue;
+        skills.set(ref, {
+          ref,
+          sourceSessionIds: [...new Set(sourceSessionIds)],
+          state,
+        });
+      } catch {
+        // History is a structured JSON process command. Skip malformed local
+        // artifacts without contaminating its process output.
+      }
+    }
+  };
+  scan(activeDir, 'installed');
+  scan(stagedDir, 'staged');
+  return [...skills.values()].sort((a, b) => a.ref.localeCompare(b.ref));
 }
 
 /**

--- a/client/packages/harness-layer/src/index.ts
+++ b/client/packages/harness-layer/src/index.ts
@@ -139,6 +139,7 @@ export {
   DEFAULT_DISTILL_CAPTURE_LIMIT,
   DEFAULT_SKILLS_INSTALL_DIR,
   coveredSessionIds,
+  localSkillProvenance,
   loadRecentCaptures,
   provenanceLabels,
   stagingDirFor,

--- a/client/packages/harness-layer/src/plugin-wiring.ts
+++ b/client/packages/harness-layer/src/plugin-wiring.ts
@@ -10,6 +10,8 @@ import { ContributionStore, resolveContributionStateDir } from './contribution-s
 import {
   DEFAULT_EPISODES_DIR,
   DEFAULT_SKILLS_INSTALL_DIR,
+  localSkillProvenance,
+  stagingDirFor,
 } from './distill-captures.js';
 import { buildDefaultLayer } from './layer-default.js';
 
@@ -37,6 +39,10 @@ export function buildPluginDepsFromEnv(overrides: Partial<JinnPluginDeps> = {}):
       }),
     },
     loadCaptures: async () => [],
+    listSkills: async () => localSkillProvenance(
+      skillsInstallDir(),
+      stagingDirFor(skillsInstallDir()),
+    ),
   });
   return { corpus, evidence, contribution, localLearning, skills };
 }

--- a/client/packages/harness-layer/test/adapters/local-learning-adapter.test.ts
+++ b/client/packages/harness-layer/test/adapters/local-learning-adapter.test.ts
@@ -23,7 +23,15 @@ function makeDistiller(distill = stubDistill): Distiller {
 const loadNothing = async (_episodeIds: string[]): Promise<CapturedTask[]> => [];
 
 function makeAdapter() {
-  return createLocalLearningAdapter({ distiller: makeDistiller(), loadCaptures: loadNothing });
+  return createLocalLearningAdapter({
+    distiller: makeDistiller(),
+    loadCaptures: loadNothing,
+    listSkills: async () => [{
+      ref: 'local-skill:stub-skill',
+      sourceSessionIds: ['session-1'],
+      state: 'installed',
+    }],
+  });
 }
 
 describeLocalLearningPortContract(makeAdapter);
@@ -71,5 +79,17 @@ describe('LocalLearningAdapter — run lifecycle', () => {
     if (runResult.status !== 'ok') throw new Error('run failed');
     await adapter.awaitRun(runResult.value.runId);
     expect(loadCaptures).toHaveBeenCalledWith(['e1', 'e2']);
+  });
+
+  it('exposes persisted skill provenance through the port', async () => {
+    const result = await makeAdapter().skills();
+    expect(result).toEqual({
+      status: 'ok',
+      value: [{
+        ref: 'local-skill:stub-skill',
+        sourceSessionIds: ['session-1'],
+        state: 'installed',
+      }],
+    });
   });
 });

--- a/client/packages/harness-layer/test/distill-captures.test.ts
+++ b/client/packages/harness-layer/test/distill-captures.test.ts
@@ -6,6 +6,7 @@ import type { CapturedTask } from '../src/capture.js';
 import { buildSkillMarkdown, type SkillPackage } from '../src/skill-package.js';
 import {
   coveredSessionIds,
+  localSkillProvenance,
   loadRecentCaptures,
   provenanceLabels,
   stagingDirFor,
@@ -105,5 +106,33 @@ describe('distill capture source helpers', () => {
     );
 
     expect(labels).toEqual(['Fix flaky distill test', 'bafyOther']);
+  });
+
+  it('derives installed and staged skill state from SKILL.md provenance', () => {
+    const active = mkdtempSync(join(tmpdir(), 'history-active-'));
+    const staged = mkdtempSync(join(tmpdir(), 'history-staged-'));
+    mkdirSync(join(active, 'installed-skill'), { recursive: true });
+    mkdirSync(join(staged, 'staged-skill'), { recursive: true });
+    writeFileSync(
+      join(active, 'installed-skill', 'SKILL.md'),
+      buildSkillMarkdown(skill('installed-skill', ['local-capture:s1', 'bafy-public'])),
+    );
+    writeFileSync(
+      join(staged, 'staged-skill', 'SKILL.md'),
+      buildSkillMarkdown(skill('staged-skill', ['local-capture:s1', 'local-capture:s2'])),
+    );
+
+    expect(localSkillProvenance(active, staged)).toEqual([
+      {
+        ref: 'local-skill:installed-skill',
+        sourceSessionIds: ['s1'],
+        state: 'installed',
+      },
+      {
+        ref: 'local-skill:staged-skill',
+        sourceSessionIds: ['s1', 's2'],
+        state: 'staged',
+      },
+    ]);
   });
 });

--- a/client/packages/harness-layer/test/process-contract.test.ts
+++ b/client/packages/harness-layer/test/process-contract.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -17,6 +17,7 @@ import {
 } from '@jinn-network/plugin';
 import { runJinnLayerCli } from '../src/cli.js';
 import { ContributionStore } from '../src/contribution-store.js';
+import { buildSkillMarkdown } from '../src/skill-package.js';
 import {
   MineableTraceStore,
   resolveMineableStateDir,
@@ -108,6 +109,7 @@ describe('jinn-layer process contract v1', () => {
     ['contract', ['contract', 'unexpected']],
     ['session pickup', ['session', 'pickup', '--unexpected']],
     ['session end', ['session', 'end', '--unexpected']],
+    ['history', ['history', '--unexpected']],
     ['contribution ledger', ['contribution', 'ledger', '--unexpected']],
   ])('rejects extra arguments on the %s interface', async (_label, argv) => {
     const out = capture();
@@ -351,8 +353,10 @@ describe('jinn-layer process contract v1', () => {
     const mineable = join(root, 'mineable');
     const previousEpisodes = process.env['JINN_LAYER_EPISODES_DIR'];
     const previousMineable = process.env['JINN_MINEABLE_STATE_DIR'];
+    const previousSkills = process.env['JINN_LAYER_SKILLS_INSTALL_DIR'];
     process.env['JINN_LAYER_EPISODES_DIR'] = episodes;
     process.env['JINN_MINEABLE_STATE_DIR'] = mineable;
+    process.env['JINN_LAYER_SKILLS_INSTALL_DIR'] = join(root, 'skills');
     try {
       const out = capture();
       expect(await runJinnLayerCli(['session', 'end'], {
@@ -405,11 +409,54 @@ describe('jinn-layer process contract v1', () => {
         },
       });
       expect(ledgerOut.output()).not.toMatch(/episode-host-1|acceptedDiff|diff --git|skillEvents/);
+
+      const skillDir = join(root, 'skills', 'session-bridge-skill');
+      mkdirSync(skillDir, { recursive: true });
+      writeFileSync(join(skillDir, 'SKILL.md'), buildSkillMarkdown({
+        name: 'session-bridge-skill',
+        description: 'Use for session bridge work. Not for: unrelated tasks.',
+        license: null,
+        jinn: {
+          schema: 'jinn.skill.v1',
+          distribution: 'coding',
+          verifiabilityTier: 'tests-passed',
+          distilledFrom: 1,
+          provenance: ['local-capture:session-host-1'],
+          distilledAt: '2026-07-15T12:03:00.000Z',
+        },
+        body: '## When to use\nBridge work.\n\n## Strategy\nReuse evidence.\n\n## Steps\n1. Verify.\n\n## Pitfalls\nKeep facts local.\n\n## Verify\nRun tests.',
+      }));
+      const historyOut = capture();
+      expect(await runJinnLayerCli(['history', '--json'], {
+        writer: historyOut.writer,
+        pluginOverrides: {
+          corpus: new InMemoryCorpusPort([]),
+          skills: new InMemorySkillsPort(),
+        },
+      })).toBe(0);
+      expect(JSON.parse(historyOut.output())).toMatchObject({
+        contractVersion: 1,
+        status: 'ok',
+        value: {
+          entries: [{
+            sessionId: 'session-host-1',
+            knowledgeSurfaced: 1,
+            knowledgeUsed: 1,
+            contributionState: { status: 'recorded' },
+            distilledSkills: [{
+              ref: 'local-skill:session-bridge-skill',
+              state: 'installed',
+            }],
+          }],
+        },
+      });
     } finally {
       if (previousEpisodes === undefined) delete process.env['JINN_LAYER_EPISODES_DIR'];
       else process.env['JINN_LAYER_EPISODES_DIR'] = previousEpisodes;
       if (previousMineable === undefined) delete process.env['JINN_MINEABLE_STATE_DIR'];
       else process.env['JINN_MINEABLE_STATE_DIR'] = previousMineable;
+      if (previousSkills === undefined) delete process.env['JINN_LAYER_SKILLS_INSTALL_DIR'];
+      else process.env['JINN_LAYER_SKILLS_INSTALL_DIR'] = previousSkills;
       rmSync(root, { recursive: true, force: true });
     }
   });
@@ -509,6 +556,88 @@ describe('jinn-layer process contract v1', () => {
       contractVersion: 1,
       status: 'unavailable',
       reason: 'contribution store offline',
+    });
+  });
+
+  it('returns derived session history through the versioned process contract', async () => {
+    const evidence = new InMemoryEvidencePort();
+    await evidence.put({
+      ...episode(),
+      activity: {
+        surfacedRefs: ['knowledge/ref-1'],
+        fetchedRefs: ['knowledge/ref-1'],
+        installedSkillRefs: [],
+      },
+      eligibility: {
+        eligible: true,
+        reason: 'accepted diff on a public repository',
+        checkedAt: '2026-07-15T12:02:00.000Z',
+      },
+    });
+    const learning = new InMemoryLocalLearningPort();
+    learning.recordSkill({
+      ref: 'local-skill:retry-budget',
+      sourceSessionIds: ['session-host-1'],
+      state: 'installed',
+    });
+    const out = capture();
+
+    expect(await runJinnLayerCli(['history', '--json'], {
+      writer: out.writer,
+      pluginOverrides: memoryDeps({ evidence, localLearning: learning }),
+    })).toBe(0);
+
+    expect(JSON.parse(out.output())).toEqual({
+      contractVersion: 1,
+      status: 'ok',
+      value: {
+        entries: [{
+          sessionId: 'session-host-1',
+          capturedAt: '2026-07-15T12:00:00.000Z',
+          taskSummary: 'Fix the session bridge',
+          knowledgeSurfaced: 1,
+          knowledgeUsed: 1,
+          captureStatus: 'captured',
+          eligibility: {
+            eligible: true,
+            reason: 'accepted diff on a public repository',
+            checkedAt: '2026-07-15T12:02:00.000Z',
+          },
+          contributionState: { status: 'none' },
+          distilledSkills: [{ ref: 'local-skill:retry-budget', state: 'installed' }],
+        }],
+      },
+    });
+  });
+
+  it('keeps history rows useful when contribution state is unavailable', async () => {
+    const evidence = new InMemoryEvidencePort();
+    await evidence.put({
+      ...episode(),
+      activity: { surfacedRefs: [], fetchedRefs: [], installedSkillRefs: [] },
+      eligibility: {
+        eligible: false,
+        reason: 'no accepted diff',
+        checkedAt: '2026-07-15T12:02:00.000Z',
+      },
+    });
+    const contribution = {
+      ...new InMemoryContributionPort(),
+      async ledger() { return unavailable('contribution store offline'); },
+    } as JinnPluginDeps['contribution'];
+    const out = capture();
+
+    expect(await runJinnLayerCli(['history', '--json'], {
+      writer: out.writer,
+      pluginOverrides: memoryDeps({ evidence, contribution }),
+    })).toBe(0);
+    expect(JSON.parse(out.output())).toMatchObject({
+      contractVersion: 1,
+      status: 'degraded',
+      reason: 'contribution: contribution store offline',
+      value: {
+        entries: [{ contributionState: { status: 'unavailable' } }],
+      },
     });
   });
 

--- a/docs/superpowers/specs/2026-07-14-jinn-plugin-stage-1-product-design.md
+++ b/docs/superpowers/specs/2026-07-14-jinn-plugin-stage-1-product-design.md
@@ -94,11 +94,13 @@ publish shows a one-time preview; after that, silence + inspection surfaces. Gas
 intake is Stage 2+.
 
 ### 4.5 History
-Net-new but small: a local, plugin-owned session history — per session: task summary,
+Net-new but small: a local, plugin-rendered session history — per session: task summary,
 knowledge surfaced/used, capture status, eligibility verdict, contribution state (queued /
 published + anchor), distilled skills produced. Surfaces: `/jinn history` (TUI) and
 `jinn-layer history` (CLI). `/jinn ledger` remains the what-left-this-machine receipt trail.
-**Invariant: history is a derived view** over episodes + ledger + mint pool; it owns no facts.
+**Invariant: history is a derived view** over canonical episodes, the canonical contribution
+store, and active/staged local-skill provenance; it owns no facts or duplicate cache. Missing
+evidence is displayed as degraded or unavailable rather than inferred as zero, false, or empty.
 
 ### 4.6 Fallbacks and failure behavior
 No network → retrieval degrades to nothing-found (fails open), work proceeds. `jinn-layer`

--- a/packages/plugin/src/history.ts
+++ b/packages/plugin/src/history.ts
@@ -7,7 +7,7 @@ import {
   type ContributionLedgerEntry,
 } from './ports/contribution-port.js';
 import type { EvidencePort } from './ports/evidence-port.js';
-import type { LocalLearningPort } from './ports/local-learning-port.js';
+import type { LocalLearningPort, LocalLearningSkill } from './ports/local-learning-port.js';
 import type { EpisodeV1 } from './schemas/episode.js';
 import type { EligibilityVerdict } from './schemas/eligibility-verdict.js';
 import type { HistoryEntry } from './schemas/history-entry.js';
@@ -23,6 +23,7 @@ export interface HistoryDeps {
 export interface HistoryResult {
   entries: HistoryEntry[];
   degraded: boolean;
+  unavailable: boolean;
   reason?: string;
 }
 
@@ -54,7 +55,11 @@ function ledgerByEpisode(
   return map;
 }
 
-function contributionState(row: ContributionLedgerEntry | undefined): HistoryEntry['contributionState'] {
+function contributionState(
+  row: ContributionLedgerEntry | undefined,
+  available = true,
+): HistoryEntry['contributionState'] {
+  if (!available) return { status: 'unavailable' };
   if (!row) return { status: 'none' };
   const anchorRef = row.publicationRef ?? row.mintRef;
   return {
@@ -68,51 +73,78 @@ function contributionState(row: ContributionLedgerEntry | undefined): HistoryEnt
  * records omit it, so reads stay backward compatible and honestly indeterminate
  * rather than silently manufacturing a verdict from incomplete inputs.
  */
-function episodeEligibility(ep: EpisodeV1): EligibilityVerdict {
-  return ep.eligibility ?? {
-    eligible: false,
-    reason: 'eligibility indeterminate from episode (contribution signals not persisted)',
-    checkedAt: ep.session.capturedAt,
-  };
+function episodeEligibility(ep: EpisodeV1): EligibilityVerdict | null {
+  return ep.eligibility ?? null;
+}
+
+function skillsBySession(skills: LocalLearningSkill[]): Map<string, HistoryEntry['distilledSkills']> {
+  const bySession = new Map<string, NonNullable<HistoryEntry['distilledSkills']>>();
+  for (const skill of skills) {
+    for (const sessionId of skill.sourceSessionIds) {
+      const rows = bySession.get(sessionId) ?? [];
+      if (!rows.some((row) => row.ref === skill.ref && row.state === skill.state)) {
+        rows.push({ ref: skill.ref, state: skill.state });
+      }
+      bySession.set(sessionId, rows);
+    }
+  }
+  return bySession;
 }
 
 export async function foldHistory(deps: HistoryDeps): Promise<HistoryResult> {
   const reasons: string[] = [];
 
-  const episodes = collect(await deps.evidence.list(), 'evidence', [] as EpisodeV1[], reasons);
-  const ledger = collect(await deps.contribution.ledger(), 'contribution', [] as ContributionLedgerEntry[], reasons);
-
-  const runsRes = await deps.localLearning.list();
-  if (runsRes.status !== 'ok') reasons.push(`localLearning: ${runsRes.reason}`);
+  const episodesResult = await deps.evidence.list();
+  const episodes = collect(episodesResult, 'evidence', [] as EpisodeV1[], reasons);
+  const ledgerResult = await deps.contribution.ledger();
+  const ledger = collect(ledgerResult, 'contribution', [] as ContributionLedgerEntry[], reasons);
+  const skillsResult = deps.localLearning.skills
+    ? await deps.localLearning.skills()
+    : ({ status: 'unavailable', reason: 'skill provenance is unavailable' } as const);
+  const skills = collect(skillsResult, 'localLearning', [] as LocalLearningSkill[], reasons);
 
   const byEpisode = ledgerByEpisode(ledger);
+  const bySession = skillsBySession(skills);
+  const contributionAvailable = ledgerResult.status !== 'unavailable';
+  const skillsAvailable = skillsResult.status !== 'unavailable';
 
-  const entries: HistoryEntry[] = episodes.map((ep) => ({
-    sessionId: ep.session.sessionId,
-    taskSummary: ep.task.summary,
-    knowledgeSurfaced: ep.activity?.surfacedRefs.length ?? 0,
-    knowledgeUsed: ep.activity?.fetchedRefs.length ?? 0,
-    captureStatus: 'captured' as const,
-    eligibility: episodeEligibility(ep),
-    contributionState: contributionState(byEpisode.get(ep.episodeId)),
-    distilledSkillRefs: [],
-  }));
+  const entries: HistoryEntry[] = [...episodes]
+    .sort((a, b) => b.session.capturedAt.localeCompare(a.session.capturedAt))
+    .map((ep) => ({
+      sessionId: ep.session.sessionId,
+      capturedAt: ep.session.capturedAt,
+      taskSummary: ep.task.summary,
+      knowledgeSurfaced: ep.activity?.surfacedRefs.length ?? null,
+      knowledgeUsed: ep.activity?.fetchedRefs.length ?? null,
+      captureStatus: 'captured' as const,
+      eligibility: episodeEligibility(ep),
+      contributionState: contributionState(byEpisode.get(ep.episodeId), contributionAvailable),
+      distilledSkills: skillsAvailable ? bySession.get(ep.session.sessionId) ?? [] : null,
+    }));
+
+  const legacyFactsUnavailable = episodes.some((ep) => !ep.activity || !ep.eligibility);
+  if (legacyFactsUnavailable) reasons.push('one or more episodes predate activity or eligibility facts');
+  const evidenceUnavailable = episodesResult.status === 'unavailable';
 
   return reasons.length > 0
-    ? { entries, degraded: true, reason: reasons.join('; ') }
-    : { entries, degraded: false };
+    ? { entries, degraded: true, unavailable: evidenceUnavailable, reason: reasons.join('; ') }
+    : { entries, degraded: false, unavailable: false };
 }
 
 export async function foldExplain(sessionRef: string, deps: HistoryDeps): Promise<SessionExplanation> {
   const reasons: string[] = [];
 
   const episodes = collect(await deps.evidence.list(), 'evidence', [] as EpisodeV1[], reasons);
-  const ledger = collect(await deps.contribution.ledger(), 'contribution', [] as ContributionLedgerEntry[], reasons);
+  const ledgerResult = await deps.contribution.ledger();
+  const ledger = collect(ledgerResult, 'contribution', [] as ContributionLedgerEntry[], reasons);
 
   const episode = episodes.find((ep) => ep.session.sessionId === sessionRef);
   const contribution = episode
-    ? contributionState(ledger.find((row) => row.sourceId === episode.episodeId))
-    : contributionState(undefined);
+    ? contributionState(
+        ledger.find((row) => row.sourceId === episode.episodeId),
+        ledgerResult.status !== 'unavailable',
+      )
+    : contributionState(undefined, ledgerResult.status !== 'unavailable');
 
   return {
     sessionRef,

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -29,7 +29,11 @@ export type {
   ContributionStatus,
   ContributionStatusSnapshot,
 } from './ports/contribution-port.js';
-export type { LocalLearningPort, LocalLearningRun } from './ports/local-learning-port.js';
+export type {
+  LocalLearningPort,
+  LocalLearningRun,
+  LocalLearningSkill,
+} from './ports/local-learning-port.js';
 export type { SkillsPort, SkillRecord } from './ports/skills-port.js';
 export { createJinnPlugin, JINN_PLUGIN_CONTRACT_VERSION, PluginSession } from './plugin.js';
 export type {

--- a/packages/plugin/src/ports/local-learning-port.ts
+++ b/packages/plugin/src/ports/local-learning-port.ts
@@ -5,8 +5,17 @@ export interface LocalLearningRun {
   state: 'pending' | 'running' | 'done' | 'failed';
 }
 
+/** One locally distilled skill plus the sessions recorded in its provenance. */
+export interface LocalLearningSkill {
+  ref: string;
+  sourceSessionIds: string[];
+  state: 'staged' | 'installed';
+}
+
 export interface LocalLearningPort {
   run(input: { episodeIds: string[] }): Promise<PortResult<{ runId: string }>>;
   status(runId: string): Promise<PortResult<LocalLearningRun>>;
   list(): Promise<PortResult<LocalLearningRun[]>>;
+  /** Optional for older adapters; history reports unavailable when absent. */
+  skills?(): Promise<PortResult<LocalLearningSkill[]>>;
 }

--- a/packages/plugin/src/schemas/history-entry.ts
+++ b/packages/plugin/src/schemas/history-entry.ts
@@ -4,11 +4,12 @@ import { EligibilityVerdictSchema } from './eligibility-verdict.js';
 
 export const HistoryEntrySchema = z.strictObject({
   sessionId: z.string().min(1),
+  capturedAt: z.iso.datetime(),
   taskSummary: z.string().min(1),
-  knowledgeSurfaced: z.number().int().nonnegative(),
-  knowledgeUsed: z.number().int().nonnegative(),
+  knowledgeSurfaced: z.number().int().nonnegative().nullable(),
+  knowledgeUsed: z.number().int().nonnegative().nullable(),
   captureStatus: z.enum(['captured', 'not-captured']),
-  eligibility: EligibilityVerdictSchema,
+  eligibility: EligibilityVerdictSchema.nullable(),
   contributionState: z.strictObject({
     status: z.enum([
       'none',
@@ -19,10 +20,14 @@ export const HistoryEntrySchema = z.strictObject({
       'queued',
       'published',
       'vetoed',
+      'unavailable',
     ]),
     anchorRef: z.string().min(1).optional(),
   }),
-  distilledSkillRefs: z.array(z.string().min(1)),
+  distilledSkills: z.array(z.strictObject({
+    ref: z.string().min(1),
+    state: z.enum(['staged', 'installed']),
+  })).nullable(),
 });
 
 export type HistoryEntry = z.infer<typeof HistoryEntrySchema>;

--- a/packages/plugin/src/testing/contract-kits.ts
+++ b/packages/plugin/src/testing/contract-kits.ts
@@ -181,6 +181,13 @@ export function describeLocalLearningPortContract(makeAdapter: () => LocalLearni
         expect(listResult.value.map((r) => r.runId)).toContain(runResult.value.runId);
       }
     });
+
+    it('skills() is typed when the adapter exposes persisted skill provenance', async () => {
+      const adapter = makeAdapter();
+      if (!adapter.skills) return;
+      const skills = await adapter.skills();
+      expect(skills.status).toBe('ok');
+    });
   });
 }
 

--- a/packages/plugin/src/testing/in-memory-local-learning.ts
+++ b/packages/plugin/src/testing/in-memory-local-learning.ts
@@ -1,8 +1,13 @@
-import type { LocalLearningPort, LocalLearningRun } from '../ports/local-learning-port.js';
+import type {
+  LocalLearningPort,
+  LocalLearningRun,
+  LocalLearningSkill,
+} from '../ports/local-learning-port.js';
 import { ok, unavailable } from '../outcome.js';
 
 export class InMemoryLocalLearningPort implements LocalLearningPort {
   private readonly runs = new Map<string, LocalLearningRun>();
+  private readonly learnedSkills = new Map<string, LocalLearningSkill>();
   private counter = 0;
 
   async run(_input: { episodeIds: string[] }) {
@@ -20,5 +25,16 @@ export class InMemoryLocalLearningPort implements LocalLearningPort {
 
   async list() {
     return ok([...this.runs.values()]);
+  }
+
+  recordSkill(skill: LocalLearningSkill): void {
+    this.learnedSkills.set(skill.ref, {
+      ...skill,
+      sourceSessionIds: [...skill.sourceSessionIds],
+    });
+  }
+
+  async skills() {
+    return ok([...this.learnedSkills.values()]);
   }
 }

--- a/packages/plugin/test/history.test.ts
+++ b/packages/plugin/test/history.test.ts
@@ -12,6 +12,7 @@ import type { ContributionPort } from '../src/ports/contribution-port.js';
 import { unavailable, type PortResult } from '../src/outcome.js';
 import type { ContributionLedgerEntry } from '../src/ports/contribution-port.js';
 import type { ContributionCandidateV1 } from '../src/schemas/contribution-candidate.js';
+import type { EpisodeV1 } from '../src/schemas/episode.js';
 
 function candidate(sourceId: string, consent = false): ContributionCandidateV1 {
   return {
@@ -28,12 +29,28 @@ function candidate(sourceId: string, consent = false): ContributionCandidateV1 {
   };
 }
 
-function buildPlugin(evidence: InMemoryEvidencePort, contribution = new InMemoryContributionPort()) {
+function currentEpisode(overrides: Partial<EpisodeV1> = {}): EpisodeV1 {
+  return makeSampleEpisode({
+    activity: { surfacedRefs: [], fetchedRefs: [], installedSkillRefs: [] },
+    eligibility: {
+      eligible: false,
+      reason: 'no accepted diff',
+      checkedAt: '2026-07-14T00:00:00.000Z',
+    },
+    ...overrides,
+  });
+}
+
+function buildPlugin(
+  evidence: InMemoryEvidencePort,
+  contribution = new InMemoryContributionPort(),
+  localLearning = new InMemoryLocalLearningPort(),
+) {
   return createJinnPlugin({
     corpus: new InMemoryCorpusPort([]),
     evidence,
     contribution,
-    localLearning: new InMemoryLocalLearningPort(),
+    localLearning,
     skills: new InMemorySkillsPort(),
   });
 }
@@ -41,8 +58,8 @@ function buildPlugin(evidence: InMemoryEvidencePort, contribution = new InMemory
 describe('plugin.history / explain (AC3 — reproducible from port reads)', () => {
   it('is reproducible: two calls over the same port state are deep-equal', async () => {
     const evidence = new InMemoryEvidencePort();
-    await evidence.put(makeSampleEpisode({ episodeId: 'ep-1' }));
-    await evidence.put(makeSampleEpisode({ episodeId: 'ep-2' }));
+    await evidence.put(currentEpisode({ episodeId: 'ep-1' }));
+    await evidence.put(currentEpisode({ episodeId: 'ep-2' }));
     const plugin = buildPlugin(evidence);
     const first = await plugin.history();
     const second = await plugin.history();
@@ -53,21 +70,18 @@ describe('plugin.history / explain (AC3 — reproducible from port reads)', () =
 
   it('joins contribution state by episodeId', async () => {
     const evidence = new InMemoryEvidencePort();
-    await evidence.put(makeSampleEpisode({ episodeId: 'ep-1' }));
+    await evidence.put(currentEpisode({ episodeId: 'ep-1' }));
     const contribution = new InMemoryContributionPort();
     const recorded = await contribution.recordMineable(candidate('ep-1', true));
     if (recorded.status !== 'ok') throw new Error('record failed');
     await contribution.authorize(recorded.value.recordId);
     const plugin = buildPlugin(evidence, contribution);
     const { entries } = await plugin.history();
-    const row = entries.find((e) => e.sessionId === makeSampleEpisode().session.sessionId);
+    const row = entries.find((e) => e.sessionId === currentEpisode().session.sessionId);
     expect(row?.contributionState.status).toBe('queued');
   });
 
-  it('reports eligibility as indeterminate — never a silently-recomputed verdict', async () => {
-    // A completed + contribution-eligible episode: at end() the accepted-diff
-    // signal made it eligible, but that signal is NOT persisted on the episode,
-    // so history must not assert a verdict it can't derive (would read false).
+  it('reports legacy eligibility as unavailable — never as a false verdict', async () => {
     const evidence = new InMemoryEvidencePort();
     await evidence.put(
       makeSampleEpisode({
@@ -78,18 +92,15 @@ describe('plugin.history / explain (AC3 — reproducible from port reads)', () =
     );
     const plugin = buildPlugin(evidence);
 
-    const indeterminate =
-      'eligibility indeterminate from episode (contribution signals not persisted)';
-
     const { entries } = await plugin.history();
     expect(entries).toHaveLength(1);
-    expect(entries[0]?.eligibility.eligible).toBe(false);
-    expect(entries[0]?.eligibility.reason).toBe(indeterminate);
+    expect(entries[0]?.eligibility).toBeNull();
+    expect(entries[0]?.knowledgeSurfaced).toBeNull();
+    expect(entries[0]?.knowledgeUsed).toBeNull();
 
     const ex = await plugin.explain('sess-fixture-1');
     expect(ex.found).toBe(true);
-    expect(ex.eligibility?.eligible).toBe(false);
-    expect(ex.eligibility?.reason).toBe(indeterminate);
+    expect(ex.eligibility).toBeNull();
   });
 
   it('projects persisted activity facts and the authoritative eligibility verdict', async () => {
@@ -99,7 +110,7 @@ describe('plugin.history / explain (AC3 — reproducible from port reads)', () =
       reason: 'accepted diff on a public repository',
       checkedAt: '2026-07-15T12:00:00.000Z',
     };
-    await evidence.put(makeSampleEpisode({
+    await evidence.put(currentEpisode({
       episodeId: 'ep-enriched',
       activity: {
         surfacedRefs: ['knowledge/a', 'knowledge/b'],
@@ -126,7 +137,7 @@ describe('plugin.history / explain (AC3 — reproducible from port reads)', () =
 
   it('explain returns a structured trace for a session', async () => {
     const evidence = new InMemoryEvidencePort();
-    await evidence.put(makeSampleEpisode({ episodeId: 'ep-1' }));
+    await evidence.put(currentEpisode({ episodeId: 'ep-1' }));
     const plugin = buildPlugin(evidence);
     const ex = await plugin.explain('sess-fixture-1');
     expect(ex.sessionRef).toBe('sess-fixture-1');
@@ -144,7 +155,7 @@ describe('plugin.history / explain (AC3 — reproducible from port reads)', () =
 
   it('folds a degraded contribution read into degraded history (no throw)', async () => {
     const evidence = new InMemoryEvidencePort();
-    await evidence.put(makeSampleEpisode({ episodeId: 'ep-1' }));
+    await evidence.put(currentEpisode({ episodeId: 'ep-1' }));
     const brokenContribution: ContributionPort = {
       async recordMineable() { return unavailable('down'); },
       async ledger(): Promise<PortResult<ContributionLedgerEntry[]>> { return unavailable('ledger down'); },
@@ -157,5 +168,28 @@ describe('plugin.history / explain (AC3 — reproducible from port reads)', () =
     expect(result.degraded).toBe(true);
     expect(result.reason).toBeTruthy();
     expect(result.entries).toHaveLength(1); // partial rows, not a throw
+    expect(result.entries[0]?.contributionState.status).toBe('unavailable');
+  });
+
+  it('joins installed and staged local skills from their session provenance', async () => {
+    const evidence = new InMemoryEvidencePort();
+    await evidence.put(currentEpisode({ episodeId: 'ep-skills' }));
+    const learning = new InMemoryLocalLearningPort();
+    learning.recordSkill({
+      ref: 'local-skill:retry-budget',
+      sourceSessionIds: ['sess-fixture-1'],
+      state: 'installed',
+    });
+    learning.recordSkill({
+      ref: 'local-skill:test-first',
+      sourceSessionIds: ['sess-fixture-1'],
+      state: 'staged',
+    });
+
+    const result = await buildPlugin(evidence, new InMemoryContributionPort(), learning).history();
+    expect(result.entries[0]?.distilledSkills).toEqual([
+      { ref: 'local-skill:retry-budget', state: 'installed' },
+      { ref: 'local-skill:test-first', state: 'staged' },
+    ]);
   });
 });

--- a/packages/plugin/test/schemas/history-entry.test.ts
+++ b/packages/plugin/test/schemas/history-entry.test.ts
@@ -5,13 +5,14 @@ describe('HistoryEntrySchema', () => {
   it('parses a valid history row', () => {
     const parsed = HistoryEntrySchema.parse({
       sessionId: 'sess-1',
+      capturedAt: '2026-07-14T00:00:00.000Z',
       taskSummary: 'Fix a failing test',
       knowledgeSurfaced: 3,
       knowledgeUsed: 1,
       captureStatus: 'captured',
       eligibility: { eligible: false, reason: 'stage-1-stub', checkedAt: '2026-07-14T00:00:00.000Z' },
       contributionState: { status: 'queued' },
-      distilledSkillRefs: [],
+      distilledSkills: [{ ref: 'local-skill:retry', state: 'installed' }],
     });
     expect(parsed.captureStatus).toBe('captured');
   });
@@ -20,14 +21,32 @@ describe('HistoryEntrySchema', () => {
     expect(() =>
       HistoryEntrySchema.parse({
         sessionId: 'sess-1',
+        capturedAt: '2026-07-14T00:00:00.000Z',
         taskSummary: 'x',
         knowledgeSurfaced: 0,
         knowledgeUsed: 0,
         captureStatus: 'not-captured',
         eligibility: { eligible: false, reason: 'r', checkedAt: '2026-07-14T00:00:00.000Z' },
         contributionState: { status: 'bogus' },
-        distilledSkillRefs: [],
+        distilledSkills: [],
       }),
     ).toThrow();
+  });
+
+  it('represents unavailable facts explicitly instead of manufacturing empty values', () => {
+    const parsed = HistoryEntrySchema.parse({
+      sessionId: 'legacy-session',
+      capturedAt: '2026-07-13T00:00:00.000Z',
+      taskSummary: 'Legacy session',
+      knowledgeSurfaced: null,
+      knowledgeUsed: null,
+      captureStatus: 'captured',
+      eligibility: null,
+      contributionState: { status: 'unavailable' },
+      distilledSkills: null,
+    });
+    expect(parsed.knowledgeSurfaced).toBeNull();
+    expect(parsed.eligibility).toBeNull();
+    expect(parsed.distilledSkills).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #1663

## Product outcome

Adds one derived, local history surface over canonical episodes, canonical contribution records, and durable installed/staged skill provenance. There is no history cache: each request reads current source stores, and missing facts remain explicitly unavailable.

## TUI format

| Line | Canonical facts | Missing-state behavior |
|---|---|---|
| Session | captured time + task summary | malformed values are sanitized |
| Knowledge | surfaced/used counts + capture status | `knowledge unavailable`; never fabricated zero |
| Eligibility | authoritative persisted verdict + reason | `eligibility unavailable`; never fabricated false |
| Contribution | recorded/minted/preview-required/queued/published/vetoed/rejected + anchor | `contribution unavailable` |
| Local skills | skill ref + installed/staged state joined by session provenance | `local skills unavailable` or explicit `none` |

## Verification

- `packages/plugin`: typecheck, 117 tests, build
- `client/packages/harness-layer`: typecheck, 572 tests
- `apps/jinn-agent`: 276 Jinn plugin tests
- `git diff --check`

## Privacy and boundaries

The history command returns only the strict projection. It does not expose trajectory content, accepted diffs/gold, local episode IDs, failures, or holdouts. The Python renderer sanitizes all layer-supplied terminal fields.