### PR TITLE
feat(plugin): make Stage 1 activity legible

### DIFF
--- a/apps/jinn-agent/plugins/jinn/__init__.py
+++ b/apps/jinn-agent/plugins/jinn/__init__.py
@@ -36,6 +36,7 @@ from . import ledger_view
 from . import onboarding
 from . import pickup
 from . import session_bridge
+from . import session_view
 from . import skills_install
 
 logger = logging.getLogger(__name__)
@@ -169,16 +170,6 @@ def _clear_veto(session_id: str) -> None:
         _vetoed_tasks.discard(session_id)
 
 
-def _contribution_line(result: Dict[str, Any]) -> Optional[str]:
-    contribution = result.get("contribution")
-    if not isinstance(contribution, dict) or contribution.get("status") not in ("ok", "degraded"):
-        return None
-    value = contribution.get("value")
-    if isinstance(value, dict) and value.get("status") == "published":
-        return "jinn: contribution published — immutable (/jinn ledger for the anchor)"
-    return None
-
-
 def _state_for(session_id: str, cwd: Optional[Path] = None) -> Dict[str, Any]:
     key = session_id or "default"
     with _session_state_lock:
@@ -212,6 +203,27 @@ def _pop_state(session_id: str) -> Dict[str, Any]:
                 "intermediateFailureDiffs": [],
             },
         )
+
+
+def _peek_state(session_id: str) -> Dict[str, Any]:
+    key = session_id or "default"
+    with _session_state_lock:
+        state = _session_states.get(key)
+        if state is None:
+            return {
+                "activity": {
+                    "surfacedRefs": [],
+                    "fetchedRefs": [],
+                    "installedSkillRefs": [],
+                },
+            }
+        return {
+            **state,
+            "activity": {
+                field: list(state.get("activity", {}).get(field) or [])
+                for field in ("surfacedRefs", "fetchedRefs", "installedSkillRefs")
+            },
+        }
 
 
 def _record_activity(session_id: str, field: str, refs: list[str]) -> None:
@@ -415,7 +427,15 @@ def _on_session_end(
     )
 
     if episode is None:
-        _pop_state(session_id)
+        state = _pop_state(session_id)
+        _user_line(session_view.render_complete(
+            summary=None,
+            activity=state.get("activity") or {},
+            capture_status="unavailable",
+            local_learning_status="unavailable",
+            contribution=None,
+            candidate_created=False,
+        ))
         return
 
     # Tee for local distillation (mono #1537) — BEFORE the veto/publish
