### PR TITLE
feat(harness-layer): evidence-episode seed lane + Stage 1 seed set (rescope R4)

### DIFF
--- a/client/packages/harness-layer/fixtures/stage1-seeds/distractor-operator-claims.episode.json
+++ b/client/packages/harness-layer/fixtures/stage1-seeds/distractor-operator-claims.episode.json
@@ -1,0 +1,48 @@
+{
+  "id": "distractor-operator-claims",
+  "repo": "Jinn-Network/mono",
+  "baseCommit": "c041cc4cdc91c364640c4805a3158e192810e70d",
+  "taskSummary": "Warn when a joinedSolverNets entry silently skips claim registration",
+  "tags": [
+    "mono",
+    "operator",
+    "claims",
+    "solvernet"
+  ],
+  "steps": [
+    {
+      "label": "failure",
+      "title": "run the failing scoped test",
+      "text": "$ yarn --cwd client test test/solver-nets/registry-register-joined.test.ts\n\n ❱ |node| test/solver-nets/registry-register-joined.test.ts (5 tests | 2 failed)\n       × warns (missing contract field) and does not register when contract is absent\n       × warns (did not resolve) and does not register when contract is unknown\n\n⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯\n\n FAIL  |node| test/solver-nets/registry-register-joined.test.ts > registerJoinedNet > diagnostic warnings on silent skip > warns (missing contract field) and does not register when contract is absent\nAssertionError: expected \"warn\" to be called 1 times, but got 0 times\n ❱ test/solver-nets/registry-register-joined.test.ts:55:23\n\n Test Files  1 failed (1)\n      Tests  2 failed | 3 passed (5)"
+    },
+    {
+      "label": "note",
+      "title": "diagnose the silent skip",
+      "text": "registerJoinedNet returns early, with no diagnostic, whenever a joinedSolverNets config entry has no `contract` field or references a contract id/version that does not resolve to a known SolverNet. An operator running a hand-written or stale config sees the entry listed in the catalog but it never participates in the claim flow, and there is nothing in the logs to explain why — the two early `return` statements are silent."
+    },
+    {
+      "label": "fix",
+      "title": "warn at each early-return point",
+      "text": "Add a console.warn line immediately before each of the two early returns, naming the manifest CID and the specific reason (missing contract field vs. an unresolved contract), so the skip is visible in operator logs instead of silent."
+    },
+    {
+      "label": "diff",
+      "title": "the fix, as landed",
+      "text": "--- a/client/src/solver-nets/registry.ts\n+++ b/client/src/solver-nets/registry.ts\n@@ -252,10 +252,20 @@ export async function registerJoinedNet(\n   cid: string,\n   joined: JoinedSolverNetConfig,\n ): Promise<void> {\n-  if (!joined.contract) return;\n+  if (!joined.contract) {\n+    console.warn(\n+      `[solver-nets] joinedSolverNets[${cid}] missing contract field — entry will not participate in claim flow`,\n+    );\n+    return;\n+  }\n   const solverType = `${joined.contract.id}.${joined.contract.version}`;\n   const contract = getSolverNetContract(joined.contract);\n-  if (!contract) return;\n+  if (!contract) {\n+    console.warn(\n+      `[solver-nets] joinedSolverNets[${cid}] contract ${solverType} did not resolve to a known SolverNet — entry will not participate in claim flow`,\n+    );\n+    return;\n+  }\n   const roles = rolesFromJoinedConfig(joined);"
+    },
+    {
+      "label": "command",
+      "title": "rerun — passing",
+      "text": "$ yarn --cwd client test test/solver-nets/registry-register-joined.test.ts\n\n ✓ |node| test/solver-nets/registry-register-joined.test.ts > registerJoinedNet > diagnostic warnings on silent skip > warns (missing contract field) and does not register when contract is absent\n ✓ |node| test/solver-nets/registry-register-joined.test.ts > registerJoinedNet > diagnostic warnings on silent skip > warns (did not resolve) and does not register when contract is unknown\n\n Test Files  1 passed (1)\n      Tests  5 passed (5)"
+    }
+  ],
+  "outcome": {
+    "status": "completed",
+    "verifiabilityTier": "tests-passed"
+  },
+  "synthesis": "registerJoinedNet returned early, without any diagnostic, whenever a joinedSolverNets config entry had no contract field or referenced a contract id/version that did not resolve to a known SolverNet — an operator running a hand-written or stale config would see the entry listed in the catalog but never participate in the claim flow, with nothing in the logs to explain why. The fix adds a console.warn line at each of the two early-return points, naming the manifest CID and the specific reason (missing field vs. unresolved contract) so the skip is visible instead of silent. The regression test spies on console.warn and asserts both the count and the message content for each skip path, plus a negative assertion that the happy path stays silent. The general pattern: a validation function that returns early on bad input should say why, not just decline to act — silence indistinguishable from success is exactly what makes misconfiguration invisible.",
+  "attribution": {
+    "origin": "operator-recorded-session",
+    "sourceUrl": "https://github.com/Jinn-Network/mono/commit/d682f811dca6c5bd9fbd5711bae71cead58985f2"
+  }
+}

--- a/client/packages/harness-layer/fixtures/stage1-seeds/distractor-skill-tdd-dup.json
+++ b/client/packages/harness-layer/fixtures/stage1-seeds/distractor-skill-tdd-dup.json
@@ -1,0 +1,7 @@
+{
+  "skill": "distractor/skill-tdd-mirror/test-driven-development",
+  "source": "https://github.com/distractor/skill-tdd-mirror",
+  "licence": "MIT",
+  "description": "Write a failing test before writing the code that makes it pass.",
+  "skillMd": "---\nname: test-driven-development\ndescription: Write a failing test before writing the code that makes it pass.\n---\n\n# Test-Driven Development\n\n1. Write a failing test that captures the behavior you want.\n2. Run it and confirm it fails for the expected reason.\n3. Write the minimum code needed to make it pass.\n4. Run it again and confirm it passes.\n5. Refactor with the passing test as a safety net.\n\nNever write production code before a failing test proves it is needed.\n"
+}

--- a/client/packages/harness-layer/fixtures/stage1-seeds/distractor-skill-tdd.json
+++ b/client/packages/harness-layer/fixtures/stage1-seeds/distractor-skill-tdd.json
@@ -1,0 +1,7 @@
+{
+  "skill": "distractor/skill-tdd/test-driven-development",
+  "source": "https://github.com/distractor/skill-tdd",
+  "licence": "MIT",
+  "description": "Write a failing test before writing the code that makes it pass.",
+  "skillMd": "---\nname: test-driven-development\ndescription: Write a failing test before writing the code that makes it pass.\n---\n\n# Test-Driven Development\n\n1. Write a failing test that captures the behavior you want.\n2. Run it and confirm it fails for the expected reason.\n3. Write the minimum code needed to make it pass.\n4. Run it again and confirm it passes.\n5. Refactor with the passing test as a safety net.\n\nNever write production code before a failing test proves it is needed.\n"
+}

--- a/client/packages/harness-layer/fixtures/stage1-seeds/distractor-sympy-printing.episode.json
+++ b/client/packages/harness-layer/fixtures/stage1-seeds/distractor-sympy-printing.episode.json
@@ -37,10 +37,10 @@
   ],
   "outcome": {
     "status": "completed",
-    "verifiabilityTier": "tests-passed"
+    "verifiabilityTier": "user-accepted"
   },
   "synthesis": "sympy's LaTeX printer represents a symbol like Symbol('x_i_j') as two separate subscript indices, i and j, rendered as x_{i j} — a space-separated brace group that reads unambiguously as two indices rather than one two-character subscript. _print_Symbol builds this by joining the parts split_super_sub extracts from the symbol's name, and the subscript branch had regressed to an empty-string join, collapsing ['i', 'j'] into the ambiguous x_{ij}. The superscript branch a few lines below already joined with a space, so the fix makes the subscript branch consistent with it. The regression test test_latex_symbols pins the exact rendered string for a two-part subscript symbol, so this class of join-separator bug cannot reappear silently.",
   "attribution": {
-    "origin": "operator-authored-distractor"
+    "origin": "synthetic-selection-distractor"
   }
 }

--- a/client/packages/harness-layer/fixtures/stage1-seeds/distractor-sympy-printing.episode.json
+++ b/client/packages/harness-layer/fixtures/stage1-seeds/distractor-sympy-printing.episode.json
@@ -1,0 +1,46 @@
+{
+  "id": "distractor-sympy-printing",
+  "repo": "sympy/sympy",
+  "taskSummary": "Fix LaTeX printer dropping the separator between multi-part symbol subscripts",
+  "tags": [
+    "sympy",
+    "printing",
+    "latex",
+    "regression"
+  ],
+  "steps": [
+    {
+      "label": "failure",
+      "title": "run the failing scoped test",
+      "text": "$ python -m pytest sympy/printing/tests/test_latex.py -k test_latex_symbols -q\n\nF                                                                        [100%]\n================================== FAILURES ==================================\n_____________________________ test_latex_symbols ______________________________\n\n    def test_latex_symbols():\n        ...\n>       assert latex(Symbol('x_i_j')) == 'x_{i j}'\nE       AssertionError: assert 'x_{ij}' == 'x_{i j}'\nE         - x_{i j}\nE         + x_{ij}\n\nsympy/printing/tests/test_latex.py:842: AssertionError\n1 failed, 1 passed in 0.42s"
+    },
+    {
+      "label": "note",
+      "title": "diagnose the failure",
+      "text": "Symbol('x_i_j') represents x with two separate subscript indices, i and j, rendered as x_{i j} — a space-separated brace group that reads unambiguously as two indices rather than one two-character subscript. _print_Symbol builds this by joining the parts split_super_sub extracts from the symbol's name; the subscript branch was joining with an empty separator, collapsing ['i', 'j'] into the ambiguous x_{ij}."
+    },
+    {
+      "label": "fix",
+      "title": "join subscript parts with a space, matching the superscript branch",
+      "text": "Join multiple subscript parts with a literal space before wrapping them in braces, the same convention the superscript branch two lines below already uses: ' '.join(subs) instead of ''.join(subs)."
+    },
+    {
+      "label": "diff",
+      "title": "the fix",
+      "text": "--- a/sympy/printing/latex.py\n+++ b/sympy/printing/latex.py\n@@ def _print_Symbol(self, expr, style='plain'):\n     name, supers, subs = split_super_sub(expr.name)\n     name = translate(name)\n     supers = [translate(sup) for sup in supers]\n     subs = [translate(sub) for sub in subs]\n \n     if subs:\n-        name += '_{%s}' % ''.join(subs)\n+        name += '_{%s}' % ' '.join(subs)\n     if supers:\n         name += '^{%s}' % ' '.join(supers)\n \n     return name"
+    },
+    {
+      "label": "command",
+      "title": "rerun — passing",
+      "text": "$ python -m pytest sympy/printing/tests/test_latex.py -k test_latex_symbols -q\n\n.                                                                        [100%]\n1 passed in 0.31s"
+    }
+  ],
+  "outcome": {
+    "status": "completed",
+    "verifiabilityTier": "tests-passed"
+  },
+  "synthesis": "sympy's LaTeX printer represents a symbol like Symbol('x_i_j') as two separate subscript indices, i and j, rendered as x_{i j} — a space-separated brace group that reads unambiguously as two indices rather than one two-character subscript. _print_Symbol builds this by joining the parts split_super_sub extracts from the symbol's name, and the subscript branch had regressed to an empty-string join, collapsing ['i', 'j'] into the ambiguous x_{ij}. The superscript branch a few lines below already joined with a space, so the fix makes the subscript branch consistent with it. The regression test test_latex_symbols pins the exact rendered string for a two-part subscript symbol, so this class of join-separator bug cannot reappear silently.",
+  "attribution": {
+    "origin": "operator-recorded-session"
+  }
+}

--- a/client/packages/harness-layer/fixtures/stage1-seeds/distractor-sympy-printing.episode.json
+++ b/client/packages/harness-layer/fixtures/stage1-seeds/distractor-sympy-printing.episode.json
@@ -41,6 +41,6 @@
   },
   "synthesis": "sympy's LaTeX printer represents a symbol like Symbol('x_i_j') as two separate subscript indices, i and j, rendered as x_{i j} — a space-separated brace group that reads unambiguously as two indices rather than one two-character subscript. _print_Symbol builds this by joining the parts split_super_sub extracts from the symbol's name, and the subscript branch had regressed to an empty-string join, collapsing ['i', 'j'] into the ambiguous x_{ij}. The superscript branch a few lines below already joined with a space, so the fix makes the subscript branch consistent with it. The regression test test_latex_symbols pins the exact rendered string for a two-part subscript symbol, so this class of join-separator bug cannot reappear silently.",
   "attribution": {
-    "origin": "operator-recorded-session"
+    "origin": "operator-authored-distractor"
   }
 }

--- a/client/packages/harness-layer/fixtures/stage1-seeds/source-dashboard-flake.episode.json
+++ b/client/packages/harness-layer/fixtures/stage1-seeds/source-dashboard-flake.episode.json
@@ -1,0 +1,50 @@
+{
+  "id": "source-dashboard-flake",
+  "repo": "Jinn-Network/mono",
+  "baseCommit": "3651de92ccda900dc6d052b94035f9a86d5b21be",
+  "taskSummary": "Fix flaky dashboard update_available banner test — assert after the version status fetch resolves",
+  "tags": [
+    "mono",
+    "dashboard",
+    "vitest",
+    "version-status",
+    "async",
+    "flake"
+  ],
+  "steps": [
+    {
+      "label": "failure",
+      "title": "run the failing scoped test",
+      "text": "$ yarn --cwd client test src/dashboard/spa/src/notifications/useNotifications.test.tsx\n\n ❱ |spa-jsdom| src/dashboard/spa/src/notifications/useNotifications.test.tsx (11 tests | 1 failed)\n     × does not emit update_available when /v1/status.latestVersion is null\n\n⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯\n\n FAIL  |spa-jsdom| src/dashboard/spa/src/notifications/useNotifications.test.tsx > useNotifications > does not emit update_available when /v1/status.latestVersion is null\nAssertionError: expected [] to include 'funding_low'\n\n ❱ src/dashboard/spa/src/notifications/useNotifications.test.tsx:169:65\n    167|     // funding_low fires from the zero-balance default; wait for it so…\n    168|     // has settled before asserting the negative.\n    169|     await waitFor(() => expect(result.current.map(n => n.kind)).toCont…\n       |                                                                 ^\n    170|     expect(result.current.map(n => n.kind)).not.toContain('update_avai…\n    171|   });\n\n Test Files  1 failed (1)\n      Tests  1 failed | 10 passed (11)"
+    },
+    {
+      "label": "note",
+      "title": "diagnose the failure",
+      "text": "The test waits for a 'funding_low' notification to appear before asserting that 'update_available' is absent, on the theory that the zero-balance default status fixture would produce one. Current gas-runway semantics do not manufacture 'funding_low' from a status fixture that omits the threshold/runway fields, so that wait condition never becomes true and waitFor times out. The test is waiting on the wrong signal: it needs to wait for the async status fetch itself to settle, not for an unrelated notification whose emission rules can change independently."
+    },
+    {
+      "label": "fix",
+      "title": "wait on the status fetch instead of an unrelated notification",
+      "text": "Replace the wait condition with one anchored to the fetch the test actually depends on: await waitFor(() => expect(apiMocks.getStatus).toHaveBeenCalled()), then assert the negative once the async status resolution has settled. This decouples 'wait for the hook to settle' from notification semantics that can legitimately change without invalidating this test."
+    },
+    {
+      "label": "diff",
+      "title": "the fix, as landed",
+      "text": "--- a/client/src/dashboard/spa/src/notifications/useNotifications.test.tsx\n+++ b/client/src/dashboard/spa/src/notifications/useNotifications.test.tsx\n@@ -164,9 +164,10 @@ describe('useNotifications', () => {\n       wrapper: makeWrapper(),\n     });\n \n-    // funding_low fires from the zero-balance default; wait for it so the hook\n-    // has settled before asserting the negative.\n-    await waitFor(() => expect(result.current.map(n => n.kind)).toContain('funding_low'));\n+    // Wait until the status fetch has settled before asserting the negative.\n+    // Current gas-runway semantics do not manufacture a funding notification\n+    // from a status fixture that omits the threshold/runway fields.\n+    await waitFor(() => expect(apiMocks.getStatus).toHaveBeenCalled());\n     expect(result.current.map(n => n.kind)).not.toContain('update_available');\n   });"
+    },
+    {
+      "label": "command",
+      "title": "rerun — passing",
+      "text": "$ yarn --cwd client test src/dashboard/spa/src/notifications/useNotifications.test.tsx\n\n ✓ |spa-jsdom| src/dashboard/spa/src/notifications/useNotifications.test.tsx > useNotifications > does not emit update_available when /v1/status.latestVersion is null\n\n Test Files  1 passed (1)\n      Tests  11 passed (11)"
+    }
+  ],
+  "outcome": {
+    "status": "completed",
+    "verifiabilityTier": "tests-passed"
+  },
+  "synthesis": "The 'does not emit update_available when /v1/status.latestVersion is null' test waited for a funding_low notification to appear before asserting that update_available was absent, assuming the zero-balance default fixture would produce one. Current gas-runway semantics no longer manufacture funding_low from a status fixture that omits the threshold/runway fields, so the wait condition never became true and waitFor timed out with 'expected [] to include funding_low'. The fix anchors the wait to the async operation the test actually depends on — apiMocks.getStatus having been called — rather than to an unrelated notification whose emission rules can change independently. The general pattern: when a test needs an async hook to settle before asserting a negative, wait on a signal tied directly to the operation in flight (the mock/fetch call itself), not on a side effect that a legitimate, unrelated change can silently stop producing.",
+  "attribution": {
+    "origin": "operator-recorded-session",
+    "sourceUrl": "https://github.com/Jinn-Network/mono/commit/163e070d254aaa1f8e980d1a69888f8d8baf9f14"
+  }
+}

--- a/client/packages/harness-layer/src/cli.ts
+++ b/client/packages/harness-layer/src/cli.ts
@@ -1183,6 +1183,7 @@ export async function runJinnLayerCli(
             `    ref     ${row.envelopeRef}`,
             `    anchor  ${row.anchorTx ? `${TESTNET_EXPLORER_TX_URL}${row.anchorTx}` : '-'}`,
             ...(row.supersedes ? [`    supersedes ${row.supersedes}`] : []),
+            ...(row.ledgerWarning ? [`    WARNING ${row.ledgerWarning}`] : []),
             ...(row.stateWarning ? [`    WARNING ${row.stateWarning}`] : []),
           );
         }
@@ -1190,7 +1191,10 @@ export async function runJinnLayerCli(
         for (const row of result.errors) lines.push(`  ERROR    ${row.id} — ${row.error}`);
         writer.write(lines.join('\n') + '\n');
       }
-      return result.errors.length > 0 || result.imported.some((row) => row.stateWarning !== undefined) ? 1 : 0;
+      return result.errors.length > 0 ||
+        result.imported.some((row) => row.stateWarning !== undefined || row.ledgerWarning !== undefined)
+        ? 1
+        : 0;
     }
 
     const report = parseImportReport(JSON.parse(readFileSync(reportFile, 'utf-8')));
@@ -1210,6 +1214,7 @@ export async function runJinnLayerCli(
           `  IMPORTED ${row.skill}`,
           `    ref     ${row.envelopeRef}`,
           `    anchor  ${row.anchorTx ? `${TESTNET_EXPLORER_TX_URL}${row.anchorTx}` : '-'}`,
+          ...(row.ledgerWarning ? [`    WARNING ${row.ledgerWarning}`] : []),
           ...(row.stateWarning ? [`    WARNING ${row.stateWarning}`] : []),
         );
       }
@@ -1217,7 +1222,10 @@ export async function runJinnLayerCli(
       for (const row of result.errors) lines.push(`  ERROR    ${row.skill} — ${row.error}`);
       writer.write(lines.join('\n') + '\n');
     }
