### PR TITLE
fix(autopilot): reap stale pr-<N> review worktrees (latent reviewCap wedge)

### DIFF
--- a/packages/autopilot/package.json
+++ b/packages/autopilot/package.json
@@ -19,6 +19,7 @@
     "triage:check": "tsx bin/jinn-triage-check.ts"
   },
   "devDependencies": {
+    "@types/node": "^22",
     "tsx": "^4.23.1",
     "typescript": "^5.6.0",
     "vitest": "^2.1.9"

--- a/packages/autopilot/scripts/run-autopilot.ts
+++ b/packages/autopilot/scripts/run-autopilot.ts
@@ -424,7 +424,11 @@ export async function runReviewPass(
     deriveReviewInFlight: () => deriveReviewInFlight(runner),
     dispatchReview: (pr: ReviewablePr) => dispatchReview(pr, cfg, { runner, spawn: spawnImpl }),
     busyPrNumbers,
+    removeWorktree: async (w) => { await runner('git', ['worktree', 'remove', '--force', w.worktreePath]); },
   });
+  if (report.reaped.length > 0) {
+    console.log(`[autopilot] review reaped stale worktree → PR #${report.reaped.join(', #')}`);
+  }
   if (report.dispatched.length > 0) {
     console.log(`[autopilot] review-pr dispatched: PR #${report.dispatched.join(', #')}`);
   }

--- a/packages/autopilot/src/dispatcher/review-loop.ts
+++ b/packages/autopilot/src/dispatcher/review-loop.ts
@@ -2,6 +2,19 @@ import type { PrSource } from './pr-source.js';
 import type { DispatcherConfig, InFlightReview, ReviewablePr } from './types.js';
 import { selectReviewable } from './review-ready-filter.js';
 
