### PR TITLE
fix(jinn-agent): strip ANSI from _user_line — TUI proxy renders raw escapes as noise (#1798)

### DIFF
--- a/apps/jinn-agent/plugins/jinn/__init__.py
+++ b/apps/jinn-agent/plugins/jinn/__init__.py
@@ -38,6 +38,7 @@ from . import pickup
 from . import session_bridge
 from . import session_view
 from . import skills_install
+from . import style
 
 logger = logging.getLogger(__name__)
 
@@ -123,9 +124,17 @@ def _user_line(msg: str) -> None:
     above the input area (the app is ``full_screen=False``); at shutdown
     and in ``-q`` mode it is plain stderr. Never raise from here — a
     feedback line must not break a session end.
+
+    Strips ANSI unconditionally before printing (mono issue #1798): the
+    ``patch_stdout`` proxy renders raw ESC bytes as ``?[38;2;…m`` noise
+    rather than interpreting them, so this channel emits plain text always,
+    regardless of ``COLORTERM``/``NO_COLOR``. The fork-precedent plugins this
+    channel was modeled on (memory/hindsight) print plain text too — the
+    styling here was our deviation. Styled surfaces that never run inside
+    the TUI (the terminal-blocking onboarding CLI) are unaffected.
     """
     try:
-        print(msg, file=sys.stderr, flush=True)
+        print(style.strip_ansi(msg), file=sys.stderr, flush=True)
     except Exception:
         pass
 

--- a/apps/jinn-agent/plugins/jinn/pickup.py
+++ b/apps/jinn-agent/plugins/jinn/pickup.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 from . import jinn_layer
+from . import style
 from .consent import get_hermes_home
 from .harness import harness_name, harness_version
 
@@ -32,13 +33,18 @@ logger = logging.getLogger(__name__)
 # The point-of-use corpus signal (design 1c / #1405 step 4; rescope §3.4).
 # Emitted once per session, only when evidence was actually provided.
 # Default sink mirrors _user_line in __init__.py: stderr, which
-# prompt_toolkit proxies above the input area while the TUI runs.
+# prompt_toolkit proxies above the input area while the TUI runs — and,
+# like that channel, strips ANSI unconditionally before printing (mono
+# issue #1798): the proxy renders raw ESC bytes as noise rather than
+# interpreting them. The onboarding CLI's own rendering of this same line
+# (render_evidence_signal_line's step-3 preview) runs terminal-blocking
+# outside the TUI and stays styled — only this funnel goes plain.
 SignalSink = Callable[[str], None]
 
 
 def _default_signal_sink(line: str) -> None:
     try:
-        print(line, file=sys.stderr, flush=True)
+        print(style.strip_ansi(line), file=sys.stderr, flush=True)
     except Exception:
         pass
 

--- a/apps/jinn-agent/plugins/jinn/style.py
+++ b/apps/jinn-agent/plugins/jinn/style.py
@@ -76,6 +76,7 @@ __all__ = [
     "box_line",
     "no_color",
     "sanitise",
+    "strip_ansi",
 ]
 
 
@@ -90,6 +91,24 @@ _CTRL = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 
 def sanitise(s: str) -> str:
     return _CTRL.sub("", s)
+
+
+# Strip complete ANSI/CSI escape sequences (SGR colour codes, incl. the
+# truecolor `\033[38;2;r;g;bm` form this module emits, and resets) rather
+# than the lone ESC byte: `sanitise` above removes `\x1b` but leaves the
+# rest of a sequence — `[38;2;122;167;220m` — behind as literal text. That
+# half-strip is exactly the `?[38;2;…m` noise mono issue #1798 reported:
+# prompt_toolkit's `patch_stdout` proxies the TUI's stderr channel and
+# renders the orphaned ESC byte as `?` without interpreting the sequence
+# that follows it. Channels that must render plain regardless of the active
+# palette (`_user_line` in __init__.py, the pickup evidence-signal sink)
+# strip with this before printing. Mirrors the CSI pattern already used
+# privately in history_view.py.
+_ANSI_SEQUENCE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def strip_ansi(text: str) -> str:
+    return _ANSI_SEQUENCE.sub("", text)
 
 
 def no_color() -> bool:

--- a/apps/jinn-agent/tests/plugins/test_jinn_pickup.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_pickup.py
@@ -167,6 +167,26 @@ def test_pickup_emits_no_signal_when_nothing_is_provided():
     assert lines == []
 
 
+def test_pickup_default_signal_sink_prints_the_marker_byte_plain(monkeypatch, capsys):
+    # mono #1798: the default sink (used whenever the host doesn't override
+    # signal_sink, i.e. the real TUI path) must strip ANSI before printing —
+    # prompt_toolkit's patch_stdout proxy renders raw ESC bytes as `?` noise
+    # rather than colour. Force the exact palette the live bug report showed.
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("COLORTERM", "truecolor")
+    monkeypatch.setenv("COLUMNS", "120")
+    runner = PickupRunner()
+
+    result = pickup.pickup(MSG, runner=runner)
+
+    assert result is not None
+    err = capsys.readouterr().err
+    assert "\x1b" not in err
+    assert "◇ corpus" in err
+    assert "provided 1 evidence packet" in err
+    assert "dashboard" in err
+
+
 # ── Fail-open paths ──────────────────────────────────────────────────────────
 
 def test_pickup_fails_open_on_broken_layer():

--- a/apps/jinn-agent/tests/plugins/test_jinn_user_line_plain.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_user_line_plain.py
@@ -1,0 +1,97 @@
+"""`_user_line` prints byte-plain regardless of the active palette (mono #1798).
+
+`_user_line` (plugins/jinn/__init__.py) is the TUI-visible feedback channel:
+`print(..., file=sys.stderr)`, proxied by prompt_toolkit's `patch_stdout`
+while the TUI runs. That proxy renders raw ESC bytes as `?[38;2;…m` noise
+rather than colour, so this channel must strip ANSI unconditionally before
+printing — matching the fork-precedent plugins (memory/hindsight) it was
+modeled on. Styled surfaces that never run inside the TUI (the
+terminal-blocking onboarding CLI) are untouched; see
+`test_jinn_onboarding.py::test_evidence_signal_line_format` for the
+still-styled counterpart.
+
+`style.strip_ansi` is unit-tested directly here; the pickup marker-line
+counterpart (`pickup._default_signal_sink`) is covered in
+`test_jinn_pickup.py`, which already owns the pickup fixtures.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+jinn = importlib.import_module("plugins.jinn")
+style = importlib.import_module("plugins.jinn.style")
+session_view = importlib.import_module("plugins.jinn.session_view")
+
+
+@pytest.fixture(autouse=True)
+def _truecolor(monkeypatch, tmp_path):
+    # Forces the exact palette the live bug report showed
+    # (`\033[38;2;122;167;220m`) — NO_COLOR unset, COLORTERM=truecolor,
+    # wide enough columns for style.supports_truecolor().
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("COLORTERM", "truecolor")
+    monkeypatch.setenv("COLUMNS", "120")
+
+
+def test_strip_ansi_removes_truecolor_and_reset_sequences():
+    styled = (
+        f"{style._TC['sky']}◇ corpus{style._RST}  "
+        f"{style._TC['fg']}provided 1 evidence packet{style._RST}"
+    )
+    assert "\x1b" in styled  # sanity: the fixture built a genuinely styled string
+
+    plain = style.strip_ansi(styled)
+
+    assert "\x1b" not in plain
+    assert plain == "◇ corpus  provided 1 evidence packet"
+
+
+def test_strip_ansi_is_a_no_op_on_plain_text():
+    assert style.strip_ansi("already plain") == "already plain"
+
+
+def test_user_line_prints_byte_plain(capsys):
+    styled = (
+        f"{style._TC['sky']}◇ corpus{style._RST}  "
+        f"{style._TC['fg']}provided 1 evidence packet{style._RST}"
+    )
+
+    jinn._user_line(styled)
+
+    err = capsys.readouterr().err
+    assert "\x1b" not in err
+    assert "◇ corpus" in err
+    assert "provided 1 evidence packet" in err
+
+
+def test_session_end_summary_rendered_block_prints_byte_plain(capsys):
+    rendered = session_view.render_complete(
+        summary={
+            "searchedTerms": ["dashboard", "vitest"],
+            "providedPackets": [{"ref": "bafySourceEpisode", "title": "x"}],
+            "nothingFound": False,
+            "eligibility": {"eligible": True, "reason": "accepted diff"},
+        },
+        activity={},
+        capture_status="captured",
+        local_learning_status="pending",
+        contribution={"status": "ok", "value": {"status": "recorded"}},
+    )
+    # Sanity: under this env the renderer itself does emit ANSI (the title
+    # line) — otherwise this test couldn't guard against the regression.
+    assert "\x1b" in rendered
+
+    jinn._user_line(rendered)
+
+    err = capsys.readouterr().err
+    assert "\x1b" not in err
+    assert "Jinn session complete" in err
+    assert "knowledge searched dashboard, vitest · provided 1 (bafySourceEpisode)" in err
+    assert "episode captured" in err
+    assert "local learning pending" in err
+    assert "eligibility eligible — accepted diff" in err
+    assert "contribution recorded" in err


### PR DESCRIPTION
## Summary

In the real Hermes TUI, `_user_line` (the session-end summary / `◇` marker channel in `plugins/jinn/__init__.py`) and the pickup evidence-signal default sink (`plugins/jinn/pickup.py`) both `print(..., file=sys.stderr)`. That stream is proxied by prompt_toolkit's `patch_stdout` while the TUI runs, and the proxy renders raw ESC bytes as `?[38;2;…m` noise instead of interpreting them — `style.py` gates color on env (`NO_COLOR`, `COLORTERM`) but never on whether the output stream actually renders ANSI.

Root cause detail: `style.sanitise()` already strips the lone `\x1b` control byte, but leaves the rest of a CSI sequence (`[38;2;122;167;220m`) behind as literal text — exactly the reported noise. A complete sequence needs a dedicated stripper.

Fix: add `style.strip_ansi(text)` — a full CSI-sequence stripper (mirrors the private `_ANSI_SEQUENCE` pattern already used in `history_view.py`) — and apply it at both funnels (`_user_line`, `pickup._default_signal_sink`) before printing. The onboarding CLI's own rendering of `render_evidence_signal_line` (terminal-blocking, runs outside the TUI) is untouched and stays styled — only the two TUI-proxied stderr funnels go plain.

## Test plan

TDD: wrote the tests first, confirmed all 5 new/changed assertions failed against the unfixed code (raw ESC bytes present), then implemented the fix and confirmed green.

- `tests/plugins/test_jinn_user_line_plain.py` (new): `style.strip_ansi` unit tests (strips truecolor+reset, no-op on plain text); `_user_line` prints byte-plain given a synthetic styled string; the session-end summary block (`session_view.render_complete`, forced truecolor via `COLORTERM`/`COLUMNS` env) prints byte-plain through `_user_line` while preserving all text content.
- `tests/plugins/test_jinn_pickup.py` (+1 test): drives `pickup.pickup()` through the real modules with the default (non-overridden) `signal_sink`, forces truecolor env, asserts the captured `◇ corpus` marker line has zero ESC bytes and full text (glyph, count, searched terms) intact.
- Full `test_jinn_*.py` set: 34 files, 354 tests, 0 failed.
- `ruff check` + `ty check` clean on all changed files.
- Manual end-to-end check calling the real `_user_line` / `pickup._default_signal_sink` funnels under `COLORTERM=truecolor` confirmed zero ESC bytes in the captured stderr output, e.g. the marker now renders as `  ◇ corpus  provided 1 evidence packet  ·  searched: dashboard, vitest, update_available` with no escape codes.

Closes #1798
Refs #1654
Refs #1775

🤖 Generated with [Claude Code](https://claude.com/claude-code)