### PR TITLE
fix(plugin): strip trailing punctuation from search terms; parse jinn-layer stdout only (R6 walkthrough defects)

### DIFF
--- a/apps/jinn-agent/hermes_cli/banner.py
+++ b/apps/jinn-agent/hermes_cli/banner.py
@@ -918,7 +918,7 @@ def _read_contribution_count() -> Optional[int]:
     """
     try:
         from plugins.jinn import jinn_layer, ledger_view
-        code, out = jinn_layer.ledger_json()
+        code, out, _err = jinn_layer.ledger_json()
         if code != 0:
             return None
         rows = ledger_view.rows_from_json(json.loads(out))
@@ -940,7 +940,7 @@ def _read_corpus() -> Dict[str, object]:
     """
     try:
         from plugins.jinn import jinn_layer
-        code, out = jinn_layer.corpus_search("", limit=500, as_json=True)
+        code, out, _err = jinn_layer.corpus_search("", limit=500, as_json=True)
         if code == 0:
             hits = json.loads(out)
             if isinstance(hits, list):

--- a/apps/jinn-agent/plugins/jinn/__init__.py
+++ b/apps/jinn-agent/plugins/jinn/__init__.py
@@ -84,7 +84,7 @@ def _check_contract() -> None:
             return
         _contract_checked = True
         try:
-            code, out = jinn_layer.contract(runner=_runner)
+            code, out, _err = jinn_layer.contract(runner=_runner)
         except Exception:
             _degraded = "jinn-layer handshake failed"
             return
