### PR TITLE
test(plugin): make Stage 1 acceptance blocking

### DIFF
--- a/.github/workflows/jinn-agent-ci.yml
+++ b/.github/workflows/jinn-agent-ci.yml
@@ -2,10 +2,32 @@ name: jinn-agent CI
 
 on:
   pull_request:
-    paths: ['apps/jinn-agent/**']
+    paths:
+      - 'apps/jinn-agent/**'
+      - 'packages/plugin/**'
+      - 'client/packages/harness-layer/**'
+      - 'client/src/solver-types/_swe-rebench-v2-*.ts'
+      - 'client/src/adapters/mech/ipfs.ts'
+      - 'client/src/harnesses/impls/swe-rebench-v2-evaluator/**'
+      - 'client/scripts/bundle-jinn-layer.mjs'
+      - 'client/scripts/stage1-task-creator-acceptance.mjs'
+      - 'client/package.json'
+      - 'client/yarn.lock'
+      - '.github/workflows/jinn-agent-ci.yml'
   push:
     branches: [next, main]
-    paths: ['apps/jinn-agent/**']
+    paths:
+      - 'apps/jinn-agent/**'
+      - 'packages/plugin/**'
+      - 'client/packages/harness-layer/**'
+      - 'client/src/solver-types/_swe-rebench-v2-*.ts'
+      - 'client/src/adapters/mech/ipfs.ts'
+      - 'client/src/harnesses/impls/swe-rebench-v2-evaluator/**'
+      - 'client/scripts/bundle-jinn-layer.mjs'
+      - 'client/scripts/stage1-task-creator-acceptance.mjs'
+      - 'client/package.json'
+      - 'client/yarn.lock'
+      - '.github/workflows/jinn-agent-ci.yml'
   workflow_dispatch:
   schedule:
     - cron: '0 7 * * *'
@@ -61,15 +83,38 @@ jobs:
           ./scripts/run_tests.sh --files "$FILES" -j 4 --file-timeout 1200 -q
 
   cold-stock-e2e:
-    name: Cold-stock e2e (advisory)
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    name: Cold-stock Stage 1 product gate
+    if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    continue-on-error: true
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
-      - name: Cold-stock e2e (network clone; advisory, never pages)
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+      - name: Enable Corepack
+        working-directory: client
+        run: corepack enable
+      - name: Install client dependencies
+        working-directory: client
+        run: yarn install --immutable
+      - name: Build the real jinn-layer and daemon
+        working-directory: client
+        run: yarn build
+      - name: Plugin package boundary, schema, type, test, and build gates
+        working-directory: client
+        run: yarn --cwd ../packages/plugin typecheck && yarn --cwd ../packages/plugin test && yarn --cwd ../packages/plugin build
+      - name: Harness store, process contract, and task-creator privacy gates
+        working-directory: client
+        run: >-
+          yarn vitest run
+          packages/harness-layer/test/contribution-store.test.ts
+          packages/harness-layer/test/process-contract.test.ts
+          test/solver-types/task-creator-session-echo.test.ts
+      - name: Pinned stock-Hermes Stage 1 product journey
+        env:
+          JINN_STAGE1_SKIP_CLIENT_BUILD: '1'
         run: bash scripts/cold-stock-e2e.sh

--- a/apps/jinn-agent/scripts/cold-stock-e2e.sh
+++ b/apps/jinn-agent/scripts/cold-stock-e2e.sh
@@ -1,74 +1,69 @@
 #!/usr/bin/env bash
-# Cold test: install the Jinn plugin into a fresh STOCK upstream Hermes and
-# verify discovery, consent-offer (harness identity + home resolver fall
-# back honestly on a stock host), corpus tools, and the /jinn + /corpus
-# command surface — all wired against a stub jinn-layer (no real corpus
-# writes). No fork files involved: this exercises only the pip-installable
-# `jinn-plugin` package (plugins/jinn/pyproject.toml, entry-point
-# `jinn = "jinn_plugin"` in group `hermes_agent.plugins`).
-#
-# Requires network (clones NousResearch/hermes-agent). If network is
-# unavailable, the register-assertion block below can still be run against
-# a venv that has ONLY the plugin installed — see the adaptation note in
-# .superpowers/sdd/task-7-report.md.
+# Blocking Stage 1 product gate: build the standalone products, install the
+# wheel into pinned stock Hermes, drive the user lifecycle, then let the real
+# task-creator read and advance the same contribution store.
 set -euo pipefail
+
 HERE="$(cd "$(dirname "$0")/.." && pwd)"
-WORK="$(mktemp -d)"; export HERMES_HOME="$WORK/home"; mkdir -p "$HERMES_HOME"
-export JINN_LAYER_BIN="$HERE/scripts/fixtures/jinn-layer-stub"
-export JINN_LAYER_STUB_LOG="$WORK/stub.log"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+CLIENT="$REPO_ROOT/client"
 HERMES_UPSTREAM_SHA="9df5f879b4a5925c0f8f947e7e16ed8e845932c3"
+WORK="$(mktemp -d)"
+export JINN_STAGE1_WORK="$WORK"
+export HOME="$WORK/home"
+export HERMES_HOME="$HOME"
+export NO_COLOR=1
+export JINN_LAYER_BIN="$CLIENT/dist/bin/jinn-layer.js"
+export JINN_LAYER_EPISODES_DIR="$WORK/state/episodes"
+export JINN_LAYER_CAPTURES_DIR="$WORK/state/captures"
+export JINN_LAYER_SKILLS_INSTALL_DIR="$HERMES_HOME/skills"
+export JINN_MINEABLE_STATE_DIR="$WORK/state/mineable"
+mkdir -p "$HOME" "$WORK/state" "$WORK/wheels"
 
 cleanup() { rm -rf "$WORK"; }
 trap cleanup EXIT
+
+NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]')"
+if (( NODE_MAJOR < 22 )); then
+  echo "Stage 1 cold-stock gate requires Node 22+ (found $(node --version))." >&2
+  exit 2
+fi
+
+if [[ "${JINN_STAGE1_SKIP_CLIENT_BUILD:-0}" != "1" ]]; then
+  (
+    cd "$CLIENT"
+    corepack enable
+    yarn install --immutable
+    yarn build
+  )
+fi
+test -x "$JINN_LAYER_BIN"
+"$JINN_LAYER_BIN" contract --json | grep -q '"contractVersion":1'
+
+# Build and install the distributable wheel. Installing the plugin source tree
+# would miss packaging errors and would not represent the user-facing product.
+python3 -m pip wheel --no-deps --wheel-dir "$WORK/wheels" "$HERE/plugins/jinn"
+WHEEL="$(find "$WORK/wheels" -maxdepth 1 -name 'jinn_plugin-*.whl' -print -quit)"
+test -n "$WHEEL"
 
 git init -q "$WORK/upstream"
 git -C "$WORK/upstream" remote add origin https://github.com/NousResearch/hermes-agent
 git -C "$WORK/upstream" fetch -q --depth 1 origin "$HERMES_UPSTREAM_SHA"
 git -C "$WORK/upstream" checkout -q --detach FETCH_HEAD
 test "$(git -C "$WORK/upstream" rev-parse HEAD)" = "$HERMES_UPSTREAM_SHA"
