### PR TITLE
fix(harness-layer): episode store read-tolerance for null optional fields

### DIFF
--- a/apps/jinn-agent/plugins/jinn/distill.py
+++ b/apps/jinn-agent/plugins/jinn/distill.py
@@ -163,6 +163,33 @@ def tee_capture(task: Dict[str, Any], session_id: str, runner: Optional[Runner] 
         return None
 
 
+def _drop_none_optional_keys(episode: Dict[str, Any]) -> Dict[str, Any]:
+    """Strip None-valued KNOWN optional slots before serializing (mono #1811).
+
+    EpisodeV1's optional fields are absent-OK but null-fatal under the strict
+    zod schema, so a persisted literal ``null`` makes the whole file
+    unreadable. Defence-in-depth, deliberately scoped to the known optional
+    slots — not a generic None sweep, which could mask a producer bug in a
+    required field.
+    """
+    out = dict(episode)
+    outcome = out.get("outcome")
+    if isinstance(outcome, dict) and outcome.get("summary") is None and "summary" in outcome:
+        out["outcome"] = {k: v for k, v in outcome.items() if k != "summary"}
+    cost = out.get("cost")
+    if isinstance(cost, dict):
+        pruned = {
+            k: v
+            for k, v in cost.items()
+            if not (k in ("tokens", "usdEstimate") and v is None)
+        }
+        if pruned != cost:
+            out["cost"] = pruned
+    if "lineage" in out and out["lineage"] is None:
+        del out["lineage"]
+    return out
+
+
 def write_episode_fallback(episode: Dict[str, Any]) -> Optional[Path]:
     """Persist one complete EpisodeV1 when the core did not.
 
@@ -184,7 +211,7 @@ def write_episode_fallback(episode: Dict[str, Any]) -> Optional[Path]:
             else f"episode-{hashlib.sha256(episode_id.encode('utf-8')).hexdigest()}"
         )
         serialized = json.dumps(
-            episode,
+            _drop_none_optional_keys(episode),
             ensure_ascii=False,
             allow_nan=False,
             sort_keys=True,

--- a/apps/jinn-agent/plugins/jinn/distill.py
+++ b/apps/jinn-agent/plugins/jinn/distill.py
@@ -168,7 +168,7 @@ def _drop_none_optional_keys(episode: Dict[str, Any]) -> Dict[str, Any]:
 
     EpisodeV1's optional fields are absent-OK but null-fatal under the strict
     zod schema, so a persisted literal ``null`` makes the whole file
-    unreadable. Defence-in-depth, deliberately scoped to the known optional
+    unreadable. Defense-in-depth, deliberately scoped to the known optional
     slots — not a generic None sweep, which could mask a producer bug in a
     required field.
     """

--- a/apps/jinn-agent/plugins/jinn/distill.py
+++ b/apps/jinn-agent/plugins/jinn/distill.py
@@ -229,7 +229,7 @@ def write_episode_fallback(episode: Dict[str, Any]) -> Optional[Path]:
                     return False
                 os.chmod(path, 0o600)
                 existing = json.loads(path.read_text(encoding="utf-8"))
-                return existing == canonical_episode
+                return _drop_none_optional_keys(existing) == canonical_episode
             except (OSError, ValueError, TypeError):
                 return False
 

--- a/apps/jinn-agent/tests/plugins/test_jinn_episode_fallback.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_episode_fallback.py
@@ -124,6 +124,37 @@ def test_fallback_drops_none_valued_optional_keys_before_serializing(
     assert "lineage" not in persisted
 
 
+def test_fallback_treats_a_pre_fix_null_bearing_file_as_identical(tmp_path, monkeypatch):
+    # mono #1811: a file written before the null-stripping fix landed
+    # persisted explicit nulls for the optional slots. A post-upgrade retry
+    # of the same session produces the stripped canonical form, which must
+    # still be recognized as identical to the pre-fix file on disk rather
+    # than reported as a collision (which would incorrectly return None for
+    # an already-valid, already-readable episode).
+    monkeypatch.setenv("JINN_LAYER_EPISODES_DIR", str(tmp_path))
+    episode = _episode()
+    episode["episodeId"] = "pre-fix-null-episode"
+    episode["outcome"]["summary"] = None
+    episode["cost"]["tokens"] = None
+    episode["cost"]["usdEstimate"] = None
+    episode["lineage"] = None
+
+    path = tmp_path / f"{episode['episodeId']}.episode.json"
+    pre_fix_serialized = json.dumps(
+        episode,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ) + "\n"
+    path.write_text(pre_fix_serialized, encoding="utf-8")
+
+    result = distill.write_episode_fallback(episode)
+
+    assert result == path
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
 def test_fallback_uses_the_core_filename_and_does_not_duplicate_a_lost_response(
     tmp_path, monkeypatch
 ):

--- a/apps/jinn-agent/tests/plugins/test_jinn_episode_fallback.py
+++ b/apps/jinn-agent/tests/plugins/test_jinn_episode_fallback.py
@@ -102,6 +102,28 @@ def test_fallback_rejects_same_id_with_different_content_without_overwrite(
     assert list(tmp_path.glob("*.tmp")) == []
 
 
+def test_fallback_drops_none_valued_optional_keys_before_serializing(
+    tmp_path, monkeypatch
+):
+    # mono #1811: an older wheel assigned explicit Nones to the optional
+    # slots; persisted literal nulls fail the strict null-fatal schema on read.
+    monkeypatch.setenv("JINN_LAYER_EPISODES_DIR", str(tmp_path))
+    episode = _episode()
+    episode["episodeId"] = "none-keys-1"
+    episode["outcome"]["summary"] = None
+    episode["cost"]["tokens"] = None
+    episode["cost"]["usdEstimate"] = None
+    episode["lineage"] = None
+
+    path = distill.write_episode_fallback(episode)
+
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    assert "summary" not in persisted["outcome"]
+    assert "tokens" not in persisted["cost"]
+    assert "usdEstimate" not in persisted["cost"]
+    assert "lineage" not in persisted
+
+
 def test_fallback_uses_the_core_filename_and_does_not_duplicate_a_lost_response(
     tmp_path, monkeypatch
 ):

--- a/client/packages/harness-layer/src/adapters/evidence-adapter.ts
+++ b/client/packages/harness-layer/src/adapters/evidence-adapter.ts
@@ -33,7 +33,7 @@ import type {
   EvidenceRetentionPolicy,
   PortResult,
 } from '@jinn-network/plugin';
-import { EpisodeV1Schema, type EpisodeV1 } from '@jinn-network/plugin';
+import { EpisodeV1Schema, parseEpisodeV1Read, type EpisodeV1 } from '@jinn-network/plugin';
 import { ok, unavailable } from '@jinn-network/plugin';
 import { parseCapturedTask, type CapturedTask } from '../capture.js';
 
@@ -140,7 +140,7 @@ export function createEvidenceAdapter(deps: EvidenceAdapterDeps): EvidencePort {
       const stat = await lstat(path);
       if (!stat.isFile() || stat.isSymbolicLink()) return 'collision';
       if (process.platform !== 'win32') await chmod(path, 0o600);
-      const existing = EpisodeV1Schema.parse(JSON.parse(await readFile(path, 'utf8')));
+      const existing = parseEpisodeV1Read(JSON.parse(await readFile(path, 'utf8')));
       return isDeepStrictEqual(existing, episode) ? 'identical' : 'collision';
     } catch (error) {
       return nodeErrorCode(error) === 'ENOENT' ? 'missing' : 'collision';
@@ -211,7 +211,7 @@ export function createEvidenceAdapter(deps: EvidenceAdapterDeps): EvidencePort {
       try {
         const path = episodePath(episodeId);
         if (!existsSync(path)) return ok(null);
-        return ok(EpisodeV1Schema.parse(JSON.parse(readFileSync(path, 'utf-8'))));
+        return ok(parseEpisodeV1Read(JSON.parse(readFileSync(path, 'utf-8'))));
       } catch (e) {
         return unavailable(`evidence store get failed: ${String(e)}`);
       }
@@ -221,12 +221,14 @@ export function createEvidenceAdapter(deps: EvidenceAdapterDeps): EvidencePort {
       try {
         if (!existsSync(capturesDir)) return ok([]);
         const episodes: EpisodeV1[] = [];
+        let unreadable = 0;
         for (const file of readdirSync(capturesDir)) {
           const path = join(capturesDir, file);
           if (file.endsWith(EPISODE_SUFFIX)) {
             try {
-              episodes.push(EpisodeV1Schema.parse(JSON.parse(readFileSync(path, 'utf-8'))));
+              episodes.push(parseEpisodeV1Read(JSON.parse(readFileSync(path, 'utf-8'))));
             } catch (err) {
+              unreadable += 1;
               console.warn(`[evidence] skipping malformed episode file ${file}: ${String(err)}`);
             }
           } else if (file.endsWith('.json')) {
@@ -236,9 +238,15 @@ export function createEvidenceAdapter(deps: EvidenceAdapterDeps): EvidencePort {
               const task = parseCapturedTask(JSON.parse(readFileSync(path, 'utf-8')));
               episodes.push(capturedTaskToEpisode(task, retention));
             } catch (err) {
+              unreadable += 1;
               console.warn(`[evidence] skipping malformed legacy capture ${file}: ${String(err)}`);
             }
           }
+        }
+        if (unreadable > 0) {
+          console.warn(
+            `[evidence] list: ${episodes.length} readable, ${unreadable} unreadable episode file(s)`,
+          );
         }
         return ok(query.limit ? episodes.slice(0, query.limit) : episodes);
       } catch (e) {

--- a/client/packages/harness-layer/test/adapters/evidence-adapter.test.ts
+++ b/client/packages/harness-layer/test/adapters/evidence-adapter.test.ts
@@ -11,7 +11,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { describeEvidencePortContract } from '@jinn-network/plugin/testing';
 import { EPISODE_SCHEMA_VERSION, EpisodeV1Schema, type EpisodeV1 } from '@jinn-network/plugin';
 import type { CapturedTask } from '../../src/capture.js';
@@ -275,5 +275,83 @@ describe('EvidenceAdapter — AC2 byte-exact round-trip', () => {
     expect(stored.status).toBe('ok');
     if (stored.status === 'ok') expect([first, second]).toContainEqual(stored.value);
     expect(readdirSync(capturesDir).filter((name) => name.includes('.tmp'))).toEqual([]);
+  });
+});
+
+describe('EvidenceAdapter — #1811 null-optional read tolerance', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /** The real broken on-disk shape: an older wheel wrote literal nulls into
+   * the optional slots, which the strict schema rejects (null ≠ absent). */
+  function makeNullBearingEpisodeJson(episodeId: string): Record<string, unknown> {
+    const base = makeSampleEpisode({ episodeId }) as Record<string, unknown>;
+    return {
+      ...base,
+      outcome: { ...(base.outcome as object), summary: null },
+      cost: { ...(base.cost as object), tokens: null, usdEstimate: null },
+      lineage: null,
+    };
+  }
+
+  it('list() returns an on-disk episode file with null optionals', async () => {
+    const capturesDir = mkdtempSync(join(tmpdir(), 'ev-null-list-'));
+    writeFileSync(
+      join(capturesDir, 'null-ep-1.episode.json'),
+      JSON.stringify(makeNullBearingEpisodeJson('null-ep-1')),
+    );
+
+    const adapter = createEvidenceAdapter({ capturesDir });
+    const result = await adapter.list();
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.value.map((e) => e.episodeId)).toEqual(['null-ep-1']);
+    expect(result.value[0].outcome.summary).toBeUndefined();
+    expect(result.value[0].cost.tokens).toBeUndefined();
+    expect(result.value[0].lineage).toBeUndefined();
+  });
+
+  it('get() returns an on-disk episode file with null optionals', async () => {
+    const capturesDir = mkdtempSync(join(tmpdir(), 'ev-null-get-'));
+    writeFileSync(
+      join(capturesDir, 'null-ep-2.episode.json'),
+      JSON.stringify(makeNullBearingEpisodeJson('null-ep-2')),
+    );
+
+    const adapter = createEvidenceAdapter({ capturesDir });
+    const result = await adapter.get('null-ep-2');
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.value?.episodeId).toBe('null-ep-2');
+    expect(result.value?.outcome.summary).toBeUndefined();
+  });
+
+  it('list() still skips a genuinely corrupt episode file', async () => {
+    const capturesDir = mkdtempSync(join(tmpdir(), 'ev-null-corrupt-'));
+    writeFileSync(join(capturesDir, 'corrupt.episode.json'), JSON.stringify({ not: 'an episode' }));
+
+    const adapter = createEvidenceAdapter({ capturesDir });
+    const result = await adapter.list();
+    expect(result).toEqual({ status: 'ok', value: [] });
+  });
+
+  it('list() warns with a readable/unreadable summary when files were skipped', async () => {
+    const capturesDir = mkdtempSync(join(tmpdir(), 'ev-null-summary-'));
+    writeFileSync(
+      join(capturesDir, 'good.episode.json'),
+      JSON.stringify(makeNullBearingEpisodeJson('good')),
+    );
+    writeFileSync(join(capturesDir, 'bad.episode.json'), JSON.stringify({ not: 'an episode' }));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const adapter = createEvidenceAdapter({ capturesDir });
+    const result = await adapter.list();
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.value.map((e) => e.episodeId)).toEqual(['good']);
+    expect(warnSpy.mock.calls.flat()).toContain(
+      '[evidence] list: 1 readable, 1 unreadable episode file(s)',
+    );
   });
 });

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -2,7 +2,7 @@
 // Public entry — grows incrementally as ports/schemas/factory land (S1-F1).
 export type { PortResult } from './outcome.js';
 export { ok, degraded, unavailable, valueOr, unwrap } from './outcome.js';
-export { EPISODE_SCHEMA_VERSION, EpisodeV1Schema, SessionActivityFactsSchema } from './schemas/episode.js';
+export { EPISODE_SCHEMA_VERSION, EpisodeV1Schema, SessionActivityFactsSchema, parseEpisodeV1Read } from './schemas/episode.js';
 export type { EpisodeV1, SessionActivityFacts } from './schemas/episode.js';
 export {
   CONTRIBUTION_CANDIDATE_SCHEMA_VERSION,

--- a/packages/plugin/src/schemas/episode.ts
+++ b/packages/plugin/src/schemas/episode.ts
@@ -87,3 +87,52 @@ export const EpisodeV1Schema = z.strictObject({
 
 export type EpisodeV1 = z.infer<typeof EpisodeV1Schema>;
 export type SessionActivityFacts = z.infer<typeof SessionActivityFactsSchema>;
+
+/** Shallow-copy `value` without the listed keys when they are literal `null`. */
+function stripNullKeys(
+  value: Record<string, unknown>,
+  keys: readonly string[],
+): Record<string, unknown> {
+  const out = { ...value };
+  for (const key of keys) {
+    if (out[key] === null) delete out[key];
+  }
+  return out;
+}
+
+/**
+ * READ-side tolerant EpisodeV1 parse (#1811). An older jinn-agent wheel
+ * serialized explicit `None`s into the optional slots, so real on-disk
+ * episodes carry literal JSON `null` in `outcome.summary`, `cost.tokens`,
+ * `cost.usdEstimate`, `lineage`, `lineage.mintRef`, `activity`, and
+ * `eligibility`. `.optional()` on a strictObject is absent-OK but null-fatal,
+ * so every such file failed strict parse and was silently dropped.
+ *
+ * This helper strips literal `null` from exactly those known optional slots,
+ * then delegates to the unchanged strict `EpisodeV1Schema.parse` — it throws
+ * on genuinely invalid input just like `.parse`. Writes stay strict: `put`
+ * and `SessionEndRequestV1Schema` must keep using `EpisodeV1Schema` directly.
+ */
+export function parseEpisodeV1Read(json: unknown): EpisodeV1 {
+  if (json === null || typeof json !== 'object' || Array.isArray(json)) {
+    return EpisodeV1Schema.parse(json);
+  }
+  let candidate = stripNullKeys(json as Record<string, unknown>, [
+    'lineage',
+    'activity',
+    'eligibility',
+  ]);
+  const outcome = candidate.outcome;
+  if (outcome && typeof outcome === 'object' && !Array.isArray(outcome)) {
+    candidate = { ...candidate, outcome: stripNullKeys(outcome as Record<string, unknown>, ['summary']) };
+  }
+  const cost = candidate.cost;
+  if (cost && typeof cost === 'object' && !Array.isArray(cost)) {
+    candidate = { ...candidate, cost: stripNullKeys(cost as Record<string, unknown>, ['tokens', 'usdEstimate']) };
+  }
+  const lineage = candidate.lineage;
+  if (lineage && typeof lineage === 'object' && !Array.isArray(lineage)) {
+    candidate = { ...candidate, lineage: stripNullKeys(lineage as Record<string, unknown>, ['mintRef']) };
+  }
+  return EpisodeV1Schema.parse(candidate);
+}

--- a/packages/plugin/test/schemas/episode.test.ts
+++ b/packages/plugin/test/schemas/episode.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { EpisodeV1Schema } from '../../src/schemas/episode.js';
+import { EpisodeV1Schema, parseEpisodeV1Read } from '../../src/schemas/episode.js';
 import { makeSampleEpisode } from '../_fixtures/episode.js';
 
 const valid = makeSampleEpisode({ episodeId: 'ep-1' });
@@ -174,5 +174,66 @@ describe('EpisodeV1Schema', () => {
       provenance: 'contributed',
     };
     expect(() => EpisodeV1Schema.parse(fromPython)).not.toThrow();
+  });
+});
+
+// #1811: real on-disk episodes carry literal JSON `null` in the optional
+// slots (an older wheel serialized explicit Nones). `.optional()` on a
+// strictObject is absent-OK but null-fatal, so every such file failed strict
+// parse. `parseEpisodeV1Read` is the read-side tolerance: strip the known
+// null slots, then delegate to the unchanged strict schema.
+describe('parseEpisodeV1Read', () => {
+  /** The real broken shape from ~/.jinn-client/harness-layer/episodes/. */
+  function makeNullBearingEpisode(): Record<string, unknown> {
+    const base = makeSampleEpisode({ episodeId: 'ep-null-1' }) as Record<string, unknown>;
+    return {
+      ...base,
+      outcome: { ...(base.outcome as object), summary: null },
+      cost: { ...(base.cost as object), tokens: null, usdEstimate: null },
+      lineage: null,
+    };
+  }
+
+  it('strict EpisodeV1Schema rejects the null-bearing on-disk shape', () => {
+    expect(() => EpisodeV1Schema.parse(makeNullBearingEpisode())).toThrow();
+  });
+
+  it('accepts the null-bearing shape, treating null optionals as absent', () => {
+    const parsed = parseEpisodeV1Read(makeNullBearingEpisode());
+    expect(parsed.outcome.summary).toBeUndefined();
+    expect(parsed.cost.tokens).toBeUndefined();
+    expect(parsed.cost.usdEstimate).toBeUndefined();
+    expect(parsed.lineage).toBeUndefined();
+    // The normalized result round-trips the unchanged strict schema.
+    expect(() => EpisodeV1Schema.parse(parsed)).not.toThrow();
+  });
+
+  it('strips a null lineage.mintRef inside a present lineage object', () => {
+    const episode = {
+      ...makeSampleEpisode({ episodeId: 'ep-null-2' }),
+      lineage: { episodeId: 'ep-0', mintRef: null },
+    };
+    const parsed = parseEpisodeV1Read(episode);
+    expect(parsed.lineage).toEqual({ episodeId: 'ep-0' });
+  });
+
+  it('strips null activity and eligibility', () => {
+    const episode = {
+      ...makeSampleEpisode({ episodeId: 'ep-null-3' }),
+      activity: null,
+      eligibility: null,
+    };
+    const parsed = parseEpisodeV1Read(episode);
+    expect(parsed.activity).toBeUndefined();
+    expect(parsed.eligibility).toBeUndefined();
+  });
+
+  it('still throws on a missing required field', () => {
+    const { retention: _retention, ...missingRequired } = makeNullBearingEpisode();
+    expect(() => parseEpisodeV1Read(missingRequired)).toThrow();
+  });
+
+  it('still throws on an unknown top-level field', () => {
+    expect(() => parseEpisodeV1Read({ ...makeNullBearingEpisode(), extra: true })).toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- Real `EpisodeV1` files on disk carry literal JSON `null` in optional fields (`outcome.summary`, `cost.tokens`, `cost.usdEstimate`, `lineage`). `EpisodeV1Schema` declares these `.optional()` on `z.strictObject` (absent-OK, null-fatal), so every such file failed parse and `evidence.list()` silently dropped it — `/jinn history` and every `EvidencePort` consumer saw zero episodes.
- Adds `parseEpisodeV1Read` (`packages/plugin/src/schemas/episode.ts`): strips literal `null` from the known optional slots (`outcome.summary`, `cost.tokens`, `cost.usdEstimate`, `lineage`, `lineage.mintRef`, `activity`, `eligibility`) then delegates to the unchanged strict `EpisodeV1Schema.parse` — canonical type unchanged, callers can never observe a null. Exported from the package barrel.
- Switches the evidence adapter's three read sites (`list`, `get`, `classifyExisting`) to the read-tolerant parser. Write paths stay strict: `put()` and `SessionEndRequestV1Schema` still use `EpisodeV1Schema.parse` directly, so writers remain forbidden from emitting nulls.
- `list()` now emits `[evidence] list: N readable, M unreadable episode file(s)` whenever anything was skipped, on top of the existing per-file warn — silent total loss is no longer possible.
- Defense in depth in the Python fallback writer: `write_episode_fallback` (`apps/jinn-agent/plugins/jinn/distill.py`) drops `None`-valued keys from the known-optional slots before `json.dumps`, and normalizes the existing on-disk file through the same strip before its identity check (so a post-upgrade retry over a pre-fix null-bearing file resolves as identical instead of a spurious collision).

## Root cause
The current-source writers cannot produce these nulls: `_build_episode` in `capture_buffer.py` conditionally omits the optional keys entirely (e.g. `cost["tokens"]` is only set `if tokens:`), and the TS core parse-gates writes (`JSON.stringify` drops `undefined`). The 18 affected files were written by an older installed wheel whose episode dict carried explicit `None`s: the strict `SessionEndRequestV1Schema` delegation to the TS core rejected each one, and `write_episode_fallback` then persisted the dict unfiltered via `json.dumps` — minting `null`-bearing files the strict reader could never load again. `mineable-traces.json` kept gaining candidates throughout because `tee_capture` writes the legacy `CapturedTask` shape best-effort BEFORE the strict session-end delegation and independently of its outcome (see `distill.py` `tee_capture`); that legacy path has no strict-schema gate, so trace mining kept succeeding while episode persistence was failing over. A session-end on the current wheel+layer persists via the TS core with no fallback write (AC4). Remaining live-machine verification (fresh Hermes session appearing in `/jinn history` on the dogfooding machine) is tracked as a post-merge dogfood check.

## Acceptance criteria
- AC1 (existing null-bearing files returned by `evidence.list()`): read-tolerant parser + adapter wiring; regression tests use a fixture mirroring the exact on-disk shape.
- AC2 (new sessions still strict-parse): write paths untouched and still strict; existing strict-schema tests unchanged and green.
- AC3 (failures surfaced): per-file warn (existing) + new readable/unreadable summary line, tested.
- AC4 (root cause confirmed): see Root cause above.

## Review notes (follow-ups, non-blocking — from the pipeline's review stages)
- The per-file warn logs the basename; logging the full path would meet AC3 even more literally.
- The seven-slot strip list mirrors the schema's `.optional()` fields but nothing enforces the mirror; a zod shape-introspection lockstep test would future-proof it.
- The null-bearing test fixture is hand-encoded in two test files; the plugin's `./testing` subpath is a natural shared home.
- The Python write-side strip covers the four observed slots only (deliberate, documented); TS read tolerance covers the rest.

## Test plan
- [x] `packages/plugin` vitest — read-tolerant parse round-trips the null-bearing shape through the strict schema; corrupt/unknown-field payloads still throw
- [x] `client` harness-layer vitest — `list()`/`get()` return the on-disk null shape; corrupt file still skipped; summary log line asserted
- [x] `apps/jinn-agent` pytest — fallback writer drops None-valued optional keys; pre-fix null-bearing file treated as identical on retry
- [x] Typecheck green (`packages/plugin`, `client` root)

Closes #1811

🤖 Generated with [Claude Code](https://claude.com/claude-code)