@@ -387,7 +387,7 @@ def _delegate_session_end(
     if contribution_candidate is not None:
         request["contributionCandidate"] = contribution_candidate
     try:
-        code, out = jinn_layer.session_end(request, runner=_runner)
+        code, out, _err = jinn_layer.session_end(request, runner=_runner)
         if code != 0:
             return None
         envelope = jinn_layer.parse_session_end_response(out)
@@ -621,7 +621,7 @@ def _handle_jinn(command_args: str = "", session_id: str = "", task_id: str = ""
         if action == "decline":
             if not confirmed:
                 return consent.confirm_decline_command()
-            code, out = jinn_layer.contribution_disable(runner=_runner)
+            code, out, err = jinn_layer.contribution_disable(runner=_runner)
             # Let the core serialize revocation with any publication already
             # crossing its boundary. The direct marker is the fail-closed host
             # fallback and mirrors the successful core write for old stubs.
@@ -631,11 +631,11 @@ def _handle_jinn(command_args: str = "", session_id: str = "", task_id: str = ""
                 return message
             if marker_ok:
                 return message + "\nexisting publication queue is fail-closed locally; jinn-layer cleanup is degraded"
-            return message + f"\nwarning: could not disable the existing publication queue: {out}"
+            return message + f"\nwarning: could not disable the existing publication queue: {err or out}"
         return consent.render_explainer(consent.COMMANDS_LINE)
 
     if sub == "preview":
-        code, out = jinn_layer.contribution_preview(acknowledge=True, runner=_runner)
+        code, out, _err = jinn_layer.contribution_preview(acknowledge=True, runner=_runner)
         if code == 0:
             try:
                 reply = jinn_layer.parse_process_response(out)
@@ -662,11 +662,11 @@ def _handle_jinn(command_args: str = "", session_id: str = "", task_id: str = ""
             # an empty screen. Does not mark previewed — the real gate stays
             # on a real trace.
             return consent.render_preview_example()
-        code, out = jinn_layer.capture_preview(pending, runner=_runner)
+        code, out, err = jinn_layer.capture_preview(pending, runner=_runner)
         if code == 0:
             consent.mark_previewed()
             return out + "\n\nlegacy preview only — this retained file will not auto-publish."
-        return f"preview failed:\n{out}"
+        return f"preview failed:\n{err or out}"
 
     if sub == "session":
         state = _peek_state(session_id)
@@ -677,9 +677,9 @@ def _handle_jinn(command_args: str = "", session_id: str = "", task_id: str = ""
         )
 
     if sub == "history":
-        code, out = jinn_layer.history_json(runner=_runner)
+        code, out, err = jinn_layer.history_json(runner=_runner)
         if code != 0:
-            return f"history unavailable:\n{out}"
+            return f"history unavailable:\n{err or out}"
         try:
             reply = jinn_layer.parse_process_response(out)
         except ValueError as exc:
@@ -702,7 +702,7 @@ def _handle_jinn(command_args: str = "", session_id: str = "", task_id: str = ""
     if sub == "ledger":
         # Prefer canonical contribution-store rows. A layer that predates the
         # command falls back to the legacy publication-receipt ledger.
-        ccode, cout = jinn_layer.contribution_ledger_json(runner=_runner)
+        ccode, cout, _cerr = jinn_layer.contribution_ledger_json(runner=_runner)
         if ccode == 0:
             try:
                 reply = jinn_layer.parse_process_response(cout)
@@ -725,7 +725,7 @@ def _handle_jinn(command_args: str = "", session_id: str = "", task_id: str = ""
 
         # Prefer structured legacy rows (design 1b columns + tier chips +
         # exact empty state), then degrade to the layer's raw text.
-        jcode, jout = jinn_layer.ledger_json(runner=_runner)
+        jcode, jout, _jerr = jinn_layer.ledger_json(runner=_runner)
         if jcode == 0:
             try:
                 rows = ledger_view.rows_from_json(json.loads(jout))
@@ -733,8 +733,8 @@ def _handle_jinn(command_args: str = "", session_id: str = "", task_id: str = ""
                 rows = None
             if rows is not None:
                 return ledger_view.render_ledger(rows, enabled=consent.share_enabled())
-        code, out = jinn_layer.ledger(runner=_runner)
-        return out if code == 0 else f"ledger unavailable:\n{out}"
+        code, out, err = jinn_layer.ledger(runner=_runner)
+        return out if code == 0 else f"ledger unavailable:\n{err or out}"
 
     if sub == "distill":
         # Local distillation (mono #1538) — all logic + rendering in distill.py;
@@ -759,8 +759,8 @@ def _handle_corpus(command_args: str = "", **_: Any) -> str:
     query = (command_args or "").strip()
     if not query:
         return "usage: /corpus <query> — search the public corpus"
-    code, out = jinn_layer.corpus_search(query, runner=_runner)
-    return out if code == 0 else f"corpus search failed:\n{out}"
+    code, out, err = jinn_layer.corpus_search(query, runner=_runner)
+    return out if code == 0 else f"corpus search failed:\n{err or out}"
 
 
 # ── Agent tools — in-session corpus consumption ──────────────────────────────
@@ -788,9 +788,9 @@ def _tool_corpus_search(args: Dict[str, Any], **_kw: Any) -> str:
     if not query:
         return "corpus_search requires a query."
     limit = int(args.get("limit") or 5)
-    code, out = jinn_layer.run(["corpus", "search", query, "--json", "--limit", str(limit)], _runner)
+    code, out, err = jinn_layer.run(["corpus", "search", query, "--json", "--limit", str(limit)], _runner)
     if code != 0:
-        return f"corpus search unavailable: {out}"
+        return f"corpus search unavailable: {err or out}"
     try:
         hits = json.loads(out)
     except json.JSONDecodeError:
@@ -817,9 +817,9 @@ def _tool_corpus_fetch(args: Dict[str, Any], **_kw: Any) -> str:
     ref = str(args.get("ref") or "").strip()
     if not ref:
         return "corpus_fetch requires a ref."
-    code, out = jinn_layer.run(["corpus", "get", ref, "--json"], _runner)
+    code, out, err = jinn_layer.run(["corpus", "get", ref, "--json"], _runner)
     if code != 0:
-        return f"corpus get unavailable: {out}"
+        return f"corpus get unavailable: {err or out}"
     try:
         record = json.loads(out)
         trace, _sha = skills_install._extract_trace(record)

--- a/apps/jinn-agent/plugins/jinn/distill.py
+++ b/apps/jinn-agent/plugins/jinn/distill.py
@@ -89,7 +89,7 @@ def distill_status(runner: Optional[Runner] = None) -> Optional[Dict[str, Any]]:
     run — e2e finding).
     """
     try:
-        code, out = jinn_layer.run(
+        code, out, _err = jinn_layer.run(
             ["distill", "status", "--json", "--out", str(skills_install.skills_dir())], runner
         )
     except Exception:
@@ -672,9 +672,9 @@ def handle_command(parts: List[str], runner: Optional[Runner] = None) -> str:
                 # and this explicit two-step start IS that consent. Record it
                 # the same way the CLI flag does, or the spawned run would
                 # read the persisted mode and silently run nothing.
-                code, out = jinn_layer.run(["distill", "--where", "local", "--json"], runner)
+                code, out, err = jinn_layer.run(["distill", "--where", "local", "--json"], runner)
                 if code != 0:
-                    return out.strip() or UPDATE_LAYER_LINE
+                    return (err or out).strip() or UPDATE_LAYER_LINE
                 cached_mode(runner, refresh=True)
             ok, msg = start_run()
             return msg
@@ -695,11 +695,11 @@ def handle_command(parts: List[str], runner: Optional[Runner] = None) -> str:
         return stop_run()
 
     if action == "review":
-        code, out = jinn_layer.run(
+        code, out, err = jinn_layer.run(
             ["distill", "staged", "--json", "--out", str(skills_install.skills_dir())], runner
         )
         if code != 0:
-            return out.strip() or UPDATE_LAYER_LINE
+            return (err or out).strip() or UPDATE_LAYER_LINE
         try:
             staged = json.loads(out)
         except ValueError:
@@ -725,7 +725,7 @@ def handle_command(parts: List[str], runner: Optional[Runner] = None) -> str:
         skills_dir = skills_install.skills_dir()
         # Read the staged provenance FIRST — the install below clears the
         # staged copies, and the marker (payoff join, uninstall guard) needs it.
-        staged_code, staged_out = jinn_layer.run(
+        staged_code, staged_out, _staged_err = jinn_layer.run(
             ["distill", "staged", "--json", "--out", str(skills_dir)], runner
         )
         provenance_by_name: Dict[str, List[str]] = {}
@@ -736,11 +736,11 @@ def handle_command(parts: List[str], runner: Optional[Runner] = None) -> str:
             except ValueError:
                 pass
         selector = ["--all"] if target == "all" else [target]
-        code, out = jinn_layer.run(
+        code, out, err = jinn_layer.run(
             ["distill", "install", *selector, "--json", "--out", str(skills_dir)], runner
         )
         if code != 0:
-            return out.strip() or UPDATE_LAYER_LINE
+            return (err or out).strip() or UPDATE_LAYER_LINE
         try:
             result = json.loads(out)
         except ValueError:
@@ -804,9 +804,9 @@ def handle_command(parts: List[str], runner: Optional[Runner] = None) -> str:
         mode = parts[1] if len(parts) > 1 else ""
         if mode not in ("local", "defer", "off"):
             return "usage: /jinn distill where local|defer|off"
-        code, out = jinn_layer.run(["distill", "--where", mode, "--json"], runner)
+        code, out, err = jinn_layer.run(["distill", "--where", mode, "--json"], runner)
         if code != 0:
-            return out.strip() or UPDATE_LAYER_LINE
+            return (err or out).strip() or UPDATE_LAYER_LINE
         cached_mode(runner, refresh=True)
         behaviour = {
             "local": "runs happen here when you start them",

--- a/apps/jinn-agent/plugins/jinn/jinn_layer.py
+++ b/apps/jinn-agent/plugins/jinn/jinn_layer.py
@@ -21,6 +21,11 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
+# The injected/test-double contract: a mock has no real OS-level stdout vs
+# stderr split, so it returns one string. `_default_runner` (the real
+# subprocess wrapper, below) genuinely has both streams and returns a
+# 3-tuple; `run()`/`session_pickup()` normalize either shape to the 3-tuple
+# every caller now sees (mono #1787).
 Runner = Callable[..., Tuple[int, str]]
 
 _TIMEOUT_S = 120
@@ -32,7 +37,7 @@ def _default_runner(
     cwd: Optional[str] = None,
     input: Optional[str] = None,
     timeout_s: int = _TIMEOUT_S,
-) -> Tuple[int, str]:
+) -> Tuple[int, str, str]:
     try:
         proc = subprocess.run(
             argv,
@@ -43,23 +48,32 @@ def _default_runner(
             cwd=cwd,
             input=input,
         )
-        out = proc.stdout + (("\n" + proc.stderr) if proc.stderr.strip() else "")
-        return proc.returncode, out.strip()
+        return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
     except FileNotFoundError:
         # The jinn-layer bin ships on the canary tag until the next stable
         # release (>= 0.1.10) carries it — flip @canary back to bare
         # @jinn-network/client here and in README.md once that stable ships
         # (see Jinn-Network/mono#1368).
-        return 127, (
+        return 127, "", (
             f"{argv[0]}: not found. Install the Jinn layer "
             "(npm install -g @jinn-network/client@canary) or set JINN_LAYER_BIN."
         )
     except subprocess.TimeoutExpired:
-        return 124, f"{argv[0]}: timed out after {timeout_s}s"
+        return 124, "", f"{argv[0]}: timed out after {timeout_s}s"
 
 
 def binary() -> str:
     return (os.environ.get("JINN_LAYER_BIN") or "").strip() or "jinn-layer"
+
+
+def _normalize_result(result: Tuple[int, str] | Tuple[int, str, str]) -> Tuple[int, str, str]:
+    """A custom `Runner` returns `(code, out)`; `_default_runner` returns
+    `(code, stdout, stderr)`. Every caller of `run()`/`session_pickup()` sees
+    the 3-tuple regardless of which one produced it (mono #1787)."""
+    if len(result) == 3:
+        return result  # type: ignore[return-value]
+    code, out = result
+    return code, out, ""
 
 
 def run(
@@ -67,10 +81,11 @@ def run(
     runner: Optional[Runner] = None,
     cwd: Optional[str] = None,
     input: Optional[str] = None,
-) -> Tuple[int, str]:
+) -> Tuple[int, str, str]:
     argv = [binary(), *args]
     if runner is not None:
-        return runner(argv, input=input) if input is not None else runner(argv)
+        result = runner(argv, input=input) if input is not None else runner(argv)
+        return _normalize_result(result)
     return _default_runner(argv, cwd, input)
 
 
@@ -100,23 +115,26 @@ def spawn(args: List[str], stdout_path: Path, stderr_path: Path) -> int:
 
 
 # ── Verbs ────────────────────────────────────────────────────────────────────
+# Every verb below is a thin `run()` wrapper, so each now returns
+# `(code, stdout, stderr)` — no verb body changes, only the shared `run()`
+# they call through (mono #1787).
 
-def capture_preview(task_file: Path, runner: Optional[Runner] = None) -> Tuple[int, str]:
+def capture_preview(task_file: Path, runner: Optional[Runner] = None) -> Tuple[int, str, str]:
     return run(["capture", "preview", str(task_file)], runner)
 
 
-def publish(task_file: Path, veto: bool = False, runner: Optional[Runner] = None) -> Tuple[int, str]:
+def publish(task_file: Path, veto: bool = False, runner: Optional[Runner] = None) -> Tuple[int, str, str]:
     args = ["publish", str(task_file)]
     if veto:
         args.append("--veto")
     return run(args, runner)
 
 
-def ledger(runner: Optional[Runner] = None) -> Tuple[int, str]:
+def ledger(runner: Optional[Runner] = None) -> Tuple[int, str, str]:
     return run(["ledger"], runner)
 
 
-def ledger_json(runner: Optional[Runner] = None) -> Tuple[int, str]:
+def ledger_json(runner: Optional[Runner] = None) -> Tuple[int, str, str]:
     """Structured ledger rows for the fork-side renderer (ledger_view).
 
     Depends on ``jinn-layer ledger --json`` (harness-layer). When the layer
@@ -131,7 +149,7 @@ def corpus_search(
     limit: int = 500,
     as_json: bool = True,
     runner: Optional[Runner] = None,
-) -> Tuple[int, str]:
+) -> Tuple[int, str, str]:
     """Corpus search. The CLI owns clamping ([1,500]) and ``""`` = all records.
 
     ``as_json`` emits ``--json`` (harness-layer prints ``JSON.stringify(hits)``,
@@ -145,12 +163,12 @@ def corpus_search(
     return run(args, runner)
 
 
-def contract(runner: Optional[Runner] = None) -> Tuple[int, str]:
+def contract(runner: Optional[Runner] = None) -> Tuple[int, str, str]:
     """Read the layer's versioned host/process contract."""
     return run(["contract", "--json"], runner)
 
 
-def session_end(request: Dict[str, Any], runner: Optional[Runner] = None) -> Tuple[int, str]:
+def session_end(request: Dict[str, Any], runner: Optional[Runner] = None) -> Tuple[int, str, str]:
     """Delegate one already-assembled EpisodeV1 through stdin."""
     payload = json.dumps(request, separators=(",", ":"))
     return run(["session", "end"], runner, input=payload)
@@ -163,20 +181,20 @@ def session_end(request: Dict[str, Any], runner: Optional[Runner] = None) -> Tup
 _SESSION_PICKUP_TIMEOUT_S = 15
 
 
-def session_pickup(request: Dict[str, Any], runner: Optional[Runner] = None) -> Tuple[int, str]:
+def session_pickup(request: Dict[str, Any], runner: Optional[Runner] = None) -> Tuple[int, str, str]:
     """Delegate one first-turn evidence-pickup request through stdin
     (Stage 1 rescope R3) — the ``session end`` stdin-JSON pattern, applied
     to the sibling verb."""
     payload = json.dumps(request, separators=(",", ":"))
     argv = [binary(), "session", "pickup"]
     if runner is not None:
-        return runner(argv, input=payload)
+        return _normalize_result(runner(argv, input=payload))
     return _default_runner(argv, input=payload, timeout_s=_SESSION_PICKUP_TIMEOUT_S)
 
 
 def contribution_preview(
     *, acknowledge: bool = False, runner: Optional[Runner] = None
-) -> Tuple[int, str]:
+) -> Tuple[int, str, str]:
     args = ["contribution", "preview"]
     if acknowledge:
         args.append("--ack")
@@ -184,15 +202,15 @@ def contribution_preview(
     return run(args, runner)
 
 
-def contribution_ledger_json(runner: Optional[Runner] = None) -> Tuple[int, str]:
+def contribution_ledger_json(runner: Optional[Runner] = None) -> Tuple[int, str, str]:
     return run(["contribution", "ledger", "--json"], runner)
 
 
-def contribution_disable(runner: Optional[Runner] = None) -> Tuple[int, str]:
+def contribution_disable(runner: Optional[Runner] = None) -> Tuple[int, str, str]:
     return run(["contribution", "disable", "--json"], runner)
 
 
-def history_json(runner: Optional[Runner] = None) -> Tuple[int, str]:
+def history_json(runner: Optional[Runner] = None) -> Tuple[int, str, str]:
     """Read history derived from canonical layer-owned evidence."""
     return run(["history", "--json"], runner)
 

--- a/apps/jinn-agent/plugins/jinn/jinn_layer.py
+++ b/apps/jinn-agent/plugins/jinn/jinn_layer.py
@@ -69,10 +69,14 @@ def binary() -> str:
 def _normalize_result(result: Tuple[int, str] | Tuple[int, str, str]) -> Tuple[int, str, str]:
     """A custom `Runner` returns `(code, out)`; `_default_runner` returns
     `(code, stdout, stderr)`. Every caller of `run()`/`session_pickup()` sees
-    the 3-tuple regardless of which one produced it (mono #1787)."""
+    the 3-tuple regardless of which one produced it (mono #1787).
+
+    Static checkers don't narrow a tuple union on `len()`, so the branches
+    below are annotated explicitly rather than left to inference.
+    """
     if len(result) == 3:
         return result  # type: ignore[return-value]
-    code, out = result
+    code, out = result  # type: ignore[misc]
     return code, out, ""
 
 

--- a/apps/jinn-agent/plugins/jinn/onboarding.py
+++ b/apps/jinn-agent/plugins/jinn/onboarding.py
@@ -119,7 +119,7 @@ def ledger_nonempty(runner: Optional[jinn_layer.Runner] = None) -> bool:
     unreachable ledger must never mark the step complete on a false negative,
     but it also must never block, so callers treat False as "still to do".
     """
-    code, out = jinn_layer.ledger_json(runner=runner)
+    code, out, _err = jinn_layer.ledger_json(runner=runner)
     if code != 0:
         return False
     try:
@@ -565,7 +565,7 @@ def _replay_first_envelope(runner: Optional[jinn_layer.Runner]) -> str:
     envelope. Degrades to the design's example CID when the ledger is
     unavailable or unparseable — honest degrade, no fabrication of a live source.
     """
-    code, out = jinn_layer.ledger_json(runner=runner)
+    code, out, _err = jinn_layer.ledger_json(runner=runner)
     if code != 0:
         return "bafkreid6qv…shxv4"
     try:

--- a/apps/jinn-agent/plugins/jinn/pickup.py
+++ b/apps/jinn-agent/plugins/jinn/pickup.py
@@ -159,7 +159,7 @@ def _pickup_inner(
         return None
 
     request = _build_request(user_message, session_id, model, repository_slug)
-    code, out = jinn_layer.session_pickup(request, runner)
+    code, out, _err = jinn_layer.session_pickup(request, runner)
     if code != 0:
         return None
 

--- a/apps/jinn-agent/plugins/jinn/skills_install.py
+++ b/apps/jinn-agent/plugins/jinn/skills_install.py
@@ -118,11 +118,11 @@ def install(ref: str, runner: Optional[jinn_layer.Runner] = None) -> str:
     """
     skills_root = skills_dir()
     skills_root.mkdir(parents=True, exist_ok=True)
-    code, out = jinn_layer.run(
+    code, out, err = jinn_layer.run(
         ["skills", "install", ref, "--json"], runner, cwd=str(skills_root)
     )
     if code != 0:
-        raise ValueError(f"skills install failed: {out}")
+        raise ValueError(f"skills install failed: {err or out}")
     try:
         result = json.loads(out)
         target = Path(result["dir"])

--- a/apps/jinn-agent/scripts/stage1-stock-product.py
+++ b/apps/jinn-agent/scripts/stage1-stock-product.py
@@ -65,15 +65,28 @@ DISTRACTOR_SKILL_DUP_REF = _to_ref(DISTRACTOR_SKILL_DUP)
 # the injection carries real content, not metadata (rescope plan §4.5 item 1).
 SOURCE_DISTINCTIVE_CONTENT = "apiMocks.getStatus"
 
-# Scenario 1/2 message: shares vocabulary with the source fixture's tags
-# (mono, dashboard, vitest, version-status, async, flake) and taskSummary
-# without quoting its sentences verbatim — verified empirically to score
-# >= the relevance floor against the source and 0 against every distractor.
+# Scenario 1/2 message (mono #1786): representative multi-sentence prose —
+# every sentence ends with a period, like real task messages do — sharing
+# vocabulary with the source fixture's tags (dashboard, vitest,
+# version-status) and taskSummary without quoting its sentences verbatim.
+# Deliberately NOT the old single-run-on-sentence message: this one carries
+# four sentence-final periods ("again.", "out.", "holds.", "green.") plus
+# one real identifier ("version-status"), so it doubles as a regression
+# canary for #1786 — verified empirically (built dist, real
+# deriveSearchTerms/scoreKnowledgeHit):
+#   - fixed cleanWord: terms = ["version-status", "acme/widget", "dashboard",
+#     "confirm", "vitest", "racing"]; source scores 3 (>= the floor of 2);
+#     both non-skill distractors score 0.
+#   - pre-#1786-fix cleanWord: the four punctuation artifacts fill the
+#     6-term budget in the identifier-shaped pass alone (`again.`, `out.`,
+#     `holds.`, `green.` plus `version-status`, then the repository slug) —
+#     `dashboard` never reaches the remainder bucket, so the source scores
+#     only 1 (< the floor) and the gate fails. A #1786 regression trips this
+#     gate instead of hiding behind a message that happens not to exercise it.
 TARGET_TASK_MESSAGE = (
-    "The client dashboard vitest suite is flaky again, and the "
-    "update_available check seems to race against the version-status "
-    "endpoint. Please track it down in client/src/dashboard and get the "
-    "suite green"
+    "The dashboard vitest suite is flaky again. It keeps racing the "
+    "version-status check and timing out. Track down the root cause and "
+    "confirm the fix holds. Report back once the suite is green."
 )
 
 # Scenario 3: shares no vocabulary with any of the five fixtures.

--- a/apps/jinn-agent/tests/plugins/test_jinn_history.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_history.py
@@ -133,3 +133,32 @@ def test_jinn_history_reports_missing_layer_as_unavailable(monkeypatch):
     monkeypatch.setattr(jinn, "_runner", lambda _argv: (127, "jinn-layer: not found"))
     out = jinn._handle_jinn(command_args="history")
     assert out == "history unavailable:\njinn-layer: not found"
+
+
+def test_jinn_history_renders_normally_when_stderr_carries_a_warning(monkeypatch):
+    """mono#1787: a real dogfooding machine hit `history unavailable: jinn-layer
+    returned malformed JSON` because `_default_runner` merged the harness's
+    `[evidence] skipping malformed legacy capture ...` stderr warning into the
+    same string as the stdout JSON before parsing. A stderr diagnostic must
+    never corrupt a structurally valid stdout response."""
+    envelope = json.dumps({
+        "contractVersion": 1,
+        "status": "ok",
+        "value": {"entries": [_entry()]},
+    })
+
+    def fake_default_runner(argv, cwd=None, input=None, timeout_s=jinn_layer._TIMEOUT_S):
+        return (
+            0,
+            envelope,
+            "[evidence] skipping malformed legacy capture "
+            "s1-1784122564637021000.json: some warning",
+        )
+
+    monkeypatch.setattr(jinn_layer, "_default_runner", fake_default_runner)
+    monkeypatch.setattr(jinn, "_runner", None)
+
+    out = _plain(jinn._handle_jinn(command_args="history"))
+
+    assert "history unavailable" not in out
+    assert "Fix the retry bridge" in out

--- a/apps/jinn-agent/tests/plugins/test_jinn_layer.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_layer.py
@@ -18,9 +18,10 @@ def test_corpus_search_emits_limit_and_json_flags():
         captured.append(argv)
         return 0, "[]"
 
-    code, out = jinn_layer.corpus_search("", limit=500, as_json=True, runner=runner)
+    code, out, err = jinn_layer.corpus_search("", limit=500, as_json=True, runner=runner)
     assert code == 0
     assert out == "[]"
+    assert err == ""
     assert captured[0][1:] == ["corpus", "search", "", "--limit", "500", "--json"]
 
 

--- a/apps/jinn-agent/tests/plugins/test_jinn_layer_verbs.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_layer_verbs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 
 from plugins.jinn import jinn_layer
 
@@ -32,7 +33,7 @@ def test_session_end_writes_one_complete_request_to_stdin():
         "eligibilityInputs": {"acceptedDiff": True},
     }
 
-    code, _ = jinn_layer.session_end(request, runner=runner)
+    code, _out, _err = jinn_layer.session_end(request, runner=runner)
 
     assert code == 0
     assert runner.calls == [
@@ -54,7 +55,7 @@ def test_session_pickup_writes_one_complete_request_to_stdin():
         "firstMessage": "fix the flaky test",
     }
 
-    code, _ = jinn_layer.session_pickup(request, runner=runner)
+    code, _out, _err = jinn_layer.session_pickup(request, runner=runner)
 
     assert code == 0
     assert runner.calls == [
@@ -70,13 +71,60 @@ def test_session_pickup_uses_a_tighter_timeout_than_the_general_default(monkeypa
 
     def fake_default_runner(argv, cwd=None, input=None, timeout_s=jinn_layer._TIMEOUT_S):
         calls.append(timeout_s)
-        return 0, '{"contractVersion":1,"status":"ok","value":{}}'
+        return 0, '{"contractVersion":1,"status":"ok","value":{}}', ""
 
     monkeypatch.setattr(jinn_layer, "_default_runner", fake_default_runner)
     jinn_layer.session_pickup({"contractVersion": 1})
 
     assert calls == [jinn_layer._SESSION_PICKUP_TIMEOUT_S]
     assert jinn_layer._SESSION_PICKUP_TIMEOUT_S < jinn_layer._TIMEOUT_S
+
+
+# ── Stream separation (mono #1787) ──────────────────────────────────────────
+#
+# `_default_runner` genuinely has separate stdout/stderr streams (unlike a
+# test double). A real subprocess writing a diagnostic to stderr — e.g. the
+# evidence-adapter's "skipping malformed legacy capture" warning — must never
+# corrupt a structurally valid stdout JSON response.
+
+def test_default_runner_separates_stdout_and_stderr_so_json_parsing_stays_clean():
+    payload = '{"contractVersion":1,"status":"ok","value":{}}'
+    script = (
+        "import sys; "
+        "sys.stderr.write('[evidence] skipping malformed legacy capture "
+        "s1-1784122564637021000.json: some warning\\n'); "
+        f"sys.stdout.write({payload!r})"
+    )
+
+    code, out, err = jinn_layer._default_runner([sys.executable, "-c", script])
+
+    assert code == 0
+    assert out == payload
+    assert "skipping malformed legacy capture" in err
+    # The actual regression: parsing must consume stdout only.
+    envelope = jinn_layer.parse_process_response(out)
+    assert envelope["status"] == "ok"
+
+
+def test_default_runner_still_reports_stderr_on_a_real_non_zero_exit():
+    script = "import sys; sys.stderr.write('boom\\n'); sys.exit(3)"
+
+    code, out, err = jinn_layer._default_runner([sys.executable, "-c", script])
+
+    assert code == 3
+    assert out == ""
+    assert err == "boom"
+
+
+def test_run_normalizes_a_two_tuple_injected_runner_to_a_three_tuple():
+    """A custom `Runner` never had a stdout/stderr split — `run()` pads it
+    with an empty stderr so every caller sees the same 3-tuple shape."""
+    def two_tuple_runner(argv, *, input=None):
+        return 0, "plain response"
+
+    code, out, err = jinn_layer.run(["contract", "--json"], two_tuple_runner)
+
+    assert (code, out, err) == (0, "plain response", "")
 
 
 def test_parse_session_pickup_response_accepts_the_exact_v1_envelope():

--- a/apps/jinn-agent/tests/plugins/test_jinn_pickup.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_pickup.py
@@ -197,6 +197,27 @@ def test_pickup_returns_none_on_unavailable_status():
     assert pickup.pickup(MSG, runner=runner) is None
 
 
+# ── Stream separation (mono #1787) ──────────────────────────────────────────
+
+def test_pickup_parses_normally_when_stderr_carries_a_warning(monkeypatch):
+    """A stderr diagnostic on the real subprocess path (e.g. the harness's
+    "skipping malformed legacy capture" warning) must never corrupt a
+    structurally valid stdout v1 envelope."""
+    def fake_default_runner(argv, cwd=None, input=None, timeout_s=jinn_layer._SESSION_PICKUP_TIMEOUT_S):
+        return (
+            0,
+            ok_response(),
+            "[evidence] skipping malformed legacy capture "
+            "s1-1784122564637021000.json: some warning",
+        )
+
+    monkeypatch.setattr(jinn_layer, "_default_runner", fake_default_runner)
+
+    result = pickup.pickup(MSG, runner=None)
+
+    assert result == {"context": CONTEXT_BLOCK}
+
+
 def test_stale_layer_response_without_packets_is_treated_as_degraded_nothing():
     """A v1 response without `packets` (a stale jinn-layer predating the
     rescope) must never reintroduce the old suggestion/install shape via

--- a/apps/jinn-agent/tests/plugins/test_jinn_plugin.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_plugin.py
@@ -512,11 +512,13 @@ def test_slash_consent_never_calls_blocking_input(isolated_home, monkeypatch):
 def test_jinn_layer_not_found_points_at_canary_tag():
     """mono#1382: bare `npm install -g @jinn-network/client` installs latest,
     which has no jinn-layer bin until stable >= 0.1.10 — the error must name
-    the canary tag."""
-    code, out = jinn_layer._default_runner(["definitely-not-a-real-binary-xyz"])
+    the canary tag. mono#1787: the diagnostic lives on stderr now (stdout
+    and stderr are reported separately), not merged into a single string."""
+    code, out, err = jinn_layer._default_runner(["definitely-not-a-real-binary-xyz"])
     assert code == 127
-    assert "@jinn-network/client@canary" in out
-    assert "JINN_LAYER_BIN" in out
+    assert out == ""
+    assert "@jinn-network/client@canary" in err
+    assert "JINN_LAYER_BIN" in err
 
 
 # ── Consent copy: current state + preview next-step (mono#1384) ──────────────

--- a/apps/jinn-agent/tests/plugins/test_jinn_session_end_delegate.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_session_end_delegate.py
@@ -161,6 +161,34 @@ def test_delegate_posts_the_complete_episode_activity_eligibility_and_candidate(
     assert request["episode"] == episode
 
 
+def test_delegate_parses_normally_when_stderr_carries_a_warning(monkeypatch):
+    """mono#1787: a stderr diagnostic on the real subprocess path (e.g. the
+    harness's "skipping malformed legacy capture" warning) must never
+    corrupt a structurally valid stdout v1 envelope."""
+    episode = _episode()
+
+    def fake_default_runner(argv, cwd=None, input=None, timeout_s=jinn.jinn_layer._TIMEOUT_S):
+        request = json.loads(input or "{}")
+        episode_id = (request.get("episode") or {}).get("episodeId", "episode-1")
+        return (
+            0,
+            _response(episode_id=episode_id),
+            "[evidence] skipping malformed legacy capture "
+            "s1-1784122564637021000.json: some warning",
+        )
+
+    monkeypatch.setattr(jinn.jinn_layer, "_default_runner", fake_default_runner)
+    jinn._runner = None
+
+    result = jinn._delegate_session_end(
+        episode, activity={}, eligibility_inputs={}, contribution_candidate=None,
+        contribution_vetoed=False,
+    )
+
+    assert result is not None
+    assert result["persistence"]["value"]["episodeId"] == "episode-1"
+
+
 def test_degraded_contribution_does_not_duplicate_successfully_persisted_episode():
     jinn._runner = SessionRunner(
         output=_response(

--- a/packages/plugin/src/pickup.ts
+++ b/packages/plugin/src/pickup.ts
@@ -19,9 +19,15 @@ const MIN_REMAINDER_LENGTH = 4;
 const QUOTED_SPAN_RE = /`([^`]+)`|"([^"]+)"|'([^']+)'/g;
 
 /** Unicode-aware alnum filter (matches Python's `str.isalnum()`), keeping the
- *  identifier separators this function itself tests for. */
+ *  identifier separators this function itself tests for — but only when they
+ *  are internal. Leading/trailing separators are stripped so ordinary
+ *  sentence-final prose (`done.`, `else.`) never reads as identifier-shaped
+ *  (mono #1786); a leading `/` on a path-like token (`/v1/status`) is
+ *  stripped too — `v1/status` stays a useful, greppable search term, and
+ *  treating every separator position the same way keeps the rule one rule. */
 function cleanWord(raw: string): string {
-  return [...raw].filter((c) => /[\p{L}\p{N}]/u.test(c) || '_-./'.includes(c)).join('');
+  const kept = [...raw].filter((c) => /[\p{L}\p{N}]/u.test(c) || '_-./'.includes(c)).join('');
+  return kept.replace(/^[_\-./]+/, '').replace(/[_\-./]+$/, '');
 }
 
 /** "Identifier-shaped": contains `_`, `-`, `.`, `/`, a digit, or a camelCase

--- a/packages/plugin/test/pickup.test.ts
+++ b/packages/plugin/test/pickup.test.ts
@@ -78,6 +78,52 @@ describe('deriveSearchTerms (rescope §3.3)', () => {
     const terms = deriveSearchTerms('café-menu needs a refactor');
     expect(terms).toContain('café-menu');
   });
+
+  // Term hygiene (mono #1786, found by the R6 live walkthrough): trailing
+  // sentence punctuation must not make an ordinary prose word look
+  // identifier-shaped and steal a priority-2 slot from real content words.
+  describe('term hygiene: leading/trailing separator stripping (#1786)', () => {
+    it('strips a trailing period from a sentence-final word instead of treating it as identifier-shaped', () => {
+      const terms = deriveSearchTerms('Say OK.');
+      expect(terms).not.toContain('ok.');
+    });
+
+    it('never derives a punctuation-suffixed term from natural prose ending in periods', () => {
+      const message =
+        'The operator dashboard still labels the AI-units claim gate in units, ' +
+        'even though the daemon now reports actual USD spend with an estimated ' +
+        'flag. Update the dashboard so it shows USD and distinguishes a metered ' +
+        'figure from an estimated one. Run the dashboard tests when you are done.';
+
+      const terms = deriveSearchTerms(message, 'Jinn-Network/mono');
+
+      expect(terms).toContain('dashboard');
+      for (const term of terms) {
+        expect(term.endsWith('.')).toBe(false);
+      }
+    });
+
+    it('strips leading/trailing separators but preserves internal ones on real identifiers', () => {
+      const terms = deriveSearchTerms(
+        'ship update_available, fix version-status, review client/src/dashboard, tune AI-units, hit /v1/status.',
+      );
+      expect(terms).toContain('update_available');
+      expect(terms).toContain('version-status');
+      expect(terms).toContain('client/src/dashboard');
+      expect(terms).toContain('ai-units');
+      // Leading `/` is stripped like any other leading separator (see #1786
+      // AC and the pickup.ts docstring for the trade-off this accepts).
+      expect(terms).toContain('v1/status');
+    });
+
+    it('falls a stripped prose word through to the remainder bucket rather than promoting it to priority 2', () => {
+      // 'else.' cleans to 'else', which is not identifier-shaped (no
+      // separator survives the strip) — it must only ever appear via the
+      // length-ranked remainder bucket, alongside ordinary prose words.
+      const terms = deriveSearchTerms('done. else. contribution');
+      expect(terms).toEqual(['contribution', 'done', 'else']);
+    });
+  });
 });
 
 describe('classifyPayload', () => {


### PR DESCRIPTION
## Summary

Fixes the two defects the R6 live walkthrough (#1775) found, plus the gate's fixture-recognition blind spot that let #1786 ship green.

- **#1786** — `cleanWord` (`packages/plugin/src/pickup.ts`) kept `_-./` anywhere in a token, including trailing, so any sentence-final prose word (`done.`, `flag.`, `else.`) read as identifier-shaped and took a priority-2 slot ahead of real content words in the 6-term search budget.
- **#1787** — `_default_runner` (`apps/jinn-agent/plugins/jinn/jinn_layer.py`) merged the child process's stdout and stderr into one string before returning it, so any stderr diagnostic (e.g. the evidence-adapter's "skipping malformed legacy capture" warning) corrupted an otherwise-valid stdout JSON response before `json.loads`. `/jinn history` was dead on any machine carrying a legacy capture the current schema rejects; the rescope had additionally routed `session pickup` / `session end` through the same strict parser.
- **Gate blind spot** — `stage1-stock-product.py`'s scenario-1 message happened to carry exactly one sentence-final period, so it passed the gate regardless of the #1786 bug. Replaced with representative multi-sentence prose that depends on the fix.

## Fix 1 — #1786 term hygiene

`cleanWord` now strips **leading and trailing** `_-./` while preserving internal separators. A leading `/` is stripped too (`/v1/status` → `v1/status`) — deliberate: it stays a useful, greppable term, and treating every separator position the same way keeps the rule one rule instead of a special case for paths.

Before/after on the walkthrough's real prose message (built `dist/pickup.js`, `repositorySlug='Jinn-Network/mono'`):

```
BEFORE: ["ai-units","flag.","one.","done.","jinn-network/mono","distinguishes"]
AFTER:  ["ai-units","jinn-network/mono","distinguishes","dashboard","estimated","operator"]
```

`dashboard` — the one term that matches the seeded evidence record's tags — now survives instead of being evicted by three punctuation artifacts.

`Say OK.` → `[]` (was `["ok."]`).

On the `2+2` fold (non-kept chars dropped, fragments joined into `22`): left as-is per the issue's own "do not gold-plate" guidance — it's orthogonal to the leading/trailing-strip fix (`+` was never a kept separator, before or after) and splitting instead of joining is a separate, larger change to `cleanWord`'s character-filtering model.

## Fix 2 — #1787 stream separation

`_default_runner` now returns `(code, stdout, stderr)` instead of `(code, merged)`. JSON parsing consumes stdout only; the FileNotFoundError/timeout synthetic failures put their message on stderr so the install-hint guidance path keeps working (verified: `test_jinn_layer_not_found_points_at_canary_tag`).

This changed the shared `run()`/`session_pickup()` contract, so I inspected and updated every caller (~24 call sites across `plugins/jinn/__init__.py`, `pickup.py`, `onboarding.py`, `skills_install.py`, `distill.py`, `hermes_cli/banner.py`, plus the test doubles in `test_jinn_layer.py` / `test_jinn_layer_verbs.py` / `test_jinn_plugin.py` that monkeypatch the runner). A custom `Runner` (test doubles, `jinn._runner` overrides) still returns the simple `(code, out)` 2-tuple it always did — `_normalize_result` pads it to `(code, out, "")` so every caller sees one consistent 3-tuple regardless of which runner produced it. The handful of failure paths that render diagnostic text now prefer `err`, falling back to `out` only when `err` is empty (protects existing tests/behavior where a test double never had a stderr channel to begin with).

Regression coverage (a runner stub emitting stderr + valid stdout, the way the walkthrough hit it):
- `test_default_runner_separates_stdout_and_stderr_so_json_parsing_stays_clean` — a real subprocess (`python -c ...`) writing `[evidence] skipping malformed legacy capture ...` to stderr and a valid v1 envelope to stdout; `_default_runner` reports them separately and `parse_process_response` parses the stdout only.
- `test_default_runner_still_reports_stderr_on_a_real_non_zero_exit` / `test_run_normalizes_a_two_tuple_injected_runner_to_a_three_tuple` — round out the contract.
- `test_jinn_history_renders_normally_when_stderr_carries_a_warning`, `test_pickup_parses_normally_when_stderr_carries_a_warning`, `test_delegate_parses_normally_when_stderr_carries_a_warning` — the three AC-named surfaces (`/jinn history`, `session pickup`, `session end`) each proven against a fake `_default_runner` with the same stderr-warning/stdout-envelope shape.

A true end-to-end repro (real `jinn-layer` binary + a real legacy capture file on disk) is what the R6 walkthrough did manually and what `cold-stock-e2e.sh` exercises in CI; it's out of reach for a fast Python unit test, so the above is the closest cheap equivalent — same mechanism (a real subprocess, real separate streams), synthetic content.

## Fix 3 — the gate's blind spot

New scenario-1 message (`apps/jinn-agent/scripts/stage1-stock-product.py`):

> The dashboard vitest suite is flaky again. It keeps racing the version-status check and timing out. Track down the root cause and confirm the fix holds. Report back once the suite is green.

Four sentences, four sentence-final periods (`again.`, `out.`, `holds.`, `green.`) — representative prose, not a single run-on sentence with one incidental artifact.

Verified empirically against the real built `deriveSearchTerms`/`scoreKnowledgeHit` (`packages/plugin/dist`, `repositorySlug='acme/widget'` — the gate's actual `work_repo` git remote, not a stand-in):

| | derived terms | source score | distractor (same-repo) | distractor (other-domain) |
|---|---|---|---|---|
| **with the #1786 fix** | `["version-status","acme/widget","dashboard","confirm","vitest","racing"]` | **3** (floor is 2) | 0 | 0 |
| **pre-#1786-fix `cleanWord`** (checked out in isolation, rebuilt, tested, not committed) | `["again.","version-status","out.","holds.","green.","acme/widget"]` | **1** (< floor) | 0 | 0 |

Under the pre-fix `cleanWord`, the four punctuation artifacts plus `version-status` plus the repository slug fill the 6-term budget entirely in the identifier-shaped pass — `dashboard` never reaches the remainder bucket. Source drops from 3 to 1, below the relevance floor, and the gate's `assert pickup is not None` / `assert target_context is not None` would fail. The gate now depends on the #1786 fix instead of merely coexisting with the bug.

Both skill distractors (`distractor-skill-tdd`, `distractor-skill-tdd-dup`) are excluded from selection categorically (`selectKnowledgeHits` drops every skill-kind hit before scoring), independent of message wording.

No 4+ consecutive-word run is shared with the source fixture's `taskSummary` (`"Fix flaky dashboard update_available banner test — assert after the version status fetch resolves"`) or `synthesis` — checked programmatically (4-gram set intersection over both texts): empty.

`cold-stock-e2e.sh` was **not** run locally (network) per instructions — reasoned through every assertion in the `finish_session(... message=TARGET_TASK_MESSAGE ...)` block instead; none depend on the message's specific wording, only on which record gets selected (source, confirmed above) and structural boundaries (skill-install language absent, sharing-off POST boundary, etc.), all of which are unaffected by the wording change. `stage1-task-creator-acceptance.mjs` (outside this PR's boundary) only reads the structural `stock-product-result.json` output (episode/session/record IDs), not the message text.

## Verification (all green)

- `packages/plugin`: `yarn install && yarn typecheck && yarn build && yarn test` — **171 tests, 23 files, all pass**. Typecheck clean.
- `client`: `yarn install && yarn typecheck` — clean. Harness-layer vitest suite (`packages/harness-layer/test/`) — **736 tests, 51 files, all pass**.
- `apps/jinn-agent`: full `test_jinn_*.py` set via `scripts/run_tests.sh` (per-file isolation) — **349 tests, 33 files, all pass**. `ruff check` clean on every touched file.
- Manually verified (git-stash isolation, rebuilt, not committed) that both the walkthrough repro and the new gate message score as claimed under the pre-#1786-fix code, confirming the regression-canary property.

Closes #1786
Closes #1787
Refs #1654
Refs #1775

🤖 Generated with [Claude Code](https://claude.com/claude-code)