+/**
+ * Staleness ceiling for `pr-<N>` review worktrees (jinn-mono#1764). Nothing
+ * else reaps this namespace: the drift sweep only reconciles numeric task
+ * worktrees, and `review-pr` sessions have no other cleanup path. Left
+ * unbounded, a review session that never exits (crash, hang, orphaned
+ * process) keeps its worktree forever and its `pr-<N>` entry counts against
+ * `reviewCap` in `deriveReviewInFlight` permanently, eventually wedging the
+ * cap at zero. Deliberately independent from any merge-prep reap constant —
+ * the two worktree namespaces (`pr-<N>` vs. a future `merge-<N>`) are tuned
+ * separately.
+ */
+export const REVIEW_REAP_MS = 2 * 60 * 60 * 1000;
+
 export interface ReviewCycleReport {
   /** PR numbers dispatched this cycle, in dispatch order. */
   dispatched: number[];
@@ -9,6 +22,13 @@ export interface ReviewCycleReport {
   skippedForCap: number;
   /** Drift strings from deriveReviewInFlight (currently always empty). */
   drift: string[];
+  /**
+   * PR numbers whose stale `pr-<N>` worktree was reaped this cycle (order:
+   * as returned by deriveReviewInFlight). Freed slots count toward this
+   * cycle's dispatch budget, so a waiting PR can dispatch the same cycle
+   * its blocker's worktree was reaped.
+   */
+  reaped: number[];
 }
 
 export interface ReviewCycleDeps {
@@ -24,26 +44,60 @@ export interface ReviewCycleDeps {
    * when merge-prep is disarmed.
    */
   busyPrNumbers?: ReadonlySet<number>;
+  /**
+   * Remove a stale review worktree (`git worktree remove --force`, jinn-mono#1764).
+   * Must not throw on the caller's behalf — `runReviewCycle` catches and logs
+   * failures itself, treating the worktree as still-live so one stuck removal
+   * cannot wedge the rest of the cycle.
+   */
+  removeWorktree(w: InFlightReview): Promise<void>;
+  /** Injectable clock for tests; defaults to `Date.now`. */
+  now?(): number;
 }
 
 /**
  * One tick of the review loop (mirrors runCycle): poll PRs, derive in-flight
- * reviews, filter reviewable, dispatch up to `reviewCap − inFlight`. Contains
- * NO gh/git calls — all I/O is injected (seam discipline).
+ * reviews, reap stale `pr-<N>` worktrees (jinn-mono#1764), filter reviewable,
+ * dispatch up to `reviewCap − live`. Contains NO gh/git calls — all I/O is
+ * injected (seam discipline).
  */
 export async function runReviewCycle(deps: ReviewCycleDeps): Promise<ReviewCycleReport> {
-  const { prSource, cfg, deriveReviewInFlight, dispatchReview } = deps;
+  const { prSource, cfg, deriveReviewInFlight, dispatchReview, removeWorktree } = deps;
+  const now = deps.now ?? Date.now;
 
   const [polled, { inFlight, drift }] = await Promise.all([
     prSource.poll(),
     deriveReviewInFlight(),
   ]);
 
-  // Exclude both in-flight reviews AND PRs with a live merge-prep session (the
-  // latter don't count against the review cap — they just must not be reviewed
-  // while a prep is pushing to the same branch).
+  // Reap stale worktrees before computing the dispatch budget, so a freed
+  // slot is available to the same cycle's dispatch pass. startedAt === 0
+  // means deriveReviewInFlight's recoverStartedAt couldn't stat the
+  // worktree (unknown age) — never reap that; it protects a session whose
+  // worktree creation is still racing the stat call.
+  const live: InFlightReview[] = [];
+  const reaped: number[] = [];
+  for (const w of inFlight) {
+    const stale = w.startedAt > 0 && now() - w.startedAt > REVIEW_REAP_MS;
+    if (!stale) {
+      live.push(w);
+      continue;
+    }
+    try {
+      await removeWorktree(w);
+      reaped.push(w.prNumber);
+    } catch (err) {
+      console.error(`[review-loop] reap failed for PR #${w.prNumber} (continuing):`, err);
+      live.push(w); // degrade to today's behaviour — occupied slot, not aborted pass
+    }
+  }
+
+  // Exclude LIVE reviews (post-reap, so a reaped PR is dispatchable again this
+  // cycle) AND PRs with a live merge-prep session — the latter don't count
+  // against the review cap, they just must not be reviewed while a prep is
+  // pushing to the same branch (DR-2026-07-16).
   const excludeSet = new Set<number>([
-    ...inFlight.map((s) => s.prNumber),
+    ...live.map((s) => s.prNumber),
     ...(deps.busyPrNumbers ?? []),
   ]);
   // Gate 2 (DR-2026-06-15): only review PRs authored by a trusted login — the
@@ -53,7 +107,7 @@ export async function runReviewCycle(deps: ReviewCycleDeps): Promise<ReviewCycle
   const authorAllowlist = new Set(cfg.authorAllowlist.map((s) => s.toLowerCase()));
   const reviewable = selectReviewable(polled, excludeSet, authorAllowlist);
 
-  const budget = Math.max(0, cfg.reviewCap - inFlight.length);
+  const budget = Math.max(0, cfg.reviewCap - live.length);
   const toDispatch = reviewable.slice(0, budget);
 
   const dispatched: number[] = [];
@@ -62,5 +116,5 @@ export async function runReviewCycle(deps: ReviewCycleDeps): Promise<ReviewCycle
     dispatched.push(pr.number);
   }
 
-  return { dispatched, skippedForCap: reviewable.length - toDispatch.length, drift };
+  return { dispatched, skippedForCap: reviewable.length - toDispatch.length, drift, reaped };
 }

--- a/packages/autopilot/test/dispatcher/review-loop.test.ts
+++ b/packages/autopilot/test/dispatcher/review-loop.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { runReviewCycle } from '../../src/dispatcher/review-loop.js';
+import { runReviewCycle, REVIEW_REAP_MS } from '../../src/dispatcher/review-loop.js';
 import type { PrSource } from '../../src/dispatcher/pr-source.js';
 import type { PolledPr, ReviewablePr, InFlightReview, DispatcherConfig } from '../../src/dispatcher/types.js';
 
@@ -25,6 +25,7 @@ describe('runReviewCycle', () => {
       prSource: source,
       cfg: CFG,
       deriveReviewInFlight: async () => ({ inFlight: [] as InFlightReview[], drift: [] }),
+      removeWorktree: async () => {},
       dispatchReview: async (p: ReviewablePr) => { dispatched.push(p.number); return { prNumber: p.number, branch: p.headRefName, worktreePath: `/pr-${p.number}`, pid: 1, startedAt: 0 }; },
     });
     expect(dispatched).toEqual([1, 2]);
@@ -39,6 +40,7 @@ describe('runReviewCycle', () => {
       prSource: source,
       cfg: CFG,
       deriveReviewInFlight: async () => ({ inFlight: [{ prNumber: 9, branch: 'x', worktreePath: '/pr-9', pid: 1, startedAt: 0 }], drift: [] }),
+      removeWorktree: async () => {},
       dispatchReview: async (p: ReviewablePr) => { dispatched.push(p.number); return { prNumber: p.number, branch: p.headRefName, worktreePath: '/x', pid: 1, startedAt: 0 }; },
     });
     expect(dispatched).toEqual([5]);
@@ -65,6 +67,7 @@ describe('runReviewCycle', () => {
       prSource: source,
       cfg: CFG,
       deriveReviewInFlight: async () => ({ inFlight: [{ prNumber: 7, branch: 'b/7', worktreePath: '/pr-7', pid: 1, startedAt: 0 }], drift: [] }),
+      removeWorktree: async () => {},
       dispatchReview: async (p: ReviewablePr) => { dispatched.push(p.number); return { prNumber: p.number, branch: p.headRefName, worktreePath: '/x', pid: 1, startedAt: 0 }; },
     });
     expect(dispatched).toEqual([]);
@@ -80,8 +83,55 @@ describe('runReviewCycle', () => {
       prSource: source,
       cfg: CFG, // allowlists 'a' only
       deriveReviewInFlight: async () => ({ inFlight: [] as InFlightReview[], drift: [] }),
+      removeWorktree: async () => {},
       dispatchReview: async (p: ReviewablePr) => { dispatched.push(p.number); return { prNumber: p.number, branch: p.headRefName, worktreePath: '/x', pid: 1, startedAt: 0 }; },
     });
     expect(dispatched).toEqual([8]);
+  });
+
+  it('reaps a stale worktree, frees its cap slot, and dispatches a waiting PR in the same cycle', async () => {
+    const NOW = 10_000_000_000; // arbitrary fixed instant
+    const stale: InFlightReview = { prNumber: 20, branch: 'b/20', worktreePath: '/pr-20', pid: 1, startedAt: NOW - REVIEW_REAP_MS - 1 };
+    const fresh: InFlightReview = { prNumber: 21, branch: 'b/21', worktreePath: '/pr-21', pid: 1, startedAt: NOW - 1_000 };
+    const unknown: InFlightReview = { prNumber: 22, branch: 'b/22', worktreePath: '/pr-22', pid: 1, startedAt: 0 };
+    const source: PrSource = { poll: async () => [pr(30)] }; // 30 = the waiting reviewable PR
+    const removed: number[] = [];
+    const dispatched: number[] = [];
+    const report = await runReviewCycle({
+      prSource: source,
+      // reviewCap: 3, deliberately equal to the 3 in-flight worktrees below —
+      // the cap is fully occupied (budget 0) BEFORE the reap runs, so a
+      // dispatch after reaping only the stale one proves the freed slot (not
+      // just spare cap) is what let PR 30 through: live drops to 2 (fresh +
+      // unknown), budget = max(0, 3 − 2) = 1.
+      cfg: { ...CFG, reviewCap: 3 },
+      now: () => NOW,
+      deriveReviewInFlight: async () => ({ inFlight: [stale, fresh, unknown], drift: [] }),
+      removeWorktree: async (w) => { removed.push(w.prNumber); },
+      dispatchReview: async (p: ReviewablePr) => { dispatched.push(p.number); return { prNumber: p.number, branch: p.headRefName, worktreePath: `/pr-${p.number}`, pid: 1, startedAt: NOW }; },
+    });
+    expect(removed).toEqual([20]);
+    expect(report.reaped).toEqual([20]);
+    expect(dispatched).toEqual([30]);
+    expect(report.dispatched).toEqual([30]);
+  });
+
+  it('keeps a worktree counted as live when removeWorktree throws, without aborting other dispatch', async () => {
+    const NOW = 10_000_000_000;
+    const stale: InFlightReview = { prNumber: 40, branch: 'b/40', worktreePath: '/pr-40', pid: 1, startedAt: NOW - REVIEW_REAP_MS - 1 };
+    const source: PrSource = { poll: async () => [pr(41)] };
+    const dispatched: number[] = [];
+    const report = await runReviewCycle({
+      prSource: source,
+      cfg: CFG, // reviewCap: 2
+      now: () => NOW,
+      deriveReviewInFlight: async () => ({ inFlight: [stale], drift: [] }),
+      removeWorktree: async () => { throw new Error('git worktree remove failed: locked'); },
+      dispatchReview: async (p: ReviewablePr) => { dispatched.push(p.number); return { prNumber: p.number, branch: p.headRefName, worktreePath: `/pr-${p.number}`, pid: 1, startedAt: NOW }; },
+    });
+    expect(report.reaped).toEqual([]);
+    // stale(40) still counts as live (1 slot used) + reviewCap 2 ⇒ budget 1 ⇒ PR 41 still dispatches
+    expect(dispatched).toEqual([41]);
+    expect(report.dispatched).toEqual([41]);
   });
 });