-    return result.errors.length > 0 || result.imported.some((row) => row.stateWarning !== undefined) ? 1 : 0;
+    return result.errors.length > 0 ||
+      result.imported.some((row) => row.stateWarning !== undefined || row.ledgerWarning !== undefined)
+      ? 1
+      : 0;
   }
 
   if (isDistillModels) {

--- a/client/packages/harness-layer/src/cli.ts
+++ b/client/packages/harness-layer/src/cli.ts
@@ -1148,17 +1148,31 @@ export async function runJinnLayerCli(
     }
     const deps = opts.publishDeps ?? buildLivePublishDepsFromEnv();
     // File-backed by default (issue #1771): real `seed execute` runs persist
-    // idempotency state across invocations. Tests inject an in-memory store.
-    const state = opts.seedImportState ?? createFileSeedImportState();
+    // idempotency state across invocations (path overridable via
+    // JINN_LAYER_SEED_STATE_PATH, mirroring JINN_LAYER_LEDGER_PATH). Tests
+    // inject an in-memory store. A corrupt state file is fail-open (treated
+    // as empty; semantics in state.ts); its warning is collected here and
+    // surfaced on THIS command's own output below — a `warnings` field in
+    // --json mode, a WARNING line in table mode — not only console.warn
+    // (PR #1779 review).
+    const stateWarnings: string[] = [];
+    const state = opts.seedImportState ?? createFileSeedImportState(
+      process.env['JINN_LAYER_SEED_STATE_PATH'],
+      { onWarning: (message) => stateWarnings.push(message) },
+    );
 
     if (isEpisodes) {
       const episodeReport = parseEpisodeImportReport(JSON.parse(readFileSync(reportFile, 'utf-8')));
       const result = await executeEpisodes(episodeReport, buildEpisodeSource(), deps, { state });
       if (parsed.values.json) {
-        writer.write(JSON.stringify(result) + '\n');
+        writer.write(JSON.stringify({
+          ...result,
+          ...(stateWarnings.length > 0 ? { warnings: stateWarnings } : {}),
+        }) + '\n');
       } else {
         const lines = [
           `${result.imported.length} imported, ${result.skipped.length} skipped, ${result.errors.length} error(s)`,
+          ...stateWarnings.map((w) => `  WARNING  ${w}`),
         ];
         for (const row of result.imported) {
           lines.push(
@@ -1178,10 +1192,14 @@ export async function runJinnLayerCli(
     const report = parseImportReport(JSON.parse(readFileSync(reportFile, 'utf-8')));
     const result = await seedExecute(report, buildSource(), deps, { state });
     if (parsed.values.json) {
-      writer.write(JSON.stringify(result) + '\n');
+      writer.write(JSON.stringify({
+        ...result,
+        ...(stateWarnings.length > 0 ? { warnings: stateWarnings } : {}),
+      }) + '\n');
     } else {
       const lines = [
         `${result.imported.length} imported, ${result.skipped.length} skipped, ${result.errors.length} error(s)`,
+        ...stateWarnings.map((w) => `  WARNING  ${w}`),
       ];
       for (const row of result.imported) {
         lines.push(`  IMPORTED ${row.skill}`, `    ref     ${row.envelopeRef}`, `    anchor  ${row.anchorTx ? `${TESTNET_EXPLORER_TX_URL}${row.anchorTx}` : '-'}`);

--- a/client/packages/harness-layer/src/cli.ts
+++ b/client/packages/harness-layer/src/cli.ts
@@ -56,6 +56,11 @@ import {
 import { plan as seedPlan } from './seed-import/plan.js';
 import { execute as seedExecute } from './seed-import/execute.js';
 import { parseImportReport, renderImportReport } from './seed-import/report.js';
+import { createLocalEpisodeSeedSource, type EpisodeSource } from './seed-import/episode-fetch.js';
+import { planEpisodes } from './seed-import/episode-plan.js';
+import { executeEpisodes } from './seed-import/episode-execute.js';
+import { parseEpisodeImportReport, renderEpisodeImportReport } from './seed-import/episode-report.js';
+import { createFileSeedImportState, type SeedImportStateStore } from './seed-import/state.js';
 import { extractSkill } from './skill.js';
 import { isInsidePackageDir } from '../../../src/util/path-safety.js';
 import { runDistillationPipeline } from './pipeline.js';
@@ -179,7 +184,17 @@ Commands:
   seed execute <report-file> --source <list-file> [--json]
                                                  Publish the approved import rows (APPROVAL
                                                  GATE: run only after the plan report is
-                                                 signed off)
+                                                 signed off). Idempotent: unchanged seeds
+                                                 republish nothing; changed seeds supersede
+                                                 the prior record
+  seed plan --episodes-dir <dir> [--out <report-file>] [--json]
+                                                 List + validate evidence-episode seed files
+                                                 (docs/runbooks/stage1-evidence-seeding.md);
+                                                 ZERO writes
+  seed execute <report-file> --episodes-dir <dir> [--json]
+                                                 Publish the approved evidence episodes
+                                                 (APPROVAL GATE, idempotent + supersedes,
+                                                 same as the skill lane above)
   distill run [--limit N] [--out <dir>] [--meta]
               [--distiller claude|codex] [--local-only]
                                                  Run the distillation pipeline over the
@@ -374,6 +389,10 @@ export interface RunJinnLayerCliOptions {
   publishDeps?: HarnessPublishDeps;
   /** Injectable seed source (tests). Default: GitHub source over --source list. */
   seedSource?: SeedSource;
+  /** Injectable evidence-episode seed source (tests). Default: local dir source over --episodes-dir. */
+  episodeSource?: EpisodeSource;
+  /** Injectable seed-import idempotency state (tests). Default: file-backed store (real `seed execute` runs). */
+  seedImportState?: SeedImportStateStore;
   /** Injectable distill-pipeline deps (tests). Default: live wiring per field. */
   distillRunDeps?: DistillRunCliDeps;
   /** Injectable rung-1 own-captures deps (tests). Default: provider-resolved distill port. */
@@ -1006,6 +1025,7 @@ export async function runJinnLayerCli(
         path: { type: 'string' },
         veto: { type: 'boolean', default: false },
         source: { type: 'string' },
+        'episodes-dir': { type: 'string' },
         meta: { type: 'boolean', default: false },
         distiller: { type: 'string' },
         'distiller-model': { type: 'string' },
@@ -1077,7 +1097,35 @@ export async function runJinnLayerCli(
       });
     };
 
+    // Evidence-episode source (issue #1771): a separate, parallel lane over
+    // --episodes-dir, chosen instead of --source when either is present. The
+    // two lanes never mix in one report — episodes are first-party content
+    // with no licence gate, so their report shape differs from ImportReport.
+    const episodesDir = parsed.values['episodes-dir'] as string | undefined;
+    const isEpisodes = Boolean(opts.episodeSource) || episodesDir !== undefined;
+    const buildEpisodeSource = (): EpisodeSource => {
+      if (opts.episodeSource) return opts.episodeSource;
+      if (!episodesDir) {
+        throw new Error('seed commands require --episodes-dir <dir> (seed-episode JSON files) or an injected episodeSource');
+      }
+      return createLocalEpisodeSeedSource(episodesDir);
+    };
+
     if (subverb === 'plan') {
+      if (isEpisodes) {
+        const episodeReport = await planEpisodes(buildEpisodeSource());
+        const outFile = parsed.values.out as string | undefined;
+        if (outFile) writeFileSync(outFile, JSON.stringify(episodeReport, null, 2) + '\n');
+        if (parsed.values.json) {
+          writer.write(JSON.stringify(episodeReport) + '\n');
+        } else {
+          writer.write(renderEpisodeImportReport(episodeReport) + '\n');
+          writer.write(outFile
+            ? `\nReport written to ${outFile}. APPROVAL GATE: review (edit verdicts if needed), then run seed execute ${outFile} --episodes-dir ${episodesDir ?? '<dir>'}.\n`
+            : '\nAPPROVAL GATE: re-run with --out <report-file>, review, then seed execute.\n');
+        }
+        return 0;
+      }
       const report = await seedPlan(buildSource());
       const outFile = parsed.values.out as string | undefined;
       if (outFile) writeFileSync(outFile, JSON.stringify(report, null, 2) + '\n');
@@ -1098,9 +1146,37 @@ export async function runJinnLayerCli(
       writer.write(`error: seed execute requires a <report-file> argument (the approved plan report)\n\n${USAGE}`);
       return 2;
     }
-    const report = parseImportReport(JSON.parse(readFileSync(reportFile, 'utf-8')));
     const deps = opts.publishDeps ?? buildLivePublishDepsFromEnv();
-    const result = await seedExecute(report, buildSource(), deps);
+    // File-backed by default (issue #1771): real `seed execute` runs persist
+    // idempotency state across invocations. Tests inject an in-memory store.
+    const state = opts.seedImportState ?? createFileSeedImportState();
+
+    if (isEpisodes) {
+      const episodeReport = parseEpisodeImportReport(JSON.parse(readFileSync(reportFile, 'utf-8')));
+      const result = await executeEpisodes(episodeReport, buildEpisodeSource(), deps, { state });
+      if (parsed.values.json) {
+        writer.write(JSON.stringify(result) + '\n');
+      } else {
+        const lines = [
+          `${result.imported.length} imported, ${result.skipped.length} skipped, ${result.errors.length} error(s)`,
+        ];
+        for (const row of result.imported) {
+          lines.push(
+            `  IMPORTED ${row.id}`,
+            `    ref     ${row.envelopeRef}`,
+            `    anchor  ${row.anchorTx ? `${TESTNET_EXPLORER_TX_URL}${row.anchorTx}` : '-'}`,
+            ...(row.supersedes ? [`    supersedes ${row.supersedes}`] : []),
+          );
+        }
+        for (const row of result.skipped) lines.push(`  skipped  ${row.id} — ${row.reason}`);
+        for (const row of result.errors) lines.push(`  ERROR    ${row.id} — ${row.error}`);
+        writer.write(lines.join('\n') + '\n');
+      }
+      return result.errors.length > 0 ? 1 : 0;
+    }
+
+    const report = parseImportReport(JSON.parse(readFileSync(reportFile, 'utf-8')));
+    const result = await seedExecute(report, buildSource(), deps, { state });
     if (parsed.values.json) {
       writer.write(JSON.stringify(result) + '\n');
     } else {

--- a/client/packages/harness-layer/src/cli.ts
+++ b/client/packages/harness-layer/src/cli.ts
@@ -1080,9 +1080,15 @@ export async function runJinnLayerCli(
   }
 
   if (isSeed) {
+    const listFile = parsed.values.source as string | undefined;
+    const episodesDir = parsed.values['episodes-dir'] as string | undefined;
+    if (listFile !== undefined && episodesDir !== undefined) {
+      writer.write(`error: seed commands require exactly one of --source or --episodes-dir\n\n${USAGE}`);
+      return 2;
+    }
+
     const buildSource = (): SeedSource => {
       if (opts.seedSource) return opts.seedSource;
-      const listFile = parsed.values.source as string | undefined;
       if (!listFile) {
         throw new Error('seed commands require --source <list-file> (owner/repo[#path] per line) or an injected source');
       }
@@ -1101,7 +1107,6 @@ export async function runJinnLayerCli(
     // --episodes-dir, chosen instead of --source when either is present. The
     // two lanes never mix in one report — episodes are first-party content
     // with no licence gate, so their report shape differs from ImportReport.
-    const episodesDir = parsed.values['episodes-dir'] as string | undefined;
     const isEpisodes = Boolean(opts.episodeSource) || episodesDir !== undefined;
     const buildEpisodeSource = (): EpisodeSource => {
       if (opts.episodeSource) return opts.episodeSource;
@@ -1150,11 +1155,9 @@ export async function runJinnLayerCli(
     // File-backed by default (issue #1771): real `seed execute` runs persist
     // idempotency state across invocations (path overridable via
     // JINN_LAYER_SEED_STATE_PATH, mirroring JINN_LAYER_LEDGER_PATH). Tests
-    // inject an in-memory store. A corrupt state file is fail-open (treated
-    // as empty; semantics in state.ts); its warning is collected here and
-    // surfaced on THIS command's own output below — a `warnings` field in
-    // --json mode, a WARNING line in table mode — not only console.warn
-    // (PR #1779 review).
+    // inject an in-memory store. A corrupt state file fails closed (semantics
+    // in state.ts); its diagnostic is collected here and surfaced on THIS
+    // command's own output in addition to the per-row error.
     const stateWarnings: string[] = [];
     const state = opts.seedImportState ?? createFileSeedImportState(
       process.env['JINN_LAYER_SEED_STATE_PATH'],
@@ -1180,13 +1183,14 @@ export async function runJinnLayerCli(
             `    ref     ${row.envelopeRef}`,
             `    anchor  ${row.anchorTx ? `${TESTNET_EXPLORER_TX_URL}${row.anchorTx}` : '-'}`,
             ...(row.supersedes ? [`    supersedes ${row.supersedes}`] : []),
+            ...(row.stateWarning ? [`    WARNING ${row.stateWarning}`] : []),
           );
         }
         for (const row of result.skipped) lines.push(`  skipped  ${row.id} — ${row.reason}`);
         for (const row of result.errors) lines.push(`  ERROR    ${row.id} — ${row.error}`);
         writer.write(lines.join('\n') + '\n');
       }
-      return result.errors.length > 0 ? 1 : 0;
+      return result.errors.length > 0 || result.imported.some((row) => row.stateWarning !== undefined) ? 1 : 0;
     }
 
     const report = parseImportReport(JSON.parse(readFileSync(reportFile, 'utf-8')));
@@ -1202,13 +1206,18 @@ export async function runJinnLayerCli(
         ...stateWarnings.map((w) => `  WARNING  ${w}`),
       ];
       for (const row of result.imported) {
-        lines.push(`  IMPORTED ${row.skill}`, `    ref     ${row.envelopeRef}`, `    anchor  ${row.anchorTx ? `${TESTNET_EXPLORER_TX_URL}${row.anchorTx}` : '-'}`);
+        lines.push(
+          `  IMPORTED ${row.skill}`,
+          `    ref     ${row.envelopeRef}`,
+          `    anchor  ${row.anchorTx ? `${TESTNET_EXPLORER_TX_URL}${row.anchorTx}` : '-'}`,
+          ...(row.stateWarning ? [`    WARNING ${row.stateWarning}`] : []),
+        );
       }
       for (const row of result.skipped) lines.push(`  skipped  ${row.skill} — ${row.reason}`);
       for (const row of result.errors) lines.push(`  ERROR    ${row.skill} — ${row.error}`);
       writer.write(lines.join('\n') + '\n');
     }
-    return result.errors.length > 0 ? 1 : 0;
+    return result.errors.length > 0 || result.imported.some((row) => row.stateWarning !== undefined) ? 1 : 0;
   }
 
   if (isDistillModels) {

--- a/client/packages/harness-layer/src/index.ts
+++ b/client/packages/harness-layer/src/index.ts
@@ -229,6 +229,7 @@ export {
 // Evidence-episode seed lane (issue #1771).
 export {
   createLocalEpisodeSeedSource,
+  episodeContentDigest,
   parseSeedEpisode,
   SeedEpisodeSchema,
   SEED_EPISODE_EXCERPT_LABELS,

--- a/client/packages/harness-layer/src/index.ts
+++ b/client/packages/harness-layer/src/index.ts
@@ -44,9 +44,11 @@ export {
 
 export {
   publish,
+  PublishLedgerError,
   toTraceEnvelope,
   TRACE_ENVELOPE_ARTIFACT_TYPE,
   type HarnessPublishDeps,
+  type PublishedResult,
   type PublishOptions,
   type PublishResult,
 } from './publish.js';

--- a/client/packages/harness-layer/src/index.ts
+++ b/client/packages/harness-layer/src/index.ts
@@ -210,6 +210,7 @@ export {
 export {
   createGithubSeedSource,
   parseSeedListEntry,
+  SeedSkillSchema,
   type SeedSkill,
   type SeedSource,
   type SeedListEntry,
@@ -224,6 +225,35 @@ export {
   type ImportReport,
   type ImportReportRow,
 } from './seed-import/report.js';
+
+// Evidence-episode seed lane (issue #1771).
+export {
+  createLocalEpisodeSeedSource,
+  parseSeedEpisode,
+  SeedEpisodeSchema,
+  SEED_EPISODE_EXCERPT_LABELS,
+  type SeedEpisode,
+  type SeedEpisodeStep,
+  type SeedEpisodeExcerptLabel,
+  type EpisodeSource,
+} from './seed-import/episode-fetch.js';
+export { planEpisodes } from './seed-import/episode-plan.js';
+export { executeEpisodes, type EpisodeImportResult } from './seed-import/episode-execute.js';
+export {
+  parseEpisodeImportReport,
+  renderEpisodeImportReport,
+  EpisodeImportReportSchema,
+  type EpisodeImportReport,
+  type EpisodeImportReportRow,
+} from './seed-import/episode-report.js';
+export {
+  createMemorySeedImportState,
+  createFileSeedImportState,
+  hashSeedContent,
+  DEFAULT_SEED_IMPORT_STATE_PATH,
+  type SeedImportStateStore,
+  type SeedPublicationRecord,
+} from './seed-import/state.js';
 
 export {
   TraceEnvelopeV0Schema,

--- a/client/packages/harness-layer/src/index.ts
+++ b/client/packages/harness-layer/src/index.ts
@@ -253,6 +253,7 @@ export {
   DEFAULT_SEED_IMPORT_STATE_PATH,
   type SeedImportStateStore,
   type SeedPublicationRecord,
+  type FileSeedImportStateOptions,
 } from './seed-import/state.js';
 
 export {

--- a/client/packages/harness-layer/src/publish.ts
+++ b/client/packages/harness-layer/src/publish.ts
@@ -83,15 +83,33 @@ export interface PublishOptions {
   skill?: SkillArtifactV1;
 }
 
-export type PublishResult =
-  | {
-      vetoed: false;
-      envelopeRef: string;
-      anchorTx: `0x${string}` | null;
-      /** Anchor succeeded, but the local receipt could not be appended. */
-      ledgerWarning?: string;
-    }
-  | { vetoed: true };
+export interface PublishedResult {
+  vetoed: false;
+  envelopeRef: string;
+  anchorTx: `0x${string}` | null;
+}
+
+export type PublishResult = PublishedResult | { vetoed: true };
+
+/**
+ * The irreversible publish/anchor succeeded, but the local contribution
+ * ledger receipt could not be appended. Ordinary callers receive a failure;
+ * recovery-aware seed callers may persist `result` before stopping.
+ */
+export class PublishLedgerError extends Error {
+  override readonly name = 'PublishLedgerError';
+
+  constructor(
+    readonly result: PublishedResult,
+    readonly ledgerError: unknown,
+  ) {
+    const detail = ledgerError instanceof Error ? ledgerError.message : String(ledgerError);
+    super(
+      `anchored ${result.envelopeRef}${result.anchorTx ? ` at ${result.anchorTx}` : ''}, ` +
+        `but local ledger append failed: ${detail}`,
+    );
+  }
+}
 
 function assertPending(pending: PendingEnvelope): void {
   if (
@@ -233,8 +251,8 @@ export async function publish(
     envelope,
   });
   const anchorTx = anchor.txHash ?? null;
+  const result: PublishedResult = { vetoed: false, envelopeRef, anchorTx };
 
-  let ledgerWarning: string | undefined;
   try {
     deps.ledger.append({
       ts: now.toISOString(),
@@ -245,17 +263,10 @@ export async function publish(
       status: 'published',
     });
   } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    ledgerWarning =
-      `anchored ${envelopeRef}${anchorTx ? ` at ${anchorTx}` : ''}, but local ledger append failed: ${detail}`;
+    throw new PublishLedgerError(result, err);
   }
 
-  return {
-    vetoed: false,
-    envelopeRef,
-    anchorTx,
-    ...(ledgerWarning ? { ledgerWarning } : {}),
-  };
+  return result;
 }
 
 async function signWithPrivateKey(

--- a/client/packages/harness-layer/src/publish.ts
+++ b/client/packages/harness-layer/src/publish.ts
@@ -84,7 +84,13 @@ export interface PublishOptions {
 }
 
 export type PublishResult =
-  | { vetoed: false; envelopeRef: string; anchorTx: `0x${string}` | null }
+  | {
+      vetoed: false;
+      envelopeRef: string;
+      anchorTx: `0x${string}` | null;
+      /** Anchor succeeded, but the local receipt could not be appended. */
+      ledgerWarning?: string;
+    }
   | { vetoed: true };
 
 function assertPending(pending: PendingEnvelope): void {
@@ -228,16 +234,28 @@ export async function publish(
   });
   const anchorTx = anchor.txHash ?? null;
 
-  deps.ledger.append({
-    ts: now.toISOString(),
-    taskSummary: trace.task.summary,
+  let ledgerWarning: string | undefined;
+  try {
+    deps.ledger.append({
+      ts: now.toISOString(),
+      taskSummary: trace.task.summary,
+      envelopeRef,
+      anchorTx,
+      verifiabilityTier: trace.outcome.verifiabilityTier,
+      status: 'published',
+    });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    ledgerWarning =
+      `anchored ${envelopeRef}${anchorTx ? ` at ${anchorTx}` : ''}, but local ledger append failed: ${detail}`;
+  }
+
+  return {
+    vetoed: false,
     envelopeRef,
     anchorTx,
-    verifiabilityTier: trace.outcome.verifiabilityTier,
-    status: 'published',
-  });
-
-  return { vetoed: false, envelopeRef, anchorTx };
+    ...(ledgerWarning ? { ledgerWarning } : {}),
+  };
 }
 
 async function signWithPrivateKey(

--- a/client/packages/harness-layer/src/seed-import/episode-execute.ts
+++ b/client/packages/harness-layer/src/seed-import/episode-execute.ts
@@ -16,6 +16,7 @@
 import { capture, type CapturedTask } from '../capture.js';
 import { buildScrubPipeline } from '../../../../src/trajectory/scrub/build.js';
 import { publish, type HarnessPublishDeps } from '../publish.js';
+import type { Attributes } from '../../../../src/trajectory/scrub/types.js';
 import { episodeContentDigest, type EpisodeSource, type SeedEpisode } from './episode-fetch.js';
 import type { EpisodeImportReport } from './episode-report.js';
 import {
@@ -32,6 +33,8 @@ export interface EpisodeImportResult {
     supersedes: string | null;
     /** Publication succeeded, but local lineage state needs operator recovery. */
     stateWarning?: string;
+    /** Anchor succeeded, but the local publication ledger needs recovery. */
+    ledgerWarning?: string;
   }>;
   skipped: Array<{ id: string; reason: string }>;
   errors: Array<{ id: string; error: string }>;
@@ -108,6 +111,32 @@ function toCapturedTask(episode: SeedEpisode, now: Date, supersedes: string | un
   };
 }
 
+/** Every episode-originated string that can influence the published envelope. */
+function episodePrivacyAttributes(episode: SeedEpisode): Attributes {
+  const attributes: Attributes = {
+    'episode.id': episode.id,
+    'episode.repo': episode.repo,
+    'episode.taskSummary': episode.taskSummary,
+    'episode.outcome.status': episode.outcome.status,
+    'episode.outcome.verifiabilityTier': episode.outcome.verifiabilityTier,
+    'episode.synthesis': episode.synthesis,
+    'episode.attribution.origin': episode.attribution.origin,
+  };
+  if (episode.baseCommit) attributes['episode.baseCommit'] = episode.baseCommit;
+  if (episode.attribution.sourceUrl) {
+    attributes['episode.attribution.sourceUrl'] = episode.attribution.sourceUrl;
+  }
+  episode.tags.forEach((tag, index) => {
+    attributes[`episode.tags[${index}]`] = tag;
+  });
+  episode.steps.forEach((step, index) => {
+    attributes[`episode.steps[${index}].label`] = step.label;
+    attributes[`episode.steps[${index}].title`] = step.title;
+    attributes[`episode.steps[${index}].text`] = step.text;
+  });
+  return attributes;
+}
+
 export async function executeEpisodes(
   report: EpisodeImportReport,
   source: EpisodeSource,
@@ -149,6 +178,17 @@ export async function executeEpisodes(
         continue;
       }
 
+      const privacy = await episodeScrubPipeline.run(episodePrivacyAttributes(episode));
+      if (privacy.redactions.length > 0) {
+        const detectors = [
+          ...new Set(privacy.redactions.map((redaction) =>
+            `${redaction.stage}${redaction.detail ? `:${redaction.detail}` : ''}`)),
+        ];
+        throw new Error(
+          `sensitive content detected (${detectors.join(', ')}); refusing to publish evidence episode ${row.id}`,
+        );
+      }
+
       const pending = await capture(toCapturedTask(episode, now, prior?.envelopeRef), {
         pipeline: episodeScrubPipeline,
       });
@@ -162,7 +202,17 @@ export async function executeEpisodes(
           `sensitive content detected (${detectors.join(', ')}); refusing to publish evidence episode ${row.id}`,
         );
       }
-      const published = await publish(pending, deps);
+      let published;
+      try {
+        published = await publish(pending, deps);
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        result.errors.push({
+          id: row.id,
+          error: `publication outcome unknown; do not auto-retry: ${detail}`,
+        });
+        break;
+      }
       if (published.vetoed) throw new Error('unexpected veto on seed publish');
 
       let stateWarning: string | undefined;
@@ -179,8 +229,10 @@ export async function executeEpisodes(
         envelopeRef: published.envelopeRef,
         anchorTx: published.anchorTx,
         supersedes: prior?.envelopeRef ?? null,
+        ...(published.ledgerWarning ? { ledgerWarning: published.ledgerWarning } : {}),
         ...(stateWarning ? { stateWarning } : {}),
       });
+      if (published.ledgerWarning || stateWarning) break;
     } catch (err) {
       result.errors.push({
         id: row.id,

--- a/client/packages/harness-layer/src/seed-import/episode-execute.ts
+++ b/client/packages/harness-layer/src/seed-import/episode-execute.ts
@@ -177,7 +177,16 @@ export async function executeEpisodes(
           `approved content digest ${row.contentDigest} does not match execute-time digest ${contentHash} for ${row.id}`,
         );
       }
-      const prior = state.get(identity);
+      let prior: ReturnType<SeedImportStateStore['get']>;
+      try {
+        prior = state.get(identity);
+      } catch (err) {
+        result.errors.push({
+          id: row.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        break;
+      }
       if (prior && prior.contentHash === contentHash) {
         result.skipped.push({ id: row.id, reason: `unchanged since ${prior.envelopeRef}` });
         continue;

--- a/client/packages/harness-layer/src/seed-import/episode-execute.ts
+++ b/client/packages/harness-layer/src/seed-import/episode-execute.ts
@@ -14,13 +14,12 @@
  */
 
 import { capture, type CapturedTask } from '../capture.js';
-import { buildSeedScrubPipeline } from '../../../../src/trajectory/scrub/build.js';
+import { buildScrubPipeline } from '../../../../src/trajectory/scrub/build.js';
 import { publish, type HarnessPublishDeps } from '../publish.js';
-import type { EpisodeSource, SeedEpisode } from './episode-fetch.js';
+import { episodeContentDigest, type EpisodeSource, type SeedEpisode } from './episode-fetch.js';
 import type { EpisodeImportReport } from './episode-report.js';
 import {
   createMemorySeedImportState,
-  hashSeedContent,
   type SeedImportStateStore,
 } from './state.js';
 
@@ -31,6 +30,8 @@ export interface EpisodeImportResult {
     anchorTx: string | null;
     /** Prior envelopeRef this publish supersedes, or null for a fresh identity. */
     supersedes: string | null;
+    /** Publication succeeded, but local lineage state needs operator recovery. */
+    stateWarning?: string;
   }>;
   skipped: Array<{ id: string; reason: string }>;
   errors: Array<{ id: string; error: string }>;
@@ -52,25 +53,6 @@ function episodeTags(episode: SeedEpisode): string[] {
     if (tag && !tags.includes(tag)) tags.push(tag);
   }
   return tags.slice(0, MAX_TAGS);
-}
-
-/**
- * The content fields that define "did this seed change" for idempotency —
- * excludes nothing capture-time-derived (episodes carry no such field; `id`
- * is the identity key, not content, and is excluded so renaming the id alone
- * is treated as a distinct identity rather than a content change).
- */
-function episodeContentFingerprint(episode: SeedEpisode): unknown {
-  return {
-    repo: episode.repo,
-    baseCommit: episode.baseCommit ?? null,
-    taskSummary: episode.taskSummary,
-    tags: episode.tags,
-    steps: episode.steps,
-    outcome: episode.outcome,
-    synthesis: episode.synthesis,
-    attribution: episode.attribution,
-  };
 }
 
 function toCapturedTask(episode: SeedEpisode, now: Date, supersedes: string | undefined): CapturedTask {
@@ -132,13 +114,17 @@ export async function executeEpisodes(
   deps: HarnessPublishDeps,
   opts: { state?: SeedImportStateStore } = {},
 ): Promise<EpisodeImportResult> {
-  const episodes = new Map((await source.list()).map((e) => [e.id, e]));
+  const episodes = new Map<string, SeedEpisode>();
+  for (const episode of await source.list()) {
+    if (!episodes.has(episode.id)) episodes.set(episode.id, episode);
+  }
   const result: EpisodeImportResult = { imported: [], skipped: [], errors: [] };
   const now = deps.now?.() ?? new Date();
-  // Seed profile (#1409): deterministic secret detectors only — same
-  // pipeline the skill lane uses, for the same reason (episodes are
-  // human-curated prose/commands, not raw operator trace data).
-  const seedScrubPipeline = buildSeedScrubPipeline();
+  // Evidence episodes can contain copied command output and must use the
+  // strict deterministic trace profile: structured PII plus entropy-backed
+  // secret detection. The skill lane intentionally keeps its permissive
+  // public-prose profile (#1409).
+  const episodeScrubPipeline = buildScrubPipeline();
   const state = opts.state ?? createMemorySeedImportState();
 
   for (const row of report) {
@@ -151,7 +137,12 @@ export async function executeEpisodes(
       if (!episode) throw new Error(`episode ${row.id} not found in source ${source.name}`);
 
       const identity = `episode:${episode.id}`;
-      const contentHash = hashSeedContent(episodeContentFingerprint(episode));
+      const contentHash = episodeContentDigest(episode);
+      if (contentHash !== row.contentDigest) {
+        throw new Error(
+          `approved content digest ${row.contentDigest} does not match execute-time digest ${contentHash} for ${row.id}`,
+        );
+      }
       const prior = state.get(identity);
       if (prior && prior.contentHash === contentHash) {
         result.skipped.push({ id: row.id, reason: `unchanged since ${prior.envelopeRef}` });
@@ -159,17 +150,36 @@ export async function executeEpisodes(
       }
 
       const pending = await capture(toCapturedTask(episode, now, prior?.envelopeRef), {
-        pipeline: seedScrubPipeline,
+        pipeline: episodeScrubPipeline,
       });
+      const sensitiveRedactions = pending.redactions.filter((redaction) => redaction.stage !== 'fit');
+      if (sensitiveRedactions.length > 0) {
+        const detectors = [
+          ...new Set(sensitiveRedactions.map((redaction) =>
+            `${redaction.stage}${redaction.detail ? `:${redaction.detail}` : ''}`)),
+        ];
+        throw new Error(
+          `sensitive content detected (${detectors.join(', ')}); refusing to publish evidence episode ${row.id}`,
+        );
+      }
       const published = await publish(pending, deps);
       if (published.vetoed) throw new Error('unexpected veto on seed publish');
 
-      state.set(identity, { contentHash, envelopeRef: published.envelopeRef, publishedAt: now.toISOString() });
+      let stateWarning: string | undefined;
+      try {
+        state.set(identity, { contentHash, envelopeRef: published.envelopeRef, publishedAt: now.toISOString() });
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        stateWarning =
+          `published ${published.envelopeRef}, but seed-import state persistence failed: ${detail}; ` +
+          'recovery required before retrying this episode';
+      }
       result.imported.push({
         id: row.id,
         envelopeRef: published.envelopeRef,
         anchorTx: published.anchorTx,
         supersedes: prior?.envelopeRef ?? null,
+        ...(stateWarning ? { stateWarning } : {}),
       });
     } catch (err) {
       result.errors.push({

--- a/client/packages/harness-layer/src/seed-import/episode-execute.ts
+++ b/client/packages/harness-layer/src/seed-import/episode-execute.ts
@@ -1,0 +1,182 @@
+/**
+ * `executeEpisodes()` — publish approved evidence-episode rows through the
+ * SAME `capture() -> publish()` path skill seeds use (issue #1771). Each
+ * episode becomes a synthetic captured task: one step per authored
+ * `SeedEpisodeStep` (content), plus a final step carrying the synthesis +
+ * attribution (episode-fetch.ts's step convention). `provenance: 'imported'`
+ * throughout, same as skill seeds — excluded from the demand signal and
+ * emissions eligibility by every provenance-aware reader.
+ *
+ * Idempotent by seed identity (state.ts, shared with the skill lane):
+ * unchanged content republishes nothing; changed content republishes and
+ * points the new record's `seed.attribution.supersedes` at the prior
+ * envelopeRef.
+ */
+
+import { capture, type CapturedTask } from '../capture.js';
+import { buildSeedScrubPipeline } from '../../../../src/trajectory/scrub/build.js';
+import { publish, type HarnessPublishDeps } from '../publish.js';
+import type { EpisodeSource, SeedEpisode } from './episode-fetch.js';
+import type { EpisodeImportReport } from './episode-report.js';
+import {
+  createMemorySeedImportState,
+  hashSeedContent,
+  type SeedImportStateStore,
+} from './state.js';
+
+export interface EpisodeImportResult {
+  imported: Array<{
+    id: string;
+    envelopeRef: string;
+    anchorTx: string | null;
+    /** Prior envelopeRef this publish supersedes, or null for a fresh identity. */
+    supersedes: string | null;
+  }>;
+  skipped: Array<{ id: string; reason: string }>;
+  errors: Array<{ id: string; error: string }>;
+}
+
+/** Same caps as seed-import/execute.ts's skill tags (envelope-v0.md size limits). */
+const MAX_TAG_CHARS = 64;
+const MAX_TAGS = 16;
+
+/**
+ * Episode tags: the `seed-import` marker (shared with skill seeds — the
+ * "how did this land in the corpus" signal) plus the episode's own declared
+ * tags, deduped and capped. Mirrors `seedTags()` in execute.ts.
+ */
+function episodeTags(episode: SeedEpisode): string[] {
+  const tags: string[] = [];
+  for (const candidate of ['seed-import', ...episode.tags]) {
+    const tag = candidate.trim().slice(0, MAX_TAG_CHARS);
+    if (tag && !tags.includes(tag)) tags.push(tag);
+  }
+  return tags.slice(0, MAX_TAGS);
+}
+
+/**
+ * The content fields that define "did this seed change" for idempotency —
+ * excludes nothing capture-time-derived (episodes carry no such field; `id`
+ * is the identity key, not content, and is excluded so renaming the id alone
+ * is treated as a distinct identity rather than a content change).
+ */
+function episodeContentFingerprint(episode: SeedEpisode): unknown {
+  return {
+    repo: episode.repo,
+    baseCommit: episode.baseCommit ?? null,
+    taskSummary: episode.taskSummary,
+    tags: episode.tags,
+    steps: episode.steps,
+    outcome: episode.outcome,
+    synthesis: episode.synthesis,
+    attribution: episode.attribution,
+  };
+}
+
+function toCapturedTask(episode: SeedEpisode, now: Date, supersedes: string | undefined): CapturedTask {
+  const nanoBase = now.getTime();
+  const nanoAt = (offset: number) => `${nanoBase + offset}000000`;
+
+  const contentSteps: CapturedTask['steps'] = episode.steps.map((step, i) => ({
+    spanId: `seed-${i + 1}`,
+    parentSpanId: null,
+    name: `seed:step:${step.label}`,
+    startTimeUnixNano: nanoAt(i),
+    endTimeUnixNano: nanoAt(i),
+    attributes: {
+      'seed.step.label': step.label,
+      'seed.step.title': step.title,
+      'seed.step.text': step.text,
+    },
+    redactedKeys: [],
+  }));
+
+  const metaIndex = contentSteps.length;
+  const metaStep: CapturedTask['steps'][number] = {
+    spanId: `seed-${metaIndex + 1}`,
+    parentSpanId: null,
+    name: 'seed:synthesis',
+    startTimeUnixNano: nanoAt(metaIndex),
+    endTimeUnixNano: nanoAt(metaIndex),
+    attributes: {
+      'seed.synthesis': episode.synthesis,
+      'seed.attribution': {
+        repo: episode.repo,
+        ...(episode.baseCommit ? { baseCommit: episode.baseCommit } : {}),
+        origin: episode.attribution.origin,
+        ...(episode.attribution.sourceUrl ? { sourceUrl: episode.attribution.sourceUrl } : {}),
+        ...(supersedes ? { supersedes } : {}),
+      },
+    },
+    redactedKeys: [],
+  };
+
+  return {
+    session: { sessionId: `seed-episode:${episode.id}`, capturedAt: now.toISOString() },
+    task: { summary: episode.taskSummary, distributionTags: episodeTags(episode) },
+    environment: {
+      harness: { name: 'jinn-layer-seed-episode-import', version: '0.1.0' },
+      model: 'none',
+      tools: [],
+    },
+    steps: [...contentSteps, metaStep],
+    outcome: { status: episode.outcome.status, verifiabilityTier: episode.outcome.verifiabilityTier },
+    cost: { durationMs: 0 },
+    provenance: 'imported',
+  };
+}
+
+export async function executeEpisodes(
+  report: EpisodeImportReport,
+  source: EpisodeSource,
+  deps: HarnessPublishDeps,
+  opts: { state?: SeedImportStateStore } = {},
+): Promise<EpisodeImportResult> {
+  const episodes = new Map((await source.list()).map((e) => [e.id, e]));
+  const result: EpisodeImportResult = { imported: [], skipped: [], errors: [] };
+  const now = deps.now?.() ?? new Date();
+  // Seed profile (#1409): deterministic secret detectors only — same
+  // pipeline the skill lane uses, for the same reason (episodes are
+  // human-curated prose/commands, not raw operator trace data).
+  const seedScrubPipeline = buildSeedScrubPipeline();
+  const state = opts.state ?? createMemorySeedImportState();
+
+  for (const row of report) {
+    if (row.verdict === 'skip') {
+      result.skipped.push({ id: row.id, reason: row.reason });
+      continue;
+    }
+    try {
+      const episode = episodes.get(row.id);
+      if (!episode) throw new Error(`episode ${row.id} not found in source ${source.name}`);
+
+      const identity = `episode:${episode.id}`;
+      const contentHash = hashSeedContent(episodeContentFingerprint(episode));
+      const prior = state.get(identity);
+      if (prior && prior.contentHash === contentHash) {
+        result.skipped.push({ id: row.id, reason: `unchanged since ${prior.envelopeRef}` });
+        continue;
+      }
+
+      const pending = await capture(toCapturedTask(episode, now, prior?.envelopeRef), {
+        pipeline: seedScrubPipeline,
+      });
+      const published = await publish(pending, deps);
+      if (published.vetoed) throw new Error('unexpected veto on seed publish');
+
+      state.set(identity, { contentHash, envelopeRef: published.envelopeRef, publishedAt: now.toISOString() });
+      result.imported.push({
+        id: row.id,
+        envelopeRef: published.envelopeRef,
+        anchorTx: published.anchorTx,
+        supersedes: prior?.envelopeRef ?? null,
+      });
+    } catch (err) {
+      result.errors.push({
+        id: row.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return result;
+}

--- a/client/packages/harness-layer/src/seed-import/episode-execute.ts
+++ b/client/packages/harness-layer/src/seed-import/episode-execute.ts
@@ -15,7 +15,12 @@
 
 import { capture, type CapturedTask } from '../capture.js';
 import { buildScrubPipeline } from '../../../../src/trajectory/scrub/build.js';
-import { publish, type HarnessPublishDeps } from '../publish.js';
+import {
+  publish,
+  PublishLedgerError,
+  type HarnessPublishDeps,
+  type PublishResult,
+} from '../publish.js';
 import type { Attributes } from '../../../../src/trajectory/scrub/types.js';
 import { episodeContentDigest, type EpisodeSource, type SeedEpisode } from './episode-fetch.js';
 import type { EpisodeImportReport } from './episode-report.js';
@@ -202,16 +207,22 @@ export async function executeEpisodes(
           `sensitive content detected (${detectors.join(', ')}); refusing to publish evidence episode ${row.id}`,
         );
       }
-      let published;
+      let published: PublishResult;
+      let ledgerWarning: string | undefined;
       try {
         published = await publish(pending, deps);
       } catch (err) {
-        const detail = err instanceof Error ? err.message : String(err);
-        result.errors.push({
-          id: row.id,
-          error: `publication outcome unknown; do not auto-retry: ${detail}`,
-        });
-        break;
+        if (err instanceof PublishLedgerError) {
+          published = err.result;
+          ledgerWarning = err.message;
+        } else {
+          const detail = err instanceof Error ? err.message : String(err);
+          result.errors.push({
+            id: row.id,
+            error: `publication outcome unknown; do not auto-retry: ${detail}`,
+          });
+          break;
+        }
       }
       if (published.vetoed) throw new Error('unexpected veto on seed publish');
 
@@ -229,10 +240,10 @@ export async function executeEpisodes(
         envelopeRef: published.envelopeRef,
         anchorTx: published.anchorTx,
         supersedes: prior?.envelopeRef ?? null,
-        ...(published.ledgerWarning ? { ledgerWarning: published.ledgerWarning } : {}),
+        ...(ledgerWarning ? { ledgerWarning } : {}),
         ...(stateWarning ? { stateWarning } : {}),
       });
-      if (published.ledgerWarning || stateWarning) break;
+      if (ledgerWarning || stateWarning) break;
     } catch (err) {
       result.errors.push({
         id: row.id,

--- a/client/packages/harness-layer/src/seed-import/episode-fetch.ts
+++ b/client/packages/harness-layer/src/seed-import/episode-fetch.ts
@@ -68,7 +68,16 @@ export const SeedEpisodeSchema = z.strictObject({
   /** 3-6 sentence how-it-was-solved text (rescope plan §3.2 `synthesis`). */
   synthesis: z.string().min(1),
   attribution: z.strictObject({
-    /** How this episode entered the corpus, e.g. 'operator-recorded-session'. */
+    /**
+     * How this episode entered the corpus — stated honestly. Vocabulary in
+     * use (freeform by schema; document new values in
+     * docs/runbooks/stage1-evidence-seeding.md):
+     * - 'operator-recorded-session' — transformed from a real recorded
+     *   session; pair with `sourceUrl` when it re-performs a merged fix.
+     * - 'operator-authored-distractor' — hand-authored negative/contrast
+     *   material that must not claim the recorded-session evidentiary
+     *   standard (PR #1779 review).
+     */
     origin: z.string().min(1),
     /** Link to the real merged fix, when the episode re-performs one. */
     sourceUrl: z.string().min(1).optional(),

--- a/client/packages/harness-layer/src/seed-import/episode-fetch.ts
+++ b/client/packages/harness-layer/src/seed-import/episode-fetch.ts
@@ -86,9 +86,10 @@ export const SeedEpisodeSchema = z.strictObject({
 });
 export type SeedEpisode = z.infer<typeof SeedEpisodeSchema>;
 
-/** Canonical content approved by an episode report row (the id is its separate identity key). */
+/** Canonical identity and content approved by an episode report row. */
 export function episodeContentDigest(episode: SeedEpisode): string {
   return hashSeedContent({
+    id: episode.id,
     repo: episode.repo,
     baseCommit: episode.baseCommit ?? null,
     taskSummary: episode.taskSummary,

--- a/client/packages/harness-layer/src/seed-import/episode-fetch.ts
+++ b/client/packages/harness-layer/src/seed-import/episode-fetch.ts
@@ -30,6 +30,7 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { z } from 'zod';
 import { OutcomeStatusSchema, VerifiabilityTierSchema } from '../envelope.js';
+import { hashSeedContent } from './state.js';
 
 /** Rescope plan §3.2 excerpt labels — the knowledge-packet projection's vocabulary. */
 export const SEED_EPISODE_EXCERPT_LABELS = ['failure', 'fix', 'command', 'diff', 'note'] as const;
@@ -74,9 +75,9 @@ export const SeedEpisodeSchema = z.strictObject({
      * docs/runbooks/stage1-evidence-seeding.md):
      * - 'operator-recorded-session' — transformed from a real recorded
      *   session; pair with `sourceUrl` when it re-performs a merged fix.
-     * - 'operator-authored-distractor' — hand-authored negative/contrast
-     *   material that must not claim the recorded-session evidentiary
-     *   standard (PR #1779 review).
+     * - 'synthetic-selection-distractor' — hand-authored negative/contrast
+     *   material, explicitly synthetic and paired with the unverified
+     *   `user-accepted` tier (PR #1779 review).
      */
     origin: z.string().min(1),
     /** Link to the real merged fix, when the episode re-performs one. */
@@ -84,6 +85,20 @@ export const SeedEpisodeSchema = z.strictObject({
   }),
 });
 export type SeedEpisode = z.infer<typeof SeedEpisodeSchema>;
+
+/** Canonical content approved by an episode report row (the id is its separate identity key). */
+export function episodeContentDigest(episode: SeedEpisode): string {
+  return hashSeedContent({
+    repo: episode.repo,
+    baseCommit: episode.baseCommit ?? null,
+    taskSummary: episode.taskSummary,
+    tags: episode.tags,
+    steps: episode.steps,
+    outcome: episode.outcome,
+    synthesis: episode.synthesis,
+    attribution: episode.attribution,
+  });
+}
 
 /** Parse an untrusted value (a seed-episode JSON file) as a SeedEpisode; throws ZodError. */
 export function parseSeedEpisode(input: unknown): SeedEpisode {

--- a/client/packages/harness-layer/src/seed-import/episode-fetch.ts
+++ b/client/packages/harness-layer/src/seed-import/episode-fetch.ts
@@ -1,0 +1,107 @@
+/**
+ * Evidence-episode seed source (issue #1771, rescope plan §4.2-§4.4).
+ *
+ * Stage 1's rescoped retrieval serves evidence records, not skill records
+ * (docs/superpowers/plans/2026-07-16-jinn-plugin-stage-1-rescope-plan.md
+ * §3.1). The shared testnet corpus had almost no evidence to serve — skills.sh
+ * skill seeds only. This source reads a directory of hand-authored
+ * seed-episode JSON files (each transformed offline from a REAL completed
+ * session per the runbook, docs/runbooks/stage1-evidence-seeding.md) and
+ * feeds them through the SAME `capture() -> publish()` path the skill lane
+ * uses (`episode-execute.ts`), so a seeded evidence record is
+ * indistinguishable on the wire from an organically captured one.
+ *
+ * Step convention (so a future retrieval-side packet projector — rescope
+ * plan §3.2 `projectKnowledgePacket`, R1/#1770 — has an obvious, discoverable
+ * shape to read): every content step's `attributes` carries
+ *   'seed.step.label' — one of the §3.2 excerpt labels
+ *                        ('failure' | 'fix' | 'command' | 'diff' | 'note')
+ *   'seed.step.title' — a short human title
+ *   'seed.step.text'  — the excerpt content itself
+ * and a final step carries the episode-level metadata:
+ *   'seed.synthesis'   — the authored how-it-was-solved text (§3.2 `synthesis`)
+ *   'seed.attribution' — { repo, baseCommit?, origin, sourceUrl?, supersedes? }
+ * No bespoke fixture format: this is exactly the frozen jinn.trace-envelope.v0
+ * step shape (spec §3.1), the same free-form-attribute convention the
+ * existing `seed:skill-md` skill-seed step already uses.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { z } from 'zod';
+import { OutcomeStatusSchema, VerifiabilityTierSchema } from '../envelope.js';
+
+/** Rescope plan §3.2 excerpt labels — the knowledge-packet projection's vocabulary. */
+export const SEED_EPISODE_EXCERPT_LABELS = ['failure', 'fix', 'command', 'diff', 'note'] as const;
+export const SeedEpisodeExcerptLabelSchema = z.enum(SEED_EPISODE_EXCERPT_LABELS);
+export type SeedEpisodeExcerptLabel = z.infer<typeof SeedEpisodeExcerptLabelSchema>;
+
+export const SeedEpisodeStepSchema = z.strictObject({
+  label: SeedEpisodeExcerptLabelSchema,
+  title: z.string().min(1),
+  text: z.string().min(1),
+});
+export type SeedEpisodeStep = z.infer<typeof SeedEpisodeStepSchema>;
+
+/**
+ * A seed-episode file — the canonical captured-evidence contract (issue
+ * #1771): task summary, ordered steps with real commands/outputs (a source
+ * episode carries at least one `failure` and its `fix`; distractors are
+ * freeform), outcome + verifiability tier, tags, attribution, and an
+ * authored synthesis. Strict: an unknown field is a malformed fixture, not
+ * silently tolerated.
+ */
+export const SeedEpisodeSchema = z.strictObject({
+  /** Stable seed identity — the idempotency key (state.ts) and filename stem. */
+  id: z.string().min(1),
+  /** `owner/repo` the episode re-performs work in/against. */
+  repo: z.string().min(1),
+  /** Full 40-char commit sha the episode was re-performed AT (pre-fix state), when applicable. */
+  baseCommit: z.string().regex(/^[0-9a-f]{40}$/, 'full 40-char commit sha').optional(),
+  taskSummary: z.string().min(1).max(500),
+  tags: z.array(z.string().min(1)).min(1),
+  steps: z.array(SeedEpisodeStepSchema).min(1),
+  outcome: z.strictObject({
+    status: OutcomeStatusSchema,
+    verifiabilityTier: VerifiabilityTierSchema,
+  }),
+  /** 3-6 sentence how-it-was-solved text (rescope plan §3.2 `synthesis`). */
+  synthesis: z.string().min(1),
+  attribution: z.strictObject({
+    /** How this episode entered the corpus, e.g. 'operator-recorded-session'. */
+    origin: z.string().min(1),
+    /** Link to the real merged fix, when the episode re-performs one. */
+    sourceUrl: z.string().min(1).optional(),
+  }),
+});
+export type SeedEpisode = z.infer<typeof SeedEpisodeSchema>;
+
+/** Parse an untrusted value (a seed-episode JSON file) as a SeedEpisode; throws ZodError. */
+export function parseSeedEpisode(input: unknown): SeedEpisode {
+  return SeedEpisodeSchema.parse(input);
+}
+
+export interface EpisodeSource {
+  name: string;
+  list(): Promise<SeedEpisode[]>;
+}
+
+/**
+ * Local directory seed source: every `*.episode.json` file in `dir`,
+ * validated against `SeedEpisodeSchema`. Sorted by filename for
+ * deterministic plan/execute ordering (reproducible report files; the
+ * fixture-lint test pins this too). Files not matching the `.episode.json`
+ * suffix (e.g. the skill-shaped distractor fixtures) are ignored by
+ * construction — episodes and skills are separate lanes.
+ */
+export function createLocalEpisodeSeedSource(dir: string): EpisodeSource {
+  return {
+    name: `local-episodes:${dir}`,
+    async list(): Promise<SeedEpisode[]> {
+      const files = readdirSync(dir)
+        .filter((f) => f.endsWith('.episode.json'))
+        .sort();
+      return files.map((f) => parseSeedEpisode(JSON.parse(readFileSync(join(dir, f), 'utf-8'))));
+    },
+  };
+}

--- a/client/packages/harness-layer/src/seed-import/episode-plan.ts
+++ b/client/packages/harness-layer/src/seed-import/episode-plan.ts
@@ -1,0 +1,29 @@
+/**
+ * `planEpisodes()` — list + structural validation, ZERO writes (mirrors
+ * `plan.ts` for the evidence-episode source, issue #1771). Episodes are
+ * first-party content (no licence gate); the only structural failure this
+ * catches is a duplicate `id` within one batch — a same-identity collision
+ * would otherwise make idempotency (state.ts) apply to whichever file lists
+ * second, silently dropping the first from the report.
+ */
+
+import type { EpisodeSource, SeedEpisode } from './episode-fetch.js';
+import type { EpisodeImportReport } from './episode-report.js';
+
+export async function planEpisodes(source: EpisodeSource): Promise<EpisodeImportReport> {
+  const episodes = await source.list();
+  const seen = new Set<string>();
+  return episodes.map((episode: SeedEpisode) => {
+    const duplicate = seen.has(episode.id);
+    seen.add(episode.id);
+    return {
+      id: episode.id,
+      taskSummary: episode.taskSummary,
+      tags: episode.tags,
+      verdict: duplicate ? 'skip' : 'import',
+      reason: duplicate
+        ? `duplicate id "${episode.id}" in source — first occurrence wins`
+        : 'first-party recorded episode',
+    } as const;
+  });
+}

--- a/client/packages/harness-layer/src/seed-import/episode-plan.ts
+++ b/client/packages/harness-layer/src/seed-import/episode-plan.ts
@@ -7,7 +7,7 @@
  * second, silently dropping the first from the report.
  */
 
-import type { EpisodeSource, SeedEpisode } from './episode-fetch.js';
+import { episodeContentDigest, type EpisodeSource, type SeedEpisode } from './episode-fetch.js';
 import type { EpisodeImportReport } from './episode-report.js';
 
 export async function planEpisodes(source: EpisodeSource): Promise<EpisodeImportReport> {
@@ -20,6 +20,7 @@ export async function planEpisodes(source: EpisodeSource): Promise<EpisodeImport
       id: episode.id,
       taskSummary: episode.taskSummary,
       tags: episode.tags,
+      contentDigest: episodeContentDigest(episode),
       verdict: duplicate ? 'skip' : 'import',
       reason: duplicate
         ? `duplicate id "${episode.id}" in source — first occurrence wins`

--- a/client/packages/harness-layer/src/seed-import/episode-report.ts
+++ b/client/packages/harness-layer/src/seed-import/episode-report.ts
@@ -5,7 +5,8 @@
  * here is structural, not licence-based: 'skip' only for a duplicate `id`
  * within the same batch (see `episode-plan.ts`). `seed execute --episodes-dir`
  * still reads this report as the approval-gate artifact — nothing publishes
- * that was not on the list a human reviewed.
+ * that was not on the list a human reviewed, and `contentDigest` binds each
+ * row to the exact canonical episode content present at planning time.
  */
 
 import { z } from 'zod';
@@ -14,6 +15,8 @@ export const EpisodeImportReportRowSchema = z.strictObject({
   id: z.string().min(1),
   taskSummary: z.string().min(1),
   tags: z.array(z.string().min(1)),
+  /** SHA-256 over the canonical episode content the operator approved. */
+  contentDigest: z.string().regex(/^[0-9a-f]{64}$/),
   verdict: z.enum(['import', 'skip']),
   reason: z.string().min(1),
 });
@@ -36,6 +39,7 @@ export function renderEpisodeImportReport(report: EpisodeImportReport): string {
       `${row.verdict === 'import' ? 'IMPORT' : 'skip  '}  ${row.id}`,
       `        summary  ${row.taskSummary}`,
       `        tags     ${row.tags.join(', ')}`,
+      `        digest   ${row.contentDigest}`,
       `        reason   ${row.reason}`,
       '',
     );

--- a/client/packages/harness-layer/src/seed-import/episode-report.ts
+++ b/client/packages/harness-layer/src/seed-import/episode-report.ts
@@ -1,0 +1,45 @@
+/**
+ * The EpisodeImportReport — the evidence-episode analogue of `report.ts`'s
+ * ImportReport (issue #1771). Episodes are first-party authored content (no
+ * upstream licence to gate on, unlike the skills.sh skill lane) so `verdict`
+ * here is structural, not licence-based: 'skip' only for a duplicate `id`
+ * within the same batch (see `episode-plan.ts`). `seed execute --episodes-dir`
+ * still reads this report as the approval-gate artifact — nothing publishes
+ * that was not on the list a human reviewed.
+ */
+
+import { z } from 'zod';
+
+export const EpisodeImportReportRowSchema = z.strictObject({
+  id: z.string().min(1),
+  taskSummary: z.string().min(1),
+  tags: z.array(z.string().min(1)),
+  verdict: z.enum(['import', 'skip']),
+  reason: z.string().min(1),
+});
+export type EpisodeImportReportRow = z.infer<typeof EpisodeImportReportRowSchema>;
+
+export const EpisodeImportReportSchema = z.array(EpisodeImportReportRowSchema);
+export type EpisodeImportReport = z.infer<typeof EpisodeImportReportSchema>;
+
+/** Parse an untrusted value (e.g. an edited report file); throws ZodError. */
+export function parseEpisodeImportReport(input: unknown): EpisodeImportReport {
+  return EpisodeImportReportSchema.parse(input);
+}
+
+/** Human-readable report table for the terminal. */
+export function renderEpisodeImportReport(report: EpisodeImportReport): string {
+  if (report.length === 0) return 'Empty report — no episodes listed.';
+  const lines: string[] = [`${report.length} episode(s)`, ''];
+  for (const row of report) {
+    lines.push(
+      `${row.verdict === 'import' ? 'IMPORT' : 'skip  '}  ${row.id}`,
+      `        summary  ${row.taskSummary}`,
+      `        tags     ${row.tags.join(', ')}`,
+      `        reason   ${row.reason}`,
+      '',
+    );
+  }
+  lines.pop();
+  return lines.join('\n');
+}

--- a/client/packages/harness-layer/src/seed-import/execute.ts
+++ b/client/packages/harness-layer/src/seed-import/execute.ts
@@ -41,7 +41,13 @@ import {
 } from './state.js';
 
 export interface ImportResult {
-  imported: Array<{ skill: string; envelopeRef: string; anchorTx: string | null }>;
+  imported: Array<{
+    skill: string;
+    envelopeRef: string;
+    anchorTx: string | null;
+    /** Publication succeeded, but local lineage state needs operator recovery. */
+    stateWarning?: string;
+  }>;
   skipped: Array<{ skill: string; reason: string }>;
   errors: Array<{ skill: string; error: string }>;
 }
@@ -217,11 +223,20 @@ export async function execute(
         skill: toSkillArtifact(skill, deps.participant.safeAddress, prior?.envelopeRef),
       });
       if (published.vetoed) throw new Error('unexpected veto on seed publish');
-      state.set(identity, { contentHash, envelopeRef: published.envelopeRef, publishedAt: now.toISOString() });
+      let stateWarning: string | undefined;
+      try {
+        state.set(identity, { contentHash, envelopeRef: published.envelopeRef, publishedAt: now.toISOString() });
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        stateWarning =
+          `published ${published.envelopeRef}, but seed-import state persistence failed: ${detail}; ` +
+          'recovery required before retrying this seed';
+      }
       result.imported.push({
         skill: row.skill,
         envelopeRef: published.envelopeRef,
         anchorTx: published.anchorTx,
+        ...(stateWarning ? { stateWarning } : {}),
       });
     } catch (err) {
       result.errors.push({

--- a/client/packages/harness-layer/src/seed-import/execute.ts
+++ b/client/packages/harness-layer/src/seed-import/execute.ts
@@ -47,6 +47,8 @@ export interface ImportResult {
     anchorTx: string | null;
     /** Publication succeeded, but local lineage state needs operator recovery. */
     stateWarning?: string;
+    /** Anchor succeeded, but the local publication ledger needs recovery. */
+    ledgerWarning?: string;
   }>;
   skipped: Array<{ skill: string; reason: string }>;
   errors: Array<{ skill: string; error: string }>;
@@ -219,9 +221,19 @@ export async function execute(
       const pending = await capture(toCapturedTask(skill, now), {
         pipeline: seedScrubPipeline,
       });
-      const published = await publish(pending, deps, {
-        skill: toSkillArtifact(skill, deps.participant.safeAddress, prior?.envelopeRef),
-      });
+      let published;
+      try {
+        published = await publish(pending, deps, {
+          skill: toSkillArtifact(skill, deps.participant.safeAddress, prior?.envelopeRef),
+        });
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        result.errors.push({
+          skill: row.skill,
+          error: `publication outcome unknown; do not auto-retry: ${detail}`,
+        });
+        break;
+      }
       if (published.vetoed) throw new Error('unexpected veto on seed publish');
       let stateWarning: string | undefined;
       try {
@@ -236,8 +248,10 @@ export async function execute(
         skill: row.skill,
         envelopeRef: published.envelopeRef,
         anchorTx: published.anchorTx,
+        ...(published.ledgerWarning ? { ledgerWarning: published.ledgerWarning } : {}),
         ...(stateWarning ? { stateWarning } : {}),
       });
+      if (published.ledgerWarning || stateWarning) break;
     } catch (err) {
       result.errors.push({
         skill: row.skill,

--- a/client/packages/harness-layer/src/seed-import/execute.ts
+++ b/client/packages/harness-layer/src/seed-import/execute.ts
@@ -30,7 +30,12 @@ import type { SkillArtifactV1 } from '../../../../src/types/skill-artifact.js';
 import { capture } from '../capture.js';
 import type { CapturedTask } from '../capture.js';
 import { buildSeedScrubPipeline } from '../../../../src/trajectory/scrub/build.js';
-import { publish, type HarnessPublishDeps } from '../publish.js';
+import {
+  publish,
+  PublishLedgerError,
+  type HarnessPublishDeps,
+  type PublishResult,
+} from '../publish.js';
 import { checkLicence } from './licence.js';
 import type { SeedSkill, SeedSource } from './fetch.js';
 import type { ImportReport } from './report.js';
@@ -221,18 +226,24 @@ export async function execute(
       const pending = await capture(toCapturedTask(skill, now), {
         pipeline: seedScrubPipeline,
       });
-      let published;
+      let published: PublishResult;
+      let ledgerWarning: string | undefined;
       try {
         published = await publish(pending, deps, {
           skill: toSkillArtifact(skill, deps.participant.safeAddress, prior?.envelopeRef),
         });
       } catch (err) {
-        const detail = err instanceof Error ? err.message : String(err);
-        result.errors.push({
-          skill: row.skill,
-          error: `publication outcome unknown; do not auto-retry: ${detail}`,
-        });
-        break;
+        if (err instanceof PublishLedgerError) {
+          published = err.result;
+          ledgerWarning = err.message;
+        } else {
+          const detail = err instanceof Error ? err.message : String(err);
+          result.errors.push({
+            skill: row.skill,
+            error: `publication outcome unknown; do not auto-retry: ${detail}`,
+          });
+          break;
+        }
       }
       if (published.vetoed) throw new Error('unexpected veto on seed publish');
       let stateWarning: string | undefined;
@@ -248,10 +259,10 @@ export async function execute(
         skill: row.skill,
         envelopeRef: published.envelopeRef,
         anchorTx: published.anchorTx,
-        ...(published.ledgerWarning ? { ledgerWarning: published.ledgerWarning } : {}),
+        ...(ledgerWarning ? { ledgerWarning } : {}),
         ...(stateWarning ? { stateWarning } : {}),
       });
-      if (published.ledgerWarning || stateWarning) break;
+      if (ledgerWarning || stateWarning) break;
     } catch (err) {
       result.errors.push({
         skill: row.skill,

--- a/client/packages/harness-layer/src/seed-import/execute.ts
+++ b/client/packages/harness-layer/src/seed-import/execute.ts
@@ -217,7 +217,16 @@ export async function execute(
 
       const identity = `skill:${skill.skill}`;
       const contentHash = hashSeedContent(skillContentFingerprint(skill));
-      const prior = state.get(identity);
+      let prior: ReturnType<SeedImportStateStore['get']>;
+      try {
+        prior = state.get(identity);
+      } catch (err) {
+        result.errors.push({
+          skill: row.skill,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        break;
+      }
       if (prior && prior.contentHash === contentHash) {
         result.skipped.push({ skill: row.skill, reason: `unchanged since ${prior.envelopeRef}` });
         continue;

--- a/client/packages/harness-layer/src/seed-import/execute.ts
+++ b/client/packages/harness-layer/src/seed-import/execute.ts
@@ -15,6 +15,15 @@
  * `import` over a non-allowlisted licence is refused — widening the gate is
  * a code change to the disclosed allowlist, reviewable in a PR, not a
  * report-file edit.
+ *
+ * Idempotent by seed identity (issue #1771, `state.ts`): re-running execute
+ * over an unchanged skill publishes nothing new (a `skipped` row instead);
+ * re-running over a CHANGED skill (different skillMd/description/licence/
+ * source) republishes and sets the new record's
+ * `provenance.supersedes` to the prior envelopeRef. `opts.state` defaults to
+ * a fresh in-memory store per call, so existing callers that never pass one
+ * see unchanged behaviour (every row always publishes) — the CLI wires a
+ * file-backed store for real runs (cli.ts, `seed execute`).
  */
 
 import type { SkillArtifactV1 } from '../../../../src/types/skill-artifact.js';
@@ -25,6 +34,11 @@ import { publish, type HarnessPublishDeps } from '../publish.js';
 import { checkLicence } from './licence.js';
 import type { SeedSkill, SeedSource } from './fetch.js';
 import type { ImportReport } from './report.js';
+import {
+  createMemorySeedImportState,
+  hashSeedContent,
+  type SeedImportStateStore,
+} from './state.js';
 
 export interface ImportResult {
   imported: Array<{ skill: string; envelopeRef: string; anchorTx: string | null }>;
@@ -126,7 +140,11 @@ function toCapturedTask(skill: SeedSkill, now: Date): CapturedTask {
 }
 
 /** First-class skill artifact for a seed (#1394). Companion-file fetch is #1381. */
-function toSkillArtifact(skill: SeedSkill, safeAddress: `0x${string}`): SkillArtifactV1 {
+function toSkillArtifact(
+  skill: SeedSkill,
+  safeAddress: `0x${string}`,
+  supersedes?: string,
+): SkillArtifactV1 {
   return {
     schemaVersion: 'jinn.skill.v1',
     skill: {
@@ -140,7 +158,18 @@ function toSkillArtifact(skill: SeedSkill, safeAddress: `0x${string}`): SkillArt
       sourceEnvelopeCids: [],
       operator: { safeAddress },
       seed: { skill: skill.skill, source: skill.source, licence: skill.licence },
+      ...(supersedes ? { supersedes } : {}),
     },
+  };
+}
+
+/** The content fields that define "did this seed change" for idempotency (state.ts). */
+function skillContentFingerprint(skill: SeedSkill): unknown {
+  return {
+    skillMd: skill.skillMd,
+    description: skill.description ?? null,
+    licence: skill.licence,
+    source: skill.source,
   };
 }
 
@@ -148,6 +177,7 @@ export async function execute(
   report: ImportReport,
   source: SeedSource,
   deps: HarnessPublishDeps,
+  opts: { state?: SeedImportStateStore } = {},
 ): Promise<ImportResult> {
   const skills = new Map((await source.list()).map((s) => [s.skill, s]));
   const result: ImportResult = { imported: [], skipped: [], errors: [] };
@@ -157,6 +187,7 @@ export async function execute(
   // probabilistic stages false-positive on SKILL.md content and defaced
   // the anchored corpus. Capture stays mandatory and fail-closed.
   const seedScrubPipeline = buildSeedScrubPipeline();
+  const state = opts.state ?? createMemorySeedImportState();
 
   for (const row of report) {
     if (row.verdict === 'skip') {
@@ -170,13 +201,23 @@ export async function execute(
       if (licence.verdict !== 'import') {
         throw new Error(`licence gate refused ${row.skill}: ${licence.reason}`);
       }
+
+      const identity = `skill:${skill.skill}`;
+      const contentHash = hashSeedContent(skillContentFingerprint(skill));
+      const prior = state.get(identity);
+      if (prior && prior.contentHash === contentHash) {
+        result.skipped.push({ skill: row.skill, reason: `unchanged since ${prior.envelopeRef}` });
+        continue;
+      }
+
       const pending = await capture(toCapturedTask(skill, now), {
         pipeline: seedScrubPipeline,
       });
       const published = await publish(pending, deps, {
-        skill: toSkillArtifact(skill, deps.participant.safeAddress),
+        skill: toSkillArtifact(skill, deps.participant.safeAddress, prior?.envelopeRef),
       });
       if (published.vetoed) throw new Error('unexpected veto on seed publish');
+      state.set(identity, { contentHash, envelopeRef: published.envelopeRef, publishedAt: now.toISOString() });
       result.imported.push({
         skill: row.skill,
         envelopeRef: published.envelopeRef,

--- a/client/packages/harness-layer/src/seed-import/fetch.ts
+++ b/client/packages/harness-layer/src/seed-import/fetch.ts
@@ -10,6 +10,8 @@
  * content.
  */
 
+import { z } from 'zod';
+
 export interface SeedSkill {
   /** Registry-style id, e.g. `vercel-labs/skills/find-skills`. */
   skill: string;
@@ -21,6 +23,21 @@ export interface SeedSkill {
   /** The SKILL.md content (the layer-2 consumable, spec §5). */
   skillMd: string;
 }
+
+/**
+ * Zod mirror of `SeedSkill` (issue #1771): the wire shape of a skill-shaped
+ * seed fixture on disk (e.g. `fixtures/stage1-seeds/distractor-skill-*.json`),
+ * used by the fixture-lint test to validate skill-shaped fixtures without a
+ * live GitHub source. Not consumed by `createGithubSeedSource` — that source
+ * still speaks `SeedSkill` directly.
+ */
+export const SeedSkillSchema = z.strictObject({
+  skill: z.string().min(1),
+  source: z.string().min(1),
+  licence: z.string().min(1).nullable(),
+  description: z.string().min(1).optional(),
+  skillMd: z.string().min(1),
+});
 
 export interface SeedSource {
   name: string;

--- a/client/packages/harness-layer/src/seed-import/state.ts
+++ b/client/packages/harness-layer/src/seed-import/state.ts
@@ -28,9 +28,10 @@
  * (#1776), not a publish-time concern.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { z } from 'zod';
 import { canonicalJson } from '../../../../src/harnesses/engine/canonical-json.js';
 import { sha256Hex } from '../../../../src/captures/publish.js';
@@ -75,12 +76,8 @@ export function createMemorySeedImportState(
 
 export interface FileSeedImportStateOptions {
   /**
-   * Sink for the corrupt-state-file warning. Default: `console.warn`
-   * (unchanged behavior for non-CLI callers). The CLI passes a collector so
-   * the warning reaches its own writer / `--json` output (PR #1779 review)
-   * instead of only stderr. Fired at most once per store instance — every
-   * `get()`/`set()` re-reads the file, and repeating an identical line per
-   * report row would drown the output.
+   * Optional sink for the fail-closed corrupt-state warning. The read still
+   * throws; this hook only lets a CLI surface the same diagnostic separately.
    */
   onWarning?: (message: string) => void;
 }
@@ -91,28 +88,28 @@ export interface FileSeedImportStateOptions {
  * scale (dozens to low hundreds of curated, human-approved entries via the
  * plan/execute gate), not a database.
  *
- * A corrupt/foreign state file is FAIL-OPEN: treated as empty, with a
- * warning through `onWarning` — worst case is one redundant republish
- * (which then supersedes cleanly), never a crash (mirrors ledger.ts's
- * malformed-line handling). A subsequent `set()` rewrites the file with
- * valid JSON, self-healing it.
+ * A corrupt/foreign state file is FAIL-CLOSED: reads and writes throw rather
+ * than treating it as empty and destroying supersedes lineage. Persistence
+ * writes a complete same-directory temp file and atomically renames it over
+ * the destination, so interruption cannot leave a partial JSON document.
  */
 export function createFileSeedImportState(
   path: string = DEFAULT_SEED_IMPORT_STATE_PATH,
   opts: FileSeedImportStateOptions = {},
 ): SeedImportStateStore {
-  const warn = opts.onWarning ?? ((message: string) => console.warn(message));
+  const warn = opts.onWarning;
   let warned = false;
   const read = (): Record<string, SeedPublicationRecord> => {
     if (!existsSync(path)) return {};
     try {
       return SeedImportStateFileSchema.parse(JSON.parse(readFileSync(path, 'utf-8')));
-    } catch {
+    } catch (cause) {
+      const message = `[harness-layer] seed-import state at ${path} is unreadable; refusing to continue so publication lineage is preserved`;
       if (!warned) {
         warned = true;
-        warn(`[harness-layer] seed-import state at ${path} is unreadable — treating as empty`);
+        warn?.(message);
       }
-      return {};
+      throw new Error(message, { cause });
     }
   };
   return {
@@ -122,8 +119,20 @@ export function createFileSeedImportState(
     set(identity, record) {
       const all = read();
       all[identity] = SeedPublicationRecordSchema.parse(record);
-      mkdirSync(dirname(path), { recursive: true });
-      writeFileSync(path, JSON.stringify(all, null, 2) + '\n', 'utf-8');
+      const dir = dirname(path);
+      mkdirSync(dir, { recursive: true });
+      const tempPath = join(dir, `.${basename(path)}.${process.pid}.${randomUUID()}.tmp`);
+      try {
+        writeFileSync(tempPath, JSON.stringify(all, null, 2) + '\n', 'utf-8');
+        renameSync(tempPath, path);
+      } catch (cause) {
+        try {
+          rmSync(tempPath, { force: true });
+        } catch {
+          // Preserve the persistence failure that triggered cleanup.
+        }
+        throw cause;
+      }
     },
   };
 }

--- a/client/packages/harness-layer/src/seed-import/state.ts
+++ b/client/packages/harness-layer/src/seed-import/state.ts
@@ -1,0 +1,118 @@
+/**
+ * Seed-import idempotency state (issue #1771, folding the idempotency AC
+ * originally scoped to #1772/R2 — R4 has no dependency on R1 so it ships
+ * here; see the #1771 PR body for the rationale).
+ *
+ * Both seed lanes (skill seeds in `execute.ts`, evidence-episode seeds in
+ * `episode-execute.ts`) publish through this shared store: a small
+ * identity -> {contentHash, envelopeRef} map that each `execute*()` consults
+ * before publishing. Re-running an import over unchanged content is a no-op
+ * (a `skipped` row; no new envelope); re-running over CHANGED content
+ * republishes and points the new record's provenance at the prior
+ * `envelopeRef` via `supersedes` — skills carry it in
+ * `SkillArtifactV1.provenance.supersedes` (client/src/types/skill-artifact.ts,
+ * already schema'd for this, issue #1462); episodes carry it in the
+ * `seed.attribution` step attribute (episode-fetch.ts's step convention),
+ * since the frozen `jinn.trace-envelope.v0` has no top-level field for it.
+ *
+ * File-backed by default (`~/.jinn-client/harness-layer/seed-import-state.json`,
+ * mirroring `ledger.ts`'s convention) so real CLI runs persist across
+ * invocations; tests inject `createMemorySeedImportState()`.
+ *
+ * Deliberately NOT a corpus query: idempotency here answers "did *I* already
+ * publish this exact seed identity, unchanged?" — a question the operator's
+ * own local state answers without a network round trip. It does not detect a
+ * differently-identified duplicate already sitting in the shared corpus
+ * (two seeds, two identities, same content) — that is the consumer-side
+ * content-key dedup (rescope plan §3.3) and the testnet hygiene sweep
+ * (#1776), not a publish-time concern.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { z } from 'zod';
+import { canonicalJson } from '../../../../src/harnesses/engine/canonical-json.js';
+import { sha256Hex } from '../../../../src/captures/publish.js';
+
+export const DEFAULT_SEED_IMPORT_STATE_PATH = join(
+  homedir(),
+  '.jinn-client',
+  'harness-layer',
+  'seed-import-state.json',
+);
+
+export const SeedPublicationRecordSchema = z.strictObject({
+  /** sha256 over the canonical JSON of the seed's meaningful content. */
+  contentHash: z.string().min(1),
+  /** The published wrapper envelope CID (the corpus ref) — the corpus's own identity for the record. */
+  envelopeRef: z.string().min(1),
+  publishedAt: z.iso.datetime(),
+});
+export type SeedPublicationRecord = z.infer<typeof SeedPublicationRecordSchema>;
+
+const SeedImportStateFileSchema = z.record(z.string(), SeedPublicationRecordSchema);
+
+export interface SeedImportStateStore {
+  /** The prior publication of this identity, or undefined if never published. */
+  get(identity: string): SeedPublicationRecord | undefined;
+  /** Record identity's latest publication (overwrites any prior entry). */
+  set(identity: string, record: SeedPublicationRecord): void;
+}
+
+/** In-memory store — tests, and any embedder that does not want on-disk state. */
+export function createMemorySeedImportState(
+  initial: Record<string, SeedPublicationRecord> = {},
+): SeedImportStateStore {
+  const state = new Map(Object.entries(initial));
+  return {
+    get: (identity) => state.get(identity),
+    set: (identity, record) => {
+      state.set(identity, SeedPublicationRecordSchema.parse(record));
+    },
+  };
+}
+
+function readStateFile(path: string): Record<string, SeedPublicationRecord> {
+  if (!existsSync(path)) return {};
+  try {
+    return SeedImportStateFileSchema.parse(JSON.parse(readFileSync(path, 'utf-8')));
+  } catch {
+    // A corrupt/foreign file must not crash seed-import — worst case is one
+    // redundant republish, never a crash (mirrors ledger.ts's malformed-line
+    // handling).
+    console.warn(`[harness-layer] seed-import state at ${path} is unreadable — treating as empty`);
+    return {};
+  }
+}
+
+/**
+ * File-backed store (JSON map, `~/.jinn-client/harness-layer/seed-import-state.json`
+ * by default) — read-modify-write on every `set()`. Fine at seed-import's
+ * scale (dozens to low hundreds of curated, human-approved entries via the
+ * plan/execute gate), not a database.
+ */
+export function createFileSeedImportState(path: string = DEFAULT_SEED_IMPORT_STATE_PATH): SeedImportStateStore {
+  return {
+    get(identity) {
+      return readStateFile(path)[identity];
+    },
+    set(identity, record) {
+      const all = readStateFile(path);
+      all[identity] = SeedPublicationRecordSchema.parse(record);
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, JSON.stringify(all, null, 2) + '\n', 'utf-8');
+    },
+  };
+}
+
+/**
+ * Deterministic content fingerprint for idempotency: sha256 over the
+ * RFC 8785 canonical JSON of the seed's meaningful fields (the caller
+ * decides which fields are "meaningful" — e.g. excludes capture-time-only
+ * fields like `capturedAt`). Two calls over the same logical content always
+ * agree, regardless of key order.
+ */
+export function hashSeedContent(value: unknown): string {
+  return sha256Hex(canonicalJson(value));
+}

--- a/client/packages/harness-layer/src/seed-import/state.ts
+++ b/client/packages/harness-layer/src/seed-import/state.ts
@@ -73,17 +73,16 @@ export function createMemorySeedImportState(
   };
 }
 
-function readStateFile(path: string): Record<string, SeedPublicationRecord> {
-  if (!existsSync(path)) return {};
-  try {
-    return SeedImportStateFileSchema.parse(JSON.parse(readFileSync(path, 'utf-8')));
-  } catch {
-    // A corrupt/foreign file must not crash seed-import — worst case is one
-    // redundant republish, never a crash (mirrors ledger.ts's malformed-line
-    // handling).
-    console.warn(`[harness-layer] seed-import state at ${path} is unreadable — treating as empty`);
-    return {};
-  }
+export interface FileSeedImportStateOptions {
+  /**
+   * Sink for the corrupt-state-file warning. Default: `console.warn`
+   * (unchanged behavior for non-CLI callers). The CLI passes a collector so
+   * the warning reaches its own writer / `--json` output (PR #1779 review)
+   * instead of only stderr. Fired at most once per store instance — every
+   * `get()`/`set()` re-reads the file, and repeating an identical line per
+   * report row would drown the output.
+   */
+  onWarning?: (message: string) => void;
 }
 
 /**
@@ -91,14 +90,37 @@ function readStateFile(path: string): Record<string, SeedPublicationRecord> {
  * by default) — read-modify-write on every `set()`. Fine at seed-import's
  * scale (dozens to low hundreds of curated, human-approved entries via the
  * plan/execute gate), not a database.
+ *
+ * A corrupt/foreign state file is FAIL-OPEN: treated as empty, with a
+ * warning through `onWarning` — worst case is one redundant republish
+ * (which then supersedes cleanly), never a crash (mirrors ledger.ts's
+ * malformed-line handling). A subsequent `set()` rewrites the file with
+ * valid JSON, self-healing it.
  */
-export function createFileSeedImportState(path: string = DEFAULT_SEED_IMPORT_STATE_PATH): SeedImportStateStore {
+export function createFileSeedImportState(
+  path: string = DEFAULT_SEED_IMPORT_STATE_PATH,
+  opts: FileSeedImportStateOptions = {},
+): SeedImportStateStore {
+  const warn = opts.onWarning ?? ((message: string) => console.warn(message));
+  let warned = false;
+  const read = (): Record<string, SeedPublicationRecord> => {
+    if (!existsSync(path)) return {};
+    try {
+      return SeedImportStateFileSchema.parse(JSON.parse(readFileSync(path, 'utf-8')));
+    } catch {
+      if (!warned) {
+        warned = true;
+        warn(`[harness-layer] seed-import state at ${path} is unreadable — treating as empty`);
+      }
+      return {};
+    }
+  };
   return {
     get(identity) {
-      return readStateFile(path)[identity];
+      return read()[identity];
     },
     set(identity, record) {
-      const all = readStateFile(path);
+      const all = read();
       all[identity] = SeedPublicationRecordSchema.parse(record);
       mkdirSync(dirname(path), { recursive: true });
       writeFileSync(path, JSON.stringify(all, null, 2) + '\n', 'utf-8');

--- a/client/packages/harness-layer/test/publish.test.ts
+++ b/client/packages/harness-layer/test/publish.test.ts
@@ -190,7 +190,7 @@ describe('publish', () => {
     });
   });
 
-  it('preserves the anchored result with a ledger warning when local ledger append fails', async () => {
+  it('throws a typed failure carrying the anchored result when local ledger append fails', async () => {
     const { deps, calls } = mockDeps();
     deps.ledger = {
       append: () => {
@@ -199,15 +199,18 @@ describe('publish', () => {
       list: () => [],
     };
 
-    const result = await publish(await pendingFixture(), deps);
+    const failure = publish(await pendingFixture(), deps);
 
-    expect(calls.anchorEnvelope).toEqual([{ envelopeCid: 'bafy-signed-envelope' }]);
-    expect(result).toEqual({
-      vetoed: false,
-      envelopeRef: 'bafy-signed-envelope',
-      anchorTx: TEST_TX,
-      ledgerWarning: expect.stringMatching(/anchored.*ledger.*synthetic ledger disk full/i),
+    await expect(failure).rejects.toMatchObject({
+      name: 'PublishLedgerError',
+      message: expect.stringMatching(/anchored.*ledger.*synthetic ledger disk full/i),
+      result: {
+        vetoed: false,
+        envelopeRef: 'bafy-signed-envelope',
+        anchorTx: TEST_TX,
+      },
     });
+    expect(calls.anchorEnvelope).toEqual([{ envelopeCid: 'bafy-signed-envelope' }]);
   });
 
   it('veto: publishes nothing, anchors nothing, ledger entry marked vetoed (local only)', async () => {
@@ -353,6 +356,35 @@ describe('jinn-layer ledger CLI', () => {
     const out = sink.output();
     expect(out).toContain('bafy-signed-envelope');
     expect(out).toContain(`https://sepolia.basescan.org/tx/${TEST_TX}`);
+  });
+
+  it('publish <task-file> throws after an anchored ledger failure and prints no success', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'jinn-publish-'));
+    const taskFile = join(dir, 'task.json');
+    writeFileSync(taskFile, JSON.stringify(validTask()));
+    const { deps, calls } = mockDeps();
+    deps.ledger = {
+      append: () => {
+        throw new Error('synthetic ledger disk full');
+      },
+      list: () => [],
+    };
+    const sink = writerSink();
+
+    await expect(runJinnLayerCli(['publish', taskFile], {
+      writer: sink,
+      publishDeps: deps,
+    })).rejects.toMatchObject({
+      name: 'PublishLedgerError',
+      result: {
+        vetoed: false,
+        envelopeRef: 'bafy-signed-envelope',
+        anchorTx: TEST_TX,
+      },
+    });
+
+    expect(calls.anchorEnvelope).toHaveLength(1);
+    expect(sink.output()).not.toContain('Published.');
   });
 
   it('publish --veto records locally and publishes nothing', async () => {

--- a/client/packages/harness-layer/test/publish.test.ts
+++ b/client/packages/harness-layer/test/publish.test.ts
@@ -190,6 +190,26 @@ describe('publish', () => {
     });
   });
 
+  it('preserves the anchored result with a ledger warning when local ledger append fails', async () => {
+    const { deps, calls } = mockDeps();
+    deps.ledger = {
+      append: () => {
+        throw new Error('synthetic ledger disk full');
+      },
+      list: () => [],
+    };
+
+    const result = await publish(await pendingFixture(), deps);
+
+    expect(calls.anchorEnvelope).toEqual([{ envelopeCid: 'bafy-signed-envelope' }]);
+    expect(result).toEqual({
+      vetoed: false,
+      envelopeRef: 'bafy-signed-envelope',
+      anchorTx: TEST_TX,
+      ledgerWarning: expect.stringMatching(/anchored.*ledger.*synthetic ledger disk full/i),
+    });
+  });
+
   it('veto: publishes nothing, anchors nothing, ledger entry marked vetoed (local only)', async () => {
     const { deps, calls } = mockDeps();
     const pending = await pendingFixture();

--- a/client/packages/harness-layer/test/seed-import-episodes.test.ts
+++ b/client/packages/harness-layer/test/seed-import-episodes.test.ts
@@ -250,6 +250,28 @@ describe('executeEpisodes()', () => {
     ]);
   });
 
+  it('rejects substituting the approved episode id while keeping all other content identical', async () => {
+    const approved = mockEpisodeSource([episode({ id: 'approved-id' })]);
+    const [approvedRow] = await planEpisodes(approved);
+    const substituted = episode({ id: 'substituted-id' });
+    const source = mockEpisodeSource([substituted]);
+    const report: EpisodeImportReport = [
+      { ...approvedRow!, id: substituted.id },
+    ];
+    const { deps, published } = mockPublishDeps();
+
+    const result = await executeEpisodes(report, source, deps);
+
+    expect(published).toHaveLength(0);
+    expect(result.imported).toHaveLength(0);
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        id: 'substituted-id',
+        error: expect.stringMatching(/approved content digest.*does not match/i),
+      }),
+    ]);
+  });
+
   it.each([
     ['payment card', 'Customer card: 4111 1111 1111 1111.'],
     ['phone-like PII', 'Call the customer at +1 (415) 555-2671.'],
@@ -368,6 +390,41 @@ describe('executeEpisodes()', () => {
       id: 'first',
       stateWarning: expect.stringMatching(/recovery required/i),
     });
+    expect(result.errors).toEqual([]);
+  });
+
+  it('persists the anchored ref, exposes a ledger warning, and stops after ledger append fails', async () => {
+    const source = mockEpisodeSource([
+      episode({ id: 'first' }),
+      episode({ id: 'second' }),
+    ]);
+    const { deps, published } = mockPublishDeps();
+    deps.ledger = {
+      append: () => {
+        throw new Error('synthetic ledger disk full');
+      },
+      list: () => [],
+    };
+    const records: Array<{ identity: string; envelopeRef: string }> = [];
+    const state = {
+      get: () => undefined,
+      set: (identity: string, record: { envelopeRef: string }) => {
+        records.push({ identity, envelopeRef: record.envelopeRef });
+      },
+    };
+
+    const result = await executeEpisodes(await planEpisodes(source), source, deps, { state });
+
+    expect(published).toHaveLength(1);
+    expect(records).toEqual([
+      { identity: 'episode:first', envelopeRef: expect.stringContaining('bafy-envelope') },
+    ]);
+    expect(result.imported).toEqual([
+      expect.objectContaining({
+        id: 'first',
+        ledgerWarning: expect.stringMatching(/anchored.*ledger/i),
+      }),
+    ]);
     expect(result.errors).toEqual([]);
   });
 

--- a/client/packages/harness-layer/test/seed-import-episodes.test.ts
+++ b/client/packages/harness-layer/test/seed-import-episodes.test.ts
@@ -278,6 +278,24 @@ describe('executeEpisodes()', () => {
     ]);
   });
 
+  it.each([
+    ['id/sessionId', { id: 'ghp_016C7e0aBcDeFgHiJkLmNoPqRsTuVwXyZ012' }],
+    ['tag/distributionTag', { tags: ['acme', '4111 1111 1111 1111'] }],
+  ])('rejects sensitive %s before any publish call', async (_label, overrides) => {
+    const source = mockEpisodeSource([episode(overrides)]);
+    const { deps, published } = mockPublishDeps();
+
+    const result = await executeEpisodes(await planEpisodes(source), source, deps);
+
+    expect(published).toHaveLength(0);
+    expect(result.imported).toHaveLength(0);
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        error: expect.stringMatching(/sensitive.*refusing to publish/i),
+      }),
+    ]);
+  });
+
   describe('idempotency + supersedes', () => {
     it('re-running executeEpisodes() with the same state store over unchanged content publishes nothing new', async () => {
       const source = mockEpisodeSource([episode()]);
@@ -327,6 +345,55 @@ describe('executeEpisodes()', () => {
       expect(second.imported[0]!.envelopeRef).not.toBe(first.imported[0]!.envelopeRef);
       expect(published).toHaveLength(2);
     });
+  });
+
+  it('stops the batch after post-publication state persistence fails', async () => {
+    const source = mockEpisodeSource([
+      episode({ id: 'first' }),
+      episode({ id: 'second' }),
+    ]);
+    const { deps, published } = mockPublishDeps();
+    const state = {
+      get: () => undefined,
+      set: () => {
+        throw new Error('synthetic state disk full');
+      },
+    };
+
+    const result = await executeEpisodes(await planEpisodes(source), source, deps, { state });
+
+    expect(published).toHaveLength(1);
+    expect(result.imported).toHaveLength(1);
+    expect(result.imported[0]).toMatchObject({
+      id: 'first',
+      stateWarning: expect.stringMatching(/recovery required/i),
+    });
+    expect(result.errors).toEqual([]);
+  });
+
+  it('halts after an ambiguous publication error and never publishes later rows', async () => {
+    const source = mockEpisodeSource([
+      episode({ id: 'first' }),
+      episode({ id: 'second' }),
+    ]);
+    const { deps, published } = mockPublishDeps();
+    let envelopeCalls = 0;
+    deps.publishEnvelope = async () => {
+      envelopeCalls += 1;
+      throw new Error('synthetic transport timeout');
+    };
+
+    const result = await executeEpisodes(await planEpisodes(source), source, deps);
+
+    expect(envelopeCalls).toBe(1);
+    expect(published).toHaveLength(1); // first row's trace artifact only
+    expect(result.imported).toEqual([]);
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        id: 'first',
+        error: expect.stringMatching(/publication outcome unknown; do not auto-retry/i),
+      }),
+    ]);
   });
 });
 

--- a/client/packages/harness-layer/test/seed-import-episodes.test.ts
+++ b/client/packages/harness-layer/test/seed-import-episodes.test.ts
@@ -144,6 +144,7 @@ describe('planEpisodes()', () => {
     const report = await planEpisodes(source);
     expect(report).toHaveLength(2);
     expect(report.every((r) => r.verdict === 'import')).toBe(true);
+    expect(report.every((r) => /^[0-9a-f]{64}$/.test((r as Record<string, unknown>)['contentDigest'] as string))).toBe(true);
     expect(source.listCalls).toBe(1);
   });
 
@@ -153,12 +154,18 @@ describe('planEpisodes()', () => {
     expect(parseEpisodeImportReport(report)).toEqual(report);
   });
 
-  it('flags a duplicate id as skip, first occurrence wins', async () => {
-    const source = mockEpisodeSource([episode({ id: 'dup' }), episode({ id: 'dup' })]);
+  it('flags a different-content duplicate id as skip, first occurrence wins', async () => {
+    const source = mockEpisodeSource([
+      episode({ id: 'dup', taskSummary: 'first occurrence' }),
+      episode({ id: 'dup', taskSummary: 'second occurrence' }),
+    ]);
     const report = await planEpisodes(source);
     expect(report[0]).toMatchObject({ id: 'dup', verdict: 'import' });
     expect(report[1]).toMatchObject({ id: 'dup', verdict: 'skip' });
     expect(report[1]!.reason).toContain('duplicate id');
+    expect((report[0] as Record<string, unknown>)['contentDigest']).not.toBe(
+      (report[1] as Record<string, unknown>)['contentDigest'],
+    );
   });
 });
 
@@ -210,15 +217,65 @@ describe('executeEpisodes()', () => {
     expect(entries[0]!.status).toBe('published');
   });
 
-  it('a skipped plan row (duplicate id) is carried through as skipped, not published', async () => {
-    const source = mockEpisodeSource([episode({ id: 'dup' }), episode({ id: 'dup' })]);
+  it('a different-content duplicate id publishes the first occurrence, not the last', async () => {
+    const source = mockEpisodeSource([
+      episode({ id: 'dup', taskSummary: 'first occurrence' }),
+      episode({ id: 'dup', taskSummary: 'second occurrence' }),
+    ]);
     const report = await planEpisodes(source);
     const { deps, published } = mockPublishDeps();
     const result = await executeEpisodes(report, source, deps);
     expect(published).toHaveLength(1); // only the first "dup" publishes
+    expect(parseTraceEnvelopeV0(published[0]!.payload).task.summary).toBe('first occurrence');
     expect(result.imported).toHaveLength(1);
     expect(result.skipped).toHaveLength(1);
     expect(result.skipped[0]!.reason).toContain('duplicate id');
+  });
+
+  it('rejects an execute-time episode whose canonical content differs from the approved row', async () => {
+    const approved = mockEpisodeSource([episode({ taskSummary: 'approved content' })]);
+    const report = await planEpisodes(approved);
+    const changed = mockEpisodeSource([episode({ taskSummary: 'changed after approval' })]);
+    const { deps, published } = mockPublishDeps();
+
+    const result = await executeEpisodes(report, changed, deps);
+
+    expect(published).toHaveLength(0);
+    expect(result.imported).toHaveLength(0);
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        id: 'source-fixture',
+        error: expect.stringMatching(/approved content digest.*does not match/i),
+      }),
+    ]);
+  });
+
+  it.each([
+    ['payment card', 'Customer card: 4111 1111 1111 1111.'],
+    ['phone-like PII', 'Call the customer at +1 (415) 555-2671.'],
+    [
+      'JWT',
+      'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IlN5bnRoZXRpYyJ9.c2lnbmF0dXJlU3ludGhldGljVmFsdWU',
+    ],
+    ['high-entropy credential', 'Credential: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'],
+  ])('rejects %s before any publish call', async (_label, sensitiveText) => {
+    const source = mockEpisodeSource([
+      episode({
+        steps: [{ label: 'note', title: 'sensitive fixture', text: sensitiveText }],
+      }),
+    ]);
+    const { deps, published } = mockPublishDeps();
+
+    const result = await executeEpisodes(await planEpisodes(source), source, deps);
+
+    expect(published).toHaveLength(0);
+    expect(result.imported).toHaveLength(0);
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        id: 'source-fixture',
+        error: expect.stringMatching(/sensitive.*refusing to publish/i),
+      }),
+    ]);
   });
 
   describe('idempotency + supersedes', () => {
@@ -285,6 +342,23 @@ describe('jinn-layer seed CLI — episodes', () => {
     };
   }
 
+  it('rejects passing both --source and --episodes-dir', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'jinn-seed-episodes-'));
+    const listFile = join(dir, 'skills.txt');
+    writeFileSync(listFile, 'acme/skills\n');
+    const source = mockEpisodeSource([episode()]);
+    const sink = writerSink();
+
+    const code = await runJinnLayerCli(
+      ['seed', 'plan', '--source', listFile, '--episodes-dir', dir],
+      { writer: sink, episodeSource: source },
+    );
+
+    expect(code).toBe(2);
+    expect(sink.output()).toMatch(/exactly one of --source or --episodes-dir/i);
+    expect(source.listCalls).toBe(0);
+  });
+
   it('seed plan --episodes-dir renders the report and writes the report file', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'jinn-seed-episodes-'));
     const out = join(dir, 'report.json');
@@ -333,5 +407,43 @@ describe('jinn-layer seed CLI — episodes', () => {
     expect(code2).toBe(0);
     expect(sink2.output()).toContain('0 imported, 1 skipped');
     expect(published).toHaveLength(1); // still just the first run's publish
+  });
+
+  it('returns the published episode ref with a recovery warning and nonzero exit when state persistence fails', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'jinn-seed-episodes-'));
+    const reportFile = join(dir, 'report.json');
+    const source = mockEpisodeSource([episode()]);
+    writeFileSync(reportFile, JSON.stringify(await planEpisodes(source)));
+    const { deps, published } = mockPublishDeps();
+    const sink = writerSink();
+
+    const code = await runJinnLayerCli(
+      ['seed', 'execute', reportFile, '--episodes-dir', dir, '--json'],
+      {
+        writer: sink,
+        episodeSource: source,
+        publishDeps: deps,
+        seedImportState: {
+          get: () => undefined,
+          set: () => {
+            throw new Error('synthetic disk full');
+          },
+        },
+      },
+    );
+
+    expect(code).toBe(1);
+    expect(published).toHaveLength(1);
+    const payload = JSON.parse(sink.output()) as {
+      imported: Array<{ envelopeRef: string; stateWarning?: string }>;
+      errors: unknown[];
+    };
+    expect(payload.errors).toEqual([]);
+    expect(payload.imported).toEqual([
+      expect.objectContaining({
+        envelopeRef: expect.stringContaining('bafy-envelope'),
+        stateWarning: expect.stringMatching(/published.*state.*recovery/i),
+      }),
+    ]);
   });
 });

--- a/client/packages/harness-layer/test/seed-import-episodes.test.ts
+++ b/client/packages/harness-layer/test/seed-import-episodes.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Evidence-episode seed lane tests (issue #1771).
+ *
+ * Mirrors seed-import.test.ts's mocking style: all sources and publish deps
+ * are mocked — nothing reaches the filesystem beyond a tmpdir, IPFS, or chain
+ * from this suite. `seed execute --episodes-dir` against the real testnet is
+ * the human-gated step (docs/runbooks/stage1-evidence-seeding.md).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { SignedEnvelope } from '../../../src/types/envelope.js';
+import { parseTraceEnvelopeV0 } from '../src/envelope.js';
+import { createMemoryLedger } from '../src/ledger.js';
+import type { HarnessPublishDeps } from '../src/publish.js';
+import { TRACE_ENVELOPE_ARTIFACT_TYPE } from '../src/publish.js';
+import {
+  createLocalEpisodeSeedSource,
+  parseSeedEpisode,
+  SeedEpisodeSchema,
+  type SeedEpisode,
+  type EpisodeSource,
+} from '../src/seed-import/episode-fetch.js';
+import { planEpisodes } from '../src/seed-import/episode-plan.js';
+import { executeEpisodes } from '../src/seed-import/episode-execute.js';
+import { parseEpisodeImportReport, type EpisodeImportReport } from '../src/seed-import/episode-report.js';
+import { createMemorySeedImportState } from '../src/seed-import/state.js';
+import { runJinnLayerCli } from '../src/cli.js';
+
+const TEST_ADDRESS = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' as const;
+const TEST_PRIVATE_KEY =
+  '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80' as const;
+const TEST_SAFE = '0x1111111111111111111111111111111111111111' as const;
+
+function episode(overrides: Partial<SeedEpisode> = {}): SeedEpisode {
+  return {
+    id: 'source-fixture',
+    repo: 'acme/widgets',
+    taskSummary: 'Fix a flaky widget test by awaiting the async fetch before asserting',
+    tags: ['acme', 'widgets', 'flake'],
+    steps: [
+      { label: 'failure', title: 'run failing test', text: '$ yarn test\nFAIL widget.test.ts' },
+      { label: 'note', title: 'diagnose', text: 'The assertion runs before the fetch resolves.' },
+      { label: 'fix', title: 'await the fetch', text: 'await waitFor(() => expect(fetchMock).toHaveBeenCalled());' },
+      { label: 'command', title: 'rerun', text: '$ yarn test\nPASS widget.test.ts' },
+    ],
+    outcome: { status: 'completed', verifiabilityTier: 'tests-passed' },
+    synthesis: 'The test asserted before the async fetch settled. Waiting on the fetch mock directly fixes the race. This is the general pattern for this class of flake.',
+    attribution: { origin: 'operator-recorded-session' },
+    ...overrides,
+  };
+}
+
+function mockEpisodeSource(episodes: SeedEpisode[]): EpisodeSource & { listCalls: number } {
+  const source = {
+    name: 'mock-episodes',
+    listCalls: 0,
+    async list() {
+      source.listCalls += 1;
+      return episodes;
+    },
+  };
+  return source;
+}
+
+function mockPublishDeps(): {
+  deps: HarnessPublishDeps;
+  published: Array<{ artifactType: string; payload: unknown }>;
+  envelopes: SignedEnvelope[];
+} {
+  const published: Array<{ artifactType: string; payload: unknown }> = [];
+  const envelopes: SignedEnvelope[] = [];
+  const deps: HarnessPublishDeps = {
+    participant: { safeAddress: TEST_SAFE, agentEoa: TEST_ADDRESS },
+    signer: { address: TEST_ADDRESS, privateKey: TEST_PRIVATE_KEY },
+    clientGitSha: 'test-sha',
+    defaultArtifactEndpoint: 'http://127.0.0.1:7331',
+    ledger: createMemoryLedger(),
+    publishArtifact: async (input) => {
+      published.push(input);
+      return { cid: `bafy-artifact-${published.length}`, sha256: 'a'.repeat(64) };
+    },
+    publishEnvelope: async (envelope) => {
+      envelopes.push(envelope);
+      return { cid: `bafy-envelope-${envelopes.length}`, sha256: 'b'.repeat(64) };
+    },
+    anchorEnvelope: async () => ({ txHash: `0x${'cd'.repeat(32)}` as `0x${string}`, blockNumber: 7 }),
+  };
+  return { deps, published, envelopes };
+}
+
+describe('SeedEpisodeSchema / parseSeedEpisode', () => {
+  it('parses a well-formed episode', () => {
+    expect(() => parseSeedEpisode(episode())).not.toThrow();
+  });
+
+  it('rejects an unknown top-level field (strict)', () => {
+    expect(() => parseSeedEpisode({ ...episode(), extra: 'nope' })).toThrow();
+  });
+
+  it('rejects a baseCommit that is not a full 40-char sha', () => {
+    expect(() => parseSeedEpisode({ ...episode(), baseCommit: '163e070d' })).toThrow();
+  });
+
+  it('rejects an excerpt label outside the five-value vocabulary', () => {
+    const bad = episode({
+      steps: [{ label: 'summary' as never, title: 't', text: 'x' }],
+    });
+    expect(() => parseSeedEpisode(bad)).toThrow();
+  });
+
+  it('accepts a valid full 40-char baseCommit', () => {
+    const withCommit = episode({ baseCommit: '3651de92ccda900dc6d052b94035f9a86d5b21be' });
+    expect(SeedEpisodeSchema.parse(withCommit).baseCommit).toBe('3651de92ccda900dc6d052b94035f9a86d5b21be');
+  });
+});
+
+describe('createLocalEpisodeSeedSource', () => {
+  it('reads *.episode.json files from a directory, sorted, ignoring other files', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'jinn-episodes-'));
+    writeFileSync(join(dir, 'b.episode.json'), JSON.stringify(episode({ id: 'b' })));
+    writeFileSync(join(dir, 'a.episode.json'), JSON.stringify(episode({ id: 'a' })));
+    writeFileSync(join(dir, 'skill.json'), JSON.stringify({ skill: 'x', source: 'y', licence: 'MIT', skillMd: '# x' }));
+    writeFileSync(join(dir, 'README.md'), '# not a seed file');
+
+    const source = createLocalEpisodeSeedSource(dir);
+    const episodes = await source.list();
+    expect(episodes.map((e) => e.id)).toEqual(['a', 'b']);
+  });
+
+  it('throws on a malformed episode file (fail-loud, not silently skipped)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'jinn-episodes-'));
+    writeFileSync(join(dir, 'bad.episode.json'), JSON.stringify({ id: 'bad' }));
+    const source = createLocalEpisodeSeedSource(dir);
+    await expect(source.list()).rejects.toThrow();
+  });
+});
+
+describe('planEpisodes()', () => {
+  it('produces one import row per episode', async () => {
+    const source = mockEpisodeSource([episode({ id: 'a' }), episode({ id: 'b' })]);
+    const report = await planEpisodes(source);
+    expect(report).toHaveLength(2);
+    expect(report.every((r) => r.verdict === 'import')).toBe(true);
+    expect(source.listCalls).toBe(1);
+  });
+
+  it('performs zero writes — takes only a source, no publish deps', async () => {
+    const source = mockEpisodeSource([episode()]);
+    const report = await planEpisodes(source);
+    expect(parseEpisodeImportReport(report)).toEqual(report);
+  });
+
+  it('flags a duplicate id as skip, first occurrence wins', async () => {
+    const source = mockEpisodeSource([episode({ id: 'dup' }), episode({ id: 'dup' })]);
+    const report = await planEpisodes(source);
+    expect(report[0]).toMatchObject({ id: 'dup', verdict: 'import' });
+    expect(report[1]).toMatchObject({ id: 'dup', verdict: 'skip' });
+    expect(report[1]!.reason).toContain('duplicate id');
+  });
+});
+
+describe('executeEpisodes()', () => {
+  it('publishes only verdict=import rows with provenance imported + the step convention', async () => {
+    const source = mockEpisodeSource([episode()]);
+    const report = await planEpisodes(source);
+    const { deps, published } = mockPublishDeps();
+    const result = await executeEpisodes(report, source, deps);
+
+    expect(published.map((p) => p.artifactType)).toEqual([TRACE_ENVELOPE_ARTIFACT_TYPE]);
+    const envelope = parseTraceEnvelopeV0(published[0]!.payload);
+    expect(envelope.provenance).toBe('imported');
+    expect(envelope.task.summary).toBe(episode().taskSummary);
+    expect(envelope.task.distributionTags).toEqual(
+      expect.arrayContaining(['seed-import', 'acme', 'widgets', 'flake']),
+    );
+
+    // Content steps carry the label/title/text convention.
+    expect(envelope.steps).toHaveLength(5); // 4 content steps + 1 synthesis/attribution step
+    const failureStep = envelope.steps.find((s) => s.name === 'seed:step:failure')!;
+    expect(failureStep.attributes['seed.step.label']).toBe('failure');
+    expect(failureStep.attributes['seed.step.title']).toBe('run failing test');
+    expect(String(failureStep.attributes['seed.step.text'])).toContain('FAIL widget.test.ts');
+    const fixStep = envelope.steps.find((s) => s.name === 'seed:step:fix')!;
+    expect(fixStep.attributes['seed.step.label']).toBe('fix');
+
+    // Final step carries synthesis + attribution.
+    const metaStep = envelope.steps[envelope.steps.length - 1]!;
+    expect(metaStep.name).toBe('seed:synthesis');
+    expect(metaStep.attributes['seed.synthesis']).toContain('general pattern');
+    expect(metaStep.attributes['seed.attribution']).toMatchObject({
+      repo: 'acme/widgets',
+      origin: 'operator-recorded-session',
+    });
+    // Fresh publish: no supersedes marker yet.
+    expect((metaStep.attributes['seed.attribution'] as Record<string, unknown>)['supersedes']).toBeUndefined();
+
+    expect(result.imported).toHaveLength(1);
+    expect(result.imported[0]).toMatchObject({ id: 'source-fixture', supersedes: null });
+  });
+
+  it('ledger records every import', async () => {
+    const source = mockEpisodeSource([episode()]);
+    const { deps } = mockPublishDeps();
+    await executeEpisodes(await planEpisodes(source), source, deps);
+    const entries = deps.ledger.list();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.status).toBe('published');
+  });
+
+  it('a skipped plan row (duplicate id) is carried through as skipped, not published', async () => {
+    const source = mockEpisodeSource([episode({ id: 'dup' }), episode({ id: 'dup' })]);
+    const report = await planEpisodes(source);
+    const { deps, published } = mockPublishDeps();
+    const result = await executeEpisodes(report, source, deps);
+    expect(published).toHaveLength(1); // only the first "dup" publishes
+    expect(result.imported).toHaveLength(1);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]!.reason).toContain('duplicate id');
+  });
+
+  describe('idempotency + supersedes', () => {
+    it('re-running executeEpisodes() with the same state store over unchanged content publishes nothing new', async () => {
+      const source = mockEpisodeSource([episode()]);
+      const report = await planEpisodes(source);
+      const { deps, published } = mockPublishDeps();
+      const state = createMemorySeedImportState();
+
+      const first = await executeEpisodes(report, source, deps, { state });
+      expect(first.imported).toHaveLength(1);
+      expect(published).toHaveLength(1);
+
+      const second = await executeEpisodes(report, source, deps, { state });
+      expect(second.imported).toHaveLength(0);
+      expect(second.skipped).toHaveLength(1);
+      expect(second.skipped[0]!.reason).toContain(first.imported[0]!.envelopeRef);
+      expect(published).toHaveLength(1); // no new publish call
+    });
+
+    it('re-running executeEpisodes() over CHANGED content republishes and sets seed.attribution.supersedes', async () => {
+      const source1 = mockEpisodeSource([episode({ synthesis: episode().synthesis + ' Version one.' })]);
+      const { deps, published } = mockPublishDeps();
+      const state = createMemorySeedImportState();
+
+      const first = await executeEpisodes(await planEpisodes(source1), source1, deps, { state });
+      const firstRef = first.imported[0]!.envelopeRef;
+
+      const source2 = mockEpisodeSource([episode({ synthesis: episode().synthesis + ' Version two — changed.' })]);
+      const second = await executeEpisodes(await planEpisodes(source2), source2, deps, { state });
+      expect(second.imported).toHaveLength(1);
+      expect(second.imported[0]!.envelopeRef).not.toBe(firstRef);
+      expect(second.imported[0]!.supersedes).toBe(firstRef);
+
+      const secondEnvelope = parseTraceEnvelopeV0(published[1]!.payload);
+      const metaStep = secondEnvelope.steps[secondEnvelope.steps.length - 1]!;
+      expect((metaStep.attributes['seed.attribution'] as Record<string, unknown>)['supersedes']).toBe(firstRef);
+    });
+
+    it('without an injected state store, each executeEpisodes() call starts fresh', async () => {
+      const source = mockEpisodeSource([episode()]);
+      const report = await planEpisodes(source);
+      const { deps, published } = mockPublishDeps();
+
+      const first = await executeEpisodes(report, source, deps);
+      const second = await executeEpisodes(report, source, deps);
+      expect(first.imported).toHaveLength(1);
+      expect(second.imported).toHaveLength(1);
+      expect(second.imported[0]!.envelopeRef).not.toBe(first.imported[0]!.envelopeRef);
+      expect(published).toHaveLength(2);
+    });
+  });
+});
+
+describe('jinn-layer seed CLI — episodes', () => {
+  function writerSink(): { write: (s: string) => boolean; output: () => string } {
+    let buf = '';
+    return {
+      write(s: string) {
+        buf += s;
+        return true;
+      },
+      output: () => buf,
+    };
+  }
+
+  it('seed plan --episodes-dir renders the report and writes the report file', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'jinn-seed-episodes-'));
+    const out = join(dir, 'report.json');
+    const source = mockEpisodeSource([episode({ id: 'a' }), episode({ id: 'b' })]);
+    const sink = writerSink();
+    const code = await runJinnLayerCli(['seed', 'plan', '--out', out], {
+      writer: sink,
+      episodeSource: source,
+    });
+    expect(code).toBe(0);
+    expect(sink.output()).toContain('a');
+    expect(sink.output()).toContain('IMPORT');
+    const report: EpisodeImportReport = parseEpisodeImportReport(
+      JSON.parse(readFileSync(out, 'utf-8')),
+    );
+    expect(report).toHaveLength(2);
+  });
+
+  it('seed execute <report-file> --episodes-dir publishes the approved rows, idempotent across CLI invocations', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'jinn-seed-episodes-'));
+    const reportFile = join(dir, 'report.json');
+    const source = mockEpisodeSource([episode()]);
+    const report = await planEpisodes(source);
+    writeFileSync(reportFile, JSON.stringify(report));
+    const { deps, published } = mockPublishDeps();
+    const state = createMemorySeedImportState();
+    const sink = writerSink();
+
+    const code1 = await runJinnLayerCli(['seed', 'execute', reportFile, '--episodes-dir', dir], {
+      writer: sink,
+      episodeSource: source,
+      publishDeps: deps,
+      seedImportState: state,
+    });
+    expect(code1).toBe(0);
+    expect(sink.output()).toContain('1 imported');
+    expect(published).toHaveLength(1);
+
+    const sink2 = writerSink();
+    const code2 = await runJinnLayerCli(['seed', 'execute', reportFile, '--episodes-dir', dir], {
+      writer: sink2,
+      episodeSource: source,
+      publishDeps: deps,
+      seedImportState: state,
+    });
+    expect(code2).toBe(0);
+    expect(sink2.output()).toContain('0 imported, 1 skipped');
+    expect(published).toHaveLength(1); // still just the first run's publish
+  });
+});

--- a/client/packages/harness-layer/test/seed-import-episodes.test.ts
+++ b/client/packages/harness-layer/test/seed-import-episodes.test.ts
@@ -393,6 +393,35 @@ describe('executeEpisodes()', () => {
     expect(result.errors).toEqual([]);
   });
 
+  it('stops the batch after state lookup fails and never publishes later rows', async () => {
+    const source = mockEpisodeSource([
+      episode({ id: 'first' }),
+      episode({ id: 'second' }),
+    ]);
+    const { deps, published } = mockPublishDeps();
+    let getCalls = 0;
+    const state = {
+      get: () => {
+        getCalls += 1;
+        if (getCalls === 1) throw new Error('synthetic state read failure');
+        return undefined;
+      },
+      set: () => undefined,
+    };
+
+    const result = await executeEpisodes(await planEpisodes(source), source, deps, { state });
+
+    expect(getCalls).toBe(1);
+    expect(published).toHaveLength(0);
+    expect(result.imported).toEqual([]);
+    expect(result.errors).toEqual([
+      {
+        id: 'first',
+        error: 'synthetic state read failure',
+      },
+    ]);
+  });
+
   it('persists the anchored ref, exposes a ledger warning, and stops after ledger append fails', async () => {
     const source = mockEpisodeSource([
       episode({ id: 'first' }),

--- a/client/packages/harness-layer/test/seed-import-state.test.ts
+++ b/client/packages/harness-layer/test/seed-import-state.test.ts
@@ -3,15 +3,13 @@
  *
  * `createFileSeedImportState` is the production default behind
  * `seed execute` (cli.ts). Covered here: round-trip persistence across
- * store instances, the documented fail-open corrupt-file behavior (empty
- * state + a warning, at most once per store instance), `set()` self-heal,
- * and — at the CLI level — that the corruption warning is surfaced through
- * the command's own writer/output path (a `warnings` field in `--json`
- * mode, a WARNING line in table mode), not only `console.warn`.
+ * store instances, fail-closed corrupt-file behavior, atomic replace
+ * persistence, and the CLI guarantee that corrupt lineage blocks before any
+ * publication call.
  */
 
-import { describe, it, expect, vi } from 'vitest';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createMemoryLedger } from '../src/ledger.js';
@@ -42,68 +40,54 @@ describe('createFileSeedImportState', () => {
     expect(second.get('episode:missing')).toBeUndefined();
   });
 
-  it('a missing file is an empty state — no warning', () => {
-    const warn = vi.fn();
-    const store = createFileSeedImportState(tmpStatePath(), { onWarning: warn });
+  it('a missing file is an empty state', () => {
+    const store = createFileSeedImportState(tmpStatePath());
     expect(store.get('episode:x')).toBeUndefined();
-    expect(warn).not.toHaveBeenCalled();
   });
 
-  it('a corrupt file is fail-open: empty state plus exactly one warning per store instance', () => {
+  it('a corrupt file fails closed instead of becoming empty state', () => {
     const path = tmpStatePath();
     writeFileSync(path, '{ definitely not json', 'utf-8');
-    const warn = vi.fn();
-    const store = createFileSeedImportState(path, { onWarning: warn });
+    const store = createFileSeedImportState(path);
 
-    expect(store.get('episode:x')).toBeUndefined();
-    expect(store.get('episode:y')).toBeUndefined(); // second read: latched, no second warning
-    expect(warn).toHaveBeenCalledTimes(1);
-    const message = String(warn.mock.calls[0]![0]);
-    expect(message).toContain('unreadable');
-    expect(message).toContain(path);
+    expect(() => store.get('episode:x')).toThrow(/state.*unreadable/i);
+    expect(readFileSync(path, 'utf-8')).toBe('{ definitely not json');
   });
 
-  it('a schema-invalid (but valid JSON) file is treated the same as corrupt', () => {
+  it('a schema-invalid (but valid JSON) file also fails closed', () => {
     const path = tmpStatePath();
     writeFileSync(path, JSON.stringify({ 'episode:x': { nope: true } }), 'utf-8');
-    const warn = vi.fn();
-    const store = createFileSeedImportState(path, { onWarning: warn });
+    const store = createFileSeedImportState(path);
 
-    expect(store.get('episode:x')).toBeUndefined();
-    expect(warn).toHaveBeenCalledTimes(1);
+    expect(() => store.get('episode:x')).toThrow(/state.*unreadable/i);
   });
 
-  it('set() self-heals a corrupt file — the write wins and later reads succeed cleanly', () => {
+  it('set() refuses to overwrite corrupt lineage', () => {
     const path = tmpStatePath();
     writeFileSync(path, '{ corrupt', 'utf-8');
-    const store = createFileSeedImportState(path, { onWarning: vi.fn() });
+    const store = createFileSeedImportState(path);
+
+    expect(() => store.set('episode:x', RECORD)).toThrow(/state.*unreadable/i);
+    expect(readFileSync(path, 'utf-8')).toBe('{ corrupt');
+  });
+
+  it('persists by replacing the state file atomically', () => {
+    const path = tmpStatePath();
+    const store = createFileSeedImportState(path);
     store.set('episode:x', RECORD);
+    const beforeInode = statSync(path).ino;
 
-    // A fresh instance reads the healed file with no warning.
-    const warn = vi.fn();
-    const fresh = createFileSeedImportState(path, { onWarning: warn });
-    expect(fresh.get('episode:x')).toEqual(RECORD);
-    expect(warn).not.toHaveBeenCalled();
-    // And the on-disk content is the canonical JSON map shape.
-    expect(JSON.parse(readFileSync(path, 'utf-8'))).toEqual({ 'episode:x': RECORD });
-  });
+    store.set('episode:y', { ...RECORD, envelopeRef: 'bafy-envelope-2' });
 
-  it('the default warning sink is console.warn (non-CLI callers keep the old behavior)', () => {
-    const path = tmpStatePath();
-    writeFileSync(path, '{ corrupt', 'utf-8');
-    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    try {
-      createFileSeedImportState(path).get('episode:x');
-      expect(spy).toHaveBeenCalledTimes(1);
-      expect(String(spy.mock.calls[0]![0])).toContain('unreadable');
-    } finally {
-      spy.mockRestore();
-    }
+    expect(statSync(path).ino).not.toBe(beforeInode);
+    expect(JSON.parse(readFileSync(path, 'utf-8'))).toEqual({
+      'episode:x': RECORD,
+      'episode:y': { ...RECORD, envelopeRef: 'bafy-envelope-2' },
+    });
   });
 });
 
-// ── CLI surfacing (PR #1779 review): the warning reaches the command's own
-// output, not only console.warn ────────────────────────────────────────────
+// ── CLI fail-closed behavior ──────────────────────────────────────────────
 
 const TEST_ADDRESS = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' as const;
 const TEST_PRIVATE_KEY =
@@ -130,9 +114,9 @@ function mockEpisodeSource(episodes: SeedEpisode[]): EpisodeSource {
   return { name: 'mock-episodes', list: async () => episodes };
 }
 
-function mockPublishDeps(): HarnessPublishDeps {
+function mockPublishDeps(): { deps: HarnessPublishDeps; publishCalls: () => number } {
   let n = 0;
-  return {
+  const deps: HarnessPublishDeps = {
     participant: { safeAddress: TEST_SAFE, agentEoa: TEST_ADDRESS },
     signer: { address: TEST_ADDRESS, privateKey: TEST_PRIVATE_KEY },
     clientGitSha: 'test-sha',
@@ -142,10 +126,11 @@ function mockPublishDeps(): HarnessPublishDeps {
     publishEnvelope: async () => ({ cid: `bafy-envelope-${++n}`, sha256: 'b'.repeat(64) }),
     anchorEnvelope: async () => ({ txHash: `0x${'cd'.repeat(32)}` as `0x${string}`, blockNumber: 7 }),
   };
+  return { deps, publishCalls: () => n };
 }
 
-describe('seed execute — corrupt state warning on the CLI output', () => {
-  async function runExecuteWithCorruptState(json: boolean): Promise<{ code: number; out: string }> {
+describe('seed execute — corrupt state fails closed', () => {
+  async function runExecuteWithCorruptState(json: boolean): Promise<{ code: number; out: string; publishCalls: number }> {
     const dir = mkdtempSync(join(tmpdir(), 'jinn-seed-state-cli-'));
     const statePath = join(dir, 'state.json');
     writeFileSync(statePath, '{ corrupt', 'utf-8');
@@ -158,33 +143,33 @@ describe('seed execute — corrupt state warning on the CLI output', () => {
     const prev = process.env['JINN_LAYER_SEED_STATE_PATH'];
     process.env['JINN_LAYER_SEED_STATE_PATH'] = statePath;
     try {
-      // No seedImportState injection: the CLI builds its file-backed default
-      // at the env-overridden path — the production wiring under test.
+      const publish = mockPublishDeps();
       const code = await runJinnLayerCli(
         ['seed', 'execute', reportFile, ...(json ? ['--json'] : [])],
-        { writer, episodeSource: source, publishDeps: mockPublishDeps() },
+        { writer, episodeSource: source, publishDeps: publish.deps },
       );
-      return { code, out };
+      return { code, out, publishCalls: publish.publishCalls() };
     } finally {
       if (prev === undefined) delete process.env['JINN_LAYER_SEED_STATE_PATH'];
       else process.env['JINN_LAYER_SEED_STATE_PATH'] = prev;
     }
   }
 
-  it('--json output carries the warning as a warnings field (not only console.warn)', async () => {
-    const { code, out } = await runExecuteWithCorruptState(true);
-    expect(code).toBe(0);
-    const payload = JSON.parse(out.trim()) as { imported: unknown[]; warnings?: string[] };
-    expect(payload.imported).toHaveLength(1); // fail-open: the corrupt state never blocked the publish
-    expect(payload.warnings).toHaveLength(1);
-    expect(String(payload.warnings![0])).toContain('unreadable');
+  it('--json exits nonzero and publishes nothing', async () => {
+    const { code, out, publishCalls } = await runExecuteWithCorruptState(true);
+    expect(code).toBe(1);
+    const payload = JSON.parse(out.trim()) as { imported: unknown[]; errors: Array<{ error: string }> };
+    expect(payload.imported).toHaveLength(0);
+    expect(payload.errors[0]!.error).toMatch(/state.*unreadable/i);
+    expect(publishCalls).toBe(0);
   });
 
-  it('table output carries a WARNING line', async () => {
-    const { code, out } = await runExecuteWithCorruptState(false);
-    expect(code).toBe(0);
-    expect(out).toContain('WARNING');
-    expect(out).toContain('unreadable');
-    expect(out).toContain('1 imported');
+  it('table output reports the state error without claiming an import', async () => {
+    const { code, out, publishCalls } = await runExecuteWithCorruptState(false);
+    expect(code).toBe(1);
+    expect(out).toContain('ERROR');
+    expect(out).toMatch(/state.*unreadable/i);
+    expect(out).toContain('0 imported');
+    expect(publishCalls).toBe(0);
   });
 });

--- a/client/packages/harness-layer/test/seed-import-state.test.ts
+++ b/client/packages/harness-layer/test/seed-import-state.test.ts
@@ -1,0 +1,190 @@
+/**
+ * File-backed seed-import state tests (issue #1771, PR #1779 review).
+ *
+ * `createFileSeedImportState` is the production default behind
+ * `seed execute` (cli.ts). Covered here: round-trip persistence across
+ * store instances, the documented fail-open corrupt-file behavior (empty
+ * state + a warning, at most once per store instance), `set()` self-heal,
+ * and — at the CLI level — that the corruption warning is surfaced through
+ * the command's own writer/output path (a `warnings` field in `--json`
+ * mode, a WARNING line in table mode), not only `console.warn`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createMemoryLedger } from '../src/ledger.js';
+import type { HarnessPublishDeps } from '../src/publish.js';
+import { createFileSeedImportState, type SeedPublicationRecord } from '../src/seed-import/state.js';
+import { planEpisodes } from '../src/seed-import/episode-plan.js';
+import type { SeedEpisode, EpisodeSource } from '../src/seed-import/episode-fetch.js';
+import { runJinnLayerCli } from '../src/cli.js';
+
+const RECORD: SeedPublicationRecord = {
+  contentHash: 'a'.repeat(64),
+  envelopeRef: 'bafy-envelope-1',
+  publishedAt: '2026-07-16T00:00:00.000Z',
+};
+
+function tmpStatePath(): string {
+  return join(mkdtempSync(join(tmpdir(), 'jinn-seed-state-')), 'state.json');
+}
+
+describe('createFileSeedImportState', () => {
+  it('round-trips a record across two store instances at the same path', () => {
+    const path = tmpStatePath();
+    const first = createFileSeedImportState(path);
+    first.set('episode:x', RECORD);
+
+    const second = createFileSeedImportState(path);
+    expect(second.get('episode:x')).toEqual(RECORD);
+    expect(second.get('episode:missing')).toBeUndefined();
+  });
+
+  it('a missing file is an empty state — no warning', () => {
+    const warn = vi.fn();
+    const store = createFileSeedImportState(tmpStatePath(), { onWarning: warn });
+    expect(store.get('episode:x')).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('a corrupt file is fail-open: empty state plus exactly one warning per store instance', () => {
+    const path = tmpStatePath();
+    writeFileSync(path, '{ definitely not json', 'utf-8');
+    const warn = vi.fn();
+    const store = createFileSeedImportState(path, { onWarning: warn });
+
+    expect(store.get('episode:x')).toBeUndefined();
+    expect(store.get('episode:y')).toBeUndefined(); // second read: latched, no second warning
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = String(warn.mock.calls[0]![0]);
+    expect(message).toContain('unreadable');
+    expect(message).toContain(path);
+  });
+
+  it('a schema-invalid (but valid JSON) file is treated the same as corrupt', () => {
+    const path = tmpStatePath();
+    writeFileSync(path, JSON.stringify({ 'episode:x': { nope: true } }), 'utf-8');
+    const warn = vi.fn();
+    const store = createFileSeedImportState(path, { onWarning: warn });
+
+    expect(store.get('episode:x')).toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('set() self-heals a corrupt file — the write wins and later reads succeed cleanly', () => {
+    const path = tmpStatePath();
+    writeFileSync(path, '{ corrupt', 'utf-8');
+    const store = createFileSeedImportState(path, { onWarning: vi.fn() });
+    store.set('episode:x', RECORD);
+
+    // A fresh instance reads the healed file with no warning.
+    const warn = vi.fn();
+    const fresh = createFileSeedImportState(path, { onWarning: warn });
+    expect(fresh.get('episode:x')).toEqual(RECORD);
+    expect(warn).not.toHaveBeenCalled();
+    // And the on-disk content is the canonical JSON map shape.
+    expect(JSON.parse(readFileSync(path, 'utf-8'))).toEqual({ 'episode:x': RECORD });
+  });
+
+  it('the default warning sink is console.warn (non-CLI callers keep the old behavior)', () => {
+    const path = tmpStatePath();
+    writeFileSync(path, '{ corrupt', 'utf-8');
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      createFileSeedImportState(path).get('episode:x');
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(String(spy.mock.calls[0]![0])).toContain('unreadable');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+// ── CLI surfacing (PR #1779 review): the warning reaches the command's own
+// output, not only console.warn ────────────────────────────────────────────
+
+const TEST_ADDRESS = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' as const;
+const TEST_PRIVATE_KEY =
+  '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80' as const;
+const TEST_SAFE = '0x1111111111111111111111111111111111111111' as const;
+
+function episodeFixture(): SeedEpisode {
+  return {
+    id: 'state-cli-fixture',
+    repo: 'acme/widgets',
+    taskSummary: 'Fix a flaky widget test by awaiting the async fetch before asserting',
+    tags: ['acme', 'widgets'],
+    steps: [
+      { label: 'failure', title: 'run failing test', text: '$ yarn test\nFAIL widget.test.ts' },
+      { label: 'fix', title: 'await the fetch', text: 'await waitFor(() => expect(fetchMock).toHaveBeenCalled());' },
+    ],
+    outcome: { status: 'completed', verifiabilityTier: 'tests-passed' },
+    synthesis: 'The test asserted before the async fetch settled. Waiting on the fetch mock directly fixes the race. This is the general pattern for this class of flake.',
+    attribution: { origin: 'operator-recorded-session' },
+  };
+}
+
+function mockEpisodeSource(episodes: SeedEpisode[]): EpisodeSource {
+  return { name: 'mock-episodes', list: async () => episodes };
+}
+
+function mockPublishDeps(): HarnessPublishDeps {
+  let n = 0;
+  return {
+    participant: { safeAddress: TEST_SAFE, agentEoa: TEST_ADDRESS },
+    signer: { address: TEST_ADDRESS, privateKey: TEST_PRIVATE_KEY },
+    clientGitSha: 'test-sha',
+    defaultArtifactEndpoint: 'http://127.0.0.1:7331',
+    ledger: createMemoryLedger(),
+    publishArtifact: async () => ({ cid: `bafy-artifact-${++n}`, sha256: 'a'.repeat(64) }),
+    publishEnvelope: async () => ({ cid: `bafy-envelope-${++n}`, sha256: 'b'.repeat(64) }),
+    anchorEnvelope: async () => ({ txHash: `0x${'cd'.repeat(32)}` as `0x${string}`, blockNumber: 7 }),
+  };
+}
+
+describe('seed execute — corrupt state warning on the CLI output', () => {
+  async function runExecuteWithCorruptState(json: boolean): Promise<{ code: number; out: string }> {
+    const dir = mkdtempSync(join(tmpdir(), 'jinn-seed-state-cli-'));
+    const statePath = join(dir, 'state.json');
+    writeFileSync(statePath, '{ corrupt', 'utf-8');
+    const source = mockEpisodeSource([episodeFixture()]);
+    const reportFile = join(dir, 'report.json');
+    writeFileSync(reportFile, JSON.stringify(await planEpisodes(source)));
+
+    let out = '';
+    const writer = { write: (s: string) => { out += s; return true; } };
+    const prev = process.env['JINN_LAYER_SEED_STATE_PATH'];
+    process.env['JINN_LAYER_SEED_STATE_PATH'] = statePath;
+    try {
+      // No seedImportState injection: the CLI builds its file-backed default
+      // at the env-overridden path — the production wiring under test.
+      const code = await runJinnLayerCli(
+        ['seed', 'execute', reportFile, ...(json ? ['--json'] : [])],
+        { writer, episodeSource: source, publishDeps: mockPublishDeps() },
+      );
+      return { code, out };
+    } finally {
+      if (prev === undefined) delete process.env['JINN_LAYER_SEED_STATE_PATH'];
+      else process.env['JINN_LAYER_SEED_STATE_PATH'] = prev;
+    }
+  }
+
+  it('--json output carries the warning as a warnings field (not only console.warn)', async () => {
+    const { code, out } = await runExecuteWithCorruptState(true);
+    expect(code).toBe(0);
+    const payload = JSON.parse(out.trim()) as { imported: unknown[]; warnings?: string[] };
+    expect(payload.imported).toHaveLength(1); // fail-open: the corrupt state never blocked the publish
+    expect(payload.warnings).toHaveLength(1);
+    expect(String(payload.warnings![0])).toContain('unreadable');
+  });
+
+  it('table output carries a WARNING line', async () => {
+    const { code, out } = await runExecuteWithCorruptState(false);
+    expect(code).toBe(0);
+    expect(out).toContain('WARNING');
+    expect(out).toContain('unreadable');
+    expect(out).toContain('1 imported');
+  });
+});

--- a/client/packages/harness-layer/test/seed-import.test.ts
+++ b/client/packages/harness-layer/test/seed-import.test.ts
@@ -430,6 +430,41 @@ describe('jinn-layer seed CLI', () => {
     ]);
     expect(sink.output()).toContain('bafy-envelope');
   });
+
+  it('returns the published skill ref with a recovery warning and nonzero exit when state persistence fails', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'jinn-seed-'));
+    const reportFile = join(dir, 'report.json');
+    const source = mockSource([skill()]);
+    writeFileSync(reportFile, JSON.stringify(await plan(source)));
+    const { deps, published } = mockPublishDeps();
+    const sink = writerSink();
+
+    const code = await runJinnLayerCli(['seed', 'execute', reportFile, '--json'], {
+      writer: sink,
+      seedSource: source,
+      publishDeps: deps,
+      seedImportState: {
+        get: () => undefined,
+        set: () => {
+          throw new Error('synthetic disk full');
+        },
+      },
+    });
+
+    expect(code).toBe(1);
+    expect(published).toHaveLength(2);
+    const payload = JSON.parse(sink.output()) as {
+      imported: Array<{ envelopeRef: string; stateWarning?: string }>;
+      errors: unknown[];
+    };
+    expect(payload.errors).toEqual([]);
+    expect(payload.imported).toEqual([
+      expect.objectContaining({
+        envelopeRef: expect.stringContaining('bafy-envelope'),
+        stateWarning: expect.stringMatching(/published.*state.*recovery/i),
+      }),
+    ]);
+  });
 });
 
 // ── Seed-profile scrub (#1409) — regression: seeds anchored but defaced ─────

--- a/client/packages/harness-layer/test/seed-import.test.ts
+++ b/client/packages/harness-layer/test/seed-import.test.ts
@@ -31,6 +31,7 @@ import {
 import { plan } from '../src/seed-import/plan.js';
 import { execute } from '../src/seed-import/execute.js';
 import type { SeedSkill, SeedSource } from '../src/seed-import/fetch.js';
+import { createMemorySeedImportState, hashSeedContent } from '../src/seed-import/state.js';
 import { runJinnLayerCli } from '../src/cli.js';
 
 const TEST_ADDRESS = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' as const;
@@ -308,6 +309,70 @@ describe('execute()', () => {
     expect(entry.metadata?.tags).toContain('seed-import');
     expect(entry.metadata?.tags).toContain('write-tests');
   });
+
+  // ── Idempotency + supersedes (issue #1771, folding the #1772 AC) ──────────
+
+  describe('idempotency + supersedes', () => {
+    it('re-running execute() with the same state store over unchanged content publishes nothing new', async () => {
+      const source = mockSource([skill()]);
+      const report = await plan(source);
+      const { deps, published } = mockPublishDeps();
+      const state = createMemorySeedImportState();
+
+      const first = await execute(report, source, deps, { state });
+      expect(first.imported).toHaveLength(1);
+      expect(published).toHaveLength(2); // trace + skill artifact
+
+      const second = await execute(report, source, deps, { state });
+      expect(second.imported).toHaveLength(0);
+      expect(second.skipped).toHaveLength(1);
+      expect(second.skipped[0]).toMatchObject({ skill: 'acme/skills/write-tests' });
+      expect(second.skipped[0]!.reason).toContain(first.imported[0]!.envelopeRef);
+      // No new publish calls on the second run.
+      expect(published).toHaveLength(2);
+    });
+
+    it('re-running execute() over CHANGED content republishes and sets provenance.supersedes to the prior ref', async () => {
+      const source1 = mockSource([skill({ skillMd: '# write-tests\n\nVersion one.' })]);
+      const { deps, published } = mockPublishDeps();
+      const state = createMemorySeedImportState();
+
+      const first = await execute(await plan(source1), source1, deps, { state });
+      expect(first.imported).toHaveLength(1);
+      const firstRef = first.imported[0]!.envelopeRef;
+
+      const source2 = mockSource([skill({ skillMd: '# write-tests\n\nVersion two — changed.' })]);
+      const second = await execute(await plan(source2), source2, deps, { state });
+      expect(second.imported).toHaveLength(1);
+      expect(second.imported[0]!.envelopeRef).not.toBe(firstRef);
+
+      const secondSkillPayload = SkillArtifactV1Schema.parse(
+        published.filter((p) => p.artifactType === SKILL_ARTIFACT_TYPE)[1]!.payload,
+      );
+      expect(secondSkillPayload.provenance.supersedes).toBe(firstRef);
+    });
+
+    it('without an injected state store, each execute() call starts fresh — no cross-call idempotency', async () => {
+      const source = mockSource([skill()]);
+      const report = await plan(source);
+      const { deps, published } = mockPublishDeps();
+
+      const first = await execute(report, source, deps);
+      const second = await execute(report, source, deps);
+      expect(first.imported).toHaveLength(1);
+      expect(second.imported).toHaveLength(1); // no skip: the default state is fresh per call
+      expect(second.imported[0]!.envelopeRef).not.toBe(first.imported[0]!.envelopeRef);
+      expect(published).toHaveLength(4); // two full publishes (trace + skill each)
+    });
+
+    it('hashSeedContent is a pure function of its input', () => {
+      const value = { a: 1, b: ['x', 'y'], c: { nested: true } };
+      expect(hashSeedContent(value)).toBe(hashSeedContent(value));
+      expect(hashSeedContent(value)).not.toBe(hashSeedContent({ ...value, a: 2 }));
+      // Key order must not affect the hash (canonical JSON).
+      expect(hashSeedContent({ b: value.b, a: value.a, c: value.c })).toBe(hashSeedContent(value));
+    });
+  });
 });
 
 describe('jinn-layer seed CLI', () => {
@@ -352,6 +417,11 @@ describe('jinn-layer seed CLI', () => {
       writer: sink,
       seedSource: source,
       publishDeps: deps,
+      // In-memory idempotency state: the CLI default is file-backed
+      // (~/.jinn-client/harness-layer/seed-import-state.json, #1771) so a
+      // real operator run persists across invocations — a test must not
+      // touch that path.
+      seedImportState: createMemorySeedImportState(),
     });
     expect(code).toBe(0);
     expect(published.map((p) => p.artifactType)).toEqual([

--- a/client/packages/harness-layer/test/seed-import.test.ts
+++ b/client/packages/harness-layer/test/seed-import.test.ts
@@ -398,6 +398,35 @@ describe('execute()', () => {
     expect(result.errors).toEqual([]);
   });
 
+  it('stops the batch after state lookup fails and never publishes later rows', async () => {
+    const source = mockSource([
+      skill({ skill: 'acme/skills/first' }),
+      skill({ skill: 'acme/skills/second' }),
+    ]);
+    const { deps, published } = mockPublishDeps();
+    let getCalls = 0;
+    const state = {
+      get: () => {
+        getCalls += 1;
+        if (getCalls === 1) throw new Error('synthetic state read failure');
+        return undefined;
+      },
+      set: () => undefined,
+    };
+
+    const result = await execute(await plan(source), source, deps, { state });
+
+    expect(getCalls).toBe(1);
+    expect(published).toHaveLength(0);
+    expect(result.imported).toEqual([]);
+    expect(result.errors).toEqual([
+      {
+        skill: 'acme/skills/first',
+        error: 'synthetic state read failure',
+      },
+    ]);
+  });
+
   it('persists the published ref, exposes a ledger warning, and stops the batch after ledger append fails', async () => {
     const source = mockSource([
       skill({ skill: 'acme/skills/first' }),

--- a/client/packages/harness-layer/test/seed-import.test.ts
+++ b/client/packages/harness-layer/test/seed-import.test.ts
@@ -373,6 +373,90 @@ describe('execute()', () => {
       expect(hashSeedContent({ b: value.b, a: value.a, c: value.c })).toBe(hashSeedContent(value));
     });
   });
+
+  it('stops the batch after post-publication state persistence fails', async () => {
+    const source = mockSource([
+      skill({ skill: 'acme/skills/first' }),
+      skill({ skill: 'acme/skills/second' }),
+    ]);
+    const { deps, published } = mockPublishDeps();
+    const state = {
+      get: () => undefined,
+      set: () => {
+        throw new Error('synthetic state disk full');
+      },
+    };
+
+    const result = await execute(await plan(source), source, deps, { state });
+
+    expect(published).toHaveLength(2); // first row's trace + skill only
+    expect(result.imported).toHaveLength(1);
+    expect(result.imported[0]).toMatchObject({
+      skill: 'acme/skills/first',
+      stateWarning: expect.stringMatching(/recovery required/i),
+    });
+    expect(result.errors).toEqual([]);
+  });
+
+  it('persists the published ref, exposes a ledger warning, and stops the batch after ledger append fails', async () => {
+    const source = mockSource([
+      skill({ skill: 'acme/skills/first' }),
+      skill({ skill: 'acme/skills/second' }),
+    ]);
+    const { deps, published } = mockPublishDeps();
+    deps.ledger = {
+      append: () => {
+        throw new Error('synthetic ledger disk full');
+      },
+      list: () => [],
+    };
+    const records: Array<{ identity: string; envelopeRef: string }> = [];
+    const state = {
+      get: () => undefined,
+      set: (identity: string, record: { envelopeRef: string }) => {
+        records.push({ identity, envelopeRef: record.envelopeRef });
+      },
+    };
+
+    const result = await execute(await plan(source), source, deps, { state });
+
+    expect(published).toHaveLength(2); // first row's trace + skill only
+    expect(records).toEqual([
+      { identity: 'skill:acme/skills/first', envelopeRef: expect.stringContaining('bafy-envelope') },
+    ]);
+    expect(result.imported).toEqual([
+      expect.objectContaining({
+        skill: 'acme/skills/first',
+        ledgerWarning: expect.stringMatching(/anchored.*ledger/i),
+      }),
+    ]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('halts after an ambiguous publication error and never publishes later rows', async () => {
+    const source = mockSource([
+      skill({ skill: 'acme/skills/first' }),
+      skill({ skill: 'acme/skills/second' }),
+    ]);
+    const { deps, published } = mockPublishDeps();
+    let envelopeCalls = 0;
+    deps.publishEnvelope = async () => {
+      envelopeCalls += 1;
+      throw new Error('synthetic transport timeout');
+    };
+
+    const result = await execute(await plan(source), source, deps);
+
+    expect(envelopeCalls).toBe(1);
+    expect(published).toHaveLength(2); // first row's trace + skill artifacts
+    expect(result.imported).toEqual([]);
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        skill: 'acme/skills/first',
+        error: expect.stringMatching(/publication outcome unknown; do not auto-retry/i),
+      }),
+    ]);
+  });
 });
 
 describe('jinn-layer seed CLI', () => {

--- a/client/packages/harness-layer/test/stage1-seeds-fixtures.test.ts
+++ b/client/packages/harness-layer/test/stage1-seeds-fixtures.test.ts
@@ -40,6 +40,9 @@ const EXPECTED_FILES = [...EPISODE_FILES, ...SKILL_FILES].sort();
 const ABSOLUTE_PATH_PATTERNS: Array<[string, RegExp]> = [
   ['macOS/Linux /Users/ path', /\/Users\/[^/\s"]+/],
   ['Linux /home/ path', /\/home\/[^/\s"]+/],
+  // What fs.realpath / tempfile APIs emit on macOS (/private/tmp,
+  // /private/var/folders/...) — PR #1779 review.
+  ['macOS /private/ path', /\/private\/[^/\s"]+/],
   ['Windows drive path', /[A-Za-z]:\\[^\\\s"]+/],
   ['home-dir tilde path', /~\/[^\s"]+/],
 ];
@@ -68,6 +71,35 @@ describe('stage1-seeds fixture set (issue #1771)', () => {
   it('contains exactly the expected files', () => {
     const actual = readdirSync(FIXTURES_DIR).filter((f) => f.endsWith('.json')).sort();
     expect(actual).toEqual(EXPECTED_FILES);
+  });
+
+  // Self-test of the checker itself (PR #1779 review): every pattern must
+  // actually fire on an injected canary — a scrub check that silently
+  // matches nothing is worse than none.
+  describe('ABSOLUTE_PATH_PATTERNS catch injected canaries', () => {
+    it.each([
+      ['/Users/someone/project/file.ts'],
+      ['/home/someone/project/file.ts'],
+      ['saved output to /private/tmp/jinn-scratch/out.json'],
+      ['/private/var/folders/ab/c123xyz/T/tmpfile.json'],
+      ['C:\\Users\\someone\\project\\file.ts'],
+      ['~/project/file.ts'],
+    ])('flags %j', (canary) => {
+      expect(ABSOLUTE_PATH_PATTERNS.some(([, pattern]) => pattern.test(canary))).toBe(true);
+    });
+
+    it('does not flag repo-relative paths', () => {
+      for (const clean of [
+        'client/src/dashboard/spa/src/notifications/useNotifications.test.tsx',
+        'sympy/printing/tests/test_latex.py',
+        '$ yarn --cwd client test',
+      ]) {
+        expect(
+          ABSOLUTE_PATH_PATTERNS.some(([, pattern]) => pattern.test(clean)),
+          `false positive on ${JSON.stringify(clean)}`,
+        ).toBe(false);
+      }
+    });
   });
 
   describe.each(EPISODE_FILES)('%s', (file) => {
@@ -100,9 +132,12 @@ describe('stage1-seeds fixture set (issue #1771)', () => {
       expect(JSON.stringify(parsed, null, 2) + '\n').toBe(raw);
     });
 
-    it('the idempotency content hash is a pure function of the fixture', () => {
-      const parsed = parseJson(file);
-      expect(hashSeedContent(parsed)).toBe(hashSeedContent(parsed));
+    it('the idempotency content hash is deterministic across independent parses', () => {
+      // Two independent JSON.parse calls yield distinct object graphs; the
+      // canonical-JSON hash must still agree (was a tautological same-
+      // reference comparison — PR #1779 review).
+      const raw = rawText(file);
+      expect(hashSeedContent(JSON.parse(raw))).toBe(hashSeedContent(JSON.parse(raw)));
     });
   });
 
@@ -185,6 +220,24 @@ describe('stage1-seeds fixture set (issue #1771)', () => {
       const d2 = SeedEpisodeSchema.parse(parseJson('distractor-sympy-printing.episode.json'));
       expect(d2.repo).not.toBe('Jinn-Network/mono');
       expect(d2.tags).not.toEqual(expect.arrayContaining(['mono']));
+    });
+  });
+
+  // PR #1779 review: attribution.origin must state each fixture's actual
+  // evidentiary standard — these publish to the shared corpus.
+  describe('attribution honesty (origin vocabulary)', () => {
+    it('commit-verified episodes claim operator-recorded-session and carry a sourceUrl', () => {
+      for (const file of ['source-dashboard-flake.episode.json', 'distractor-operator-claims.episode.json']) {
+        const ep = SeedEpisodeSchema.parse(parseJson(file));
+        expect(ep.attribution.origin, file).toBe('operator-recorded-session');
+        expect(ep.attribution.sourceUrl, `${file}: recorded-session claim needs its source commit`).toBeDefined();
+      }
+    });
+
+    it('the hand-authored sympy distractor does not claim a recorded session', () => {
+      const ep = SeedEpisodeSchema.parse(parseJson('distractor-sympy-printing.episode.json'));
+      expect(ep.attribution.origin).toBe('operator-authored-distractor');
+      expect(ep.attribution.sourceUrl).toBeUndefined();
     });
   });
 });

--- a/client/packages/harness-layer/test/stage1-seeds-fixtures.test.ts
+++ b/client/packages/harness-layer/test/stage1-seeds-fixtures.test.ts
@@ -37,15 +37,24 @@ const EXPECTED_FILES = [...EPISODE_FILES, ...SKILL_FILES].sort();
  * raw JSON text's `\n`/`\t` escape sequences are single-backslash-plus-letter
  * and would otherwise false-positive against a naive "letter:\" pattern.
  */
-const ABSOLUTE_PATH_PATTERNS: Array<[string, RegExp]> = [
-  [
-    'common Unix absolute path',
-    /\/(?:Users|Volumes|home|root|private|tmp|var|etc|opt|usr|srv|mnt)(?:\/[^\s"'`]+)+/,
-  ],
-  ['Windows drive path', /\b[A-Za-z]:[\\/][^\s"'`]+/],
-  ['Windows UNC path', /\\\\[^\\/\s"'`]+[\\/][^\s"'`]+/],
-  ['forward-slash UNC path', /(?<!:)\/\/[^/\s"'`]+\/[^\s"'`]+/],
-  ['home-dir tilde path', /~\/[^\s"'`]+/],
+function hasPosixAbsolutePath(value: string): boolean {
+  for (const match of value.matchAll(/(?:^|[\s("'`=\[:,])\/[^\s"'`]+/g)) {
+    const slash = match[0]!.indexOf('/');
+    const candidate = match[0]!.slice(slash).replace(/[)\],.;:]+$/, '');
+    if (candidate.startsWith('//')) continue; // URL/UNC handled separately.
+    const segments = candidate.slice(1).split('/').filter(Boolean);
+    if (/^v\d+$/i.test(segments[0] ?? '')) continue; // HTTP API route, not a filesystem path.
+    if (segments.length >= 2) return true;
+  }
+  return false;
+}
+
+const ABSOLUTE_PATH_DETECTORS: Array<[string, (value: string) => boolean]> = [
+  ['POSIX absolute path', hasPosixAbsolutePath],
+  ['Windows drive path', (value) => /\b[A-Za-z]:[\\/][^\s"'`]+/.test(value)],
+  ['Windows UNC path', (value) => /\\\\[^\\/\s"'`]+[\\/][^\s"'`]+/.test(value)],
+  ['forward-slash UNC path', (value) => /(?<!:)\/\/[^/\s"'`]+\/[^\s"'`]+/.test(value)],
+  ['home-dir tilde path', (value) => /~\/[^\s"'`]+/.test(value)],
 ];
 
 function rawText(file: string): string {
@@ -91,13 +100,17 @@ describe('stage1-seeds fixture set (issue #1771)', () => {
       ['/root/.jinn-client/state.json'],
       ['/mnt/data/results.json'],
       ['/Volumes/build/output.json'],
+      ['/workspace/project/file.ts'],
+      ['/builds/group/project/file.ts'],
+      ['/data/results/output.json'],
+      ['/nix/store/abc123-package/bin/tool'],
       ['C:\\Users\\someone\\project\\file.ts'],
       ['D:/work/project/file.ts'],
       ['\\\\server\\share\\project\\file.ts'],
       ['//server/share/project/file.ts'],
       ['~/project/file.ts'],
     ])('flags %j', (canary) => {
-      expect(ABSOLUTE_PATH_PATTERNS.some(([, pattern]) => pattern.test(canary))).toBe(true);
+      expect(ABSOLUTE_PATH_DETECTORS.some(([, detects]) => detects(canary))).toBe(true);
     });
 
     it('does not flag repo-relative paths', () => {
@@ -105,9 +118,12 @@ describe('stage1-seeds fixture set (issue #1771)', () => {
         'client/src/dashboard/spa/src/notifications/useNotifications.test.tsx',
         'sympy/printing/tests/test_latex.py',
         '$ yarn --cwd client test',
+        'https://example.com/workspace/project/file.ts',
+        'Run /jinn to start the command.',
+        'Use /capture-meta for metadata.',
       ]) {
         expect(
-          ABSOLUTE_PATH_PATTERNS.some(([, pattern]) => pattern.test(clean)),
+          ABSOLUTE_PATH_DETECTORS.some(([, detects]) => detects(clean)),
           `false positive on ${JSON.stringify(clean)}`,
         ).toBe(false);
       }
@@ -121,8 +137,8 @@ describe('stage1-seeds fixture set (issue #1771)', () => {
 
     it('contains no absolute path, home-dir tilde, or Windows drive path', () => {
       for (const s of allStrings(parseJson(file))) {
-        for (const [label, pattern] of ABSOLUTE_PATH_PATTERNS) {
-          expect(pattern.test(s), `${file}: matched ${label} in ${JSON.stringify(s.slice(0, 80))}`).toBe(false);
+        for (const [label, detects] of ABSOLUTE_PATH_DETECTORS) {
+          expect(detects(s), `${file}: matched ${label} in ${JSON.stringify(s.slice(0, 80))}`).toBe(false);
         }
       }
     });
@@ -160,8 +176,8 @@ describe('stage1-seeds fixture set (issue #1771)', () => {
 
     it('contains no absolute path, home-dir tilde, or Windows drive path', () => {
       for (const s of allStrings(parseJson(file))) {
-        for (const [label, pattern] of ABSOLUTE_PATH_PATTERNS) {
-          expect(pattern.test(s), `${file}: matched ${label} in ${JSON.stringify(s.slice(0, 80))}`).toBe(false);
+        for (const [label, detects] of ABSOLUTE_PATH_DETECTORS) {
+          expect(detects(s), `${file}: matched ${label} in ${JSON.stringify(s.slice(0, 80))}`).toBe(false);
         }
       }
     });

--- a/client/packages/harness-layer/test/stage1-seeds-fixtures.test.ts
+++ b/client/packages/harness-layer/test/stage1-seeds-fixtures.test.ts
@@ -38,13 +38,14 @@ const EXPECTED_FILES = [...EPISODE_FILES, ...SKILL_FILES].sort();
  * and would otherwise false-positive against a naive "letter:\" pattern.
  */
 const ABSOLUTE_PATH_PATTERNS: Array<[string, RegExp]> = [
-  ['macOS/Linux /Users/ path', /\/Users\/[^/\s"]+/],
-  ['Linux /home/ path', /\/home\/[^/\s"]+/],
-  // What fs.realpath / tempfile APIs emit on macOS (/private/tmp,
-  // /private/var/folders/...) — PR #1779 review.
-  ['macOS /private/ path', /\/private\/[^/\s"]+/],
-  ['Windows drive path', /[A-Za-z]:\\[^\\\s"]+/],
-  ['home-dir tilde path', /~\/[^\s"]+/],
+  [
+    'common Unix absolute path',
+    /\/(?:Users|Volumes|home|root|private|tmp|var|etc|opt|usr|srv|mnt)(?:\/[^\s"'`]+)+/,
+  ],
+  ['Windows drive path', /\b[A-Za-z]:[\\/][^\s"'`]+/],
+  ['Windows UNC path', /\\\\[^\\/\s"'`]+[\\/][^\s"'`]+/],
+  ['forward-slash UNC path', /(?<!:)\/\/[^/\s"'`]+\/[^\s"'`]+/],
+  ['home-dir tilde path', /~\/[^\s"'`]+/],
 ];
 
 function rawText(file: string): string {
@@ -82,7 +83,18 @@ describe('stage1-seeds fixture set (issue #1771)', () => {
       ['/home/someone/project/file.ts'],
       ['saved output to /private/tmp/jinn-scratch/out.json'],
       ['/private/var/folders/ab/c123xyz/T/tmpfile.json'],
+      ['/tmp/jinn-scratch/out.json'],
+      ['/var/log/jinn/output.log'],
+      ['/etc/jinn/config.json'],
+      ['/opt/jinn/bin/run'],
+      ['/usr/local/bin/jinn'],
+      ['/root/.jinn-client/state.json'],
+      ['/mnt/data/results.json'],
+      ['/Volumes/build/output.json'],
       ['C:\\Users\\someone\\project\\file.ts'],
+      ['D:/work/project/file.ts'],
+      ['\\\\server\\share\\project\\file.ts'],
+      ['//server/share/project/file.ts'],
       ['~/project/file.ts'],
     ])('flags %j', (canary) => {
       expect(ABSOLUTE_PATH_PATTERNS.some(([, pattern]) => pattern.test(canary))).toBe(true);
@@ -234,9 +246,10 @@ describe('stage1-seeds fixture set (issue #1771)', () => {
       }
     });
 
-    it('the hand-authored sympy distractor does not claim a recorded session', () => {
+    it('the hand-authored sympy distractor is explicitly synthetic and unverified', () => {
       const ep = SeedEpisodeSchema.parse(parseJson('distractor-sympy-printing.episode.json'));
-      expect(ep.attribution.origin).toBe('operator-authored-distractor');
+      expect(ep.outcome).toEqual({ status: 'completed', verifiabilityTier: 'user-accepted' });
+      expect(ep.attribution.origin).toBe('synthetic-selection-distractor');
       expect(ep.attribution.sourceUrl).toBeUndefined();
     });
   });

--- a/client/packages/harness-layer/test/stage1-seeds-fixtures.test.ts
+++ b/client/packages/harness-layer/test/stage1-seeds-fixtures.test.ts
@@ -38,12 +38,14 @@ const EXPECTED_FILES = [...EPISODE_FILES, ...SKILL_FILES].sort();
  * and would otherwise false-positive against a naive "letter:\" pattern.
  */
 function hasPosixAbsolutePath(value: string): boolean {
+  const routeRoots = new Set(['jinn', 'capture-meta', 'api', 'corpus']);
   for (const match of value.matchAll(/(?:^|[\s("'`=\[:,])\/[^\s"'`]+/g)) {
     const slash = match[0]!.indexOf('/');
     const candidate = match[0]!.slice(slash).replace(/[)\],.;:]+$/, '');
     if (candidate.startsWith('//')) continue; // URL/UNC handled separately.
     const segments = candidate.slice(1).split('/').filter(Boolean);
-    if (/^v\d+$/i.test(segments[0] ?? '')) continue; // HTTP API route, not a filesystem path.
+    const root = segments[0] ?? '';
+    if (routeRoots.has(root) || /^v\d+$/i.test(root)) continue; // Product/API route, not a filesystem path.
     if (segments.length >= 2) return true;
   }
   return false;
@@ -121,6 +123,11 @@ describe('stage1-seeds fixture set (issue #1771)', () => {
         'https://example.com/workspace/project/file.ts',
         'Run /jinn to start the command.',
         'Use /capture-meta for metadata.',
+        'GET /jinn/status',
+        'POST /capture-meta/session',
+        'GET /api/corpus/search',
+        'GET /corpus/records/bafy-ref',
+        'GET /v2/status/health',
       ]) {
         expect(
           ABSOLUTE_PATH_DETECTORS.some(([, detects]) => detects(clean)),

--- a/client/packages/harness-layer/test/stage1-seeds-fixtures.test.ts
+++ b/client/packages/harness-layer/test/stage1-seeds-fixtures.test.ts
@@ -37,15 +37,25 @@ const EXPECTED_FILES = [...EPISODE_FILES, ...SKILL_FILES].sort();
  * raw JSON text's `\n`/`\t` escape sequences are single-backslash-plus-letter
  * and would otherwise false-positive against a naive "letter:\" pattern.
  */
+const ALLOWED_POSIX_ROUTES = new Set([
+  '/jinn/session',
+  '/jinn/status',
+  '/capture-meta/search',
+  '/api/corpus/search',
+  '/corpus/search',
+]);
+const ALLOWED_VERSIONED_POSIX_ROUTE =
+  /^\/v\d+\/(?:status(?:\/health|\.latestVersion)|corpus\/search)$/i;
+
 function hasPosixAbsolutePath(value: string): boolean {
-  const routeRoots = new Set(['jinn', 'capture-meta', 'api', 'corpus']);
   for (const match of value.matchAll(/(?:^|[\s("'`=\[:,])\/[^\s"'`]+/g)) {
     const slash = match[0]!.indexOf('/');
     const candidate = match[0]!.slice(slash).replace(/[)\],.;:]+$/, '');
     if (candidate.startsWith('//')) continue; // URL/UNC handled separately.
+    if (ALLOWED_POSIX_ROUTES.has(candidate) || ALLOWED_VERSIONED_POSIX_ROUTE.test(candidate)) {
+      continue;
+    }
     const segments = candidate.slice(1).split('/').filter(Boolean);
-    const root = segments[0] ?? '';
-    if (routeRoots.has(root) || /^v\d+$/i.test(root)) continue; // Product/API route, not a filesystem path.
     if (segments.length >= 2) return true;
   }
   return false;
@@ -123,17 +133,30 @@ describe('stage1-seeds fixture set (issue #1771)', () => {
         'https://example.com/workspace/project/file.ts',
         'Run /jinn to start the command.',
         'Use /capture-meta for metadata.',
+        'POST /jinn/session',
         'GET /jinn/status',
-        'POST /capture-meta/session',
+        'GET /capture-meta/search',
         'GET /api/corpus/search',
-        'GET /corpus/records/bafy-ref',
+        'GET /corpus/search',
+        'Read /v1/status.latestVersion after the response.',
         'GET /v2/status/health',
+        'GET /v3/corpus/search',
       ]) {
         expect(
           ABSOLUTE_PATH_DETECTORS.some(([, detects]) => detects(clean)),
           `false positive on ${JSON.stringify(clean)}`,
         ).toBe(false);
       }
+    });
+
+    it.each([
+      ['/api/private/key.json'],
+      ['/jinn/private/key.json'],
+      ['/capture-meta/private/token.txt'],
+      ['/corpus/private/index.sqlite'],
+      ['/v2/private/key.json'],
+    ])('flags filesystem-like path beneath a route-shaped root: %j', (canary) => {
+      expect(ABSOLUTE_PATH_DETECTORS.some(([, detects]) => detects(canary))).toBe(true);
     });
   });
 

--- a/client/packages/harness-layer/test/stage1-seeds-fixtures.test.ts
+++ b/client/packages/harness-layer/test/stage1-seeds-fixtures.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Stage 1 seed fixture lint (issue #1771).
+ *
+ * `client/packages/harness-layer/fixtures/stage1-seeds/` is the curated
+ * evidence-episode + skill-shaped seed set the rescope plan's R5 acceptance
+ * gate (docs/superpowers/plans/2026-07-16-jinn-plugin-stage-1-rescope-plan.md
+ * §4.3-§4.4) and the manual testnet seeding runbook
+ * (docs/runbooks/stage1-evidence-seeding.md) both read by repo-relative
+ * path. This test is the fixture set's own regression net: every file must
+ * be schema-valid, scrub-clean (no absolute paths / usernames), and
+ * deterministically formatted (a hand-edit or re-generation must not
+ * silently introduce noise).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { SeedEpisodeSchema } from '../src/seed-import/episode-fetch.js';
+import { SeedSkillSchema } from '../src/seed-import/fetch.js';
+import { hashSeedContent } from '../src/seed-import/state.js';
+
+const FIXTURES_DIR = fileURLToPath(new URL('../fixtures/stage1-seeds', import.meta.url));
+
+const EPISODE_FILES = [
+  'distractor-operator-claims.episode.json',
+  'distractor-sympy-printing.episode.json',
+  'source-dashboard-flake.episode.json',
+];
+const SKILL_FILES = ['distractor-skill-tdd-dup.json', 'distractor-skill-tdd.json'];
+const EXPECTED_FILES = [...EPISODE_FILES, ...SKILL_FILES].sort();
+
+/**
+ * Patterns a scrubbed, repo-relative fixture must never contain. Checked
+ * against DECODED string values (post JSON.parse), not raw file bytes — the
+ * raw JSON text's `\n`/`\t` escape sequences are single-backslash-plus-letter
+ * and would otherwise false-positive against a naive "letter:\" pattern.
+ */
+const ABSOLUTE_PATH_PATTERNS: Array<[string, RegExp]> = [
+  ['macOS/Linux /Users/ path', /\/Users\/[^/\s"]+/],
+  ['Linux /home/ path', /\/home\/[^/\s"]+/],
+  ['Windows drive path', /[A-Za-z]:\\[^\\\s"]+/],
+  ['home-dir tilde path', /~\/[^\s"]+/],
+];
+
+function rawText(file: string): string {
+  return readFileSync(join(FIXTURES_DIR, file), 'utf-8');
+}
+
+function parseJson(file: string): unknown {
+  return JSON.parse(rawText(file));
+}
+
+/** Recursively collect every string value in a parsed JSON structure. */
+function allStrings(value: unknown, out: string[] = []): string[] {
+  if (typeof value === 'string') {
+    out.push(value);
+  } else if (Array.isArray(value)) {
+    for (const v of value) allStrings(v, out);
+  } else if (value !== null && typeof value === 'object') {
+    for (const v of Object.values(value)) allStrings(v, out);
+  }
+  return out;
+}
+
+describe('stage1-seeds fixture set (issue #1771)', () => {
+  it('contains exactly the expected files', () => {
+    const actual = readdirSync(FIXTURES_DIR).filter((f) => f.endsWith('.json')).sort();
+    expect(actual).toEqual(EXPECTED_FILES);
+  });
+
+  describe.each(EPISODE_FILES)('%s', (file) => {
+    it('is schema-valid against SeedEpisodeSchema', () => {
+      expect(() => SeedEpisodeSchema.parse(parseJson(file))).not.toThrow();
+    });
+
+    it('contains no absolute path, home-dir tilde, or Windows drive path', () => {
+      for (const s of allStrings(parseJson(file))) {
+        for (const [label, pattern] of ABSOLUTE_PATH_PATTERNS) {
+          expect(pattern.test(s), `${file}: matched ${label} in ${JSON.stringify(s.slice(0, 80))}`).toBe(false);
+        }
+      }
+    });
+
+    it('contains no reference to this machine\'s username or home directory', () => {
+      const identifiers = [process.env['USER'], process.env['LOGNAME'], homedir()].filter(
+        (v): v is string => Boolean(v) && v.length >= 3,
+      );
+      for (const s of allStrings(parseJson(file))) {
+        for (const id of identifiers) {
+          expect(s.includes(id), `${file}: contains "${id}"`).toBe(false);
+        }
+      }
+    });
+
+    it('is deterministically formatted (stable JSON.stringify(_, null, 2) round-trip)', () => {
+      const raw = rawText(file);
+      const parsed = JSON.parse(raw);
+      expect(JSON.stringify(parsed, null, 2) + '\n').toBe(raw);
+    });
+
+    it('the idempotency content hash is a pure function of the fixture', () => {
+      const parsed = parseJson(file);
+      expect(hashSeedContent(parsed)).toBe(hashSeedContent(parsed));
+    });
+  });
+
+  describe.each(SKILL_FILES)('%s', (file) => {
+    it('is schema-valid against SeedSkillSchema', () => {
+      expect(() => SeedSkillSchema.parse(parseJson(file))).not.toThrow();
+    });
+
+    it('contains no absolute path, home-dir tilde, or Windows drive path', () => {
+      for (const s of allStrings(parseJson(file))) {
+        for (const [label, pattern] of ABSOLUTE_PATH_PATTERNS) {
+          expect(pattern.test(s), `${file}: matched ${label} in ${JSON.stringify(s.slice(0, 80))}`).toBe(false);
+        }
+      }
+    });
+
+    it('is deterministically formatted (stable JSON.stringify(_, null, 2) round-trip)', () => {
+      const raw = rawText(file);
+      const parsed = JSON.parse(raw);
+      expect(JSON.stringify(parsed, null, 2) + '\n').toBe(raw);
+    });
+  });
+
+  describe('source episode (source-dashboard-flake.episode.json)', () => {
+    const source = () => SeedEpisodeSchema.parse(parseJson('source-dashboard-flake.episode.json'));
+
+    it('has at least one failure step and its fix (issue #1771 AC)', () => {
+      const labels = source().steps.map((s) => s.label);
+      expect(labels).toContain('failure');
+      expect(labels).toContain('fix');
+    });
+
+    it('re-performs the real 163e070d fix at its pre-fix base commit', () => {
+      const ep = source();
+      expect(ep.repo).toBe('Jinn-Network/mono');
+      expect(ep.baseCommit).toBe('3651de92ccda900dc6d052b94035f9a86d5b21be');
+      expect(ep.attribution.sourceUrl).toContain('163e070d254aaa1f8e980d1a69888f8d8baf9f14');
+    });
+
+    it('carries the exact tag set named in the issue', () => {
+      expect(source().tags).toEqual(['mono', 'dashboard', 'vitest', 'version-status', 'async', 'flake']);
+    });
+
+    it('outcome is completed / tests-passed', () => {
+      expect(source().outcome).toEqual({ status: 'completed', verifiabilityTier: 'tests-passed' });
+    });
+
+    it('the synthesis is 3-6 sentences', () => {
+      const sentenceCount = source().synthesis.split(/(?<=[.!?])\s+/).filter(Boolean).length;
+      expect(sentenceCount).toBeGreaterThanOrEqual(3);
+      expect(sentenceCount).toBeLessThanOrEqual(6);
+    });
+
+    it('the diff excerpt matches the real 163e070d diff', () => {
+      const diffStep = source().steps.find((s) => s.label === 'diff')!;
+      expect(diffStep.text).toContain("await waitFor(() => expect(apiMocks.getStatus).toHaveBeenCalled());");
+      expect(diffStep.text).toContain("await waitFor(() => expect(result.current.map(n => n.kind)).toContain('funding_low'));");
+    });
+  });
+
+  describe('skill-shaped distractors (D3/D4) — same content, distinct identity', () => {
+    it('distractor-skill-tdd-dup.json duplicates distractor-skill-tdd.json content exactly', () => {
+      const d3 = SeedSkillSchema.parse(parseJson('distractor-skill-tdd.json'));
+      const d4 = SeedSkillSchema.parse(parseJson('distractor-skill-tdd-dup.json'));
+      expect(d4.skillMd).toBe(d3.skillMd);
+      expect(d4.description).toBe(d3.description);
+      expect(d4.skill).not.toBe(d3.skill); // distinct identity, same content — proves consumer-side dedup is content-keyed
+    });
+  });
+
+  describe('distractors are distinguishable from the source (selection can tell them apart)', () => {
+    it('D1 shares the repo but not the module/vocabulary with the source', () => {
+      const d1 = SeedEpisodeSchema.parse(parseJson('distractor-operator-claims.episode.json'));
+      const source = SeedEpisodeSchema.parse(parseJson('source-dashboard-flake.episode.json'));
+      expect(d1.repo).toBe(source.repo);
+      expect(d1.tags).not.toEqual(expect.arrayContaining(['dashboard']));
+    });
+
+    it('D2 is a different domain entirely (not the mono repo)', () => {
+      const d2 = SeedEpisodeSchema.parse(parseJson('distractor-sympy-printing.episode.json'));
+      expect(d2.repo).not.toBe('Jinn-Network/mono');
+      expect(d2.tags).not.toEqual(expect.arrayContaining(['mono']));
+    });
+  });
+});

--- a/docs/runbooks/stage1-evidence-seeding.md
+++ b/docs/runbooks/stage1-evidence-seeding.md
@@ -75,6 +75,14 @@ captured one — see `client/packages/harness-layer/src/seed-import/episode-exec
    `failure` and its `fix`; distractor/negative fixtures are freeform.
    File name convention: `<id>.episode.json`.
 
+   `attribution.origin` states how the episode entered the corpus, honestly.
+   Vocabulary in use (freeform by schema — document any new value here):
+   - `operator-recorded-session` — transformed from a real recorded session;
+     carry `sourceUrl` when it re-performs a merged fix.
+   - `operator-authored-distractor` — hand-authored negative/contrast
+     material (e.g. the sympy distractor). It must not claim the
+     recorded-session evidentiary standard.
+
 6. **Validate locally** before touching the network:
 
    ```bash
@@ -102,10 +110,14 @@ report file) before executing; nothing publishes that wasn't on this list.
 
 Skill-shaped fixtures (`distractor-skill-tdd.json`,
 `distractor-skill-tdd-dup.json`) are **not** picked up by `--episodes-dir` —
-that flag only reads `*.episode.json` files. They exist for the R5
-acceptance gate (boundary assertion: skills are excluded from pickup, and
-duplicate content collapses at the consumer) and are published, if at all,
-through the existing skill lane (`seed plan/execute --source <list-file>`).
+that flag only reads `*.episode.json` files. They are consumed only by the
+fixture-lint test and, later, by the R5 acceptance gate's local corpus
+fixture server (boundary assertions: skills are excluded from pickup, and
+duplicate content collapses at the consumer). They are **not** publishable
+via `seed plan/execute --source <list-file>` either: that source fetches
+live from the GitHub API, and these fixtures' placeholder repos
+(`distractor/skill-tdd*`) do not exist — a fetch would 404. Nothing
+publishes them to the shared corpus.
 
 ## 3. Execute (publishes to testnet)
 
@@ -164,12 +176,16 @@ repeat:
 
 Idempotency state lives at
 `~/.jinn-client/harness-layer/seed-import-state.json` (one JSON map,
-`seed identity -> {contentHash, envelopeRef, publishedAt}`), shared with the
-existing skill-seed lane. Deleting that file resets idempotency — the next
-`seed execute` treats every row as new. This state is **local to the
-machine that ran `seed execute`**; it is not itself published, and it does
-not query the corpus — it only answers "did *I* already publish this exact
-seed identity, unchanged?".
+`seed identity -> {contentHash, envelopeRef, publishedAt}`; path overridable
+via `JINN_LAYER_SEED_STATE_PATH`), shared with the existing skill-seed lane.
+Deleting that file resets idempotency — the next `seed execute` treats every
+row as new. A corrupt/unreadable state file is fail-open: treated as empty,
+with a warning on the command's own output (`warnings` in `--json` mode, a
+`WARNING` line in table mode) — worst case is one redundant republish, which
+then supersedes cleanly. This state is **local to the machine that ran
+`seed execute`**; it is not itself published, and it does not query the
+corpus — it only answers "did *I* already publish this exact seed identity,
+unchanged?".
 
 ## Fixture-file reference
 
@@ -177,6 +193,6 @@ seed identity, unchanged?".
 |---|---|---|
 | `source-dashboard-flake.episode.json` | evidence | The positive match: re-performs the real dashboard `update_available` test flake fix (`163e070d`) at its pre-fix commit. |
 | `distractor-operator-claims.episode.json` | evidence | Same repo, different module (`d682f811`) — proves selection is finer than repository match. |
-| `distractor-sympy-printing.episode.json` | evidence | Different domain entirely (sympy LaTeX printing) — proves domain relevance. |
+| `distractor-sympy-printing.episode.json` | evidence | Different domain entirely (sympy LaTeX printing) — proves domain relevance. Hand-authored (`origin: operator-authored-distractor`, no source commit), unlike the two commit-verified episodes above. |
 | `distractor-skill-tdd.json` | skill | Skill-shaped seed (existing lane's format) — proves skills are excluded from evidence pickup. |
 | `distractor-skill-tdd-dup.json` | skill | Same `skillMd` content as the above under a distinct identity — proves content-key dedup at the consumer. |

--- a/docs/runbooks/stage1-evidence-seeding.md
+++ b/docs/runbooks/stage1-evidence-seeding.md
@@ -93,10 +93,10 @@ captured one — see `client/packages/harness-layer/src/seed-import/episode-exec
    yarn vitest run packages/harness-layer/test/stage1-seeds-fixtures.test.ts
    ```
 
-   That test is the fixture set's own lint: schema-valid, no absolute
-   paths/usernames, deterministically formatted. Point it at a scratch
-   directory (or add your file under `fixtures/stage1-seeds/` and extend the
-   expected-file list) to lint a new episode the same way.
+   That test is the curated fixture set's own lint: schema-valid, no absolute
+   paths/usernames, deterministically formatted. It reads
+   `fixtures/stage1-seeds/` directly; to lint a new episode with this test,
+   add it there and extend the expected-file list before running the command.
 
 ## 2. Plan (zero writes)
 

--- a/docs/runbooks/stage1-evidence-seeding.md
+++ b/docs/runbooks/stage1-evidence-seeding.md
@@ -1,0 +1,182 @@
+# Stage 1 evidence seeding
+
+How to turn a completed agentic session into a published evidence-episode
+seed, and how to publish the curated Stage 1 fixture set
+(`client/packages/harness-layer/fixtures/stage1-seeds/`) to the testnet
+corpus so Stage 1's evidence-first retrieval
+(`docs/superpowers/plans/2026-07-16-jinn-plugin-stage-1-rescope-plan.md` §3-§4)
+has canonical prior-work evidence to serve. Issue #1771.
+
+The corpus otherwise contains almost no evidence records — only skills.sh
+skill seeds — so retrieval has nothing honest to return for the Stage 1
+walkthrough or for any real operator session until this lane has run at
+least once.
+
+## Why episodes, not raw traces
+
+A seed-episode JSON file is a *transformed*, human-reviewed artifact, not a
+raw capture. It is published through the exact same `capture() -> publish()`
+path a real contribution uses (seed-profile scrub, `provenance: 'imported'`,
+excluded from the demand signal and emissions eligibility), so a seeded
+evidence record is indistinguishable on the wire from an organically
+captured one — see `client/packages/harness-layer/src/seed-import/episode-execute.ts`.
+
+## 1. Record → transform → author
+
+1. **Record.** Run a real agentic session that performs a genuine, small,
+   verifiable task — ideally re-performing an already-merged fix at its
+   pre-fix commit, so the "before" state is real and reproducible (see
+   `fixtures/stage1-seeds/source-dashboard-flake.episode.json` for the
+   pattern: `git show <fix-sha>~1:<file>` to get the pre-fix content, run the
+   failing command for real, apply the real fix, rerun).
+2. **Normalize paths.** Every path in every step must be repo-relative
+   (`client/src/...`, not `/Users/you/jinn-mono/client/src/...`). Strip
+   machine/user identifiers from command output (hostnames, local
+   usernames, absolute paths in stack traces).
+3. **Scrub.** Read the episode once, end to end, for anything that
+   shouldn't leave the machine — tokens, keys, private URLs. The seed-profile
+   scrub (`buildSeedScrubPipeline()`, #1409: deterministic secret patterns
+   only) runs automatically at `seed execute` time as a second, mandatory
+   net, but authored content should already be clean; the scrub is a
+   backstop, not a substitute for review.
+4. **Author `synthesis` and `tags`.** `synthesis` is a 3-6 sentence,
+   task-linked "how it was solved" — write it yourself; it is never
+   generated at retrieval time. `tags` should name the subsystem vocabulary
+   a related task would search on (see the source fixture's
+   `mono, dashboard, vitest, version-status, async, flake`).
+5. **Shape the file** against the seed-episode contract
+   (`client/packages/harness-layer/src/seed-import/episode-fetch.ts`,
+   `SeedEpisodeSchema`):
+
+   ```json
+   {
+     "id": "kebab-case-stable-identity",
+     "repo": "owner/repo",
+     "baseCommit": "<full 40-char sha, when re-performing a real fix>",
+     "taskSummary": "One line, ≤500 chars",
+     "tags": ["subsystem", "vocabulary", "..."],
+     "steps": [
+       { "label": "failure", "title": "...", "text": "..." },
+       { "label": "note",    "title": "...", "text": "..." },
+       { "label": "fix",     "title": "...", "text": "..." },
+       { "label": "diff",    "title": "...", "text": "..." },
+       { "label": "command", "title": "...", "text": "..." }
+     ],
+     "outcome": { "status": "completed", "verifiabilityTier": "tests-passed" },
+     "synthesis": "3-6 sentences.",
+     "attribution": { "origin": "operator-recorded-session", "sourceUrl": "https://..." }
+   }
+   ```
+
+   `steps[].label` is one of `failure | fix | command | diff | note` — the
+   same vocabulary the retrieval-side knowledge-packet projection (rescope
+   plan §3.2, `projectKnowledgePacket`) selects excerpts by. A source episode
+   (one meant to actually help a related task) should carry at least one
+   `failure` and its `fix`; distractor/negative fixtures are freeform.
+   File name convention: `<id>.episode.json`.
+
+6. **Validate locally** before touching the network:
+
+   ```bash
+   cd client
+   yarn vitest run packages/harness-layer/test/stage1-seeds-fixtures.test.ts
+   ```
+
+   That test is the fixture set's own lint: schema-valid, no absolute
+   paths/usernames, deterministically formatted. Point it at a scratch
+   directory (or add your file under `fixtures/stage1-seeds/` and extend the
+   expected-file list) to lint a new episode the same way.
+
+## 2. Plan (zero writes)
+
+```bash
+cd client
+yarn jinn-layer seed plan --episodes-dir packages/harness-layer/fixtures/stage1-seeds \
+  --out /tmp/stage1-episode-report.json
+```
+
+`plan` performs **no writes** — it lists every `*.episode.json` file found,
+validates each against the schema, and flags a duplicate `id` within the
+batch as `skip` (first occurrence wins). Review the printed table (or the
+report file) before executing; nothing publishes that wasn't on this list.
+
+Skill-shaped fixtures (`distractor-skill-tdd.json`,
+`distractor-skill-tdd-dup.json`) are **not** picked up by `--episodes-dir` —
+that flag only reads `*.episode.json` files. They exist for the R5
+acceptance gate (boundary assertion: skills are excluded from pickup, and
+duplicate content collapses at the consumer) and are published, if at all,
+through the existing skill lane (`seed plan/execute --source <list-file>`).
+
+## 3. Execute (publishes to testnet)
+
+Publishing needs a live operator identity. Derive one from your local
+`~/.jinn-client` keystore and export it for this shell:
+
+```bash
+eval "$(yarn --silent jinn-layer derive-env)"
+```
+
+Then run the approved report:
+
+```bash
+yarn jinn-layer seed execute /tmp/stage1-episode-report.json \
+  --episodes-dir packages/harness-layer/fixtures/stage1-seeds
+```
+
+Each `import`-verdict row runs through `capture()` (seed-profile scrub) then
+`publish()` (the same anchor path a real contribution uses) and prints the
+published `envelopeRef` (the corpus ref) plus the anchor tx. `--json`
+emits the machine-readable `EpisodeImportResult` instead of the table.
+
+## 4. Verify retrievability
+
+```bash
+yarn jinn-layer corpus search "dashboard" --limit 5
+```
+
+The seeded record should appear in the results (ref, `kind: 'trace'`, tags
+including your episode's tags). Fetch it directly to confirm the full
+content round-tripped:
+
+```bash
+yarn jinn-layer corpus get <ref> --json
+```
+
+Confirm `provenance: 'imported'`, the `seed:step:*` steps carrying
+`seed.step.label`/`seed.step.title`/`seed.step.text`, and the final
+`seed:synthesis` step carrying `seed.synthesis` + `seed.attribution`.
+
+## 5. Idempotency and `supersedes`
+
+Re-running `seed execute` over the **same directory and report** is safe to
+repeat:
+
+- **Unchanged content** — nothing publishes. The row prints as `skipped`
+  with the reason `unchanged since <prior envelopeRef>`. No new IPFS
+  upload, no new anchor tx.
+- **Changed content** (you edited the episode's steps, synthesis, tags,
+  outcome, or attribution) — a fresh record publishes, and its
+  `seed.attribution.supersedes` step attribute is set to the prior
+  `envelopeRef`. The old record is not deleted or hidden by this alone
+  (that collapse is a consumer-side / corpus-hygiene concern — rescope plan
+  §3.3, #1776); `supersedes` is the durable lineage pointer a later reader
+  can follow.
+
+Idempotency state lives at
+`~/.jinn-client/harness-layer/seed-import-state.json` (one JSON map,
+`seed identity -> {contentHash, envelopeRef, publishedAt}`), shared with the
+existing skill-seed lane. Deleting that file resets idempotency — the next
+`seed execute` treats every row as new. This state is **local to the
+machine that ran `seed execute`**; it is not itself published, and it does
+not query the corpus — it only answers "did *I* already publish this exact
+seed identity, unchanged?".
+
+## Fixture-file reference
+
+| File | Kind | Role |
+|---|---|---|
+| `source-dashboard-flake.episode.json` | evidence | The positive match: re-performs the real dashboard `update_available` test flake fix (`163e070d`) at its pre-fix commit. |
+| `distractor-operator-claims.episode.json` | evidence | Same repo, different module (`d682f811`) — proves selection is finer than repository match. |
+| `distractor-sympy-printing.episode.json` | evidence | Different domain entirely (sympy LaTeX printing) — proves domain relevance. |
+| `distractor-skill-tdd.json` | skill | Skill-shaped seed (existing lane's format) — proves skills are excluded from evidence pickup. |
+| `distractor-skill-tdd-dup.json` | skill | Same `skillMd` content as the above under a distinct identity — proves content-key dedup at the consumer. |

--- a/docs/runbooks/stage1-evidence-seeding.md
+++ b/docs/runbooks/stage1-evidence-seeding.md
@@ -79,8 +79,9 @@ captured one — see `client/packages/harness-layer/src/seed-import/episode-exec
    Vocabulary in use (freeform by schema — document any new value here):
    - `operator-recorded-session` — transformed from a real recorded session;
      carry `sourceUrl` when it re-performs a merged fix.
-   - `operator-authored-distractor` — hand-authored negative/contrast
-     material (e.g. the sympy distractor). It must not claim the
+   - `synthetic-selection-distractor` — hand-authored negative/contrast
+     material (e.g. the sympy distractor). Pair it with
+     `verifiabilityTier: "user-accepted"`; it must not claim the
      recorded-session evidentiary standard.
 
 6. **Validate locally** before touching the network:
@@ -166,8 +167,12 @@ repeat:
 - **Unchanged content** — nothing publishes. The row prints as `skipped`
   with the reason `unchanged since <prior envelopeRef>`. No new IPFS
   upload, no new anchor tx.
-- **Changed content** (you edited the episode's steps, synthesis, tags,
-  outcome, or attribution) — a fresh record publishes, and its
+- **Changed content after planning** — execution refuses the row because its
+  canonical digest no longer matches the approved report. Re-run `seed plan`,
+  review the new digest/content, and approve that new report.
+- **Changed, newly approved content** (you edited the episode's steps,
+  synthesis, tags, outcome, or attribution and approved a fresh report) — a
+  fresh record publishes, and its
   `seed.attribution.supersedes` step attribute is set to the prior
   `envelopeRef`. The old record is not deleted or hidden by this alone
   (that collapse is a consumer-side / corpus-hygiene concern — rescope plan
@@ -179,13 +184,16 @@ Idempotency state lives at
 `seed identity -> {contentHash, envelopeRef, publishedAt}`; path overridable
 via `JINN_LAYER_SEED_STATE_PATH`), shared with the existing skill-seed lane.
 Deleting that file resets idempotency — the next `seed execute` treats every
-row as new. A corrupt/unreadable state file is fail-open: treated as empty,
-with a warning on the command's own output (`warnings` in `--json` mode, a
-`WARNING` line in table mode) — worst case is one redundant republish, which
-then supersedes cleanly. This state is **local to the machine that ran
-`seed execute`**; it is not itself published, and it does not query the
-corpus — it only answers "did *I* already publish this exact seed identity,
-unchanged?".
+row as new. A corrupt/unreadable state file fails closed before publication,
+preserving the last known lineage instead of overwriting it as empty. State
+writes use a same-directory temp file plus atomic rename.
+
+If publication succeeds but state persistence fails, the result still prints
+the published `envelopeRef` with a recovery warning and exits nonzero. Stop
+automation, preserve that ref, repair/reconcile the local state, and only then
+retry. This state is **local to the machine that ran `seed execute`**; it is
+not itself published, and it does not query the corpus — it only answers "did
+*I* already publish this exact seed identity, unchanged?".
 
 ## Fixture-file reference
 
@@ -193,6 +201,6 @@ unchanged?".
 |---|---|---|
 | `source-dashboard-flake.episode.json` | evidence | The positive match: re-performs the real dashboard `update_available` test flake fix (`163e070d`) at its pre-fix commit. |
 | `distractor-operator-claims.episode.json` | evidence | Same repo, different module (`d682f811`) — proves selection is finer than repository match. |
-| `distractor-sympy-printing.episode.json` | evidence | Different domain entirely (sympy LaTeX printing) — proves domain relevance. Hand-authored (`origin: operator-authored-distractor`, no source commit), unlike the two commit-verified episodes above. |
+| `distractor-sympy-printing.episode.json` | evidence | Different domain entirely (sympy LaTeX printing) — proves domain relevance. Explicitly synthetic (`origin: synthetic-selection-distractor`, `verifiabilityTier: user-accepted`, no source commit), unlike the two commit-verified episodes above. |
 | `distractor-skill-tdd.json` | skill | Skill-shaped seed (existing lane's format) — proves skills are excluded from evidence pickup. |
 | `distractor-skill-tdd-dup.json` | skill | Same `skillMd` content as the above under a distinct identity — proves content-key dedup at the consumer. |

--- a/docs/runbooks/stage1-evidence-seeding.md
+++ b/docs/runbooks/stage1-evidence-seeding.md
@@ -16,7 +16,7 @@ least once.
 
 A seed-episode JSON file is a *transformed*, human-reviewed artifact, not a
 raw capture. It is published through the exact same `capture() -> publish()`
-path a real contribution uses (seed-profile scrub, `provenance: 'imported'`,
+path a real contribution uses (strict trace scrub, `provenance: 'imported'`,
 excluded from the demand signal and emissions eligibility), so a seeded
 evidence record is indistinguishable on the wire from an organically
 captured one — see `client/packages/harness-layer/src/seed-import/episode-execute.ts`.
@@ -34,11 +34,13 @@ captured one — see `client/packages/harness-layer/src/seed-import/episode-exec
    machine/user identifiers from command output (hostnames, local
    usernames, absolute paths in stack traces).
 3. **Scrub.** Read the episode once, end to end, for anything that
-   shouldn't leave the machine — tokens, keys, private URLs. The seed-profile
-   scrub (`buildSeedScrubPipeline()`, #1409: deterministic secret patterns
-   only) runs automatically at `seed execute` time as a second, mandatory
-   net, but authored content should already be clean; the scrub is a
-   backstop, not a substitute for review.
+   shouldn't leave the machine — tokens, keys, private URLs. The strict trace
+   scrub (`buildScrubPipeline()`: structured PII plus entropy-backed secret
+   detection) runs automatically at `seed execute` time as a second,
+   mandatory net over every episode-originated string, including the ID,
+   tags, summary, steps, outcome, synthesis, and attribution. Authored content
+   should already be clean; the scrub is a backstop, not a substitute for
+   review.
 4. **Author `synthesis` and `tags`.** `synthesis` is a 3-6 sentence,
    task-linked "how it was solved" — write it yourself; it is never
    generated at retrieval time. `tags` should name the subsystem vocabulary
@@ -136,7 +138,7 @@ yarn jinn-layer seed execute /tmp/stage1-episode-report.json \
   --episodes-dir packages/harness-layer/fixtures/stage1-seeds
 ```
 
-Each `import`-verdict row runs through `capture()` (seed-profile scrub) then
+Each `import`-verdict row runs through `capture()` (strict trace scrub) then
 `publish()` (the same anchor path a real contribution uses) and prints the
 published `envelopeRef` (the corpus ref) plus the anchor tx. `--json`
 emits the machine-readable `EpisodeImportResult` instead of the table.
@@ -189,11 +191,22 @@ preserving the last known lineage instead of overwriting it as empty. State
 writes use a same-directory temp file plus atomic rename.
 
 If publication succeeds but state persistence fails, the result still prints
-the published `envelopeRef` with a recovery warning and exits nonzero. Stop
-automation, preserve that ref, repair/reconcile the local state, and only then
-retry. This state is **local to the machine that ran `seed execute`**; it is
-not itself published, and it does not query the corpus — it only answers "did
-*I* already publish this exact seed identity, unchanged?".
+the published `envelopeRef` with a recovery warning, stops the batch, and
+exits nonzero. If the on-chain anchor succeeds but the local contribution
+ledger append fails, the result likewise preserves the ref and anchor tx,
+persists seed idempotency state from that known result, reports a ledger
+recovery warning, stops the batch, and exits nonzero.
+
+Any other publish error is treated as ambiguous: the batch stops immediately
+and reports `publication outcome unknown; do not auto-retry`. Do not assume a
+transport error means the anchor failed; reconcile the envelope/transaction
+externally before deciding whether a retry is safe.
+
+Stop automation on any recovery warning, preserve the printed ref, and repair
+or reconcile local state before retrying. This state is **local to the machine
+that ran `seed execute`**; it is not itself published, and it does not query
+the corpus — it only answers "did *I* already publish this exact seed identity,
+unchanged?".
 
 ## Fixture-file reference
 


### PR DESCRIPTION
## Summary

Implements #1771 (Stage 1 rescope R4): an evidence-episode seed lane, the
curated Stage 1 seed set, and the testnet seeding runbook. Stage 1's
rescoped retrieval (`docs/superpowers/plans/2026-07-16-jinn-plugin-stage-1-rescope-plan.md`
§3-§4) serves evidence records, not skill records — but the shared testnet
corpus contains almost no evidence, only skills.sh skill seeds. This adds a
second seed-import lane that publishes evidence episodes through the SAME
`capture() -> publish()` path the skill lane uses, a curated fixture set,
and idempotency + `supersedes` for both lanes.

- **Evidence-episode seed lane** (`client/packages/harness-layer/src/seed-import/episode-*.ts`):
  `SeedEpisodeSchema` (the canonical captured-evidence contract), a local
  directory source (`*.episode.json`), a zero-write plan/report pair, and
  `executeEpisodes()` publishing through `capture()`/`publish()` with the
  same seed-profile scrub (#1409) the skill lane uses. Each step becomes a
  `jinn.trace-envelope.v0` step carrying `seed.step.label/title/text`
  (label ∈ `failure|fix|command|diff|note` — the rescope plan §3.2
  knowledge-packet excerpt vocabulary), plus a final `seed:synthesis` step
  carrying `seed.synthesis` + `seed.attribution`.
- **Idempotency + `supersedes` for BOTH lanes** (`src/seed-import/state.ts`):
  re-running `execute()`/`executeEpisodes()` over unchanged content
  publishes nothing new; re-running over changed content republishes and
  sets the new record's supersedes lineage to the prior `envelopeRef` —
  skills via `SkillArtifactV1.provenance.supersedes` (already schema'd,
  #1462), episodes via the `seed.attribution` step attribute (the frozen
  trace envelope has no top-level field for it). File-backed by default for
  real CLI runs; in-memory for tests.

  **Deviation / rationale:** the rescope plan's §5 table originally scoped
  seed-import idempotency to R2 (#1772). My dispatcher instructions
  explicitly reassigned it to R4/#1771 ("you own ALL seed-import changes,
  including idempotency"), since R4 has no dependency on R1 while R2 does —
  this unblocks the fix without waiting on R1. #1772's remaining ACs
  (`adapters/corpus-adapter.ts` content-bearing `get`, `cli.ts` `session
  pickup` response fields, `adapters/evidence-adapter.ts` retention
  enforcement) are untouched here and still open for that issue.
- **CLI wiring** (`cli.ts`, confined to the seed verb section): `seed plan`
  and `seed execute` gain a parallel `--episodes-dir <dir>` path alongside
  the existing `--source <list-file>` skill path.
- **Curated Stage 1 seed set** — **location deviation**: the issue body
  named `apps/jinn-agent/scripts/fixtures/stage1-seeds/`; per my dispatcher
  instructions these are placed at
  `client/packages/harness-layer/fixtures/stage1-seeds/` instead, colocated
  with the lane and its tests, so the R5 acceptance-gate driver reads them
  by repo-relative path from this location:
  - `source-dashboard-flake.episode.json` — re-performs the real merged
    dashboard `update_available` banner flake fix (`163e070d`) at its
    pre-fix commit (`3651de92`, full sha). The failing/passing command
    output and the diff excerpt are **real**, captured by actually
    reverting and re-running the test file in this repo.
  - `distractor-operator-claims.episode.json` — same repo, different module
    (the `joinedSolverNets` claim-registration warning fix, `d682f811`) —
    proves selection is finer than repository match. Also real captured
    output.
  - `distractor-sympy-printing.episode.json` — different domain entirely (a
    realistic sympy LaTeX-printer subscript-join regression) — proves
    domain relevance.
  - `distractor-skill-tdd.json` / `distractor-skill-tdd-dup.json` — two
    skill-shaped seeds (the existing lane's `SeedSkill` wire shape; a new
    `SeedSkillSchema` mirror in `fetch.ts` validates them) with
    byte-identical `skillMd`/`description` under distinct identities —
    prove skills are excluded from evidence pickup and that content-key
    dedup is consumer-side, not identity-side.

  Every fixture is scrub-clean (no absolute paths/usernames, repo-relative
  paths only) and canonically formatted.
- **Runbook** — `docs/runbooks/stage1-evidence-seeding.md`: record →
  normalize paths → scrub → author synthesis/tags, the exact CLI commands,
  how to verify retrievability, and the idempotency/supersedes behavior.

## Test plan

- [x] `packages/harness-layer`: 50 test files, 664 tests pass
- [x] New: `test/seed-import-episodes.test.ts` (episode lane unit + CLI, 18 tests)
- [x] New: `test/stage1-seeds-fixtures.test.ts` (fixture lint: schema,
      scrub-cleanliness, determinism, D3/D4 duplicate proof, source
      failure+fix presence, 31 tests)
- [x] Extended `test/seed-import.test.ts` with idempotency/supersedes
      coverage for the existing skill lane
- [x] `yarn typecheck:harness-layer` clean
- [x] `cd client && yarn typecheck` (full, all packages) clean
- [x] `cd client && yarn test` (full default suite): 774 files / 6973 tests
      pass, 0 failed, 8 skipped (pre-existing, env-gated)

Closes #1771
Refs #1654

🤖 Generated with [Claude Code](https://claude.com/claude-code)