### PR TITLE
fix(dashboard): show USD actual spend and estimated-vs-metered on claim-gate surfaces

### DIFF
--- a/client/src/dashboard/spa/src/pages/AiUnitsPauseAlert.test.tsx
+++ b/client/src/dashboard/spa/src/pages/AiUnitsPauseAlert.test.tsx
@@ -28,6 +28,11 @@ describe('AiUnitsPauseAlert', () => {
               unitsThisWeek: 200,
               capPerBlock: 100,
               capPerWeek: 2800,
+              usdMicrosThisBlock: 300000,
+              usdMicrosThisWeek: 2000000,
+              capPerBlockUsdMicros: 1000000,
+              capPerWeekUsdMicros: 14000000,
+              estimated: false,
               paused: false,
               blockResetsAt: '2026-05-28T18:00:00.000Z',
               weekResetsAt: '2026-06-04T13:00:00.000Z',
@@ -39,7 +44,7 @@ describe('AiUnitsPauseAlert', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('renders a banner per paused credential with the reset time', () => {
+  it('renders USD spend and metered status for a paused credential', () => {
     render(
       <AiUnitsPauseAlert
         aiUnits={{
@@ -50,6 +55,11 @@ describe('AiUnitsPauseAlert', () => {
               unitsThisWeek: 200,
               capPerBlock: 100,
               capPerWeek: 2800,
+              usdMicrosThisBlock: 1000000,
+              usdMicrosThisWeek: 2000000,
+              capPerBlockUsdMicros: 1000000,
+              capPerWeekUsdMicros: 14000000,
+              estimated: false,
               paused: true,
               blockResetsAt: '2026-05-28T18:00:00.000Z',
               weekResetsAt: '2026-06-04T13:00:00.000Z',
@@ -61,7 +71,9 @@ describe('AiUnitsPauseAlert', () => {
     const alert = screen.getByTestId('ai-units-pause-alert-anthropic:api-key');
     expect(alert.textContent).toContain('anthropic:api-key');
     expect(alert.textContent).toContain('Paused');
-    expect(alert.textContent).toContain('AI-unit');
+    expect(alert.textContent).toContain('spend cap');
+    expect(alert.textContent).toContain('metered');
+    expect(alert.textContent).toContain('$1.0000 / $1.0000');
   });
 
   it('does not render an idle credential as active (#891)', () => {
@@ -76,6 +88,11 @@ describe('AiUnitsPauseAlert', () => {
               unitsThisWeek: 0,
               capPerBlock: 100,
               capPerWeek: 2800,
+              usdMicrosThisBlock: 0,
+              usdMicrosThisWeek: 0,
+              capPerBlockUsdMicros: 1000000,
+              capPerWeekUsdMicros: 14000000,
+              estimated: false,
               paused: false,
               active: false,
               blockResetsAt: '2026-05-28T18:00:00.000Z',
@@ -101,6 +118,11 @@ describe('AiUnitsPauseAlert', () => {
               unitsThisWeek: 200,
               capPerBlock: 100,
               capPerWeek: 2800,
+              usdMicrosThisBlock: 1000000,
+              usdMicrosThisWeek: 2000000,
+              capPerBlockUsdMicros: 1000000,
+              capPerWeekUsdMicros: 14000000,
+              estimated: false,
               paused: true,
               active: true,
               blockResetsAt: '2026-05-28T18:00:00.000Z',
@@ -125,6 +147,11 @@ describe('AiUnitsPauseAlert', () => {
               unitsThisWeek: 500,
               capPerBlock: 100,
               capPerWeek: 2800,
+              usdMicrosThisBlock: 1000000,
+              usdMicrosThisWeek: 5000000,
+              capPerBlockUsdMicros: 1000000,
+              capPerWeekUsdMicros: 14000000,
+              estimated: false,
               paused: true,
               blockResetsAt: '2026-05-28T18:00:00.000Z',
               weekResetsAt: '2026-06-04T13:00:00.000Z',
@@ -135,6 +162,11 @@ describe('AiUnitsPauseAlert', () => {
               unitsThisWeek: 2800,
               capPerBlock: 100,
               capPerWeek: 2800,
+              usdMicrosThisBlock: 50000,
+              usdMicrosThisWeek: 14000000,
+              capPerBlockUsdMicros: 1000000,
+              capPerWeekUsdMicros: 14000000,
+              estimated: true,
               paused: true,
               blockResetsAt: '2026-05-28T18:00:00.000Z',
               weekResetsAt: '2026-06-04T13:00:00.000Z',
@@ -145,5 +177,6 @@ describe('AiUnitsPauseAlert', () => {
     );
     expect(screen.getByTestId('ai-units-pause-alert-a:k').textContent).toMatch(/6h/);
     expect(screen.getByTestId('ai-units-pause-alert-b:k').textContent).toMatch(/7d|week/i);
+    expect(screen.getByTestId('ai-units-pause-alert-b:k').textContent).toContain('estimated');
   });
 });

--- a/client/src/dashboard/spa/src/pages/AiUnitsPauseAlert.tsx
+++ b/client/src/dashboard/spa/src/pages/AiUnitsPauseAlert.tsx
@@ -2,11 +2,11 @@
  * AiUnitsPauseAlert — issue #815 running-mode surface.
  *
  * Compact per-credential banner shown on the Overview while one or more
- * credentials are paused by the AI-units ceiling. The acceptance
- * criterion: "the running-mode dashboard surfaces the pause reason and
- * the next reset time (e.g. 'Paused — 6h AI-unit cap reached. Claims
- * resume at 12:00 UTC.')". Render-only — no event subscription; the
- * /v1/status poll on Overview is the upstream feed.
+ * credentials are paused by the claim-spend ceiling. The daemon now emits
+ * USD accumulators plus an `estimated` bit, so the running-mode surface must
+ * show the real spend units and distinguish metered from estimated usage.
+ * Render-only — no event subscription; the /v1/status poll on Overview is the
+ * upstream feed.
  */
 import type { JSX } from 'react';
 import { PauseCircle } from 'lucide-react';
@@ -18,6 +18,16 @@ export interface AiUnitsStatusRow {
   unitsThisWeek: number;
   capPerBlock: number;
   capPerWeek: number;
+  /** Actual USD spend this 6h block, in micros. Optional for backward-compat. */
+  usdMicrosThisBlock?: number;
+  /** Actual USD spend this 7d window, in micros. Optional for backward-compat. */
+  usdMicrosThisWeek?: number;
+  /** USD cap for the current 6h block, in micros. Optional for backward-compat. */
+  capPerBlockUsdMicros?: number;
+  /** USD cap for the current 7d window, in micros. Optional for backward-compat. */
+  capPerWeekUsdMicros?: number;
+  /** True when the summed spend includes any estimate-backed rows. */
+  estimated?: boolean;
   paused: boolean;
   /**
    * True when this credential has spend in the current 7d window — i.e. it is
@@ -46,6 +56,10 @@ function formatUtc(iso: string): string {
   return `${hh}:${mm} UTC`;
 }
 
+function formatUsdMicros(usdMicros: number): string {
+  return `$${(usdMicros / 1_000_000).toFixed(4)}`;
+}
+
 export function AiUnitsPauseAlert({ aiUnits }: AiUnitsPauseAlertProps): JSX.Element | null {
   if (!aiUnits) return null;
   const paused = aiUnits.credentials.filter((c) => c.paused);
@@ -54,11 +68,32 @@ export function AiUnitsPauseAlert({ aiUnits }: AiUnitsPauseAlertProps): JSX.Elem
   return (
     <div className="flex flex-col gap-2">
       {paused.map((row) => {
+        const hasUsdFields =
+          typeof row.usdMicrosThisBlock === 'number' &&
+          typeof row.usdMicrosThisWeek === 'number' &&
+          typeof row.capPerBlockUsdMicros === 'number' &&
+          typeof row.capPerWeekUsdMicros === 'number';
+        const usdMicrosThisBlock = row.usdMicrosThisBlock ?? 0;
+        const usdMicrosThisWeek = row.usdMicrosThisWeek ?? 0;
+        const capPerBlockUsdMicros = row.capPerBlockUsdMicros ?? 0;
+        const capPerWeekUsdMicros = row.capPerWeekUsdMicros ?? 0;
         // Pick the binding window — whichever sum has actually reached its cap.
-        const blockHit = row.unitsThisBlock >= row.capPerBlock;
+        const blockHit = hasUsdFields
+          ? usdMicrosThisBlock >= capPerBlockUsdMicros
+          : row.unitsThisBlock >= row.capPerBlock;
         const window: 'block' | 'week' = blockHit ? 'block' : 'week';
         const resumeAt = window === 'block' ? row.blockResetsAt : row.weekResetsAt;
         const windowLabel = window === 'block' ? '6h' : '7d';
+        const usageLabel = hasUsdFields
+          ? `${row.estimated ? 'estimated' : 'metered'} ${
+              window === 'block'
+                ? `${formatUsdMicros(usdMicrosThisBlock)} / ${formatUsdMicros(capPerBlockUsdMicros)}`
+                : `${formatUsdMicros(usdMicrosThisWeek)} / ${formatUsdMicros(capPerWeekUsdMicros)}`
+            }`
+          : window === 'block'
+            ? `${row.unitsThisBlock} / ${row.capPerBlock} units`
+            : `${row.unitsThisWeek} / ${row.capPerWeek} units`;
+        const periodLabel = window === 'block' ? 'this block' : 'this 7-day window';
         // A paused credential is by definition the active one; default to active
         // for daemons predating the `active` field (issue #891).
         const isActive = row.active ?? true;
@@ -70,7 +105,7 @@ export function AiUnitsPauseAlert({ aiUnits }: AiUnitsPauseAlertProps): JSX.Elem
           >
             <PauseCircle className="h-4 w-4" aria-hidden="true" />
             <AlertTitle className="font-mono text-[13px]">
-              Paused — {windowLabel} AI-unit cap reached
+              Paused — {windowLabel} spend cap reached
               {isActive ? (
                 <span
                   className="ml-2 text-foreground"
@@ -83,9 +118,7 @@ export function AiUnitsPauseAlert({ aiUnits }: AiUnitsPauseAlertProps): JSX.Elem
             <AlertDescription className="font-mono text-[12px] text-muted-foreground">
               <span>
                 Credential <span className="text-foreground">{row.credentialId}</span> used{' '}
-                {window === 'block'
-                  ? `${row.unitsThisBlock} / ${row.capPerBlock} units this block`
-                  : `${row.unitsThisWeek} / ${row.capPerWeek} units this 7-day window`}
+                {usageLabel} {periodLabel}
                 . Claims resume at <span className="text-foreground">{formatUtc(resumeAt)}</span>.
               </span>
             </AlertDescription>

--- a/client/src/dashboard/spa/src/pages/Overview.tsx
+++ b/client/src/dashboard/spa/src/pages/Overview.tsx
@@ -137,6 +137,11 @@ interface OverviewStatusV1 {
       unitsThisWeek: number;
       capPerBlock: number;
       capPerWeek: number;
+      usdMicrosThisBlock?: number;
+      usdMicrosThisWeek?: number;
+      capPerBlockUsdMicros?: number;
+      capPerWeekUsdMicros?: number;
+      estimated?: boolean;
       paused: boolean;
       /** True when the credential has spend this 7d window (issue #891). Optional for backward-compat. */
       active?: boolean;


### PR DESCRIPTION
## What

`AiUnitsPauseAlert` and `Overview` stop labeling the claim-gate figure in "units": they render the USD actual spend the daemon reports since #1004, and distinguish a metered figure from an estimated one via the status payload's `estimated` flag. Test-first — the alert suite gained estimated/metered cases before the component change.

**Refs #1006 (partial).** Not covered here: `HarnessFootprintPanel`, which #1006's acceptance criteria also name — follow-up needed before #1006 closes.

## Verification

Diff applied onto clean `origin/next` and re-verified: dashboard SPA suite **78 files / 685 tests green**, client typecheck clean. Original session's own TDD cycle: alert tests red (2 failed) → component change → 6/6 green, re-run green after each subsequent patch.

## Provenance

This diff was produced in the operator's live Hermes session during the Stage 1 R6 walkthrough (#1775, #1654): Jinn retrieved the seeded dashboard-testing evidence into the agent's context, the agent did the work, and the session's captured contribution candidate carries this exact diff — the plugin's loop producing a real PR as its work product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)