### PR TITLE
feat(jinn-agent): host flip to evidence pickup + gate rewrite (Stage 1 rescope R3+R5)

### DIFF
--- a/apps/jinn-agent/plugins/jinn/__init__.py
+++ b/apps/jinn-agent/plugins/jinn/__init__.py
@@ -174,6 +174,19 @@ def _clear_veto(session_id: str) -> None:
         _vetoed_tasks.discard(session_id)
 
 
+def _empty_activity() -> Dict[str, list]:
+    """Evidence-first pickup facts (searchedTerms/providedRefs, rescope §3.6)
+    plus the internal fetch-attempt detail the corpus_search/corpus_fetch
+    agent tools still record (surfacedRefs/fetchedRefs). installedSkillRefs
+    is gone with the skill adopt/install path pickup no longer has."""
+    return {
+        "searchedTerms": [],
+        "providedRefs": [],
+        "surfacedRefs": [],
+        "fetchedRefs": [],
+    }
+
+
 def _state_for(session_id: str, cwd: Optional[Path] = None) -> Dict[str, Any]:
     key = session_id or "default"
     with _session_state_lock:
@@ -181,11 +194,7 @@ def _state_for(session_id: str, cwd: Optional[Path] = None) -> Dict[str, Any]:
         if state is None:
             state = {
                 "snapshot": session_bridge.snapshot_repository(key, cwd=cwd),
-                "activity": {
-                    "surfacedRefs": [],
-                    "fetchedRefs": [],
-                    "installedSkillRefs": [],
-                },
+                "activity": _empty_activity(),
                 "intermediateFailureDiffs": [],
             }
             _session_states[key] = state
@@ -199,11 +208,7 @@ def _pop_state(session_id: str) -> Dict[str, Any]:
             key,
             {
                 "snapshot": None,
-                "activity": {
-                    "surfacedRefs": [],
-                    "fetchedRefs": [],
-                    "installedSkillRefs": [],
-                },
+                "activity": _empty_activity(),
                 "intermediateFailureDiffs": [],
             },
         )
@@ -214,25 +219,24 @@ def _peek_state(session_id: str) -> Dict[str, Any]:
     with _session_state_lock:
         state = _session_states.get(key)
         if state is None:
-            return {
-                "activity": {
-                    "surfacedRefs": [],
-                    "fetchedRefs": [],
-                    "installedSkillRefs": [],
-                },
-            }
+            return {"activity": _empty_activity()}
         return {
             **state,
             "activity": {
                 field: list(state.get("activity", {}).get(field) or [])
-                for field in ("surfacedRefs", "fetchedRefs", "installedSkillRefs")
+                for field in ("searchedTerms", "providedRefs", "surfacedRefs", "fetchedRefs")
             },
         }
 
 
 def _record_activity(session_id: str, field: str, refs: list[str]) -> None:
-    """Record only refs a successful host action actually observed."""
-    if not session_id or field not in ("surfacedRefs", "fetchedRefs", "installedSkillRefs"):
+    """Record only refs a successful host action actually observed.
+
+    Internal fetch-attempt detail only (surfacedRefs/fetchedRefs, from the
+    corpus_search/corpus_fetch agent tools) — searchedTerms/providedRefs are
+    set wholesale by pickup.pickup()'s own response, not appended here.
+    """
+    if not session_id or field not in ("surfacedRefs", "fetchedRefs"):
         return
     state = _state_for(session_id)
     with _session_state_lock:
@@ -291,12 +295,21 @@ def _on_pre_llm_call(
     # precedes this turn's tool calls (post_tool_call) and the assistant turn
     # (post_llm_call). Local capture, so unconditional per mono#1714.
     buf.record_user_turn(task_id, session_id, user_message)
-    # Consumption side — NEVER consent-gated: payload-agnostic corpus pickup.
+    # Consumption side — NEVER consent-gated: evidence-first corpus pickup.
     # Returns {"context": ...} (injected into the user message, cache-safe)
     # or None. Fails open inside pickup().
     if is_first_turn:
         state = _state_for(session_id)
-        return pickup.pickup(user_message, runner=_runner, activity=state["activity"])
+        snapshot = state.get("snapshot")
+        repository_slug = snapshot.repository_slug if snapshot is not None else None
+        return pickup.pickup(
+            user_message,
+            runner=_runner,
+            activity=state["activity"],
+            session_id=session_id,
+            model=model,
+            repository_slug=repository_slug,
+        )
     return None
 
 
@@ -359,9 +372,10 @@ def _delegate_session_end(
     if _degraded is not None:
         return None
     normalized_activity = {
+        "searchedTerms": list(activity.get("searchedTerms") or []),
+        "providedRefs": list(activity.get("providedRefs") or []),
         "surfacedRefs": list(activity.get("surfacedRefs") or []),
         "fetchedRefs": list(activity.get("fetchedRefs") or []),
-        "installedSkillRefs": list(activity.get("installedSkillRefs") or []),
     }
     request: Dict[str, Any] = {
         "contractVersion": jinn_layer.CONTRACT_VERSION,
@@ -501,14 +515,16 @@ def _on_session_end(
             else "off" if distill.cached_mode(_runner) == "off"
             else "unavailable"
         )
+        activity = state.get("activity") or {}
         _user_line(session_view.render_complete(
             summary={
-                **(state.get("activity") or {}),
-                "nothingFound": not bool(
-                    (state.get("activity") or {}).get("surfacedRefs")
-                ),
+                "searchedTerms": list(activity.get("searchedTerms") or []),
+                "providedPackets": [
+                    {"ref": ref, "title": ref} for ref in (activity.get("providedRefs") or [])
+                ],
+                "nothingFound": not bool(activity.get("providedRefs")),
             },
-            activity=state.get("activity") or {},
+            activity=activity,
             capture_status="captured-locally" if fallback_path is not None else "unavailable",
             local_learning_status=learning_status,
             contribution=None,
@@ -547,13 +563,10 @@ _JINN_HELP = (
     "  /jinn status    consent + capture state\n"
     "  /jinn consent   run the consent flow\n"
     "  /jinn preview   inspect a retained legacy capture, or a labelled example\n"
-    "  /jinn session   current surfaced, capture, learning, and contribution state\n"
+    "  /jinn session   current searched/provided, capture, learning, and contribution state\n"
     "  /jinn history   sessions derived from episodes, contributions, and local skills\n"
     "  /jinn ledger    the contribution ledger — what left this machine\n"
     "  /jinn veto      withhold the current task (recorded locally, never published)\n"
-    "  /jinn skills install <ref>   install a corpus-published skill into the agent's skills\n"
-    "  /jinn skills list            jinn-installed skills\n"
-    "  /jinn skills uninstall <slug>  remove a jinn-installed skill\n"
     "  /jinn distill   local distillation — your captures into reusable skills\n"
     "  /jinn distill where local|defer|off   set where distillation runs\n"
 )
@@ -723,31 +736,6 @@ def _handle_jinn(command_args: str = "", session_id: str = "", task_id: str = ""
         code, out = jinn_layer.ledger(runner=_runner)
         return out if code == 0 else f"ledger unavailable:\n{out}"
 
-    if sub == "skills":
-        # Consuming is always allowed — no consent check on this entire path.
-        action = parts[1] if len(parts) > 1 else "list"
-        if action == "install":
-            if len(parts) < 3:
-                return "usage: /jinn skills install <ref> (a corpus ref from /corpus search)"
-            try:
-                path = skills_install.install(parts[2], runner=_runner)
-            except Exception as exc:
-                return f"install failed: {exc}"
-            _record_activity(session_id, "installedSkillRefs", [parts[2]])
-            return f"installed — {path}\nThe agent's skill loader picks it up from here."
-        if action == "uninstall":
-            if len(parts) < 3:
-                return "usage: /jinn skills uninstall <slug>"
-            try:
-                skills_install.uninstall(parts[2])
-            except Exception as exc:
-                return f"uninstall failed: {exc}"
-            return f"uninstalled {parts[2]}."
-        installed = skills_install.list_installed()
-        if not installed:
-            return "No jinn-installed skills. /corpus <query> to find some, then /jinn skills install <ref>."
-        return "\n".join(f"{row['slug']}  ({row['ref'] or 'ref unknown'})" for row in installed)
-
     if sub == "distill":
         # Local distillation (mono #1538) — all logic + rendering in distill.py;
         # this dispatch stays a one-liner like the other module-backed verbs.
@@ -893,7 +881,7 @@ def register(ctx) -> None:
     # a no-op; --replay re-renders without re-asking.
     ctx.register_cli_command(
         "onboarding",
-        help="Guided first-run onboarding (consent → publish → rewards → signals).",
+        help="Guided first-run onboarding (consent → publish → signals).",
         setup_fn=onboarding.setup_parser,
         handler_fn=onboarding.cli_handler,
         description="Walk the core loop once, one confirmed step at a time. --replay re-shows it.",

--- a/apps/jinn-agent/plugins/jinn/consent.py
+++ b/apps/jinn-agent/plugins/jinn/consent.py
@@ -66,14 +66,6 @@ RECORDED_OFF = (
     "Sharing is OFF. Nothing derived from your work leaves this machine. "
     "Turn on any time: /jinn consent"
 )
-NODE_STUB = (
-    "Run a network node? Running a node executes tasks for others and earns "
-    "rewards. Separate setup; not needed to share or read. "
-    "[L] Later — show docs · [Enter] Skip"
-)
-NODE_STUB_LATER = (
-    "See docs.jinn.network/run-a-node when you're ready. Nothing to do now."
-)
 
 KEYS_LINE = "[Y] Yes · [N] No · [P] Preview what would be shared · [?] Docs"
 
@@ -228,7 +220,9 @@ def run_consent_flow(
     Returns the recorded shareConsent (True when sharing was accepted).
 
     Per-action lifecycle ``idle -> confirming -> recorded``. Bare Enter
-    defaults to decline — the safe default shares nothing.
+    defaults to decline — the safe default shares nothing. This is the ONE
+    sharing question (mono#1714 copy collapse) — no second, unrelated
+    question follows it.
     """
     print_fn(render_explainer_styled())
     while True:
@@ -263,13 +257,7 @@ def run_consent_flow(
             print_fn(render_recorded_styled(on=False))
             break
 
-    share = share_enabled()
-
-    print_fn(render_node_stub_styled())
-    node = input_fn("> ").strip().lower()
-    if node == "l":
-        print_fn(NODE_STUB_LATER)
-    return share
+    return share_enabled()
 
 
 # ── Styled renderers — reuse the #1417 splash palette ────────────────────────
@@ -379,15 +367,12 @@ def render_recorded_styled(on: bool) -> str:
     dim = lambda s: _style.wrap(pal, rst, "dim", s)
     fg = lambda s: _style.wrap(pal, rst, "fg", s)
     sky = lambda s: _style.wrap(pal, rst, "sky", s)
-    gold = lambda s: _style.wrap(pal, rst, "gold", s)
     green = lambda s: _style.wrap(pal, rst, "green", s)
     if on:
         body = [
             green("  recorded") + dim(" — sharing is ") + green("ON"),
             "",
             dim("  " + RECORDED_ON),
-            "",
-            dim("  Verified shared tasks earn ") + gold("OLAS") + dim("."),
             "",
             dim("  Manage:  ") + sky("/jinn consent") + dim("  |  ") + sky("/jinn veto") + dim("  |  ") + sky("/jinn ledger"),
         ]
@@ -398,25 +383,6 @@ def render_recorded_styled(on: bool) -> str:
             dim("  " + RECORDED_OFF),
         ]
     return "\n".join([_sigil_head(pal, rst), "", *body])
-
-
-def render_node_stub_styled() -> str:
-    pal, rst = _style.palette()
-    dim = lambda s: _style.wrap(pal, rst, "dim", s)
-    fg = lambda s: _style.wrap(pal, rst, "fg", s)
-    gold = lambda s: _style.wrap(pal, rst, "gold", s)
-    kbd = lambda s: _style.wrap(pal, rst, "gold", s)
-    return "\n".join([
-        _sigil_head(pal, rst),
-        "",
-        dim("  One more, optional —"),
-        "",
-        gold("  RUN A NETWORK NODE?"),
-        dim("  Running a node executes tasks for others and earns rewards. It is a"),
-        dim("  separate setup and is not needed to share or to read."),
-        "",
-        "  " + kbd("[L]") + fg(" Later — show me the docs") + dim("  (recommended)") + "     " + kbd("[Enter]") + dim(" Skip for now"),
-    ])
 
 
 def render_preview_example() -> str:

--- a/apps/jinn-agent/plugins/jinn/history_view.py
+++ b/apps/jinn-agent/plugins/jinn/history_view.py
@@ -29,11 +29,13 @@ def _time(value: object) -> str:
 
 
 def _knowledge(entry: Dict[str, Any]) -> str:
-    surfaced = entry.get("knowledgeSurfaced")
-    used = entry.get("knowledgeUsed")
-    if not isinstance(surfaced, int) or not isinstance(used, int):
+    # knowledgeSurfaced/knowledgeUsed are the wire field names (unchanged);
+    # their meaning is searched/provided counts as of the rescope (§3.6).
+    searched = entry.get("knowledgeSurfaced")
+    provided = entry.get("knowledgeUsed")
+    if not isinstance(searched, int) or not isinstance(provided, int):
         return "knowledge unavailable"
-    return f"knowledge {surfaced} surfaced · {used} used"
+    return f"knowledge searched {searched} · provided {provided}"
 
 
 def _eligibility(value: object) -> str:

--- a/apps/jinn-agent/plugins/jinn/jinn_layer.py
+++ b/apps/jinn-agent/plugins/jinn/jinn_layer.py
@@ -28,14 +28,17 @@ CONTRACT_VERSION = 1
 
 
 def _default_runner(
-    argv: List[str], cwd: Optional[str] = None, input: Optional[str] = None
+    argv: List[str],
+    cwd: Optional[str] = None,
+    input: Optional[str] = None,
+    timeout_s: int = _TIMEOUT_S,
 ) -> Tuple[int, str]:
     try:
         proc = subprocess.run(
             argv,
             capture_output=True,
             text=True,
-            timeout=_TIMEOUT_S,
+            timeout=timeout_s,
             check=False,
             cwd=cwd,
             input=input,
@@ -52,7 +55,7 @@ def _default_runner(
             "(npm install -g @jinn-network/client@canary) or set JINN_LAYER_BIN."
         )
     except subprocess.TimeoutExpired:
-        return 124, f"{argv[0]}: timed out after {_TIMEOUT_S}s"
+        return 124, f"{argv[0]}: timed out after {timeout_s}s"
 
 
 def binary() -> str:
@@ -153,6 +156,24 @@ def session_end(request: Dict[str, Any], runner: Optional[Runner] = None) -> Tup
     return run(["session", "end"], runner, input=payload)
 
 
+# Pickup runs on the first turn, before the LLM call — tighter than the
+# general 120s default (rescope plan §3.5): a broken jinn-layer must cost
+# seconds, not the session. Only applies to the real subprocess runner; an
+# injected test runner owns its own return timing.
+_SESSION_PICKUP_TIMEOUT_S = 15
+
+
+def session_pickup(request: Dict[str, Any], runner: Optional[Runner] = None) -> Tuple[int, str]:
+    """Delegate one first-turn evidence-pickup request through stdin
+    (Stage 1 rescope R3) — the ``session end`` stdin-JSON pattern, applied
+    to the sibling verb."""
+    payload = json.dumps(request, separators=(",", ":"))
+    argv = [binary(), "session", "pickup"]
+    if runner is not None:
+        return runner(argv, input=payload)
+    return _default_runner(argv, input=payload, timeout_s=_SESSION_PICKUP_TIMEOUT_S)
+
+
 def contribution_preview(
     *, acknowledge: bool = False, runner: Optional[Runner] = None
 ) -> Tuple[int, str]:
@@ -189,6 +210,11 @@ def parse_process_response(raw: str) -> Dict[str, Any]:
 
 
 def parse_session_end_response(raw: str) -> Dict[str, Any]:
+    """Parse the outer v1 status envelope; reject transport/version drift."""
+    return parse_process_response(raw)
+
+
+def parse_session_pickup_response(raw: str) -> Dict[str, Any]:
     """Parse the outer v1 status envelope; reject transport/version drift."""
     return parse_process_response(raw)
 

--- a/apps/jinn-agent/plugins/jinn/onboarding.py
+++ b/apps/jinn-agent/plugins/jinn/onboarding.py
@@ -8,12 +8,13 @@ confirmed step at a time:
   2. publish   — a waiting screen shown once; the publish confirmation
                  (task · tier · envelope · anchor + the gold ``view it``
                  deep link) fires on the real publish event.
-  3. rewards   — "None yet" + the honest trigger (evaluator verification
-                 under bond, not publication, not guaranteed); an earned
-                 variant states amount + count.
-  4. signals   — the ``◇ corpus`` signal-line format, shown once; thereafter
-                 the line renders in real runs at the point of use (product
-                 behaviour, wired into pickup.py's consumption path).
+  3. signals   — the ``◇ corpus`` evidence-pickup signal-line format, shown
+                 once; thereafter the line renders in real runs at the
+                 point of use (product behaviour, wired into pickup.py's
+                 first-turn pickup). Rewards/OLAS-earning copy and the
+                 "run a network node" stub are Stage 3 economy concepts and
+                 do not belong in Stage 1 onboarding (rescope plan §1); a
+                 prior draft of this flow had a step 3 for them, removed.
 
 Persistence is FACTS OVER FLAGS (design's model). A per-machine flag file
 lives beside the other jinn state (``<home>/jinn/onboarding.json``), but
@@ -30,9 +31,9 @@ writes them.
 
 Rendering is pure ANSI (reuses the #1417 splash palette via ``style``), so
 every screen is snapshot-testable — the #1417/#1418 discipline. The step
-rail (``consent · publish · rewards · signals``) is words, colour carries
-state (green done · gold current · amber skipped · dim future); no glyph
-icons. Voice is plain on consent + money (design copy verbatim).
+rail (``consent · publish · signals``) is words, colour carries state
+(green done · gold current · amber skipped · dim future); no glyph icons.
+Voice is plain on consent + money (design copy verbatim).
 
 Design artifact:
 ``docs/design/artifacts/2026-07-06-corpus-onboarding/1405-cli-onboarding.html``.
@@ -56,17 +57,17 @@ from .consent import get_hermes_home
 
 logger = logging.getLogger(__name__)
 
-# The four steps, in order. Rail labels are words (no glyphs) — colour carries
-# state per the no-unicode-icons rule.
-STEPS = ("consent", "publish", "rewards", "signals")
+# The three steps, in order. Rail labels are words (no glyphs) — colour
+# carries state per the no-unicode-icons rule.
+STEPS = ("consent", "publish", "signals")
 
 
 # ── Persistence — facts over flags ───────────────────────────────────────────
 #
-# The flag file only holds the two pure seen-flags (steps 3 and 4). Consent and
-# publish are never flags: they are derived from the consent record and the
-# ledger. Deleting the flag file therefore re-runs ONLY steps 3–4 — consent and
-# publish state survive because they were never onboarding's to keep.
+# The flag file holds the one pure seen-flag (step 3). Consent and publish are
+# never flags: they are derived from the consent record and the ledger.
+# Deleting the flag file therefore re-runs ONLY step 3 — consent and publish
+# state survive because they were never onboarding's to keep.
 
 
 def state_path() -> Path:
@@ -74,24 +75,21 @@ def state_path() -> Path:
 
 
 def load_flags() -> Dict[str, object]:
-    """The two pure seen-flags. Never carries consent or publish state."""
+    """The one pure seen-flag. Never carries consent or publish state."""
     path = state_path()
     if not path.exists():
-        return {"rewards_explained": False, "signals_shown": False}
+        return {"signals_shown": False}
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-        return {
-            "rewards_explained": bool(data.get("rewards_explained", False)),
-            "signals_shown": bool(data.get("signals_shown", False)),
-        }
+        return {"signals_shown": bool(data.get("signals_shown", False))}
     except Exception:
         logger.warning("jinn: unreadable onboarding flags at %s — treating as unseen", path)
-        return {"rewards_explained": False, "signals_shown": False}
+        return {"signals_shown": False}
 
 
 def mark_flag(name: str) -> None:
-    """Set one seen-flag. ``name`` is ``rewards_explained`` | ``signals_shown``."""
-    if name not in ("rewards_explained", "signals_shown"):
+    """Set one seen-flag. ``name`` is ``signals_shown``."""
+    if name != "signals_shown":
         raise ValueError(f"unknown onboarding flag: {name}")
     flags = load_flags()
     flags[name] = True
@@ -134,22 +132,22 @@ def ledger_nonempty(runner: Optional[jinn_layer.Runner] = None) -> bool:
 def is_complete(runner: Optional[jinn_layer.Runner] = None) -> bool:
     """True when every gate is satisfied — a returning operator sees nothing.
 
-    consent decided AND ledger non-empty AND both seen-flags set. Because the
-    first two are facts, a returning operator (consented + published) satisfies
-    them without ever having run onboarding, and the flags are the only piece
-    onboarding itself owns.
+    consent decided AND ledger non-empty AND the signals flag set. Because
+    the first two are facts, a returning operator (consented + published)
+    satisfies them without ever having run onboarding, and the flag is the
+    only piece onboarding itself owns.
     """
     if not consent_decided():
         return False
     # Reader-only operators (declined) never publish, so the ledger fact does
-    # not gate them — steps 2–3 are set aside on the decline path. They are
+    # not gate them — step 2 is set aside on the decline path. They are
     # complete once consent is decided and the signals flag is set.
     flags = load_flags()
     if not consent.share_enabled():
         return bool(flags["signals_shown"])
     if not ledger_nonempty(runner):
         return False
-    return bool(flags["rewards_explained"] and flags["signals_shown"])
+    return bool(flags["signals_shown"])
 
 
 # ── Shared chrome (design 1b) ────────────────────────────────────────────────
@@ -185,7 +183,7 @@ def _step_head(pal, rst: str, n: int, label: str, statuses: Dict[str, str]) -> L
     gold = lambda s: _style.wrap(pal, rst, "gold", s)
     head = (
         sky("◇") + " " + fg(_harness.harness_name()) + dim("  ·  first run  ·  ")
-        + gold(f"step {n} of 4") + dim("  ·  ") + fg(label)
+        + gold(f"step {n} of {len(STEPS)}") + dim("  ·  ") + fg(label)
     )
     return [head, "  " + _rail(pal, rst, statuses, n - 1), _style.wrap(pal, rst, "dim", "─" * 70)]
 
@@ -242,12 +240,12 @@ def render_consent_recorded_off(pal=None, rst=None) -> str:
         "",
         dim("  Turn on any time:  ") + sky("/jinn consent"),
         "",
-        dim("  Steps 2 and 3 cover sharing and rewards — they apply only when"),
-        dim("  sharing is on, so they're set aside. Step 4 still applies:"),
+        dim("  Step 2 (your first publish) applies only when sharing is on, so"),
+        dim("  it's set aside. Step 3 still applies:"),
         dim("  reading the corpus is on for everyone."),
         "",
         _style.wrap(pal, rst, "dim", "─" * 70),
-        "  " + kbd("[Enter]") + fg(" Continue — step 4 · corpus signals"),
+        "  " + kbd("[Enter]") + fg(" Continue — step 3 · corpus signals"),
     ])
 
 
@@ -335,143 +333,72 @@ def render_first_publish_confirmed(
         dim("  ref, and check its anchor. Your ledger: ") + sky("/jinn ledger"),
         "",
         _style.wrap(pal, rst, "dim", "─" * 70),
-        "  " + kbd("[Enter]") + fg(" Continue — step 3 · rewards")
+        "  " + kbd("[Enter]") + fg(" Continue — step 3 · corpus signals")
         + "      " + kbd("[V]") + dim(" Veto — pull it back"),
     ])
 
 
-# ── Step 3 · rewards ─────────────────────────────────────────────────────────
+# ── Step 3 · corpus signals ──────────────────────────────────────────────────
 
 
-def render_rewards_none(pal=None, rst=None) -> str:
-    """"None yet" + the honest trigger. Plain speech on money (design verbatim):
-    publication alone does not earn; verification triggers it, not guaranteed."""
-    if pal is None:
-        pal, rst = _style.palette()
-    dim = lambda s: _style.wrap(pal, rst, "dim", s)
-    fg = lambda s: _style.wrap(pal, rst, "fg", s)
-    sky = lambda s: _style.wrap(pal, rst, "sky", s)
-    green = lambda s: _style.wrap(pal, rst, "green", s)
-    gold = lambda s: _style.wrap(pal, rst, "gold", s)
-    kbd = lambda s: _style.wrap(pal, rst, "gold", s)
-    return "\n".join([
-        *_step_head(pal, rst, 3, "rewards", {"consent": "done", "publish": "done"}),
-        "",
-        fg("  OLAS earned: ") + dim("none yet."),
-        "",
-        dim("  Publication alone does not earn — verification does. OLAS accrues"),
-        dim("  when an evaluator scores one of your published traces under bond;"),
-        dim("  verification triggers it, and it is not guaranteed."),
-        "",
-        dim("  Your first trace is published at tier ") + green("tests-passed") + dim(". If an"),
-        dim("  evaluator verifies it, the tier moves to ") + gold("evaluator-verified"),
-        dim("  and the reward lands on your operator address."),
-        "",
-        dim("  Check any time:  ") + sky("/jinn rewards"),
-        "",
-        _style.wrap(pal, rst, "dim", "─" * 70),
-        "  " + kbd("[Enter]") + fg(" Continue — step 4 · corpus signals")
-        + "      " + kbd("[S]") + dim(" Skip"),
-    ])
-
-
-def render_rewards_earned(amount: str, count: int, pal=None, rst=None) -> str:
-    """Earned variant — states amount + verified count, links the rewards view.
-
-    The amount is not a fork-native synchronous source (no rewards lookup wired
-    yet); callers pass ``amount='checking…'`` to degrade honestly (design's
-    error state) rather than fabricate a figure.
-    """
-    if pal is None:
-        pal, rst = _style.palette()
-    dim = lambda s: _style.wrap(pal, rst, "dim", s)
-    fg = lambda s: _style.wrap(pal, rst, "fg", s)
-    sky = lambda s: _style.wrap(pal, rst, "sky", s)
-    gold = lambda s: _style.wrap(pal, rst, "gold", s)
-    kbd = lambda s: _style.wrap(pal, rst, "gold", s)
-    verified = f"{count} trace{'s' if count != 1 else ''} evaluator-verified"
-    return "\n".join([
-        *_step_head(pal, rst, 3, "rewards", {"consent": "done", "publish": "done"}),
-        "",
-        fg("  OLAS earned: ") + gold(amount) + dim(f" · {verified}."),
-        "",
-        dim("  Accrues on verification, not publication: an evaluator scored those"),
-        dim("  traces under bond. Details and per-trace provenance:"),
-        "",
-        dim("  ") + sky("/jinn rewards") + dim("   ·   each entry links its evaluation and anchor tx."),
-        "",
-        _style.wrap(pal, rst, "dim", "─" * 70),
-        "  " + kbd("[Enter]") + fg(" Continue — step 4 · corpus signals"),
-    ])
-
-
-# ── Step 4 · corpus signals ──────────────────────────────────────────────────
-
-
-def render_corpus_signal_line(
-    skill: str,
-    provenance: str,
-    env_ref: str,
+def render_evidence_signal_line(
+    searched_terms: List[str],
+    provided_count: int,
     pal=None,
     rst=None,
-    *,
-    action: str = "using",
 ) -> str:
-    """One in-run line at the point of corpus use (design 1c) — the permanent
-    artefact of step 4. ``◇ corpus`` prefix (sky), skill name bright, provenance
-    dim, the envelope ref carried so the claim is checkable. One line per use.
+    """One in-run line at the point of evidence pickup (rescope plan §3.4) —
+    the permanent artefact of step 3. ``◇ corpus`` prefix (sky), the provided
+    count bright, the searched terms dim. One line per session, emitted only
+    when evidence was actually provided.
 
-    This is the product-behaviour render hooked into pickup.py's consumption
-    path — NOT onboarding-only. Kept here so the format has a single source.
+    This is the product-behaviour render hooked into pickup.py's first-turn
+    pickup path — NOT onboarding-only. Kept here so the format has a single
+    source.
 
-    Every dynamic field (``skill``, ``provenance``, ``env_ref``) is sanitised
-    of C0/C1 control chars at this boundary: the corpus is PUBLIC and
-    cross-operator, so a hostile ``summary``/``slug``/``ref`` carrying
-    ``\\x1b[…]``/``\\r``/CSI bytes would otherwise reach a victim operator's
-    terminal raw on auto-adoption (screen manipulation, output spoofing). We
-    sanitise unconditionally here rather than trusting upstream slug/tier
-    constraints, so every caller is covered.
+    ``searched_terms`` are sanitised of C0/C1 control chars at this boundary:
+    they are derived from the session's own first message, but a corpus
+    record's `contextBlock` (rendered separately, not here) is PUBLIC and
+    cross-operator, so this boundary sanitises unconditionally rather than
+    trusting upstream term derivation, matching the rest of this module's
+    convention.
     """
     if pal is None:
         pal, rst = _style.palette()
-    skill = _style.sanitise(skill)
-    provenance = _style.sanitise(provenance)
-    env_ref = _style.sanitise(env_ref)
-    action = "surfaced" if action == "surfaced" else "using"
+    terms = ", ".join(_style.sanitise(term) for term in searched_terms)
+    noun = "packet" if provided_count == 1 else "packets"
     sky = lambda s: _style.wrap(pal, rst, "sky", s)
-    skyh = lambda s: _style.wrap(pal, rst, "fg", s)  # bright skill name
     fg = lambda s: _style.wrap(pal, rst, "fg", s)
     dim = lambda s: _style.wrap(pal, rst, "dim", s)
     return (
-        "  " + sky("◇ corpus") + "  " + fg(action + " ") + skyh(skill)
-        + dim(f"  ·  {provenance}  ·  ") + sky(f"env {env_ref}")
+        "  " + sky("◇ corpus") + "  " + fg(f"provided {provided_count} evidence {noun}")
+        + dim(f"  ·  searched: {terms}")
     )
 
 
 def render_signals(statuses: Dict[str, str], pal=None, rst=None) -> str:
-    """The step-4 screen — shows the signal-line format once."""
+    """The step-3 screen — shows the signal-line format once."""
     if pal is None:
         pal, rst = _style.palette()
     dim = lambda s: _style.wrap(pal, rst, "dim", s)
     fg = lambda s: _style.wrap(pal, rst, "fg", s)
+    sky = lambda s: _style.wrap(pal, rst, "sky", s)
     kbd = lambda s: _style.wrap(pal, rst, "gold", s)
-    example = render_corpus_signal_line(
-        "retry-backoff-patterns", "learned from 214 contributions", "bafkr…hx2c", pal, rst
-    )
+    example = render_evidence_signal_line(["dashboard", "vitest", "flake"], 1, pal, rst)
     return "\n".join([
-        *_step_head(pal, rst, 4, "corpus signals", statuses),
+        *_step_head(pal, rst, 3, "corpus signals", statuses),
         "",
-        fg("  When a run draws on the corpus, you'll see it."),
+        fg("  When your work matches prior evidence, you'll see it."),
         "",
-        dim("  Any time this harness uses a network skill or another operator's"),
-        dim("  contribution inside your own run, one line marks it at the point"),
+        dim("  Any time your first message matches relevant evidence in the shared"),
+        dim("  corpus, one line marks what was searched and provided at the point"),
         dim("  of use — like this:"),
         "",
         example,
         "",
-        dim("  One line per use, in the scrying as it happens. Every line carries"),
-        dim("  the envelope ref, so the claim is checkable — nothing uses the"),
-        dim("  corpus invisibly."),
+        dim("  One line per session, when evidence is provided. The source is"),
+        dim("  checkable in the injected context and ") + sky("/jinn session")
+        + dim(" — nothing uses the corpus invisibly."),
         "",
         _style.wrap(pal, rst, "dim", "─" * 70),
         "  " + kbd("[Enter]") + fg(" Finish"),
@@ -489,9 +416,9 @@ def render_done(reader_only: bool = False, first_publish: str = "", pal=None, rs
     sky = lambda s: _style.wrap(pal, rst, "sky", s)
     green = lambda s: _style.wrap(pal, rst, "green", s)
     if reader_only:
-        statuses = {"consent": "done", "publish": "skipped", "rewards": "skipped", "signals": "done"}
+        statuses = {"consent": "done", "publish": "skipped", "signals": "done"}
     else:
-        statuses = {"consent": "done", "publish": "done", "rewards": "done", "signals": "done"}
+        statuses = {"consent": "done", "publish": "done", "signals": "done"}
     head = (
         sky("◇") + " " + fg(_harness.harness_name()) + dim("  ·  first run  ·  ") + green("complete")
     )
@@ -507,13 +434,12 @@ def render_done(reader_only: bool = False, first_publish: str = "", pal=None, rs
         out += [
             dim("  Contribution is ") + fg("off · reader only") + dim(" — no trace leaves this"),
             dim("  machine. If you turn it on later (") + sky("/jinn consent") + dim("), the"),
-            dim("  publish and rewards steps run then, once."),
+            dim("  publish step runs then, once."),
         ]
     else:
         out += [
             dim("  contribution   ") + green("on"),
             dim("  first publish  ") + sky(first_publish or "recorded"),
-            dim("  rewards        ") + dim("explained"),
             dim("  signals        ") + dim("shown"),
         ]
     out += [
@@ -551,16 +477,15 @@ def run_onboarding(
     replay: bool = False,
     runner: Optional[jinn_layer.Runner] = None,
     publish_wait_fn: Optional[Callable[[], Optional[Dict[str, str]]]] = None,
-    rewards_fn: Optional[Callable[[], Optional[Dict[str, object]]]] = None,
 ) -> None:
-    """Walk the four steps for a PLAIN TERMINAL (blocking reads).
+    """Walk the three steps for a PLAIN TERMINAL (blocking reads).
 
     One confirmed step at a time — every screen exits on an explicit key.
     Nothing auto-advances on a timer. Step 2 advances on the real publish event
     (``publish_wait_fn``) and says so; when no event source is wired it degrades
     to a keyboard confirm in walkthrough mode.
 
-    ``replay=True`` re-renders all four screens but re-asks nothing: a recorded
+    ``replay=True`` re-renders all three screens but re-asks nothing: a recorded
     consent shows its current state, step 2 shows the actual first envelope from
     the ledger. It never mutates consent or the ledger.
 
@@ -586,9 +511,9 @@ def run_onboarding(
         input_fn("> ")
 
     if not on:
-        # Decline / reader-only path: steps 2–3 set aside, jump to step 4.
+        # Decline / reader-only path: step 2 set aside, jump to step 3.
         print_fn(render_signals(
-            {"consent": "done", "publish": "skipped", "rewards": "skipped"}, pal, rst
+            {"consent": "done", "publish": "skipped"}, pal, rst
         ))
         input_fn("> ")
         if not replay:
@@ -622,20 +547,9 @@ def run_onboarding(
                 print_fn(render_first_publish_confirmed(pal=pal, rst=rst))
             input_fn("> ")
 
-    # ── Step 3 · rewards ──
-    earned = rewards_fn() if rewards_fn is not None else None
-    if earned and earned.get("count"):
-        amount = str(earned.get("amount") or "checking…")
-        print_fn(render_rewards_earned(amount, int(earned["count"]), pal, rst))
-    else:
-        print_fn(render_rewards_none(pal, rst))
-    input_fn("> ")
-    if not replay:
-        mark_flag("rewards_explained")
-
-    # ── Step 4 · corpus signals ──
+    # ── Step 3 · corpus signals ──
     print_fn(render_signals(
-        {"consent": "done", "publish": "done", "rewards": "done"}, pal, rst
+        {"consent": "done", "publish": "done"}, pal, rst
     ))
     input_fn("> ")
     if not replay:
@@ -673,7 +587,7 @@ def setup_parser(parser) -> None:
     parser.add_argument(
         "--replay",
         action="store_true",
-        help="Re-render all four onboarding screens without re-asking consent.",
+        help="Re-render all three onboarding screens without re-asking consent.",
     )
 
 

--- a/apps/jinn-agent/plugins/jinn/pickup.py
+++ b/apps/jinn-agent/plugins/jinn/pickup.py
@@ -1,24 +1,16 @@
-"""Payload-agnostic auto-pickup — the corpus's receiving end (mono #1345).
+"""Evidence-first auto-pickup — thin delegation to ``jinn-layer session
+pickup`` (Stage 1 rescope R3, closes mono #1732).
 
-At task start the harness works out what kind of task this is, looks up the
-corpus for matching payloads, and decides per candidate:
-
-  - **suggest** by default: the candidate is surfaced to the agent as injected
-    context (cache-safe: Hermes injects plugin context into the user message,
-    never the system prompt), and installing stays a deliberate act — remote
-    skills are manual-approval by default (ratified).
-  - **adopt automatically** only when the operator has opted in
-    (``autoAdopt: true`` in ``pickup.json``) AND the payload's verifiability
-    tier meets the configured threshold (default: ``evaluator-verified``) AND
-    an adopter exists for its payload type. Verification under bond is the
-    trust gate for the tier check, but auto-adoption itself is opt-in, not
-    the default.
-
-Payload-agnostic: adopters are a registry keyed by payload type. v0 ships
-one adopter (``skill`` → install into Hermes's native skills dir). Richer
-payloads — loadout recommendations (model/toolset per distribution), full
-optimised loadouts — plug in as new adopters without touching the pickup
-flow: same rail, richer payloads.
+At the first turn the plugin sends the raw first message (plus session
+metadata) to the core's evidence-first retrieval policy
+(``docs/superpowers/plans/2026-07-16-jinn-plugin-stage-1-rescope-plan.md``
+§3, implemented once in ``packages/plugin``) and renders whatever
+``contextBlock`` comes back, verbatim, into the injected context. Term
+derivation, corpus search, selection, and knowledge-packet projection all
+live in the core now — this module owns none of it, and carries no skill
+classification or auto-adopt logic (that entire rail was removed from
+pickup by R1; skills are excluded from evidence selection outright, not
+suggested or installed from here).
 
 Consumption is never consent-gated. Consent gates contributing only.
 """
@@ -27,23 +19,20 @@ from __future__ import annotations
 
 import json
 import logging
-import subprocess
 import sys
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional
 
 from . import jinn_layer
-from . import onboarding
-from . import skills_install
 from .consent import get_hermes_home
+from .harness import harness_name, harness_version
 
 logger = logging.getLogger(__name__)
 
-# The point-of-use corpus signal (design 1c / #1405 step 4). Emitted once per
-# surfaced contribution: suggestions say ``surfaced`` while auto-adopted
-# knowledge says ``using``, so visibility never overclaims adoption. Default
-# sink mirrors _user_line in __init__.py:
-# stderr, which prompt_toolkit proxies above the input area while the TUI runs.
+# The point-of-use corpus signal (design 1c / #1405 step 4; rescope §3.4).
+# Emitted once per session, only when evidence was actually provided.
+# Default sink mirrors _user_line in __init__.py: stderr, which
+# prompt_toolkit proxies above the input area while the TUI runs.
 SignalSink = Callable[[str], None]
 
 
@@ -54,56 +43,17 @@ def _default_signal_sink(line: str) -> None:
         pass
 
 
-def _emit_corpus_signal(
-    sink: SignalSink,
-    skill: str,
-    provenance: str,
-    env_ref: str,
-    *,
-    action: str = "using",
-) -> None:
-    """Render + emit one ``◇ corpus`` line. Never raises — a signal must not
-    break a pickup that otherwise succeeded."""
-    try:
-        sink(onboarding.render_corpus_signal_line(
-            skill, provenance, env_ref, action=action
-        ))
-    except Exception:
-        logger.debug("jinn: corpus signal render failed", exc_info=True)
+# The one pickup setting still host-configurable. Auto-adopt, its tier
+# threshold, and the candidate cap moved into the core's fixed evidence-first
+# selection policy (rescope §3.3) and are no longer read from here — see
+# `packages/plugin/src/schemas/pickup-config.ts`'s `@deprecated` fields.
+DEFAULT_CONFIG: Dict[str, Any] = {"enabled": True}
 
-
-def _short_ref(ref: str) -> str:
-    """Abbreviate a long content ref for the signal line's envelope column."""
-    r = str(ref or "")
-    if len(r) <= 12:
-        return r
-    return f"{r[:5]}…{r[-4:]}"
-
-# Weakest → strongest; mirrors VERIFIABILITY_TIERS in the frozen envelope schema.
-TIER_ORDER = ["user-accepted", "tests-passed", "evaluator-verified"]
-
-DEFAULT_CONFIG: Dict[str, Any] = {
-    "enabled": True,
-    # Remote skills are manual-approval by default (ratified). Auto-adopt is an
-    # explicit opt-in; when off, verified candidates are SUGGESTED, not installed.
-    "autoAdopt": False,
-    # The tier at (or above) which a payload is adopted without asking, once
-    # autoAdopt is opted in.
-    "autoAdoptTier": "evaluator-verified",
-    "maxCandidates": 3,
-}
-
-# Pickup runs on the first turn, before the LLM call — keep it snappy and
-# fail-open. A broken jinn-layer must cost seconds, not the session.
-_PICKUP_TIMEOUT_S = 15
-
-_STOPWORDS = {
-    "the", "a", "an", "and", "or", "but", "for", "with", "into", "onto",
-    "this", "that", "these", "those", "from", "then", "than", "when",
-    "what", "which", "where", "how", "why", "can", "could", "should",
-    "would", "will", "just", "please", "help", "need", "want", "make",
-    "using", "about", "have", "has", "had", "you", "your", "our", "not",
-}
+# First-message length carried as the pickup request's placeholder
+# `taskSummary` (the process contract requires a non-empty string; the real
+# task summary isn't assembled until session end). Generous but bounded —
+# never truncates a realistic message, never sends unbounded input.
+_MAX_TASK_SUMMARY_CHARS = 2000
 
 
 def config_path() -> Path:
@@ -111,107 +61,84 @@ def config_path() -> Path:
 
 
 def load_config() -> Dict[str, Any]:
+    """The one pickup setting the host still owns: ``enabled``."""
     path = config_path()
     if not path.exists():
         return dict(DEFAULT_CONFIG)
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
         merged = dict(DEFAULT_CONFIG)
-        if isinstance(data, dict):
-            merged.update(data)
-        if merged.get("autoAdoptTier") not in TIER_ORDER:
-            merged["autoAdoptTier"] = DEFAULT_CONFIG["autoAdoptTier"]
+        if isinstance(data, dict) and "enabled" in data:
+            merged["enabled"] = bool(data["enabled"])
         return merged
     except Exception:
         logger.warning("jinn: unreadable pickup config at %s — using defaults", path)
         return dict(DEFAULT_CONFIG)
 
 
-def tier_at_least(tier: str, threshold: str) -> bool:
+def _emit_evidence_signal(sink: SignalSink, searched_terms: List[str], provided_count: int) -> None:
+    """Render + emit one ``◇ corpus`` line (rescope §3.4). Never raises — a
+    signal must not break a pickup that otherwise succeeded."""
     try:
-        return TIER_ORDER.index(tier) >= TIER_ORDER.index(threshold)
-    except ValueError:
-        return False  # unknown tier never auto-adopts
+        from . import onboarding  # local import: avoids a module cycle at import time
+        sink(onboarding.render_evidence_signal_line(searched_terms, provided_count))
+    except Exception:
+        logger.debug("jinn: corpus signal render failed", exc_info=True)
 
 
-def _pickup_runner(argv: List[str]) -> Tuple[int, str]:
-    try:
-        proc = subprocess.run(
-            argv, capture_output=True, text=True, timeout=_PICKUP_TIMEOUT_S, check=False,
-        )
-        return proc.returncode, proc.stdout.strip()
-    except Exception as exc:  # timeout, missing binary — pickup fails open
-        return 1, str(exc)
+def _build_request(
+    user_message: str,
+    session_id: str,
+    model: str,
+    repository_slug: Optional[str],
+) -> Dict[str, Any]:
+    meta: Dict[str, Any] = {
+        "sessionId": session_id or "default",
+        "taskSummary": (user_message or "(no message yet)")[:_MAX_TASK_SUMMARY_CHARS],
+        "harness": {"name": harness_name(), "version": harness_version()},
+        "model": model or "unknown",
+        "tools": [],
+    }
+    if repository_slug:
+        meta["repositorySlug"] = repository_slug
+    return {
+        "contractVersion": jinn_layer.CONTRACT_VERSION,
+        "meta": meta,
+        "firstMessage": user_message or "",
+    }
 
-
-def derive_terms(user_message: str, max_terms: int = 2) -> List[str]:
-    """Naive v0 distribution guess: distinctive words from the first line.
-
-    The corpus content search is a substring match over tags + summaries, so
-    single tokens are the useful query shape. Replaceable by real distribution
-    classification (tags from a local model, embedding lookup) without
-    touching the pickup flow.
-    """
-    first_line = (user_message or "").strip().splitlines()[0] if user_message else ""
-    terms: List[str] = []
-    for raw in first_line.lower().split():
-        word = "".join(c for c in raw if c.isalnum() or c in "-_")
-        if len(word) >= 4 and word not in _STOPWORDS and word not in terms:
-            terms.append(word)
-        if len(terms) >= max_terms:
-            break
-    return terms
-
-
-# ── Payload classification + adopters ────────────────────────────────────────
-
-def classify_payload(trace: Dict[str, Any]) -> str:
-    """Payload type of a corpus trace. v0 knows 'skill'; everything else is
-    'unknown' and is never adopted (only mentioned)."""
-    steps = trace.get("steps")
-    if isinstance(steps, list):
-        for step in steps:
-            attrs = step.get("attributes") if isinstance(step, dict) else None
-            if isinstance(attrs, dict) and isinstance(attrs.get("skill.md"), str):
-                return "skill"
-    return "unknown"
-
-
-def _adopt_skill(ref: str, runner: Optional[jinn_layer.Runner]) -> str:
-    # Auto-adopt is a real install: use the default cwd-aware runner (the pickup
-    # runner has no cwd support). Dormant by default (see Task 5).
-    path = skills_install.install(ref, runner=None)
-    return f"installed skill at {path}"
-
-
-# Payload type → adopter(ref, runner) -> human-readable receipt.
-# New payload types (loadout recommendations, full loadouts) register here.
-PAYLOAD_ADOPTERS: Dict[str, Callable[[str, Optional[jinn_layer.Runner]], str]] = {
-    "skill": _adopt_skill,
-}
-
-
-# ── The pickup ───────────────────────────────────────────────────────────────
 
 def pickup(
     user_message: str,
     runner: Optional[jinn_layer.Runner] = None,
     signal_sink: Optional[SignalSink] = None,
     activity: Optional[Dict[str, List[str]]] = None,
+    session_id: str = "",
+    model: str = "",
+    repository_slug: Optional[str] = None,
 ) -> Optional[Dict[str, str]]:
-    """First-turn corpus lookup. Returns ``{"context": ...}`` for the
-    pre_llm_call hook (or None when there is nothing worth saying).
-    Fails open: any error returns None and the task proceeds untouched.
+    """First-turn evidence pickup. Returns ``{"context": ...}`` for the
+    pre_llm_call hook (rendered verbatim into the injected context; cache-safe,
+    as today) or ``None`` when there is nothing worth injecting. Fails open:
+    any error — missing binary, contract mismatch, timeout, malformed
+    response — returns ``None`` and the task proceeds untouched.
 
-    ``signal_sink`` receives one ``◇ corpus`` line per surfaced contribution
-    (design 1c). Defaults to stderr; tests pass a collector.
+    ``activity``, when given, is populated with ``searchedTerms``/
+    ``providedRefs`` from the core's response (rescope §3.6) — the caller's
+    per-session activity dict, mutated in place.
+
+    ``signal_sink`` receives the one ``◇ corpus`` line emitted when evidence
+    is provided (rescope §3.4). Defaults to stderr; tests pass a collector.
     """
     try:
         return _pickup_inner(
             user_message,
-            runner or _pickup_runner,
+            runner,
             signal_sink or _default_signal_sink,
             activity,
+            session_id,
+            model,
+            repository_slug,
         )
     except Exception as exc:
         logger.warning("jinn: pickup failed open: %s", exc)
@@ -220,114 +147,57 @@ def pickup(
 
 def _pickup_inner(
     user_message: str,
-    runner: jinn_layer.Runner,
+    runner: Optional[jinn_layer.Runner],
     signal_sink: SignalSink,
-    activity: Optional[Dict[str, List[str]]] = None,
+    activity: Optional[Dict[str, List[str]]],
+    session_id: str,
+    model: str,
+    repository_slug: Optional[str],
 ) -> Optional[Dict[str, str]]:
     config = load_config()
     if not config.get("enabled", True):
         return None
-    terms = derive_terms(user_message)
-    if not terms:
+
+    request = _build_request(user_message, session_id, model, repository_slug)
+    code, out = jinn_layer.session_pickup(request, runner)
+    if code != 0:
         return None
 
-    # Search per term; dedupe by ref.
-    candidates: Dict[str, Dict[str, Any]] = {}
-    for term in terms:
-        code, out = jinn_layer.run(["corpus", "search", term, "--json", "--limit", "3"], runner)
-        if code != 0:
-            continue
-        try:
-            hits = json.loads(out)
-        except json.JSONDecodeError:
-            continue
-        if not isinstance(hits, list):
-            continue
-        for hit in hits:
-            if isinstance(hit, dict) and isinstance(hit.get("ref"), str):
-                candidates.setdefault(hit["ref"], hit)
-    if not candidates:
+    try:
+        envelope = jinn_layer.parse_session_pickup_response(out)
+    except ValueError:
+        return None
+    if envelope.get("status") == "unavailable":
         return None
 
-    installed = {row["slug"] for row in skills_install.list_installed()}
-    threshold = str(config["autoAdoptTier"])
-    adopted: List[str] = []
-    suggested: List[str] = []
-
-    for ref in list(candidates)[: int(config["maxCandidates"])]:
-        code, out = jinn_layer.run(["corpus", "get", ref, "--json"], runner)
-        if code != 0:
-            continue
-        try:
-            record = json.loads(out)
-            trace, _sha = skills_install._extract_trace(record)
-        except Exception:
-            continue
-        if activity is not None and ref not in activity.setdefault("fetchedRefs", []):
-            activity["fetchedRefs"].append(ref)
-
-        payload_type = classify_payload(trace)
-        tier = str(((trace.get("outcome") or {}).get("verifiabilityTier")) or "")
-        summary = str(((trace.get("task") or {}).get("summary")) or ref)[:120]
-
-        if payload_type == "skill":
-            try:
-                _md, slug = skills_install._skill_md_and_slug(trace, ref)
-            except Exception:
-                continue
-            if slug in installed:
-                continue
-            if config.get("autoAdopt") and tier_at_least(tier, threshold):
-                try:
-                    receipt = PAYLOAD_ADOPTERS[payload_type](ref, runner)
-                    adopted.append(f"- {slug} ({tier}): {receipt}")
-                    if activity is not None:
-                        if ref not in activity.setdefault("surfacedRefs", []):
-                            activity["surfacedRefs"].append(ref)
-                        if ref not in activity.setdefault("installedSkillRefs", []):
-                            activity["installedSkillRefs"].append(ref)
-                    # Point-of-use signal: the harness is now using this
-                    # operator-contributed skill in the run. One line, checkable.
-                    _emit_corpus_signal(
-                        signal_sink, slug, f"{tier} · {summary}", _short_ref(ref)
-                    )
-                except Exception as exc:
-                    logger.warning("jinn: auto-adopt of %s failed: %s", ref, exc)
-                continue
-            suggested.append(
-                f"- {slug} (tier: {tier}) — {summary}\n  ref: {ref} · install: /jinn skills install {ref}"
-            )
-            if activity is not None and ref not in activity.setdefault("surfacedRefs", []):
-                activity["surfacedRefs"].append(ref)
-            _emit_corpus_signal(
-                signal_sink,
-                slug,
-                f"{tier} · {summary}",
-                _short_ref(ref),
-                action="surfaced",
-            )
-        else:
-            # Unknown payload types are never adopted; mention verified ones only.
-            if tier_at_least(tier, threshold):
-                suggested.append(f"- ({payload_type}, {tier}) {summary} — ref: {ref}")
-                if activity is not None and ref not in activity.setdefault("surfacedRefs", []):
-                    activity["surfacedRefs"].append(ref)
-                _emit_corpus_signal(
-                    signal_sink,
-                    payload_type,
-                    f"{tier} · {summary}",
-                    _short_ref(ref),
-                    action="surfaced",
-                )
-
-    if not adopted and not suggested:
+    value = envelope.get("value")
+    if not isinstance(value, dict):
+        return None
+    # A v1 response without `packets` is treated as degraded-nothing: a stale
+    # jinn-layer that predates this field would otherwise round-trip an old
+    # `contextBlock` shape (skill suggestion/install text) through the new
+    # rendering path unverified. Never reintroduce install hints (rescope R3 AC).
+    if "packets" not in value:
         return None
 
-    lines = ["[jinn corpus] Relevant to this task:"]
-    if adopted:
-        lines.append("Adopted automatically (verified):")
-        lines.extend(adopted)
-    if suggested:
-        lines.append("Available in the corpus (unverified — read with the corpus tools, or the user can install):")
-        lines.extend(suggested)
-    return {"context": "\n".join(lines)}
+    searched_terms = [
+        term for term in (value.get("searchedTerms") or [])
+        if isinstance(term, str) and term
+    ]
+    packets = value.get("packets")
+    provided_refs: List[str] = []
+    if isinstance(packets, list):
+        for packet in packets:
+            if isinstance(packet, dict) and isinstance(packet.get("ref"), str) and packet["ref"]:
+                provided_refs.append(packet["ref"])
+
+    if activity is not None:
+        activity["searchedTerms"] = searched_terms
+        activity["providedRefs"] = provided_refs
+
+    context_block = value.get("contextBlock")
+    if not isinstance(context_block, str) or not context_block.strip():
+        return None
+
+    _emit_evidence_signal(signal_sink, searched_terms, len(provided_refs))
+    return {"context": context_block}

--- a/apps/jinn-agent/plugins/jinn/plugin.yaml
+++ b/apps/jinn-agent/plugins/jinn/plugin.yaml
@@ -6,4 +6,5 @@ hooks:
   - on_session_start
   - pre_llm_call
   - post_tool_call
+  - post_llm_call
   - on_session_end

--- a/apps/jinn-agent/plugins/jinn/session_view.py
+++ b/apps/jinn-agent/plugins/jinn/session_view.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Iterable, List
 
 from . import style
 
@@ -13,29 +13,31 @@ def _text(value: object, fallback: str = "unavailable") -> str:
     return style.sanitise(value.strip())
 
 
-def _refs(activity: Dict[str, Any], field: str) -> list[str]:
-    value = activity.get(field)
+def _terms(value: object) -> List[str]:
     if not isinstance(value, list):
         return []
-    return [_text(ref, "") for ref in value if _text(ref, "")]
+    return [_text(term, "") for term in value if _text(term, "")]
 
 
-def _knowledge_lines(activity: Dict[str, Any], nothing_found: bool) -> list[str]:
-    surfaced = _refs(activity, "surfacedRefs")
-    fetched = _refs(activity, "fetchedRefs")
-    installed = _refs(activity, "installedSkillRefs")
+def _refs(value: object) -> List[str]:
+    """Accepts either `providedPackets` (`[{ref, title}, ...]`, the
+    SessionSummary shape) or a bare ref list (the activity fallback)."""
+    if not isinstance(value, list):
+        return []
+    refs: List[str] = []
+    for item in value:
+        ref = _text(item.get("ref"), "") if isinstance(item, dict) else _text(item, "")
+        if ref:
+            refs.append(ref)
+    return refs
+
+
+def _knowledge_lines(searched_terms: List[str], provided_refs: List[str], nothing_found: bool) -> List[str]:
     if nothing_found:
-        return ["knowledge nothing relevant found"]
-    lines = [
-        f"knowledge {len(surfaced)} surfaced · {len(fetched)} fetched · "
-        f"{len(installed)} installed"
-    ]
-    if surfaced:
-        lines.append("surfaced " + ", ".join(surfaced))
-    used = list(dict.fromkeys([*fetched, *installed]))
-    if used:
-        lines.append("used " + ", ".join(used))
-    return lines
+        return ["knowledge searched · nothing relevant found"]
+    terms = ", ".join(searched_terms) if searched_terms else "(none)"
+    refs = ", ".join(provided_refs)
+    return [f"knowledge searched {terms} · provided {len(provided_refs)} ({refs})"]
 
 
 def _render(title: str, lines: Iterable[str]) -> str:
@@ -49,14 +51,12 @@ def render_current(
     *, activity: Dict[str, Any], capture_active: bool, share_enabled: bool
 ) -> str:
     """Render live state only; eligibility/contribution are end-of-session facts."""
-    nothing_yet = not any(
-        _refs(activity, field)
-        for field in ("surfacedRefs", "fetchedRefs", "installedSkillRefs")
-    )
+    searched_terms = _terms(activity.get("searchedTerms"))
+    provided_refs = _refs(activity.get("providedRefs"))
     knowledge = (
         ["knowledge nothing relevant found yet"]
-        if nothing_yet
-        else _knowledge_lines(activity, False)
+        if not searched_terms and not provided_refs
+        else _knowledge_lines(searched_terms, provided_refs, nothing_found=not provided_refs)
     )
     return _render("Jinn session", [
         *knowledge,
@@ -102,23 +102,21 @@ def render_complete(
     contribution: object,
     candidate_created: bool = True,
 ) -> str:
-    """Render one complete outcome from core facts plus host-local capture state."""
+    """Render one complete outcome from core facts plus host-local capture state.
+
+    ``summary`` is the core's `SessionSummary` (searchedTerms/providedPackets/
+    nothingFound) when the process bridge produced one; ``activity`` is the
+    host-local fallback (searchedTerms/providedRefs) used when it did not
+    (rescope §3.6).
+    """
     core = summary if isinstance(summary, dict) else {}
-    summary_activity = {
-        "surfacedRefs": core.get("surfacedRefs", activity.get("surfacedRefs", [])),
-        "fetchedRefs": core.get("fetchedRefs", activity.get("fetchedRefs", [])),
-        "installedSkillRefs": core.get(
-            "installedSkillRefs", activity.get("installedSkillRefs", [])
-        ),
-    }
+    searched_terms = _terms(core.get("searchedTerms")) or _terms(activity.get("searchedTerms"))
+    provided_refs = _refs(core.get("providedPackets")) or _refs(activity.get("providedRefs"))
     stated_nothing_found = core.get("nothingFound")
     nothing_found = (
         stated_nothing_found
         if isinstance(stated_nothing_found, bool)
-        else not any(
-            _refs(summary_activity, field)
-            for field in ("surfacedRefs", "fetchedRefs", "installedSkillRefs")
-        )
+        else not bool(provided_refs)
     )
     learning = {
         "pending": "local learning pending — capture reserved for distillation",
@@ -136,7 +134,7 @@ def render_complete(
         else "contribution no reusable public-task candidate"
     )
     return _render("Jinn session complete", [
-        *_knowledge_lines(summary_activity, nothing_found),
+        *_knowledge_lines(searched_terms, provided_refs, nothing_found),
         capture,
         learning,
         _eligibility(core.get("eligibility")),

--- a/apps/jinn-agent/scripts/stage1-stock-product.py
+++ b/apps/jinn-agent/scripts/stage1-stock-product.py
@@ -4,6 +4,12 @@
 The surrounding shell owns the stock checkout and built artifacts. This driver
 owns the user-visible lifecycle and a local HTTP stand-in for external corpus
 services; the plugin and ``jinn-layer`` process bridge are the real builds.
+
+Stage 1 rescope (R5, closes #1774): the corpus fixture serves the R4 seed set
+(client/packages/harness-layer/fixtures/stage1-seeds/) instead of one
+hand-written skill trace — the real built `jinn-layer` performs search, get,
+and evidence-first packet projection against it (no plugin stubs). Scenarios
+follow the rescope plan §4.5.
 """
 
 from __future__ import annotations
@@ -14,6 +20,7 @@ import importlib.metadata
 import io
 import json
 import os
+import re
 import subprocess
 import sys
 import threading
@@ -26,7 +33,61 @@ import yaml
 
 
 PINNED_HERMES = "9df5f879b4a5925c0f8f947e7e16ed8e845932c3"
-CORPUS_REF = "bafyStage1TddSkill"
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SEED_FIXTURES_DIR = REPO_ROOT / "client" / "packages" / "harness-layer" / "fixtures" / "stage1-seeds"
+
+# The five curated Stage 1 seed fixtures (rescope R4, #1771 / PR #1779),
+# identified by filename stem. Refs below are this driver's own stand-in
+# CIDs — deterministic, not real IPFS content addresses.
+SOURCE_FIXTURE = "source-dashboard-flake"
+DISTRACTOR_SAME_REPO = "distractor-operator-claims"
+DISTRACTOR_OTHER_DOMAIN = "distractor-sympy-printing"
+DISTRACTOR_SKILL = "distractor-skill-tdd"
+DISTRACTOR_SKILL_DUP = "distractor-skill-tdd-dup"
+
+
+def _to_ref(stem: str) -> str:
+    """Deterministic stand-in CID from a fixture filename stem."""
+    parts = re.split(r"[-_]", stem)
+    return "bafyStage1" + "".join(p.capitalize() for p in parts if p)
+
+
+SOURCE_REF = _to_ref(SOURCE_FIXTURE)
+DISTRACTOR_SAME_REPO_REF = _to_ref(DISTRACTOR_SAME_REPO)
+DISTRACTOR_OTHER_DOMAIN_REF = _to_ref(DISTRACTOR_OTHER_DOMAIN)
+DISTRACTOR_SKILL_REF = _to_ref(DISTRACTOR_SKILL)
+DISTRACTOR_SKILL_DUP_REF = _to_ref(DISTRACTOR_SKILL_DUP)
+
+# A distinctive, verbatim excerpt line from the source fixture's "fix" step
+# (client/packages/harness-layer/fixtures/stage1-seeds/source-dashboard-flake.episode.json)
+# that is NOT one of the scenario-1 message's derived search terms — proves
+# the injection carries real content, not metadata (rescope plan §4.5 item 1).
+SOURCE_DISTINCTIVE_CONTENT = "apiMocks.getStatus"
+
+# Scenario 1/2 message: shares vocabulary with the source fixture's tags
+# (mono, dashboard, vitest, version-status, async, flake) and taskSummary
+# without quoting its sentences verbatim — verified empirically to score
+# >= the relevance floor against the source and 0 against every distractor.
+TARGET_TASK_MESSAGE = (
+    "The client dashboard vitest suite is flaky again, and the "
+    "update_available check seems to race against the version-status "
+    "endpoint. Please track it down in client/src/dashboard and get the "
+    "suite green"
+)
+
+# Scenario 3: shares no vocabulary with any of the five fixtures.
+NO_RESULT_MESSAGE = (
+    "Investigate why the OLAS staking reward-claim loop occasionally "
+    "double-counts checkpoint epochs on Base Sepolia."
+)
+
+# Scenario 4 (corpus unavailable): content is irrelevant — the corpus 503s
+# before any query would matter — but still evidence-shaped, for realism.
+UNAVAILABLE_MESSAGE = "Offline corpus investigation for a flaky dashboard test."
+
+MISSING_LAYER_MESSAGE = "Preserve local capture"
+INCOMPATIBLE_LAYER_MESSAGE = "Preserve incompatible capture"
 
 
 def require_env(name: str) -> Path:
@@ -73,65 +134,156 @@ def make_repo(path: Path) -> Path:
     return path
 
 
-class CorpusFixture:
-    def __init__(self) -> None:
-        self.unavailable = False
-        self.requests: list[tuple[str, str]] = []
-        self.endpoint = ""
-        self.trace = {
-            "schemaVersion": "jinn.trace-envelope.v0",
-            "session": {
-                "sessionId": "seed:acme/skills/test-driven-development",
-                "capturedAt": "2026-07-04T00:00:00.000Z",
+# ── Seed fixture loading (rescope R4 seed set → wire shapes) ─────────────────
+#
+# Mirrors the SAME wire shapes the real seed-import lane produces
+# (client/packages/harness-layer/src/seed-import/{episode-execute,execute}.ts)
+# so the real built jinn-layer performs search/get/packet-projection exactly
+# as it would against a seeded testnet corpus. No bespoke fixture format.
+
+_NANO_BASE = 1_751_587_200_000_000_000
+
+
+def _episode_trace(seed: dict[str, Any]) -> dict[str, Any]:
+    """`jinn.trace-envelope.v0` for an evidence-episode seed — the same step
+    shape `episode-execute.ts`'s `toCapturedTask()` produces: one step per
+    authored excerpt (`seed.step.label/title/text`) plus a final
+    `seed:synthesis` step (`seed.synthesis`/`seed.attribution`)."""
+    content_steps = []
+    for i, step in enumerate(seed["steps"]):
+        nano = str(_NANO_BASE + i)
+        content_steps.append({
+            "spanId": f"seed-{i + 1}",
+            "parentSpanId": None,
+            "name": f"seed:step:{step['label']}",
+            "startTimeUnixNano": nano,
+            "endTimeUnixNano": nano,
+            "attributes": {
+                "seed.step.label": step["label"],
+                "seed.step.title": step["title"],
+                "seed.step.text": step["text"],
             },
-            "task": {
-                "summary": "Seed import: acme/skills/test-driven-development",
-                "distributionTags": ["seed-import", "tdd", "refactoring"],
+            "redactedKeys": [],
+        })
+    meta_index = len(content_steps)
+    nano = str(_NANO_BASE + meta_index)
+    attribution: dict[str, Any] = {
+        "repo": seed["repo"],
+        "origin": seed["attribution"]["origin"],
+    }
+    if seed.get("baseCommit"):
+        attribution["baseCommit"] = seed["baseCommit"]
+    if seed["attribution"].get("sourceUrl"):
+        attribution["sourceUrl"] = seed["attribution"]["sourceUrl"]
+    meta_step = {
+        "spanId": f"seed-{meta_index + 1}",
+        "parentSpanId": None,
+        "name": "seed:synthesis",
+        "startTimeUnixNano": nano,
+        "endTimeUnixNano": nano,
+        "attributes": {
+            "seed.synthesis": seed["synthesis"],
+            "seed.attribution": attribution,
+        },
+        "redactedKeys": [],
+    }
+    tags = ["seed-import"] + [t for t in seed["tags"] if t != "seed-import"]
+    return {
+        "schemaVersion": "jinn.trace-envelope.v0",
+        "session": {"sessionId": f"seed-episode:{seed['id']}", "capturedAt": "2026-07-04T00:00:00.000Z"},
+        "task": {"summary": seed["taskSummary"], "distributionTags": tags},
+        "environment": {
+            "harness": {"name": "jinn-layer-seed-episode-import", "version": "0.1.0"},
+            "model": "none",
+            "tools": [],
+        },
+        "steps": content_steps + [meta_step],
+        "outcome": {"status": seed["outcome"]["status"], "verifiabilityTier": seed["outcome"]["verifiabilityTier"]},
+        "cost": {"durationMs": 0},
+        "consent": {"contributionConsent": True, "scrubCompleted": True},
+        "provenance": "imported",
+    }
+
+
+def _skill_tags(seed: dict[str, Any]) -> list[str]:
+    segments = [s for s in seed["skill"].split("/") if s]
+    repo_name = segments[1] if len(segments) > 1 else seed["skill"]
+    slug = segments[-1] if segments else seed["skill"]
+    tags = ["seed-import"]
+    for candidate in (repo_name, slug):
+        if candidate not in tags:
+            tags.append(candidate)
+    return tags
+
+
+def _skill_trace(seed: dict[str, Any]) -> dict[str, Any]:
+    """`jinn.trace-envelope.v0` for a skill seed — the existing skills.sh
+    lane's wire shape (`seed-import/execute.ts`'s `toCapturedTask()`):
+    `skill.md` + `seed.attribution` on one step. Legacy shape (no first-class
+    `jinn.skill.v1` artifact) — proves selection excludes it by relevance,
+    same as any other unrelated record (rescope plan §3.3 step 1)."""
+    summary = f"Seed import: {seed['skill']}"
+    if seed.get("description"):
+        summary += f" — {seed['description']}"
+    return {
+        "schemaVersion": "jinn.trace-envelope.v0",
+        "session": {"sessionId": f"seed:{seed['skill']}", "capturedAt": "2026-07-04T00:00:00.000Z"},
+        "task": {"summary": summary, "distributionTags": _skill_tags(seed)},
+        "environment": {
+            "harness": {"name": "jinn-layer-seed-import", "version": "0.1.0"},
+            "model": "none",
+            "tools": [],
+        },
+        "steps": [{
+            "spanId": "seed-1",
+            "parentSpanId": None,
+            "name": "seed:skill-md",
+            "startTimeUnixNano": str(_NANO_BASE),
+            "endTimeUnixNano": str(_NANO_BASE),
+            "attributes": {
+                "skill.md": seed["skillMd"],
+                "seed.attribution": {
+                    "skill": seed["skill"],
+                    "source": seed["source"],
+                    "licence": seed["licence"],
+                },
             },
-            "environment": {
-                "harness": {"name": "jinn-layer-seed-import", "version": "0.1.0"},
-                "model": "none",
-                "tools": [],
-            },
-            "steps": [
-                {
-                    "spanId": "seed-1",
-                    "parentSpanId": None,
-                    "name": "seed:skill-md",
-                    "startTimeUnixNano": "1751587200000000000",
-                    "endTimeUnixNano": "1751587200000000000",
-                    "attributes": {
-                        "skill.md": "# Test-driven development\n\nRed, green, refactor.\n",
-                        "seed.attribution": {
-                            "skill": "acme/skills/test-driven-development",
-                            "source": "https://github.com/acme/skills",
-                            "licence": "MIT",
-                        },
-                    },
-                    "redactedKeys": [],
-                }
-            ],
-            "outcome": {
-                "status": "completed",
-                "verifiabilityTier": "user-accepted",
-            },
-            "cost": {"durationMs": 0},
-            "consent": {"contributionConsent": True, "scrubCompleted": True},
-            "provenance": "imported",
-        }
-        self.trace_bytes = json.dumps(
-            self.trace, separators=(",", ":"), sort_keys=True
-        ).encode()
+            "redactedKeys": [],
+        }],
+        "outcome": {"status": "completed", "verifiabilityTier": "user-accepted"},
+        "cost": {"durationMs": 0},
+        "consent": {"contributionConsent": True, "scrubCompleted": True},
+        "provenance": "imported",
+    }
+
+
+class FixtureRecord:
+    def __init__(self, ref: str, trace: dict[str, Any]):
+        self.ref = ref
+        self.trace = trace
+        self.trace_bytes = json.dumps(trace, separators=(",", ":"), sort_keys=True).encode()
         self.trace_sha = hashlib.sha256(self.trace_bytes).hexdigest()
 
-    def envelope(self) -> dict[str, Any]:
+    @property
+    def task_summary(self) -> str:
+        return str(self.trace["task"]["summary"])
+
+    @property
+    def tags(self) -> list[str]:
+        return list(self.trace["task"]["distributionTags"])
+
+    @property
+    def verifiability_tier(self) -> str:
+        return str(self.trace["outcome"]["verifiabilityTier"])
+
+    def envelope(self, endpoint: str) -> dict[str, Any]:
         return {
             "schemaVersion": "jinn.execution.v1",
             "solverType": "capture",
             "role": "solution",
             "generatedAt": 1_745_978_400,
             "task": {
-                "cid": "bafyStage1Task",
+                "cid": self.ref,
                 "onchainCreationTx": "0x" + "a" * 64,
                 "onchainCreationBlock": 1,
                 "requestId": "0x" + "b" * 64,
@@ -160,7 +312,7 @@ class CorpusFixture:
                 {
                     "artifactType": "jinn.trace-envelope.v0",
                     "sha256": self.trace_sha,
-                    "access": {"endpoint": self.endpoint, "priceUsdc": "0"},
+                    "access": {"endpoint": endpoint, "priceUsdc": "0"},
                 }
             ],
             "payload": {},
@@ -171,6 +323,54 @@ class CorpusFixture:
                 "sig": "0x" + "f" * 130,
             },
         }
+
+
+def load_seed_records() -> dict[str, FixtureRecord]:
+    """The five curated Stage 1 fixtures, keyed by filename stem."""
+    episodes = {
+        SOURCE_FIXTURE: SOURCE_REF,
+        DISTRACTOR_SAME_REPO: DISTRACTOR_SAME_REPO_REF,
+        DISTRACTOR_OTHER_DOMAIN: DISTRACTOR_OTHER_DOMAIN_REF,
+    }
+    skills = {
+        DISTRACTOR_SKILL: DISTRACTOR_SKILL_REF,
+        DISTRACTOR_SKILL_DUP: DISTRACTOR_SKILL_DUP_REF,
+    }
+    records: dict[str, FixtureRecord] = {}
+    for stem, ref in episodes.items():
+        seed = json.loads((SEED_FIXTURES_DIR / f"{stem}.episode.json").read_text(encoding="utf-8"))
+        records[stem] = FixtureRecord(ref, _episode_trace(seed))
+    for stem, ref in skills.items():
+        seed = json.loads((SEED_FIXTURES_DIR / f"{stem}.json").read_text(encoding="utf-8"))
+        records[stem] = FixtureRecord(ref, _skill_trace(seed))
+    return records
+
+
+class CorpusFixture:
+    def __init__(self) -> None:
+        self.unavailable = False
+        self.requests: list[tuple[str, str]] = []
+        self.endpoint = ""
+        self.records = load_seed_records()
+        self.by_ref = {record.ref: record for record in self.records.values()}
+        self.by_sha = {record.trace_sha: record for record in self.records.values()}
+
+    def search(self, query: str) -> list[dict[str, Any]]:
+        needle = query.strip().lower()
+        if not needle:
+            return []
+        hits = []
+        for record in self.records.values():
+            haystack = f"{record.task_summary} {' '.join(record.tags)}".lower()
+            if needle in haystack:
+                hits.append({
+                    "manifestCid": record.ref,
+                    "taskSummary": record.task_summary,
+                    "tags": record.tags,
+                    "provenance": "imported",
+                    "verifiabilityTier": record.verifiability_tier,
+                })
+        return hits
 
 
 def start_corpus_server(fixture: CorpusFixture) -> tuple[ThreadingHTTPServer, threading.Thread]:
@@ -199,29 +399,28 @@ def start_corpus_server(fixture: CorpusFixture) -> tuple[ThreadingHTTPServer, th
                 if fixture.unavailable:
                     self.write_json(503, {"error": "fixture unavailable"})
                     return
-                query = " ".join(parse_qs(parsed.query).get("q", [])).lower()
-                hits: list[dict[str, Any]] = []
-                if "tdd-style" in query or "refactoring" in query:
-                    hits.append(
-                        {
-                            "manifestCid": CORPUS_REF,
-                            "taskSummary": "Seed import: acme/skills/test-driven-development",
-                            "tags": ["seed-import", "tdd", "refactoring"],
-                            "provenance": "imported",
-                            "verifiabilityTier": "user-accepted",
-                        }
-                    )
-                self.write_json(200, hits)
+                query = " ".join(parse_qs(parsed.query).get("q", []))
+                self.write_json(200, fixture.search(query))
                 return
-            if parsed.path == f"/ipfs/{CORPUS_REF}":
-                self.write_json(200, fixture.envelope())
+            if parsed.path.startswith("/ipfs/"):
+                ref = parsed.path[len("/ipfs/"):]
+                record = fixture.by_ref.get(ref)
+                if record is None:
+                    self.write_json(404, {"error": "not found"})
+                    return
+                self.write_json(200, record.envelope(fixture.endpoint))
                 return
-            if parsed.path == f"/v1/artifacts/{fixture.trace_sha}/content":
+            if parsed.path.startswith("/v1/artifacts/"):
+                sha = parsed.path[len("/v1/artifacts/"):].removesuffix("/content")
+                record = fixture.by_sha.get(sha)
+                if record is None:
+                    self.write_json(404, {"error": "not found"})
+                    return
                 self.send_response(200)
                 self.send_header("content-type", "application/octet-stream")
-                self.send_header("content-length", str(len(fixture.trace_bytes)))
+                self.send_header("content-length", str(len(record.trace_bytes)))
                 self.end_headers()
-                self.wfile.write(fixture.trace_bytes)
+                self.wfile.write(record.trace_bytes)
                 return
             self.write_json(404, {"error": "not found"})
 
@@ -334,8 +533,12 @@ def finish_session(
     expected_pickup: bool,
     expected_publication: str,
     mutate: str | None = None,
-    install_ref: bool = False,
-) -> tuple[str, str | None]:
+) -> tuple[str, str | None, str]:
+    """Drive one complete session lifecycle.
+
+    Returns (session-end stderr, the injected pickup context or None, the
+    pickup point-of-use marker text observed on stderr).
+    """
     jinn._on_session_start(session_id=session_id, cwd=str(repo), platform="cli")
     pickup_stderr = io.StringIO()
     with contextlib.redirect_stderr(pickup_stderr):
@@ -347,19 +550,13 @@ def finish_session(
             model="stage1-model",
             platform="cli",
         )
+    marker = pickup_stderr.getvalue()
     if expected_pickup:
-        assert pickup and "[jinn corpus] Relevant to this task" in pickup["context"]
-        marker = pickup_stderr.getvalue()
-        assert "◇ corpus" in marker and "surfaced" in marker, marker
-        if install_ref:
-            receipt = jinn._handle_jinn(
-                f"skills install {CORPUS_REF}",
-                session_id=session_id,
-                task_id=task_id,
-            )
-            assert receipt.startswith("installed —"), receipt
+        assert pickup is not None, f"expected pickup context, got None (marker={marker!r})"
+        assert "[jinn corpus] Prior evidence relevant to this task:" in pickup["context"]
+        assert "◇ corpus" in marker and "provided" in marker, marker
     else:
-        assert pickup is None
+        assert pickup is None, f"expected no pickup, got {pickup!r}"
 
     current = jinn._handle_jinn("session", session_id=session_id, task_id=task_id)
     assert "capture active" in current.lower(), current
@@ -391,9 +588,9 @@ def finish_session(
             session_id=session_id,
             task_id=task_id,
             completed=True,
-            skills_loadout=[CORPUS_REF] if install_ref else [],
+            skills_loadout=[],
         )
-    return summary.getvalue(), pickup["context"] if pickup else None
+    return summary.getvalue(), (pickup["context"] if pickup else None), marker
 
 
 def read_store_records() -> list[dict[str, Any]]:
@@ -403,7 +600,12 @@ def read_store_records() -> list[dict[str, Any]]:
 
 
 def write_local_skill_provenance(session_id: str) -> None:
-    """Install a deterministic output of the already-local distillation rail."""
+    """Install a deterministic output of the already-local distillation rail.
+
+    Unrelated to network evidence pickup: local distillation (rung 1) is an
+    independent capability (#1486) whose provenance rows still surface in
+    history (rescope plan §2 — "keep local distilledSkills provenance").
+    """
     target = LOCAL_SKILLS_DIR / "stage1-local-pattern"
     target.mkdir(parents=True, exist_ok=True)
     target.joinpath("SKILL.md").write_text(
@@ -431,6 +633,13 @@ Use this for the Stage 1 acceptance fixture.
     )
 
 
+def episode_by_provided_ref(episodes: list[dict[str, Any]], ref: str) -> dict[str, Any] | None:
+    for episode in episodes:
+        if ref in ((episode.get("activity") or {}).get("providedRefs") or []):
+            return episode
+    return None
+
+
 def main() -> None:
     assert_installed_product()
     assert_disabled_is_stock_silent()
@@ -445,8 +654,11 @@ def main() -> None:
     os.environ["JINN_DISCOVERY_URL"] = fixture.endpoint
     os.environ["JINN_IPFS_GATEWAY_URL"] = fixture.endpoint
 
+    # Smoke-check the real jinn-layer against the real fixture rails before
+    # driving any session — search finds the source episode by content, get
+    # returns it by ref.
     search_probe = subprocess.run(
-        [str(LAYER_BIN), "corpus", "search", "tdd-style", "--json", "--limit", "3"],
+        [str(LAYER_BIN), "corpus", "search", "dashboard", "--json", "--limit", "10"],
         check=False,
         capture_output=True,
         text=True,
@@ -456,13 +668,14 @@ def main() -> None:
         f"stderr={search_probe.stderr!r} requests={fixture.requests!r}"
     )
     search_hits = json.loads(search_probe.stdout)
-    assert search_hits and search_hits[0]["ref"] == CORPUS_REF, (
-        f"real jinn-layer corpus search returned no fixture: "
+    search_refs = {hit["ref"] for hit in search_hits}
+    assert SOURCE_REF in search_refs, (
+        f"real jinn-layer corpus search did not return the source fixture: "
         f"stdout={search_probe.stdout!r} stderr={search_probe.stderr!r} "
         f"requests={fixture.requests!r}"
     )
     get_probe = subprocess.run(
-        [str(LAYER_BIN), "corpus", "get", CORPUS_REF, "--json"],
+        [str(LAYER_BIN), "corpus", "get", SOURCE_REF, "--json"],
         check=False,
         capture_output=True,
         text=True,
@@ -471,7 +684,7 @@ def main() -> None:
         f"real jinn-layer corpus get failed: stdout={get_probe.stdout!r} "
         f"stderr={get_probe.stderr!r} requests={fixture.requests!r}"
     )
-    assert json.loads(get_probe.stdout)["ref"] == CORPUS_REF
+    assert json.loads(get_probe.stdout)["ref"] == SOURCE_REF
 
     legacy = HERMES_HOME / "jinn" / "pending" / "legacy-raw-trace.json"
     legacy.parent.mkdir(parents=True, exist_ok=True)
@@ -480,36 +693,75 @@ def main() -> None:
     work_repo = make_repo(WORK / "oss-work")
     clean_repo = make_repo(WORK / "oss-clean")
     try:
+        # ── Scenario 1/2/5/7: target-task session, evidence provided, most
+        # relevant wins, attribution visible, sharing off stays local ──────
         reset_session_runtime(jinn)
         jinn.consent.save_state(False, previewed=False)
-        share_off_summary, _ = finish_session(
+        requests_before_target = list(fixture.requests)
+        share_off_summary, target_context, target_marker = finish_session(
             jinn,
-            session_id="stage1-share-off",
-            task_id="task-share-off",
+            session_id="stage1-target-task",
+            task_id="task-target-task",
             repo=work_repo,
-            message="Tdd-style refactoring for this widget",
+            message=TARGET_TASK_MESSAGE,
             expected_pickup=True,
             expected_publication="OFF",
             mutate="SECRET_ACCEPTED_DIFF_OFF = True",
-            install_ref=True,
         )
+        assert target_context is not None
+        # (1) Content, not metadata: a distinctive excerpt line, source
+        # attribution, and the corpus_fetch pointer.
+        assert SOURCE_DISTINCTIVE_CONTENT in target_context, target_context
+        assert f"source: {SOURCE_REF}" in target_context, target_context
+        assert f"corpus_fetch {SOURCE_REF}" in target_context, target_context
+        # (2) Most relevant wins: distractor and skill refs absent.
+        for absent_ref in (
+            DISTRACTOR_SAME_REPO_REF,
+            DISTRACTOR_OTHER_DOMAIN_REF,
+            DISTRACTOR_SKILL_REF,
+            DISTRACTOR_SKILL_DUP_REF,
+        ):
+            assert absent_ref not in target_context, (absent_ref, target_context)
+        # Boundary: no skill-install language in the injection, ever.
+        assert "skills install" not in target_context.lower()
+        assert "adopted automatically" not in target_context.lower()
+        # (5) Attribution visible in /jinn session mid-task.
+        mid_session = jinn._handle_jinn(
+            "session", session_id="stage1-target-task", task_id="task-target-task"
+        )
+        assert SOURCE_REF in mid_session, mid_session
         assert "captured" in share_off_summary.lower()
         assert "contribution recorded" in share_off_summary.lower(), share_off_summary
+        assert SOURCE_REF in share_off_summary, share_off_summary
         assert list(CAPTURES_DIR.glob("*.json")), "local distillation tee missing"
-        write_local_skill_provenance("stage1-share-off")
+        write_local_skill_provenance("stage1-target-task")
+        # (7) Sharing off: only /graphql search traffic (never a publish-
+        # shaped POST) happened during this session.
+        new_requests = fixture.requests[len(requests_before_target):]
+        assert all(method != "POST" or path == "/graphql" for method, path in new_requests), (
+            f"a non-search POST happened with sharing off: {new_requests!r}"
+        )
 
+        # ── Scenario 3: honest no-result, on the sharing-on session that
+        # also carries the mint/preview/history mechanics ──────────────────
         jinn.consent.save_state(True, previewed=False)
-        share_on_summary, _ = finish_session(
+        no_result_summary, no_result_context, _no_result_marker = finish_session(
             jinn,
-            session_id="stage1-share-on",
-            task_id="task-share-on",
+            session_id="stage1-no-result",
+            task_id="task-no-result",
             repo=work_repo,
-            message="Investigate quasar unobtainium",
+            message=NO_RESULT_MESSAGE,
             expected_pickup=False,
             expected_publication="ON",
             mutate="SECRET_ACCEPTED_DIFF_ON = True",
         )
-        assert "nothing relevant found" in share_on_summary.lower()
+        assert no_result_context is None
+        assert "knowledge searched · nothing relevant found" in no_result_summary.lower()
+        no_result_session = jinn._handle_jinn(
+            "session", session_id="stage1-no-result", task_id="task-no-result"
+        )
+        assert "nothing relevant found" in no_result_session.lower()
+
         records_before_preview = read_store_records()
         share_on = next(
             row for row in records_before_preview if row["candidate"]["publishMinedTasksConsent"]
@@ -529,33 +781,40 @@ def main() -> None:
         )["publicationState"] == "queued"
         history_after_preview = jinn._handle_jinn("history")
         assert "queued" in history_after_preview.lower()
+        # Local distillation provenance still shows (a retained, independent
+        # concept — rescope plan §2), but no shared/network-skill install copy.
         assert "stage1-local-pattern" in history_after_preview, history_after_preview
+        assert "jinn-installed skill" not in history_after_preview.lower()
+        assert "skills install" not in history_after_preview.lower()
 
+        # ── Scenario 4: corpus 503 — session proceeds, degraded, no injection ──
         fixture.unavailable = True
-        unavailable_summary, _ = finish_session(
+        unavailable_summary, unavailable_context, _unavailable_marker = finish_session(
             jinn,
             session_id="stage1-corpus-unavailable",
             task_id="task-corpus-unavailable",
             repo=clean_repo,
-            message="Offline corpus investigation",
+            message=UNAVAILABLE_MESSAGE,
             expected_pickup=False,
             expected_publication="ON",
         )
         fixture.unavailable = False
-        assert "nothing relevant found" in unavailable_summary.lower()
+        assert unavailable_context is None
+        assert "knowledge searched · nothing relevant found" in unavailable_summary.lower()
 
         real_layer = os.environ["JINN_LAYER_BIN"]
         os.environ["JINN_LAYER_BIN"] = str(WORK / "missing-jinn-layer")
         reset_session_runtime(jinn)
-        missing_summary, _ = finish_session(
+        missing_summary, missing_context, _missing_marker = finish_session(
             jinn,
             session_id="stage1-missing-layer",
             task_id="task-missing-layer",
             repo=clean_repo,
-            message="Preserve local capture",
+            message=MISSING_LAYER_MESSAGE,
             expected_pickup=False,
             expected_publication="ON",
         )
+        assert missing_context is None
         assert "captured locally" in missing_summary.lower()
         assert "process bridge degraded" in missing_summary.lower()
         os.environ["JINN_LAYER_BIN"] = real_layer
@@ -571,24 +830,51 @@ def main() -> None:
 
         jinn._runner = IncompatibleRunner()
         reset_session_runtime(jinn)
-        incompatible_summary, _ = finish_session(
+        incompatible_summary, incompatible_context, _incompatible_marker = finish_session(
             jinn,
             session_id="stage1-incompatible-layer",
             task_id="task-incompatible-layer",
             repo=clean_repo,
-            message="Preserve incompatible capture",
+            message=INCOMPATIBLE_LAYER_MESSAGE,
             expected_pickup=False,
             expected_publication="ON",
         )
+        assert incompatible_context is None
         assert "captured locally" in incompatible_summary.lower()
         assert "process bridge degraded" in incompatible_summary.lower()
         jinn._runner = None
+
+        # ── Boundary: no shared/network-skill install-or-adopt state anywhere
+        # (disabled plugin stays stock-silent, asserted up front). Local
+        # distillation's own "N installed" count (a different, retained
+        # concept — rescope plan §2) is deliberately NOT banned wholesale;
+        # the boundary is the removed shared-skill command surface and its
+        # copy, not the bare word "installed".
+        for rendered in (
+            share_off_summary, no_result_summary, unavailable_summary,
+            missing_summary, incompatible_summary,
+            mid_session, no_result_session,
+        ):
+            assert "skills install" not in rendered.lower()
+            assert "adopted automatically" not in rendered.lower()
+            assert "jinn-installed skill" not in rendered.lower()
+        # The `/jinn skills` command branch is gone outright — every
+        # subcommand now falls through to the unknown-command help text.
+        for skills_args in (
+            f"skills install {SOURCE_REF}", "skills list", "skills uninstall anything",
+        ):
+            reply = jinn._handle_jinn(skills_args, session_id="stage1-boundary-check")
+            assert reply == jinn._JINN_HELP, (skills_args, reply)
+        status_output = jinn._handle_jinn("status")
+        assert "skills install" not in status_output.lower()
+        assert "jinn-installed skill" not in status_output.lower()
 
         assert legacy.read_text(encoding="utf-8") == '{"raw":"LEGACY_RAW_TRACE_SENTINEL"}\n'
         episodes = [
             json.loads(path.read_text(encoding="utf-8"))
             for path in sorted(EPISODES_DIR.glob("*.episode.json"))
         ]
+        # (6) Exactly one episode per completed session.
         assert len(episodes) >= 5
         for episode in episodes:
             assert episode["schemaVersion"] == "jinn.episode.v1"
@@ -597,7 +883,20 @@ def main() -> None:
             assert episode["trajectory"]
             assert all(str(span["startTimeUnixNano"]).isdigit() for span in episode["trajectory"])
 
+        # (6) The target-task episode's activity carries populated
+        # searchedTerms/providedRefs; every other episode's providedRefs is
+        # honestly empty.
+        target_episode = episode_by_provided_ref(episodes, SOURCE_REF)
+        assert target_episode is not None, [e.get("activity") for e in episodes]
+        assert target_episode["activity"]["searchedTerms"], target_episode["activity"]
+        assert target_episode["activity"]["providedRefs"] == [SOURCE_REF]
+        for episode in episodes:
+            if episode is target_episode:
+                continue
+            assert episode.get("activity", {}).get("providedRefs") in ([], None), episode["activity"]
+
         records = read_store_records()
+        # (6) Exactly one contribution candidate per eligible session.
         assert len(records) == 2, records
         episode_ids = {episode["episodeId"] for episode in episodes}
         assert {row["candidate"]["sourceId"] for row in records}.issubset(episode_ids)

--- a/apps/jinn-agent/scripts/stage1-stock-product.py
+++ b/apps/jinn-agent/scripts/stage1-stock-product.py
@@ -907,6 +907,13 @@ def main() -> None:
         assert any(not row["candidate"]["publishMinedTasksConsent"] for row in records)
         assert any(row["candidate"]["publishMinedTasksConsent"] for row in records)
 
+        episode_by_id = {episode["episodeId"]: episode for episode in episodes}
+        share_off_row = next(
+            row for row in records if not row["candidate"]["publishMinedTasksConsent"]
+        )
+        share_on_row = next(
+            row for row in records if row["candidate"]["publishMinedTasksConsent"]
+        )
         result = {
             "episodeIds": sorted(episode_ids),
             "sessions": [
@@ -917,16 +924,18 @@ def main() -> None:
                 }
                 for episode in episodes
             ],
-            "shareOffRecordId": next(
-                row["recordId"]
-                for row in records
-                if not row["candidate"]["publishMinedTasksConsent"]
-            ),
-            "shareOnRecordId": next(
-                row["recordId"]
-                for row in records
-                if row["candidate"]["publishMinedTasksConsent"]
-            ),
+            "shareOffRecordId": share_off_row["recordId"],
+            "shareOnRecordId": share_on_row["recordId"],
+            # Explicit session handoff for the daemon-side .mjs leg (PR #1781
+            # review): derived from the store rows via each candidate's
+            # sourceId → episode → sessionId, never hard-coded, so renaming a
+            # driver session cannot silently break the second leg's lookup.
+            "shareOffSessionId": episode_by_id[
+                share_off_row["candidate"]["sourceId"]
+            ]["session"]["sessionId"],
+            "shareOnSessionId": episode_by_id[
+                share_on_row["candidate"]["sourceId"]
+            ]["session"]["sessionId"],
             "legacyPending": str(legacy),
         }
         (WORK / "stock-product-result.json").write_text(

--- a/apps/jinn-agent/scripts/stage1-stock-product.py
+++ b/apps/jinn-agent/scripts/stage1-stock-product.py
@@ -533,11 +533,14 @@ def finish_session(
     expected_pickup: bool,
     expected_publication: str,
     mutate: str | None = None,
-) -> tuple[str, str | None, str]:
+) -> tuple[str, str | None, str, str]:
     """Drive one complete session lifecycle.
 
     Returns (session-end stderr, the injected pickup context or None, the
-    pickup point-of-use marker text observed on stderr).
+    pickup point-of-use marker text observed on stderr, the mid-session
+    `/jinn session` text). The mid-session text is captured HERE, while the
+    session's state is live — `_on_session_end` pops it, so a caller
+    re-querying `/jinn session` after this returns would read empty state.
     """
     jinn._on_session_start(session_id=session_id, cwd=str(repo), platform="cli")
     pickup_stderr = io.StringIO()
@@ -590,7 +593,7 @@ def finish_session(
             completed=True,
             skills_loadout=[],
         )
-    return summary.getvalue(), (pickup["context"] if pickup else None), marker
+    return summary.getvalue(), (pickup["context"] if pickup else None), marker, current
 
 
 def read_store_records() -> list[dict[str, Any]]:
@@ -698,7 +701,7 @@ def main() -> None:
         reset_session_runtime(jinn)
         jinn.consent.save_state(False, previewed=False)
         requests_before_target = list(fixture.requests)
-        share_off_summary, target_context, target_marker = finish_session(
+        share_off_summary, target_context, target_marker, target_mid_session = finish_session(
             jinn,
             session_id="stage1-target-task",
             task_id="task-target-task",
@@ -725,11 +728,10 @@ def main() -> None:
         # Boundary: no skill-install language in the injection, ever.
         assert "skills install" not in target_context.lower()
         assert "adopted automatically" not in target_context.lower()
-        # (5) Attribution visible in /jinn session mid-task.
-        mid_session = jinn._handle_jinn(
-            "session", session_id="stage1-target-task", task_id="task-target-task"
-        )
-        assert SOURCE_REF in mid_session, mid_session
+        # (5) Attribution visible in /jinn session mid-task — asserted on the
+        # mid-session text finish_session captured while the state was live
+        # (session end pops it; a re-query here would read empty state).
+        assert SOURCE_REF in target_mid_session, target_mid_session
         assert "captured" in share_off_summary.lower()
         assert "contribution recorded" in share_off_summary.lower(), share_off_summary
         assert SOURCE_REF in share_off_summary, share_off_summary
@@ -745,7 +747,7 @@ def main() -> None:
         # ── Scenario 3: honest no-result, on the sharing-on session that
         # also carries the mint/preview/history mechanics ──────────────────
         jinn.consent.save_state(True, previewed=False)
-        no_result_summary, no_result_context, _no_result_marker = finish_session(
+        no_result_summary, no_result_context, _no_result_marker, no_result_mid_session = finish_session(
             jinn,
             session_id="stage1-no-result",
             task_id="task-no-result",
@@ -757,10 +759,12 @@ def main() -> None:
         )
         assert no_result_context is None
         assert "knowledge searched · nothing relevant found" in no_result_summary.lower()
-        no_result_session = jinn._handle_jinn(
-            "session", session_id="stage1-no-result", task_id="task-no-result"
+        # The honest no-result line comes from THIS session's live state (the
+        # search happened, nothing cleared the floor) — not from the empty
+        # render an ended/unknown session would also produce.
+        assert "knowledge searched · nothing relevant found" in no_result_mid_session.lower(), (
+            no_result_mid_session
         )
-        assert "nothing relevant found" in no_result_session.lower()
 
         records_before_preview = read_store_records()
         share_on = next(
@@ -789,7 +793,7 @@ def main() -> None:
 
         # ── Scenario 4: corpus 503 — session proceeds, degraded, no injection ──
         fixture.unavailable = True
-        unavailable_summary, unavailable_context, _unavailable_marker = finish_session(
+        unavailable_summary, unavailable_context, _unavailable_marker, _unavailable_mid = finish_session(
             jinn,
             session_id="stage1-corpus-unavailable",
             task_id="task-corpus-unavailable",
@@ -805,7 +809,7 @@ def main() -> None:
         real_layer = os.environ["JINN_LAYER_BIN"]
         os.environ["JINN_LAYER_BIN"] = str(WORK / "missing-jinn-layer")
         reset_session_runtime(jinn)
-        missing_summary, missing_context, _missing_marker = finish_session(
+        missing_summary, missing_context, _missing_marker, _missing_mid = finish_session(
             jinn,
             session_id="stage1-missing-layer",
             task_id="task-missing-layer",
@@ -830,7 +834,7 @@ def main() -> None:
 
         jinn._runner = IncompatibleRunner()
         reset_session_runtime(jinn)
-        incompatible_summary, incompatible_context, _incompatible_marker = finish_session(
+        incompatible_summary, incompatible_context, _incompatible_marker, _incompatible_mid = finish_session(
             jinn,
             session_id="stage1-incompatible-layer",
             task_id="task-incompatible-layer",
@@ -853,7 +857,7 @@ def main() -> None:
         for rendered in (
             share_off_summary, no_result_summary, unavailable_summary,
             missing_summary, incompatible_summary,
-            mid_session, no_result_session,
+            target_mid_session, no_result_mid_session,
         ):
             assert "skills install" not in rendered.lower()
             assert "adopted automatically" not in rendered.lower()
@@ -874,8 +878,8 @@ def main() -> None:
             json.loads(path.read_text(encoding="utf-8"))
             for path in sorted(EPISODES_DIR.glob("*.episode.json"))
         ]
-        # (6) Exactly one episode per completed session.
-        assert len(episodes) >= 5
+        # (6) Exactly one episode per completed session — five sessions driven.
+        assert len(episodes) == 5, [e["session"]["sessionId"] for e in episodes]
         for episode in episodes:
             assert episode["schemaVersion"] == "jinn.episode.v1"
             assert episode["episodeId"]

--- a/apps/jinn-agent/tests/plugins/test_jinn_consent_ledger_tui.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_consent_ledger_tui.py
@@ -114,13 +114,13 @@ def test_recorded_off_keeps_everything_local():
     assert "Nothing derived from your work leaves this machine" in off
 
 
-def test_node_stub_is_later_or_skip_and_sets_nothing_up():
-    plain = _plain(consent.render_node_stub_styled())
-    assert "RUN A NETWORK NODE?" in plain
-    assert "[L]" in plain and "Later" in plain
-    assert "[Enter]" in plain and "Skip" in plain
-    # Not needed to share or read — the stub configures nothing.
-    assert "not needed to share or to read" in plain
+def test_recorded_screens_never_mention_a_network_node():
+    # The node-stub prompt (a second, unrelated question after the one
+    # sharing question) is removed — the recorded screens are the flow's end.
+    for on in (True, False):
+        plain = _plain(consent.render_recorded_styled(on=on)).lower()
+        assert "network node" not in plain
+        assert "olas" not in plain
 
 
 # ── Preview example fixture ──────────────────────────────────────────────────

--- a/apps/jinn-agent/tests/plugins/test_jinn_history.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_history.py
@@ -51,7 +51,7 @@ def test_history_renders_real_session_facts_and_skill_state():
     out = _plain(history_view.render_history([_entry()]))
     assert "Jinn history · 1 session" in out
     assert "Fix the retry bridge" in out
-    assert "2 surfaced · 1 used" in out
+    assert "knowledge searched 2 · provided 1" in out
     assert "eligible" in out
     assert "contribution queued" in out
     assert "retry-budget (installed)" in out

--- a/apps/jinn-agent/tests/plugins/test_jinn_layer_verbs.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_layer_verbs.py
@@ -28,7 +28,7 @@ def test_session_end_writes_one_complete_request_to_stdin():
     request = {
         "contractVersion": 1,
         "episode": {"schemaVersion": "jinn.episode.v1", "episodeId": "episode-1"},
-        "activity": {"surfacedRefs": [], "fetchedRefs": [], "installedSkillRefs": []},
+        "activity": {"searchedTerms": [], "providedRefs": [], "surfacedRefs": [], "fetchedRefs": []},
         "eligibilityInputs": {"acceptedDiff": True},
     }
 
@@ -38,6 +38,76 @@ def test_session_end_writes_one_complete_request_to_stdin():
     assert runner.calls == [
         ([jinn_layer.binary(), "session", "end"], json.dumps(request, separators=(",", ":")))
     ]
+
+
+def test_session_pickup_writes_one_complete_request_to_stdin():
+    runner = StdinRunner()
+    request = {
+        "contractVersion": 1,
+        "meta": {
+            "sessionId": "s1",
+            "taskSummary": "fix the flaky test",
+            "harness": {"name": "jinn-agent", "version": "0.1.0"},
+            "model": "claude-test",
+            "tools": [],
+        },
+        "firstMessage": "fix the flaky test",
+    }
+
+    code, _ = jinn_layer.session_pickup(request, runner=runner)
+
+    assert code == 0
+    assert runner.calls == [
+        ([jinn_layer.binary(), "session", "pickup"], json.dumps(request, separators=(",", ":")))
+    ]
+
+
+def test_session_pickup_uses_a_tighter_timeout_than_the_general_default(monkeypatch):
+    # The real subprocess runner (no injected runner) must apply the tighter
+    # 15s pickup budget (rescope plan §3.5), not the general 120s default —
+    # pickup runs before the LLM call and must fail open in seconds.
+    calls = []
+
+    def fake_default_runner(argv, cwd=None, input=None, timeout_s=jinn_layer._TIMEOUT_S):
+        calls.append(timeout_s)
+        return 0, '{"contractVersion":1,"status":"ok","value":{}}'
+
+    monkeypatch.setattr(jinn_layer, "_default_runner", fake_default_runner)
+    jinn_layer.session_pickup({"contractVersion": 1})
+
+    assert calls == [jinn_layer._SESSION_PICKUP_TIMEOUT_S]
+    assert jinn_layer._SESSION_PICKUP_TIMEOUT_S < jinn_layer._TIMEOUT_S
+
+
+def test_parse_session_pickup_response_accepts_the_exact_v1_envelope():
+    response = jinn_layer.parse_session_pickup_response(
+        json.dumps({
+            "contractVersion": 1,
+            "status": "ok",
+            "value": {
+                "contextBlock": "[jinn corpus] Prior evidence relevant to this task:\n…",
+                "packets": [{"ref": "bafyRef1"}],
+                "searchedTerms": ["dashboard", "vitest"],
+            },
+        })
+    )
+    assert response["status"] == "ok"
+    assert response["value"]["packets"][0]["ref"] == "bafyRef1"
+
+
+def test_parse_session_pickup_response_rejects_malformed_or_wrong_version():
+    for raw in (
+        "not json",
+        "[]",
+        '{"contractVersion":2,"status":"ok","value":{}}',
+        '{"contractVersion":1,"status":"mystery"}',
+    ):
+        try:
+            jinn_layer.parse_session_pickup_response(raw)
+        except ValueError:
+            pass
+        else:  # pragma: no cover - makes each bad fixture independently legible
+            raise AssertionError(f"accepted invalid session-pickup response: {raw}")
 
 
 def test_history_contribution_preview_ledger_and_disable_use_versioned_json_commands():
@@ -73,9 +143,8 @@ def test_parse_session_end_response_accepts_the_exact_v1_envelope():
                     "eligibility": {"eligible": True, "reason": "accepted diff", "checkedAt": "2026-07-15T00:00:00Z"},
                     "summary": {
                         "episodeRef": "episode-1",
-                        "surfacedHits": [],
-                        "fetchedHits": [],
-                        "installedSkillRefs": [],
+                        "searchedTerms": [],
+                        "providedPackets": [],
                         "eligibility": {"eligible": True, "reason": "accepted diff", "checkedAt": "2026-07-15T00:00:00Z"},
                         "nothingFound": True,
                     },

--- a/apps/jinn-agent/tests/plugins/test_jinn_onboarding.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_onboarding.py
@@ -4,20 +4,20 @@ The capstone of the CLI TUI chain (#1417 splash → #1418 consent/ledger →
 this). These tests assert the *presentation* (exact copy, keys, step-rail
 states) and the *contract*: facts-over-flags persistence (returning operators
 see nothing; reads are non-destructive), the confirmed-step-at-a-time flow,
-``--replay`` re-rendering without re-asking, and the ``◇ corpus`` signal-line
-format wired into pickup's consumption path.
+``--replay`` re-rendering without re-asking, and the ``◇ corpus`` evidence
+signal-line format wired into pickup's first-turn pickup path (Stage 1
+rescope R3 — the walk is now consent → publish → signals; the rewards step
+and the "run a network node" stub are Stage 3 economy concepts, removed).
 
 Design artifact:
 ``docs/design/artifacts/2026-07-06-corpus-onboarding/1405-cli-onboarding.html``.
 
-Rendering is pure ANSI (reuses the #1417 splash palette), so every screen is
-re-derivable from these strings. Colours asserted against the truecolor
-palette; visible text against the ANSI-stripped render.
+Rendering is pure ANSI (reuses the #1417 splash palette). Colours asserted
+against the truecolor palette; visible text against the ANSI-stripped render.
 """
 
 from __future__ import annotations
 
-import importlib
 import json
 import re
 
@@ -77,25 +77,31 @@ _PUBLISHED_ROW = {
 
 def test_step1_recorded_on_continues_to_publish():
     plain = _plain(onboarding.render_consent_recorded())
-    assert "step 1 of 4" in plain
+    assert "step 1 of 3" in plain
     assert "sharing is ON" in plain
     assert "Continue — step 2 · your first publish" in plain
     assert "[Enter]" in plain
     assert not _EMOJI.search(plain)
 
 
-def test_step1_recorded_off_sets_aside_publish_and_rewards():
+def test_step1_recorded_off_sets_aside_publish():
     plain = _plain(onboarding.render_consent_recorded_off())
     assert "OFF · reader only" in plain
-    assert "they're set aside" in plain
+    assert "set aside" in plain
     assert "reading the corpus is on for everyone" in plain
-    assert "Continue — step 4 · corpus signals" in plain
+    assert "Continue — step 3 · corpus signals" in plain
 
 
 def test_step1_rail_shows_consent_current_gold():
     out = onboarding.render_consent_recorded()
     # The rail's current step (consent, index 0) is gold.
     assert f"{_TC['gold']}consent" in out
+
+
+def test_step1_rail_has_exactly_three_steps():
+    plain = _plain(onboarding.render_consent_recorded())
+    assert "consent" in plain and "publish" in plain and "signals" in plain
+    assert "rewards" not in plain.lower()
 
 
 # ── Step 2 · first publish ───────────────────────────────────────────────────
@@ -131,160 +137,99 @@ def test_step2_rail_consent_done_publish_current():
     assert f"{_TC['gold']}publish" in out    # current
 
 
-# ── Step 3 · rewards ─────────────────────────────────────────────────────────
+def test_step2_confirmed_continues_directly_to_signals():
+    # No rewards step: publish transitions straight to step 3.
+    plain = _plain(onboarding.render_first_publish_confirmed())
+    assert "Continue — step 3 · corpus signals" in plain
+    assert "rewards" not in plain.lower()
 
 
-def test_step3_none_yet_states_the_honest_trigger():
-    plain = _plain(onboarding.render_rewards_none())
-    assert "OLAS earned:" in plain and "none yet" in plain
-    # Plain speech on money — protocol-native verb (no pay/paid): publication
-    # alone does not earn; verification triggers it and is not guaranteed.
-    assert "Publication alone does not earn" in plain
-    assert "verification" in plain and "it is not guaranteed." in plain
-    assert not _EMOJI.search(plain)
+# ── Step 3 · corpus signals + the evidence signal line ───────────────────────
 
 
-def test_step3_names_the_tier_ladder_with_ledger_colours():
-    out = onboarding.render_rewards_none()
-    assert f"{_TC['green']}tests-passed" in out
-    assert f"{_TC['gold']}evaluator-verified" in out
-
-
-def test_step3_earned_variant_states_amount_and_count():
-    plain = _plain(onboarding.render_rewards_earned("12.40 OLAS", 3))
-    assert "12.40 OLAS" in plain
-    assert "3 traces evaluator-verified" in plain
-    assert "not publication" in plain
-
-
-def test_step3_earned_singular_count_grammar():
-    plain = _plain(onboarding.render_rewards_earned("4.10 OLAS", 1))
-    assert "1 trace evaluator-verified" in plain
-
-
-def test_step3_earned_degrades_amount_honestly():
-    # No fabricated figure — 'checking…' is passed straight through.
-    plain = _plain(onboarding.render_rewards_earned("checking…", 2))
-    assert "checking…" in plain
-
-
-# ── Step 4 · corpus signals + the signal line ────────────────────────────────
-
-
-def test_step4_shows_the_signal_line_format_once():
-    plain = _plain(onboarding.render_signals({"consent": "done", "publish": "done", "rewards": "done"}))
-    assert "When a run draws on the corpus, you'll see it." in plain
+def test_step3_shows_the_signal_line_format_once():
+    plain = _plain(onboarding.render_signals({"consent": "done", "publish": "done"}))
+    assert "step 3 of 3" in plain
+    assert "prior evidence" in plain.lower()
     assert "◇ corpus" in plain
-    assert "One line per use" in plain
     assert "Finish" in plain
 
 
-def test_corpus_signal_line_format():
-    out = onboarding.render_corpus_signal_line(
-        "retry-backoff-patterns", "learned from 214 contributions", "bafkr…hx2c"
-    )
+def test_evidence_signal_line_format():
+    out = onboarding.render_evidence_signal_line(["dashboard", "vitest", "flake"], 1)
     plain = _plain(out)
     assert plain.startswith("  ◇ corpus")
-    assert "using retry-backoff-patterns" in plain
-    assert "learned from 214 contributions" in plain
-    assert "env bafkr…hx2c" in plain
-    # ◇ prefix is sky (structure), skill name is bright fg.
+    assert "provided 1 evidence packet" in plain
+    assert "searched: dashboard, vitest, flake" in plain
+    # ◇ prefix is sky (structure); the provided-count phrase is bright fg.
     assert f"{_TC['sky']}◇ corpus" in out
-    assert f"{_TC['fg']}retry-backoff-patterns" in out
+    assert f"{_TC['fg']}provided 1 evidence packet" in out
     assert not _EMOJI.search(plain)
 
 
-def test_corpus_signal_line_strips_terminal_control_chars():
-    # The corpus is PUBLIC + cross-operator: a hostile adopted skill/summary/ref
-    # carrying ESC / CR / BEL must not reach a victim operator's terminal raw
-    # (ANSI injection, screen manipulation) on auto-adoption.
-    out = onboarding.render_corpus_signal_line(
-        "evil\x1b[31mSKILL",
-        "pwn\rned\x07",
-        "bafk\x1b[2Jref",
-    )
+def test_evidence_signal_line_pluralises_the_packet_noun():
+    plain = _plain(onboarding.render_evidence_signal_line(["dashboard"], 2))
+    assert "provided 2 evidence packets" in plain
+    singular = _plain(onboarding.render_evidence_signal_line(["dashboard"], 1))
+    assert "provided 1 evidence packet " in singular or singular.rstrip().endswith("packet")
+
+
+def test_evidence_signal_line_strips_terminal_control_chars():
+    # Searched terms are derived from the session's own first message, but
+    # sanitise unconditionally anyway (matches the rest of this module's
+    # convention for any dynamic field reaching the terminal).
+    out = onboarding.render_evidence_signal_line(["evil\x1b[31mterm", "pwn\rned\x07"], 1)
     plain = _plain(out)
-    # The ESC that would open a raw ANSI sequence is stripped; the bracket text
-    # that follows survives as inert literal characters.
-    assert "evil[31mSKILL" in plain
+    assert "evil[31mterm" in plain
     assert "pwnned" in plain
-    assert "bafk[2Jref" in plain
-    # CR and BEL (never emitted by styling) are gone from the raw output.
     assert "\r" not in out and "\x07" not in out
-    # No stray ESC other than the palette's own well-formed SGR codes.
     stray = _ANSI.sub("", out)
     assert "\033" not in stray
 
 
-def test_corpus_signal_line_hooked_into_pickup(tmp_path, monkeypatch):
-    """Adopting a verified corpus skill emits exactly one ◇ corpus line."""
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    # Auto-adopt is opt-in by default (manual-approval-by-default); opt in so
-    # this test can exercise the adopt-signal path.
-    cfg = tmp_path / "jinn" / "pickup.json"
-    cfg.parent.mkdir(parents=True, exist_ok=True)
-    cfg.write_text(json.dumps({"autoAdopt": True}))
-    # Reload pickup fresh so its module-level state is clean.
-    pickup = importlib.reload(importlib.import_module("plugins.jinn.pickup"))
-
-    tp = importlib.import_module("tests.plugins.test_jinn_pickup")
-    skills_install = importlib.import_module("plugins.jinn.skills_install")
-    # The adopt DECISION (and its signal-line emission) is under test here,
-    # not the layer shell-out (that's covered in test_jinn_skills_install.py).
-    monkeypatch.setattr(skills_install, "install", tp._fake_install(tmp_path))
-    runner = tp.CorpusRunner(tp.trace(tier="evaluator-verified", slug="tdd"))
-
-    lines = []
-    result = pickup.pickup(tp.MSG, runner=runner, signal_sink=lines.append)
-    assert result is not None
-    assert "Adopted automatically (verified)" in result["context"]
-    # Exactly one signal line, at the point of use, carrying the ref.
-    assert len(lines) == 1
-    plain = _plain(lines[0])
-    assert plain.startswith("  ◇ corpus")
-    assert "using tdd" in plain
-    assert "evaluator-verified" in plain
-    assert "env " in plain
+def test_no_installed_skill_or_adopt_language_anywhere_in_onboarding():
+    # Boundary: Stage 3 concepts (skill install/adopt) must not leak into
+    # Stage 1 onboarding copy.
+    screens = [
+        onboarding.render_consent_recorded(),
+        onboarding.render_consent_recorded_off(),
+        onboarding.render_first_publish_waiting(),
+        onboarding.render_first_publish_confirmed(),
+        onboarding.render_signals({"consent": "done", "publish": "done"}),
+        onboarding.render_done(reader_only=False),
+        onboarding.render_done(reader_only=True),
+    ]
+    for screen in screens:
+        plain = _plain(screen).lower()
+        assert "install" not in plain
+        assert "adopt" not in plain
+        assert "skill" not in plain
 
 
-def test_pickup_suggested_but_not_adopted_emits_surfaced_signal(tmp_path, monkeypatch):
-    """Every suggestion is visibly marked without claiming it was used."""
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    pickup = importlib.reload(importlib.import_module("plugins.jinn.pickup"))
-    tp = importlib.import_module("tests.plugins.test_jinn_pickup")
-    runner = tp.CorpusRunner(tp.trace(tier="user-accepted", slug="tdd"))
-    lines = []
-    result = pickup.pickup(tp.MSG, runner=runner, signal_sink=lines.append)
-    assert result is not None
-    assert "unverified" in result["context"]
-    assert len(lines) == 1
-    plain = _plain(lines[0])
-    assert plain.startswith("  ◇ corpus")
-    assert "surfaced tdd" in plain
-    assert "using tdd" not in plain
-
-
-def test_pickup_unknown_suggestion_is_also_visibly_surfaced(tmp_path, monkeypatch):
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    pickup = importlib.reload(importlib.import_module("plugins.jinn.pickup"))
-    tp = importlib.import_module("tests.plugins.test_jinn_pickup")
-    runner = tp.CorpusRunner(tp.trace(
-        tier="evaluator-verified", payload="opaque", slug="opaque-pattern"
-    ))
-    lines = []
-    result = pickup.pickup(tp.MSG, runner=runner, signal_sink=lines.append)
-    assert result is not None
-    assert len(lines) == 1
-    assert "surfaced unknown" in _plain(lines[0])
+def test_no_rewards_or_olas_earning_language_anywhere_in_onboarding():
+    screens = [
+        onboarding.render_consent_recorded(),
+        onboarding.render_consent_recorded_off(),
+        onboarding.render_first_publish_waiting(),
+        onboarding.render_first_publish_confirmed(),
+        onboarding.render_signals({"consent": "done", "publish": "done"}),
+        onboarding.render_done(reader_only=False),
+        onboarding.render_done(reader_only=True),
+    ]
+    for screen in screens:
+        plain = _plain(screen).lower()
+        assert "rewards" not in plain
+        assert "olas earned" not in plain
+        assert "/jinn rewards" not in plain
+        assert "run a network node" not in plain
 
 
 # ── Persistence — facts over flags ───────────────────────────────────────────
 
 
 def test_returning_operator_is_complete_and_sees_nothing(tmp_path):
-    # Consent recorded + ledger non-empty + both flags → complete.
+    # Consent recorded + ledger non-empty + the signals flag → complete.
     consent.record_accept()
-    onboarding.mark_flag("rewards_explained")
     onboarding.mark_flag("signals_shown")
     runner = LedgerRunner([_PUBLISHED_ROW])
     assert onboarding.is_complete(runner=runner) is True
@@ -299,7 +244,6 @@ def test_unset_consent_is_not_complete(tmp_path):
 
 def test_accepted_but_empty_ledger_is_not_complete(tmp_path):
     consent.record_accept()
-    onboarding.mark_flag("rewards_explained")
     onboarding.mark_flag("signals_shown")
     runner = LedgerRunner([])  # ledger empty → step 2 fact unsatisfied
     assert onboarding.ledger_nonempty(runner=runner) is False
@@ -307,7 +251,7 @@ def test_accepted_but_empty_ledger_is_not_complete(tmp_path):
 
 
 def test_declined_operator_complete_on_signals_flag_only(tmp_path):
-    # Reader-only: publish/rewards set aside, so the ledger fact does not gate.
+    # Reader-only: publish is set aside, so the ledger fact does not gate.
     consent.record_decline()
     runner = LedgerRunner([])
     assert onboarding.is_complete(runner=runner) is False  # signals not shown yet
@@ -315,23 +259,26 @@ def test_declined_operator_complete_on_signals_flag_only(tmp_path):
     assert onboarding.is_complete(runner=runner) is True
 
 
-def test_deleting_flag_file_reruns_only_steps_3_and_4(tmp_path):
-    # Consent + publish are facts (survive); flags are onboarding's own.
+def test_only_signals_shown_is_a_valid_flag_name(tmp_path):
+    with pytest.raises(ValueError):
+        onboarding.mark_flag("rewards_explained")
+
+
+def test_deleting_flag_file_reruns_only_step_3(tmp_path):
+    # Consent + publish are facts (survive); the flag is onboarding's own.
     consent.record_accept()
-    onboarding.mark_flag("rewards_explained")
     onboarding.mark_flag("signals_shown")
     onboarding.state_path().unlink()
     # Facts survive:
     assert onboarding.consent_decided() is True
-    # Flags reset:
+    # Flag resets:
     flags = onboarding.load_flags()
-    assert flags["rewards_explained"] is False and flags["signals_shown"] is False
+    assert flags["signals_shown"] is False
 
 
 def test_flag_writes_never_touch_consent_or_ledger(tmp_path):
     consent.record_accept()
     before = consent.state_path().read_text()
-    onboarding.mark_flag("rewards_explained")
     onboarding.mark_flag("signals_shown")
     # Non-destructive: onboarding writes only its own flag file.
     assert consent.state_path().read_text() == before
@@ -374,51 +321,48 @@ class Driver:
         return _plain("\n".join(self.screens))
 
 
-def test_driver_accept_path_walks_all_four_steps(tmp_path, monkeypatch):
-    # consent 'a' → confirm 'y' → node skip enter, then step-1 enter, step-2
-    # enter, step-3 enter, step-4 enter.
-    d = Driver(["a", "y", "", "", "", "", ""])
+def test_driver_accept_path_walks_all_three_steps(tmp_path, monkeypatch):
+    # consent 'a' → confirm 'y', then step-1 enter, step-2 enter, step-3 enter.
+    d = Driver(["a", "y", "", "", ""])
     onboarding.run_onboarding(d.input, d.print)
     text = d.plain()
-    # Sharing recorded ON, then all four step surfaces + done.
+    # Sharing recorded ON, then both remaining step surfaces + done.
     assert "sharing is ON" in text
     assert "your first publish" in text
-    assert "OLAS earned:" in text
-    assert "When a run draws on the corpus" in text
+    assert "prior evidence" in text.lower()
     assert "complete" in text.lower()
-    # Flags set (facts-over-flags: sharing consent is on, both seen-flags true).
+    assert "rewards" not in text.lower()
+    # Facts-over-flags: sharing consent is on, the signals flag is true.
     assert consent.share_enabled() is True
     flags = onboarding.load_flags()
-    assert flags["rewards_explained"] and flags["signals_shown"]
+    assert flags["signals_shown"]
 
 
 def test_driver_decline_path_skips_to_signals(tmp_path):
-    # consent bare-enter → decline confirm 'y' → node enter; step-1 enter,
-    # step-4 enter.
-    d = Driver(["", "y", "", "", ""])
+    # consent bare-enter → decline confirm 'y'; step-1 enter, step-3 enter.
+    d = Driver(["", "y", "", ""])
     onboarding.run_onboarding(d.input, d.print)
     text = d.plain()
     assert "reader only" in text
-    # Publish + rewards are set aside — never rendered on the decline path.
-    assert "your first publish" not in text
-    assert "OLAS earned:" not in text
-    assert "When a run draws on the corpus" in text
-    # Only the signals flag is set; rewards stays unseen.
+    # The publish CONFIRMATION SCREEN is never rendered on the decline path
+    # (step 1's own explanation names step 2, which is a different thing).
+    assert "Run your first task." not in text
+    assert "published — your first contribution" not in text
+    assert "prior evidence" in text.lower()
     flags = onboarding.load_flags()
-    assert flags["signals_shown"] and not flags["rewards_explained"]
+    assert flags["signals_shown"]
 
 
 def test_driver_replay_re_asks_nothing_and_writes_nothing(tmp_path):
     # A returning operator replays: consent recorded, ledger has the row.
     consent.record_accept()
-    onboarding.mark_flag("rewards_explained")
     onboarding.mark_flag("signals_shown")
     before_consent = consent.state_path().read_text()
     before_flags = onboarding.state_path().read_text()
 
     runner = LedgerRunner([_PUBLISHED_ROW])
-    # 4 confirmations, one per screen. No consent keystrokes — never re-asked.
-    d = Driver(["", "", "", ""])
+    # 3 confirmations, one per screen. No consent keystrokes — never re-asked.
+    d = Driver(["", "", ""])
     onboarding.run_onboarding(d.input, d.print, replay=True, runner=runner)
     text = d.plain()
     # Shows the recorded consent state + the ACTUAL first envelope from ledger.
@@ -429,15 +373,12 @@ def test_driver_replay_re_asks_nothing_and_writes_nothing(tmp_path):
     assert onboarding.state_path().read_text() == before_flags
 
 
-def test_driver_earned_variant_when_rewards_fn_reports(tmp_path):
-    d = Driver(["a", "y", "", "", "", "", ""])
-    onboarding.run_onboarding(
-        d.input, d.print,
-        rewards_fn=lambda: {"amount": "12.40 OLAS", "count": 3},
-    )
-    text = d.plain()
-    assert "12.40 OLAS" in text
-    assert "3 traces evaluator-verified" in text
+def test_run_onboarding_no_longer_accepts_a_rewards_fn(tmp_path):
+    # The rewards step (and its rewards_fn hook) is gone — passing it is a
+    # TypeError, proving the parameter was actually removed, not just unused.
+    d = Driver(["a", "y", "", "", ""])
+    with pytest.raises(TypeError):
+        onboarding.run_onboarding(d.input, d.print, rewards_fn=lambda: None)
 
 
 # ── NO_COLOR degrades to plain text ──────────────────────────────────────────
@@ -449,9 +390,8 @@ def test_no_color_yields_plain_text(monkeypatch, tmp_path):
     for out in (
         onboarding.render_consent_recorded(),
         onboarding.render_first_publish_confirmed(),
-        onboarding.render_rewards_none(),
         onboarding.render_signals({"consent": "done"}),
-        onboarding.render_corpus_signal_line("s", "p", "e"),
+        onboarding.render_evidence_signal_line(["dashboard"], 1),
     ):
         assert _ANSI.search(out) is None
 
@@ -462,7 +402,6 @@ def test_no_color_yields_plain_text(monkeypatch, tmp_path):
 def test_cli_returning_operator_is_a_noop(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     consent.record_accept()
-    onboarding.mark_flag("rewards_explained")
     onboarding.mark_flag("signals_shown")
     # Patch the ledger fact to "non-empty" so is_complete() is satisfied.
     monkeypatch.setattr(onboarding, "ledger_nonempty", lambda runner=None: True)

--- a/apps/jinn-agent/tests/plugins/test_jinn_pickup.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_pickup.py
@@ -1,71 +1,58 @@
-"""Payload-agnostic auto-pickup tests (mono #1345, tier-keyed design).
+"""Evidence-first auto-pickup tests (Stage 1 rescope R3, closes mono #1732).
 
-The policy under test: adoption is gated by VERIFICATION TIER, not by a
-human keystroke — `evaluator-verified` payloads adopt automatically;
-unverified ones are suggested to the agent as injected context; unknown
-payload types are never adopted; and none of it is consent-gated
-(consuming is always allowed).
+The policy under test lives in `packages/plugin` now (rescope R1) — pickup.py
+is a thin delegation to `jinn-layer session pickup`. These tests cover the
+delegation itself: request shape, verbatim contextBlock rendering, activity
+recording, the evidence signal line, and every fail-open path (missing
+binary, malformed response, contract mismatch, disabled config, a stale
+layer whose response predates the `packets` field).
 """
 
 from __future__ import annotations
 
-import base64
-import hashlib
-import importlib
 import json
-from pathlib import Path
+import importlib
 
 import pytest
 
 jinn = importlib.import_module("plugins.jinn")
-consent = importlib.import_module("plugins.jinn.consent")
 pickup = importlib.import_module("plugins.jinn.pickup")
-skills_install = importlib.import_module("plugins.jinn.skills_install")
+jinn_layer = importlib.import_module("plugins.jinn.jinn_layer")
 
-REF = "bafyPickupSkill"
+MSG = "The client dashboard vitest suite is flaky again — the update_available check races the version status fetch"
+
+CONTEXT_BLOCK = (
+    "[jinn corpus] Prior evidence relevant to this task:\n"
+    "Fix the dashboard flake · completed/tests-passed\n"
+    "- failure: FAIL version-status.test.ts\n"
+    "  source: bafySourceEpisode · operator-recorded-session · captured 2026-07-04 · "
+    "full episode: corpus_fetch bafySourceEpisode"
+)
 
 
-def trace(tier: str = "user-accepted", payload: str = "skill", slug: str = "tdd") -> dict:
-    step_attrs: dict = {"seed.attribution": {"skill": f"acme/skills/{slug}"}}
-    if payload == "skill":
-        step_attrs["skill.md"] = f"# {slug}\n\nRed, green, refactor."
-    return {
-        "schemaVersion": "jinn.trace-envelope.v0",
-        "task": {"summary": f"Seed import: acme/skills/{slug}", "distributionTags": ["seed-import", slug]},
-        "steps": [{"spanId": "s1", "name": "seed:skill-md", "attributes": step_attrs}],
-        "outcome": {"status": "completed", "verifiabilityTier": tier},
-        "provenance": "imported",
+def ok_response(**value_overrides) -> str:
+    value = {
+        "contextBlock": CONTEXT_BLOCK,
+        "packets": [{"ref": "bafySourceEpisode"}],
+        "searchedTerms": ["dashboard", "vitest", "update_available"],
+        **value_overrides,
     }
+    return json.dumps({"contractVersion": 1, "status": "ok", "value": value})
 
 
-def record_for(t: dict) -> dict:
-    content = json.dumps(t).encode("utf-8")
-    return {
-        "ref": REF,
-        "artifacts": [{
-            "artifactType": "jinn.trace-envelope.v0",
-            "sha256": hashlib.sha256(content).hexdigest(),
-            "contentBase64": base64.b64encode(content).decode("ascii"),
-        }],
-    }
+class PickupRunner:
+    """Serves `jinn-layer session pickup` with one canned response."""
 
+    def __init__(self, code: int = 0, out: str = "", raw_value: dict | None = None):
+        self.code = code
+        self.out = out or ok_response()
+        self.calls: list[tuple[list[str], str | None]] = []
+        if raw_value is not None:
+            self.out = json.dumps({"contractVersion": 1, "status": "ok", "value": raw_value})
 
-class CorpusRunner:
-    """Serves corpus search + corpus get for one canned record."""
-
-    def __init__(self, t: dict, search_hit: bool = True):
-        self.record = record_for(t)
-        self.search_hit = search_hit
-        self.calls: list[list[str]] = []
-
-    def __call__(self, argv: list[str]) -> tuple[int, str]:
-        self.calls.append(argv)
-        if argv[1] == "corpus" and argv[2] == "search":
-            hits = [{"ref": REF, "tags": ["tdd"], "summary": "Seed import: acme/skills/tdd"}] if self.search_hit else []
-            return 0, json.dumps(hits)
-        if argv[1] == "corpus" and argv[2] == "get":
-            return 0, json.dumps(self.record)
-        return 1, f"unexpected: {argv}"
+    def __call__(self, argv: list[str], *, input: str | None = None) -> tuple[int, str]:
+        self.calls.append((argv, input))
+        return self.code, self.out
 
 
 @pytest.fixture(autouse=True)
@@ -76,158 +63,186 @@ def isolated_home(tmp_path, monkeypatch):
     jinn._reset_session_state()
 
 
-MSG = "Help me with tdd-style refactoring of this suite"
+# ── Delegation ────────────────────────────────────────────────────────────────
+
+def test_pickup_delegates_to_session_pickup_with_the_v1_request_shape():
+    runner = PickupRunner()
+    pickup.pickup(MSG, runner=runner, session_id="s1", model="claude-test", repository_slug="acme/widget")
+
+    assert len(runner.calls) == 1
+    argv, raw_input = runner.calls[0]
+    assert argv == [jinn_layer.binary(), "session", "pickup"]
+    request = json.loads(raw_input)
+    assert request["contractVersion"] == jinn_layer.CONTRACT_VERSION
+    assert request["firstMessage"] == MSG
+    assert request["meta"]["sessionId"] == "s1"
+    assert request["meta"]["model"] == "claude-test"
+    assert request["meta"]["repositorySlug"] == "acme/widget"
+    assert request["meta"]["harness"]["name"]
+    assert isinstance(request["meta"]["taskSummary"], str) and request["meta"]["taskSummary"]
+    assert request["meta"]["tools"] == []
 
 
-def _fake_install(tmp_path, slug: str = "tdd"):
-    """Stand in for skills_install.install(): the adopt DECISION is under
-    test here, not the layer shell-out (that's covered in
-    test_jinn_skills_install.py). Writes the SKILL.md + .jinn-ref marker so
-    on-disk assertions and list_installed()-based dedup still hold."""
-    def fake(ref, runner=None):
-        target = tmp_path / "skills" / slug
-        target.mkdir(parents=True, exist_ok=True)
-        (target / "SKILL.md").write_text(f"# {slug}\n")
-        (target / ".jinn-ref").write_text(json.dumps({"ref": ref}) + "\n")
-        return str(target / "SKILL.md")
-    return fake
+def test_pickup_omits_repository_slug_when_unknown():
+    runner = PickupRunner()
+    pickup.pickup(MSG, runner=runner, session_id="s1")
+    request = json.loads(runner.calls[0][1])
+    assert "repositorySlug" not in request["meta"]
 
 
-def test_verified_candidate_is_suggested_not_adopted_by_default(tmp_path):
-    # Ratified: remote skills are manual-approval by default. With no
-    # pickup.json (autoAdopt defaults to False), even an evaluator-verified
-    # candidate is only suggested — never installed without a keystroke.
-    runner = CorpusRunner(trace(tier="evaluator-verified"))
+def test_pickup_renders_the_context_block_verbatim():
+    runner = PickupRunner()
     result = pickup.pickup(MSG, runner=runner)
-    assert result is not None
-    ctx = result["context"]
-    assert "install: /jinn skills install" in ctx      # suggested
-    assert "Adopted automatically" not in ctx          # NOT adopted
-    assert not (tmp_path / "skills").exists()
+    assert result == {"context": CONTEXT_BLOCK}
 
 
-def test_opt_in_auto_adopts(tmp_path, monkeypatch):
-    monkeypatch.setattr(skills_install, "install", _fake_install(tmp_path))
-    cfg = tmp_path / "jinn" / "pickup.json"
-    cfg.parent.mkdir(parents=True, exist_ok=True)
-    cfg.write_text(json.dumps({"autoAdopt": True}))
-    runner = CorpusRunner(trace(tier="evaluator-verified"))
-    result = pickup.pickup(MSG, runner=runner)
-    assert result is not None
-    assert "Adopted automatically (verified)" in result["context"]
-    # The skill landed where Hermes's native loader reads it — no confirm step.
-    assert (tmp_path / "skills" / "tdd" / "SKILL.md").exists()
+def test_pickup_returns_none_when_nothing_is_provided():
+    runner = PickupRunner(out=ok_response(contextBlock=None, packets=[]))
+    assert pickup.pickup(MSG, runner=runner) is None
 
 
-def test_pickup_reports_only_safely_observed_activity(tmp_path):
-    runner = CorpusRunner(trace(tier="evaluator-verified"))
-    activity = {"surfacedRefs": [], "fetchedRefs": [], "installedSkillRefs": []}
+def test_pickup_returns_none_when_context_block_is_blank():
+    runner = PickupRunner(out=ok_response(contextBlock="   "))
+    assert pickup.pickup(MSG, runner=runner) is None
+
+
+# ── Activity recording (rescope §3.6) ───────────────────────────────────────
+
+def test_pickup_records_searched_terms_and_provided_refs():
+    runner = PickupRunner()
+    activity = {"searchedTerms": [], "providedRefs": [], "surfacedRefs": [], "fetchedRefs": []}
 
     pickup.pickup(MSG, runner=runner, activity=activity)
 
-    assert activity == {
-        "surfacedRefs": [REF],
-        "fetchedRefs": [REF],
-        "installedSkillRefs": [],
-    }
+    assert activity["searchedTerms"] == ["dashboard", "vitest", "update_available"]
+    assert activity["providedRefs"] == ["bafySourceEpisode"]
+    # Internal fetch-attempt fields are untouched by pickup itself.
+    assert activity["surfacedRefs"] == []
+    assert activity["fetchedRefs"] == []
 
 
-def test_auto_adopt_reports_the_installed_ref(tmp_path, monkeypatch):
-    monkeypatch.setattr(skills_install, "install", _fake_install(tmp_path))
-    cfg = tmp_path / "jinn" / "pickup.json"
-    cfg.parent.mkdir(parents=True, exist_ok=True)
-    cfg.write_text(json.dumps({"autoAdopt": True}))
-    activity = {"surfacedRefs": [], "fetchedRefs": [], "installedSkillRefs": []}
+def test_pickup_records_searched_terms_even_when_nothing_is_provided():
+    # Honest legibility: a search that found nothing still records what was
+    # searched — only the injection (and the derived nothing-found summary
+    # line) omits the terms.
+    runner = PickupRunner(out=ok_response(contextBlock=None, packets=[], searchedTerms=["quasar", "unobtainium"]))
+    activity: dict = {}
 
-    pickup.pickup(
-        MSG,
-        runner=CorpusRunner(trace(tier="evaluator-verified")),
-        activity=activity,
-    )
+    pickup.pickup(MSG, runner=runner, activity=activity)
 
-    assert activity["installedSkillRefs"] == [REF]
+    assert activity["searchedTerms"] == ["quasar", "unobtainium"]
+    assert activity["providedRefs"] == []
 
 
-def test_unverified_payload_suggests_but_never_installs(tmp_path):
-    runner = CorpusRunner(trace(tier="user-accepted"))
-    result = pickup.pickup(MSG, runner=runner)
+def test_pickup_does_not_touch_activity_when_the_call_fails():
+    runner = PickupRunner(code=1, out="boom")
+    activity = {"searchedTerms": ["stale"], "providedRefs": ["stale-ref"]}
+
+    pickup.pickup(MSG, runner=runner, activity=activity)
+
+    assert activity == {"searchedTerms": ["stale"], "providedRefs": ["stale-ref"]}
+
+
+# ── The evidence signal line (rescope §3.4) ─────────────────────────────────
+
+def test_pickup_emits_exactly_one_evidence_signal_when_provided():
+    runner = PickupRunner()
+    lines: list[str] = []
+
+    result = pickup.pickup(MSG, runner=runner, signal_sink=lines.append)
+
     assert result is not None
-    assert "unverified" in result["context"]
-    assert "/jinn skills install" in result["context"]
-    assert not (tmp_path / "skills").exists()
+    assert len(lines) == 1
+    assert "◇ corpus" in lines[0]
+    assert "provided" in lines[0]
+    assert "dashboard" in lines[0]
 
 
-def test_tests_passed_tier_respects_configured_threshold(tmp_path, monkeypatch):
-    monkeypatch.setattr(skills_install, "install", _fake_install(tmp_path))
-    # Default threshold is evaluator-verified: tests-passed only suggests…
-    runner = CorpusRunner(trace(tier="tests-passed"))
-    result = pickup.pickup(MSG, runner=runner)
-    assert not (tmp_path / "skills").exists()
-    assert result is not None
-    # …but an operator who opts into auto-adopt and lowers the threshold
-    # gets auto-adoption.
-    cfg = tmp_path / "jinn" / "pickup.json"
-    cfg.parent.mkdir(parents=True, exist_ok=True)
-    cfg.write_text(json.dumps({"autoAdopt": True, "autoAdoptTier": "tests-passed"}))
-    runner2 = CorpusRunner(trace(tier="tests-passed"))
-    pickup.pickup(MSG, runner=runner2)
-    assert (tmp_path / "skills" / "tdd" / "SKILL.md").exists()
+def test_pickup_emits_no_signal_when_nothing_is_provided():
+    runner = PickupRunner(out=ok_response(contextBlock=None, packets=[]))
+    lines: list[str] = []
+
+    pickup.pickup(MSG, runner=runner, signal_sink=lines.append)
+
+    assert lines == []
 
 
-def test_unknown_payload_type_is_never_adopted(tmp_path):
-    runner = CorpusRunner(trace(tier="evaluator-verified", payload="opaque"))
-    result = pickup.pickup(MSG, runner=runner)
-    # Verified unknown payloads are surfaced (suggest-only default must not
-    # swallow them into silence) but never adopted.
-    assert result is not None
-    ctx = result["context"]
-    assert "unknown" in ctx
-    assert REF in ctx
-    assert "Adopted automatically" not in ctx
-    assert not (tmp_path / "skills").exists()
+# ── Fail-open paths ──────────────────────────────────────────────────────────
+
+def test_pickup_fails_open_on_broken_layer():
+    def broken(argv, **_kw):
+        raise RuntimeError("boom")
+    assert pickup.pickup(MSG, runner=broken) is None
 
 
-def test_pickup_is_not_consent_gated(tmp_path, monkeypatch):
-    monkeypatch.setattr(skills_install, "install", _fake_install(tmp_path))
-    cfg = tmp_path / "jinn" / "pickup.json"
-    cfg.parent.mkdir(parents=True, exist_ok=True)
-    cfg.write_text(json.dumps({"autoAdopt": True}))
-    consent.save_state(False)
-    runner = CorpusRunner(trace(tier="evaluator-verified"))
-    result = pickup.pickup(MSG, runner=runner)
-    assert result is not None
-    assert (tmp_path / "skills" / "tdd" / "SKILL.md").exists()
+def test_pickup_fails_open_on_missing_binary():
+    runner = PickupRunner(code=127, out="jinn-layer: not found")
+    assert pickup.pickup(MSG, runner=runner) is None
+
+
+def test_pickup_fails_open_on_malformed_json():
+    runner = PickupRunner(out="not json")
+    assert pickup.pickup(MSG, runner=runner) is None
+
+
+def test_pickup_fails_open_on_contract_version_mismatch():
+    runner = PickupRunner(out=json.dumps({"contractVersion": 2, "status": "ok", "value": {}}))
+    assert pickup.pickup(MSG, runner=runner) is None
+
+
+def test_pickup_returns_none_on_unavailable_status():
+    runner = PickupRunner(out=json.dumps({
+        "contractVersion": 1, "status": "unavailable", "reason": "jinn-layer unreachable",
+    }))
+    assert pickup.pickup(MSG, runner=runner) is None
+
+
+def test_stale_layer_response_without_packets_is_treated_as_degraded_nothing():
+    """A v1 response without `packets` (a stale jinn-layer predating the
+    rescope) must never reintroduce the old suggestion/install shape via
+    contextBlock — treated as degraded-nothing (R3 AC)."""
+    runner = PickupRunner(out=json.dumps({
+        "contractVersion": 1,
+        "status": "ok",
+        "value": {
+            # Old shape: no "packets" key, but still carries a contextBlock —
+            # must not be rendered.
+            "contextBlock": "[jinn corpus] Relevant to this task:\n- old skill suggestion",
+            "suggestions": ["- old skill suggestion"],
+        },
+    }))
+    activity: dict = {}
+
+    result = pickup.pickup(MSG, runner=runner, activity=activity)
+
+    assert result is None
+    assert activity == {}
 
 
 def test_disabled_config_is_a_no_op(tmp_path):
     cfg = tmp_path / "jinn" / "pickup.json"
     cfg.parent.mkdir(parents=True, exist_ok=True)
     cfg.write_text(json.dumps({"enabled": False}))
-    runner = CorpusRunner(trace(tier="evaluator-verified"))
+    runner = PickupRunner()
     assert pickup.pickup(MSG, runner=runner) is None
     assert runner.calls == []
 
 
-def test_already_installed_skill_is_skipped(tmp_path, monkeypatch):
-    monkeypatch.setattr(skills_install, "install", _fake_install(tmp_path))
+def test_load_config_defaults_to_enabled_when_absent(tmp_path):
+    assert pickup.load_config() == {"enabled": True}
+
+
+def test_load_config_ignores_unreadable_file(tmp_path):
     cfg = tmp_path / "jinn" / "pickup.json"
     cfg.parent.mkdir(parents=True, exist_ok=True)
-    cfg.write_text(json.dumps({"autoAdopt": True}))
-    runner = CorpusRunner(trace(tier="evaluator-verified"))
-    pickup.pickup(MSG, runner=runner)
-    runner2 = CorpusRunner(trace(tier="evaluator-verified"))
-    result = pickup.pickup(MSG, runner=runner2)
-    assert result is None  # nothing new to say
+    cfg.write_text("not json")
+    assert pickup.load_config() == {"enabled": True}
 
 
-def test_pickup_fails_open_on_broken_layer(tmp_path):
-    def broken(argv):
-        raise RuntimeError("boom")
-    assert pickup.pickup(MSG, runner=broken) is None
+# ── Hook wiring ──────────────────────────────────────────────────────────────
 
-
-def test_hook_returns_pickup_context_on_first_turn(tmp_path):
-    runner = CorpusRunner(trace(tier="user-accepted"))
+def test_hook_returns_pickup_context_on_first_turn():
+    runner = PickupRunner()
     jinn._runner = runner
     try:
         result = jinn._on_pre_llm_call(
@@ -239,32 +254,61 @@ def test_hook_returns_pickup_context_on_first_turn(tmp_path):
     assert jinn._on_pre_llm_call(session_id="s1", user_message=MSG, is_first_turn=False) is None
 
 
-def test_derive_terms_skips_stopwords():
-    assert pickup.derive_terms("Help me with tdd-style refactoring")[0] == "tdd-style"
-    assert pickup.derive_terms("") == []
-
-
-# ── Agent tools ──────────────────────────────────────────────────────────────
+# ── Agent tools (unaffected by the pickup delegation) ───────────────────────
 
 def test_corpus_search_tool_formats_hits_and_records_surfaced_refs(tmp_path):
-    runner = CorpusRunner(trace())
+    ref = "bafyPickupSkill"
+
+    def runner(argv):
+        if argv[1] == "corpus" and argv[2] == "search":
+            return 0, json.dumps([{"ref": ref, "tags": ["tdd"], "summary": "Seed import: acme/skills/tdd"}])
+        return 1, f"unexpected: {argv}"
+
     jinn._runner = runner
     try:
         out = jinn._tool_corpus_search({"query": "tdd"}, session_id="s1")
     finally:
         jinn._runner = None
-    assert f"ref={REF}" in out
+    assert f"ref={ref}" in out
     assert "tags=[tdd]" in out
-    assert jinn._state_for("s1")["activity"]["surfacedRefs"] == [REF]
+    assert jinn._state_for("s1")["activity"]["surfacedRefs"] == [ref]
 
 
 def test_corpus_fetch_tool_returns_skill_content_and_records_fetched_ref(tmp_path):
-    runner = CorpusRunner(trace(tier="user-accepted"))
+    import base64
+    import hashlib
+
+    ref = "bafyPickupSkill"
+    trace = {
+        "schemaVersion": "jinn.trace-envelope.v0",
+        "task": {"summary": "Seed import: acme/skills/tdd", "distributionTags": ["seed-import", "tdd"]},
+        "steps": [{"spanId": "s1", "name": "seed:skill-md", "attributes": {
+            "skill.md": "# tdd\n\nRed, green, refactor.",
+            "seed.attribution": {"skill": "acme/skills/tdd"},
+        }}],
+        "outcome": {"status": "completed", "verifiabilityTier": "user-accepted"},
+        "provenance": "imported",
+    }
+    content = json.dumps(trace).encode("utf-8")
+    record = {
+        "ref": ref,
+        "artifacts": [{
+            "artifactType": "jinn.trace-envelope.v0",
+            "sha256": hashlib.sha256(content).hexdigest(),
+            "contentBase64": base64.b64encode(content).decode("ascii"),
+        }],
+    }
+
+    def runner(argv):
+        if argv[1] == "corpus" and argv[2] == "get":
+            return 0, json.dumps(record)
+        return 1, f"unexpected: {argv}"
+
     jinn._runner = runner
     try:
-        out = jinn._tool_corpus_fetch({"ref": REF}, session_id="s1")
+        out = jinn._tool_corpus_fetch({"ref": ref}, session_id="s1")
     finally:
         jinn._runner = None
     assert "[user-accepted]" in out
     assert "Red, green, refactor." in out
-    assert jinn._state_for("s1")["activity"]["fetchedRefs"] == [REF]
+    assert jinn._state_for("s1")["activity"]["fetchedRefs"] == [ref]

--- a/apps/jinn-agent/tests/plugins/test_jinn_plugin.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_plugin.py
@@ -47,9 +47,8 @@ class RunnerSpy:
                 "eligibility": eligibility,
                 "summary": {
                     "episodeRef": episode_id,
-                    "surfacedHits": [],
-                    "fetchedHits": [],
-                    "installedSkillRefs": [],
+                    "searchedTerms": [],
+                    "providedPackets": [],
                     "eligibility": eligibility,
                     "nothingFound": True,
                 },
@@ -330,8 +329,9 @@ def test_session_end_without_corpus_result_prints_complete_summary(isolated_home
 # ── Consent flow ─────────────────────────────────────────────────────────────
 
 def test_consent_flow_bare_enter_defaults_to_decline(isolated_home):
-    # explainer -> decline confirm -> node stub skip
-    answers = iter(["", "y", ""])
+    # explainer -> decline confirm. The single sharing question — no second,
+    # unrelated question follows it.
+    answers = iter(["", "y"])
     printed: list[str] = []
     share = consent.run_consent_flow(lambda _: next(answers), printed.append)
     assert share is False
@@ -339,8 +339,8 @@ def test_consent_flow_bare_enter_defaults_to_decline(isolated_home):
 
 
 def test_consent_flow_accept_requires_deliberate_confirm(isolated_home):
-    # accept -> back out -> accept -> confirm -> skip stub
-    answers = iter(["a", "n", "a", "y", ""])
+    # accept -> back out -> accept -> confirm
+    answers = iter(["a", "n", "a", "y"])
     printed: list[str] = []
     share = consent.run_consent_flow(lambda _: next(answers), printed.append)
     assert share is True

--- a/apps/jinn-agent/tests/plugins/test_jinn_session_end_delegate.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_session_end_delegate.py
@@ -35,9 +35,8 @@ def _response(
         },
         "summary": {
             "episodeRef": "episode-1",
-            "surfacedHits": [],
-            "fetchedHits": [],
-            "installedSkillRefs": [],
+            "searchedTerms": [],
+            "providedPackets": [],
             "eligibility": {
                 "eligible": True,
                 "reason": "accepted diff",
@@ -134,9 +133,10 @@ def test_delegate_posts_the_complete_episode_activity_eligibility_and_candidate(
     result = jinn._delegate_session_end(
         episode,
         activity={
+            "searchedTerms": ["dashboard", "vitest"],
+            "providedRefs": ["ref-a"],
             "surfacedRefs": ["ref-a"],
             "fetchedRefs": ["ref-a"],
-            "installedSkillRefs": [],
         },
         eligibility_inputs={"acceptedDiff": True},
         contribution_candidate=candidate,
@@ -149,9 +149,10 @@ def test_delegate_posts_the_complete_episode_activity_eligibility_and_candidate(
         "contractVersion": 1,
         "episode": episode,
         "activity": {
+            "searchedTerms": ["dashboard", "vitest"],
+            "providedRefs": ["ref-a"],
             "surfacedRefs": ["ref-a"],
             "fetchedRefs": ["ref-a"],
-            "installedSkillRefs": [],
         },
         "eligibilityInputs": {"acceptedDiff": True},
         "contributionCandidate": candidate,

--- a/apps/jinn-agent/tests/plugins/test_jinn_session_view.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_session_view.py
@@ -1,4 +1,4 @@
-"""Current-session and session-completion product legibility."""
+"""Current-session and session-completion product legibility (searched → provided)."""
 
 from __future__ import annotations
 
@@ -29,19 +29,18 @@ def reset(tmp_path, monkeypatch):
     jinn._reset_session_state()
 
 
-def test_current_session_renders_all_stage_1_state():
+def test_current_session_renders_searched_and_provided():
     out = _plain(session_view.render_current(
         activity={
-            "surfacedRefs": ["knowledge/ref-a", "knowledge/ref-b"],
-            "fetchedRefs": ["knowledge/ref-a"],
-            "installedSkillRefs": ["knowledge/ref-a"],
+            "searchedTerms": ["dashboard", "vitest"],
+            "providedRefs": ["knowledge/ref-a"],
         },
         capture_active=True,
         share_enabled=False,
     ))
 
     assert "Jinn session" in out
-    assert "2 surfaced · 1 fetched · 1 installed" in out
+    assert "knowledge searched dashboard, vitest · provided 1 (knowledge/ref-a)" in out
     assert "capture active" in out
     assert "eligibility pending until session end" in out
     assert "contribution pending until session end · publication OFF" in out
@@ -50,7 +49,7 @@ def test_current_session_renders_all_stage_1_state():
 
 def test_current_session_nothing_found_yet_is_explicit():
     out = _plain(session_view.render_current(
-        activity={"surfacedRefs": [], "fetchedRefs": [], "installedSkillRefs": []},
+        activity={"searchedTerms": [], "providedRefs": []},
         capture_active=False,
         share_enabled=True,
     ))
@@ -58,51 +57,46 @@ def test_current_session_nothing_found_yet_is_explicit():
     assert "capture waiting for ordinary work" in out
 
 
-def test_current_session_does_not_call_directly_fetched_knowledge_nothing():
+def test_current_session_searched_but_nothing_provided_is_the_honest_line():
     out = _plain(session_view.render_current(
-        activity={
-            "surfacedRefs": [],
-            "fetchedRefs": ["knowledge/direct-ref"],
-            "installedSkillRefs": [],
-        },
+        activity={"searchedTerms": ["quasar", "unobtainium"], "providedRefs": []},
         capture_active=True,
         share_enabled=False,
     ))
-    assert "0 surfaced · 1 fetched · 0 installed" in out
-    assert "nothing relevant found" not in out
+    assert "knowledge searched · nothing relevant found" in out
+    # The honest nothing-found line never lists terms (rescope §3.4).
+    assert "quasar" not in out
 
 
 def test_session_end_renders_nothing_found_capture_learning_and_contribution():
     out = _plain(session_view.render_complete(
         summary={
-            "surfacedRefs": [],
-            "fetchedRefs": [],
-            "installedSkillRefs": [],
+            "searchedTerms": ["quasar"],
+            "providedPackets": [],
             "nothingFound": True,
             "eligibility": {
                 "eligible": True,
                 "reason": "accepted diff on a public repository",
             },
         },
-        activity={"surfacedRefs": [], "fetchedRefs": [], "installedSkillRefs": []},
+        activity={"searchedTerms": ["quasar"], "providedRefs": []},
         capture_status="captured",
         local_learning_status="pending",
         contribution={"status": "ok", "value": {"status": "recorded"}},
     ))
     assert "Jinn session complete" in out
-    assert "nothing relevant found" in out
+    assert "knowledge searched · nothing relevant found" in out
     assert "episode captured" in out
     assert "local learning pending" in out
     assert "eligibility eligible — accepted diff on a public repository" in out
     assert "contribution recorded" in out
 
 
-def test_session_end_renders_relevant_knowledge_and_used_refs():
+def test_session_end_renders_relevant_knowledge_and_provided_refs():
     out = _plain(session_view.render_complete(
         summary={
-            "surfacedRefs": ["knowledge/ref-a", "knowledge/ref-b"],
-            "fetchedRefs": ["knowledge/ref-a"],
-            "installedSkillRefs": ["knowledge/ref-a"],
+            "searchedTerms": ["dashboard", "vitest", "flake"],
+            "providedPackets": [{"ref": "bafySourceEpisode", "title": "Fix the dashboard flake"}],
             "nothingFound": False,
             "eligibility": {"eligible": False, "reason": "no accepted diff"},
         },
@@ -111,9 +105,7 @@ def test_session_end_renders_relevant_knowledge_and_used_refs():
         local_learning_status="pending",
         contribution={"status": "ok", "value": {"status": "queued"}},
     ))
-    assert "2 surfaced · 1 fetched · 1 installed" in out
-    assert "surfaced knowledge/ref-a, knowledge/ref-b" in out
-    assert "used knowledge/ref-a" in out
+    assert "knowledge searched dashboard, vitest, flake · provided 1 (bafySourceEpisode)" in out
     assert "contribution queued" in out
 
 
@@ -132,12 +124,28 @@ def test_session_end_distinguishes_no_candidate_from_unavailable_pipeline():
     assert "contribution no reusable public-task candidate" in out
 
 
+def test_session_end_falls_back_to_activity_when_summary_is_absent():
+    # The process-bridge-degraded fallback path (__init__.py) builds a
+    # synthetic summary from the local activity dict — render_complete must
+    # honor it the same way it honors a real core summary.
+    out = _plain(session_view.render_complete(
+        summary=None,
+        activity={"searchedTerms": ["dashboard"], "providedRefs": ["bafySourceEpisode"]},
+        capture_status="captured-locally",
+        local_learning_status="pending",
+        contribution=None,
+        candidate_created=True,
+    ))
+    assert "knowledge searched dashboard · provided 1 (bafySourceEpisode)" in out
+
+
 def test_jinn_session_reads_the_live_buffer_and_activity(monkeypatch):
     state = jinn._state_for("s1")
     state["activity"] = {
-        "surfacedRefs": ["knowledge/ref-a"],
-        "fetchedRefs": ["knowledge/ref-a"],
-        "installedSkillRefs": [],
+        "searchedTerms": ["dashboard"],
+        "providedRefs": ["knowledge/ref-a"],
+        "surfacedRefs": [],
+        "fetchedRefs": [],
     }
     buf.record_first_turn("t1", "s1", "fix retry", "model", "cli")
     buf.record_user_turn("t1", "s1", "fix retry")
@@ -146,5 +154,28 @@ def test_jinn_session_reads_the_live_buffer_and_activity(monkeypatch):
     out = _plain(jinn._handle_jinn(
         command_args="session", session_id="s1", task_id="t1"
     ))
-    assert "1 surfaced · 1 fetched · 0 installed" in out
+    assert "knowledge searched dashboard · provided 1 (knowledge/ref-a)" in out
     assert "capture active" in out
+
+
+def test_boundary_no_installed_skill_state_anywhere_in_session_rendering():
+    complete = _plain(session_view.render_complete(
+        summary={
+            "searchedTerms": ["dashboard"],
+            "providedPackets": [{"ref": "bafyRef1", "title": "x"}],
+            "nothingFound": False,
+            "eligibility": {"eligible": True, "reason": "ok"},
+        },
+        activity={},
+        capture_status="captured",
+        local_learning_status="pending",
+        contribution={"status": "ok", "value": {"status": "recorded"}},
+    ))
+    current = _plain(session_view.render_current(
+        activity={"searchedTerms": ["dashboard"], "providedRefs": ["bafyRef1"]},
+        capture_active=True,
+        share_enabled=True,
+    ))
+    for out in (complete, current):
+        assert "installed" not in out.lower()
+        assert "skill" not in out.lower()

--- a/apps/jinn-agent/tests/plugins/test_jinn_skills_install.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_skills_install.py
@@ -1,11 +1,19 @@
-"""/jinn skills install — shells to the layer (mono #1345, thin-fork boundary).
+"""skills_install module — shells to the layer (mono #1345, thin-fork boundary).
 
 The acceptance criteria: install() no longer parses envelopes or verifies
 hashes itself — it shells to `jinn-layer skills install <ref> --json`, which
 does the extraction + sha256 verification + SKILL.md write, and only drops
-the `.jinn-ref` marker into the dir the layer reports back. Declined consent
-does NOT block install (consuming is always allowed — consent gates
-contributing only); uninstall never touches skills the user made themselves.
+the `.jinn-ref` marker into the dir the layer reports back; uninstall never
+touches skills the user made themselves.
+
+The module is retained as a quarantined Stage-3 surface (rescope plan §2):
+the `/jinn skills install|list|uninstall` command branch that used to call
+these functions is removed (Stage 1 rescope R3; skills are Stage 3), and
+pickup's own auto-adopt path (which also called `install()`) is gone with
+it. `skills_dir()`/`_extract_trace()`/`_skill_md_and_slug()` stay live,
+consumed by `/jinn distill`'s staging dir and the `corpus_fetch` agent tool.
+These tests cover the module's own functions directly, independent of any
+command surface.
 """
 
 from __future__ import annotations
@@ -17,7 +25,6 @@ from pathlib import Path
 import pytest
 
 jinn = importlib.import_module("plugins.jinn")
-consent = importlib.import_module("plugins.jinn.consent")
 skills_install = importlib.import_module("plugins.jinn.skills_install")
 
 REF = "bafySeedTdd"
@@ -67,30 +74,6 @@ def test_install_raises_on_unreadable_result(tmp_path):
 
     with pytest.raises(ValueError, match="unreadable skills install result"):
         skills_install.install(REF, runner=fake_runner)
-
-
-def test_declined_consent_does_not_block_install(tmp_path):
-    # Consuming is always allowed — consent gates contributing only.
-    consent.save_state(False)
-    skills_root = tmp_path / "skills"
-
-    def fake_runner(argv):
-        target = skills_root / "test-driven-development"
-        target.mkdir(parents=True)
-        (target / "SKILL.md").write_text("# TDD\n")
-        return 0, json.dumps({"dir": str(target), "name": "test-driven-development",
-                              "shape": "package", "files": [], "provenance": {}})
-
-    jinn._runner = fake_runner
-    try:
-        out = jinn._handle_jinn(
-            command_args=f"skills install {REF}", session_id="session-1"
-        )
-    finally:
-        jinn._runner = None
-    assert "installed" in out
-    assert (tmp_path / "skills" / "test-driven-development" / "SKILL.md").exists()
-    assert jinn._state_for("session-1")["activity"]["installedSkillRefs"] == [REF]
 
 
 def test_uninstall_refuses_unmarked(tmp_path, monkeypatch):

--- a/client/packages/harness-layer/src/adapters/corpus-adapter.ts
+++ b/client/packages/harness-layer/src/adapters/corpus-adapter.ts
@@ -18,7 +18,7 @@ import {
   type HarnessLayer,
   type HarnessLayerConfig,
 } from '../consume.js';
-import { parseTraceEnvelopeV0 } from '../envelope.js';
+import { parseTraceEnvelopeV0, type TraceStep } from '../envelope.js';
 import { TRACE_ENVELOPE_ARTIFACT_TYPE } from '../publish.js';
 
 export interface CorpusAdapterDeps {
@@ -50,6 +50,21 @@ function toKnowledgeHit(hit: CorpusSearchHit): KnowledgeHit {
 }
 
 /**
+ * The evidence-episode seed lane (`seed-import/episode-execute.ts`) authors a
+ * synthesis longer than `outcome.summary`'s 500-char cap allows, so it carries
+ * the text on a step attribute (`seed.synthesis`, on the final `seed:synthesis`
+ * step) instead. Fall back to it only when the envelope's own `outcome.summary`
+ * is absent — a real capture's synthesis, when present, always wins.
+ */
+function seedStepSynthesis(steps: readonly TraceStep[]): string | undefined {
+  for (const step of steps) {
+    const value = step.attributes['seed.synthesis'];
+    if (typeof value === 'string' && value.trim().length > 0) return value;
+  }
+  return undefined;
+}
+
+/**
  * Decode the record's `jinn.trace-envelope.v0` artifact into the plugin's
  * content-bearing `CorpusRecord`. Verifies the artifact bytes against the
  * record's own sha256 before parsing — a mismatch refuses to serve
@@ -74,12 +89,13 @@ function decodeRecord(record: WireCorpusRecord): CorpusRecord | null {
   // Packet attribution is display-only, so safeAddress remains an acceptable
   // fallback here after trustworthy agentId; it is never used for hit dedup.
   const origin = record.provenance.operator.agentId || record.provenance.operator.safeAddress || record.ref;
+  const synthesis = envelope.outcome.summary ?? seedStepSynthesis(envelope.steps);
 
   return {
     ref: record.ref,
     task: { summary: envelope.task.summary },
     outcome: { status: envelope.outcome.status, verifiabilityTier: envelope.outcome.verifiabilityTier },
-    ...(envelope.outcome.summary ? { synthesis: envelope.outcome.summary } : {}),
+    ...(synthesis ? { synthesis } : {}),
     steps: envelope.steps.map((step) => ({ name: step.name, attributes: step.attributes })),
     tags: envelope.task.distributionTags,
     provenance: envelope.provenance,

--- a/client/packages/harness-layer/test/adapters/corpus-adapter.test.ts
+++ b/client/packages/harness-layer/test/adapters/corpus-adapter.test.ts
@@ -215,6 +215,71 @@ describe('CorpusAdapter.get() — content-bearing decode (rescope R2, #1772)', (
     expect(result.value).toBeNull();
   });
 
+  it('falls back to a seed-authored synthesis step when outcome.summary is absent (rescope R4 seed lane)', async () => {
+    // The evidence-episode seed lane (seed-import/episode-execute.ts) authors
+    // synthesis longer than outcome.summary's 500-char cap allows, so it
+    // carries the text on a `seed.synthesis` step attribute instead.
+    const layer = makeFakeLayer();
+    const wireRecord = wireRecordWithTrace({
+      outcome: { status: 'completed', verifiabilityTier: 'tests-passed' },
+      steps: [
+        {
+          spanId: 's1',
+          parentSpanId: null,
+          name: 'seed:step:failure',
+          startTimeUnixNano: '1000000000',
+          endTimeUnixNano: '1000000000',
+          attributes: { 'seed.step.label': 'failure', 'seed.step.title': 't', 'seed.step.text': 'FAIL' },
+          redactedKeys: [],
+        },
+        {
+          spanId: 's2',
+          parentSpanId: null,
+          name: 'seed:synthesis',
+          startTimeUnixNano: '2000000000',
+          endTimeUnixNano: '2000000000',
+          attributes: {
+            'seed.synthesis': 'A synthesis longer than the 500-char outcome.summary cap would allow.',
+            'seed.attribution': { repo: 'acme/widget', origin: 'operator-recorded-session' },
+          },
+          redactedKeys: [],
+        },
+      ],
+    });
+    layer.corpus.get = async () => wireRecord;
+    const adapter = createCorpusAdapter({ layer });
+
+    const result = await adapter.get('bafySourceEpisode');
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok' || result.value === null) throw new Error('expected a decoded record');
+    expect(result.value.synthesis).toBe('A synthesis longer than the 500-char outcome.summary cap would allow.');
+  });
+
+  it('prefers outcome.summary over a seed-authored synthesis step when both are present', async () => {
+    const layer = makeFakeLayer();
+    const wireRecord = wireRecordWithTrace({
+      outcome: { status: 'completed', verifiabilityTier: 'tests-passed', summary: 'the real capture synthesis' },
+      steps: [
+        {
+          spanId: 's1',
+          parentSpanId: null,
+          name: 'seed:synthesis',
+          startTimeUnixNano: '1000000000',
+          endTimeUnixNano: '1000000000',
+          attributes: { 'seed.synthesis': 'a seed synthesis that must not win' },
+          redactedKeys: [],
+        },
+      ],
+    });
+    layer.corpus.get = async () => wireRecord;
+    const adapter = createCorpusAdapter({ layer });
+
+    const result = await adapter.get('bafySourceEpisode');
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok' || result.value === null) throw new Error('expected a decoded record');
+    expect(result.value.synthesis).toBe('the real capture synthesis');
+  });
+
   it('returns ok(null) for a record carrying no trace-envelope artifact (e.g. a skill-only record)', async () => {
     const layer = makeFakeLayer();
     const wireRecord = wireRecordWithTrace();

--- a/client/packages/harness-layer/test/process-contract.test.ts
+++ b/client/packages/harness-layer/test/process-contract.test.ts
@@ -434,9 +434,12 @@ describe('jinn-layer process contract v1', () => {
             },
           },
           summary: {
-            surfacedRefs: ['knowledge/ref-1'],
-            fetchedRefs: ['knowledge/ref-1'],
-            nothingFound: false,
+            // The request's activity carries only the pre-rescope legacy
+            // fields (no searchedTerms/providedRefs) — the summary honestly
+            // reports nothing provided in the new-shape sense (rescope §3.6).
+            searchedTerms: [],
+            providedPackets: [],
+            nothingFound: true,
           },
         },
       });

--- a/client/scripts/stage1-task-creator-acceptance.mjs
+++ b/client/scripts/stage1-task-creator-acceptance.mjs
@@ -176,8 +176,18 @@ try {
   assert.equal(shareOn.publicationState, 'queued');
   assert.equal(shareOff.candidate.sourceId, result.shareOffRecordId);
   assert.equal(shareOn.candidate.sourceId, result.shareOnRecordId);
-  const shareOnSession = result.sessions.find((row) => row.sessionId === 'stage1-share-on');
-  assert.ok(shareOnSession);
+  // The Python driver declares which of its sessions carried each candidate
+  // (shareOn/shareOffSessionId) — look the sessions up by that declared id,
+  // then verify the store linkage independently via episodeId. Selecting by
+  // episodeId instead would make the linkage assertion tautological.
+  const shareOffSession = result.sessions.find(
+    (row) => row.sessionId === result.shareOffSessionId,
+  );
+  const shareOnSession = result.sessions.find(
+    (row) => row.sessionId === result.shareOnSessionId,
+  );
+  assert.ok(shareOffSession && shareOnSession);
+  assert.equal(shareOff.candidate.sourceId, shareOffSession.episodeId);
   assert.equal(shareOn.candidate.sourceId, shareOnSession.episodeId);
 
   // With no publication sidecar, both records still mint locally and nothing

--- a/packages/plugin/src/plugin.ts
+++ b/packages/plugin/src/plugin.ts
@@ -179,13 +179,10 @@ export interface CompleteSessionInput {
 }
 
 interface CompletionSummaryHits {
-  surfacedHits: KnowledgeHit[];
-  fetchedHits: KnowledgeHit[];
   /** The packets actually provided to the agent this session, when the
    *  caller drove pickup through `PluginSession` (embedded-host path). Absent
    *  (defaults to `[]`) for process-delegated `session end` calls, which
-   *  never round-trip packets through this in-process value — same as
-   *  `surfacedHits`/`fetchedHits` today. */
+   *  never round-trip packets through this in-process value. */
   providedPackets: KnowledgePacket[];
 }
 
@@ -201,7 +198,7 @@ function packetTitle(packet: KnowledgePacket): { ref: string; title: string } {
 async function completeSession(
   deps: JinnPluginDeps,
   input: CompleteSessionInput,
-  hits: CompletionSummaryHits = { surfacedHits: [], fetchedHits: [], providedPackets: [] },
+  hits: CompletionSummaryHits = { providedPackets: [] },
 ): Promise<SessionEndResult> {
   if (input.contractVersion !== JINN_PLUGIN_CONTRACT_VERSION) {
     throw new Error(`unsupported plugin contract version: ${String(input.contractVersion)}`);
@@ -290,21 +287,8 @@ async function completeSession(
     episodeRef: episode.episodeId,
     searchedTerms: activity.searchedTerms,
     providedPackets,
-    // Transitional legacy fields (rescope §3.6): retained through this PR;
-    // R3+R5 remove them when the host and acceptance gate flip. A new-shape
-    // activity (providedRefs populated) wins; a pre-rescope caller's own
-    // surfacedRefs echoes through unchanged until then.
-    surfacedRefs: activity.providedRefs.length > 0 ? activity.providedRefs : activity.surfacedRefs,
-    fetchedRefs: activity.fetchedRefs,
-    surfacedHits: hits.surfacedHits,
-    fetchedHits: hits.fetchedHits,
-    installedSkillRefs: [],
     eligibility,
-    nothingFound:
-      activity.providedRefs.length === 0
-      && activity.surfacedRefs.length === 0
-      && activity.fetchedRefs.length === 0
-      && activity.installedSkillRefs.length === 0,
+    nothingFound: activity.providedRefs.length === 0,
   };
 
   return {
@@ -322,9 +306,6 @@ export class PluginSession {
   private providedRefs: string[] = [];
   private fetchedRefs: string[] = [];
   private packets: KnowledgePacket[] = [];
-  /** The selected hits behind `packets` — kept only to populate the legacy
-   *  `SessionSummary.surfacedHits`/`fetchedHits` fields (rescope §3.6). */
-  private selectedHits: KnowledgeHit[] = [];
   private readonly capturedAt = new Date().toISOString();
 
   constructor(
@@ -386,7 +367,6 @@ export class PluginSession {
     this.fetchedRefs = fetchedRefs;
     this.providedRefs = packets.map((packet) => packet.ref);
     this.packets = packets;
-    this.selectedHits = selected;
 
     if (packets.length === 0) {
       return {
@@ -478,11 +458,7 @@ export class PluginSession {
           acceptedDiff: outcome.acceptedDiff,
         },
       },
-      {
-        surfacedHits: this.selectedHits,
-        fetchedHits: this.selectedHits,
-        providedPackets: this.packets,
-      },
+      { providedPackets: this.packets },
     );
   }
 }

--- a/packages/plugin/src/schemas/knowledge-packet.ts
+++ b/packages/plugin/src/schemas/knowledge-packet.ts
@@ -85,15 +85,45 @@ function stepNote(step: CorpusRecordStep): string | undefined {
   return attrString(step.attributes, 'note') ?? attrString(step.attributes, 'turn.text');
 }
 
+const EXCERPT_LABELS = new Set<KnowledgePacketExcerpt['label']>([
+  'failure', 'fix', 'command', 'diff', 'note',
+]);
+
 /**
- * Deterministic excerpt selection over a record's steps, in step order:
- * the first failing command with its output, the next command after it that
- * is not itself a failure (the correction), the last passing command overall
- * (the final backstop), and a diff step when present. Falls back to a single
- * free-form note when nothing command-shaped is found. Selects only — never
- * paraphrases.
+ * Seed-authored evidence (`client/packages/harness-layer/src/seed-import/
+ * episode-execute.ts`) carries its own excerpt directly on the step —
+ * `seed.step.label` (one of this schema's five excerpt labels) and
+ * `seed.step.text` (the excerpt content, already selected by the seed
+ * author offline) — rather than the `tool.args`/`tool.exitCode` real-capture
+ * convention `stepCommand`/`stepExitCode` read. Trust it verbatim: the
+ * heuristic below exists to *infer* an excerpt from a raw trajectory; a seed
+ * step has already done that inference by hand, so re-deriving it from a
+ * synthetic exit code would only risk corrupting what the seed author wrote.
+ */
+function seedStepExcerpt(step: CorpusRecordStep): ExcerptCandidate | undefined {
+  const label = step.attributes['seed.step.label'];
+  const text = attrString(step.attributes, 'seed.step.text');
+  if (typeof label !== 'string' || text === undefined) return undefined;
+  return EXCERPT_LABELS.has(label as KnowledgePacketExcerpt['label'])
+    ? { label: label as KnowledgePacketExcerpt['label'], text }
+    : undefined;
+}
+
+/**
+ * Deterministic excerpt selection over a record's steps, in step order.
+ * Seed-authored steps (see `seedStepExcerpt`) are trusted verbatim, in step
+ * order, when present. Otherwise: the first failing command with its
+ * output, the next command after it that is not itself a failure (the
+ * correction), the last passing command overall (the final backstop), and a
+ * diff step when present. Falls back to a single free-form note when
+ * nothing command-shaped is found. Selects only — never paraphrases.
  */
 function selectExcerpts(steps: CorpusRecordStep[]): ExcerptCandidate[] {
+  const seedExcerpts = steps
+    .map(seedStepExcerpt)
+    .filter((candidate): candidate is ExcerptCandidate => candidate !== undefined);
+  if (seedExcerpts.length > 0) return seedExcerpts;
+
   const excerpts: ExcerptCandidate[] = [];
 
   let failureIndex = -1;

--- a/packages/plugin/src/schemas/pickup-config.ts
+++ b/packages/plugin/src/schemas/pickup-config.ts
@@ -8,10 +8,17 @@ export type Tier = (typeof TIER_ORDER)[number];
 
 export const PickupConfigSchema = z.strictObject({
   enabled: z.boolean().default(true),
-  /** @deprecated Legacy host compatibility only. Pickup does not read either
-   *  auto-adopt field; R3+R5 remove them when the host and acceptance gate flip. */
+  /** @deprecated Legacy host compatibility only — a pre-rescope `pickup.json`
+   *  may still send this; evidence-first pickup (rescope §3.3) never reads
+   *  it. Auto-adopt and skill classification were removed from the pickup
+   *  path entirely by R1/R3 (skills are excluded from selection outright,
+   *  not gated by a threshold), so there is no adopt decision left for a
+   *  tier to threshold. */
   autoAdopt: z.boolean().default(false),
+  /** @deprecated Legacy host compatibility only — same as `autoAdopt`. */
   autoAdoptTier: z.enum(TIER_ORDER).default('evaluator-verified'),
+  /** @deprecated Legacy host compatibility only — selection has a fixed cap
+   *  (`MAX_SELECTED_PACKETS` in `pickup.ts`), not an operator-configurable one. */
   maxCandidates: z.number().int().positive().default(3),
 });
 

--- a/packages/plugin/src/schemas/session-summary.ts
+++ b/packages/plugin/src/schemas/session-summary.ts
@@ -1,28 +1,20 @@
 /** Assembled at session end() (product design §4.2 legibility requirement — "when Jinn found nothing, it says so"). */
 import { z } from 'zod';
 import { EligibilityVerdictSchema } from './eligibility-verdict.js';
-import { KnowledgeHitSchema } from './knowledge-hit.js';
 
 export const SessionSummarySchema = z.strictObject({
   episodeRef: z.string().min(1),
-  /** Evidence-first pickup facts (rescope §3.6). */
+  /** Evidence-first pickup facts (rescope §3.6) — the only knowledge-activity
+   *  shape a session summary carries. The pre-rescope `surfacedRefs`/
+   *  `fetchedRefs`/`surfacedHits`/`fetchedHits`/`installedSkillRefs` quintet
+   *  is dropped as of R3+R5 (the host and acceptance gate that consumed it
+   *  have flipped); `Episode.activity` still accepts those fields on read for
+   *  old episode files (rescope §3.6), but no summary emits them again. */
   searchedTerms: z.array(z.string().min(1)).default([]),
   providedPackets: z.array(z.strictObject({
     ref: z.string().min(1),
     title: z.string().min(1),
   })).default([]),
-  /** @deprecated Transitional rescope compatibility — retained through this
-   *  PR for downstream harness-layer/CLI/Python renderers. R3+R5 remove these
-   *  fields when the host and acceptance gate flip to searchedTerms/
-   *  providedPackets. Populated from providedPackets when present, else echoes
-   *  whatever legacy refs a pre-rescope caller submitted. */
-  surfacedRefs: z.array(z.string().min(1)).default([]),
-  /** @deprecated rescope */
-  fetchedRefs: z.array(z.string().min(1)).default([]),
-  surfacedHits: z.array(KnowledgeHitSchema),
-  fetchedHits: z.array(KnowledgeHitSchema),
-  /** @deprecated rescope — always empty; the skill adopt/install path no longer exists. */
-  installedSkillRefs: z.array(z.string().min(1)),
   eligibility: EligibilityVerdictSchema,
   nothingFound: z.boolean(),
 });

--- a/packages/plugin/test/plugin/complete-session.test.ts
+++ b/packages/plugin/test/plugin/complete-session.test.ts
@@ -94,9 +94,6 @@ describe('JinnPlugin.completeSession()', () => {
         status: 'recorded',
       },
     });
-    expect(result.summary.surfacedRefs).toEqual(ACTIVITY.surfacedRefs);
-    expect(result.summary.fetchedRefs).toEqual(ACTIVITY.fetchedRefs);
-
     const stored = await evidence.get('episode-complete');
     expect(stored.status).toBe('ok');
     if (stored.status !== 'ok' || !stored.value) return;

--- a/packages/plugin/test/plugin/session-smoke.test.ts
+++ b/packages/plugin/test/plugin/session-smoke.test.ts
@@ -69,10 +69,6 @@ describe('createJinnPlugin session → end smoke (AC5)', () => {
     expect(result.summary.nothingFound).toBe(false);
     expect(result.summary.searchedTerms.length).toBeGreaterThan(0);
     expect(result.summary.providedPackets).toEqual([{ ref: 'seed-1', title: 'Fixing a flaky assertion in the debug harness' }]);
-    // Legacy fields stay populated for compatibility (rescope §3.6).
-    expect(result.summary.surfacedRefs).toEqual(['seed-1']);
-    expect(result.summary.fetchedRefs).toEqual(['seed-1']);
-    expect(result.summary.installedSkillRefs).toEqual([]);
 
     const stored = await evidence.get(result.episodeRef);
     expect(stored.status).toBe('ok');

--- a/packages/plugin/test/schemas/knowledge-packet.test.ts
+++ b/packages/plugin/test/schemas/knowledge-packet.test.ts
@@ -151,6 +151,46 @@ describe('projectKnowledgePacket (rescope §3.2)', () => {
     expect(packet.excerpts).toEqual([]);
   });
 
+  describe('seed-authored steps (rescope R4 — seed.step.label/text convention)', () => {
+    it('trusts a seed-authored excerpt verbatim, in step order, instead of the tool.* heuristic', () => {
+      const steps: CorpusRecordStep[] = [
+        step({ attributes: { 'seed.step.label': 'failure', 'seed.step.text': 'FAIL: expected true' } }),
+        step({ attributes: { 'seed.step.label': 'note', 'seed.step.text': 'diagnosis prose' } }),
+        step({ attributes: { 'seed.step.label': 'fix', 'seed.step.text': 'the correction, in prose' } }),
+        step({ attributes: { 'seed.step.label': 'diff', 'seed.step.text': '--- a/x\n+++ b/x' } }),
+        step({ attributes: { 'seed.step.label': 'command', 'seed.step.text': 'yarn test — passing' } }),
+      ];
+      const packet = projectKnowledgePacket(record({ steps }));
+      expect(packet.excerpts).toEqual([
+        { label: 'failure', text: 'FAIL: expected true' },
+        { label: 'note', text: 'diagnosis prose' },
+        { label: 'fix', text: 'the correction, in prose' },
+        { label: 'diff', text: '--- a/x\n+++ b/x' },
+        { label: 'command', text: 'yarn test — passing' },
+      ]);
+    });
+
+    it('ignores a seed step with an invalid label rather than crashing', () => {
+      const steps: CorpusRecordStep[] = [
+        step({ attributes: { 'seed.step.label': 'bogus', 'seed.step.text': 'x' } }),
+        step({ attributes: { 'tool.args': 'pytest', 'tool.exitCode': 1, 'tool.result': 'FAIL' } }),
+      ];
+      const packet = projectKnowledgePacket(record({ steps }));
+      // No valid seed-shaped step exists, so selection falls through to the
+      // tool.* heuristic rather than emitting an excerpt for the bogus label.
+      expect(packet.excerpts).toEqual([{ label: 'failure', text: 'pytest\nFAIL' }]);
+    });
+
+    it('never mixes seed-authored steps with the tool.* heuristic on the same record', () => {
+      const steps: CorpusRecordStep[] = [
+        step({ attributes: { 'seed.step.label': 'command', 'seed.step.text': 'the seed-authored command' } }),
+        step({ attributes: { 'tool.args': 'a real tool call', 'tool.exitCode': 0 } }),
+      ];
+      const packet = projectKnowledgePacket(record({ steps }));
+      expect(packet.excerpts).toEqual([{ label: 'command', text: 'the seed-authored command' }]);
+    });
+  });
+
   it('never paraphrases: excerpt text is a verbatim slice of the source attributes', () => {
     const verbatim = 'AssertionError: expected true to be false at line 42';
     const steps: CorpusRecordStep[] = [

--- a/packages/plugin/test/schemas/session-summary.test.ts
+++ b/packages/plugin/test/schemas/session-summary.test.ts
@@ -5,9 +5,6 @@ describe('SessionSummarySchema', () => {
   it('parses a nothing-found summary', () => {
     const parsed = SessionSummarySchema.parse({
       episodeRef: 'ep-1',
-      surfacedHits: [],
-      fetchedHits: [],
-      installedSkillRefs: [],
       eligibility: { eligible: false, reason: 'stage-1-stub', checkedAt: '2026-07-14T00:00:00.000Z' },
       nothingFound: true,
     });
@@ -22,28 +19,32 @@ describe('SessionSummarySchema', () => {
       episodeRef: 'ep-1',
       searchedTerms: ['dashboard', 'vitest'],
       providedPackets: [{ ref: 'bafyRef1', title: 'Fix the dashboard flake' }],
-      surfacedRefs: ['bafyRef1'],
-      fetchedRefs: ['bafyRef1'],
-      surfacedHits: [{ ref: 'bafyRef1', kind: 'trace' }],
-      fetchedHits: [{ ref: 'bafyRef1', kind: 'trace' }],
-      installedSkillRefs: [],
       eligibility: { eligible: false, reason: 'stage-1-stub', checkedAt: '2026-07-14T00:00:00.000Z' },
       nothingFound: false,
     });
     expect(parsed.searchedTerms).toEqual(['dashboard', 'vitest']);
     expect(parsed.providedPackets).toEqual([{ ref: 'bafyRef1', title: 'Fix the dashboard flake' }]);
-    expect(parsed.surfacedHits).toHaveLength(1);
   });
 
   it('rejects an unknown top-level field (strict)', () => {
     expect(() => SessionSummarySchema.parse({
       episodeRef: 'ep-1',
-      surfacedHits: [],
-      fetchedHits: [],
-      installedSkillRefs: [],
       eligibility: { eligible: false, reason: 'x', checkedAt: '2026-07-14T00:00:00.000Z' },
       nothingFound: true,
       knowledgeSurfaced: 0,
+    })).toThrow();
+  });
+
+  it('rejects the pre-rescope legacy fields (dropped by R3+R5)', () => {
+    expect(() => SessionSummarySchema.parse({
+      episodeRef: 'ep-1',
+      eligibility: { eligible: false, reason: 'x', checkedAt: '2026-07-14T00:00:00.000Z' },
+      nothingFound: true,
+      surfacedRefs: [],
+      fetchedRefs: [],
+      surfacedHits: [],
+      fetchedHits: [],
+      installedSkillRefs: [],
     })).toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Implements R3 and R5 of the [2026-07-16 Jinn Plugin Stage 1 rescope](https://github.com/Jinn-Network/mono/blob/claude/jinn-plugin-stage-1-rescope-315d0e/docs/superpowers/plans/2026-07-16-jinn-plugin-stage-1-rescope-plan.md) as one PR — the host flip (Python delegates pickup to the core) and the acceptance-gate rewrite must land atomically, since flipping the Python surfaces turns the blocking `cold-stock-e2e` gate red unless its assertions are rewritten in the same merge.

**R3 — host flip (`apps/jinn-agent`)**
- `pickup.py` is now a thin delegation to `jinn-layer session pickup`: builds the v1 request, renders the returned `contextBlock` verbatim, records `searchedTerms`/`providedRefs` into session activity, emits the `◇ corpus — provided N evidence packet(s) (searched: <terms>)` marker. All term-derivation/selection/skill-classification logic that used to live in Python is gone — implemented once, in `packages/plugin` (R1, PR #1780). A v1 response without `packets` (a stale layer) degrades to nothing rather than risk reintroducing the old suggestion/install shape.
- `jinn_layer.py` gains `session_pickup()`/`parse_session_pickup_response()` (the `session end` stdin-JSON pattern, applied to the sibling verb), with a tighter 15s timeout than the general 120s default.
- `__init__.py`: the `/jinn skills install|list|uninstall` command branch is removed outright (`skills_install.py` itself stays — `/jinn distill`'s staging path and `corpus_fetch`'s display path still use it). Session activity drops `installedSkillRefs`, gains `searchedTerms`/`providedRefs`.
- `session_view.py` + `history_view.py` render `searched → provided`.
- `onboarding.py` collapses to three steps (consent → publish → corpus signals) — the rewards step (OLAS-earning promises, `/jinn rewards` references) is removed outright, Stage 3 scope. `consent.py` drops the "run a network node" stub and the OLAS-earning line from the single sharing question.
- `plugin.yaml` declares `post_llm_call` (code already registered 5 hooks; the manifest listed 4).

Closes #1732.

**Carried findings from PR #1780's review** (comment on #1773) — verified each site directly: `packages/plugin`'s budget-overshoot fix, `foldExplain`/`SessionExplanation` searchedTerms migration, the `knowledge-hit.ts` citation, the tier-pinned skill-exclusion test, and the evidence-adapter filename tie-break were **already resolved** in the merged PR #1780 (verified by reading each site and confirming the existing/expected test coverage — no changes needed). Two were genuinely still open and are fixed here:
- Dropped the deprecated `SessionSummary` legacy fields (`surfacedRefs`/`fetchedRefs`/`surfacedHits`/`fetchedHits`/`installedSkillRefs`) now that the Python host (this PR) is the last consumer. `Episode.activity` keeps them for read-compat with old episode files.
- Extended the legacy-compat doc comment to `autoAdoptTier`/`maxCandidates` in `pickup-config.ts` (previously only `autoAdopt` carried it).

**Integration fix discovered while preparing R5**: the evidence-episode seed lane (PR #1779) writes `seed.step.label`/`seed.step.text` and a `seed.synthesis` step attribute, but `projectKnowledgePacket`'s excerpt selection and the corpus adapter's synthesis mapping only understood the `tool.args`/`tool.exitCode` real-capture convention and `outcome.summary`. A seeded evidence record therefore round-tripped through the real pipeline with **zero excerpts and no synthesis** — the R5 gate's core assertion (injected context contains real content) would have been unsatisfiable. Fixed: `selectExcerpts` now trusts seed-authored steps verbatim (the seed author already did the selection by hand); the corpus adapter falls back to a `seed.synthesis` step when `outcome.summary` is absent (the seed lane uses the step because `outcome.summary`'s 500-char cap can't hold a full synthesis). Verified end-to-end against the real built `jinn-layer.js` binary.

**R5 — acceptance gate rewrite (`apps/jinn-agent/scripts` + tests)**

`stage1-stock-product.py`'s `CorpusFixture` now serves the R4 curated seed set (`client/packages/harness-layer/fixtures/stage1-seeds/`, PR #1779) instead of one hand-written skill trace, built into the exact wire shape the real seed-import lane produces, so the real built `jinn-layer` performs search/get/packet-projection end to end — no plugin stubs. Scenarios per plan §4.5:

1. **Target-task session** — a realistic first message sharing the source fixture's vocabulary (dashboard/vitest/update_available/version-status) without quoting its sentences verbatim; the injection contains a distinctive source-episode excerpt string (`apiMocks.getStatus`, from the fix step — not a search term), the `source: <ref>` attribution, and the `corpus_fetch <ref>` pointer.
2. **Most-relevant wins** — the same injection omits both evidence distractors and both skill distractors.
3. **Honest no-result** — a message sharing no fixture vocabulary gets no injection; summary and `/jinn session` render the nothing-found line.
4. **Corpus 503** — session proceeds, degraded, no injection.
5. **Attribution visible** in `/jinn session` mid-task.
6. **Exactly one episode/candidate/history row** per session; the target episode's `activity.searchedTerms`/`providedRefs` are populated, every other episode's `providedRefs` is honestly empty.
7. **Sharing off** — only `/graphql` search traffic during the session, never a publish-shaped POST.

Boundary: no "skills install" text in any injection; the `/jinn skills` command branch falls through to the unknown-command help text outright; no shared-skill install/adopt copy in any summary/session/status/history rendering (local distillation's own retained "N installed" count and `distilledSkills` provenance rows are a different, explicitly-kept concept). Skill fixture refs never appear in any injection. Contribution/privacy/mint mechanics are unchanged in substance.

`test_jinn_stage1_acceptance_gate.py` and `.github/workflows/jinn-agent-ci.yml` needed **no changes** — neither pins any driver-internal string this PR touches (confirmed by running the static-pin test directly).

**This PR intentionally flips the gate's scenario set** — the pinned `cold-stock-e2e` job that exercised the pre-rescope skill journey now exercises the evidence-first journey described above. That's the point of R3+R5 landing together.

## Test plan

- [x] `cd packages/plugin && yarn install && yarn typecheck && yarn build && yarn test` — 167/167 tests, clean typecheck, clean build
- [x] `cd client && yarn install && yarn typecheck` — clean
- [x] `cd client && yarn vitest run packages/harness-layer/test/` — 736/736 tests
- [x] Python: `find tests/plugins -maxdepth 1 -name 'test_jinn_*.py' | xargs ./scripts/run_tests.sh` — 343/343 tests, 33/33 files, clean
- [x] Verified the full delegation path (Python `pickup.py` → real subprocess → real built `jinn-layer.js` → fixture HTTP server → real TS core) end-to-end via a standalone verification harness (not committed) covering: contract handshake, corpus search/get against the R4 seed set, and `session pickup` for the target-task, no-result, and corpus-unavailable scenarios — all round-trip correctly, including the seed-episode content fix.
- [ ] `cold-stock-e2e.sh` full run — needs network (pinned Hermes wheel install); left to CI per instructions. Reasoned through the driver end-to-end instead, including a real-binary verification harness covering everything the shell script's Python half exercises.

Closes #1773
Closes #1774
Closes #1732
Refs #1654

🤖 Generated with [Claude Code](https://claude.com/claude-code)