--- a/packages/autopilot/test/dispatcher/review-loop.test.ts
+++ b/packages/autopilot/test/dispatcher/review-loop.test.ts
@@ -54,6 +54,7 @@ describe('runReviewCycle', () => {
       cfg: CFG, // reviewCap 2
       deriveReviewInFlight: async () => ({ inFlight: [] as InFlightReview[], drift: [] }),
       dispatchReview: async (p: ReviewablePr) => { dispatched.push(p.number); return { prNumber: p.number, branch: p.headRefName, worktreePath: `/pr-${p.number}`, pid: 1, startedAt: 0 }; },
+      removeWorktree: async () => {},
       busyPrNumbers: new Set([5]),
     });
     expect(dispatched).toEqual([6]);       // #5 excluded (prep in flight)

--- a/packages/autopilot/yarn.lock
+++ b/packages/autopilot/yarn.lock
@@ -361,6 +361,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jinn-network/autopilot@workspace:."
   dependencies:
+    "@types/node": "npm:^22"
     tsx: "npm:^4.23.1"
     typescript: "npm:^5.6.0"
     vitest: "npm:^2.1.9"
@@ -564,6 +565,15 @@ __metadata:
   version: 1.0.9
   resolution: "@types/estree@npm:1.0.9"
   checksum: 10c0/3ad3286ca2988cd550dafb8f2ad599c8474868e954fa601a36655bdfefd8039f7c714b8c1c7f2ae219ffbd58bd4660e66fa7479a0120fc02d4777057d4865387
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^22":
+  version: 22.20.1
+  resolution: "@types/node@npm:22.20.1"
+  dependencies:
+    undici-types: "npm:~6.21.0"
+  checksum: 10c0/f2ba54d3d1fb92e1c57c78d32c3a17655b1e87363b707136f55c422b4838d4054901ce5d27f75bb0e5ecb7ebfee3804e0987822d22b473473008091857a09353
   languageName: node
   linkType: hard
 
