### PR TITLE
fix(plugin): exclude content-classified skill records and empty packets from pickup (#1782)

### DIFF
--- a/client/packages/harness-layer/src/adapters/corpus-adapter.ts
+++ b/client/packages/harness-layer/src/adapters/corpus-adapter.ts
@@ -18,8 +18,9 @@ import {
   type HarnessLayer,
   type HarnessLayerConfig,
 } from '../consume.js';
-import { parseTraceEnvelopeV0, type TraceStep } from '../envelope.js';
+import { parseTraceEnvelopeV0, type TraceEnvelopeV0, type TraceStep } from '../envelope.js';
 import { TRACE_ENVELOPE_ARTIFACT_TYPE } from '../publish.js';
+import { SKILL_ARTIFACT_TYPE } from '../../../../src/types/skill-artifact.js';
 
 export interface CorpusAdapterDeps {
   /** A ready HarnessLayer (test seam: a fake `{ corpus: { search, get } }`). */
@@ -65,6 +66,33 @@ function seedStepSynthesis(steps: readonly TraceStep[]): string | undefined {
 }
 
 /**
+ * True when any step carries a string `skill.md` attribute — the legacy
+ * pre-#1394 seed shape (`seed-import/execute.ts` `toCapturedTask`). Checks
+ * every step, not only one named `seed:skill-md`: the wire shape this guard
+ * exists for already lied about `kind` once, so detection here keys on the
+ * attribute itself, not a step-naming convention layered on top of it.
+ */
+function hasSkillMdAttribute(steps: readonly TraceStep[]): boolean {
+  return steps.some((step) => {
+    const value = step.attributes['skill.md'];
+    return typeof value === 'string' && value.length > 0;
+  });
+}
+
+/**
+ * Content-level skill-payload classification (mono #1782): true when the
+ * record is a skill package regardless of the search hit's wire `kind` —
+ * either a first-class `jinn.skill.v1` artifact (checked by presence only,
+ * not parsed/validated here — parsing a malformed skill artifact's body is
+ * `extractSkill()`'s job, and must not be able to fail *this* guard), or the
+ * legacy seeded shape `hasSkillMdAttribute` recognises.
+ */
+function detectSkillPayload(record: WireCorpusRecord, envelope: TraceEnvelopeV0): boolean {
+  if (record.artifacts.some((a) => a.artifactType === SKILL_ARTIFACT_TYPE)) return true;
+  return hasSkillMdAttribute(envelope.steps);
+}
+
+/**
  * Decode the record's `jinn.trace-envelope.v0` artifact into the plugin's
  * content-bearing `CorpusRecord`. Verifies the artifact bytes against the
  * record's own sha256 before parsing — a mismatch refuses to serve
@@ -91,6 +119,16 @@ function decodeRecord(record: WireCorpusRecord): CorpusRecord | null {
   const origin = record.provenance.operator.agentId || record.provenance.operator.safeAddress || record.ref;
   const synthesis = envelope.outcome.summary ?? seedStepSynthesis(envelope.steps);
 
+  // Fails open (mono #1782): a detection error never blocks the rest of the
+  // record's content from being served — it just leaves the fact
+  // undetermined, exactly as if this guard did not exist for that record.
+  let isSkillPayload = false;
+  try {
+    isSkillPayload = detectSkillPayload(record, envelope);
+  } catch {
+    isSkillPayload = false;
+  }
+
   return {
     ref: record.ref,
     task: { summary: envelope.task.summary },
@@ -101,6 +139,7 @@ function decodeRecord(record: WireCorpusRecord): CorpusRecord | null {
     provenance: envelope.provenance,
     origin,
     capturedAt: envelope.session.capturedAt,
+    ...(isSkillPayload ? { isSkillPayload: true } : {}),
   };
 }
 

--- a/client/packages/harness-layer/test/adapters/corpus-adapter.test.ts
+++ b/client/packages/harness-layer/test/adapters/corpus-adapter.test.ts
@@ -5,7 +5,8 @@ import { describeCorpusPortContract } from '@jinn-network/plugin/testing';
 import type { HarnessLayer, CorpusSearchHit, CorpusRecord as WireCorpusRecord } from '../../src/consume.js';
 import { createCorpusAdapter } from '../../src/adapters/corpus-adapter.js';
 import { TRACE_ENVELOPE_ARTIFACT_TYPE } from '../../src/publish.js';
-import type { TraceEnvelopeV0 } from '../../src/envelope.js';
+import type { TraceEnvelopeV0, TraceStep } from '../../src/envelope.js';
+import { SKILL_ARTIFACT_TYPE } from '../../../../src/types/skill-artifact.js';
 
 function makeHit(overrides: Partial<CorpusSearchHit> = {}): CorpusSearchHit {
   return {
@@ -293,5 +294,120 @@ describe('CorpusAdapter.get() — content-bearing decode (rescope R2, #1772)', (
   it('returns ok(null) when the underlying manifest is missing (unknown ref)', async () => {
     const adapter = createCorpusAdapter({ layer: makeFakeLayer() });
     expect(await adapter.get('does-not-exist')).toEqual({ status: 'ok', value: null });
+  });
+});
+
+/** The exact step shape `seed-import/execute.ts` `toCapturedTask` publishes
+ *  for a legacy (pre-#1394) seed-imported skill: a single synthetic step
+ *  named `seed:skill-md` carrying the SKILL.md as a string `skill.md`
+ *  attribute plus `seed.attribution` — no first-class `jinn.skill.v1`
+ *  artifact, so this record's wire `kind` is `'trace'`. */
+function seedSkillMdStep(skillMd = '# Video Edit\n\nEdit video clips with RunComfy workflows.'): TraceStep {
+  return {
+    spanId: 'seed-1',
+    parentSpanId: null,
+    name: 'seed:skill-md',
+    startTimeUnixNano: '1000000000',
+    endTimeUnixNano: '1000000000',
+    attributes: {
+      'skill.md': skillMd,
+      'seed.attribution': {
+        skill: 'agentspace-so/runcomfy-agent-skills/video-edit',
+        source: 'https://github.com/agentspace-so/runcomfy-agent-skills',
+        licence: 'MIT',
+      },
+    },
+    redactedKeys: [],
+  };
+}
+
+describe('CorpusAdapter.get() — content-level skill classification (mono #1782)', () => {
+  it('classifies a legacy pre-#1394 seeded record as a skill payload via its skill.md step attribute, even though the wire kind is trace', async () => {
+    const layer = makeFakeLayer();
+    const wireRecord = wireRecordWithTrace({
+      task: {
+        summary: 'Seed import: agentspace-so/runcomfy-agent-skills/video-edit',
+        distributionTags: ['seed-import', 'runcomfy-agent-skills', 'video-edit'],
+      },
+      steps: [seedSkillMdStep()],
+      outcome: { status: 'completed', verifiabilityTier: 'user-accepted' },
+      provenance: 'imported',
+    });
+    layer.corpus.get = async () => wireRecord;
+    const adapter = createCorpusAdapter({ layer });
+
+    const result = await adapter.get('bafySourceEpisode');
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok' || result.value === null) throw new Error('expected a decoded record');
+    expect(result.value.isSkillPayload).toBe(true);
+  });
+
+  it('recognises a skill.md attribute on any step, not only one named seed:skill-md', async () => {
+    const layer = makeFakeLayer();
+    const wireRecord = wireRecordWithTrace({
+      steps: [{ ...seedSkillMdStep(), name: 'some-other-step-name' }],
+    });
+    layer.corpus.get = async () => wireRecord;
+    const adapter = createCorpusAdapter({ layer });
+
+    const result = await adapter.get('bafySourceEpisode');
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok' || result.value === null) throw new Error('expected a decoded record');
+    expect(result.value.isSkillPayload).toBe(true);
+  });
+
+  it('classifies a first-class jinn.skill.v1-backed record as a skill payload even when the wire kind says trace', async () => {
+    const layer = makeFakeLayer();
+    const wireRecord = wireRecordWithTrace();
+    wireRecord.artifacts.push({
+      sha256: 'a'.repeat(64),
+      artifactType: SKILL_ARTIFACT_TYPE,
+      content: Buffer.from('{}'),
+      source: 'ipfs',
+      sizeBytes: 2,
+    });
+    layer.corpus.get = async () => wireRecord;
+    const adapter = createCorpusAdapter({ layer });
+
+    const result = await adapter.get('bafySourceEpisode');
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok' || result.value === null) throw new Error('expected a decoded record');
+    expect(result.value.isSkillPayload).toBe(true);
+  });
+
+  it('does not set isSkillPayload for an ordinary trace record (regression — the seeded evidence fixtures project as before)', async () => {
+    const layer = makeFakeLayer();
+    const wireRecord = wireRecordWithTrace();
+    layer.corpus.get = async () => wireRecord;
+    const adapter = createCorpusAdapter({ layer });
+
+    const result = await adapter.get('bafySourceEpisode');
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok' || result.value === null) throw new Error('expected a decoded record');
+    expect(result.value.isSkillPayload).toBeUndefined();
+  });
+
+  it('does not classify a step whose skill.md attribute is present but empty or non-string', async () => {
+    const layer = makeFakeLayer();
+    const wireRecord = wireRecordWithTrace({
+      steps: [
+        {
+          spanId: 's1',
+          parentSpanId: null,
+          name: 'run tests',
+          startTimeUnixNano: '1000000000',
+          endTimeUnixNano: '2000000000',
+          attributes: { 'skill.md': '', 'tool.args': 'yarn test', 'tool.exitCode': 0 },
+          redactedKeys: [],
+        },
+      ],
+    });
+    layer.corpus.get = async () => wireRecord;
+    const adapter = createCorpusAdapter({ layer });
+
+    const result = await adapter.get('bafySourceEpisode');
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok' || result.value === null) throw new Error('expected a decoded record');
+    expect(result.value.isSkillPayload).toBeUndefined();
   });
 });

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -57,6 +57,7 @@ export {
   dedupeKnowledgeHits,
   scoreKnowledgeHit,
   selectKnowledgeHits,
+  rankKnowledgeHits,
   MAX_SELECTED_PACKETS,
 } from './pickup.js';
 export {

--- a/packages/plugin/src/pickup.ts
+++ b/packages/plugin/src/pickup.ts
@@ -237,12 +237,20 @@ function tierRank(tier: string | undefined): number {
 }
 
 /**
- * Evidence-first selection (rescope §3.3): drop skill hits, dedup, score,
- * apply the relevance floor (honest nothing-found below it), rank
- * score desc → tier desc → recency desc, take the top
- * `MAX_SELECTED_PACKETS`.
+ * Full ranked candidate pool (rescope §3.3 selection policy): drop skill
+ * hits, dedup, score, apply the relevance floor (honest nothing-found below
+ * it), rank score desc → tier desc → recency desc — every candidate that
+ * clears the floor, not sliced to `MAX_SELECTED_PACKETS`.
+ *
+ * Content-level guards that can only run after a candidate's content is
+ * fetched (mono #1782: post-fetch skill-payload classification, empty-packet
+ * honesty) need to walk past a disqualified top candidate to the
+ * next-ranked one, so the orchestrator (`plugin.ts` `firstTurnPickup`) walks
+ * this unsliced list and does its own promotion-aware slicing.
+ * `selectKnowledgeHits` remains the pre-guards convenience wrapper for
+ * callers that only need the top slice.
  */
-export function selectKnowledgeHits(
+export function rankKnowledgeHits(
   hits: KnowledgeHit[],
   terms: string[],
 ): KnowledgeHit[] {
@@ -259,5 +267,20 @@ export function selectKnowledgeHits(
     return (b.hit.publishedAt ?? 0) - (a.hit.publishedAt ?? 0);
   });
 
-  return scored.slice(0, MAX_SELECTED_PACKETS).map((scoredHit) => scoredHit.hit);
+  return scored.map((scoredHit) => scoredHit.hit);
+}
+
+/**
+ * Evidence-first selection (rescope §3.3): the top `MAX_SELECTED_PACKETS` of
+ * `rankKnowledgeHits`. A caller that also needs to apply the post-fetch
+ * content-level guards (mono #1782) should walk `rankKnowledgeHits` directly
+ * instead — slicing here happens before those guards can run, so a
+ * candidate they disqualify would lose its slot rather than promoting the
+ * next-ranked one.
+ */
+export function selectKnowledgeHits(
+  hits: KnowledgeHit[],
+  terms: string[],
+): KnowledgeHit[] {
+  return rankKnowledgeHits(hits, terms).slice(0, MAX_SELECTED_PACKETS);
 }

--- a/packages/plugin/src/plugin.ts
+++ b/packages/plugin/src/plugin.ts
@@ -30,7 +30,7 @@ import {
 import type { KnowledgeHit } from './schemas/knowledge-hit.js';
 import type { SessionSummary } from './schemas/session-summary.js';
 import { projectKnowledgePacket, type KnowledgePacket } from './schemas/knowledge-packet.js';
-import { deriveSearchTerms, selectKnowledgeHits } from './pickup.js';
+import { deriveSearchTerms, rankKnowledgeHits, MAX_SELECTED_PACKETS } from './pickup.js';
 import { degraded, ok, unavailable, valueOr, type PortResult } from './outcome.js';
 import { parsePickupConfig, type PickupConfig } from './schemas/pickup-config.js';
 import { deriveEligibility } from './eligibility.js';
@@ -334,8 +334,8 @@ export class PluginSession {
       }
     }
 
-    const selected = selectKnowledgeHits([...byRef.values()], terms);
-    if (selected.length === 0) {
+    const ranked = rankKnowledgeHits([...byRef.values()], terms);
+    if (ranked.length === 0) {
       return {
         contextBlock: null,
         packets: [],
@@ -344,12 +344,21 @@ export class PluginSession {
       };
     }
 
-    // Fetch full content for the selected refs and project packets. A
-    // projection failure degrades that one ref to nothing-found rather than
-    // throwing into the caller (§3.5).
+    // Fetch full content for ranked candidates and project packets, walking
+    // down the ranked list until MAX_SELECTED_PACKETS valid packets are
+    // found or candidates are exhausted (mono #1782). Two post-fetch guards
+    // can disqualify a candidate without spending its slot, promoting the
+    // next-ranked one: (1) content-level skill classification — excludes a
+    // legacy skill-shaped record (skill.md step attribute) or a
+    // jinn.skill.v1-backed record that slipped the wire kind filter, exactly
+    // as a wire kind:'skill' hit is excluded at selection time; (2)
+    // empty-packet honesty — a projection with zero excerpts and no
+    // synthesis is not evidence. A projection failure degrades that one ref
+    // to nothing-found rather than throwing into the caller (§3.5).
     const fetchedRefs: string[] = [];
     const packets: KnowledgePacket[] = [];
-    for (const hit of selected) {
+    for (const hit of ranked) {
+      if (packets.length >= MAX_SELECTED_PACKETS) break;
       fetchedRefs.push(hit.ref);
       const result = await this.deps.corpus.get(hit.ref);
       if (result.status !== 'ok') {
@@ -358,11 +367,18 @@ export class PluginSession {
       }
       const record: CorpusRecord | null = result.value;
       if (record === null) continue;
+      if (record.isSkillPayload === true) continue;
+
+      let packet: KnowledgePacket;
       try {
-        packets.push(projectKnowledgePacket(record));
+        packet = projectKnowledgePacket(record);
       } catch (error) {
         degradedReason ??= `packet projection failed for ${hit.ref}: ${errorReason(error)}`;
+        continue;
       }
+      if (packet.excerpts.length === 0 && packet.synthesis === undefined) continue;
+
+      packets.push(packet);
     }
 
     this.fetchedRefs = fetchedRefs;

--- a/packages/plugin/src/ports/corpus-port.ts
+++ b/packages/plugin/src/ports/corpus-port.ts
@@ -40,6 +40,20 @@ export interface CorpusRecord {
    *  search hit's trustworthy `origin`. */
   origin: string;
   capturedAt: string;
+  /**
+   * True when the adapter's decode determined the record's payload is a
+   * skill package — a step carrying a string `skill.md` attribute (legacy
+   * pre-#1394 seed shape) or the record backed by a `jinn.skill.v1` artifact
+   * (first-class shape) — regardless of the search hit's wire `kind`/
+   * `payloadKind` (mono #1782: a legacy skill-shaped record classifies as
+   * `kind: 'trace'` on the wire and slips the selection-time filter).
+   * Adapter-computed fact; the core (`plugin.ts` `firstTurnPickup`) enforces
+   * exclusion — keeps the core the policy owner, the adapter the fact
+   * provider. Undefined when undetermined, including when the adapter's own
+   * detection errors — the guard fails open, exactly like an ordinary trace
+   * record.
+   */
+  isSkillPayload?: boolean;
 }
 
 export interface CorpusPort {

--- a/packages/plugin/test/pickup.test.ts
+++ b/packages/plugin/test/pickup.test.ts
@@ -3,6 +3,7 @@ import {
   classifyPayload,
   dedupeKnowledgeHits,
   deriveSearchTerms,
+  rankKnowledgeHits,
   scoreKnowledgeHit,
   selectKnowledgeHits,
   MAX_SELECTED_PACKETS,
@@ -365,6 +366,46 @@ describe('selectKnowledgeHits (rescope §3.3)', () => {
 
   it('no candidates → empty selection', () => {
     expect(selectKnowledgeHits([], ['anything'])).toEqual([]);
+  });
+});
+
+// Mono #1782: content-level guards that only run after a candidate's
+// content is fetched (skill-payload classification, empty-packet honesty)
+// need to promote past a disqualified top candidate to the next-ranked one.
+// selectKnowledgeHits alone cannot support that — it is already sliced to
+// MAX_SELECTED_PACKETS before any post-fetch guard could run.
+describe('rankKnowledgeHits (mono #1782)', () => {
+  // Distinct origins: three different source episodes that happen to score
+  // similarly — not duplicated seeds of one another (dedup is covered above).
+  function threeRankedHits(): [KnowledgeHit, KnowledgeHit, KnowledgeHit] {
+    const a = hit({ ref: 'a', snippet: 'dashboard vitest flake', tier: 'evaluator-verified', publishedAt: 3, origin: 'op-a' });
+    const b = hit({ ref: 'b', snippet: 'dashboard vitest flake', tier: 'tests-passed', publishedAt: 2, origin: 'op-b' });
+    const c = hit({ ref: 'c', snippet: 'dashboard vitest flake', tier: 'user-accepted', publishedAt: 1, origin: 'op-c' });
+    return [a, b, c];
+  }
+
+  it('returns every above-floor candidate, not sliced to MAX_SELECTED_PACKETS', () => {
+    const [a, b, c] = threeRankedHits();
+    const terms = ['dashboard', 'vitest', 'flake'];
+
+    const ranked = rankKnowledgeHits([a, b, c], terms);
+    expect(ranked.map((h) => h.ref)).toEqual(['a', 'b', 'c']);
+    expect(ranked.length).toBeGreaterThan(MAX_SELECTED_PACKETS);
+  });
+
+  it('selectKnowledgeHits is exactly the top MAX_SELECTED_PACKETS slice of rankKnowledgeHits', () => {
+    const [a, b, c] = threeRankedHits();
+    const terms = ['dashboard', 'vitest', 'flake'];
+
+    expect(selectKnowledgeHits([a, b, c], terms)).toEqual(
+      rankKnowledgeHits([a, b, c], terms).slice(0, MAX_SELECTED_PACKETS),
+    );
+  });
+
+  it('still drops skill hits and applies the relevance floor — same filter pipeline as selectKnowledgeHits', () => {
+    const skill = hit({ ref: 'skill-1', kind: 'skill', snippet: 'dashboard vitest flake', tags: ['dashboard'] });
+    const weak = hit({ ref: 'weak', snippet: 'dashboard only', tags: [] });
+    expect(rankKnowledgeHits([skill, weak], ['dashboard', 'vitest'])).toEqual([]);
   });
 });
 

--- a/packages/plugin/test/plugin/first-turn-pickup.test.ts
+++ b/packages/plugin/test/plugin/first-turn-pickup.test.ts
@@ -120,6 +120,149 @@ function skillDistractor(ref: string): InMemoryCorpusSeed {
   };
 }
 
+/**
+ * Mono #1782 — the live R6 escalation: a legacy pre-#1394 seed-imported skill
+ * record. The seed-import lane (`seed-import/execute.ts` `toCapturedTask`)
+ * publishes the SKILL.md as a single synthetic step named `seed:skill-md`
+ * carrying a string `skill.md` attribute — no first-class `jinn.skill.v1`
+ * artifact — so the real indexer classifies it `kind: 'trace'` on the wire
+ * (`consume.ts` `toSearchHit`: kind is derived from artifact presence only).
+ * The structural shape (step name + attribute key) mirrors the real
+ * RunComfy record verbatim; only the tags/summary vocabulary is invented so
+ * this fixture can be scored deterministically without a live indexer.
+ */
+function runComfySkillLeak(): InMemoryCorpusSeed {
+  return {
+    ref: 'bafyRunComfySkillLeak',
+    kind: 'trace', // wire kind lies for a legacy skill-shaped seed — this is the bug.
+    task: { summary: 'Seed import: agentspace-so/runcomfy-agent-skills/video-edit' },
+    outcome: { status: 'completed', verifiabilityTier: 'user-accepted' },
+    steps: [
+      {
+        name: 'seed:skill-md',
+        attributes: {
+          'skill.md': '# Video Edit\n\nEdit video clips with RunComfy workflows.',
+          'seed.attribution': {
+            skill: 'agentspace-so/runcomfy-agent-skills/video-edit',
+            source: 'https://github.com/agentspace-so/runcomfy-agent-skills',
+            licence: 'MIT',
+          },
+        },
+      },
+    ],
+    tags: ['seed-import', 'runcomfy-agent-skills', 'video-edit'],
+    provenance: 'imported',
+    origin: 'seed:runcomfy-video-edit',
+    capturedAt: '2026-07-02T00:00:00.000Z',
+    tier: 'user-accepted',
+    // Content-level fact the corpus adapter derives from the skill.md step
+    // attribute (client/packages/harness-layer/src/adapters/corpus-adapter.ts)
+    // — hand-set here because the plugin package never decodes trace
+    // envelopes itself; that derivation is covered by
+    // client/packages/harness-layer/test/adapters/corpus-adapter.test.ts.
+    isSkillPayload: true,
+  };
+}
+
+/** Real evidence paired with the leak above — the record the live
+ *  escalation's "two packets" bug still ought to deliver once the leak is
+ *  excluded. */
+function checkoutEvidence(): InMemoryCorpusSeed {
+  return {
+    ref: 'bafyCheckoutEvidence',
+    kind: 'trace',
+    task: { summary: 'Fix the checkout button double-submit bug' },
+    outcome: { status: 'completed', verifiabilityTier: 'tests-passed' },
+    synthesis:
+      'The submit handler was not debounced, so a fast double click double-submitted '
+      + 'the checkout order. Adding a debounce guard fixed it.',
+    steps: [
+      {
+        name: 'run tests',
+        attributes: {
+          'tool.args': 'yarn test checkout',
+          'tool.result': 'FAIL: expected 1 submit got 2',
+          'tool.exitCode': 1,
+        },
+      },
+      { name: 'apply fix', attributes: { 'tool.args': 'add debounce guard', 'tool.exitCode': 0 } },
+    ],
+    tags: ['checkout', 'double-submit', 'debounce'],
+    provenance: 'imported',
+    origin: 'seed:checkout-double-submit',
+    capturedAt: '2026-07-10T00:00:00.000Z',
+    tier: 'tests-passed',
+  };
+}
+
+/** Defensive scenario (mono #1782 guard 1, second case): a first-class
+ *  `jinn.skill.v1`-backed record whose wire `kind` is (still, somehow)
+ *  `'trace'` — content-level classification must exclude it independent of
+ *  *why* the wire kind under-reported. */
+function distilledSkillLeak(): InMemoryCorpusSeed {
+  return {
+    ref: 'bafyDistilledSkillLeak',
+    kind: 'trace',
+    task: { summary: 'Distilled skill: retry-budget-tuning' },
+    outcome: { status: 'completed', verifiabilityTier: 'evaluator-verified' },
+    steps: [{ name: 'distill', attributes: { 'tool.args': 'distill retry-budget-tuning', 'tool.exitCode': 0 } }],
+    tags: ['retry-budget-tuning', 'distilled'],
+    provenance: 'contributed',
+    origin: 'agent-distill-1',
+    capturedAt: '2026-07-12T00:00:00.000Z',
+    tier: 'evaluator-verified',
+    isSkillPayload: true, // adapter found a jinn.skill.v1 artifact on the record
+  };
+}
+
+/** Mono #1782 guard 2: a record whose steps carry nothing excerpt-shaped and
+ *  no synthesis — `projectKnowledgePacket` yields zero excerpts. Not
+ *  evidence; must not consume a packet slot. */
+function emptyPacketDecoy(): InMemoryCorpusSeed {
+  return {
+    ref: 'bafyEmptyPacketDecoy',
+    kind: 'trace',
+    task: { summary: 'Investigate the payment retry queue backlog' },
+    outcome: { status: 'completed', verifiabilityTier: 'evaluator-verified' },
+    steps: [],
+    tags: ['payment', 'retry-queue', 'backlog'],
+    provenance: 'imported',
+    origin: 'seed:payment-retry-queue',
+    capturedAt: '2026-07-11T00:00:00.000Z',
+    tier: 'evaluator-verified',
+  };
+}
+
+/** The next-ranked, genuinely evidential record the empty decoy above must
+ *  promote to once dropped. */
+function paymentRetryFix(): InMemoryCorpusSeed {
+  return {
+    ref: 'bafyPaymentRetryFix',
+    kind: 'trace',
+    task: { summary: 'Fix the payment retry queue backlog by capping retry count' },
+    outcome: { status: 'completed', verifiabilityTier: 'tests-passed' },
+    synthesis:
+      'The retry queue had no max-attempts cap, so poison messages recirculated forever. '
+      + 'Capping retries at 5 cleared the backlog.',
+    steps: [
+      {
+        name: 'run tests',
+        attributes: {
+          'tool.args': 'yarn test retry-queue',
+          'tool.result': 'FAIL: queue depth 500 after 1h',
+          'tool.exitCode': 1,
+        },
+      },
+      { name: 'apply fix', attributes: { 'tool.args': 'cap retries at 5', 'tool.exitCode': 0 } },
+    ],
+    tags: ['payment', 'retry-queue', 'backlog'],
+    provenance: 'imported',
+    origin: 'seed:payment-retry-queue-fix',
+    capturedAt: '2026-07-13T00:00:00.000Z',
+    tier: 'tests-passed',
+  };
+}
+
 const TARGET_MESSAGE = 'the dashboard `version-status` test is flaking on vitest, likely an unawaited async fetch';
 
 describe('firstTurnPickup over ports — evidence-first pickup (rescope §3/§4.5)', () => {
@@ -192,6 +335,67 @@ describe('firstTurnPickup over ports — evidence-first pickup (rescope §3/§4.
     expect(result.contextBlock).not.toContain('skills install');
     expect(result.contextBlock).not.toContain('bafySkillD3');
     expect(result.contextBlock).not.toContain('bafySkillD4');
+  });
+
+  // Mono #1782 — the live R6 escalation (next @ 1ae580dd3): a natural,
+  // on-topic message returned two packets — the seeded evidence record, and
+  // the legacy RunComfy skill seed (kind:'trace' on the wire, slipping the
+  // rescope's kind:'skill' selection filter, then projecting empty). This
+  // test PINS that regression: pre-fix it returns both refs (mirroring the
+  // live "two packets" symptom); post-fix only the real evidence surfaces.
+  it('mono #1782 pin: a legacy skill-shaped seed (skill.md step attribute, wire kind trace) is excluded by content even though it clears the relevance floor, and the co-ranked real evidence still surfaces', async () => {
+    const plugin = buildPlugin(new InMemoryCorpusPort([
+      checkoutEvidence(),
+      runComfySkillLeak(),
+    ]));
+    const session = plugin.session(META);
+    const message =
+      'the checkout double-submit bug needs a fix, and please check the runcomfy video-edit skill workflow too';
+    const result = await session.firstTurnPickup(message);
+
+    expect(result.packets.map((p) => p.ref)).toEqual(['bafyCheckoutEvidence']);
+    expect(result.contextBlock).not.toContain('bafyRunComfySkillLeak');
+    expect(result.contextBlock).not.toContain('runcomfy');
+  });
+
+  it('mono #1782 guard 1: a legacy skill-shaped seed alone yields an honest nothing-found, not an empty injected packet', async () => {
+    const plugin = buildPlugin(new InMemoryCorpusPort([runComfySkillLeak()]));
+    const session = plugin.session(META);
+    const message = 'please help me use the `runcomfy-agent-skills` video-edit skill';
+    const result = await session.firstTurnPickup(message);
+
+    expect(result.packets).toEqual([]);
+    expect(result.contextBlock).toBeNull();
+  });
+
+  it('mono #1782 guard 1: a first-class jinn.skill.v1-backed record is excluded by content even when the wire kind says trace', async () => {
+    const plugin = buildPlugin(new InMemoryCorpusPort([distilledSkillLeak()]));
+    const session = plugin.session(META);
+    const result = await session.firstTurnPickup('please apply the retry-budget-tuning distilled skill');
+
+    expect(result.packets).toEqual([]);
+    expect(result.contextBlock).toBeNull();
+  });
+
+  it('mono #1782 guard 2: a zero-excerpt, no-synthesis packet is dropped and the next above-floor candidate is promoted into its slot', async () => {
+    const plugin = buildPlugin(new InMemoryCorpusPort([
+      emptyPacketDecoy(),
+      paymentRetryFix(),
+    ]));
+    const session = plugin.session(META);
+    const result = await session.firstTurnPickup('the payment retry queue backlog needs a fix');
+
+    expect(result.packets.map((p) => p.ref)).toEqual(['bafyPaymentRetryFix']);
+    expect(result.contextBlock).not.toContain('bafyEmptyPacketDecoy');
+  });
+
+  it('mono #1782 guard 2: a zero-excerpt, no-synthesis packet with nothing to promote yields an honest nothing-found', async () => {
+    const plugin = buildPlugin(new InMemoryCorpusPort([emptyPacketDecoy()]));
+    const session = plugin.session(META);
+    const result = await session.firstTurnPickup('the payment retry queue backlog needs a fix');
+
+    expect(result.packets).toEqual([]);
+    expect(result.contextBlock).toBeNull();
   });
 
   it('records the searched terms even when nothing is found', async () => {

--- a/packages/plugin/test/plugin/first-turn-pickup.test.ts
+++ b/packages/plugin/test/plugin/first-turn-pickup.test.ts
@@ -215,6 +215,47 @@ function distilledSkillLeak(): InMemoryCorpusSeed {
   };
 }
 
+/**
+ * Isolates guard 1 from guard 2 for the legacy skill.md-attribute detection
+ * path (`distilledSkillLeak` above does the same for the first-class
+ * artifact path). Unlike `runComfySkillLeak` — whose lone `seed:skill-md`
+ * step mirrors the real seed-import shape and never produces an excerpt on
+ * its own — this record ALSO carries an ordinary command step, so guard 2
+ * (empty-packet honesty) would not exclude it by itself: only guard 1
+ * (content-level classification) can be responsible if it is still
+ * excluded. The extra step is not part of the real seed-import shape; it
+ * exists solely to make this isolation possible (independent-review finding
+ * on mono #1782).
+ */
+function skillMdLeakWithExcerpt(): InMemoryCorpusSeed {
+  return {
+    ref: 'bafySkillMdLeakWithExcerpt',
+    kind: 'trace',
+    task: { summary: 'Seed import: acme/skills/deploy-helper' },
+    outcome: { status: 'completed', verifiabilityTier: 'user-accepted' },
+    steps: [
+      {
+        name: 'seed:skill-md',
+        attributes: {
+          'skill.md': '# Deploy Helper\n\nHelps deploy things.',
+          'seed.attribution': {
+            skill: 'acme/skills/deploy-helper',
+            source: 'https://github.com/acme/skills',
+            licence: 'MIT',
+          },
+        },
+      },
+      { name: 'run tests', attributes: { 'tool.args': 'yarn test deploy-helper', 'tool.exitCode': 0 } },
+    ],
+    tags: ['seed-import', 'acme', 'deploy-helper'],
+    provenance: 'imported',
+    origin: 'seed:acme-deploy-helper',
+    capturedAt: '2026-07-08T00:00:00.000Z',
+    tier: 'user-accepted',
+    isSkillPayload: true,
+  };
+}
+
 /** Mono #1782 guard 2: a record whose steps carry nothing excerpt-shaped and
  *  no synthesis — `projectKnowledgePacket` yields zero excerpts. Not
  *  evidence; must not consume a packet slot. */
@@ -259,6 +300,98 @@ function paymentRetryFix(): InMemoryCorpusSeed {
     provenance: 'imported',
     origin: 'seed:payment-retry-queue-fix',
     capturedAt: '2026-07-13T00:00:00.000Z',
+    tier: 'tests-passed',
+  };
+}
+
+/**
+ * Compound promotion scenario (mono #1782, independent-review
+ * recommendation): four above-floor candidates, ranked 1-4 by descending
+ * score. Rank 1 is disqualified by guard 1 (content-classified skill, but
+ * would otherwise project a real excerpt); rank 2 is disqualified by guard
+ * 2 (empty projection). Both must be skipped — not just one — so ranks 3
+ * and 4 are promoted into the two packet slots. Scores are engineered via
+ * a strict term-count gradient (6/4/3/2, all >= the floor of 2) so ranking
+ * is unambiguous without relying on tier tiebreaks.
+ */
+function compoundRank1SkillLeak(): InMemoryCorpusSeed {
+  return {
+    ref: 'bafyCompoundRank1SkillLeak',
+    kind: 'trace',
+    task: { summary: 'widget catalog inventory pricing images sync' },
+    outcome: { status: 'completed', verifiabilityTier: 'evaluator-verified' },
+    steps: [{ name: 'run tests', attributes: { 'tool.args': 'yarn test widget-catalog', 'tool.exitCode': 0 } }],
+    tags: ['widget', 'catalog'],
+    provenance: 'imported',
+    origin: 'seed:compound-rank1-skill-leak',
+    capturedAt: '2026-07-06T00:00:00.000Z',
+    tier: 'evaluator-verified',
+    isSkillPayload: true,
+  };
+}
+
+function compoundRank2EmptyDecoy(): InMemoryCorpusSeed {
+  return {
+    ref: 'bafyCompoundRank2EmptyDecoy',
+    kind: 'trace',
+    task: { summary: 'widget catalog inventory pricing' },
+    outcome: { status: 'completed', verifiabilityTier: 'evaluator-verified' },
+    steps: [],
+    tags: ['widget'],
+    provenance: 'imported',
+    origin: 'seed:compound-rank2-empty-decoy',
+    capturedAt: '2026-07-07T00:00:00.000Z',
+    tier: 'evaluator-verified',
+  };
+}
+
+function compoundRank3Valid(): InMemoryCorpusSeed {
+  return {
+    ref: 'bafyCompoundRank3Valid',
+    kind: 'trace',
+    task: { summary: 'widget catalog inventory' },
+    outcome: { status: 'completed', verifiabilityTier: 'tests-passed' },
+    synthesis:
+      'The widget catalog inventory count drifted from the source of truth; a reconciliation job fixed it.',
+    steps: [
+      {
+        name: 'run tests',
+        attributes: {
+          'tool.args': 'yarn test inventory-sync',
+          'tool.result': 'FAIL: count mismatch',
+          'tool.exitCode': 1,
+        },
+      },
+    ],
+    tags: [],
+    provenance: 'imported',
+    origin: 'seed:compound-rank3-valid',
+    capturedAt: '2026-07-08T00:00:00.000Z',
+    tier: 'tests-passed',
+  };
+}
+
+function compoundRank4Valid(): InMemoryCorpusSeed {
+  return {
+    ref: 'bafyCompoundRank4Valid',
+    kind: 'trace',
+    task: { summary: 'widget catalog' },
+    outcome: { status: 'completed', verifiabilityTier: 'tests-passed' },
+    synthesis: 'The widget catalog page threw on an undefined image URL; a null check fixed the crash.',
+    steps: [
+      {
+        name: 'run tests',
+        attributes: {
+          'tool.args': 'yarn test widget-catalog-page',
+          'tool.result': 'FAIL: cannot read property of undefined',
+          'tool.exitCode': 1,
+        },
+      },
+    ],
+    tags: [],
+    provenance: 'imported',
+    origin: 'seed:compound-rank4-valid',
+    capturedAt: '2026-07-09T00:00:00.000Z',
     tier: 'tests-passed',
   };
 }
@@ -396,6 +529,38 @@ describe('firstTurnPickup over ports — evidence-first pickup (rescope §3/§4.
 
     expect(result.packets).toEqual([]);
     expect(result.contextBlock).toBeNull();
+  });
+
+  // Independent-review finding: runComfySkillLeak (the real seed-import
+  // shape) never produces an excerpt regardless of guard 1, so the pin test
+  // above doesn't by itself prove guard 1 is necessary for that record —
+  // guard 2 alone would also exclude it. This test isolates guard 1: the
+  // record would project a real, non-empty packet if guard 1 did not exist.
+  it('mono #1782 guard 1: a legacy skill.md-attribute record that would otherwise project a non-empty packet is still excluded by content (isolates guard 1 from guard 2)', async () => {
+    const plugin = buildPlugin(new InMemoryCorpusPort([skillMdLeakWithExcerpt()]));
+    const session = plugin.session(META);
+    const result = await session.firstTurnPickup('please use the acme deploy-helper skill for deployment');
+
+    expect(result.packets).toEqual([]);
+    expect(result.contextBlock).toBeNull();
+  });
+
+  // Independent-review recommendation: the promotion loop must skip PAST
+  // multiple consecutive disqualified candidates (a mix of both guards),
+  // not just one, to reach the next valid ones.
+  it('mono #1782: promotion skips past multiple consecutive disqualified candidates (guard 1 then guard 2) to fill both slots', async () => {
+    const plugin = buildPlugin(new InMemoryCorpusPort([
+      compoundRank1SkillLeak(),
+      compoundRank2EmptyDecoy(),
+      compoundRank3Valid(),
+      compoundRank4Valid(),
+    ]));
+    const session = plugin.session(META);
+    const result = await session.firstTurnPickup('please sync the widget catalog inventory pricing images now');
+
+    expect(result.packets.map((p) => p.ref)).toEqual(['bafyCompoundRank3Valid', 'bafyCompoundRank4Valid']);
+    expect(result.contextBlock).not.toContain('bafyCompoundRank1SkillLeak');
+    expect(result.contextBlock).not.toContain('bafyCompoundRank2EmptyDecoy');
   });
 
   it('records the searched terms even when nothing is found', async () => {

--- a/packages/plugin/test/ports/corpus-port.test.ts
+++ b/packages/plugin/test/ports/corpus-port.test.ts
@@ -59,4 +59,33 @@ describe('InMemoryCorpusPort (rescope §3 — content-bearing get())', () => {
     const port = new InMemoryCorpusPort([seedRecord()]);
     expect(await port.get('does-not-exist')).toEqual({ status: 'ok', value: null });
   });
+
+  // Mono #1782: isSkillPayload is a content-level fact on CorpusRecord,
+  // independent of the search hit's wire kind/payloadKind — the kit must
+  // carry it through get() so a fixture can express "hit-level says
+  // nothing, content-level says skill" (the legacy-seed bug shape).
+  it('get() carries the content-level isSkillPayload fact through, independent of the hit-level kind/payloadKind', async () => {
+    const port = new InMemoryCorpusPort([
+      seedRecord({ ref: 'bafySkillPayload', kind: 'trace', isSkillPayload: true }),
+    ]);
+    const result = await port.get('bafySkillPayload');
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok' || result.value === null) throw new Error('expected a decoded record');
+    expect(result.value.isSkillPayload).toBe(true);
+
+    const hitResult = await port.search('bafySkillPayload');
+    expect(hitResult.status).toBe('ok');
+    if (hitResult.status !== 'ok') return;
+    // The synthesized search hit never carries a content-level fact — only
+    // the adapter's real decode path can classify a payload post-fetch.
+    expect(hitResult.value[0]).not.toHaveProperty('isSkillPayload');
+  });
+
+  it('get() omits isSkillPayload when the seed does not set it (no false-y noise on an ordinary record)', async () => {
+    const port = new InMemoryCorpusPort([seedRecord()]);
+    const result = await port.get('bafySeed1');
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok' || result.value === null) throw new Error('expected a decoded record');
+    expect(result.value).not.toHaveProperty('isSkillPayload');
+  });
 });


### PR DESCRIPTION
## Summary

Evidence-first pickup's kind filter excludes wire `kind: 'skill'` hits, but a legacy pre-#1394 seed-imported skill record (SKILL.md as a step attribute, no first-class `jinn.skill.v1` artifact) classifies as `kind: 'trace'` on the real indexer wire shape and slips the filter. This manifested live on 2026-07-17 (R6 walkthrough, `next @ 1ae580dd3`): a natural on-topic message returned two packets — the seeded evidence record, and the legacy RunComfy skill seed, which also projected empty (zero excerpts, no synthesis — a skill payload has no seed steps), wasting one of the two injection slots.

Two composable guards, both applied after a candidate's content is fetched (per the issue's ratified scope):

1. **Content-level skill classification.** The corpus adapter (`client/packages/harness-layer/src/adapters/corpus-adapter.ts`) now derives `isSkillPayload` on `CorpusRecord` — true when the record carries a `jinn.skill.v1` artifact, or any step carries a string `skill.md` attribute — independent of the wire `kind`. The core (`packages/plugin/src/plugin.ts` `firstTurnPickup`) enforces exclusion, keeping the adapter the fact provider and the core the policy owner.
2. **Empty-packet honesty.** A projection with zero excerpts and no synthesis is dropped rather than occupying a packet slot.

Both guards need to promote the next-ranked candidate when they disqualify the current one, which `selectKnowledgeHits` (pre-sliced to `MAX_SELECTED_PACKETS`) can't support. Added `rankKnowledgeHits` — the full ranked-but-unsliced candidate pool; `selectKnowledgeHits` is now its top-slice convenience wrapper, unchanged in behavior/tests. `firstTurnPickup` walks the ranked list, applying both guards, until it has `MAX_SELECTED_PACKETS` valid packets or candidates are exhausted.

Both guards fail open: a detection or projection error degrades that one record to the pre-guard behavior, never a crash.

## Test plan

- `mono #1782 pin: ...` (`packages/plugin/test/plugin/first-turn-pickup.test.ts`) reproduces the live escalation's exact "two packets" symptom (fails pre-fix returning both `bafyCheckoutEvidence` and `bafyRunComfySkillLeak`; passes post-fix returning only the real evidence) — **this is the pinning test**.
- `mono #1782 guard 1: a legacy skill.md-attribute record that would otherwise project a non-empty packet is still excluded by content (isolates guard 1 from guard 2)` — proves guard 1 is independently necessary, not just piggybacking on guard 2's empty-packet exclusion (added after independent review flagged the original pin as guard-2-confoundable for that fixture shape).
- `mono #1782 guard 1: a first-class jinn.skill.v1-backed record is excluded by content even when the wire kind says trace` — the defensive/first-class variant from the issue's AC.
- `mono #1782 guard 2: a zero-excerpt, no-synthesis packet is dropped and the next above-floor candidate is promoted into its slot` + the "nothing to promote" honest-nothing-found variant.
- `mono #1782: promotion skips past multiple consecutive disqualified candidates (guard 1 then guard 2) to fill both slots` — 4-candidate compound scenario (added after independent review).
- `client/packages/harness-layer/test/adapters/corpus-adapter.test.ts` — new `describe('CorpusAdapter.get() — content-level skill classification (mono #1782)')` block: legacy step-attribute detection (including on a step not named `seed:skill-md`), first-class artifact detection, and two negative/regression cases (ordinary trace record, empty/non-string `skill.md` attribute).
- All new tests independently verified to fail pre-fix and pass post-fix (via `git checkout HEAD~1 -- <src files>` against the test files, then restored) — not just asserted.
- Regression: all pre-existing pickup/adapter tests (seeded evidence fixtures projecting/injecting as before) pass unmodified.
- Both guards' fail-open behavior verified via code inspection and try/catch coverage in the adapter's detection path.

Verification run:
- [x] `cd packages/plugin && yarn install && yarn typecheck && yarn build && yarn test` — 198/198 passing.
- [x] `cd client && yarn install && yarn typecheck` — clean (builds sdk/plugin/harness-layer-store, then `tsc --noEmit` across the client tree plus a dedicated `tsc -p packages/harness-layer/tsconfig.json`).
- [x] `cd client && yarn vitest run packages/harness-layer/` — 741/741 passing (18/18 in `corpus-adapter.test.ts` specifically).
- [x] Independent review (fresh subagent, read-only checkout, independently re-verified TDD red/green on the real production decode path) — verdict: ready to merge; two test-precision recommendations, both since implemented in the second commit.

Closes #1782
Refs #1654
Refs #1775

🤖 Generated with [Claude Code](https://claude.com/claude-code)