### PR TITLE
fix(autopilot): run triage from self-contained package

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -72,18 +72,19 @@ Before any worktree is created and before `Status` is flipped to `In Progress`, 
 
 ### Invoke the CLI
 
-Run the reality-check from the primary checkout (not the worktree — the worktree doesn't exist yet):
+Run the reality-check from the self-contained Autopilot package in the primary checkout
+(not the worktree — the worktree doesn't exist yet). The repository root has no Yarn
+workspace, so invoke the package directly:
 
 ```bash
-cd <repo-root>
-yarn workspace @jinn-network/autopilot triage:check <N>
+(cd <repo-root>/packages/autopilot && yarn triage:check <N>)
 # Emits one line of JSON to stdout; non-zero exit on failure.
 ```
 
 Parse the JSON verdict:
 
 ```bash
-VERDICT_JSON=$(yarn workspace @jinn-network/autopilot triage:check <N>)
+VERDICT_JSON=$(cd <repo-root>/packages/autopilot && yarn triage:check <N>)
 CLASSIFICATION=$(echo "$VERDICT_JSON" | jq -r '.classification')
 SUGGESTED_COMMENT=$(echo "$VERDICT_JSON" | jq -r '.suggestedComment')
 SUGGESTED_BLOCKED_ON=$(echo "$VERDICT_JSON" | jq -r '.suggestedBlockedOn')

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -77,14 +77,14 @@ Run the reality-check from the self-contained Autopilot package in the primary c
 workspace, so invoke the package directly:
 
 ```bash
-(cd <repo-root>/packages/autopilot && yarn triage:check <N>)
+(cd "<repo-root>/packages/autopilot" && yarn triage:check <N>)
 # Emits one line of JSON to stdout; non-zero exit on failure.
 ```
 
 Parse the JSON verdict:
 
 ```bash
-VERDICT_JSON=$(cd <repo-root>/packages/autopilot && yarn triage:check <N>)
+VERDICT_JSON=$(cd "<repo-root>/packages/autopilot" && yarn triage:check <N>)
 CLASSIFICATION=$(echo "$VERDICT_JSON" | jq -r '.classification')
 SUGGESTED_COMMENT=$(echo "$VERDICT_JSON" | jq -r '.suggestedComment')
 SUGGESTED_BLOCKED_ON=$(echo "$VERDICT_JSON" | jq -r '.suggestedBlockedOn')

--- a/packages/autopilot/test/implement-issue-skill.test.ts
+++ b/packages/autopilot/test/implement-issue-skill.test.ts
@@ -37,8 +37,14 @@ describe('implement-issue SKILL.md triage invocation', () => {
   const doc = readFileSync(SKILL_PATH, 'utf8');
 
   it('runs the self-contained Autopilot triage CLI from its package directory', () => {
-    expect(doc).toContain('cd <repo-root>/packages/autopilot');
-    expect(doc).toContain('yarn triage:check <N>');
+    expect(doc).toContain(
+      '(cd "<repo-root>/packages/autopilot" && yarn triage:check <N>)',
+    );
+    expect(doc).toContain(
+      'VERDICT_JSON=$(cd "<repo-root>/packages/autopilot" && yarn triage:check <N>)',
+    );
     expect(doc).not.toContain('yarn workspace @jinn-network/autopilot triage:check');
+    expect(doc).not.toContain('(cd <repo-root>/packages/autopilot');
+    expect(doc).not.toContain('VERDICT_JSON=$(cd <repo-root>/packages/autopilot');
   });
 });

--- a/packages/autopilot/test/implement-issue-skill.test.ts
+++ b/packages/autopilot/test/implement-issue-skill.test.ts
@@ -32,3 +32,13 @@ describe('implement-issue SKILL.md (#657 depth-fix)', () => {
     expect(doc).not.toContain('Each stage is performed by dispatching a **fresh subagent**');
   });
 });
+
+describe('implement-issue SKILL.md triage invocation', () => {
+  const doc = readFileSync(SKILL_PATH, 'utf8');
+
+  it('runs the self-contained Autopilot triage CLI from its package directory', () => {
+    expect(doc).toContain('cd <repo-root>/packages/autopilot');
+    expect(doc).toContain('yarn triage:check <N>');
+    expect(doc).not.toContain('yarn workspace @jinn-network/autopilot triage:check');
+  });
+});


### PR DESCRIPTION
## Summary

- run the mandatory reality-check from `packages/autopilot`, which is a self-contained Yarn project
- remove the invalid root-workspace invocation that blocked #1822 before implementation
- guard the command contract with a focused skill-content regression test

## Root cause

The repository intentionally has no root `package.json`, but the implementation skill invoked `yarn workspace @jinn-network/autopilot` from the repository root. Yarn therefore could not resolve the workspace and every implementation session stopped at the mandatory fail-loud triage gate.

## Verification

- `yarn test test/implement-issue-skill.test.ts` — 4 passed
- `yarn test` — 62 files, 558 tests passed
- `yarn triage:check 1822` under the Autopilot implementer identity — `classification: clear`
- `yarn typecheck` remains red on unchanged `next` because the self-contained package does not declare `@types/node`; this PR does not alter TypeScript sources or dependencies

Refs #1822