@@ -1308,6 +1318,13 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~6.21.0":
+  version: 6.21.0
+  resolution: "undici-types@npm:6.21.0"
+  checksum: 10c0/c01ed51829b10aa72fc3ce64b747f8e74ae9b60eafa19a7b46ef624403508a54c526ffab06a14a26b3120d055e1104d7abe7c9017e83ced038ea5cf52f8d5e04
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Review sessions create `jinn-mono_worktrees/pr-<N>` worktrees that nothing removed: the drift sweep only reconciles numeric task worktrees, `review-pr` has no cleanup step, and `deriveReviewInFlight` counted every `pr-<N>` worktree as in-flight forever — enough stale ones permanently wedge `reviewCap` at zero.

This adds a staleness reaper as step 1 of `runReviewCycle` (mirroring the merge-prep pattern from #1759, with an independent `REVIEW_REAP_MS = 2h` constant since the namespaces are tuned separately):

- In-flight reviews are partitioned before the dispatch budget is computed: `startedAt > 0 && now − startedAt > REVIEW_REAP_MS` → reaped via an injected `removeWorktree` dep; everything else stays live. Budget and `inFlightSet` come from the live set, so a freed slot lets a waiting PR dispatch the same cycle.
- Unknown-age worktrees (`startedAt === 0`, stat failure) are never reaped — protects a fresh session whose worktree creation races the stat.
- A failed removal is caught and logged, and the worktree counted still-live — degrades to today's behaviour (occupied slot) instead of aborting the pass.
- `runReviewPass` (`scripts/run-autopilot.ts`) wires `removeWorktree` to `git worktree remove --force <path>` via the existing `CommandRunner` and logs `[autopilot] review reaped stale worktree → PR #…`.
- Separate chore commit: `@types/node` devDependency — `yarn typecheck` was broken on clean HEAD (~150 errors on `node:*` imports); types-only, trivially droppable.

Forced removal is safe in this namespace: review worktrees are checked out with `worktree add -B <headBranch> origin/<headBranch>`, so committed work survives on the branch ref, and `-B` makes a leftover local branch harmless on re-dispatch.

## Known trade-offs (review findings, judged non-blocking — inherent to the issue-prescribed 2h-age pattern; candidates for a follow-up issue)

- Age is a proxy for death: an alive-but-slow (>2h) review session gets its worktree removed and the PR re-dispatched; 2h effectively doubles as the review session wall-clock, same as merge-prep.
- Uncommitted (not committed-but-unpushed) work in a >2h worktree is discarded by `--force`.
- A worktree whose directory vanished outside git stats to `startedAt 0` and is never reaped (nothing runs `git worktree prune`); the AC explicitly mandates the startedAt-0 protection, so closing this hole (distinguish vanished-dir from stat race) is follow-up scope.
- A *locked* worktree fails removal every cycle (loudly logged, slot occupied) — same limitation as the drift sweep.

## Test plan

TDD: the two regression tests were written first and watched fail, then implementation made them pass.

- `reaps a stale worktree, frees its cap slot, and dispatches a waiting PR in the same cycle` — `reviewCap: 3` deliberately equals the 3 pre-reap in-flight worktrees (stale / fresh / unknown-age), so budget is 0 before the reap; the waiting PR dispatching proves the freed slot (not spare cap) enabled it. Also asserts the unknown-age worktree is not removed.
- `keeps a worktree counted as live when removeWorktree throws, without aborting other dispatch`.
- Full suite: `cd packages/autopilot && yarn typecheck && yarn test` — 58 files, 510 tests, green.

Closes #1764

🤖 Generated with [Claude Code](https://claude.com/claude-code)