### PR TITLE
docs(runbooks): fix derive-env eval for Yarn Berry (no --silent flag)

### DIFF
--- a/docs/runbooks/stage1-evidence-seeding.md
+++ b/docs/runbooks/stage1-evidence-seeding.md
@@ -128,7 +128,7 @@ Publishing needs a live operator identity. Derive one from your local
 `~/.jinn-client` keystore and export it for this shell:
 
 ```bash
-eval "$(yarn --silent jinn-layer derive-env)"
+eval "$(yarn jinn-layer derive-env)"
 ```
 
 Then run the approved report:


### PR DESCRIPTION
One-line runbook correction found during the first live seeding run: Yarn 4's `run` has no `--silent` flag, so `eval "$(yarn --silent jinn-layer derive-env)"` dumps yarn's help into the eval buffer and fails (derive-env never executes — no secret exposure). The flagless form was verified live: it emits exactly the export lines, and the seeding run completed with it.

Review evidence: the corrected command is exactly what the successful 2026-07-16 seeding run used (receipts on #1654). Refs #1771.

🤖 Generated with [Claude Code](https://claude.com/claude-code)