@@ -423,8 +443,11 @@ def _on_session_end(
     # capture (a veto withholds from the NETWORK; local distillation never
     # leaves this machine). Distinct dir + lifecycle from the pending file:
     # the publish drain unlinks pending files, never captures.
-    if task is not None:
+    tee_path = (
         distill.tee_capture(task, session_id or task_id, runner=_runner)
+        if task is not None
+        else None
+    )
 
     state = _pop_state(session_id)
     snapshot = state.get("snapshot")
@@ -451,7 +474,25 @@ def _on_session_end(
         contribution_vetoed=vetoed,
     )
     if result is None:
-        distill.write_episode_fallback(episode)
+        fallback_path = distill.write_episode_fallback(episode)
+        learning_status = (
+            "pending" if tee_path is not None
+            else "off" if distill.cached_mode(_runner) == "off"
+            else "unavailable"
+        )
+        _user_line(session_view.render_complete(
+            summary={
+                **(state.get("activity") or {}),
+                "nothingFound": not bool(
+                    (state.get("activity") or {}).get("surfacedRefs")
+                ),
+            },
+            activity=state.get("activity") or {},
+            capture_status="captured-locally" if fallback_path is not None else "unavailable",
+            local_learning_status=learning_status,
+            contribution=None,
+            candidate_created=candidate is not None,
+        ))
     else:
         contribution = result.get("contribution")
         value = contribution.get("value") if isinstance(contribution, dict) else None
@@ -463,9 +504,19 @@ def _on_session_end(
             and value.get("status") == "vetoed"
         ):
             _clear_veto(session_id)
-        line = _contribution_line(result)
-        if line:
-            _user_line(line)
+        learning_status = (
+            "pending" if tee_path is not None
+            else "off" if distill.cached_mode(_runner) == "off"
+            else "unavailable"
+        )
+        _user_line(session_view.render_complete(
+            summary=result.get("summary"),
+            activity=state.get("activity") or {},
+            capture_status="captured",
+            local_learning_status=learning_status,
+            contribution=result.get("contribution"),
+            candidate_created=candidate is not None,
+        ))
 
 
 # ── Slash commands ───────────────────────────────────────────────────────────
@@ -475,6 +526,7 @@ _JINN_HELP = (
     "  /jinn status    consent + capture state\n"
     "  /jinn consent   run the consent flow\n"
     "  /jinn preview   inspect a retained legacy capture, or a labelled example\n"
+    "  /jinn session   current surfaced, capture, learning, and contribution state\n"
     "  /jinn history   sessions derived from episodes, contributions, and local skills\n"
     "  /jinn ledger    the contribution ledger — what left this machine\n"
     "  /jinn veto      withhold the current task (recorded locally, never published)\n"
@@ -572,6 +624,14 @@ def _handle_jinn(command_args: str = "", session_id: str = "", task_id: str = ""
             consent.mark_previewed()
             return out + "\n\nlegacy preview only — this retained file will not auto-publish."
         return f"preview failed:\n{out}"
+
+    if sub == "session":
+        state = _peek_state(session_id)
+        return session_view.render_current(
+            activity=state.get("activity") or {},
+            capture_active=buf.has_capture(task_id, session_id),
+            share_enabled=consent.share_enabled(),
+        )
 
     if sub == "history":
         code, out = jinn_layer.history_json(runner=_runner)
@@ -784,7 +844,7 @@ def register(ctx) -> None:
     ctx.register_command(
         "jinn",
         handler=_handle_jinn,
-        description="Jinn layer: consent, preview, ledger, veto.",
+        description="Jinn layer: session, history, consent, and contribution state.",
     )
     ctx.register_command(
         "corpus",

--- a/apps/jinn-agent/plugins/jinn/capture_buffer.py
+++ b/apps/jinn-agent/plugins/jinn/capture_buffer.py
@@ -160,6 +160,13 @@ def has_steps(task_id: str, session_id: str) -> bool:
         return bool(buf and buf["steps"])
 
 
+def has_capture(task_id: str, session_id: str) -> bool:
+    """Whether any ordinary agent activity is currently captured locally."""
+    with _lock:
+        buf = _buffers.get(_key(task_id, session_id))
+        return bool(buf and (buf["steps"] or buf.get("turns")))
+
+
 def _pop(task_id: str, session_id: str) -> Optional[Dict[str, Any]]:
     """Pop the buffer once (None if absent or wholly empty).
 

--- a/apps/jinn-agent/plugins/jinn/onboarding.py
+++ b/apps/jinn-agent/plugins/jinn/onboarding.py
@@ -414,6 +414,8 @@ def render_corpus_signal_line(
     env_ref: str,
     pal=None,
     rst=None,
+    *,
+    action: str = "using",
 ) -> str:
     """One in-run line at the point of corpus use (design 1c) — the permanent
     artefact of step 4. ``◇ corpus`` prefix (sky), skill name bright, provenance
@@ -435,12 +437,13 @@ def render_corpus_signal_line(
     skill = _style.sanitise(skill)
     provenance = _style.sanitise(provenance)
     env_ref = _style.sanitise(env_ref)
+    action = "surfaced" if action == "surfaced" else "using"
     sky = lambda s: _style.wrap(pal, rst, "sky", s)
     skyh = lambda s: _style.wrap(pal, rst, "fg", s)  # bright skill name
     fg = lambda s: _style.wrap(pal, rst, "fg", s)
     dim = lambda s: _style.wrap(pal, rst, "dim", s)
     return (
-        "  " + sky("◇ corpus") + "  " + fg("using ") + skyh(skill)
+        "  " + sky("◇ corpus") + "  " + fg(action + " ") + skyh(skill)
         + dim(f"  ·  {provenance}  ·  ") + sky(f"env {env_ref}")
     )
 

--- a/apps/jinn-agent/plugins/jinn/pickup.py
+++ b/apps/jinn-agent/plugins/jinn/pickup.py
@@ -40,10 +40,9 @@ from .consent import get_hermes_home
 logger = logging.getLogger(__name__)
 
 # The point-of-use corpus signal (design 1c / #1405 step 4). Emitted once per
-# adopted contribution — the harness is actually *using* another operator's
-# work in this run, so the operator sees a checkable line at that moment. A
-# suggested-but-not-adopted candidate is only injected context (not used), so
-# it never emits a signal. Default sink mirrors _user_line in __init__.py:
+# surfaced contribution: suggestions say ``surfaced`` while auto-adopted
+# knowledge says ``using``, so visibility never overclaims adoption. Default
+# sink mirrors _user_line in __init__.py:
 # stderr, which prompt_toolkit proxies above the input area while the TUI runs.
 SignalSink = Callable[[str], None]
 
@@ -55,11 +54,20 @@ def _default_signal_sink(line: str) -> None:
         pass
 
 
-def _emit_corpus_signal(sink: SignalSink, skill: str, provenance: str, env_ref: str) -> None:
+def _emit_corpus_signal(
+    sink: SignalSink,
+    skill: str,
+    provenance: str,
+    env_ref: str,
+    *,
+    action: str = "using",
+) -> None:
     """Render + emit one ``◇ corpus`` line. Never raises — a signal must not
     break a pickup that otherwise succeeded."""
     try:
-        sink(onboarding.render_corpus_signal_line(skill, provenance, env_ref))
+        sink(onboarding.render_corpus_signal_line(
+            skill, provenance, env_ref, action=action
+        ))
     except Exception:
         logger.debug("jinn: corpus signal render failed", exc_info=True)
 
@@ -195,7 +203,7 @@ def pickup(
     pre_llm_call hook (or None when there is nothing worth saying).
     Fails open: any error returns None and the task proceeds untouched.
 
-    ``signal_sink`` receives one ``◇ corpus`` line per adopted contribution
+    ``signal_sink`` receives one ``◇ corpus`` line per surfaced contribution
     (design 1c). Defaults to stderr; tests pass a collector.
     """
     try:
@@ -291,12 +299,26 @@ def _pickup_inner(
             )
             if activity is not None and ref not in activity.setdefault("surfacedRefs", []):
                 activity["surfacedRefs"].append(ref)
+            _emit_corpus_signal(
+                signal_sink,
+                slug,
+                f"{tier} · {summary}",
+                _short_ref(ref),
+                action="surfaced",
+            )
         else:
             # Unknown payload types are never adopted; mention verified ones only.
             if tier_at_least(tier, threshold):
                 suggested.append(f"- ({payload_type}, {tier}) {summary} — ref: {ref}")
                 if activity is not None and ref not in activity.setdefault("surfacedRefs", []):
                     activity["surfacedRefs"].append(ref)
+                _emit_corpus_signal(
+                    signal_sink,
+                    payload_type,
+                    f"{tier} · {summary}",
+                    _short_ref(ref),
+                    action="surfaced",
+                )
 
     if not adopted and not suggested:
         return None

--- a/apps/jinn-agent/plugins/jinn/session_view.py
+++ b/apps/jinn-agent/plugins/jinn/session_view.py
@@ -1,0 +1,144 @@
+"""Pure Stage 1 current-session and completion renderers."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable
+
+from . import style
+
+
+def _text(value: object, fallback: str = "unavailable") -> str:
+    if not isinstance(value, str) or not value.strip():
+        return fallback
+    return style.sanitise(value.strip())
+
+
+def _refs(activity: Dict[str, Any], field: str) -> list[str]:
+    value = activity.get(field)
+    if not isinstance(value, list):
+        return []
+    return [_text(ref, "") for ref in value if _text(ref, "")]
+
+
+def _knowledge_lines(activity: Dict[str, Any], nothing_found: bool) -> list[str]:
+    surfaced = _refs(activity, "surfacedRefs")
+    fetched = _refs(activity, "fetchedRefs")
+    installed = _refs(activity, "installedSkillRefs")
+    if nothing_found:
+        return ["knowledge nothing relevant found"]
+    lines = [
+        f"knowledge {len(surfaced)} surfaced · {len(fetched)} fetched · "
+        f"{len(installed)} installed"
+    ]
+    if surfaced:
+        lines.append("surfaced " + ", ".join(surfaced))
+    used = list(dict.fromkeys([*fetched, *installed]))
+    if used:
+        lines.append("used " + ", ".join(used))
+    return lines
+
+
+def _render(title: str, lines: Iterable[str]) -> str:
+    pal, rst = style.palette()
+    output = [style.wrap(pal, rst, "fg", title)]
+    output.extend("  " + line for line in lines)
+    return "\n".join(output)
+
+
+def render_current(
+    *, activity: Dict[str, Any], capture_active: bool, share_enabled: bool
+) -> str:
+    """Render live state only; eligibility/contribution are end-of-session facts."""
+    nothing_yet = not any(
+        _refs(activity, field)
+        for field in ("surfacedRefs", "fetchedRefs", "installedSkillRefs")
+    )
+    knowledge = (
+        ["knowledge nothing relevant found yet"]
+        if nothing_yet
+        else _knowledge_lines(activity, False)
+    )
+    return _render("Jinn session", [
+        *knowledge,
+        "capture active" if capture_active else "capture waiting for ordinary work",
+        "local learning reserves this capture at session end",
+        "eligibility pending until session end",
+        "contribution pending until session end · publication "
+        + ("ON" if share_enabled else "OFF"),
+    ])
+
+
+def _eligibility(value: object) -> str:
+    if not isinstance(value, dict) or not isinstance(value.get("eligible"), bool):
+        return "eligibility unavailable"
+    verdict = "eligible" if value["eligible"] else "not eligible"
+    reason = _text(value.get("reason"), "")
+    return f"eligibility {verdict}" + (f" — {reason}" if reason else "")
+
+
+def _contribution(value: object) -> str:
+    if value is None or not isinstance(value, dict):
+        return "contribution unavailable"
+    port_status = value.get("status")
+    if port_status == "unavailable":
+        reason = _text(value.get("reason"), "")
+        return "contribution unavailable" + (f" — {reason}" if reason else "")
+    receipt = value.get("value")
+    if not isinstance(receipt, dict):
+        return "contribution unavailable"
+    status = _text(receipt.get("status"), "unavailable")
+    line = f"contribution {status}"
+    if status == "published":
+        line = "jinn: contribution published — immutable (/jinn ledger for the anchor)"
+    return line
+
+
+def render_complete(
+    *,
+    summary: object,
+    activity: Dict[str, Any],
+    capture_status: str,
+    local_learning_status: str,
+    contribution: object,
+    candidate_created: bool = True,
+) -> str:
+    """Render one complete outcome from core facts plus host-local capture state."""
+    core = summary if isinstance(summary, dict) else {}
+    summary_activity = {
+        "surfacedRefs": core.get("surfacedRefs", activity.get("surfacedRefs", [])),
+        "fetchedRefs": core.get("fetchedRefs", activity.get("fetchedRefs", [])),
+        "installedSkillRefs": core.get(
+            "installedSkillRefs", activity.get("installedSkillRefs", [])
+        ),
+    }
+    stated_nothing_found = core.get("nothingFound")
+    nothing_found = (
+        stated_nothing_found
+        if isinstance(stated_nothing_found, bool)
+        else not any(
+            _refs(summary_activity, field)
+            for field in ("surfacedRefs", "fetchedRefs", "installedSkillRefs")
+        )
+    )
+    learning = {
+        "pending": "local learning pending — capture reserved for distillation",
+        "off": "local learning off",
+        "unavailable": "local learning unavailable — capture was not reserved",
+    }.get(local_learning_status, "local learning unavailable")
+    capture = {
+        "captured": "episode captured",
+        "captured-locally": "episode captured locally — process bridge degraded",
+        "unavailable": "episode capture unavailable",
+    }.get(capture_status, "episode capture unavailable")
+    contribution_line = (
+        _contribution(contribution)
+        if candidate_created
+        else "contribution no reusable public-task candidate"
+    )
+    return _render("Jinn session complete", [
+        *_knowledge_lines(summary_activity, nothing_found),
+        capture,
+        learning,
+        _eligibility(core.get("eligibility")),
+        contribution_line,
+    ])

--- a/apps/jinn-agent/tests/plugins/test_jinn_onboarding.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_onboarding.py
@@ -247,9 +247,8 @@ def test_corpus_signal_line_hooked_into_pickup(tmp_path, monkeypatch):
     assert "env " in plain
 
 
-def test_pickup_suggested_but_not_adopted_emits_no_signal(tmp_path, monkeypatch):
-    """A suggested (unadopted) candidate is only injected context, not used —
-    so it must NOT emit a signal."""
+def test_pickup_suggested_but_not_adopted_emits_surfaced_signal(tmp_path, monkeypatch):
+    """Every suggestion is visibly marked without claiming it was used."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     pickup = importlib.reload(importlib.import_module("plugins.jinn.pickup"))
     tp = importlib.import_module("tests.plugins.test_jinn_pickup")
@@ -258,7 +257,25 @@ def test_pickup_suggested_but_not_adopted_emits_no_signal(tmp_path, monkeypatch)
     result = pickup.pickup(tp.MSG, runner=runner, signal_sink=lines.append)
     assert result is not None
     assert "unverified" in result["context"]
-    assert lines == []
+    assert len(lines) == 1
+    plain = _plain(lines[0])
+    assert plain.startswith("  ◇ corpus")
+    assert "surfaced tdd" in plain
+    assert "using tdd" not in plain
+
+
+def test_pickup_unknown_suggestion_is_also_visibly_surfaced(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    pickup = importlib.reload(importlib.import_module("plugins.jinn.pickup"))
+    tp = importlib.import_module("tests.plugins.test_jinn_pickup")
+    runner = tp.CorpusRunner(tp.trace(
+        tier="evaluator-verified", payload="opaque", slug="opaque-pattern"
+    ))
+    lines = []
+    result = pickup.pickup(tp.MSG, runner=runner, signal_sink=lines.append)
+    assert result is not None
+    assert len(lines) == 1
+    assert "surfaced unknown" in _plain(lines[0])
 
 
 # ── Persistence — facts over flags ───────────────────────────────────────────

--- a/apps/jinn-agent/tests/plugins/test_jinn_plugin.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_plugin.py
@@ -245,7 +245,9 @@ def test_veto_with_no_active_task_reports_nothing_to_veto(isolated_home):
     assert not jinn._vetoed_tasks
 
 
-def test_process_failure_persists_episode_fallback_without_pending_file(tmp_path, monkeypatch):
+def test_process_failure_persists_episode_fallback_without_pending_file(
+    tmp_path, monkeypatch, capsys
+):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     capture_buffer.reset()
     consent.save_state(True, previewed=True)
@@ -260,6 +262,11 @@ def test_process_failure_persists_episode_fallback_without_pending_file(tmp_path
     episodes = sorted((tmp_path / "episodes").glob("*.json"))
     assert len(episodes) == 1
     assert json.loads(episodes[0].read_text())["schemaVersion"] == "jinn.episode.v1"
+    err = capsys.readouterr().err
+    assert "episode captured locally — process bridge degraded" in err
+    assert "local learning pending" in err
+    assert "eligibility unavailable" in err
+    assert "contribution unavailable" in err
 
 
 def test_abandoned_session_is_marked_abandoned(isolated_home, tmp_path):
@@ -309,9 +316,15 @@ def test_session_end_published_outcome_says_contribution_is_immutable(
     assert "jinn: contribution published — immutable (/jinn ledger for the anchor)" in err
 
 
-def test_session_end_without_capture_prints_nothing(isolated_home, capsys):
-    _run_session()  # local persistence without a contribution is terminal-silent
-    assert capsys.readouterr().err == ""
+def test_session_end_without_corpus_result_prints_complete_summary(isolated_home, capsys):
+    _run_session()
+    err = capsys.readouterr().err
+    assert "Jinn session complete" in err
+    assert "nothing relevant found" in err
+    assert "episode captured" in err
+    assert "local learning pending" in err
+    assert "eligibility not eligible — test fixture" in err
+    assert "contribution unavailable" in err
 
 
 # ── Consent flow ─────────────────────────────────────────────────────────────

--- a/apps/jinn-agent/tests/plugins/test_jinn_session_view.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_session_view.py
@@ -1,0 +1,150 @@
+"""Current-session and session-completion product legibility."""
+
+from __future__ import annotations
+
+import importlib
+import re
+
+import pytest
+
+jinn = importlib.import_module("plugins.jinn")
+buf = importlib.import_module("plugins.jinn.capture_buffer")
+session_view = importlib.import_module("plugins.jinn.session_view")
+
+_ANSI = re.compile(r"\033\[[0-9;]*m")
+
+
+def _plain(value: str) -> str:
+    return _ANSI.sub("", value)
+
+
+@pytest.fixture(autouse=True)
+def reset(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("NO_COLOR", "1")
+    buf.reset()
+    jinn._reset_session_state()
+    yield
+    buf.reset()
+    jinn._reset_session_state()
+
+
+def test_current_session_renders_all_stage_1_state():
+    out = _plain(session_view.render_current(
+        activity={
+            "surfacedRefs": ["knowledge/ref-a", "knowledge/ref-b"],
+            "fetchedRefs": ["knowledge/ref-a"],
+            "installedSkillRefs": ["knowledge/ref-a"],
+        },
+        capture_active=True,
+        share_enabled=False,
+    ))
+
+    assert "Jinn session" in out
+    assert "2 surfaced · 1 fetched · 1 installed" in out
+    assert "capture active" in out
+    assert "eligibility pending until session end" in out
+    assert "contribution pending until session end · publication OFF" in out
+    assert "local learning reserves this capture at session end" in out
+
+
+def test_current_session_nothing_found_yet_is_explicit():
+    out = _plain(session_view.render_current(
+        activity={"surfacedRefs": [], "fetchedRefs": [], "installedSkillRefs": []},
+        capture_active=False,
+        share_enabled=True,
+    ))
+    assert "nothing relevant found yet" in out
+    assert "capture waiting for ordinary work" in out
+
+
+def test_current_session_does_not_call_directly_fetched_knowledge_nothing():
+    out = _plain(session_view.render_current(
+        activity={
+            "surfacedRefs": [],
+            "fetchedRefs": ["knowledge/direct-ref"],
+            "installedSkillRefs": [],
+        },
+        capture_active=True,
+        share_enabled=False,
+    ))
+    assert "0 surfaced · 1 fetched · 0 installed" in out
+    assert "nothing relevant found" not in out
+
+
+def test_session_end_renders_nothing_found_capture_learning_and_contribution():
+    out = _plain(session_view.render_complete(
+        summary={
+            "surfacedRefs": [],
+            "fetchedRefs": [],
+            "installedSkillRefs": [],
+            "nothingFound": True,
+            "eligibility": {
+                "eligible": True,
+                "reason": "accepted diff on a public repository",
+            },
+        },
+        activity={"surfacedRefs": [], "fetchedRefs": [], "installedSkillRefs": []},
+        capture_status="captured",
+        local_learning_status="pending",
+        contribution={"status": "ok", "value": {"status": "recorded"}},
+    ))
+    assert "Jinn session complete" in out
+    assert "nothing relevant found" in out
+    assert "episode captured" in out
+    assert "local learning pending" in out
+    assert "eligibility eligible — accepted diff on a public repository" in out
+    assert "contribution recorded" in out
+
+
+def test_session_end_renders_relevant_knowledge_and_used_refs():
+    out = _plain(session_view.render_complete(
+        summary={
+            "surfacedRefs": ["knowledge/ref-a", "knowledge/ref-b"],
+            "fetchedRefs": ["knowledge/ref-a"],
+            "installedSkillRefs": ["knowledge/ref-a"],
+            "nothingFound": False,
+            "eligibility": {"eligible": False, "reason": "no accepted diff"},
+        },
+        activity={},
+        capture_status="captured",
+        local_learning_status="pending",
+        contribution={"status": "ok", "value": {"status": "queued"}},
+    ))
+    assert "2 surfaced · 1 fetched · 1 installed" in out
+    assert "surfaced knowledge/ref-a, knowledge/ref-b" in out
+    assert "used knowledge/ref-a" in out
+    assert "contribution queued" in out
+
+
+def test_session_end_distinguishes_no_candidate_from_unavailable_pipeline():
+    out = _plain(session_view.render_complete(
+        summary=None,
+        activity={},
+        capture_status="captured-locally",
+        local_learning_status="off",
+        contribution=None,
+        candidate_created=False,
+    ))
+    assert "episode captured locally — process bridge degraded" in out
+    assert "local learning off" in out
+    assert "eligibility unavailable" in out
+    assert "contribution no reusable public-task candidate" in out
+
+
+def test_jinn_session_reads_the_live_buffer_and_activity(monkeypatch):
+    state = jinn._state_for("s1")
+    state["activity"] = {
+        "surfacedRefs": ["knowledge/ref-a"],
+        "fetchedRefs": ["knowledge/ref-a"],
+        "installedSkillRefs": [],
+    }
+    buf.record_first_turn("t1", "s1", "fix retry", "model", "cli")
+    buf.record_user_turn("t1", "s1", "fix retry")
+    monkeypatch.setattr(jinn.consent, "share_enabled", lambda: False)
+
+    out = _plain(jinn._handle_jinn(
+        command_args="session", session_id="s1", task_id="t1"
+    ))
+    assert "1 surfaced · 1 fetched · 0 installed" in out
+    assert "capture active" in out

--- a/apps/jinn-agent/tests/plugins/test_jinn_veto_durable.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_veto_durable.py
@@ -9,6 +9,7 @@ import pytest
 
 jinn = importlib.import_module("plugins.jinn")
 buf = importlib.import_module("plugins.jinn.capture_buffer")
+session_view = importlib.import_module("plugins.jinn.session_view")
 
 
 @pytest.fixture(autouse=True)
@@ -61,13 +62,15 @@ def test_veto_marker_and_directory_are_owner_only():
 
 
 def test_published_message_says_the_record_is_immutable():
-    line = jinn._contribution_line(
-        {
-            "contribution": {
-                "status": "ok",
-                "value": {"recordId": "episode-1", "status": "published"},
-            }
-        }
+    line = session_view.render_complete(
+        summary=None,
+        activity={},
+        capture_status="captured",
+        local_learning_status="pending",
+        contribution={
+            "status": "ok",
+            "value": {"recordId": "episode-1", "status": "published"},
+        },
     )
 
-    assert line == "jinn: contribution published — immutable (/jinn ledger for the anchor)"
+    assert "jinn: contribution published — immutable (/jinn ledger for the anchor)" in line

--- a/client/packages/harness-layer/test/process-contract.test.ts
+++ b/client/packages/harness-layer/test/process-contract.test.ts
@@ -368,6 +368,26 @@ describe('jinn-layer process contract v1', () => {
           skills: new InMemorySkillsPort(),
         },
       })).toBe(0);
+      expect(JSON.parse(out.output())).toMatchObject({
+        contractVersion: 1,
+        status: 'ok',
+        value: {
+          persistence: { status: 'ok', value: { episodeId: 'episode-host-1' } },
+          contribution: {
+            status: 'ok',
+            value: {
+              localState: 'recorded',
+              publicationState: 'disabled',
+              status: 'recorded',
+            },
+          },
+          summary: {
+            surfacedRefs: ['knowledge/ref-1'],
+            fetchedRefs: ['knowledge/ref-1'],
+            nothingFound: false,
+          },
+        },
+      });
 
       const persisted = JSON.parse(readFileSync(join(episodes, 'episode-host-1.episode.json'), 'utf8'));
       expect(persisted.episodeId).toBe('episode-host-1');

--- a/packages/plugin/src/plugin.ts
+++ b/packages/plugin/src/plugin.ts
@@ -7,7 +7,11 @@
 
 /// <reference types="node" />
 import { randomUUID } from 'node:crypto';
-import type { ContributionLedgerEntry, ContributionPort } from './ports/contribution-port.js';
+import type {
+  ContributionLedgerEntry,
+  ContributionPort,
+  ContributionStatusSnapshot,
+} from './ports/contribution-port.js';
 import type { CorpusPort } from './ports/corpus-port.js';
 import type { EvidencePort } from './ports/evidence-port.js';
 import type { LocalLearningPort } from './ports/local-learning-port.js';
@@ -99,8 +103,7 @@ export interface SessionEndResult {
 }
 
 export type ContributionCompletionReceipt =
-  | { recordId: string }
-  | { recordId: string; publicationState: 'vetoed'; status: 'vetoed' };
+  { recordId: string } & Partial<ContributionStatusSnapshot>;
 
 export interface ContributionPreview {
   recordId: string;
@@ -248,6 +251,23 @@ async function completeSession(
             { recordId },
           );
         }
+      } else if (contribution.status === 'ok') {
+        const recordId = contribution.value.recordId;
+        try {
+          const snapshot = await deps.contribution.mintStatus(recordId);
+          if (snapshot.status === 'ok') {
+            contribution = ok({ recordId, ...snapshot.value });
+          } else if (snapshot.status === 'degraded' && snapshot.value !== undefined) {
+            contribution = degraded(snapshot.reason, { recordId, ...snapshot.value });
+          } else {
+            contribution = degraded(snapshot.reason, { recordId });
+          }
+        } catch (error) {
+          contribution = degraded(
+            `contribution status failed: ${errorReason(error)}`,
+            { recordId },
+          );
+        }
       }
     }
   }
@@ -260,7 +280,10 @@ async function completeSession(
     fetchedHits: hits.fetchedHits,
     installedSkillRefs: activity.installedSkillRefs,
     eligibility,
-    nothingFound: activity.surfacedRefs.length === 0,
+    nothingFound:
+      activity.surfacedRefs.length === 0
+      && activity.fetchedRefs.length === 0
+      && activity.installedSkillRefs.length === 0,
   };
 
   return {

--- a/packages/plugin/test/plugin/complete-session.test.ts
+++ b/packages/plugin/test/plugin/complete-session.test.ts
@@ -84,6 +84,14 @@ describe('JinnPlugin.completeSession()', () => {
     expect(result.episodeRef).toBe('episode-complete');
     expect(result.persistence.status).toBe('ok');
     expect(result.contribution?.status).toBe('ok');
+    expect(result.contribution).toMatchObject({
+      status: 'ok',
+      value: {
+        localState: 'recorded',
+        publicationState: 'disabled',
+        status: 'recorded',
+      },
+    });
     expect(result.summary.surfacedRefs).toEqual(ACTIVITY.surfacedRefs);
     expect(result.summary.fetchedRefs).toEqual(ACTIVITY.fetchedRefs);
 
@@ -154,6 +162,31 @@ describe('JinnPlugin.completeSession()', () => {
     if (result.contribution?.status === 'ok') {
       expect(contribution.getCandidate(result.contribution.value.recordId)).toEqual(candidate());
     }
+  });
+
+  it('keeps a recorded candidate when its immediate status projection is unavailable', async () => {
+    class StatusUnavailablePort extends InMemoryContributionPort {
+      override async mintStatus() {
+        return unavailable('sidecar status unavailable');
+      }
+    }
+    const contribution = new StatusUnavailablePort();
+
+    const result = await invoke(pluginWith(new InMemoryEvidencePort(), contribution), {
+      contractVersion: 1,
+      episode: makeSampleEpisode({ episodeId: 'episode-complete' }),
+      activity: ACTIVITY,
+      eligibilityInputs: { publicRepo: true, acceptedDiff: true },
+      contributionCandidate: candidate(),
+    });
+    if (!result) return;
+
+    expect(result.contribution).toEqual({
+      status: 'degraded',
+      reason: 'sidecar status unavailable',
+      value: { recordId: 'record-1' },
+    });
+    expect(contribution.getCandidate('record-1')).toEqual(candidate());
   });
 
   it('rejects a cross-episode candidate attachment without losing the episode', async () => {


### PR DESCRIPTION
Closes #1665

## Product outcome

Makes the Stage 1 boost visible throughout ordinary work: every suggestion is marked as `surfaced`, adopted knowledge remains marked as `using`, `/jinn session` derives live activity from the capture buffer, and session end always reports knowledge, evidence, local learning, eligibility, and contribution state.

## Copy table

| Moment | Copy/state | Source |
|---|---|---|
| Suggested knowledge | `◇ corpus surfaced …` | successful pickup suggestion |
| Auto-adopted knowledge | `◇ corpus using …` | successful installed adoption |
| `/jinn session` | surfaced/fetched/installed, capture, learning, eligibility pending, contribution pending + publication preference | live host buffer/activity |
| Session end, relevant | surfaced + used refs, captured episode, local-learning pending/off/unavailable, authoritative eligibility, contribution state | core completion + host-local tee |
| Session end, no result | explicit `nothing relevant found` plus the same outcome lines | core completion |
| Process bridge failure | `captured locally — process bridge degraded`; unavailable facts remain explicit | fallback episode write |

## Verification

- `packages/plugin`: typecheck, 118 tests, build
- `client/packages/harness-layer`: typecheck, 572 tests; process contract focused gate
- `apps/jinn-agent`: 284 Jinn plugin tests
- `git diff --check`

## Boundaries

No Hermes core or model-tool changes. The disabled plugin still registers no hooks, tools, or commands and emits no output or state. Session/history rendering owns no duplicate state.