### PR TITLE
fix(plugin): lexical-v2 term selection — message-order terms, path segments, repo-name vote, plural fold (R6 retrieval)

### DIFF
--- a/docs/superpowers/plans/2026-07-16-jinn-plugin-stage-1-rescope-plan.md
+++ b/docs/superpowers/plans/2026-07-16-jinn-plugin-stage-1-rescope-plan.md
@@ -187,11 +187,18 @@ one `corpus_fetch` away; nothing is model-generated in the hot path.
 
 ### 3.3 Search and ranking
 
-- **Terms:** `deriveSearchTerms(firstMessage, repositorySlug?)` replaces the 2-token heuristic.
-  Up to 6 terms, in priority order: backticked/quoted tokens; identifier-shaped tokens (contains
-  `_`, `-`, `.`, `/`, a digit, or CamelCase); the session's repository slug (known at session
-  start from `session_bridge.snapshot_repository`); remaining longest non-stopword tokens.
-  Whole first message, not just line one. Deterministic.
+- **Terms (lexical v2 — #1791, #1790, #1789):** `deriveSearchTerms(firstMessage, repositorySlug?)`
+  replaces the 2-token heuristic. Up to 10 terms, in priority order: backticked/quoted tokens
+  (edge-stripped through the same leading/trailing `_-./` strip as other terms, #1789);
+  identifier-shaped tokens (contains `_`, `-`, `.`, `/`, a digit, or CamelCase) — a `/`-bearing
+  token also contributes its path segments (each cleaned, ≥3 chars, stopword-filtered,
+  deduplicated), right after the full token; the session repository's **name** — the segment
+  after the last `/` of `repositorySlug` (known at session start from
+  `session_bridge.snapshot_repository`), ≥3 chars — not the full slug, which can never appear in
+  a record's text (#1790); the remaining non-stopword tokens (≥4 chars) in **message order**
+  (order of first appearance, not longest-first — length is not a retrievability signal against a
+  corpus of short summaries and tags, #1791). Whole first message, not just line one.
+  Deterministic.
 - **Search:** per-term `CorpusPort.search` (capture-meta first, manifest floor fallback — existing
   rails), results merged.
 - **Selection:**
@@ -200,10 +207,17 @@ one `corpus_fetch` away; nothing is model-generated in the hot path.
      they are simply not what pickup serves.)
   2. Dedup by ref **and** by content key `(taskSummary, origin)` — kills the duplicated-seed
      symptom at the consumer even before store hygiene lands.
-  3. Score = count of matched terms across `taskSummary + tags`, with a repository-slug match
-     counting 2. **Relevance floor: score ≥ 2**, otherwise honest nothing-found. Tier is a
-     ranking preference, not a filter: sort score desc → tier desc (`TIER_ORDER`) → recency desc.
+  3. Score = count of matched terms across `taskSummary + tags`; **every match counts 1** — the
+     old repository-slug +2 bonus is gone (#1790, #1791) now that the repository's name is a
+     normal derived term. A term matches verbatim or, for a term ending in a simple plural `s`
+     (length > 3), by its singular form (plural fold, #1791). **Relevance floor: score ≥ 2**,
+     otherwise honest nothing-found. Tier is a ranking preference, not a filter: sort score desc
+     → tier desc (`TIER_ORDER`) → recency desc.
   4. Take the top 2; fetch full content; project packets.
+
+Escalation ladder if lexical v2 proves insufficient: lexical v2 (above) → two-stage content
+re-scoring for near-miss candidates against synthesis/steps (#1792, deterministic, model-free) →
+embeddings only with Stage 2 evidence.
 
 ### 3.4 Injection
 

--- a/packages/plugin/src/pickup.ts
+++ b/packages/plugin/src/pickup.ts
@@ -1,6 +1,7 @@
-/** Evidence-first pickup policy (rescope design §3.3). No I/O: term
- *  derivation + selection only. Orchestration (search/get over ports,
- *  packet projection, rendering) lives in plugin.ts. */
+/** Evidence-first pickup policy (rescope design §3.3; lexical v2 term
+ *  selection — #1791, #1790, #1789). No I/O: term derivation + selection
+ *  only. Orchestration (search/get over ports, packet projection, rendering)
+ *  lives in plugin.ts. */
 import type { KnowledgeHit } from './schemas/knowledge-hit.js';
 import { TIER_ORDER } from './schemas/pickup-config.js';
 
@@ -13,8 +14,14 @@ export const STOPWORDS: ReadonlySet<string> = new Set([
   'using', 'about', 'have', 'has', 'had', 'you', 'your', 'our', 'not',
 ]);
 
-const MAX_TERMS = 6;
+// Lexical v2 (#1791): a tight 6-term budget forced real trade-offs between
+// terms that could plausibly match a record's summary/tags — 10 gives
+// selection room to include more of the message before the floor decides
+// relevance. Search is one cheap indexer call per term.
+const MAX_TERMS = 10;
 const MIN_REMAINDER_LENGTH = 4;
+const MIN_PATH_SEGMENT_LENGTH = 3;
+const MIN_REPO_NAME_LENGTH = 3;
 
 const QUOTED_SPAN_RE = /`([^`]+)`|"([^"]+)"|'([^']+)'/g;
 
@@ -24,9 +31,13 @@ const QUOTED_SPAN_RE = /`([^`]+)`|"([^"]+)"|'([^']+)'/g;
  *  sentence-final prose (`done.`, `else.`) never reads as identifier-shaped
  *  (mono #1786); a leading `/` on a path-like token (`/v1/status`) is
  *  stripped too — `v1/status` stays a useful, greppable search term, and
- *  treating every separator position the same way keeps the rule one rule. */
+ *  treating every separator position the same way keeps the rule one rule.
+ *  Space is also kept (not just alnum/`_-./`) so this same function is safe
+ *  to run on a multi-word backticked/quoted span (#1789) — the other two
+ *  call sites split on whitespace first, so a raw space never reaches them
+ *  and this is a no-op there. */
 function cleanWord(raw: string): string {
-  const kept = [...raw].filter((c) => /[\p{L}\p{N}]/u.test(c) || '_-./'.includes(c)).join('');
+  const kept = [...raw].filter((c) => /[\p{L}\p{N}]/u.test(c) || '_-./ '.includes(c)).join('');
   return kept.replace(/^[_\-./]+/, '').replace(/[_\-./]+$/, '');
 }
 
@@ -36,11 +47,37 @@ function isIdentifierShaped(word: string): boolean {
   return /[_\-./]/.test(word) || /\d/.test(word) || /[a-z][A-Z]/.test(word);
 }
 
+/** Path segments of a `/`-bearing identifier-shaped token (#1791 root cause
+ *  1): an over-specific path like `client/src/dashboard/spa/src` rarely
+ *  matches a record's summary/tags verbatim, but a shorter segment within it
+ *  (`dashboard`) often does. Each segment is cleaned, filtered to
+ *  `MIN_PATH_SEGMENT_LENGTH`, stopword-filtered, and deduplicated against
+ *  itself (the caller's `push` handles dedup against the running term list). */
+function pathSegments(token: string): string[] {
+  const seenLocal = new Set<string>();
+  const segments: string[] = [];
+  for (const raw of token.split('/')) {
+    const cleaned = cleanWord(raw);
+    const lower = cleaned.toLowerCase();
+    if (cleaned.length < MIN_PATH_SEGMENT_LENGTH || STOPWORDS.has(lower) || seenLocal.has(lower)) {
+      continue;
+    }
+    seenLocal.add(lower);
+    segments.push(cleaned);
+  }
+  return segments;
+}
+
 /**
  * Up to `maxTerms` deterministic lowercase search terms, in priority order
- * (rescope §3.3): backticked/quoted tokens; identifier-shaped tokens; the
- * session's repository slug; the longest remaining non-stopword tokens.
- * Operates over the whole message (not just the first line). Deduplicated.
+ * (rescope §3.3, lexical v2 — #1791/#1790/#1789): backticked/quoted tokens
+ * (edge-stripped, near-verbatim); identifier-shaped tokens — a `/`-bearing
+ * one also contributes its path segments, right after the full token; the
+ * session repository's NAME (not its full slug, #1790); the remaining
+ * non-stopword tokens (>=4 chars) in MESSAGE ORDER — order of first
+ * appearance, not longest-first (#1791: length is not a retrievability
+ * signal against a corpus of short summaries and tags). Operates over the
+ * whole message (not just the first line). Deduplicated.
  */
 export function deriveSearchTerms(
   message: string,
@@ -60,34 +97,59 @@ export function deriveSearchTerms(
     terms.push(lower);
   };
 
-  // 1. Backticked/quoted tokens — each span is one term, taken near-verbatim.
+  // 1. Backticked/quoted tokens — each span is one term, taken near-verbatim
+  //    but run through cleanWord's leading/trailing `_-./` strip (#1789) so
+  //    a captured span like "npm test." doesn't keep its trailing period.
+  //    cleanWord also keeps internal spaces, so a multi-word span
+  //    ("version status fetch") and a path-shaped one ("client/src/dash")
+  //    both keep their shape.
   for (const match of text.matchAll(QUOTED_SPAN_RE)) {
     if (terms.length >= maxTerms) break;
-    push(match[1] ?? match[2] ?? match[3] ?? '');
+    push(cleanWord(match[1] ?? match[2] ?? match[3] ?? ''));
   }
 
-  // 2. Identifier-shaped tokens (whole message).
+  // 2. Identifier-shaped tokens (whole message). A `/`-bearing token also
+  //    contributes its path segments, right after the full token (#1791
+  //    root cause 1) — the full token is often over-specific for a record's
+  //    summary/tags, while a shorter segment within it often matches.
   if (terms.length < maxTerms) {
     for (const rawWord of text.split(/\s+/)) {
       if (terms.length >= maxTerms) break;
       const word = cleanWord(rawWord);
       if (word.length < 2 || STOPWORDS.has(word.toLowerCase())) continue;
-      if (isIdentifierShaped(word)) push(word);
+      if (!isIdentifierShaped(word)) continue;
+      push(word);
+      if (word.includes('/')) {
+        for (const segment of pathSegments(word)) {
+          if (terms.length >= maxTerms) break;
+          push(segment);
+        }
+      }
     }
   }
 
-  // 3. The session's repository slug.
+  // 3. The session repository's NAME — the segment after the last `/` of
+  //    `repositorySlug` (e.g. `mono` from `Jinn-Network/mono`), not the full
+  //    slug: no record's text ever contains the literal `owner/repo` slug,
+  //    so the slug itself was dead weight as a search term (#1790).
   if (terms.length < maxTerms && repositorySlug && repositorySlug.trim().length > 0) {
-    push(repositorySlug);
+    const slug = repositorySlug.trim();
+    const lastSlash = slug.lastIndexOf('/');
+    const repoName = lastSlash >= 0 ? slug.slice(lastSlash + 1) : slug;
+    if (repoName.length >= MIN_REPO_NAME_LENGTH) push(repoName);
   }
 
-  // 4. Remaining longest non-stopword tokens (>=4 chars), longest first.
+  // 4. Remaining non-stopword tokens (>=4 chars), in MESSAGE ORDER (#1791
+  //    root cause 2) — order of first appearance, not longest-first. Length
+  //    is not a retrievability signal: a short on-topic word ("flaky", 5
+  //    chars) is a better search term than a long one ("deterministic", 13
+  //    chars) against a corpus of short summaries and tags, but the old
+  //    longest-first sort always preferred the long word.
   if (terms.length < maxTerms) {
     const remainder = text
       .split(/\s+/)
       .map(cleanWord)
-      .filter((word) => word.length >= MIN_REMAINDER_LENGTH && !STOPWORDS.has(word.toLowerCase()))
-      .sort((a, b) => b.length - a.length);
+      .filter((word) => word.length >= MIN_REMAINDER_LENGTH && !STOPWORDS.has(word.toLowerCase()));
     for (const word of remainder) {
       if (terms.length >= maxTerms) break;
       push(word);
@@ -143,19 +205,28 @@ function haystackFor(hit: KnowledgeHit): string {
   return `${hit.snippet ?? hit.title ?? ''} ${hit.tags.join(' ')}`.toLowerCase();
 }
 
-/** Count of matched terms across `taskSummary + tags`; a repository-slug
- *  match counts 2 (rescope §3.3 step 3). */
-export function scoreKnowledgeHit(
-  hit: KnowledgeHit,
-  terms: string[],
-  repositorySlug?: string,
-): number {
+/** A term matches if it appears verbatim, or — for a term ending in a
+ *  simple plural `s` — its singular form does (#1791 lexical v2: closes
+ *  small, common bag-of-words vocabulary gaps like `tests` -> `test`).
+ *  One-directional (term -> singular only) and length-gated
+ *  (`term.length > 3`) so a short word like `its` never folds to `it`. */
+function termMatches(haystack: string, term: string): boolean {
+  if (haystack.includes(term)) return true;
+  return term.endsWith('s') && term.length > 3 && haystack.includes(term.slice(0, -1));
+}
+
+/** Count of matched terms across `taskSummary + tags` (rescope §3.3 step 3,
+ *  lexical v2 — #1790/#1791) — every match counts 1. The repository-slug
+ *  match used to count 2, but the slug it matched against could never
+ *  appear in a record's text (#1790); the repository's NAME is now a
+ *  normal derived term (see `deriveSearchTerms` step 3) and scores like any
+ *  other term, with no special case. */
+export function scoreKnowledgeHit(hit: KnowledgeHit, terms: string[]): number {
   const haystack = haystackFor(hit);
-  const repoTerm = repositorySlug?.trim().toLowerCase();
   let score = 0;
   for (const term of terms) {
-    if (!haystack.includes(term)) continue;
-    score += term.length > 0 && term === repoTerm ? 2 : 1;
+    if (term.length === 0) continue;
+    if (termMatches(haystack, term)) score += 1;
   }
   return score;
 }
@@ -174,12 +245,11 @@ function tierRank(tier: string | undefined): number {
 export function selectKnowledgeHits(
   hits: KnowledgeHit[],
   terms: string[],
-  repositorySlug?: string,
 ): KnowledgeHit[] {
   const evidence = hits.filter((hit) => !isSkillHit(hit));
   const deduped = dedupeKnowledgeHits(evidence);
   const scored = deduped
-    .map((hit) => ({ hit, score: scoreKnowledgeHit(hit, terms, repositorySlug) }))
+    .map((hit) => ({ hit, score: scoreKnowledgeHit(hit, terms) }))
     .filter((scoredHit) => scoredHit.score >= RELEVANCE_FLOOR);
 
   scored.sort((a, b) => {

--- a/packages/plugin/src/plugin.ts
+++ b/packages/plugin/src/plugin.ts
@@ -54,7 +54,8 @@ export interface SessionMeta {
   skillsLoadout?: string[];
   pickup?: PickupConfig;
   /** Known at session start (e.g. `session_bridge.snapshot_repository`) —
-   *  fed into `deriveSearchTerms` and the selection policy's repo-match bonus. */
+   *  fed into `deriveSearchTerms`, which derives the repository's name (not
+   *  its full slug) as a normal search term (#1790). */
   repositorySlug?: string;
 }
 
@@ -333,7 +334,7 @@ export class PluginSession {
       }
     }
 
-    const selected = selectKnowledgeHits([...byRef.values()], terms, this.meta.repositorySlug);
+    const selected = selectKnowledgeHits([...byRef.values()], terms);
     if (selected.length === 0) {
       return {
         contextBlock: null,

--- a/packages/plugin/test/pickup.test.ts
+++ b/packages/plugin/test/pickup.test.ts
@@ -42,15 +42,48 @@ describe('deriveSearchTerms (rescope §3.3)', () => {
     expect(terms).toContain('sessionbridge');
   });
 
-  it('includes the repository slug when provided, lowercased', () => {
+  // The full repository slug can never match a record's text (no record
+  // carries the literal `owner/repo` string) — the repository's NAME (the
+  // segment after the last `/`) replaces it as the derived term (#1790).
+  it('derives the repository NAME, not the full slug, when repositorySlug is provided', () => {
     const terms = deriveSearchTerms('generic unrelated words here', 'Jinn-Network/mono');
-    expect(terms).toContain('jinn-network/mono');
+    expect(terms).toContain('mono');
+    expect(terms).not.toContain('jinn-network/mono');
   });
 
-  it('falls back to the longest remaining non-stopword tokens (>=4 chars)', () => {
+  it('does not derive a repo-name term shorter than 3 chars', () => {
+    const terms = deriveSearchTerms('generic unrelated words here', 'acme/ab');
+    expect(terms).not.toContain('ab');
+  });
+
+  it('uses the whole slug as the repo name when it has no `/`', () => {
+    const terms = deriveSearchTerms('generic unrelated words here', 'monorepo');
+    expect(terms).toContain('monorepo');
+  });
+
+  // #1791: length is not a retrievability signal against a corpus of short
+  // summaries and tags — the remainder bucket is message order (order of
+  // first appearance), not longest-first.
+  it('falls back to the remaining non-stopword tokens (>=4 chars) in message order, not longest-first', () => {
     const terms = deriveSearchTerms('please help with the retry budget for tests');
-    // 'please' and 'help' and 'the' and 'with' and 'for' are stopwords; longest remainder first.
-    expect(terms).toEqual(['budget', 'retry', 'tests']);
+    // 'please', 'help', 'with', 'for' are stopwords; 'retry' appears before
+    // 'budget' in the message even though it is shorter — message order wins
+    // (#1791; the old longest-first sort produced ['budget','retry','tests']).
+    expect(terms).toEqual(['retry', 'budget', 'tests']);
+  });
+
+  it('orders the remainder bucket by first appearance — a short early topical word beats a longer later one (#1791)', () => {
+    // Mirrors the real R6 walkthrough finding: 'flaky' (5 chars) lost the old
+    // longest-first sort to 'deterministic' (13 chars) and was evicted from
+    // the 6-term budget entirely, even though it was the term that would
+    // have matched the seeded record.
+    const terms = deriveSearchTerms(
+      'flaky tests are annoying because the retry logic is not deterministic',
+    );
+    const flakyIndex = terms.indexOf('flaky');
+    const deterministicIndex = terms.indexOf('deterministic');
+    expect(flakyIndex).toBeGreaterThanOrEqual(0);
+    expect(deterministicIndex).toBeGreaterThan(flakyIndex);
   });
 
   it('reads the whole message, not just the first line', () => {
@@ -64,9 +97,28 @@ describe('deriveSearchTerms (rescope §3.3)', () => {
     expect(deriveSearchTerms('retryBudget retryBudget retryBudget')).toEqual(terms);
   });
 
-  it('caps at 6 terms', () => {
-    const terms = deriveSearchTerms('`one` `two` `three` `four` `five` `six` `seven` `eight`');
-    expect(terms).toHaveLength(6);
+  // Budget raised 6 -> 10 (#1791): a tight budget forced real terms out.
+  it('caps at 10 terms', () => {
+    const terms = deriveSearchTerms(
+      '`one` `two` `three` `four` `five` `six` `seven` `eight` `nine` `ten` `eleven` `twelve`',
+    );
+    expect(terms).toHaveLength(10);
+  });
+
+  it('path-segments a `/`-bearing identifier-shaped token, contributing each cleaned segment (>=3 chars) after the full token (#1791)', () => {
+    const terms = deriveSearchTerms('fix the flake under client/src/dashboard/spa/src please');
+    expect(terms).toContain('client/src/dashboard/spa/src');
+    expect(terms).toContain('client');
+    expect(terms).toContain('dashboard');
+    expect(terms).toContain('spa');
+    // 'src' is exactly MIN_PATH_SEGMENT_LENGTH (3 chars) — included, not excluded.
+    expect(terms).toContain('src');
+  });
+
+  it('does not path-segment a token with no `/`', () => {
+    const terms = deriveSearchTerms('fix version-status.test.ts please');
+    expect(terms).not.toContain('version');
+    expect(terms).not.toContain('status');
   });
 
   it('returns an empty list for blank or all-stopword input', () => {
@@ -88,6 +140,13 @@ describe('deriveSearchTerms (rescope §3.3)', () => {
       expect(terms).not.toContain('ok.');
     });
 
+    // This message is Run A from the #1791 decision comment's validation
+    // table (the real #1006 "dashboard USD labels" walkthrough task,
+    // re-derived here) — its pre-lexical-v2 derived terms
+    // (['ai-units','jinn-network/mono','distinguishes','dashboard',
+    // 'estimated','operator']) are recorded verbatim in #1654's R6
+    // walkthrough #3 comment. See the 'lexical v2 validation table' describe
+    // block below for its post-lexical-v2 scores against the real fixtures.
     it('never derives a punctuation-suffixed term from natural prose ending in periods', () => {
       const message =
         'The operator dashboard still labels the AI-units claim gate in units, ' +
@@ -119,9 +178,33 @@ describe('deriveSearchTerms (rescope §3.3)', () => {
     it('falls a stripped prose word through to the remainder bucket rather than promoting it to priority 2', () => {
       // 'else.' cleans to 'else', which is not identifier-shaped (no
       // separator survives the strip) — it must only ever appear via the
-      // length-ranked remainder bucket, alongside ordinary prose words.
+      // remainder bucket, alongside ordinary prose words, in message order
+      // (#1791 — the old longest-first sort produced
+      // ['contribution','done','else']).
       const terms = deriveSearchTerms('done. else. contribution');
-      expect(terms).toEqual(['contribution', 'done', 'else']);
+      expect(terms).toEqual(['done', 'else', 'contribution']);
+    });
+  });
+
+  // #1789: the captured span bypassed cleanWord, keeping trailing
+  // punctuation (`npm test.` never matched a corpus tag or summary).
+  describe('quoted/backtick span cleaning (#1789)', () => {
+    it('strips trailing punctuation from a backticked span via the same edge strip as other terms', () => {
+      const terms = deriveSearchTerms('run `npm test.` now');
+      expect(terms).toContain('npm test');
+      for (const term of terms) {
+        expect(term.endsWith('.')).toBe(false);
+      }
+    });
+
+    it("preserves a multi-word quoted span's shape (internal space, no split)", () => {
+      const terms = deriveSearchTerms('please check `version status fetch` today');
+      expect(terms).toContain('version status fetch');
+    });
+
+    it('preserves internal separators on a path-shaped backticked span', () => {
+      const terms = deriveSearchTerms('look at `client/src/dashboard` please');
+      expect(terms).toContain('client/src/dashboard');
     });
   });
 });
@@ -148,14 +231,35 @@ describe('scoreKnowledgeHit (rescope §3.3 step 3)', () => {
     expect(scoreKnowledgeHit(h, ['dashboard', 'nonexistent'])).toBe(1);
   });
 
-  it('counts a repository-slug match as 2', () => {
-    const h = hit({ snippet: 'fix a bug', tags: ['jinn-network/mono'] });
-    expect(scoreKnowledgeHit(h, ['jinn-network/mono'], 'Jinn-Network/mono')).toBe(2);
+  // The old +2 repository-slug bonus is gone (#1790, #1791): the slug it
+  // matched against could never appear in a record's text, so the bonus
+  // never actually fired. The repository's NAME is now a normal derived
+  // term (see deriveSearchTerms) and counts 1 like everything else.
+  it('a repo-name term counts 1 like any other matched term — no special case', () => {
+    const h = hit({ snippet: 'fix a bug', tags: ['mono'] });
+    expect(scoreKnowledgeHit(h, ['mono'])).toBe(1);
   });
 
   it('is case-insensitive', () => {
     const h = hit({ snippet: 'Fix The Dashboard Flake', tags: [] });
     expect(scoreKnowledgeHit(h, ['dashboard'])).toBe(1);
+  });
+
+  describe('plural fold (#1791 lexical v2)', () => {
+    it('folds a plural term to match a singular haystack', () => {
+      const h = hit({ snippet: 'the flaky test needs a fix', tags: [] });
+      expect(scoreKnowledgeHit(h, ['tests'])).toBe(1);
+    });
+
+    it('does not fold a term of length <= 3 ending in s ("its" does not fold to "it")', () => {
+      const h = hit({ snippet: 'fix it now', tags: [] });
+      expect(scoreKnowledgeHit(h, ['its'])).toBe(0);
+    });
+
+    it('does not require the fold when the plural already matches verbatim', () => {
+      const h = hit({ snippet: 'the flaky tests need a fix', tags: [] });
+      expect(scoreKnowledgeHit(h, ['tests'])).toBe(1);
+    });
   });
 });
 
@@ -261,5 +365,100 @@ describe('selectKnowledgeHits (rescope §3.3)', () => {
 
   it('no candidates → empty selection', () => {
     expect(selectKnowledgeHits([], ['anything'])).toEqual([]);
+  });
+});
+
+// Rebuilds the five-message x three-record validation table from #1791's
+// decision comment as unit tests. Hit shapes mirror the real Stage 1 seed
+// fixtures verbatim (client/packages/harness-layer/fixtures/stage1-seeds/
+// *.episode.json): taskSummary -> snippet, tags -> tags — the only two
+// fields haystackFor() reads, so this is a faithful proxy for the real
+// corpus records without needing the seed-import/IPFS machinery in a unit
+// test. repositorySlug is REPO ('Jinn-Network/mono') throughout, matching
+// the real corpus's actual repository (the source and operator-claims
+// fixtures are both genuinely from Jinn-Network/mono; sympy is not).
+describe('lexical v2 validation table (#1791 decision comment)', () => {
+  const SOURCE = hit({
+    ref: 'source-dashboard-flake',
+    snippet:
+      'Fix flaky dashboard update_available banner test — assert after the version status fetch resolves',
+    tags: ['mono', 'dashboard', 'vitest', 'version-status', 'async', 'flake'],
+  });
+  const OPERATOR_CLAIMS = hit({
+    ref: 'distractor-operator-claims',
+    snippet: 'Warn when a joinedSolverNets entry silently skips claim registration',
+    tags: ['mono', 'operator', 'claims', 'solvernet'],
+  });
+  const SYMPY = hit({
+    ref: 'distractor-sympy-printing',
+    snippet: 'Fix LaTeX printer dropping the separator between multi-part symbol subscripts',
+    tags: ['sympy', 'printing', 'latex', 'regression'],
+  });
+  const ALL_THREE = [SOURCE, OPERATOR_CLAIMS, SYMPY];
+
+  it('Run B (verbatim, #1791): retrieves the on-topic source record; the same-repo distractor scores repo-name-only and is excluded; the other-domain distractor scores 0', () => {
+    const message =
+      'The dashboard notification tests keep going flaky in CI. Please look at the async waits in ' +
+      'the notifications tests under client/src/dashboard/spa/src and make them deterministic, then ' +
+      'run that test file.';
+    const terms = deriveSearchTerms(message, REPO);
+
+    expect(scoreKnowledgeHit(SOURCE, terms)).toBe(3);
+    expect(scoreKnowledgeHit(OPERATOR_CLAIMS, terms)).toBe(1);
+    expect(scoreKnowledgeHit(SYMPY, terms)).toBe(0);
+
+    const selected = selectKnowledgeHits(ALL_THREE, terms);
+    expect(selected.map((h) => h.ref)).toEqual(['source-dashboard-flake']);
+  });
+
+  it('Run A (#1006, dashboard USD labels): both the source and the same-repo distractor clear the floor, and the distractor ranks first — an accepted precision limit', () => {
+    // Accepted trade-off (#1791 decision comment): "Run A's lexical
+    // collision ('AI-units claim gate' vs 'claim registration') ranks D1
+    // above the source. Bag-of-words ceiling; accepted for Stage 1 (provided
+    // != helped; attribution visible; 2-packet cap) and pinned in a unit
+    // test as documented behavior." This is that pin.
+    const message =
+      'The operator dashboard still labels the AI-units claim gate in units, ' +
+      'even though the daemon now reports actual USD spend with an estimated ' +
+      'flag. Update the dashboard so it shows USD and distinguishes a metered ' +
+      'figure from an estimated one. Run the dashboard tests when you are done.';
+    const terms = deriveSearchTerms(message, REPO);
+
+    expect(scoreKnowledgeHit(SOURCE, terms)).toBe(2);
+    expect(scoreKnowledgeHit(OPERATOR_CLAIMS, terms)).toBe(3);
+    expect(scoreKnowledgeHit(SYMPY, terms)).toBe(0);
+
+    const selected = selectKnowledgeHits(ALL_THREE, terms);
+    expect(selected.map((h) => h.ref)).toEqual([
+      'distractor-operator-claims',
+      'source-dashboard-flake',
+    ]);
+  });
+
+  it("the gate's no-result message (verbatim, apps/jinn-agent/scripts/stage1-stock-product.py): scores below the floor against every fixture — honest nothing-found", () => {
+    const message =
+      'Investigate why the OLAS staking reward-claim loop occasionally ' +
+      'double-counts checkpoint epochs on Base Sepolia.';
+    const terms = deriveSearchTerms(message, REPO);
+
+    expect(scoreKnowledgeHit(SOURCE, terms)).toBe(1);
+    expect(scoreKnowledgeHit(OPERATOR_CLAIMS, terms)).toBe(1);
+    expect(scoreKnowledgeHit(SYMPY, terms)).toBe(0);
+    expect(selectKnowledgeHits(ALL_THREE, terms)).toEqual([]);
+  });
+
+  it('an unrelated same-repo message with zero content overlap does not clear the floor on the repo-name term alone (#1791 AC, #1790)', () => {
+    const message = 'Draft the quarterly OKR review deck for the leadership meeting next week.';
+    const terms = deriveSearchTerms(message, REPO);
+
+    // Only the repo-name term ('mono') can possibly match either mono-repo
+    // fixture; content overlap is zero by construction. One point is below
+    // RELEVANCE_FLOOR (2), so nothing is selected — the honest outcome
+    // #1791's AC requires: "A same-repo record with zero content overlap
+    // does not clear the floor."
+    expect(scoreKnowledgeHit(SOURCE, terms)).toBe(1);
+    expect(scoreKnowledgeHit(OPERATOR_CLAIMS, terms)).toBe(1);
+    expect(scoreKnowledgeHit(SYMPY, terms)).toBe(0);
+    expect(selectKnowledgeHits(ALL_THREE, terms)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Faithful implementation of the ratified "lexical v2" design from #1791's decision comment (empirically validated by the issue author against the three real Stage 1 seed fixtures and five representative messages before landing). Closes three related term-selection defects in `packages/plugin/src/pickup.ts` as one cohesive change:

- **#1791** — term selection optimized for length/identifier-shape, not retrievability. A tight 6-term budget, longest-first remainder ordering, and over-specific path tokens starved real, on-topic tasks below the relevance floor.
- **#1790** — the repository-slug term was dead weight: it could never match a record's text (no record's text contains the literal `owner/repo` string), so it both stole a term slot and its `+2` scoring bonus never fired.
- **#1789** — quoted/backtick spans bypassed `cleanWord`, keeping trailing punctuation (e.g. `` `npm test.` `` kept its period and could never match).

### What changed in `deriveSearchTerms` / `scoreKnowledgeHit` / `selectKnowledgeHits`

1. `MAX_TERMS` 6 → 10.
2. Remainder bucket is now **message order** (order of first appearance), not longest-first.
3. Any identifier-shaped token containing `/` also contributes its **path segments** (cleaned, ≥3 chars, stopword-filtered, deduplicated), right after the full token.
4. The repository's **name** (segment after the last `/` of `repositorySlug`, ≥3 chars) replaces the full slug as a normal term. The `term === repoTerm ? 2 : 1` special case in `scoreKnowledgeHit` is deleted — every matched term counts 1. The now-dead `repositorySlug` parameter is removed from `scoreKnowledgeHit`/`selectKnowledgeHits` (`plugin.ts` still passes `repositorySlug` to `deriveSearchTerms`, which is where it now does all its work).
5. **Plural fold** at match time: a term matches verbatim, or — for a term ending in a simple plural `s` with length > 3 — its singular form matches.
6. Quoted/backtick spans now run through `cleanWord`'s leading/trailing `_-./` strip before being pushed. `cleanWord` gains space to its character whitelist so this is safe on multi-word spans (the two existing single-word call sites never see a raw space, so this is a no-op there).
7. Floor stays 2; top-2 selection, skill exclusion, and dedup are unchanged.

### `plugin.ts`

No behavior change to the wiring intent: `firstTurnPickup` still passes `repositorySlug` to `deriveSearchTerms` (derivation). The now-dead 3rd argument to `selectKnowledgeHits` (the old repo-bonus plumbing) is removed, since the repo-name signal now flows entirely through the derived `terms` array like any other term.

### Tests

`packages/plugin/test/pickup.test.ts` rebuilds the five-message × three-fixture validation table from #1791's decision comment as unit tests, using hit shapes that mirror the real Stage 1 seed fixtures verbatim (`client/packages/harness-layer/fixtures/stage1-seeds/*.episode.json` — `taskSummary` → `snippet`, `tags` → `tags`, the only two fields `haystackFor()` reads):

- Run B (the real on-topic walkthrough task, verbatim from #1791) → source clears the floor and is selected; the same-repo distractor scores repo-name-only (1, excluded); the other-domain distractor scores 0.
- Run A (#1006, dashboard USD labels — reconstructed from the exact pre-lexical-v2 derived-terms fingerprint recorded verbatim in #1654's R6 walkthrough #3 comment, and now cross-verified against the real fixtures) → both source and the same-repo distractor clear the floor, distractor ranks first — pinned as documented, accepted behavior citing #1791's accepted-trade-off paragraph.
- The gate's own no-result message (verbatim) and a constructed same-repo/zero-content-overlap control → nothing clears the floor in either case, pinning #1791's AC ("a same-repo record with zero content overlap does not clear the floor").
- New `deriveSearchTerms` unit tests: message-order remainder (a 5-char early word beats a 13-char later one), path segmentation (`client/src/dashboard/spa/src` → full token + `dashboard`/`spa`/`client`/`src`, `src` included at exactly the 3-char minimum), repo-name derivation (`Jinn-Network/mono` → `mono`, short names <3 chars excluded, no-slash slugs used whole), plural fold (`tests` matches `test`; `its` does not fold), quoted-span stripping (`` `npm test.` `` → `npm test`, no trailing period; multi-word and path-shaped spans keep their shape).
- Existing tests that pinned the old `+2` repo bonus, the old 6-term cap, or longest-first order are rewritten to pin the new behavior, citing the issue numbers. Every other existing test stays green **unmodified** — notably the existing `#1786` term-hygiene test using the real Run A message text needed no changes at all (its loose `toContain`/no-trailing-period assertions hold under both the old and new algorithm).

### Reproduced validation table (built `dist/pickup.js`, `repositorySlug = 'Jinn-Network/mono'`)

Matches #1791's decision comment **exactly**:

| message | source | D1 operator-claims | D2 sympy | selected (top-2, ranked) |
|---|---|---|---|---|
| Run B (flaky notification tests — the real on-topic task) | **3** | 1 | 0 | source-dashboard-flake |
| Run A (USD labels) | 2 | **3** | 0 | distractor-operator-claims, source-dashboard-flake |
| gate scenario-1 | **5** | 1 | 0 | source-dashboard-flake |
| gate no-result | 1 | 1 | 0 | (none) |
| unrelated control (same-repo/zero-content AC) | 1 | 1 | 0 | (none) |

### Gate-margin verification (`apps/jinn-agent/scripts/stage1-stock-product.py`) — driver **not** edited

The decision-comment table above (and the pinned unit tests) use `repositorySlug = 'Jinn-Network/mono'` — the real corpus's actual repository, matching the issue author's validation methodology. The **live gate driver** itself derives `repositorySlug` from its fixture git repo's remote (`https://github.com/acme/widget.git` → `acme/widget`, via `session_bridge._repository_slug`/`snapshot_repository` in `apps/jinn-agent/plugins/jinn/session_bridge.py:75-108`, exercised end-to-end by `apps/jinn-agent/tests/plugins/test_jinn_session_evidence.py::test_snapshot_and_accepted_diff_cover_every_change_without_mutation`, which asserts a `git@github.com:Jinn-Network/example.git` remote yields `repository_slug == "Jinn-Network/example"`), which is unrelated to the corpus fixtures' real repo. Computed with that **actual** driver-path slug:

| message | source | D1 | D2 | floor |
|---|---|---|---|---|
| gate scenario-1 (`TARGET_TASK_MESSAGE`) | **4** | 0 | 0 | 2 |
| gate no-result (`NO_RESULT_MESSAGE`) | 0 | 0 | 0 | 2 |

Scenario-1 clears the floor with a margin of 2 and is the sole candidate above it (distractors both at 0); the no-result message stays at 0 against every fixture. Both driver assertions (`expected_pickup=True` for scenario 1, `expected_pickup=False` for the no-result scenario) hold under the new scorer. Per the task's instructions, since both hold, **the driver is not edited** — this section is that stated verification. (Note: `TARGET_TASK_MESSAGE`'s inline comment block in the driver, lines 68–85, still describes the pre-lexical-v2 score of 3; it is now stale documentation, not a functional problem, and was left alone per the "do not edit the driver" instruction — worth a follow-up doc-only touch-up if desired.)

### Verification

- `cd packages/plugin && yarn install && yarn typecheck && yarn build && yarn test` — 186/186 tests green, 23 test files.
- `cd client && yarn install && yarn typecheck` — green.
- `cd client && npx vitest run packages/harness-layer/test` (after `yarn build:sdk && yarn build:plugin && yarn build:harness-layer-store`, so the adapters compile against the freshly built plugin) — 736/736 tests green, 51 test files.
- Decision table and gate-margin numbers above reproduced against the built `packages/plugin/dist/pickup.js`.

Closes #1791
Closes #1790
Closes #1789
Refs #1654
Refs #1775
Refs #1792

🤖 Generated with [Claude Code](https://claude.com/claude-code)