+
 python3 -m venv "$WORK/venv"
 "$WORK/venv/bin/pip" install -q "$WORK/upstream"
-"$WORK/venv/bin/pip" install -q "$HERE/plugins/jinn"
+"$WORK/venv/bin/pip" install -q "$WHEEL"
 
-# 1. discovered + register() runs (import surface); 2. consent inert until
-# set; 3. harness identity + home resolver fall back honestly with no fork
-# env exported (this venv only has stock hermes_cli/hermes_constants).
-"$WORK/venv/bin/python" - <<'PY'
-import jinn_plugin, types
-calls = {"hooks": {}, "tools": [], "cmds": [], "cli": []}
-ctx = types.SimpleNamespace(
-    register_hook=lambda n, cb: calls["hooks"].__setitem__(n, cb),
-    register_tool=lambda **k: calls["tools"].append(k["name"]),
-    register_command=lambda n, **k: calls["cmds"].append(n),
-    register_cli_command=lambda n, **k: calls["cli"].append(n),
+(
+  cd "$WORK/upstream"
+  "$WORK/venv/bin/python" "$HERE/scripts/stage1-stock-product.py"
 )
-jinn_plugin.register(ctx)
-required_hooks = {"on_session_start","pre_llm_call","post_tool_call","post_llm_call","on_session_end"}
-assert required_hooks.issubset(calls["hooks"]), calls
-assert all(callable(calls["hooks"][name]) for name in required_hooks), calls
-assert set(calls["tools"]) == {"corpus_search","corpus_fetch"}, calls
-assert "jinn" in calls["cmds"] and "corpus" in calls["cmds"], calls
-assert "onboarding" in calls["cli"], calls
 
-# Correct import path under a pip install is `jinn_plugin.*` (the package-dir
-# mapping in pyproject.toml maps `jinn_plugin` to `.`) — NOT `plugins.jinn`,
-# which only resolves inside this repo's own tree.
-from jinn_plugin import consent, harness
+(
+  cd "$CLIENT"
+  node scripts/stage1-task-creator-acceptance.mjs
+)
 
-assert harness.harness_name() == "hermes-agent", harness.harness_name()
-print("register ok:", calls)
-PY
-
-# 4. skill install round-trips through the stub jinn-layer contract
-# (extract+verify+write is the layer's job; the plugin only shells out and
-# drops the .jinn-ref marker — thin-fork boundary, Task 4).
-"$WORK/venv/bin/python" - <<'PY'
-from jinn_plugin import skills_install
-path = skills_install.install("stub-ref-001")
-assert path.endswith("stub-skill/SKILL.md"), path
-installed = skills_install.list_installed()
-assert installed == [{"slug": "stub-skill", "ref": "stub-ref-001"}], installed
-print("skill install ok:", path)
-PY
-
-echo "COLD E2E PASS"
+echo "COLD STOCK STAGE 1 PRODUCT GATE PASS"

--- a/apps/jinn-agent/scripts/stage1-stock-product.py
+++ b/apps/jinn-agent/scripts/stage1-stock-product.py
@@ -1,0 +1,642 @@
+#!/usr/bin/env python3
+"""Pinned-stock Hermes product journey using the installed Jinn wheel.
+
+The surrounding shell owns the stock checkout and built artifacts. This driver
+owns the user-visible lifecycle and a local HTTP stand-in for external corpus
+services; the plugin and ``jinn-layer`` process bridge are the real builds.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import importlib.metadata
+import io
+import json
+import os
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import yaml
+
+
+PINNED_HERMES = "9df5f879b4a5925c0f8f947e7e16ed8e845932c3"
+CORPUS_REF = "bafyStage1TddSkill"
+
+
+def require_env(name: str) -> Path:
+    value = os.environ.get(name, "").strip()
+    assert value, f"{name} is required"
+    return Path(value).resolve()
+
+
+WORK = require_env("JINN_STAGE1_WORK")
+HERMES_HOME = require_env("HERMES_HOME")
+LAYER_BIN = require_env("JINN_LAYER_BIN")
+EPISODES_DIR = require_env("JINN_LAYER_EPISODES_DIR")
+CAPTURES_DIR = require_env("JINN_LAYER_CAPTURES_DIR")
+MINEABLE_DIR = require_env("JINN_MINEABLE_STATE_DIR")
+LOCAL_SKILLS_DIR = require_env("JINN_LAYER_SKILLS_INSTALL_DIR")
+
+
+def run(*args: str, cwd: Path | None = None) -> str:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def make_repo(path: Path) -> Path:
+    path.mkdir(parents=True)
+    run("git", "init", "-q", cwd=path)
+    run("git", "config", "user.email", "stage1@example.invalid", cwd=path)
+    run("git", "config", "user.name", "Stage 1", cwd=path)
+    (path / "widget.py").write_text("VALUE = 1\n", encoding="utf-8")
+    run("git", "add", "widget.py", cwd=path)
+    run("git", "commit", "-qm", "fixture", cwd=path)
+    run(
+        "git",
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/acme/widget.git",
+        cwd=path,
+    )
+    return path
+
+
+class CorpusFixture:
+    def __init__(self) -> None:
+        self.unavailable = False
+        self.requests: list[tuple[str, str]] = []
+        self.endpoint = ""
+        self.trace = {
+            "schemaVersion": "jinn.trace-envelope.v0",
+            "session": {
+                "sessionId": "seed:acme/skills/test-driven-development",
+                "capturedAt": "2026-07-04T00:00:00.000Z",
+            },
+            "task": {
+                "summary": "Seed import: acme/skills/test-driven-development",
+                "distributionTags": ["seed-import", "tdd", "refactoring"],
+            },
+            "environment": {
+                "harness": {"name": "jinn-layer-seed-import", "version": "0.1.0"},
+                "model": "none",
+                "tools": [],
+            },
+            "steps": [
+                {
+                    "spanId": "seed-1",
+                    "parentSpanId": None,
+                    "name": "seed:skill-md",
+                    "startTimeUnixNano": "1751587200000000000",
+                    "endTimeUnixNano": "1751587200000000000",
+                    "attributes": {
+                        "skill.md": "# Test-driven development\n\nRed, green, refactor.\n",
+                        "seed.attribution": {
+                            "skill": "acme/skills/test-driven-development",
+                            "source": "https://github.com/acme/skills",
+                            "licence": "MIT",
+                        },
+                    },
+                    "redactedKeys": [],
+                }
+            ],
+            "outcome": {
+                "status": "completed",
+                "verifiabilityTier": "user-accepted",
+            },
+            "cost": {"durationMs": 0},
+            "consent": {"contributionConsent": True, "scrubCompleted": True},
+            "provenance": "imported",
+        }
+        self.trace_bytes = json.dumps(
+            self.trace, separators=(",", ":"), sort_keys=True
+        ).encode()
+        self.trace_sha = hashlib.sha256(self.trace_bytes).hexdigest()
+
+    def envelope(self) -> dict[str, Any]:
+        return {
+            "schemaVersion": "jinn.execution.v1",
+            "solverType": "capture",
+            "role": "solution",
+            "generatedAt": 1_745_978_400,
+            "task": {
+                "cid": "bafyStage1Task",
+                "onchainCreationTx": "0x" + "a" * 64,
+                "onchainCreationBlock": 1,
+                "requestId": "0x" + "b" * 64,
+            },
+            "participant": {
+                "safeAddress": "0x" + "1" * 40,
+                "agentEoa": "0x" + "2" * 40,
+            },
+            "window": {"startTs": 0, "endTs": 1_745_978_400},
+            "executor": {
+                "implName": "stage1-fixture",
+                "implVersion": "1.0.0",
+                "clientGitSha": "stage1",
+                "codeDigest": "sha256:" + "c" * 64,
+                "runtimeBundleDigest": "sha256:" + "d" * 64,
+                "plugins": [],
+                "signingKey": {
+                    "kind": "agent-eoa",
+                    "pubkey": "0x" + "e" * 128,
+                },
+            },
+            "evidenceTier": "self-signed",
+            "attestation": None,
+            "trajectory": None,
+            "artifacts": [
+                {
+                    "artifactType": "jinn.trace-envelope.v0",
+                    "sha256": self.trace_sha,
+                    "access": {"endpoint": self.endpoint, "priceUsdc": "0"},
+                }
+            ],
+            "payload": {},
+            "signature": {
+                "algo": "secp256k1",
+                "signer": "0x" + "2" * 40,
+                "hash": "0x" + "e" * 64,
+                "sig": "0x" + "f" * 130,
+            },
+        }
+
+
+def start_corpus_server(fixture: CorpusFixture) -> tuple[ThreadingHTTPServer, threading.Thread]:
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, _format: str, *_args: object) -> None:
+            return
+
+        def write_json(self, status: int, body: object) -> None:
+            payload = json.dumps(body).encode()
+            self.send_response(status)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+            parsed = urlparse(self.path)
+            fixture.requests.append(("GET", parsed.path))
+            if parsed.path == "/ready":
+                if fixture.unavailable:
+                    self.write_json(503, {"ready": False})
+                else:
+                    self.write_json(200, {"ready": True})
+                return
+            if parsed.path == "/capture-meta":
+                if fixture.unavailable:
+                    self.write_json(503, {"error": "fixture unavailable"})
+                    return
+                query = " ".join(parse_qs(parsed.query).get("q", [])).lower()
+                hits: list[dict[str, Any]] = []
+                if "tdd-style" in query or "refactoring" in query:
+                    hits.append(
+                        {
+                            "manifestCid": CORPUS_REF,
+                            "taskSummary": "Seed import: acme/skills/test-driven-development",
+                            "tags": ["seed-import", "tdd", "refactoring"],
+                            "provenance": "imported",
+                            "verifiabilityTier": "user-accepted",
+                        }
+                    )
+                self.write_json(200, hits)
+                return
+            if parsed.path == f"/ipfs/{CORPUS_REF}":
+                self.write_json(200, fixture.envelope())
+                return
+            if parsed.path == f"/v1/artifacts/{fixture.trace_sha}/content":
+                self.send_response(200)
+                self.send_header("content-type", "application/octet-stream")
+                self.send_header("content-length", str(len(fixture.trace_bytes)))
+                self.end_headers()
+                self.wfile.write(fixture.trace_bytes)
+                return
+            self.write_json(404, {"error": "not found"})
+
+        def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+            parsed = urlparse(self.path)
+            fixture.requests.append(("POST", parsed.path))
+            length = int(self.headers.get("content-length", "0"))
+            if length:
+                self.rfile.read(length)
+            if parsed.path == "/graphql":
+                self.write_json(200, {"data": {"envelopes": {"items": []}}})
+                return
+            self.write_json(404, {"error": "not found"})
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    fixture.endpoint = f"http://127.0.0.1:{server.server_port}"
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+def assert_installed_product() -> None:
+    assert run("git", "rev-parse", "HEAD", cwd=Path.cwd()) == PINNED_HERMES
+    assert LAYER_BIN.is_file() and os.access(LAYER_BIN, os.X_OK)
+    contract = json.loads(run(str(LAYER_BIN), "contract", "--json"))
+    assert contract == {"contractVersion": 1}
+
+    distribution = importlib.metadata.distribution("jinn-plugin")
+    assert distribution.version == "0.1.0"
+    entrypoints = importlib.metadata.entry_points(group="hermes_agent.plugins")
+    assert any(ep.name == "jinn" and ep.value == "jinn_plugin" for ep in entrypoints)
+
+
+def assert_disabled_is_stock_silent() -> None:
+    import hermes_cli.plugins as plugins_module
+    from hermes_cli.plugins import PluginManager
+
+    disabled_home = WORK / "disabled-home"
+    disabled_home.mkdir()
+    (disabled_home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": ["jinn"], "disabled": ["jinn"]}}),
+        encoding="utf-8",
+    )
+    original_home = os.environ["HERMES_HOME"]
+    os.environ["HERMES_HOME"] = str(disabled_home)
+    try:
+        manager = PluginManager()
+        plugins_module._plugin_manager = manager
+        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(
+            io.StringIO()
+        ):
+            manager.discover_and_load()
+        loaded = {
+            (plugin.manifest.key or plugin.manifest.name): plugin
+            for plugin in manager._plugins.values()
+        }
+        plugin = loaded.get("jinn")
+        assert plugin is not None and plugin.enabled is False
+        assert plugin.hooks_registered == []
+        assert plugin.tools_registered == []
+        assert plugin.commands_registered == []
+        assert not (disabled_home / "jinn").exists()
+    finally:
+        os.environ["HERMES_HOME"] = original_home
+
+
+def register_product(jinn: Any) -> dict[str, Any]:
+    calls: dict[str, Any] = {"hooks": {}, "tools": {}, "commands": {}, "cli": {}}
+
+    class Context:
+        def register_hook(self, name: str, callback: Any) -> None:
+            calls["hooks"][name] = callback
+
+        def register_tool(self, name: str, handler: Any, **kwargs: Any) -> None:
+            calls["tools"][name] = {"handler": handler, **kwargs}
+
+        def register_command(self, name: str, handler: Any, **kwargs: Any) -> None:
+            calls["commands"][name] = {"handler": handler, **kwargs}
+
+        def register_cli_command(self, name: str, handler_fn: Any, **kwargs: Any) -> None:
+            calls["cli"][name] = {"handler": handler_fn, **kwargs}
+
+    jinn.register(Context())
+    assert {
+        "on_session_start",
+        "pre_llm_call",
+        "post_tool_call",
+        "post_llm_call",
+        "on_session_end",
+    }.issubset(calls["hooks"])
+    assert {"corpus_search", "corpus_fetch"}.issubset(calls["tools"])
+    assert {"jinn", "corpus"}.issubset(calls["commands"])
+    return calls
+
+
+def reset_session_runtime(jinn: Any) -> None:
+    jinn.buf.reset()
+    jinn.distill.reset()
+    jinn._reset_contract_state()
+    jinn._reset_session_state()
+
+
+def finish_session(
+    jinn: Any,
+    *,
+    session_id: str,
+    task_id: str,
+    repo: Path,
+    message: str,
+    expected_pickup: bool,
+    expected_publication: str,
+    mutate: str | None = None,
+    install_ref: bool = False,
+) -> tuple[str, str | None]:
+    jinn._on_session_start(session_id=session_id, cwd=str(repo), platform="cli")
+    pickup_stderr = io.StringIO()
+    with contextlib.redirect_stderr(pickup_stderr):
+        pickup = jinn._on_pre_llm_call(
+            session_id=session_id,
+            task_id=task_id,
+            user_message=message,
+            is_first_turn=True,
+            model="stage1-model",
+            platform="cli",
+        )
+    if expected_pickup:
+        assert pickup and "[jinn corpus] Relevant to this task" in pickup["context"]
+        marker = pickup_stderr.getvalue()
+        assert "◇ corpus" in marker and "surfaced" in marker, marker
+        if install_ref:
+            receipt = jinn._handle_jinn(
+                f"skills install {CORPUS_REF}",
+                session_id=session_id,
+                task_id=task_id,
+            )
+            assert receipt.startswith("installed —"), receipt
+    else:
+        assert pickup is None
+
+    current = jinn._handle_jinn("session", session_id=session_id, task_id=task_id)
+    assert "capture active" in current.lower(), current
+    assert f"publication {expected_publication}" in current, current
+
+    if mutate:
+        target = repo / "widget.py"
+        target.write_text(target.read_text(encoding="utf-8") + f"{mutate}\n", encoding="utf-8")
+
+    jinn._on_post_tool_call(
+        tool_name="terminal",
+        args={"command": "pytest tests/test_widget.py"},
+        result={"exit_code": 0, "stdout": "1 passed"},
+        session_id=session_id,
+        task_id=task_id,
+        tool_call_id=f"call-{session_id}",
+        duration_ms=8,
+    )
+    jinn._on_post_llm_call(
+        session_id=session_id,
+        task_id=task_id,
+        assistant_response="Implemented and verified the change.",
+        input_tokens=21,
+        output_tokens=13,
+    )
+    summary = io.StringIO()
+    with contextlib.redirect_stderr(summary):
+        jinn._on_session_end(
+            session_id=session_id,
+            task_id=task_id,
+            completed=True,
+            skills_loadout=[CORPUS_REF] if install_ref else [],
+        )
+    return summary.getvalue(), pickup["context"] if pickup else None
+
+
+def read_store_records() -> list[dict[str, Any]]:
+    store = json.loads((MINEABLE_DIR / "mineable-traces.json").read_text(encoding="utf-8"))
+    assert store["schemaVersion"] == "jinn.contribution-store.v2"
+    return list(store["records"].values())
+
+
+def write_local_skill_provenance(session_id: str) -> None:
+    """Install a deterministic output of the already-local distillation rail."""
+    target = LOCAL_SKILLS_DIR / "stage1-local-pattern"
+    target.mkdir(parents=True, exist_ok=True)
+    target.joinpath("SKILL.md").write_text(
+        """---
+name: stage1-local-pattern
+description: Use the locally distilled Stage 1 pattern. Not for unrelated work.
+license: null
+metadata:
+  jinn:
+    schema: jinn.skill.v1
+    distribution: coding
+    verifiabilityTier: user-accepted
+    distilledFrom: 1
+    provenance:
+      - local-capture:%s
+    distilledAt: "2026-07-15T00:00:00.000Z"
+    skillKind: strategic-pattern
+---
+## When to use
+
+Use this for the Stage 1 acceptance fixture.
+"""
+        % session_id,
+        encoding="utf-8",
+    )
+
+
+def main() -> None:
+    assert_installed_product()
+    assert_disabled_is_stock_silent()
+
+    import jinn_plugin as jinn
+
+    assert Path(jinn.__file__).resolve().is_relative_to(Path(sys.prefix).resolve())
+    register_product(jinn)
+
+    fixture = CorpusFixture()
+    server, thread = start_corpus_server(fixture)
+    os.environ["JINN_DISCOVERY_URL"] = fixture.endpoint
+    os.environ["JINN_IPFS_GATEWAY_URL"] = fixture.endpoint
+
+    search_probe = subprocess.run(
+        [str(LAYER_BIN), "corpus", "search", "tdd-style", "--json", "--limit", "3"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert search_probe.returncode == 0, (
+        f"real jinn-layer corpus search failed: stdout={search_probe.stdout!r} "
+        f"stderr={search_probe.stderr!r} requests={fixture.requests!r}"
+    )
+    search_hits = json.loads(search_probe.stdout)
+    assert search_hits and search_hits[0]["ref"] == CORPUS_REF, (
+        f"real jinn-layer corpus search returned no fixture: "
+        f"stdout={search_probe.stdout!r} stderr={search_probe.stderr!r} "
+        f"requests={fixture.requests!r}"
+    )
+    get_probe = subprocess.run(
+        [str(LAYER_BIN), "corpus", "get", CORPUS_REF, "--json"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert get_probe.returncode == 0, (
+        f"real jinn-layer corpus get failed: stdout={get_probe.stdout!r} "
+        f"stderr={get_probe.stderr!r} requests={fixture.requests!r}"
+    )
+    assert json.loads(get_probe.stdout)["ref"] == CORPUS_REF
+
+    legacy = HERMES_HOME / "jinn" / "pending" / "legacy-raw-trace.json"
+    legacy.parent.mkdir(parents=True, exist_ok=True)
+    legacy.write_text('{"raw":"LEGACY_RAW_TRACE_SENTINEL"}\n', encoding="utf-8")
+
+    work_repo = make_repo(WORK / "oss-work")
+    clean_repo = make_repo(WORK / "oss-clean")
+    try:
+        reset_session_runtime(jinn)
+        jinn.consent.save_state(False, previewed=False)
+        share_off_summary, _ = finish_session(
+            jinn,
+            session_id="stage1-share-off",
+            task_id="task-share-off",
+            repo=work_repo,
+            message="Tdd-style refactoring for this widget",
+            expected_pickup=True,
+            expected_publication="OFF",
+            mutate="SECRET_ACCEPTED_DIFF_OFF = True",
+            install_ref=True,
+        )
+        assert "captured" in share_off_summary.lower()
+        assert "contribution recorded" in share_off_summary.lower(), share_off_summary
+        assert list(CAPTURES_DIR.glob("*.json")), "local distillation tee missing"
+        write_local_skill_provenance("stage1-share-off")
+
+        jinn.consent.save_state(True, previewed=False)
+        share_on_summary, _ = finish_session(
+            jinn,
+            session_id="stage1-share-on",
+            task_id="task-share-on",
+            repo=work_repo,
+            message="Investigate quasar unobtainium",
+            expected_pickup=False,
+            expected_publication="ON",
+            mutate="SECRET_ACCEPTED_DIFF_ON = True",
+        )
+        assert "nothing relevant found" in share_on_summary.lower()
+        records_before_preview = read_store_records()
+        share_on = next(
+            row for row in records_before_preview if row["candidate"]["publishMinedTasksConsent"]
+        )
+        assert share_on["publicationState"] == "preview-required"
+        assert "preview-required" in jinn._handle_jinn("history").lower()
+
+        preview = jinn._handle_jinn("preview")
+        assert "preview acknowledged" in preview.lower()
+        assert all(
+            method != "POST" or path == "/graphql"
+            for method, path in fixture.requests
+        ), f"publication happened before the task-creator ran: {fixture.requests!r}"
+        records_after_preview = read_store_records()
+        assert next(
+            row for row in records_after_preview if row["recordId"] == share_on["recordId"]
+        )["publicationState"] == "queued"
+        history_after_preview = jinn._handle_jinn("history")
+        assert "queued" in history_after_preview.lower()
+        assert "stage1-local-pattern" in history_after_preview, history_after_preview
+
+        fixture.unavailable = True
+        unavailable_summary, _ = finish_session(
+            jinn,
+            session_id="stage1-corpus-unavailable",
+            task_id="task-corpus-unavailable",
+            repo=clean_repo,
+            message="Offline corpus investigation",
+            expected_pickup=False,
+            expected_publication="ON",
+        )
+        fixture.unavailable = False
+        assert "nothing relevant found" in unavailable_summary.lower()
+
+        real_layer = os.environ["JINN_LAYER_BIN"]
+        os.environ["JINN_LAYER_BIN"] = str(WORK / "missing-jinn-layer")
+        reset_session_runtime(jinn)
+        missing_summary, _ = finish_session(
+            jinn,
+            session_id="stage1-missing-layer",
+            task_id="task-missing-layer",
+            repo=clean_repo,
+            message="Preserve local capture",
+            expected_pickup=False,
+            expected_publication="ON",
+        )
+        assert "captured locally" in missing_summary.lower()
+        assert "process bridge degraded" in missing_summary.lower()
+        os.environ["JINN_LAYER_BIN"] = real_layer
+
+        class IncompatibleRunner:
+            def __call__(
+                self, argv: list[str], *, input: str | None = None
+            ) -> tuple[int, str]:
+                del input
+                if argv[1:] == ["contract", "--json"]:
+                    return 0, '{"contractVersion":999}'
+                return 1, "incompatible layer"
+
+        jinn._runner = IncompatibleRunner()
+        reset_session_runtime(jinn)
+        incompatible_summary, _ = finish_session(
+            jinn,
+            session_id="stage1-incompatible-layer",
+            task_id="task-incompatible-layer",
+            repo=clean_repo,
+            message="Preserve incompatible capture",
+            expected_pickup=False,
+            expected_publication="ON",
+        )
+        assert "captured locally" in incompatible_summary.lower()
+        assert "process bridge degraded" in incompatible_summary.lower()
+        jinn._runner = None
+
+        assert legacy.read_text(encoding="utf-8") == '{"raw":"LEGACY_RAW_TRACE_SENTINEL"}\n'
+        episodes = [
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in sorted(EPISODES_DIR.glob("*.episode.json"))
+        ]
+        assert len(episodes) >= 5
+        for episode in episodes:
+            assert episode["schemaVersion"] == "jinn.episode.v1"
+            assert episode["episodeId"]
+            assert episode["session"]["capturedAt"].endswith("Z")
+            assert episode["trajectory"]
+            assert all(str(span["startTimeUnixNano"]).isdigit() for span in episode["trajectory"])
+
+        records = read_store_records()
+        assert len(records) == 2, records
+        episode_ids = {episode["episodeId"] for episode in episodes}
+        assert {row["candidate"]["sourceId"] for row in records}.issubset(episode_ids)
+        assert any(not row["candidate"]["publishMinedTasksConsent"] for row in records)
+        assert any(row["candidate"]["publishMinedTasksConsent"] for row in records)
+
+        result = {
+            "episodeIds": sorted(episode_ids),
+            "sessions": [
+                {
+                    "episodeId": episode["episodeId"],
+                    "sessionId": episode["session"]["sessionId"],
+                    "capturedAt": episode["session"]["capturedAt"],
+                }
+                for episode in episodes
+            ],
+            "shareOffRecordId": next(
+                row["recordId"]
+                for row in records
+                if not row["candidate"]["publishMinedTasksConsent"]
+            ),
+            "shareOnRecordId": next(
+                row["recordId"]
+                for row in records
+                if row["candidate"]["publishMinedTasksConsent"]
+            ),
+            "legacyPending": str(legacy),
+        }
+        (WORK / "stock-product-result.json").write_text(
+            json.dumps(result, indent=2) + "\n", encoding="utf-8"
+        )
+    finally:
+        jinn._runner = None
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    print("STOCK PRODUCT JOURNEY PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/jinn-agent/tests/plugins/test_jinn_stage1_acceptance_gate.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_stage1_acceptance_gate.py
@@ -1,0 +1,59 @@
+"""Static contract for the blocking Stage 1 cold-stock product gate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+AGENT_ROOT = REPO_ROOT / "apps" / "jinn-agent"
+
+
+def test_cold_stock_script_uses_built_products_and_both_lifecycle_drivers():
+    script = (AGENT_ROOT / "scripts" / "cold-stock-e2e.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert "9df5f879b4a5925c0f8f947e7e16ed8e845932c3" in script
+    assert "pip wheel" in script
+    assert "dist/bin/jinn-layer.js" in script
+    assert "scripts/fixtures/jinn-layer-stub" not in script
+    assert "stage1-stock-product.py" in script
+    assert "stage1-task-creator-acceptance.mjs" in script
+
+
+def test_stage1_gate_is_blocking_for_every_product_boundary():
+    workflow = yaml.safe_load(
+        (REPO_ROOT / ".github" / "workflows" / "jinn-agent-ci.yml").read_text(
+            encoding="utf-8"
+        )
+    )
+    triggers = workflow[True]
+    pull_request_paths = triggers["pull_request"]["paths"]
+    gate = workflow["jobs"]["cold-stock-e2e"]
+
+    assert "apps/jinn-agent/**" in pull_request_paths
+    assert "packages/plugin/**" in pull_request_paths
+    assert "client/packages/harness-layer/**" in pull_request_paths
+    assert gate["name"] == "Cold-stock Stage 1 product gate"
+    assert gate.get("continue-on-error") is not True
+    assert "pull_request" in gate["if"]
+    assert "push" in gate["if"]
+    rendered_steps = "\n".join(
+        str(step.get("run", "")) for step in gate["steps"]
+    )
+    assert "yarn build" in rendered_steps
+    assert "packages/plugin" in rendered_steps
+    assert "process-contract.test.ts" in rendered_steps
+    assert "task-creator-session-echo.test.ts" in rendered_steps
+    assert "cold-stock-e2e.sh" in rendered_steps
+
+
+def test_acceptance_drivers_are_repo_owned_executables():
+    python_driver = AGENT_ROOT / "scripts" / "stage1-stock-product.py"
+    daemon_driver = REPO_ROOT / "client" / "scripts" / "stage1-task-creator-acceptance.mjs"
+
+    assert python_driver.is_file()
+    assert daemon_driver.is_file()

--- a/apps/jinn-agent/tests/plugins/test_jinn_stock_load.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_stock_load.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 COLD_STOCK = REPO_ROOT / "scripts" / "cold-stock-e2e.sh"
+STOCK_DRIVER = REPO_ROOT / "scripts" / "stage1-stock-product.py"
 PINNED_HERMES_SHA = "9df5f879b4a5925c0f8f947e7e16ed8e845932c3"
 
 
@@ -30,7 +31,9 @@ def test_plugin_imports_with_stock_banner(monkeypatch):
 
 def test_cold_stock_e2e_pins_upstream_and_checks_required_hooks_by_subset():
     script = COLD_STOCK.read_text(encoding="utf-8")
+    driver = STOCK_DRIVER.read_text(encoding="utf-8")
     assert PINNED_HERMES_SHA in script
     assert "git clone --depth 1" not in script
-    assert "required_hooks.issubset" in script
-    assert "post_llm_call" in script
+    assert "stage1-stock-product.py" in script
+    assert ".issubset(calls[\"hooks\"])" in driver
+    assert "post_llm_call" in driver

--- a/client/scripts/stage1-task-creator-acceptance.mjs
+++ b/client/scripts/stage1-task-creator-acceptance.mjs
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+/**
+ * Stage 1 daemon-side acceptance over the contribution candidate written by
+ * the stock Python host. External evaluation/publication services are local
+ * fakes; the task-creator miner, stores, privacy projection and jinn-layer
+ * history binary are the real build.
+ */
+
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { readFile, stat } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { join, resolve } from 'node:path';
+import { promisify } from 'node:util';
+
+import { mineSessionEchoes } from '../dist/solver-types/_swe-rebench-v2-session-echo.js';
+import { MineableTraceStore } from '../dist/solver-types/_swe-rebench-v2-mineable-store.js';
+import {
+  EVAL_SEMANTICS_VERSION,
+  ValidatedPoolStore,
+} from '../dist/solver-types/_swe-rebench-v2-validated-pool.js';
+import { MintedPoolStore } from '../dist/solver-types/_swe-rebench-v2-minted-pool.js';
+
+const execFileAsync = promisify(execFile);
+const work = resolve(requiredEnv('JINN_STAGE1_WORK'));
+const contributionStateDir = resolve(requiredEnv('JINN_MINEABLE_STATE_DIR'));
+const layerBin = resolve(requiredEnv('JINN_LAYER_BIN'));
+const result = JSON.parse(await readFile(join(work, 'stock-product-result.json'), 'utf8'));
+
+function requiredEnv(name) {
+  const value = process.env[name]?.trim();
+  assert.ok(value, `${name} is required`);
+  return value;
+}
+
+const REPO = 'acme/widget';
+const SOURCE_INSTANCE = 'acme__widget-1';
+const SOURCE_TASK = {
+  instance_id: SOURCE_INSTANCE,
+  hf_dataset: 'nebius/SWE-rebench-leaderboard',
+  hf_split: '2024_06',
+  repo: REPO,
+  base_commit: 'sourcebase123',
+  patch: 'source-gold-patch',
+  test_patch: 'diff --git a/tests/test_widget.py',
+  language: 'python',
+};
+const SOURCE_HF_ROW = {
+  instance_id: SOURCE_INSTANCE,
+  repo: REPO,
+  image_name: 'acme/widget:img',
+  FAIL_TO_PASS: ['tests/test_widget.py::test_fix'],
+  PASS_TO_PASS: ['tests/test_widget.py::test_other'],
+  test_patch: 'diff --git a/tests/test_widget.py',
+  install_config: {
+    test_cmd: 'pytest tests/test_widget.py',
+    log_parser: 'parse_log_pytest',
+    install: ['pip install -e .'],
+  },
+};
+
+function successfulRunner() {
+  let call = 0;
+  return {
+    async runEval() {
+      const phase = call++ % 4;
+      if (phase === 0 || phase === 3) {
+        return {
+          passed: ['tests/test_widget.py::test_other'],
+          failed: ['tests/test_widget.py::test_fix'],
+          passed_match: false,
+        };
+      }
+      return {
+        passed: ['tests/test_widget.py::test_fix', 'tests/test_widget.py::test_other'],
+        failed: [],
+        passed_match: true,
+        ...(phase === 2 ? { imageDigest: `sha256:${'d'.repeat(64)}` } : {}),
+      };
+    },
+  };
+}
+
+const uploads = [];
+const publicationServer = createServer((request, response) => {
+  const chunks = [];
+  request.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+  request.on('end', () => {
+    const body = Buffer.concat(chunks);
+    if (request.method === 'POST' && request.url?.startsWith('/api/v0/add')) {
+      uploads.push({ url: request.url, body });
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end('{"Hash":"bafyStage1Published"}\n');
+      return;
+    }
+    response.writeHead(404);
+    response.end('not found');
+  });
+});
+await new Promise((resolveListen) => publicationServer.listen(0, '127.0.0.1', resolveListen));
+const address = publicationServer.address();
+assert.ok(address && typeof address === 'object');
+const publicationUrl = `http://127.0.0.1:${address.port}`;
+
+const daemonStateDir = join(work, 'task-creator-state');
+const validatedStore = new ValidatedPoolStore({ stateDir: daemonStateDir });
+const mintedStore = new MintedPoolStore({ stateDir: daemonStateDir });
+const mineableStore = new MineableTraceStore({ stateDir: contributionStateDir });
+await validatedStore.record(SOURCE_INSTANCE, {
+  scorable: true,
+  reason: 'gold-patch-resolves',
+  checkedAt: '2026-07-15T00:00:00.000Z',
+  rowHash: 'sha256:stage1',
+  imageName: SOURCE_HF_ROW.image_name,
+  imageDigest: `sha256:${'e'.repeat(64)}`,
+}, EVAL_SEMANTICS_VERSION);
+
+const hfFetcher = {
+  async fetchTaskRow(args) {
+    assert.equal(args.instance_id, SOURCE_INSTANCE);
+    return SOURCE_HF_ROW;
+  },
+};
+
+function deps(runner, { publish, isPublic = async () => true }) {
+  return {
+    stateDir: daemonStateDir,
+    ipfsRegistryUrl: publicationUrl,
+    ipfsGatewayUrl: publicationUrl,
+    validatedStore,
+    mintedStore,
+    hfFetcher,
+    runner,
+    upstreamRepoDir: daemonStateDir,
+    publicRepoChecker: { isPublic },
+    minterSafe: '0x00000000000000000000000000000000000000aa',
+    operatorSafe: '0x00000000000000000000000000000000000000bb',
+    publish,
+    mineableStore,
+    pool: [SOURCE_TASK],
+  };
+}
+
+async function layerJson(...args) {
+  const { stdout } = await execFileAsync(layerBin, args, {
+    env: process.env,
+    maxBuffer: 4 * 1024 * 1024,
+  });
+  return JSON.parse(stdout);
+}
+
+function candidate(sourceId, overrides = {}) {
+  return {
+    sourceId,
+    kind: 'harness-session',
+    repo: REPO,
+    baseCommit: 'a'.repeat(40),
+    acceptedDiff: `SECRET_ACCEPTED_DIFF_${sourceId}`,
+    testRuns: [],
+    intermediateFailureDiffs: [`SECRET_FAILURE_${sourceId}`],
+    skillEvents: [{ skill: `SECRET_SKILL_${sourceId}`, action: 'loaded' }],
+    publishMinedTasksConsent: true,
+    createdAt: '2026-07-15T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+try {
+  await stat(layerBin);
+  let records = await mineableStore.list();
+  assert.equal(records.length, 2, 'daemon did not read the two Python-written candidates');
+  const shareOff = records.find((row) => row.recordId === result.shareOffRecordId);
+  const shareOn = records.find((row) => row.recordId === result.shareOnRecordId);
+  assert.ok(shareOff && shareOn);
+  assert.equal(shareOff.publicationState, 'disabled');
+  assert.equal(shareOn.publicationState, 'queued');
+  assert.equal(shareOff.candidate.sourceId, result.shareOffRecordId);
+  assert.equal(shareOn.candidate.sourceId, result.shareOnRecordId);
+  const shareOnSession = result.sessions.find((row) => row.sessionId === 'stage1-share-on');
+  assert.ok(shareOnSession);
+  assert.equal(shareOn.candidate.sourceId, shareOnSession.episodeId);
+
+  // With no publication sidecar, both records still mint locally and nothing
+  // leaves the machine. The share-enabled record remains durably queued.
+  const localTick = await mineSessionEchoes(deps(successfulRunner(), { publish: false }));
+  assert.equal(localTick.admitted.length, 2);
+  assert.equal(uploads.length, 0);
+  assert.deepEqual(await mineableStore.get(result.shareOffRecordId).then((row) => ({
+    localState: row?.localState,
+    publicationState: row?.publicationState,
+  })), { localState: 'minted', publicationState: 'disabled' });
+  assert.deepEqual(await mineableStore.get(result.shareOnRecordId).then((row) => ({
+    localState: row?.localState,
+    publicationState: row?.publicationState,
+  })), { localState: 'minted', publicationState: 'queued' });
+
+  const queuedHistory = await layerJson('history', '--json');
+  assert.equal(queuedHistory.contractVersion, 1);
+  assert.equal(queuedHistory.status, 'degraded');
+  assert.match(queuedHistory.reason ?? '', /predate activity or eligibility/);
+  const queuedHistoryText = JSON.stringify(queuedHistory);
+  assert.match(queuedHistoryText, /queued/);
+  const queuedEntry = queuedHistory.value.entries.find(
+    (entry) => entry.sessionId === shareOnSession.sessionId,
+  );
+  assert.ok(queuedEntry);
+  assert.equal(queuedEntry.capturedAt, shareOnSession.capturedAt);
+  assert.equal(queuedEntry.contributionState.status, 'queued');
+
+  // Once the acknowledged candidate has a publication worker, D5 is checked
+  // immediately before the one outbound public-task artifact.
+  const publicChecks = [];
+  const publishTick = await mineSessionEchoes(deps(successfulRunner(), {
+    publish: true,
+    isPublic: async (repo) => {
+      publicChecks.push(repo);
+      return true;
+    },
+  }));
+  assert.ok(publishTick.admitted.length >= 1);
+  assert.deepEqual(publicChecks, [REPO]);
+  assert.equal(uploads.length, 1);
+  const published = await mineableStore.get(result.shareOnRecordId);
+  assert.equal(published?.localState, 'minted');
+  assert.equal(published?.publicationState, 'published');
+  assert.equal(published?.publicationRef, 'ipfs://bafyStage1Published');
+
+  const outbound = uploads[0].body.toString('utf8');
+  for (const record of records) {
+    assert.ok(!outbound.includes(record.candidate.sourceId));
+    assert.ok(!outbound.includes(record.candidate.acceptedDiff));
+    for (const failure of record.candidate.intermediateFailureDiffs) {
+      assert.ok(!outbound.includes(failure));
+    }
+    for (const skill of record.candidate.skillEvents) {
+      assert.ok(!outbound.includes(skill.skillRef));
+    }
+  }
+  assert.ok(!outbound.includes('LEGACY_RAW_TRACE_SENTINEL'));
+
+  const publishedHistory = await layerJson('history', '--json');
+  const publishedHistoryText = JSON.stringify(publishedHistory);
+  assert.match(publishedHistoryText, /published/);
+  const publishedEntry = publishedHistory.value.entries.find(
+    (entry) => entry.sessionId === shareOnSession.sessionId,
+  );
+  assert.equal(publishedEntry?.capturedAt, shareOnSession.capturedAt);
+  assert.equal(publishedEntry?.contributionState.status, 'published');
+  assert.equal(publishedEntry?.contributionState.anchorRef, 'ipfs://bafyStage1Published');
+  assert.ok(!publishedHistoryText.includes('SECRET_ACCEPTED_DIFF'));
+  await assert.rejects(
+    () => mineableStore.veto(result.shareOnRecordId),
+    /published and immutable/,
+  );
+
+  await mineableStore.append(candidate('stage1-veto-candidate'));
+  assert.equal((await mineableStore.get('stage1-veto-candidate'))?.publicationState, 'queued');
+  await mineableStore.veto('stage1-veto-candidate');
+  const uploadsBeforeVetoTick = uploads.length;
+  const vetoTick = await mineSessionEchoes(deps(successfulRunner(), { publish: true }));
+  assert.equal(vetoTick.discovered, 1);
+  assert.equal(vetoTick.admitted.length, 1, 'veto must not suppress useful local minting');
+  assert.equal(uploads.length, uploadsBeforeVetoTick);
+  assert.deepEqual(await mineableStore.get('stage1-veto-candidate').then((row) => ({
+    localState: row?.localState,
+    publicationState: row?.publicationState,
+  })), { localState: 'minted', publicationState: 'vetoed' });
+
+  await mineableStore.append(candidate('stage1-private-candidate'));
+  const privateChecks = [];
+  const privateTick = await mineSessionEchoes(deps(successfulRunner(), {
+    publish: true,
+    isPublic: async (repo) => {
+      privateChecks.push(repo);
+      return false;
+    },
+  }));
+  assert.deepEqual(privateChecks, [REPO]);
+  assert.match(privateTick.rejected[0]?.reason ?? '', /not public/);
+  assert.equal(uploads.length, uploadsBeforeVetoTick);
+  assert.deepEqual(await mineableStore.get('stage1-private-candidate').then((row) => ({
+    localState: row?.localState,
+    publicationState: row?.publicationState,
+  })), { localState: 'minted', publicationState: 'queued' });
+
+  await mineableStore.append(candidate('stage1-sidecar-absent'));
+  await mineSessionEchoes(deps(successfulRunner(), { publish: false }));
+  assert.deepEqual(await mineableStore.get('stage1-sidecar-absent').then((row) => ({
+    localState: row?.localState,
+    publicationState: row?.publicationState,
+  })), { localState: 'minted', publicationState: 'queued' });
+  assert.equal(uploads.length, uploadsBeforeVetoTick);
+
+  const contributionLedger = await layerJson('contribution', 'ledger', '--json');
+  const contributionLedgerText = JSON.stringify(contributionLedger);
+  assert.match(contributionLedgerText, /vetoed/);
+  assert.match(contributionLedgerText, /queued/);
+
+  const disabled = await layerJson('contribution', 'disable', '--json');
+  assert.equal(disabled.contractVersion, 1);
+  assert.equal(disabled.status, 'ok');
+  assert.equal((await mineableStore.get('stage1-private-candidate'))?.publicationState, 'disabled');
+  assert.equal((await mineableStore.get('stage1-sidecar-absent'))?.publicationState, 'disabled');
+  assert.equal((await mineableStore.get('stage1-veto-candidate'))?.publicationState, 'vetoed');
+
+  const legacy = await readFile(result.legacyPending, 'utf8');
+  assert.equal(legacy, '{"raw":"LEGACY_RAW_TRACE_SENTINEL"}\n');
+  console.log('TASK CREATOR ACCEPTANCE PASS');
+} finally {
+  await new Promise((resolveClose, rejectClose) => publicationServer.close((error) => {
+    if (error) rejectClose(error);
+    else resolveClose();
+  }));
+}


### PR DESCRIPTION
Refs #1666

## What changed

- turns the pinned stock-Hermes run from an advisory stub check into a blocking Stage 1 product gate
- installs the built standalone Jinn wheel into unmodified Hermes at `9df5f879b4a5925c0f8f947e7e16ed8e845932c3`
- drives the real `jinn-layer`, contribution store, task creator, privacy projection, session/history UI, and failure fallbacks across one shared product journey
- expands CI path coverage and runs package-boundary, schema, contract, locking, migration, veto, publication, and privacy regressions before the cold-stock journey

## Product proof

The gate covers install, OSS pickup, visibly marked suggestions, complete local capture, the local distillation tee and skill provenance, local contribution recording/minting, the one-time sanitized preview, public-repository publication, veto and private-repository behavior, `/jinn session`, `/jinn history`, missing/incompatible sidecars, disabled-plugin silence, and preservation of legacy raw pending traces without publication.

External corpus, evaluation, storage, and publication services are local deterministic seams. The plugin wheel, stock Hermes host, `jinn-layer`, stores, privacy projection, and task-creator workflow are the real built products.

## Verification

- 287 Jinn Python plugin tests
- 59 focused harness/process-contract/task-creator tests
- 118 standalone plugin package tests, plus typecheck and build
- pinned cold-stock product journey: `STOCK PRODUCT JOURNEY PASS`
- daemon acceptance: `TASK CREATOR ACCEPTANCE PASS`
- aggregate blocking gate: `COLD STOCK STAGE 1 PRODUCT GATE PASS`
