### PR TITLE
feat(autopilot): structured stuck-PR report + deterministic needs-human escalation

### DIFF
--- a/packages/autopilot/scripts/run-autopilot.ts
+++ b/packages/autopilot/scripts/run-autopilot.ts
@@ -19,6 +19,7 @@ import { deriveInFlight, listTaskWorktrees } from '../src/dispatcher/state.js';
 import { syncReviewLabels } from '../src/dispatcher/label-sweep.js';
 import { syncDrift } from '../src/dispatcher/drift-sweep.js';
 import { syncMerges } from '../src/dispatcher/merge-sweep.js';
+import { escalateStuckPrs } from '../src/dispatcher/stuck-escalation.js';
 import { dispatchIssue } from '../src/dispatcher/dispatch.js';
 import { SESSIONS_LOG_DIR } from '../src/dispatcher/session-log.js';
 import { GhPrSource } from '../src/dispatcher/pr-source.js';
@@ -740,6 +741,23 @@ async function main(): Promise<void> {
           }
           for (const s of mr.skipped) {
             console.log(`[autopilot] merge (waiting/needs a human): ${s}`);
+          }
+          // Stage A: make stuck PRs (conflict / still-behind) visible on the
+          // board — label review:needs-human + linked-issue Blocked on: Human +
+          // one comment. Idempotent (the label suppresses re-escalation next
+          // cycle via StuckPr.escalated).
+          if (mr.stuck.length > 0) {
+            const esc = await escalateStuckPrs(
+              mr.stuck, snapshot, cyclePrByIssue, cycleFieldCache, realRunner,
+            );
+            if (esc.escalated.length > 0) {
+              console.log(
+                `[autopilot] merge: stuck → escalated (needs-human) → PR #${esc.escalated.join(', PR #')}`,
+              );
+            }
+            for (const sk of esc.skipped) {
+              console.log(`[autopilot] merge: stuck escalation skipped: ${sk}`);
+            }
           }
         } catch (err) {
           console.error('[autopilot] merge sweep error (cycle unaffected):', err);

--- a/packages/autopilot/src/dispatcher/merge-sweep.ts
+++ b/packages/autopilot/src/dispatcher/merge-sweep.ts
@@ -326,6 +326,15 @@ export async function syncMerges(
       continue;
     }
 
+    // Refuse to merge without a head to pin: gh silently drops an empty
+    // `--match-head-commit ''`, which would merge unvalidated — the exact
+    // "merge blind" the pin exists to prevent. An eligible OPEN PR always
+    // carries a headRefOid, so this is a fail-safe for a malformed payload.
+    if (c.headRefOid === '') {
+      report.skipped.push(`PR #${c.number}: missing headRefOid — refusing to merge without a validated head pin`);
+      continue;
+    }
+
     try {
       // Pin the head we validated: a push landing between the list fetch above
       // and this merge (e.g. a merge-prep session's resolution) must not be

--- a/packages/autopilot/src/dispatcher/merge-sweep.ts
+++ b/packages/autopilot/src/dispatcher/merge-sweep.ts
@@ -34,6 +34,7 @@ import { REPO } from './constants.js';
 
 export interface MergeCandidate {
   number: number;
+  title: string;
   isDraft: boolean;
   author: string;
   labels: string[];
@@ -41,6 +42,7 @@ export interface MergeCandidate {
   mergeable: string;
   mergeStateStatus: string;
   headRefName: string;
+  headRefOid: string;
   statusChecks: RollupEntry[];
 }
 
@@ -51,7 +53,7 @@ export interface RollupEntry {
   state?: string; // StatusContext: SUCCESS | FAILURE | PENDING | …
 }
 
-const NEEDS_HUMAN_LABEL = 'review:needs-human';
+export const NEEDS_HUMAN_LABEL = 'review:needs-human';
 const GREEN_CONCLUSIONS = new Set(['SUCCESS', 'NEUTRAL', 'SKIPPED']);
 const MERGEABLE_STATES = new Set(['CLEAN', 'HAS_HOOKS']);
 
@@ -103,8 +105,60 @@ export function classifyCandidate(
   return 'eligible';
 }
 
+/**
+ * Why a PR that already cleared review can no longer be merged by the sweep.
+ * `conflicting` — GitHub reports a textual conflict against `next`.
+ * `still-behind` — behind `next` and its one `update-branch` attempt did not
+ *   catch it up (a conflicting update-branch, or the base advanced again).
+ * `update-branch-failed` — the `update-branch` call itself errored (commonly
+ *   because the update would conflict).
+ */
+export type StuckReason = 'conflicting' | 'still-behind' | 'update-branch-failed';
+
+/** A merge candidate the sweep cannot merge and cannot self-heal — the input
+ *  to deterministic needs-human escalation (Stage A) and to the merge-prep
+ *  session (Stage B). */
+export interface StuckPr {
+  number: number;
+  title: string;
+  reason: StuckReason;
+  headRefName: string;
+  headRefOid: string;
+  /** `review:needs-human` is already on the PR — already escalated (or an
+   *  advisory-mode PR); do not re-escalate and do not prep. */
+  escalated: boolean;
+}
+
+/**
+ * Detect a *conflicting* stuck PR, INDEPENDENTLY of the `review:needs-human`
+ * label. This is deliberate and load-bearing: `classifyCandidate` short-circuits
+ * on that label BEFORE the mergeable check, so once escalation applies the label
+ * a naive re-classify would go blind to the very conflict that is still stuck.
+ * `classifyStuck` re-derives stuckness from the objective merge state so the
+ * signal survives its own escalation.
+ *
+ * A conflicting PR is one that already cleared the review gate — non-draft,
+ * allowlist-authored, APPROVED, CI-green — but GitHub reports
+ * `mergeable=CONFLICTING` (or `mergeStateStatus=DIRTY`). `mergeable=UNKNOWN` is
+ * transient (GitHub still computing) and is never stuck. The `still-behind` and
+ * `update-branch-failed` reasons are runtime states, populated inside
+ * `syncMerges`, not here.
+ */
+export function classifyStuck(
+  c: MergeCandidate,
+  authorAllowlist: ReadonlySet<string>,
+): StuckReason | null {
+  if (c.isDraft) return null;
+  if (!authorAllowlist.has(c.author.toLowerCase())) return null;
+  if (c.reviewDecision !== 'APPROVED') return null;
+  if (rollupVerdict(c.statusChecks) !== 'green') return null;
+  if (c.mergeable === 'CONFLICTING' || c.mergeStateStatus === 'DIRTY') return 'conflicting';
+  return null;
+}
+
 interface GhListEntry {
   number: number;
+  title?: string;
   isDraft: boolean;
   author?: { login?: string };
   labels?: Array<{ name?: string }>;
@@ -112,6 +166,7 @@ interface GhListEntry {
   mergeable?: string;
   mergeStateStatus?: string;
   headRefName?: string;
+  headRefOid?: string;
   statusCheckRollup?: RollupEntry[];
 }
 
@@ -126,12 +181,13 @@ export async function fetchMergeCandidates(
     '--base', 'next',
     '--label', reviewLabel,
     '--json',
-    'number,isDraft,author,labels,reviewDecision,mergeable,mergeStateStatus,headRefName,statusCheckRollup',
+    'number,title,isDraft,author,labels,reviewDecision,mergeable,mergeStateStatus,headRefName,headRefOid,statusCheckRollup',
     '--limit', '100',
   ]);
   const entries = JSON.parse(raw) as GhListEntry[];
   return entries.map((e) => ({
     number: e.number,
+    title: e.title ?? '',
     isDraft: Boolean(e.isDraft),
     author: e.author?.login ?? '',
     labels: (e.labels ?? []).map((l) => l.name ?? '').filter((n) => n !== ''),
@@ -139,6 +195,7 @@ export async function fetchMergeCandidates(
     mergeable: e.mergeable ?? 'UNKNOWN',
     mergeStateStatus: e.mergeStateStatus ?? 'UNKNOWN',
     headRefName: e.headRefName ?? '',
+    headRefOid: e.headRefOid ?? '',
     statusChecks: e.statusCheckRollup ?? [],
   }));
 }
@@ -171,7 +228,7 @@ async function isBehindNext(headRefName: string, runner: CommandRunner): Promise
  * determined (fail-safe: uncertainty routes to a human, mirrors
  * review-dispatch).
  */
-async function touchesOwned(prNumber: number, runner: CommandRunner): Promise<boolean> {
+export async function touchesOwned(prNumber: number, runner: CommandRunner): Promise<boolean> {
   try {
     const [filesRaw, codeowners] = await Promise.all([
       runner('gh', ['pr', 'view', String(prNumber), '--repo', REPO, '--json', 'files']),
@@ -190,6 +247,22 @@ export interface MergeSweepReport {
   merged: number[];
   updatedBranch: number[];
   skipped: string[];
+  /** PRs that cleared review but cannot be merged and cannot self-heal —
+   *  structured so the orchestrator can escalate (Stage A) or dispatch a
+   *  merge-prep session (Stage B) rather than parse the free-text `skipped`. */
+  stuck: StuckPr[];
+}
+
+/** Build a StuckPr from a candidate; `escalated` reflects the current label. */
+function toStuck(c: MergeCandidate, reason: StuckReason): StuckPr {
+  return {
+    number: c.number,
+    title: c.title,
+    reason,
+    headRefName: c.headRefName,
+    headRefOid: c.headRefOid,
+    escalated: c.labels.includes(NEEDS_HUMAN_LABEL),
+  };
 }
 
 export async function syncMerges(
@@ -198,7 +271,7 @@ export async function syncMerges(
   attemptedUpdateBranch: Set<number>,
   reviewLabel = 'engine:review',
 ): Promise<MergeSweepReport> {
-  const report: MergeSweepReport = { merged: [], updatedBranch: [], skipped: [] };
+  const report: MergeSweepReport = { merged: [], updatedBranch: [], skipped: [], stuck: [] };
 
   let candidates: MergeCandidate[];
   try {
@@ -209,6 +282,12 @@ export async function syncMerges(
   }
 
   for (const c of candidates) {
+    // Conflict detection runs independently of classifyCandidate (which is
+    // label-blinded by review:needs-human, see classifyStuck).
+    if (classifyStuck(c, authorAllowlist) === 'conflicting') {
+      report.stuck.push(toStuck(c, 'conflicting'));
+    }
+
     let verdict = classifyCandidate(c, authorAllowlist);
 
     // Independent stale-base gate: `next` runs strict=false branch protection,
@@ -221,6 +300,7 @@ export async function syncMerges(
     if (verdict === 'behind') {
       if (attemptedUpdateBranch.has(c.number)) {
         report.skipped.push(`PR #${c.number}: still BEHIND after update-branch — needs a human`);
+        report.stuck.push(toStuck(c, 'still-behind'));
         continue;
       }
       try {
@@ -229,6 +309,7 @@ export async function syncMerges(
         report.updatedBranch.push(c.number);
       } catch (err) {
         console.error(`[merge-sweep] update-branch failed for #${c.number} (continuing):`, err);
+        report.stuck.push(toStuck(c, 'update-branch-failed'));
       }
       continue;
     }
@@ -246,7 +327,14 @@ export async function syncMerges(
     }
 
     try {
-      await runner('gh', ['pr', 'merge', String(c.number), '--repo', REPO, '--squash']);
+      // Pin the head we validated: a push landing between the list fetch above
+      // and this merge (e.g. a merge-prep session's resolution) must not be
+      // merged unvalidated. GitHub rejects the merge if the head has moved.
+      await runner('gh', [
+        'pr', 'merge', String(c.number),
+        '--repo', REPO, '--squash',
+        '--match-head-commit', c.headRefOid,
+      ]);
       report.merged.push(c.number);
     } catch (err) {
       console.error(`[merge-sweep] merge failed for #${c.number} (continuing):`, err);

--- a/packages/autopilot/src/dispatcher/stuck-escalation.ts
+++ b/packages/autopilot/src/dispatcher/stuck-escalation.ts
@@ -1,0 +1,135 @@
+/**
+ * Deterministic stuck-PR escalation (Stage A of the merge-prep design).
+ *
+ * The auto-merge sweep (`merge-sweep.ts`) surfaces PRs it cannot merge and
+ * cannot self-heal — a real conflict against `next`, or still-behind after its
+ * one `update-branch` — as structured `StuckPr` entries. Before Stage A these
+ * were log-only: an engine-approved, un-drafted, green PR could sit unmergeable
+ * indefinitely with nothing on the board to draw a human's eye.
+ *
+ * This module makes a stuck PR *visible*, with no AI in the loop:
+ *   1. label the PR `review:needs-human` (also the idempotency marker — the
+ *      sweep reports `escalated:true` next cycle so we never double-escalate),
+ *   2. set the linked issue's `Blocked on` field to `Human` (so `syncHumanLane`
+ *      promotes it into the Human status lane on the next cycle), and
+ *   3. leave one explanatory PR comment.
+ *
+ * Best-effort per PR; a per-item failure is recorded and never aborts the rest
+ * (sweep convention). The `review:needs-human` label makes the merge-prep
+ * session (Stage B) skip the PR too — a human owns it once escalated.
+ */
+
+import { REPO } from './constants.js';
+import type { CommandRunner } from './issue-source.js';
+import type { ProjectSnapshot } from './project-snapshot.js';
+import type { FieldCache } from './field-cache.js';
+import type { PrLink } from './pr-links.js';
+import { NEEDS_HUMAN_LABEL, type StuckPr } from './merge-sweep.js';
+
+export interface StuckEscalationReport {
+  /** PR numbers freshly escalated this cycle. */
+  escalated: number[];
+  /** Operator-visible skip/failure lines (already-escalated PRs are silent). */
+  skipped: string[];
+}
+
+/** Human-readable cause line for the PR comment, per stuck reason. */
+function reasonPhrase(s: StuckPr): string {
+  switch (s.reason) {
+    case 'conflicting':
+      return 'it has a merge conflict against `next`';
+    case 'still-behind':
+      return 'it is still behind `next` after an automatic update-branch attempt';
+    case 'update-branch-failed':
+      return 'the automatic update-branch attempt failed (typically a conflict)';
+  }
+}
+
+/**
+ * Resolve the linked issue number for a PR by inverting the per-cycle
+ * issue→closing-PRs map (`fetchIssuePrMap`). Returns the first issue the PR
+ * closes, or null if the PR has no `Closes #N` link.
+ */
+function linkedIssueFor(prNumber: number, prByIssue: Map<number, PrLink[]>): number | null {
+  for (const [issueNumber, links] of prByIssue) {
+    if (links.some((l) => l.prNumber === prNumber)) return issueNumber;
+  }
+  return null;
+}
+
+/**
+ * Escalate a single fresh stuck PR: label + Blocked-on:Human (best-effort if a
+ * linked issue exists on the board) + one comment. Throws only if the label add
+ * fails (the caller records it as skipped); the board edit is isolated so a PR
+ * with no linked issue still gets labeled and commented.
+ */
+export async function escalateStuckPr(
+  s: StuckPr,
+  snapshot: ProjectSnapshot,
+  prByIssue: Map<number, PrLink[]>,
+  fieldCache: FieldCache,
+  runner: CommandRunner,
+): Promise<void> {
+  // 1. Label — the idempotency marker. Do this first: if it fails, we abort
+  //    (thrown to caller) rather than comment/blocked-on without the marker,
+  //    which would re-escalate every cycle.
+  await runner('gh', ['pr', 'edit', String(s.number), '--repo', REPO, '--add-label', NEEDS_HUMAN_LABEL]);
+
+  // 2. Blocked on: Human on the linked issue (so it enters the Human lane).
+  //    Isolated — a PR with no linked issue, or one not on the board, still
+  //    gets labeled + commented above/below.
+  const issueNumber = linkedIssueFor(s.number, prByIssue);
+  if (issueNumber != null) {
+    const item = snapshot.items.find((i) => i.contentType === 'Issue' && i.number === issueNumber);
+    if (item != null) {
+      try {
+        await runner('gh', [
+          'project', 'item-edit',
+          '--id', item.id,
+          '--project-id', fieldCache.projectId,
+          '--field-id', fieldCache.blockedOn.fieldId,
+          '--single-select-option-id', fieldCache.blockedOn.options.Human,
+        ]);
+      } catch (err) {
+        console.error(
+          `[stuck-escalation] PR #${s.number}: could not set issue #${issueNumber} Blocked on: Human (continuing):`,
+          err,
+        );
+      }
+    }
+  }
+
+  // 3. One explanatory comment.
+  const headShort = s.headRefOid.slice(0, 9) || '(unknown)';
+  const body =
+    `The autopilot merge sweep cannot merge this PR: ${reasonPhrase(s)} ` +
+    `(head \`${headShort}\`). The engine review passed, but the merge is blocked and cannot ` +
+    `self-heal, so it needs a human — rebase onto \`next\` and resolve the conflict, then let the ` +
+    `review loop re-approve. The linked issue (if any) is set to \`Blocked on: Human\`.`;
+  await runner('gh', ['pr', 'comment', String(s.number), '--repo', REPO, '--body', body]);
+}
+
+/**
+ * Escalate every FRESH stuck PR (`escalated === false`). Already-escalated PRs
+ * are silently skipped (a human owns them). Per-PR failures are isolated.
+ */
+export async function escalateStuckPrs(
+  stuck: StuckPr[],
+  snapshot: ProjectSnapshot,
+  prByIssue: Map<number, PrLink[]>,
+  fieldCache: FieldCache,
+  runner: CommandRunner,
+): Promise<StuckEscalationReport> {
+  const report: StuckEscalationReport = { escalated: [], skipped: [] };
+  for (const s of stuck) {
+    if (s.escalated) continue; // already labeled needs-human — a human owns it
+    try {
+      await escalateStuckPr(s, snapshot, prByIssue, fieldCache, runner);
+      report.escalated.push(s.number);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      report.skipped.push(`PR #${s.number}: escalation failed — ${msg}`);
+    }
+  }
+  return report;
+}

--- a/packages/autopilot/test/dispatcher/merge-sweep.test.ts
+++ b/packages/autopilot/test/dispatcher/merge-sweep.test.ts
@@ -276,6 +276,14 @@ describe('syncMerges', () => {
     expect(report.stuck).toEqual([]);
   });
 
+  it('refuses to merge an eligible PR with an empty headRefOid (no blind merge)', async () => {
+    const { runner, calls } = scriptedRunner({ list: [ghEntry({ headRefOid: '' })] });
+    const report = await syncMerges(runner, ALLOWLIST, new Set());
+    expect(report.merged).toEqual([]);
+    expect(report.skipped.some((s) => s.includes('missing headRefOid'))).toBe(true);
+    expect(calls.some((c) => c.args[1] === 'merge')).toBe(false);
+  });
+
   it('code-owned PR is never merged (DR-2026-06-03)', async () => {
     const { runner, calls } = scriptedRunner({
       list: [ghEntry()],

--- a/packages/autopilot/test/dispatcher/merge-sweep.test.ts
+++ b/packages/autopilot/test/dispatcher/merge-sweep.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   classifyCandidate,
+  classifyStuck,
   rollupVerdict,
   syncMerges,
   type MergeCandidate,
@@ -15,6 +16,7 @@ const GREEN: RollupEntry[] = [{ status: 'COMPLETED', conclusion: 'SUCCESS' }];
 function candidate(over: Partial<MergeCandidate> = {}): MergeCandidate {
   return {
     number: 10,
+    title: 'a stuck PR',
     isDraft: false,
     author: 'ritsukai',
     labels: ['engine:review', 'review:approved'],
@@ -22,6 +24,7 @@ function candidate(over: Partial<MergeCandidate> = {}): MergeCandidate {
     mergeable: 'MERGEABLE',
     mergeStateStatus: 'CLEAN',
     headRefName: 'feat/10-x',
+    headRefOid: 'abc123def456',
     statusChecks: GREEN,
     ...over,
   };
@@ -109,6 +112,47 @@ describe('classifyCandidate', () => {
   });
 });
 
+describe('classifyStuck', () => {
+  it('APPROVED + green + CONFLICTING → conflicting', () => {
+    expect(classifyStuck(candidate({ mergeable: 'CONFLICTING' }), ALLOWLIST)).toBe('conflicting');
+  });
+
+  it('mergeStateStatus DIRTY alone → conflicting', () => {
+    expect(
+      classifyStuck(candidate({ mergeable: 'UNKNOWN', mergeStateStatus: 'DIRTY' }), ALLOWLIST),
+    ).toBe('conflicting');
+  });
+
+  it('LABEL-BLIND: stays conflicting even carrying review:needs-human (survives its own escalation)', () => {
+    const c = candidate({
+      mergeable: 'CONFLICTING',
+      labels: ['engine:review', 'review:needs-human'],
+    });
+    // classifyCandidate short-circuits on the label; classifyStuck must not.
+    expect(classifyCandidate(c, ALLOWLIST)).toContain('review:needs-human');
+    expect(classifyStuck(c, ALLOWLIST)).toBe('conflicting');
+  });
+
+  it('clean/mergeable → null (not stuck)', () => {
+    expect(classifyStuck(candidate(), ALLOWLIST)).toBeNull();
+  });
+
+  it('UNKNOWN mergeable with no DIRTY → null (transient, GitHub still computing)', () => {
+    expect(classifyStuck(candidate({ mergeable: 'UNKNOWN' }), ALLOWLIST)).toBeNull();
+  });
+
+  it('not-yet-cleared PRs are never stuck (draft / not-approved / pending / non-allowlisted)', () => {
+    expect(classifyStuck(candidate({ mergeable: 'CONFLICTING', isDraft: true }), ALLOWLIST)).toBeNull();
+    expect(
+      classifyStuck(candidate({ mergeable: 'CONFLICTING', reviewDecision: 'CHANGES_REQUESTED' }), ALLOWLIST),
+    ).toBeNull();
+    expect(
+      classifyStuck(candidate({ mergeable: 'CONFLICTING', statusChecks: [{ status: 'IN_PROGRESS' }] }), ALLOWLIST),
+    ).toBeNull();
+    expect(classifyStuck(candidate({ mergeable: 'CONFLICTING', author: 'outsider' }), ALLOWLIST)).toBeNull();
+  });
+});
+
 // ---------------------------------------------------------------------------
 // syncMerges — scripted end-to-end over the gh seam
 // ---------------------------------------------------------------------------
@@ -146,6 +190,7 @@ function scriptedRunner(cfg: {
 function ghEntry(over: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     number: 10,
+    title: 'a stuck PR',
     isDraft: false,
     author: { login: 'ritsukai' },
     labels: [{ name: 'engine:review' }],
@@ -153,6 +198,7 @@ function ghEntry(over: Record<string, unknown> = {}): Record<string, unknown> {
     mergeable: 'MERGEABLE',
     mergeStateStatus: 'CLEAN',
     headRefName: 'feat/10-x',
+    headRefOid: 'abc123def456',
     statusCheckRollup: GREEN,
     ...over,
   };
@@ -166,6 +212,68 @@ describe('syncMerges', () => {
     const merge = calls.find((c) => c.args[1] === 'merge');
     expect(merge?.args).toContain('--squash');
     expect(merge?.args).not.toContain('--admin');
+    // TOCTOU pin: the merge is scoped to the exact head the sweep validated.
+    expect(merge?.args).toContain('--match-head-commit');
+    expect(merge?.args).toContain('abc123def456');
+  });
+
+  it('a CONFLICTING PR is reported as stuck (conflicting) and never merged', async () => {
+    const { runner, calls } = scriptedRunner({
+      list: [ghEntry({ mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY' })],
+    });
+    const report = await syncMerges(runner, ALLOWLIST, new Set());
+    expect(report.merged).toEqual([]);
+    expect(report.stuck).toEqual([
+      {
+        number: 10,
+        title: 'a stuck PR',
+        reason: 'conflicting',
+        headRefName: 'feat/10-x',
+        headRefOid: 'abc123def456',
+        escalated: false,
+      },
+    ]);
+    expect(calls.some((c) => c.args[1] === 'merge')).toBe(false);
+  });
+
+  it('a CONFLICTING PR already labeled needs-human is stuck with escalated:true', async () => {
+    const { runner } = scriptedRunner({
+      list: [ghEntry({ mergeable: 'CONFLICTING', labels: [{ name: 'engine:review' }, { name: 'review:needs-human' }] })],
+    });
+    const report = await syncMerges(runner, ALLOWLIST, new Set());
+    expect(report.stuck).toHaveLength(1);
+    expect(report.stuck[0]).toMatchObject({ reason: 'conflicting', escalated: true });
+  });
+
+  it('still-BEHIND after update-branch is reported as stuck, keeping the legacy skipped string', async () => {
+    const attempted = new Set<number>([10]); // one update-branch already spent this process
+    const { runner } = scriptedRunner({ list: [ghEntry({ mergeStateStatus: 'BEHIND' })] });
+    const report = await syncMerges(runner, ALLOWLIST, attempted);
+    expect(report.skipped.some((s) => s.includes('still BEHIND'))).toBe(true); // back-compat
+    expect(report.stuck).toEqual([
+      {
+        number: 10, title: 'a stuck PR', reason: 'still-behind',
+        headRefName: 'feat/10-x', headRefOid: 'abc123def456', escalated: false,
+      },
+    ]);
+  });
+
+  it('an update-branch failure is reported as stuck (update-branch-failed)', async () => {
+    const calls: { cmd: string; args: string[] }[] = [];
+    const runner: CommandRunner = async (cmd, args) => {
+      calls.push({ cmd, args });
+      if (cmd === 'gh' && args[1] === 'list') return JSON.stringify([ghEntry({ mergeStateStatus: 'BEHIND' })]);
+      if (cmd === 'gh' && args[1] === 'update-branch') throw new Error('update would conflict');
+      return '';
+    };
+    const report = await syncMerges(runner, ALLOWLIST, new Set());
+    expect(report.stuck.map((s) => s.reason)).toEqual(['update-branch-failed']);
+  });
+
+  it('a clean sweep reports no stuck PRs', async () => {
+    const { runner } = scriptedRunner({ list: [ghEntry()] });
+    const report = await syncMerges(runner, ALLOWLIST, new Set());
+    expect(report.stuck).toEqual([]);
   });
 
   it('code-owned PR is never merged (DR-2026-06-03)', async () => {

--- a/packages/autopilot/test/dispatcher/stuck-escalation.test.ts
+++ b/packages/autopilot/test/dispatcher/stuck-escalation.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { escalateStuckPrs } from '../../src/dispatcher/stuck-escalation.js';
+import type { StuckPr } from '../../src/dispatcher/merge-sweep.js';
+import type { CommandRunner } from '../../src/dispatcher/issue-source.js';
+import type { FieldCache } from '../../src/dispatcher/field-cache.js';
+import type { ProjectSnapshot, SnapshotItem } from '../../src/dispatcher/project-snapshot.js';
+import type { PrLink } from '../../src/dispatcher/pr-links.js';
+
+const PROJECT_ID = 'PVT_test';
+const BLOCKED_FIELD_ID = 'field_blocked';
+const BLOCKED_HUMAN_OPT = 'opt_b_human';
+
+const FIELD_CACHE: FieldCache = {
+  projectId: PROJECT_ID,
+  status: {
+    fieldId: 'field_status',
+    options: {
+      Todo: 'opt_todo', 'In Progress': 'opt_inprog', Human: 'opt_human',
+      'In Review': 'opt_inreview', Done: 'opt_done',
+    },
+  },
+  blockedOn: {
+    fieldId: BLOCKED_FIELD_ID,
+    options: { Nothing: 'opt_nothing', Human: BLOCKED_HUMAN_OPT, 'Another issue': 'opt_another' },
+  },
+};
+
+function item(over: Partial<SnapshotItem> & Pick<SnapshotItem, 'id' | 'number'>): SnapshotItem {
+  return {
+    contentType: 'Issue', status: null, priority: null, effort: null,
+    blockedOn: null, issueType: null, blockedByIssues: [], sprintIterationId: null,
+    ...over,
+  };
+}
+
+function snapshot(items: SnapshotItem[]): ProjectSnapshot {
+  return { items, rateLimit: { remaining: 5000, used: 0, resetAt: '2026-01-01T00:00:00Z' }, currentSprintIterationId: null };
+}
+
+function stuck(over: Partial<StuckPr> = {}): StuckPr {
+  return {
+    number: 42, title: 't', reason: 'conflicting',
+    headRefName: 'feat/50-x', headRefOid: 'deadbeef1234', escalated: false, ...over,
+  };
+}
+
+/** PR #42 closes issue #50. */
+function prMap(): Map<number, PrLink[]> {
+  const link: PrLink = {
+    prNumber: 42, headRefName: 'feat/50-x', baseRefName: 'next',
+    state: 'OPEN', isDraft: false, author: 'ritsukai', labels: ['engine:review'],
+  };
+  return new Map([[50, [link]]]);
+}
+
+function recordingRunner(fail?: (cmd: string, args: string[]) => boolean) {
+  const calls: { cmd: string; args: string[] }[] = [];
+  const runner: CommandRunner = async (cmd, args) => {
+    calls.push({ cmd, args });
+    if (fail?.(cmd, args)) throw new Error('boom');
+    return '';
+  };
+  return { runner, calls };
+}
+
+describe('escalateStuckPrs', () => {
+  it('fresh stuck PR: label + linked-issue Blocked-on:Human + exactly one comment', async () => {
+    const { runner, calls } = recordingRunner();
+    const report = await escalateStuckPrs([stuck()], snapshot([item({ id: 'PVTI_50', number: 50 })]), prMap(), FIELD_CACHE, runner);
+
+    expect(report.escalated).toEqual([42]);
+
+    const label = calls.find((c) => c.args.includes('--add-label'));
+    expect(label?.args).toEqual(['pr', 'edit', '42', '--repo', expect.any(String), '--add-label', 'review:needs-human']);
+
+    const edit = calls.find((c) => c.args[1] === 'item-edit');
+    expect(edit?.args).toContain('PVTI_50');
+    expect(edit?.args).toContain(BLOCKED_FIELD_ID);
+    expect(edit?.args).toContain(BLOCKED_HUMAN_OPT);
+
+    const comments = calls.filter((c) => c.args[1] === 'comment');
+    expect(comments).toHaveLength(1);
+  });
+
+  it('already-escalated PR is skipped entirely (zero calls)', async () => {
+    const { runner, calls } = recordingRunner();
+    const report = await escalateStuckPrs([stuck({ escalated: true })], snapshot([item({ id: 'PVTI_50', number: 50 })]), prMap(), FIELD_CACHE, runner);
+    expect(report.escalated).toEqual([]);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('no linked issue: still labels + comments, makes no board edit', async () => {
+    const { runner, calls } = recordingRunner();
+    const report = await escalateStuckPrs([stuck()], snapshot([]), new Map(), FIELD_CACHE, runner);
+    expect(report.escalated).toEqual([42]);
+    expect(calls.some((c) => c.args.includes('--add-label'))).toBe(true);
+    expect(calls.some((c) => c.args[1] === 'item-edit')).toBe(false);
+    expect(calls.some((c) => c.args[1] === 'comment')).toBe(true);
+  });
+
+  it('board edit failure does not prevent the comment (isolated)', async () => {
+    const { runner, calls } = recordingRunner((_cmd, args) => args[1] === 'item-edit');
+    const report = await escalateStuckPrs([stuck()], snapshot([item({ id: 'PVTI_50', number: 50 })]), prMap(), FIELD_CACHE, runner);
+    expect(report.escalated).toEqual([42]); // still succeeds
+    expect(calls.some((c) => c.args[1] === 'comment')).toBe(true);
+  });
+
+  it('label failure aborts that PR (recorded skipped) but the next PR still processes', async () => {
+    const { runner } = recordingRunner((_cmd, args) => args[1] === 'edit' && args[2] === '42');
+    const two = [stuck(), stuck({ number: 43 })];
+    const report = await escalateStuckPrs(two, snapshot([]), new Map(), FIELD_CACHE, runner);
+    expect(report.escalated).toEqual([43]);
+    expect(report.skipped.some((s) => s.includes('#42'))).toBe(true);
+  });
+});


### PR DESCRIPTION
Stage A of the merge-prep design (parent #1756). The auto-merge sweep surfaced un-mergeable PRs (real conflict vs `next`, or still-behind after its one update-branch) only as log lines. This makes them visible on the board.

- `merge-sweep`: label-blind `classifyStuck` (survives its own `review:needs-human` escalation) + structured `MergeSweepReport.stuck` (conflicting / still-behind / update-branch-failed); `--match-head-commit` merge pin (closes the fetch→merge TOCTOU); exported `touchesOwned`/`NEEDS_HUMAN_LABEL`.
- `stuck-escalation` (new): label + linked-issue Blocked-on:Human + one comment; idempotent; per-PR isolated.
- `run-autopilot`: route the sweep's stuck report through escalation each cycle.

**Verification:** `packages/autopilot` typecheck clean, 524 tests pass (39 new/changed). This package is not covered by repo CI — the local suite is the gate.

Closes #1757