### PR TITLE
fix(jinn-agent): forward session tokens on CLI session-end so cost.tokens populates

### DIFF
--- a/apps/jinn-agent/cli.py
+++ b/apps/jinn-agent/cli.py
@@ -1188,6 +1188,10 @@ def _emit_interrupted_session_end(cli, *, reason: str = "keyboard_interrupt") ->
             model=getattr(agent, "model", None),
             platform=getattr(agent, "platform", None) or "cli",
             reason=reason,
+            # Forward session token counters so the jinn plugin populates
+            # cost.tokens on interrupted -p runs too (mono #1662, #1840).
+            input_tokens=getattr(agent, "session_input_tokens", 0),
+            output_tokens=getattr(agent, "session_output_tokens", 0),
         )
     except Exception:
         pass
@@ -15511,6 +15515,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         model=getattr(self.agent, 'model', None),
                         platform=getattr(self.agent, 'platform', None) or "cli",
                         reason="shutdown",
+                        # Forward session token counters so cost.tokens
+                        # populates on mid-turn shutdown too (mono #1662, #1840).
+                        input_tokens=getattr(self.agent, 'session_input_tokens', 0),
+                        output_tokens=getattr(self.agent, 'session_output_tokens', 0),
                     )
                 except Exception:
                     pass

--- a/apps/jinn-agent/tests/agent/test_cli_session_end_forwards_tokens.py
+++ b/apps/jinn-agent/tests/agent/test_cli_session_end_forwards_tokens.py
@@ -1,0 +1,55 @@
+"""CLI session-end fire sites forward session token counters (mono #1662, #1840).
+
+turn_finalizer already forwards `input_tokens`/`output_tokens` on the
+normal-completion path, but real `-p`/interrupted jinn runs terminate through
+the CLI fire sites (`_emit_interrupted_session_end` and the mid-turn shutdown
+safety-net). Those omitted the token kwargs, so the jinn plugin's
+`_on_session_end` guard (`if input_tokens or output_tokens`) was false and
+`cost.tokens` was never assembled — 0% of real episodes carried it.
+
+This pins the interrupt fire site. The shutdown safety-net (~cli.py:15507)
+receives the identical additive kwargs off `self.agent`; it lives inside a large
+prompt_toolkit CLI method that can't be unit-driven cleanly, so it is not
+exercised in isolation here.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import cli as jinn_cli
+
+
+def _fake_cli():
+    agent = SimpleNamespace(
+        session_id="sess-A",
+        model="test-model",
+        platform="cli",
+        session_input_tokens=100,
+        session_output_tokens=50,
+        _current_task_id="task-1",
+        _current_turn_id="turn-1",
+        _current_api_request_id="req-1",
+        interrupt=lambda *a, **k: None,
+    )
+    return SimpleNamespace(agent=agent, session_id="sess-A")
+
+
+def _run(monkeypatch):
+    calls: list[tuple[str, dict]] = []
+
+    def invoke_hook(name, **kwargs):
+        calls.append((name, kwargs))
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", invoke_hook)
+
+    jinn_cli._emit_interrupted_session_end(_fake_cli(), reason="keyboard_interrupt")
+    return calls
+
+
+def test_interrupted_session_end_forwards_token_counters(monkeypatch):
+    calls = _run(monkeypatch)
+    end = dict(calls)["on_session_end"]
+    assert end["input_tokens"] == 100
+    assert end["output_tokens"] == 50


### PR DESCRIPTION
## Summary
`turn_finalizer` forwards `input_tokens`/`output_tokens` into the `on_session_end` hook on the normal-completion path, so the jinn plugin's `_on_session_end` guard (`if input_tokens or output_tokens`) records `cost.tokens`. But real `-p`/interrupted runs terminate through two CLI fire sites — `_emit_interrupted_session_end` and the mid-turn shutdown safety-net in `HermesCLI.__exit__` — which omitted the token kwargs. The guard then saw `None/None` and never recorded tokens, so **0% of real episodes carried `cost.tokens`** (mono #1662, #1840).

This forwards the session counters (`agent.session_input_tokens`/`session_output_tokens`, additive kwargs, `getattr` default 0) at both fire sites, matching the normal-completion path. No redesign — host-side reporting repair only.

## Test plan
- New regression test `tests/agent/test_cli_session_end_forwards_tokens.py` pins the interrupt fire site: asserts `on_session_end` carries `input_tokens`/`output_tokens`. Verified **red without the fix** (KeyError) and **green with it**.
- The shutdown safety-net lives inside a large prompt_toolkit CLI method that can't be unit-driven in isolation; it forwards the identical additive kwargs off `self.agent` and is covered by inspection (documented in the test module docstring).
- Independent code review + `/security-review`: no findings.
- Scope: two 4-line additive kwargs + one new test; no behavior change on the already-working normal path.

## Verification
Plugin suite green for the changed surface; the regression test pins nonzero-token forwarding. (3 pre-existing `test_anthropic_adapter.py::TestRunOauthSetupToken` failures on `next` are unrelated to this diff.)

Closes #1840

🤖 Generated with [Claude Code](https://claude.com/claude-code)